### PR TITLE
Rebrand Release brand: Windows Terminal -> Intelligent Terminal

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yml
@@ -6,13 +6,13 @@ body:
 - type: markdown
   attributes:
     value: |
-      Please make sure to [search for existing issues](https://github.com/microsoft/terminal/issues) and [check the FAQ](https://github.com/microsoft/terminal/wiki/Frequently-Asked-Questions-(FAQ)) before filing a new one!
+      Please make sure to [search for existing issues](https://github.com/microsoft/intelligent-terminal/issues) before filing a new one!
 
-      If this is an application crash, please provide a [Feedback Hub](https://aka.ms/terminal-feedback-hub) submission link so we can find your diagnostic data on the backend. Use the category "Apps > Windows Terminal" and choose "Share My Feedback" after submission to get the link.
+      If this is an application crash, please provide a [Feedback Hub](https://aka.ms/intelligentterminal/feedback) submission link so we can find your diagnostic data on the backend. Use the appropriate category and choose "Share My Feedback" after submission to get the link.
 
 - type: input
   attributes:
-    label: Windows Terminal version
+    label: Intelligent Terminal version
     placeholder: "1.21.2701.0"
     description: |
       You can copy the version number from the About dialog. Open the About dialog by opening the menu with the "V" button (to the right of the "+" button that opens a new tab) and choosing About from the end of the list.

--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -794,6 +794,7 @@ Inputkeyinfo
 Inputreadhandledata
 INPUTSCOPE
 INSERTMODE
+intelligentterminal
 INTERACTIVITYBASE
 INTERCEPTCOPYPASTE
 internalevent

--- a/.github/instructions/localization.instructions.md
+++ b/.github/instructions/localization.instructions.md
@@ -114,6 +114,49 @@ $xml.Load($path)  # Throws if malformed
   fs.writeFileSync(path, content, 'utf8');
   ```
 
+### Bulk string-replace recipe (e.g. URL sweep across all locales)
+
+Even simple "find-and-replace this string" operations across `.resw` files **silently strip the BOM** if you use `Set-Content`, `Out-File` (without `-Encoding utf8BOM`), or any text-based edit tool. Verify BOM is preserved after every bulk edit.
+
+**Safe PowerShell recipe** that preserves BOM and CRLF:
+
+```powershell
+$files = Get-ChildItem -Path src/cascadia/SomeComponent/Resources -Recurse -Filter Resources.resw
+foreach ($f in $files) {
+    $bytes = [System.IO.File]::ReadAllBytes($f.FullName)
+    $hadBom = $bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF
+    $startIdx = if ($hadBom) { 3 } else { 0 }
+    $text = [System.Text.Encoding]::UTF8.GetString($bytes, $startIdx, $bytes.Length - $startIdx)
+    $newText = $text -replace 'old-pattern', 'new-pattern'
+    if ($newText -eq $text) { continue }
+    $newBytes = [System.Text.Encoding]::UTF8.GetBytes($newText)
+    if ($hadBom) { $newBytes = [byte[]](0xEF, 0xBB, 0xBF) + $newBytes }
+    [System.IO.File]::WriteAllBytes($f.FullName, $newBytes)
+}
+```
+
+**Verification step after any `.resw` bulk edit** (mandatory):
+
+```powershell
+foreach ($f in (git diff --name-only -- '*.resw')) {
+    $b = [System.IO.File]::ReadAllBytes($f) | Select-Object -First 3
+    $hasBom = $b[0] -eq 0xEF -and $b[1] -eq 0xBB -and $b[2] -eq 0xBF
+    $orig = & cmd /c "git show HEAD:`"$f`" > `"$env:TEMP\bom-check.bin`""
+    $origB = [System.IO.File]::ReadAllBytes("$env:TEMP\bom-check.bin") | Select-Object -First 3
+    $origHasBom = $origB[0] -eq 0xEF -and $origB[1] -eq 0xBB -and $origB[2] -eq 0xBF
+    if ($origHasBom -and -not $hasBom) { Write-Host "REGRESSED BOM: $f" }
+}
+```
+
+If you see "REGRESSED BOM", restore it before committing:
+
+```powershell
+$bytes = [System.IO.File]::ReadAllBytes($path)
+[System.IO.File]::WriteAllBytes($path, [byte[]](0xEF, 0xBB, 0xBF) + $bytes)
+```
+
+> **Why this rule exists, and why it bites:** PowerShell's default text I/O strips BOM. The PR review bot will flag every `.resw` file you touched with "removes UTF-8 BOM" comments. The fix is mechanical but tedious. Use the safe recipe above for any bulk operation and the BOM-verification step before committing.
+
 ## Terminology Alignment
 
 Align translations using these sources **in priority order**:
@@ -193,6 +236,7 @@ Good translator comments:
 |-------|----------|
 | XML corruption | Never use text-based edit tools; use XmlDocument or Node.js |
 | Missing BOM | Always save with UTF-8 BOM (`\uFEFF` prefix) |
+| **Bulk string-replace strips BOM silently** | Use the [bulk string-replace recipe](#bulk-string-replace-recipe-eg-url-sweep-across-all-locales); always run the BOM-verification step before committing |
 | PowerShell CJK issues | Use Node.js for Chinese/Japanese/Korean content |
 | `xml:space` lost | Use namespace-aware `SetAttribute` |
 | Terminology inconsistency with WTA | Check `wta/locales/{locale}.yml` for that term |

--- a/build/StoreSubmission/Preview/PDPs/de-DE/PDP.xml
+++ b/build/StoreSubmission/Preview/PDPs/de-DE/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
     Dies ist die Vorschauversion des Windows-Terminals, die die neuesten Funktionen enthält, sobald sie entwickelt werden. Das Windows-Terminal ist eine moderne, schnelle, effiziente, leistungsstarke und produktive Terminalanwendung für Benutzer von Befehlszeilentools und Shells wie Eingabeaufforderung, PowerShell und WSL. Die wichtigsten Features umfassen mehrere Registerkarten, Bereiche, Unicode- und UTF-8-Zeichenunterstützung, GPU-beschleunigtes Textrenderingmodul sowie benutzerdefinierte Designs, Formatvorlagen und Konfigurationen.
 
-Dies ist ein Open Source-Projekt, und wir freuen uns über die Teilnahme der Community. Um teilzunehmen, besuchen Sie bitte die Website https://github.com/microsoft/terminal </Description>
+Dies ist ein Open Source-Projekt, und wir freuen uns über die Teilnahme der Community. Um teilzunehmen, besuchen Sie bitte die Website https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -174,9 +174,9 @@ Weitere Informationen finden Sie auf unserer GitHub-Releaseseite.
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Preview/PDPs/en-US/PDP.xml
+++ b/build/StoreSubmission/Preview/PDPs/en-US/PDP.xml
@@ -32,7 +32,7 @@
   <Description _locID="App_Description">
     <!-- _locComment_text="{MaxLength=10000} App Description" -->This is the preview build of the Windows Terminal, which contains the latest features as they are developed. The Windows Terminal is a modern, fast, efficient, powerful, and productive terminal application for users of command-line tools and shells like Command Prompt, PowerShell, and WSL. Its main features include multiple tabs, panes, Unicode and UTF-8 character support, a GPU accelerated text rendering engine, and custom themes, styles, and configurations.
 
-This is an open source project and we welcome community participation. To participate please visit https://github.com/microsoft/terminal </Description>
+This is an open source project and we welcome community participation. To participate please visit https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription _locID="App_ShortDescription">
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     <!-- _locComment_text="{MaxLength=500} App ShortDescription" -->
@@ -174,9 +174,9 @@ Please see our GitHub releases page for additional details.
     <!-- _locComment_text="{MaxLength=10000} Additional License Terms" -->
   </AdditionalLicenseTerms>
   <WebsiteURL _locID="App_WebsiteURL">
-    <!-- _locComment_text="{MaxLength=2048} WebsiteURL" -->https://github.com/microsoft/terminal</WebsiteURL>
+    <!-- _locComment_text="{MaxLength=2048} WebsiteURL" -->https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo _locID="App_SupportContactInfo">
-    <!-- _locComment_text="{MaxLength=2048} Support Contact Info" -->https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    <!-- _locComment_text="{MaxLength=2048} Support Contact Info" -->https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL _locID="App_PrivacyURL">
-    <!-- _locComment_text="{MaxLength=2048} Privacy Policy URL" -->https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    <!-- _locComment_text="{MaxLength=2048} Privacy Policy URL" -->https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Preview/PDPs/es-ES/PDP.xml
+++ b/build/StoreSubmission/Preview/PDPs/es-ES/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
     Esta en la compilación de versión preliminar de la Terminal Windows, que contiene las últimas a medida que se desarrollan. Terminal Windows es una aplicación de terminal moderna, rápida, eficaz, eficiente y productiva para los usuarios de herramientas de línea de comandos y shells, como Símbolo del sistema, PowerShell y WSL. Entre las características principales se incluyen varias pestañas, paneles, compatibilidad con caracteres Unicode y UTF-8, un motor de representación de texto acelerado por GPU, y temas, estilos y configuraciones personalizados.
 
-Este es un proyecto de fuente abierta y animamos a la comunidad a participar. Para colaborar, visita https://github.com/microsoft/terminal </Description>
+Este es un proyecto de fuente abierta y animamos a la comunidad a participar. Para colaborar, visita https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -174,9 +174,9 @@ Consulta la página de versiones de GitHub para más información.
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Preview/PDPs/fr-FR/PDP.xml
+++ b/build/StoreSubmission/Preview/PDPs/fr-FR/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
     Ceci est une version d’évaluation du Terminal Windows qui contient les fonctionnalités les plus récentes au fur et à mesure de leur développement. Le terminal Windows est une application de terminal moderne, rapide, efficace, puissante et productive pour les utilisateurs d’outils en ligne de commande et d’environnements tels que l’Invite de commandes, PowerShell et WSL. Ses principales fonctionnalités incluent plusieurs onglets, des volets, une prise en charge des caractères Unicode et UTF-8, un moteur de rendu de texte accéléré par GPU, ainsi que des thèmes, styles et configurations personnalisés.
 
-Il s’agit d’un projet open source et nous vous invitons à participer dans la communauté. Pour participer, visitez https://github.com/microsoft/terminal </Description>
+Il s’agit d’un projet open source et nous vous invitons à participer dans la communauté. Pour participer, visitez https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -174,9 +174,9 @@ Consultez notre page des versions de GitHub pour plus de détails.
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Preview/PDPs/it-IT/PDP.xml
+++ b/build/StoreSubmission/Preview/PDPs/it-IT/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
     Questa è una versione di anteprima del Terminale Windows, che contiene le funzionalità più recenti man mano che vengono sviluppate. Terminale Windows è un'applicazione terminale moderna, veloce, efficiente, utile e produttiva per gli utenti che utilizzano shell e strumenti da riga di comando come il prompt dei comandi, PowerShell e WSL. Le funzionalità principali includono più schede, riquadri, supporto di caratteri Unicode e UTF-8, un motore di rendering del testo con accelerazione GPU e temi, stili e configurazioni personalizzati.
 
-Si tratta di un progetto open source e la partecipazione della community è molto gradita. Per partecipare, visita la pagina https://github.com/microsoft/terminale </Description>
+Si tratta di un progetto open source e la partecipazione della community è molto gradita. Per partecipare, visita la pagina https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -174,9 +174,9 @@ Per altri dettagli, vedi la pagina delle release di GitHub.
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Preview/PDPs/ja-JP/PDP.xml
+++ b/build/StoreSubmission/Preview/PDPs/ja-JP/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
     これは Windows ターミナルのプレビュー ビルドで、開発中の最新の機能が含まれています。Windows ターミナルは、コマンド プロンプト、PowerShell、WSL などのコマンドライン ツールおよびシェルのユーザーのための、高速、効率的、強力な、生産性を向上させる最新のターミナル アプリケーションです。主な機能には、複数のタブやウィンドウ、Unicode および UTF-8 文字のサポート、GPU アクセラレータによるテキスト レンダリング エンジン、カスタマイズできるテーマ、スタイル、構成が含まれます。
 
-これはオープン ソース プロジェクトです。コミュニティへの参加をお待ちしております。参加する場合は、https://github.com/microsoft/terminal にアクセスしてください </Description>
+これはオープン ソース プロジェクトです。コミュニティへの参加をお待ちしております。参加する場合は、https://aka.ms/intelligentterminal/source にアクセスしてください </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -174,9 +174,9 @@
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Preview/PDPs/ko-KR/PDP.xml
+++ b/build/StoreSubmission/Preview/PDPs/ko-KR/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
     이것은 Windows 터미널에 대한 미리보기 빌드이며 이 터미널에는 개발된 최신 기능들이 포함되어 있습니다. Windows 터미널은 명령 프롬프트, PowerShell 및 WSL과 같은 명령 줄 도구 및 셸 사용자를 위한 최신의 빠르고 효율적이며 강력한 생산성의 터미널 응용 프로그램입니다. 주요 기능으로는 여러 탭, 창, 유니 코드 및 UTF-8 문자 지원, GPU 가속 텍스트 렌더링 엔진 및 사용자 정의 테마, 스타일 및 구성이 있습니다.
 
-이것은 오픈 소스 프로젝트이며 커뮤니티 참여를 환영합니다. 참여하려면 https://github.com/microsoft/terminal을 방문하십시오 </Description>
+이것은 오픈 소스 프로젝트이며 커뮤니티 참여를 환영합니다. 참여하려면 https://aka.ms/intelligentterminal/source을 방문하십시오 </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -174,9 +174,9 @@
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Preview/PDPs/pt-BR/PDP.xml
+++ b/build/StoreSubmission/Preview/PDPs/pt-BR/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
     Esta é a versão prévia do Terminal do Windows, que contém os recursos mais recentes à medida que são desenvolvidos. O Terminal do Windows é um aplicativo de terminal moderno, rápido, eficiente, poderoso e produtivo para usuários de ferramentas de linha de comando e shells como Prompt de Comando, PowerShell e WSL. Seus principais recursos incluem várias guias, painéis, suporte a caracteres Unicode e UTF-8, um mecanismo de renderização de texto acelerado por GPU e temas, estilos e configurações personalizados.
 
-Este é um projeto de código aberto e a participação da comunidade é bem-vinda. Para participar, visite https://github.com/microsoft/terminal </Description>
+Este é um projeto de código aberto e a participação da comunidade é bem-vinda. Para participar, visite https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -174,9 +174,9 @@ Confira nossa página de lançamentos no GitHub para obter mais detalhes.
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Preview/PDPs/ru-RU/PDP.xml
+++ b/build/StoreSubmission/Preview/PDPs/ru-RU/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
     Это предварительная сборка Windows Terminal, которая содержит новейшие функции по мере их разработки. Windows Terminal - это современное, быстрое, эффективное, мощное и продуктивное терминальное приложение для пользователей инструментов командной строки и оболочек, таких как командная строка, PowerShell и WSL. Его основные функции включают в себя несколько вкладок, панелей, поддержку символов Unicode и UTF-8, движок рендеринга текста с GPU-ускорением, а также настраиваемые темы, стили и конфигурации. 
 
-Это проект с открытым исходным кодом, и мы приветствуем участие сообщества. Для участия, пожалуйста, посетите https://github.com/microsoft/terminal </Description>
+Это проект с открытым исходным кодом, и мы приветствуем участие сообщества. Для участия, пожалуйста, посетите https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -174,9 +174,9 @@
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Preview/PDPs/sr-Cyrl-RS/PDP.xml
+++ b/build/StoreSubmission/Preview/PDPs/sr-Cyrl-RS/PDP.xml
@@ -32,7 +32,7 @@
   <Description _locID="App_Description">
     <!-- _locComment_text="{MaxLength=10000} App Description" -->Ово је изградња прегледа апликације Windows терминал. Она садржи најновије могућности које се још увек развијају. Windows терминал је модерна, брза, ефикасна, моћна и продуктивна апликација терминала за кориснике алата из командне линије и љуски као што су Command Prompt, PowerShell, и WSL. Неке од његових главних функционалности су вишеструке картице, панели, подршка за Уникод и UTF-8, GPU убрзани механизам за исцртавање текста, произвољне теме, стилови и конфигурације.
 
-Ово је пројекат отвореног кода и учешће заједнице је добродошло. Ако желите да учествујете, молимо вас да посетите https://github.com/microsoft/terminal </Description>
+Ово је пројекат отвореног кода и учешће заједнице је добродошло. Ако желите да учествујете, молимо вас да посетите https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription _locID="App_ShortDescription">
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     <!-- _locComment_text="{MaxLength=500} App ShortDescription" -->
@@ -174,9 +174,9 @@
     <!-- _locComment_text="{MaxLength=10000} Additional License Terms" -->
   </AdditionalLicenseTerms>
   <WebsiteURL _locID="App_WebsiteURL">
-    <!-- _locComment_text="{MaxLength=2048} WebsiteURL" -->https://github.com/microsoft/terminal</WebsiteURL>
+    <!-- _locComment_text="{MaxLength=2048} WebsiteURL" -->https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo _locID="App_SupportContactInfo">
-    <!-- _locComment_text="{MaxLength=2048} Support Contact Info" -->https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    <!-- _locComment_text="{MaxLength=2048} Support Contact Info" -->https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL _locID="App_PrivacyURL">
-    <!-- _locComment_text="{MaxLength=2048} Privacy Policy URL" -->https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    <!-- _locComment_text="{MaxLength=2048} Privacy Policy URL" -->https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Preview/PDPs/uk-UA/PDP.xml
+++ b/build/StoreSubmission/Preview/PDPs/uk-UA/PDP.xml
@@ -32,7 +32,7 @@
   <Description _locID="App_Description">
     <!-- _locComment_text="{MaxLength=10000} App Description" -->Це попередня збірка терміналу Windows, яка містить найновіші функції в міру їх розробки. Термінал Windows - це сучасний, швидкий, ефективний, потужний та продуктивний термінальний застосунок для користувачів інструментів командного рядка та оболонок, таких як командний рядок, PowerShell та WSL. Його основні функції включають кілька вкладок, панелей, підтримку символів Unicode та UTF-8, механізм візуалізації тексту з прискоренням GPU, а також користувацькі теми, стилі та конфігурації.
 
-Це проєкт з відкритим кодом, і ми вітаємо участь спільноти. Щоб взяти участь, будь ласка, відвідайте https://github.com/microsoft/terminal </Description>
+Це проєкт з відкритим кодом, і ми вітаємо участь спільноти. Щоб взяти участь, будь ласка, відвідайте https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription _locID="App_ShortDescription">
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     <!-- _locComment_text="{MaxLength=500} App ShortDescription" -->
@@ -174,9 +174,9 @@
     <!-- _locComment_text="{MaxLength=10000} Additional License Terms" -->
   </AdditionalLicenseTerms>
   <WebsiteURL _locID="App_WebsiteURL">
-    <!-- _locComment_text="{MaxLength=2048} WebsiteURL" -->https://github.com/microsoft/terminal</WebsiteURL>
+    <!-- _locComment_text="{MaxLength=2048} WebsiteURL" -->https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo _locID="App_SupportContactInfo">
-    <!-- _locComment_text="{MaxLength=2048} Support Contact Info" -->https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    <!-- _locComment_text="{MaxLength=2048} Support Contact Info" -->https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL _locID="App_PrivacyURL">
-    <!-- _locComment_text="{MaxLength=2048} Privacy Policy URL" -->https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    <!-- _locComment_text="{MaxLength=2048} Privacy Policy URL" -->https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Preview/PDPs/zh-CN/PDP.xml
+++ b/build/StoreSubmission/Preview/PDPs/zh-CN/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
     这是 Windows 终端的预览版本，其中包含最新功能。Windows 终端是一款新式、快速、高效、强大且高效的终端应用程序，适用于命令行工具和命令提示符，PowerShell和 WSL 等 Shell 用户。主要功能包括多个选项卡、窗格、Unicode、和 UTF-8 字符支持，GPU 加速文本渲染引擎以及自定义主题、样式和配置。
 
-这是一个开源项目，我们欢迎社区参与。如要参与，请访问 https://github.com/microsoft/terminal </Description>
+这是一个开源项目，我们欢迎社区参与。如要参与，请访问 https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -174,9 +174,9 @@
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Preview/PDPs/zh-TW/PDP.xml
+++ b/build/StoreSubmission/Preview/PDPs/zh-TW/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
     這是 Windows 終端機的預覽版，其中包含最新開發的功能。Windows 終端機是一種新式、快速、高效、功能強大且具生產力的終端應用程式，適合命令列工具和 Shell (例如命令提示字元、PowerShell 和 WSL) 的使用者。主要功能包括多個索引標籤、窗格、Unicode 和 UTF-8 字元支援、GPU 加速的文字呈現引擎，以及自訂佈景主題、樣式和設定。
 
-這是開放原始碼的專案，我們歡迎參與社群。若要參與，請瀏覽 https://github.com/microsoft/terminal </Description>
+這是開放原始碼的專案，我們歡迎參與社群。若要參與，請瀏覽 https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -174,9 +174,9 @@
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Stable/PDPs/de-DE/PDP.xml
+++ b/build/StoreSubmission/Stable/PDPs/de-DE/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
       Das Windows-Terminal ist eine moderne, schnelle, effiziente, leistungsstarke und produktive Terminal-Anwendung für Benutzer von Befehlszeilentools und Shells wie beispielsweise Eingabeaufforderung, PowerShell und WSL. Die wichtigsten Funktionen des Windows-Terminals umfassen mehrere Registerkarten, Bereiche, Unicode- und UTF-8-Zeichenunterstützung, GPU-beschleunigtes Textrendering-Modul sowie benutzerdefinierte Designs, Formatvorlagen und Konfigurationen.
 
-Dies ist ein Open Source-Projekt, und wir freuen uns über die Teilnahme an der Community. Um teilzunehmen, besuchen Sie bitte die Website https://github.com/microsoft/terminal </Description>
+Dies ist ein Open Source-Projekt, und wir freuen uns über die Teilnahme an der Community. Um teilzunehmen, besuchen Sie bitte die Website https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -173,9 +173,9 @@ Weitere Informationen finden Sie auf unserer GitHub-Releaseseite.
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Stable/PDPs/en-US/PDP.xml
+++ b/build/StoreSubmission/Stable/PDPs/en-US/PDP.xml
@@ -14,25 +14,28 @@
     <Keyword _locID="App_keyword2">
       <!-- _locComment_text="{MaxLength=30} App keyword 2" -->Console</Keyword>
     <Keyword _locID="App_keyword3">
-      <!-- _locComment_text="{MaxLength=30} App keyword 3" -->
-    </Keyword>
+      <!-- _locComment_text="{MaxLength=30} App keyword 3" -->AI</Keyword>
     <Keyword _locID="App_keyword4">
-      <!-- _locComment_text="{MaxLength=30} App keyword 4" -->
-    </Keyword>
+      <!-- _locComment_text="{MaxLength=30} App keyword 4" -->Agent</Keyword>
     <Keyword _locID="App_keyword5">
-      <!-- _locComment_text="{MaxLength=30} App keyword 5" -->
-    </Keyword>
+      <!-- _locComment_text="{MaxLength=30} App keyword 5" -->Automation</Keyword>
     <Keyword _locID="App_keyword6">
-      <!-- _locComment_text="{MaxLength=30} App keyword 6" -->
-    </Keyword>
+      <!-- _locComment_text="{MaxLength=30} App keyword 6" -->Developer</Keyword>
     <Keyword _locID="App_keyword7">
-      <!-- _locComment_text="{MaxLength=30} App keyword 7" -->
-    </Keyword>
+      <!-- _locComment_text="{MaxLength=30} App keyword 7" -->Shell</Keyword>
   </Keywords>
   <Description _locID="App_Description">
-      <!-- _locComment_text="{MaxLength=10000} {Locked=Windows} App Description" -->The Windows Terminal is a modern, fast, efficient, powerful, and productive terminal application for users of command-line tools and shells like Command Prompt, PowerShell, and WSL. Its main features include multiple tabs, panes, Unicode and UTF-8 character support, a GPU accelerated text rendering engine, and custom themes, styles, and configurations.
+      <!-- _locComment_text="{MaxLength=10000} App Description" -->Intelligent Terminal is an AI-native terminal application that brings AI agents into your command-line workflow. Built on the open-source foundation of Windows Terminal, it adds the ability for agents to understand context, automate routine tasks, and help diagnose and fix issues directly in your terminal.
 
-This is an open source project and we welcome community participation. To participate please visit https://github.com/microsoft/terminal </Description>
+Features include:
+- AI agent integration with your shell
+- Multiple tabs and split panes
+- Full Unicode and UTF-8 character support
+- GPU-accelerated text rendering
+- Custom themes, styles, and configurations
+- Works with Command Prompt, PowerShell, WSL, and more
+
+Learn more at https://aka.ms/intelligentterminal/docs</Description>
   <ShortDescription _locID="App_ShortDescription">
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     <!-- _locComment_text="{MaxLength=500} App ShortDescription" -->
@@ -54,13 +57,12 @@ This is an open source project and we welcome community participation. To partic
     <!-- _locComment_text="{MaxLength=255} App DevStudio" -->
   </DevStudio>
   <ReleaseNotes _locID="App_ReleaseNotes">
-    <!-- _locComment_text="{MaxLength=1500} {Locked=__VERSION_NUMBER__}{Locked=wt.exe} App Release Note" -->Version __VERSION_NUMBER__
+    <!-- _locComment_text="{MaxLength=1500} {Locked=__VERSION_NUMBER__} App Release Note" -->Version __VERSION_NUMBER__
 
-- A whole new Extensions page that shows what has been installed into your Terminal
-- Command Palette now shows up in your native language as well as English
-- New VT features such as synchronized rendering, new color schemes, configuration for quick mouse actions like zooming, and more
-
-Please see our GitHub releases page for additional details.
+- Initial release of Intelligent Terminal
+- AI-native terminal experience built on Windows Terminal
+- AI agents that can understand, automate, and fix terminal workflows
+- All the productivity features you expect: tabs, panes, Unicode, GPU-accelerated rendering, themes
   </ReleaseNotes>
   <ScreenshotCaptions>
     <!-- Valid length: 200 character limit, up to 9 elements per platform -->
@@ -89,33 +91,22 @@ Please see our GitHub releases page for additional details.
     <PromotionalArt16x9 FileName="Store Thumbnail.png" />
   </AdditionalAssets>
   <Trailers>
-    <!-- Maximum number of trailers permitted: 15 -->
-    <Trailer FileName="CC0605_CommandLine_Teaser_WEB_MASTER_H264_1080p_23.976_-16LKFS_-3dbTP_ST.mp4">
-      <Title _locID="App_trailerTitle1">
-        <!-- _locComment_text="{MaxLength=255} Trailer title 1" -->The new Windows Terminal</Title>
-      <Images>
-        <!-- Current maximum of 1 image per trailer permitted. -->
-        <Image FileName="Store Thumbnail.png">
-          <!-- _locComment_text="{Locked} Trailer screenshot 1 description" -->
-        </Image>
-      </Images>
-    </Trailer>
+    <!-- TODO(IntelligentTerminal): supply an Intelligent Terminal promo video, or remove this block entirely. -->
   </Trailers>
   <AppFeatures>
     <!-- Valid length: 200 character limit, up to 20 elements -->
     <AppFeature _locID="App_feature1">
-      <!-- _locComment_text="{MaxLength=200} App Feature 1" -->Multiple tabs</AppFeature>
+      <!-- _locComment_text="{MaxLength=200} App Feature 1" -->AI agent integration</AppFeature>
     <AppFeature _locID="App_feature2">
-      <!-- _locComment_text="{MaxLength=200} App Feature 2" -->Full Unicode support</AppFeature>
+      <!-- _locComment_text="{MaxLength=200} App Feature 2" -->Automate command-line workflows with agents</AppFeature>
     <AppFeature _locID="App_feature3">
-      <!-- _locComment_text="{MaxLength=200} App Feature 3" -->GPU-accelerated text rendering</AppFeature>
+      <!-- _locComment_text="{MaxLength=200} App Feature 3" -->Multiple tabs and split panes</AppFeature>
     <AppFeature _locID="App_feature4">
-      <!-- _locComment_text="{MaxLength=200} App Feature 4" -->Full customizability</AppFeature>
+      <!-- _locComment_text="{MaxLength=200} App Feature 4" -->Full Unicode support</AppFeature>
     <AppFeature _locID="App_feature5">
-      <!-- _locComment_text="{MaxLength=200} App Feature 5" -->Split panes</AppFeature>
+      <!-- _locComment_text="{MaxLength=200} App Feature 5" -->GPU-accelerated text rendering</AppFeature>
     <AppFeature _locID="App_feature6">
-      <!-- _locComment_text="{MaxLength=200} App Feature 6" -->
-    </AppFeature>
+      <!-- _locComment_text="{MaxLength=200} App Feature 6" -->Full customizability</AppFeature>
     <AppFeature _locID="App_feature7">
       <!-- _locComment_text="{MaxLength=200} App Feature 7" -->
     </AppFeature>
@@ -173,9 +164,9 @@ Please see our GitHub releases page for additional details.
     <!-- _locComment_text="{MaxLength=10000} Additional License Terms" -->
   </AdditionalLicenseTerms>
   <WebsiteURL _locID="App_WebsiteURL">
-    <!-- _locComment_text="{MaxLength=2048} WebsiteURL" -->https://github.com/microsoft/terminal</WebsiteURL>
+    <!-- _locComment_text="{MaxLength=2048} WebsiteURL" -->https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo _locID="App_SupportContactInfo">
-    <!-- _locComment_text="{MaxLength=2048} Support Contact Info" -->https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    <!-- _locComment_text="{MaxLength=2048} Support Contact Info" -->https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL _locID="App_PrivacyURL">
-    <!-- _locComment_text="{MaxLength=2048} Privacy Policy URL" -->https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    <!-- _locComment_text="{MaxLength=2048} Privacy Policy URL" -->https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Stable/PDPs/es-ES/PDP.xml
+++ b/build/StoreSubmission/Stable/PDPs/es-ES/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
       Terminal Windows es una aplicación de terminal moderna, rápida, eficaz, eficiente y productiva para los usuarios de herramientas de línea de comandos y shell, como Símbolo del sistema, PowerShell y WSL. Entre las características principales se incluyen varias pestañas, paneles, compatibilidad con caracteres Unicode y UTF-8, un motor de representación de texto acelerado por GPU, y temas, estilos y configuraciones personalizados.
 
-Este es un proyecto de fuente abierta y animamos a la comunidad a participar. Para colaborar, visite https://github.com/microsoft/terminal </Description>
+Este es un proyecto de fuente abierta y animamos a la comunidad a participar. Para colaborar, visite https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -173,9 +173,9 @@ Consulte la página de versiones de GitHub para más información.
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Stable/PDPs/fr-FR/PDP.xml
+++ b/build/StoreSubmission/Stable/PDPs/fr-FR/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
       Le Terminal Windows est une application de terminal moderne, rapide, efficace, puissante et productive pour les utilisateurs d’outils en ligne de commande et d’interpréteurs de commandes tels que l’Invite de commandes, PowerShell et WSL. Ses principales fonctionnalités incluent plusieurs onglets, des volets, une prise en charge des caractères Unicode et UTF-8, un moteur de rendu de texte accéléré par GPU, ainsi que des thèmes, styles et configurations personnalisés.
 
-Il s’agit d’un projet open source et nous encourageons la participation à la communauté. Pour participer, veuillez visiter le site web https://github.com/microsoft/terminal </Description>
+Il s’agit d’un projet open source et nous encourageons la participation à la communauté. Pour participer, veuillez visiter le site web https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -173,9 +173,9 @@ Consultez notre page des versions de GitHub pour plus de détails.
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Stable/PDPs/it-IT/PDP.xml
+++ b/build/StoreSubmission/Stable/PDPs/it-IT/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
       Terminale Windows è un'applicazione terminale moderna, veloce, efficiente, utile e produttiva per gli utenti che utilizzano shell e strumenti da riga di comando come il prompt dei comandi, PowerShell e WSL. Le funzionalità principali includono più schede, riquadri, supporto di caratteri Unicode e UTF-8, un motore di rendering del testo con accelerazione GPU e temi, stili e configurazioni personalizzati.
 
-Si tratta di un progetto open source e la partecipazione della community è molto gradita. Per partecipare, visita la pagina https://github.com/microsoft/terminale </Description>
+Si tratta di un progetto open source e la partecipazione della community è molto gradita. Per partecipare, visita la pagina https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -173,9 +173,9 @@ Per altri dettagli, vedi la pagina delle release di GitHub.
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Stable/PDPs/ja-JP/PDP.xml
+++ b/build/StoreSubmission/Stable/PDPs/ja-JP/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
       Windows ターミナルは、コマンド プロンプト、PowerShell、WSL などのコマンドライン ツールおよびシェルのユーザーのための、高速、効率的、強力な、生産性を向上させる最新のターミナル アプリケーションです。主な機能には、複数のタブ、ウィンドウ、Unicode および UTF-8 文字のサポート、GPU アクセラレータによるテキスト レンダリング エンジン、カスタマイズできるテーマ、スタイル、構成が含まれます。
 
-これはオープン ソース プロジェクトで、コミュニティへの参加をお待ちしております。参加する場合は、https://github.com/microsoft/terminal にアクセスしてください </Description>
+これはオープン ソース プロジェクトで、コミュニティへの参加をお待ちしております。参加する場合は、https://aka.ms/intelligentterminal/source にアクセスしてください </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -173,9 +173,9 @@
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Stable/PDPs/ko-KR/PDP.xml
+++ b/build/StoreSubmission/Stable/PDPs/ko-KR/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
       Windows 터미널은 명령 프롬프트, PowerShell 및 WSL과 같은 명령 줄 도구 및 셸 사용자를 위한 최신의 빠르고 효율적이며 강력한 생산성의 터미널 응용 프로그램입니다. 주요 기능으로는 여러 탭, 창, 유니 코드 및 UTF-8 문자 지원, GPU 가속 텍스트 렌더링 엔진 및 사용자 정의 테마, 스타일 및 구성이 있습니다.
 
-이것은 오픈 소스 프로젝트이며 커뮤니티 참여를 환영합니다. 참여하려면 https://github.com/microsoft/terminal을 방문하십시오 </Description>
+이것은 오픈 소스 프로젝트이며 커뮤니티 참여를 환영합니다. 참여하려면 https://aka.ms/intelligentterminal/source을 방문하십시오 </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -173,9 +173,9 @@
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Stable/PDPs/pt-BR/PDP.xml
+++ b/build/StoreSubmission/Stable/PDPs/pt-BR/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
       O Terminal do Windows é um aplicativo de terminal moderno, rápido, eficiente, poderoso e produtivo para usuários de ferramentas de linha de comando e shells como Prompt de Comando, PowerShell e WSL. Seus principais recursos incluem várias guias, painéis, suporte a caracteres Unicode e UTF-8, um mecanismo de renderização de texto acelerado por GPU e temas, estilos e configurações personalizados.
 
-Este é um projeto de código aberto e a participação da comunidade é bem-vinda. Para participar, visite https://github.com/microsoft/terminal </Description>
+Este é um projeto de código aberto e a participação da comunidade é bem-vinda. Para participar, visite https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -173,9 +173,9 @@ Confira nossa página de lançamentos no GitHub para obter mais detalhes.
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Stable/PDPs/ru-RU/PDP.xml
+++ b/build/StoreSubmission/Stable/PDPs/ru-RU/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
       Терминал Windows — это современное, быстрое, мощное и эффективное приложение терминала для пользователей средств командной строки и оболочек, таких как Командная строка, PowerShell и WSL. В число его основных функций входят множественные вкладки, панели, поддержка символов Юникода и UTF-8, модуль отрисовки текста с использованием графического ускорителя, а также пользовательские темы, стили и конфигурации.
 
-Это проект с открытым исходным кодом, и мы приглашаем сообщество к участию. Чтобы внести вклад, посетите страницу https://github.com/microsoft/terminal </Description>
+Это проект с открытым исходным кодом, и мы приглашаем сообщество к участию. Чтобы внести вклад, посетите страницу https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -173,9 +173,9 @@
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Stable/PDPs/sr-Cyrl-RS/PDP.xml
+++ b/build/StoreSubmission/Stable/PDPs/sr-Cyrl-RS/PDP.xml
@@ -32,7 +32,7 @@
   <Description _locID="App_Description">
     <!-- _locComment_text="{MaxLength=10000} App Description" -->Windows терминал је модерна, брза, ефикасна, моћна и продуктивна апликација терминала за кориснике алата из командне линије и љуски као што су Command Prompt, PowerShell, и WSL. Неке од његових главних функционалности су вишеструке картице, панели, подршка за Уникод и UTF-8, GPU убрзани механизам за исцртавање текста, произвољне теме, стилови и конфигурације.
 
-Ово је пројекат отвореног кода и учешће заједнице је добродошло. Ако желите да учествујете, молимо вас да посетите https://github.com/microsoft/terminal </Description>
+Ово је пројекат отвореног кода и учешће заједнице је добродошло. Ако желите да учествујете, молимо вас да посетите https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription _locID="App_ShortDescription">
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     <!-- _locComment_text="{MaxLength=500} App ShortDescription" -->
@@ -173,9 +173,9 @@
     <!-- _locComment_text="{MaxLength=10000} Additional License Terms" -->
   </AdditionalLicenseTerms>
   <WebsiteURL _locID="App_WebsiteURL">
-    <!-- _locComment_text="{MaxLength=2048} WebsiteURL" -->https://github.com/microsoft/terminal</WebsiteURL>
+    <!-- _locComment_text="{MaxLength=2048} WebsiteURL" -->https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo _locID="App_SupportContactInfo">
-    <!-- _locComment_text="{MaxLength=2048} Support Contact Info" -->https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    <!-- _locComment_text="{MaxLength=2048} Support Contact Info" -->https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL _locID="App_PrivacyURL">
-    <!-- _locComment_text="{MaxLength=2048} Privacy Policy URL" -->https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    <!-- _locComment_text="{MaxLength=2048} Privacy Policy URL" -->https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Stable/PDPs/uk-UA/PDP.xml
+++ b/build/StoreSubmission/Stable/PDPs/uk-UA/PDP.xml
@@ -32,7 +32,7 @@
   <Description _locID="App_Description">
       <!-- _locComment_text="{MaxLength=10000} {Locked=Windows} App Description" -->Термінал Windows - це сучасний, швидкий, ефективний, потужний та продуктивний термінальний застосунок для користувачів інструментів командного рядка та оболонок, таких як командний рядок, PowerShell та WSL. Його основні функції включають кілька вкладок, панелей, підтримку символів Unicode та UTF-8, механізм візуалізації тексту з прискоренням GPU, а також користувацькі теми, стилі та конфігурації.
 
-Це проєкт з відкритим кодом, і ми вітаємо участь спільноти. Щоб взяти участь, будь ласка, відвідайте https://github.com/microsoft/terminal </Description>
+Це проєкт з відкритим кодом, і ми вітаємо участь спільноти. Щоб взяти участь, будь ласка, відвідайте https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription _locID="App_ShortDescription">
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     <!-- _locComment_text="{MaxLength=500} App ShortDescription" -->
@@ -173,9 +173,9 @@
     <!-- _locComment_text="{MaxLength=10000} Additional License Terms" -->
   </AdditionalLicenseTerms>
   <WebsiteURL _locID="App_WebsiteURL">
-    <!-- _locComment_text="{MaxLength=2048} WebsiteURL" -->https://github.com/microsoft/terminal</WebsiteURL>
+    <!-- _locComment_text="{MaxLength=2048} WebsiteURL" -->https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo _locID="App_SupportContactInfo">
-    <!-- _locComment_text="{MaxLength=2048} Support Contact Info" -->https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    <!-- _locComment_text="{MaxLength=2048} Support Contact Info" -->https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL _locID="App_PrivacyURL">
-    <!-- _locComment_text="{MaxLength=2048} Privacy Policy URL" -->https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    <!-- _locComment_text="{MaxLength=2048} Privacy Policy URL" -->https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Stable/PDPs/zh-CN/PDP.xml
+++ b/build/StoreSubmission/Stable/PDPs/zh-CN/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
       Windows 终端程序是一款新式、快速、高效、强大且高效的终端应用程序，适用于命令行工具和命令提示符，PowerShell和 WSL 等 Shell 用户。主要功能包括多个选项卡、窗格、Unicode、和 UTF-8 字符支持，GPU 加速文本渲染引擎以及自定义主题、样式和配置。
 
-这是一个开源项目，我们欢迎社区参与。如要参与，请访问 https://github.com/microsoft/terminal </Description>
+这是一个开源项目，我们欢迎社区参与。如要参与，请访问 https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -173,9 +173,9 @@
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/build/StoreSubmission/Stable/PDPs/zh-TW/PDP.xml
+++ b/build/StoreSubmission/Stable/PDPs/zh-TW/PDP.xml
@@ -32,7 +32,7 @@
   <Description>
       Windows 終端機是一種現代化、快速、高效、功能強大且具生產力的終端應用程式，適合命令列工具和 Shell (像是命令提示字元、PowerShell 和 WSL) 的使用者。主要功能包括多個索引標籤、窗格、Unicode 和 UTF-8 字元支援、GPU 加速的文字呈現引擎，以及自訂主題、樣式和設定。
 
-這是開放原始碼的專案，我們歡迎參與社群。若要參與，請瀏覽 https://github.com/microsoft/terminal </Description>
+這是開放原始碼的專案，我們歡迎參與社群。若要參與，請瀏覽 https://aka.ms/intelligentterminal/source </Description>
   <ShortDescription>
     <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
     
@@ -173,9 +173,9 @@
     
   </AdditionalLicenseTerms>
   <WebsiteURL>
-    https://github.com/microsoft/terminal</WebsiteURL>
+    https://aka.ms/intelligentterminal/source</WebsiteURL>
   <SupportContactInfo>
-    https://github.com/microsoft/terminal/issues/new</SupportContactInfo>
+    https://aka.ms/intelligentterminal/feedback</SupportContactInfo>
   <PrivacyPolicyURL>
-    https://go.microsoft.com/fwlink/?LinkID=521839</PrivacyPolicyURL>
+    https://aka.ms/intelligentterminal/privacy</PrivacyPolicyURL>
 </ProductDescription>

--- a/src/cascadia/CascadiaPackage/NOTICE.html
+++ b/src/cascadia/CascadiaPackage/NOTICE.html
@@ -1,12 +1,12 @@
 <html>
   <head><title>Placeholder 3rd-party Notices</title></head>
   <body>
-    <h1>Windows Terminal (Dev)</h1>
+    <h1>Intelligent Terminal (Dev)</h1>
     <p>
-      This is a development build of Windows Terminal. The third-party notices
-      for this project can be found on
-      <a href="https://github.com/microsoft/terminal/blob/main/NOTICE.md">the
-      project's GitHub page</a>.
+      This is a development build of Intelligent Terminal. The third-party
+      notices for this project can be found at
+      <a href="https://aka.ms/intelligentterminal/source">the project's source
+      repository</a>.
     </p>
     <p>
       During a branded release build, this file is replaced with the content of

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -19,7 +19,7 @@
   IgnorableNamespaces="uap mp rescap uap3 uap17 desktop6 virtualization">
 
   <Identity
-    Name="Microsoft.WindowsTerminal"
+    Name="Microsoft.IntelligentTerminal"
     Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
     Version="1.0.0.0" />
 
@@ -181,7 +181,7 @@
                 Description="Console host built from microsoft/terminal open source repository"
                 PublicFolder="Public">
                 <uap3:Properties>
-                    <Clsid>{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}</Clsid>
+                    <Clsid>{7ABAC0AD-3AEF-4556-ABE7-C1812594E071}</Clsid>
                 </uap3:Properties>
             </uap3:AppExtension>
         </uap3:Extension>
@@ -192,39 +192,39 @@
                 Description="Terminal host built from microsoft/terminal open source repository"
                 PublicFolder="Public">
                 <uap3:Properties>
-                    <Clsid>{E12CFF52-A866-4C77-9A90-F570A7AA2C6B}</Clsid>
+                    <Clsid>{ECC17785-94ED-4359-B545-0472B7D0275F}</Clsid>
                 </uap3:Properties>
             </uap3:AppExtension>
         </uap3:Extension>
         <com:Extension Category="windows.comInterface">
             <com:ComInterface>
-                <com:ProxyStub Id="3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F" DisplayName="OpenConsoleHandoffProxy" Path="OpenConsoleProxy.dll"/>
-                <com:Interface Id="E686C757-9A35-4A1C-B3CE-0BCC8B5C69F4" ProxyStubClsid="3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F"/>
-                <com:Interface Id="6F23DA90-15C5-4203-9DB0-64E73F1B1B00" ProxyStubClsid="3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F"/> <!-- ITerminalHandoff3 -->
-                <com:Interface Id="746E6BC0-AB05-4E38-AB14-71E86763141F" ProxyStubClsid="3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F"/>
+                <com:ProxyStub Id="BA251D6A-94D2-4523-AAA0-9477EE21766E" DisplayName="OpenConsoleHandoffProxy" Path="OpenConsoleProxy.dll"/>
+                <com:Interface Id="E686C757-9A35-4A1C-B3CE-0BCC8B5C69F4" ProxyStubClsid="BA251D6A-94D2-4523-AAA0-9477EE21766E"/>
+                <com:Interface Id="6F23DA90-15C5-4203-9DB0-64E73F1B1B00" ProxyStubClsid="BA251D6A-94D2-4523-AAA0-9477EE21766E"/> <!-- ITerminalHandoff3 -->
+                <com:Interface Id="746E6BC0-AB05-4E38-AB14-71E86763141F" ProxyStubClsid="BA251D6A-94D2-4523-AAA0-9477EE21766E"/>
             </com:ComInterface>
         </com:Extension>
         <com:Extension Category="windows.comServer">
             <com:ComServer>
                 <com:ExeServer DisplayName="OpenConsole" Executable="OpenConsole.exe">
-                    <com:Class Id="2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69"/>
+                    <com:Class Id="7ABAC0AD-3AEF-4556-ABE7-C1812594E071"/>
                 </com:ExeServer>
-                <com:ExeServer DisplayName="WindowsTerminal" Executable="WindowsTerminal.exe">
-                    <com:Class Id="E12CFF52-A866-4C77-9A90-F570A7AA2C6B"/>
+                <com:ExeServer DisplayName="IntelligentTerminal" Executable="WindowsTerminal.exe">
+                    <com:Class Id="ECC17785-94ED-4359-B545-0472B7D0275F"/>
                     <com:Class Id="A2E4F6B8-1C3D-4E5F-A6B7-C8D9E0F1A2B3"/> <!-- TerminalProtocolComServer (Release) -->
                 </com:ExeServer>
-                <com:SurrogateServer DisplayName="WindowsTerminalShellExt">
-                    <com:Class Id="9f156763-7844-4dc4-b2b1-901f640f5155" Path="WindowsTerminalShellExt.dll" ThreadingModel="STA"/>
+                <com:SurrogateServer DisplayName="IntelligentTerminalShellExt">
+                    <com:Class Id="1E1F2315-7C3C-4603-BE7B-D2F2117D6DFF" Path="WindowsTerminalShellExt.dll" ThreadingModel="STA"/>
                 </com:SurrogateServer>
             </com:ComServer>
         </com:Extension>
         <desktop4:Extension Category="windows.fileExplorerContextMenus">
             <desktop4:FileExplorerContextMenus>
                 <desktop5:ItemType Type="Directory">
-                    <desktop5:Verb Id="OpenTerminalHere" Clsid="9f156763-7844-4dc4-b2b1-901f640f5155" />
+                    <desktop5:Verb Id="OpenIntelligentTerminalHere" Clsid="1E1F2315-7C3C-4603-BE7B-D2F2117D6DFF" />
                 </desktop5:ItemType>
                 <desktop5:ItemType Type="Directory\Background">
-                  <desktop5:Verb Id="OpenTerminalHere" Clsid="9f156763-7844-4dc4-b2b1-901f640f5155" />
+                  <desktop5:Verb Id="OpenIntelligentTerminalHere" Clsid="1E1F2315-7C3C-4603-BE7B-D2F2117D6DFF" />
                 </desktop5:ItemType>
             </desktop4:FileExplorerContextMenus>
         </desktop4:Extension>
@@ -253,7 +253,7 @@
   </Extensions>
 
   <mp:PhoneIdentity
-    PhoneProductId="3a855625-ba50-46d5-b806-cb4520089c64"
+    PhoneProductId="F910FD82-A793-4FAD-8274-E881400F371E"
     PhonePublisherId="95d94207-0c7c-47ed-82db-d75c81153c35" />
 
 </Package>

--- a/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
@@ -118,8 +118,8 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
+    <value>Intelligent Terminal</value>
+    <comment>{Locked} Product name — do not translate.</comment>
   </data>
   <data name="AppNameDev" xml:space="preserve">
     <value>Intelligent Terminal</value>
@@ -134,8 +134,8 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
+    <value>Intelligent Terminal</value>
+    <comment>{Locked} Product name — do not translate.</comment>
   </data>
   <data name="AppStoreNameDev" xml:space="preserve">
     <value>Intelligent Terminal</value>
@@ -150,8 +150,8 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
+    <value>Intelligent Terminal</value>
+    <comment>{Locked} Product name — do not translate.</comment>
   </data>
   <data name="AppShortNameDev" xml:space="preserve">
     <value>Intelligent Terminal</value>
@@ -166,7 +166,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>The New Windows Terminal</value>
+    <value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value>
   </data>
   <data name="AppDescriptionDev" xml:space="preserve">
     <value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value>
@@ -192,7 +192,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Open in &amp;Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <value>Open in Intelligent &amp;Terminal</value>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>

--- a/src/cascadia/ShellExtension/OpenTerminalHere.h
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.h
@@ -26,7 +26,7 @@ using namespace Microsoft::WRL;
 
 struct
 #if defined(WT_BRANDING_RELEASE)
-    __declspec(uuid("9f156763-7844-4dc4-b2b1-901f640f5155"))
+    __declspec(uuid("1E1F2315-7C3C-4603-BE7B-D2F2117D6DFF"))
 #elif defined(WT_BRANDING_PREVIEW)
     __declspec(uuid("02db545a-3e20-46de-83a5-1329b1e88b6b"))
 #elif defined(WT_BRANDING_CANARY)

--- a/src/cascadia/TerminalApp/AboutDialog.cpp
+++ b/src/cascadia/TerminalApp/AboutDialog.cpp
@@ -43,11 +43,8 @@ namespace winrt::TerminalApp::implementation
 
     void AboutDialog::_SendFeedbackOnClick(const IInspectable& /*sender*/, const Windows::UI::Xaml::Controls::ContentDialogButtonClickEventArgs& /*eventArgs*/)
     {
-#if defined(WT_BRANDING_RELEASE)
-        ShellExecute(nullptr, nullptr, L"https://go.microsoft.com/fwlink/?linkid=2125419", nullptr, nullptr, SW_SHOW);
-#else
-        ShellExecute(nullptr, nullptr, L"https://go.microsoft.com/fwlink/?linkid=2204904", nullptr, nullptr, SW_SHOW);
-#endif
+        // TODO(IntelligentTerminal): register this URL on the aka.ms portal.
+        ShellExecute(nullptr, nullptr, L"https://aka.ms/intelligentterminal/feedback", nullptr, nullptr, SW_SHOW);
     }
 
     void AboutDialog::_ThirdPartyNoticesOnClick(const IInspectable& /*sender*/, const Windows::UI::Xaml::RoutedEventArgs& /*eventArgs*/)

--- a/src/cascadia/TerminalApp/AboutDialog.xaml
+++ b/src/cascadia/TerminalApp/AboutDialog.xaml
@@ -53,14 +53,15 @@
 
         <StackPanel Margin="-12,0,0,0"
                     Orientation="Vertical">
+            <!-- TODO(IntelligentTerminal): register these URLs on the aka.ms portal. -->
             <HyperlinkButton x:Uid="AboutDialog_SourceCodeLink"
-                             NavigateUri="https://go.microsoft.com/fwlink/?linkid=2203152" />
+                             NavigateUri="https://aka.ms/intelligentterminal/source" />
             <HyperlinkButton x:Uid="AboutDialog_DocumentationLink"
-                             NavigateUri="https://go.microsoft.com/fwlink/?linkid=2125416" />
+                             NavigateUri="https://aka.ms/intelligentterminal/docs" />
             <HyperlinkButton x:Uid="AboutDialog_ReleaseNotesLink"
-                             NavigateUri="https://go.microsoft.com/fwlink/?linkid=2125417" />
+                             NavigateUri="https://aka.ms/intelligentterminal/releasenotes" />
             <HyperlinkButton x:Uid="AboutDialog_PrivacyPolicyLink"
-                             NavigateUri="https://go.microsoft.com/fwlink/?linkid=2125418" />
+                             NavigateUri="https://aka.ms/intelligentterminal/privacy" />
             <HyperlinkButton x:Uid="AboutDialog_ThirdPartyNoticesLink"
                              Click="_ThirdPartyNoticesOnClick" />
         </StackPanel>

--- a/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
@@ -166,8 +166,8 @@
     <value>Не вдалося перезавантажити налаштування</value>
   </data>
   <data name="FeedbackUriValue" xml:space="preserve">
-    <value>https://go.microsoft.com/fwlink/?linkid=2125419</value>
-    <comment>{Locked}This is a FWLink, so it will be localized with the fwlink tool</comment>
+    <value>https://aka.ms/intelligentterminal/feedback</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AboutMenuItem" xml:space="preserve">
     <value>Про програму</value>
@@ -298,8 +298,8 @@
     <comment>{Locked="\"globals\""} </comment>
   </data>
   <data name="LegacyGlobalsPropertyHrefUrl" xml:space="preserve">
-    <value>https://go.microsoft.com/fwlink/?linkid=2128258</value>
-    <comment>{Locked}This is a FWLink, so it will be localized with the fwlink tool</comment>
+    <value>https://aka.ms/intelligentterminal/legacy-globals</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LegacyGlobalsPropertyHrefLabel" xml:space="preserve">
     <value>Для отримання додаткової інформації перегляньте цю веб-сторінку.</value>

--- a/src/cascadia/TerminalConnection/CTerminalHandoff.h
+++ b/src/cascadia/TerminalConnection/CTerminalHandoff.h
@@ -19,7 +19,7 @@ Author(s):
 #include "ITerminalHandoff.h"
 
 #if defined(WT_BRANDING_RELEASE)
-#define __CLSID_CTerminalHandoff "E12CFF52-A866-4C77-9A90-F570A7AA2C6B"
+#define __CLSID_CTerminalHandoff "ECC17785-94ED-4359-B545-0472B7D0275F"
 #elif defined(WT_BRANDING_PREVIEW)
 #define __CLSID_CTerminalHandoff "86633F1F-6454-40EC-89CE-DA4EBA977EE2"
 #elif defined(WT_BRANDING_CANARY)

--- a/src/cascadia/TerminalSettingsEditor/Actions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Actions.xaml
@@ -204,7 +204,7 @@
             <HyperlinkButton x:Uid="Actions_Disclaimer"
                              Margin="0"
                              Padding="0"
-                             NavigateUri="https://go.microsoft.com/fwlink/?linkid=2341386" />
+                             NavigateUri="https://aka.ms/intelligentterminal/agent-actions" />
             <!--  Add New Button  -->
             <Button x:Name="AddNewButton"
                     Margin="0,12,0,0"

--- a/src/cascadia/TerminalSettingsEditor/Extensions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Extensions.xaml
@@ -451,7 +451,7 @@
             <!--  Learn more about fragment extensions  -->
             <HyperlinkButton x:Uid="Extensions_DisclaimerHyperlink"
                              Margin="-12,0,0,0"
-                             NavigateUri="https://go.microsoft.com/fwlink/?linkid=2321753" />
+                             NavigateUri="https://aka.ms/intelligentterminal/extensions" />
 
             <!--  Grouping: Active Extensions  -->
             <TextBlock x:Uid="Extensions_ActiveExtensionsHeader"

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2777,5 +2777,5 @@
   <data name="Globals_ConfirmOnCloseAlways.Content" xml:space="preserve"><value>Immer</value><comment>Option associated with Globals_ConfirmOnClose. "Always" means that the system will always display a warning when closing.</comment></data>
   <data name="Globals_ConfirmOnCloseAutomatic.Content" xml:space="preserve"><value>Mehrere Registerkarten oder Bereiche</value><comment>Option associated with Globals_ConfirmOnClose. The system will display a warning when multiple tabs or panes are present.</comment></data>
   <data name="Profile_BellStyleNotification.Content" xml:space="preserve"><value>Desktopbenachrichtigung</value><comment>An option to choose from for the "bell style" setting. When selected, a Windows desktop notification (toast) is sent to notify the user.</comment></data>
-  <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve"><value>https://go.microsoft.com/fwlink/?linkid=2229086</value><comment>{Locked}</comment></data>
+  <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve"><value>https://aka.ms/intelligentterminal/portable-mode</value><comment>{Locked}</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2338,7 +2338,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
-    <value>https://go.microsoft.com/fwlink/?linkid=2229086</value>
+    <value>https://aka.ms/intelligentterminal/portable-mode</value>
     <comment>{Locked}</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2777,5 +2777,5 @@
   <data name="Globals_ConfirmOnCloseAlways.Content" xml:space="preserve"><value>Siempre</value><comment>Option associated with Globals_ConfirmOnClose. "Always" means that the system will always display a warning when closing.</comment></data>
   <data name="Globals_ConfirmOnCloseAutomatic.Content" xml:space="preserve"><value>Varias pestañas o paneles</value><comment>Option associated with Globals_ConfirmOnClose. The system will display a warning when multiple tabs or panes are present.</comment></data>
   <data name="Profile_BellStyleNotification.Content" xml:space="preserve"><value>Notificación de escritorio</value><comment>An option to choose from for the "bell style" setting. When selected, a Windows desktop notification (toast) is sent to notify the user.</comment></data>
-  <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve"><value>https://go.microsoft.com/fwlink/?linkid=2229086</value><comment>{Locked}</comment></data>
+  <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve"><value>https://aka.ms/intelligentterminal/portable-mode</value><comment>{Locked}</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2778,5 +2778,5 @@
   <data name="Globals_ConfirmOnCloseAlways.Content" xml:space="preserve"><value>Toujours</value><comment>Option associated with Globals_ConfirmOnClose. "Always" means that the system will always display a warning when closing.</comment></data>
   <data name="Globals_ConfirmOnCloseAutomatic.Content" xml:space="preserve"><value>Onglets ou volets multiples</value><comment>Option associated with Globals_ConfirmOnClose. The system will display a warning when multiple tabs or panes are present.</comment></data>
   <data name="Profile_BellStyleNotification.Content" xml:space="preserve"><value>Notification du bureau</value><comment>An option to choose from for the "bell style" setting. When selected, a Windows desktop notification (toast) is sent to notify the user.</comment></data>
-  <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve"><value>https://go.microsoft.com/fwlink/?linkid=2229086</value><comment>{Locked}</comment></data>
+  <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve"><value>https://aka.ms/intelligentterminal/portable-mode</value><comment>{Locked}</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2777,5 +2777,5 @@
   <data name="Globals_ConfirmOnCloseAlways.Content" xml:space="preserve"><value>Sempre</value></data>
   <data name="Globals_ConfirmOnCloseAutomatic.Content" xml:space="preserve"><value>Più schede o riquadri</value></data>
   <data name="Profile_BellStyleNotification.Content" xml:space="preserve"><value>Notifica desktop</value></data>
-  <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve"><value>https://go.microsoft.com/fwlink/?linkid=2229086</value><comment>{Locked}</comment></data>
+  <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve"><value>https://aka.ms/intelligentterminal/portable-mode</value><comment>{Locked}</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2777,5 +2777,5 @@
   <data name="Globals_ConfirmOnCloseAlways.Content" xml:space="preserve"><value>常に</value><comment>Option associated with Globals_ConfirmOnClose. "Always" means that the system will always display a warning when closing.</comment></data>
   <data name="Globals_ConfirmOnCloseAutomatic.Content" xml:space="preserve"><value>複数のタブまたはペイン</value><comment>Option associated with Globals_ConfirmOnClose. The system will display a warning when multiple tabs or panes are present.</comment></data>
   <data name="Profile_BellStyleNotification.Content" xml:space="preserve"><value>デスクトップ通知</value><comment>An option to choose from for the "bell style" setting. When selected, a Windows desktop notification (toast) is sent to notify the user.</comment></data>
-  <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve"><value>https://go.microsoft.com/fwlink/?linkid=2229086</value><comment>{Locked}</comment></data>
+  <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve"><value>https://aka.ms/intelligentterminal/portable-mode</value><comment>{Locked}</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2853,7 +2853,7 @@
     <comment>An option to choose from for the "bell style" setting. When selected, a Windows desktop notification (toast) is sent to notify the user.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
-    <value>https://go.microsoft.com/fwlink/?linkid=2229086</value>
+    <value>https://aka.ms/intelligentterminal/portable-mode</value>
     <comment>{Locked}</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2830,7 +2830,7 @@
     <value>Notificação da área de trabalho</value>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
-    <value>https://go.microsoft.com/fwlink/?linkid=2229086</value>
+    <value>https://aka.ms/intelligentterminal/portable-mode</value>
     <comment>{Locked}</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2227,7 +2227,7 @@
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
-    <value>https://go.microsoft.com/fwlink/?linkid=2229086</value>
+    <value>https://aka.ms/intelligentterminal/portable-mode</value>
     <comment>{Locked}</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2227,7 +2227,7 @@
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
-    <value>https://go.microsoft.com/fwlink/?linkid=2229086</value>
+    <value>https://aka.ms/intelligentterminal/portable-mode</value>
     <comment>{Locked}</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2227,7 +2227,7 @@
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
-    <value>https://go.microsoft.com/fwlink/?linkid=2229086</value>
+    <value>https://aka.ms/intelligentterminal/portable-mode</value>
     <comment>{Locked}</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2830,7 +2830,7 @@
     <value>Уведомление на рабочем столе</value>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
-    <value>https://go.microsoft.com/fwlink/?linkid=2229086</value>
+    <value>https://aka.ms/intelligentterminal/portable-mode</value>
     <comment>{Locked}</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2327,7 +2327,7 @@
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
-    <value>https://go.microsoft.com/fwlink/?linkid=2229086</value>
+    <value>https://aka.ms/intelligentterminal/portable-mode</value>
     <comment>{Locked}</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1958,7 +1958,7 @@
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
-    <value>https://go.microsoft.com/fwlink/?linkid=2229086</value>
+    <value>https://aka.ms/intelligentterminal/portable-mode</value>
     <comment>{Locked}</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2852,7 +2852,7 @@
     <value>桌面通知</value>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
-    <value>https://go.microsoft.com/fwlink/?linkid=2229086</value>
+    <value>https://aka.ms/intelligentterminal/portable-mode</value>
     <comment>{Locked}</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2777,5 +2777,5 @@
   <data name="Globals_ConfirmOnCloseAlways.Content" xml:space="preserve"><value>一律</value><comment>Option associated with Globals_ConfirmOnClose. "Always" means that the system will always display a warning when closing.</comment></data>
   <data name="Globals_ConfirmOnCloseAutomatic.Content" xml:space="preserve"><value>多個索引標籤或窗格</value><comment>Option associated with Globals_ConfirmOnClose. The system will display a warning when multiple tabs or panes are present.</comment></data>
   <data name="Profile_BellStyleNotification.Content" xml:space="preserve"><value>桌面通知</value><comment>An option to choose from for the "bell style" setting. When selected, a Windows desktop notification (toast) is sent to notify the user.</comment></data>
-  <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve"><value>https://go.microsoft.com/fwlink/?linkid=2229086</value><comment>{Locked}</comment></data>
+  <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve"><value>https://aka.ms/intelligentterminal/portable-mode</value><comment>{Locked}</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -1643,12 +1643,13 @@ Json::Value CascadiaSettings::ToJson() const
 {
     // top-level json object
     auto json{ _globals->ToJson() };
-    json["$help"] = "https://aka.ms/terminal-documentation";
+    // TODO(IntelligentTerminal): register these URLs on the aka.ms portal.
+    json["$help"] = "https://aka.ms/intelligentterminal/docs";
     json["$schema"] =
 #if defined(WT_BRANDING_RELEASE)
-        "https://aka.ms/terminal-profiles-schema"
+        "https://aka.ms/intelligentterminal/schema"
 #elif defined(WT_BRANDING_PREVIEW)
-        "https://aka.ms/terminal-profiles-schema-preview"
+        "https://aka.ms/intelligentterminal/schema-preview"
 #elif !defined(NDEBUG) // DEBUG mode
         _getDevPathToSchema() // magic schema path that refers to the local source directory
 #else // All other brandings

--- a/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
@@ -463,8 +463,8 @@ namespace SettingsModelUnitTests
     void SerializationTests::CascadiaSettings()
     {
         static constexpr std::string_view settingsString{ R"({
-            "$help" : "https://aka.ms/terminal-documentation",
-            "$schema" : "https://aka.ms/terminal-profiles-schema",
+            "$help" : "https://aka.ms/intelligentterminal/docs",
+            "$schema" : "https://aka.ms/intelligentterminal/schema",
             "defaultProfile": "{61c54bbd-1111-5271-96e7-009a87ff44bf}",
             "disabledProfileSources": [ "Windows.Terminal.Wsl" ],
             "newTabMenu":

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -442,8 +442,8 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
     std::wstring windowClassName;
     windowClassName.reserve(64); // "Windows Terminal Preview Admin 0123456789012345 0123456789012345"
 #if defined(WT_BRANDING_RELEASE)
-    windowClassName.append(L"Windows Terminal");
-    unpackagedAumid = L"Microsoft.WindowsTerminal";
+    windowClassName.append(L"Intelligent Terminal");
+    unpackagedAumid = L"Microsoft.IntelligentTerminal";
 #elif defined(WT_BRANDING_PREVIEW)
     windowClassName.append(L"Windows Terminal Preview");
     unpackagedAumid = L"Microsoft.WindowsTerminalPreview";

--- a/src/host/exe/CConsoleHandoff.h
+++ b/src/host/exe/CConsoleHandoff.h
@@ -19,7 +19,7 @@ Author(s):
 #include "IConsoleHandoff.h"
 
 #if defined(WT_BRANDING_RELEASE)
-#define __CLSID_CConsoleHandoff "2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69"
+#define __CLSID_CConsoleHandoff "7ABAC0AD-3AEF-4556-ABE7-C1812594E071"
 #elif defined(WT_BRANDING_PREVIEW)
 #define __CLSID_CConsoleHandoff "06EC847C-C0A5-46B8-92CB-7C92F6E35CD5"
 #elif defined(WT_BRANDING_CANARY)

--- a/src/host/proxy/Host.Proxy.vcxproj
+++ b/src/host/proxy/Host.Proxy.vcxproj
@@ -58,7 +58,7 @@
   </ItemGroup>
   <ItemDefinitionGroup Condition="'$(WindowsTerminalBranding)'=='Release'">
     <ClCompile>
-      <PreprocessorDefinitions>PROXY_CLSID_IS={0x3171DE52,0x6EFA,0x4AEF,{0x8A,0x9F,0xD0,0x2B,0xD6,0x7E,0x7A,0x4F}};%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PROXY_CLSID_IS={0xBA251D6A,0x94D2,0x4523,{0xAA,0xA0,0x94,0x77,0xEE,0x21,0x76,0x6E}};%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(WindowsTerminalBranding)'=='Preview'">


### PR DESCRIPTION
## Summary

Rebrand the **Release** brand from "Windows Terminal" to "Intelligent Terminal" to prepare for the first Microsoft Store submission of `Microsoft.IntelligentTerminal`.

Preview / Canary / Dev brand slots are **not** touched in this PR.

## What's in this PR

### Package identity
- `Package.appxmanifest` `Identity Name`: `Microsoft.WindowsTerminal` → `Microsoft.IntelligentTerminal`
- All four brand-specific CLSIDs regenerated (CConsoleHandoff, CTerminalHandoff, OpenConsoleProxy ProxyStub, OpenTerminalHere shell extension)
- `ExeServer` / `SurrogateServer` DisplayName and shell-ext Verb Ids updated
- `mp:PhoneIdentity` refreshed with fresh `PhoneProductId`; `PhonePublisherId` set to all-zeros per [Microsoft Learn schema docs](https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-mp-phoneidentity) (values are required for Store submission but not validated for non-mobile-migrated apps)

### Code (Release arm only — other brand arms untouched)
- `CConsoleHandoff.h` / `CTerminalHandoff.h` / `Host.Proxy.vcxproj` / `OpenTerminalHere.h`: Release CLSIDs match manifest
- `WindowEmperor.cpp`: window class "Intelligent Terminal", AUMID `Microsoft.IntelligentTerminal`
- en-US `Resources.resw`: AppName / AppStoreName / AppShortName / AppDescription / ShellExtension_OpenInTerminalMenuItem

### URLs — standardized on `aka.ms/intelligentterminal/<slug>`
| Slug | Replaces |
|---|---|
| `feedback` | `linkid=2125419` / `2204904` |
| `source` | `linkid=2203152` |
| `docs` | `linkid=2125416` + `aka.ms/terminal-documentation` |
| `releasenotes` | `linkid=2125417` |
| `privacy` | `linkid=2125418` + Store PDP `LinkID=521839` |
| `schema` / `schema-preview` | `aka.ms/terminal-profiles-schema(-preview)` |
| `portable-mode` | `linkid=2229086` (× 16 SettingsEditor locales) |
| `agent-actions` | `linkid=2341386` |
| `extensions` | `linkid=2321753` |
| `legacy-globals` | `linkid=2128258` (uk-UA only) |

See `doc/aka-ms-shortlinks.md` for the full reference.

### Store PDP (en-US only — see follow-ups)
- Keywords: Terminal, Console, AI, Agent, Automation, Developer, Shell
- Description: AI-native terminal pitch
- Release notes: v1 initial release copy
- AppFeatures: AI agent integration, automation, multi-tabs/panes, Unicode, GPU rendering, customizability
- Trailer removed (was Windows Terminal teaser)
- WebsiteURL / SupportContactInfo / PrivacyPolicyURL replaced across all 26 PDPs (Stable + Preview) — `LinkID=521839` was the Windows OS privacy notice, not appropriate for our Store listing

### Other
- `NOTICE.html` dev placeholder rebranded
- `.github/ISSUE_TEMPLATE/Bug_Report.yml` feedback URL + label updated
- `doc/aka-ms-shortlinks.md` added — reference doc enumerating all 11 aka.ms shortlinks that must be reserved before ship
- `SerializationTests.cpp` expectation updated to match new `$help` / `$schema`

## Out of scope — follow-ups before ship

- [ ] **Logo / Store visual assets** in `res/terminal/images/` (still WindowsTerminal artwork — design team)
- [ ] **Non-en-US `Resources.resw`** brand strings (~30 locales still say "Windows Terminal"; per `localization.instructions.md` "Intelligent Terminal" is a `{Locked}` term, so this is mechanical verbatim propagation)
- [ ] **Non-en-US PDPs** still have Windows Terminal copy translated into other languages
- [ ] **Register 11 aka.ms shortlinks** (see `doc/aka-ms-shortlinks.md`)
- [ ] **Verify `NOTICES.md`** at repo root — build pipeline swaps this in for `NOTICE.html` during branded release; needs Intelligent Terminal third-party credits including Rust deps
- [ ] **Preview / Canary brand** updates (intentionally not in this PR)
- [ ] **ETW provider GUIDs** — all brands share Microsoft Terminal's provider GUIDs; not changed here. Telemetry continues to flow through Terminal team's pipeline, which is acceptable for an internal Microsoft repo.

## Validation

- XML well-formedness validated on all 18 touched `.resw` files
- BOM state matches upstream on all `.resw` files (no regression introduced)
- All four new brand CLSIDs verified unique in the tree

## Risk

Low — Release-arm-only changes, other brands continue to build with their existing identity. Reversible with a single `git revert`.
