### PR TITLE
Dev/localize intelligent terminal

### DIFF
--- a/.github/instructions/localization.instructions.md
+++ b/.github/instructions/localization.instructions.md
@@ -206,7 +206,7 @@ Terms that should always be locked:
 | PATH | Environment variable |
 | PowerShell | Product name |
 | Copilot, Claude, Gemini | Brand names |
-| Intelligent Terminal | Product name |
+| Intelligent Terminal | Product name — lock only for pseudo-locales (`{Locked=qps-ploc,qps-ploca,qps-plocm}`). Translate for all real locales. Example: zh-CN 智能终端, zh-TW 智慧終端機, ja-JP インテリジェント ターミナル |
 | JSON, YAML, XML | Technical formats |
 
 ### Translator guidance comments

--- a/.github/instructions/localization.instructions.md
+++ b/.github/instructions/localization.instructions.md
@@ -206,7 +206,6 @@ Terms that should always be locked:
 | PATH | Environment variable |
 | PowerShell | Product name |
 | Copilot, Claude, Gemini | Brand names |
-| Intelligent Terminal | Product name — lock only for pseudo-locales (`{Locked=qps-ploc,qps-ploca,qps-plocm}`). Translate for all real locales. Example: zh-CN 智能终端, zh-TW 智慧終端機, ja-JP インテリジェント ターミナル |
 | JSON, YAML, XML | Technical formats |
 
 ### Translator guidance comments

--- a/src/cascadia/CascadiaPackage/Resources/af-ZA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/af-ZA/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminaal</value>
+    <value>Intelligente Terminaal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows-terminaal</value>
+    <value>Intelligente Terminaal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminaal</value>
+    <value>Intelligente Terminaal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Die nuwe Windows-terminaal</value>
+    <value>KI-inheemse terminaal — agente kan terminalwerkvloei verstaan, regstel en outomatiseer</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows-terminaal met ’n voorskou van opkomende kenmerke</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Maak oop in &amp;Terminaal</value>
+    <value>Maak oop in Intelligente &amp;Terminaal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/af-ZA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/af-ZA/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Maak oop in &amp;Terminaalvoorskou</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Maak oop in &amp;Intelligente Terminaal</value>

--- a/src/cascadia/CascadiaPackage/Resources/af-ZA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/af-ZA/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Maak oop in Intelligente &amp;Terminaal</value>
+    <value>Maak oop in &amp;Intelligente Terminaal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/af-ZA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/af-ZA/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Maak oop in &amp;Terminaalvoorskou</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Maak oop in &amp;Intelligente Terminaal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/am-ET/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/am-ET/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>ተረሚናል</value>
+    <value>ብልህ ተርሚናል</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>የ Windows መቆጣጠሪያ</value>
+    <value>ብልህ ተርሚናል</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>ተረሚናል</value>
+    <value>ብልህ ተርሚናል</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>አድሱ Windows መቆጣጠሪያ ገጽ</value>
+    <value>በAI ላይ የተገነባ ተርሚናል — ኤጀንቶች የተርሚናል የስራ ፍሰቶችን መረዳት፣ ማስተካከል እና ራስ-ሰር ማድረግ ይችላሉ</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>የ Windows መቆጣጠሪያ ገጽ ከመጪ ባህሪያት ቅድመ እይታ ጋር</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>በ&amp;ተርሚናል ውስጥ ይክፈቱ</value>
+    <value>በ&amp;ብልህ ተርሚናል ውስጥ ይክፈቱ</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/am-ET/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/am-ET/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>በ&amp;ብልህ ተርሚናል ውስጥ ይክፈቱ</value>
+    <value>በብልህ ተርሚናል ውስጥ ይክፈቱ(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/am-ET/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/am-ET/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>በተርሚናል &amp;ቅድመ ዕይታ ውስጥ ይክፈቱ</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>በብልህ ተርሚናል ውስጥ ይክፈቱ(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/am-ET/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/am-ET/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>በተርሚናል &amp;ቅድመ ዕይታ ውስጥ ይክፈቱ</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>በብልህ ተርሚናል ውስጥ ይክፈቱ(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ar-SA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ar-SA/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>الوحدة الطرفية</value>
+    <value>الوحدة الطرفية الذكية</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>وحدة طرفية لـ Windows</value>
+    <value>الوحدة الطرفية الذكية</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>الوحدة الطرفية</value>
+    <value>الوحدة الطرفية الذكية</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>الوحدة الطرفية لـ Windows الجديدة</value>
+    <value>محطة طرفية مبنية حول الذكاء الاصطناعي — يمكن للوكلاء فهم مساراق عمل الطرفية وإصلاحها وأتمتتها</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>وحدة طرفية لـ Windows مع معاينة للميزات القادمة</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>فتح في &amp;الوحدة الطرفية</value>
+    <value>فتح في الوحدة الطرفية ال&amp;ذكية</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ar-SA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ar-SA/Resources.resw
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>محطة طرفية مبنية حول الذكاء الاصطناعي — يمكن للوكلاء فهم مساراق عمل الطرفية وإصلاحها وأتمتتها</value>
+    <value>محطة طرفية مبنية حول الذكاء الاصطناعي — يمكن للوكلاء فهم مسارات عمل الطرفية وإصلاحها وأتمتتها</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>وحدة طرفية لـ Windows مع معاينة للميزات القادمة</value>

--- a/src/cascadia/CascadiaPackage/Resources/ar-SA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ar-SA/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>فتح في "&amp;معاينة الوحدة الطرفية"</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>فتح في الوحدة الطرفية الذكية(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ar-SA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ar-SA/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>فتح في "&amp;معاينة الوحدة الطرفية"</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>فتح في الوحدة الطرفية الذكية(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/ar-SA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ar-SA/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>فتح في الوحدة الطرفية ال&amp;ذكية</value>
+    <value>فتح في الوحدة الطرفية الذكية(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/as-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/as-IN/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>টাৰ্মিনেল</value>
+    <value>ইন্টেলিজেন্ট টাৰ্মিনেল</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows টাৰ্মিনেল</value>
+    <value>ইন্টেলিজেন্ট টাৰ্মিনেল</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>টাৰ্মিনেল</value>
+    <value>ইন্টেলিজেন্ট টাৰ্মিনেল</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>নতুন Windows টাৰ্মিনেল</value>
+    <value>AI-নেটিভ টাৰ্মিনেল — এজেণ্টে টাৰ্মিনেল ৱৰ্কফ্ল’ বুজিব, ঠিক কৰিব আৰু স্বয়ংক্ৰিয় কৰিব পাৰে</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>আগন্তুক সুবিধাসমূহৰ পূৰ্বলোকনৰ সৈতে Windows টাৰ্মিনেল</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;টাৰ্মিনেলত খোলক</value>
+    <value>ইন্টেলিজেন্ট &amp;টাৰ্মিনেলত খোলক</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/as-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/as-IN/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>ইন্টেলিজেন্ট &amp;টাৰ্মিনেলত খোলক</value>
+    <value>ইন্টেলিজেন্ট টাৰ্মিনেলত খোলক(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/as-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/as-IN/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>টাৰ্মিনেল &amp;পূৰ্বলোকনত খোলক</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ইন্টেলিজেন্ট টাৰ্মিনেলত খোলক(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/as-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/as-IN/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>টাৰ্মিনেল &amp;পূৰ্বলোকনত খোলক</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ইন্টেলিজেন্ট টাৰ্মিনেলত খোলক(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/az-Latn-AZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/az-Latn-AZ/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Ağıllı Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>Ağıllı Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Ağıllı Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Yeni Windows Terminalı</value>
+    <value>Süni intellekt əsaslı terminal — agentlər terminal iş axınlarını anlaya, düzəldə və avtomatlaşdıra bilər</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Gözlənilən xüsusiyyətlərin önbaxışı ilə Windows Terminalı</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;Terminalda açın</value>
+    <value>&amp;Ağıllı Terminalda açın</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/az-Latn-AZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/az-Latn-AZ/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Terminalın &amp;Önbaxış versiyasında açın</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Ağıllı Terminalda açın(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/az-Latn-AZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/az-Latn-AZ/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Terminalın &amp;Önbaxış versiyasında açın</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Ağıllı Terminalda açın(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/az-Latn-AZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/az-Latn-AZ/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;Ağıllı Terminalda açın</value>
+    <value>Ağıllı Terminalda açın(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/bg-BG/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/bg-BG/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Терминал</value>
+    <value>Интелигентен Терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Терминал на Windows</value>
+    <value>Интелигентен Терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Терминал</value>
+    <value>Интелигентен Терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Новият терминал на Windows</value>
+    <value>Терминал, създаден с AI в основата си — агентите могат да разбират, поправят и автоматизират работните потоци в терминала</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Терминал на Windows с предварителен преглед на предстоящите функции</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Отваряне в &amp;"Терминал"</value>
+    <value>Отваряне в Интелигентния &amp;Терминал</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/bg-BG/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/bg-BG/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Отваряне в "Терминал" &amp;предварителен преглед</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Отваряне в Интелигентния Терминал(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/bg-BG/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/bg-BG/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Отваряне в "Терминал" &amp;предварителен преглед</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Отваряне в Интелигентния Терминал(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/bg-BG/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/bg-BG/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Отваряне в Интелигентния &amp;Терминал</value>
+    <value>Отваряне в Интелигентния Терминал(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/bn-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/bn-IN/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>টার্মিনাল</value>
+    <value>ইন্টেলিজেন্ট টার্মিনাল</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows টার্মিনাল</value>
+    <value>ইন্টেলিজেন্ট টার্মিনাল</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>টার্মিনাল</value>
+    <value>ইন্টেলিজেন্ট টার্মিনাল</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>নতুন Windows টার্মিনাল</value>
+    <value>AI-নেটিভ টার্মিনাল — এজেন্টরা টার্মিনাল ওয়ার্কফ্লো বুঝতে, ঠিক করতে এবং স্বয়ংক্রিয় করতে পারে</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>আসন্ন বৈশিষ্ট্যগুলির পূর্বরূপ সহ Windows টার্মিনাল</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;টার্মিনাল-এ খুলুন</value>
+    <value>ইন্টেলিজেন্ট &amp;টার্মিনালে খুলুন</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/bn-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/bn-IN/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>টার্মিনাল &amp;প্রাকদর্শন-এ খুলুন</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ইন্টেলিজেন্ট টার্মিনালে খুলুন(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/bn-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/bn-IN/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>টার্মিনাল &amp;প্রাকদর্শন-এ খুলুন</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ইন্টেলিজেন্ট টার্মিনালে খুলুন(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/bn-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/bn-IN/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>ইন্টেলিজেন্ট &amp;টার্মিনালে খুলুন</value>
+    <value>ইন্টেলিজেন্ট টার্মিনালে খুলুন(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/bs-Latn-BA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/bs-Latn-BA/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Inteligentni Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>Inteligentni Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Inteligentni Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Novi Windows terminal</value>
+    <value>Terminal izgrađen na AI-ju — agenti mogu razumjeti, ispraviti i automatizirati tokove rada u terminalu</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows terminal sa pregledom predstojećih funkcija</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Otvori u aplikaciji T&amp;erminal</value>
+    <value>Otvori u Inteligentnom &amp;Terminalu</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/bs-Latn-BA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/bs-Latn-BA/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Otvori u verziji za &amp;pregled aplikacije Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Otvori u &amp;Inteligentnom Terminalu</value>

--- a/src/cascadia/CascadiaPackage/Resources/bs-Latn-BA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/bs-Latn-BA/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Otvori u Inteligentnom &amp;Terminalu</value>
+    <value>Otvori u &amp;Inteligentnom Terminalu</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/bs-Latn-BA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/bs-Latn-BA/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Otvori u verziji za &amp;pregled aplikacije Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Otvori u &amp;Inteligentnom Terminalu</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ca-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ca-ES/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Intel·ligent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminal del Windows</value>
+    <value>Terminal Intel·ligent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Intel·ligent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>El nou Terminal del Windows</value>
+    <value>Terminal nadiu d’IA — els agents poden entendre, corregir i automatitzar fluxos de treball del terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminal del Windows amb una visualització prèvia de les pròximes característiques</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Obrir al &amp;terminal</value>
+    <value>Obrir al &amp;terminal intel·ligent</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ca-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ca-ES/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Obrir al &amp;terminal intel·ligent</value>
+    <value>Obrir al terminal &amp;intel·ligent</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ca-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ca-ES/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Obrir a la visualització &amp;prèvia del terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Obrir al terminal &amp;intel·ligent</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ca-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ca-ES/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Obrir a la visualització &amp;prèvia del terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Obrir al terminal &amp;intel·ligent</value>

--- a/src/cascadia/CascadiaPackage/Resources/ca-Es-VALENCIA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ca-Es-VALENCIA/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Intel·ligent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminal del Windows</value>
+    <value>Terminal Intel·ligent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Intel·ligent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>El nou Terminal del Windows</value>
+    <value>Terminal natiu d’IA — els agents poden entendre, corregir i automatitzar fluxos de treball del terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminal del Windows amb una visualització prèvia de les pròximes característiques</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Obri-ho en el &amp;Terminal</value>
+    <value>Obri-ho en el &amp;Terminal Intel·ligent</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ca-Es-VALENCIA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ca-Es-VALENCIA/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Obri-ho en la &amp;visualització prèvia del Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Obri-ho en el Terminal &amp;Intel·ligent</value>

--- a/src/cascadia/CascadiaPackage/Resources/ca-Es-VALENCIA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ca-Es-VALENCIA/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Obri-ho en la &amp;visualització prèvia del Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Obri-ho en el Terminal &amp;Intel·ligent</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ca-Es-VALENCIA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ca-Es-VALENCIA/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Obri-ho en el &amp;Terminal Intel·ligent</value>
+    <value>Obri-ho en el Terminal &amp;Intel·ligent</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/cs-CZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/cs-CZ/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminál</value>
+    <value>Inteligentní Terminál</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminál Windows</value>
+    <value>Inteligentní Terminál</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminál</value>
+    <value>Inteligentní Terminál</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Nový Terminál Windows</value>
+    <value>Terminál postavený na AI — agenti dokáží rozumět pracovním postupům v terminálu, opravovat je a automatizovat</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminál Windows s náhledem připravovaných funkcí</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Otevřít v &amp;Terminálu</value>
+    <value>Otevřít v Inteligentním &amp;Terminálu</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/cs-CZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/cs-CZ/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Otevřít v Inteligentním &amp;Terminálu</value>
+    <value>Otevřít v &amp;Inteligentním Terminálu</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/cs-CZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/cs-CZ/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Otevřít &amp;náhled Terminálu</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Otevřít v &amp;Inteligentním Terminálu</value>

--- a/src/cascadia/CascadiaPackage/Resources/cs-CZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/cs-CZ/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Otevřít &amp;náhled Terminálu</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Otevřít v &amp;Inteligentním Terminálu</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/cy-GB/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/cy-GB/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terfynell</value>
+    <value>Terfynell Ddeallus</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terfynell Windows</value>
+    <value>Terfynell Ddeallus</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terfynell</value>
+    <value>Terfynell Ddeallus</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Y Derfynell Windows Newydd</value>
+    <value>Terfynell wedi’i hadeiladu o amgylch AI — gall asiantau ddeall, trwsio ac awtomeiddio llifoedd gwaith y derfynell</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terfynell Windows gyda rhagolwg o nodweddion i ddod</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Agor yn y &amp;Derfynell</value>
+    <value>Agor yn y &amp;Derfynell Ddeallus</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/cy-GB/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/cy-GB/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Agor yn y &amp;Rhagowlg Terfynell</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Agor yn y Derfynell Ddeallus(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/cy-GB/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/cy-GB/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Agor yn y &amp;Derfynell Ddeallus</value>
+    <value>Agor yn y Derfynell Ddeallus(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/cy-GB/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/cy-GB/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Agor yn y &amp;Rhagowlg Terfynell</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Agor yn y Derfynell Ddeallus(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/da-DK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/da-DK/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Den nye Windows Terminal</value>
+    <value>AI-native terminal — agenter kan forstå, løse og automatisere terminalarbejdsgange</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows Terminal med en forhåndsvisning af kommende funktioner</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Åbn i &amp;Terminal</value>
+    <value>Åbn i Intelligent &amp;Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/da-DK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/da-DK/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Åbn i Terminal &amp;Forhåndsvisning</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Åbn i &amp;Intelligent Terminal</value>

--- a/src/cascadia/CascadiaPackage/Resources/da-DK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/da-DK/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Åbn i Terminal &amp;Forhåndsvisning</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Åbn i &amp;Intelligent Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/da-DK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/da-DK/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Åbn i Intelligent &amp;Terminal</value>
+    <value>Åbn i &amp;Intelligent Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/de-DE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/de-DE/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligentes Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows-Terminal</value>
+    <value>Intelligentes Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligentes Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Das neue Windows-Terminal</value>
+    <value>KI-natives Terminal — Agenten können Terminal-Workflows verstehen, beheben und automatisieren</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows-Terminal mit einer Vorschau auf bevorstehende Features</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>In &amp;Terminal öffnen</value>
+    <value>In Intelligentem &amp;Terminal öffnen</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/de-DE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/de-DE/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>In Terminal &amp; Vorschau öffnen</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>In &amp;Intelligentem Terminal öffnen</value>

--- a/src/cascadia/CascadiaPackage/Resources/de-DE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/de-DE/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>In Intelligentem &amp;Terminal öffnen</value>
+    <value>In &amp;Intelligentem Terminal öffnen</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/de-DE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/de-DE/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>In Terminal &amp; Vorschau öffnen</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>In &amp;Intelligentem Terminal öffnen</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/el-GR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/el-GR/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Τερματικό</value>
+    <value>Έξυπνο Τερματικό</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Τερματικό Windows</value>
+    <value>Έξυπνο Τερματικό</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Τερματικό</value>
+    <value>Έξυπνο Τερματικό</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Το Νέο Τερματικό Windows</value>
+    <value>Τερματικό με AI στον πυρήνα του — οι πράκτορες μπορούν να κατανοούν, να διορθώνουν και να αυτοματοποιούν ροές εργασίας στο τερματικό</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Τερματικό Windows με μια προεπισκόπηση των επερχόμενων δυνατοτήτων</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Άνοιγμα στο &amp;Τερματικό</value>
+    <value>Άνοιγμα στο Έξυπνο &amp;Τερματικό</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/el-GR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/el-GR/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Άνοιγμα σε τερματικό &amp;Προεπισκόπηση</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Άνοιγμα στο Έξυπνο Τερματικό(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/el-GR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/el-GR/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Άνοιγμα σε τερματικό &amp;Προεπισκόπηση</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Άνοιγμα στο Έξυπνο Τερματικό(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/el-GR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/el-GR/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Άνοιγμα στο Έξυπνο &amp;Τερματικό</value>
+    <value>Άνοιγμα στο Έξυπνο Τερματικό(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/en-GB/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-GB/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>The New Windows Terminal</value>
+    <value>AI-native terminal — agents can understand, fix and automate terminal workflows</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows Terminal with a preview of forthcoming features</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Open in &amp;Terminal</value>
+    <value>Open in Intelligent &amp;Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/en-GB/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-GB/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Open in Terminal &amp;Preview</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Open in &amp;Intelligent Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/en-GB/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-GB/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Open in Terminal &amp;Preview</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Open in &amp;Intelligent Terminal</value>

--- a/src/cascadia/CascadiaPackage/Resources/en-GB/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-GB/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Open in Intelligent &amp;Terminal</value>
+    <value>Open in &amp;Intelligent Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
@@ -189,7 +189,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Open in Terminal &amp;Preview</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Open in &amp;Intelligent Terminal</value>

--- a/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
@@ -189,7 +189,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Open in Terminal &amp;Preview</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Open in &amp;Intelligent Terminal</value>

--- a/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
@@ -192,7 +192,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Open in Intelligent &amp;Terminal</value>
+    <value>Open in &amp;Intelligent Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>

--- a/src/cascadia/CascadiaPackage/Resources/es-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/es-ES/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Inteligente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminal Windows</value>
+    <value>Terminal Inteligente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Inteligente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>La nueva Terminal Windows</value>
+    <value>Terminal nativo de IA — los agentes pueden comprender, corregir y automatizar flujos de trabajo del terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminal Windows con una vista previa de las características futuras</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Abrir en &amp;Terminal</value>
+    <value>Abrir en &amp;Terminal Inteligente</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/es-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/es-ES/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Abrir en &amp;Terminal Inteligente</value>
+    <value>Abrir en Terminal &amp;Inteligente</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/es-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/es-ES/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Abrir en la versión preliminar de &amp;Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Abrir en Terminal &amp;Inteligente</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/es-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/es-ES/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Abrir en la versión preliminar de &amp;Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Abrir en Terminal &amp;Inteligente</value>

--- a/src/cascadia/CascadiaPackage/Resources/es-MX/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/es-MX/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Inteligente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminal Windows</value>
+    <value>Terminal Inteligente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Inteligente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>La nueva Terminal Windows</value>
+    <value>Terminal nativa de IA — los agentes pueden entender, corregir y automatizar flujos de trabajo en la terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminal Windows con una vista previa de las características futuras</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Abrir en &amp;Terminal</value>
+    <value>Abrir en &amp;Terminal Inteligente</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/es-MX/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/es-MX/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Abrir en &amp;Terminal Inteligente</value>
+    <value>Abrir en Terminal &amp;Inteligente</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/es-MX/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/es-MX/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Abrir en la versión preliminar de &amp;Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Abrir en Terminal &amp;Inteligente</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/es-MX/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/es-MX/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Abrir en la versión preliminar de &amp;Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Abrir en Terminal &amp;Inteligente</value>

--- a/src/cascadia/CascadiaPackage/Resources/et-EE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/et-EE/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Nutikas Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windowsi terminal</value>
+    <value>Nutikas Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Nutikas Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Uus Windowsi terminal</value>
+    <value>Tehisarul põhinev terminal — agendid suudavad mõista, parandada ja automatiseerida terminali töövooge</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windowsi terminal tulevaste funktsioonide eeltutvustusega</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Ava &amp;terminalis</value>
+    <value>Ava Nutikas &amp;Terminalis</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/et-EE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/et-EE/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Ava Nutikas &amp;Terminalis</value>
+    <value>Ava Nutikas Terminalis(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/et-EE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/et-EE/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Ava terminali &amp;eelvaates</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Ava Nutikas Terminalis(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/et-EE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/et-EE/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Ava terminali &amp;eelvaates</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Ava Nutikas Terminalis(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/eu-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/eu-ES/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminala</value>
+    <value>Terminal Adimenduna</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows terminala</value>
+    <value>Terminal Adimenduna</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminala</value>
+    <value>Terminal Adimenduna</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Windows terminal berria</value>
+    <value>AA natiboko terminala — agenteek terminaleko lan-fluxuak ulertu, konpondu eta automatiza ditzakete</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows terminala laster eskuragarri egongo diren eginbideen aurrebistarekin</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Ireki &amp;terminalean</value>
+    <value>Ireki &amp;terminal adimendunean</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/eu-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/eu-ES/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Ireki &amp;terminal adimendunean</value>
+    <value>Ireki terminal adimendunean(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/eu-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/eu-ES/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Ireki terminalaren &amp;ikuspegian</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Ireki terminal adimendunean(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/eu-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/eu-ES/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Ireki terminalaren &amp;ikuspegian</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Ireki terminal adimendunean(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/fa-IR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fa-IR/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>پایانه</value>
+    <value>پایانه هوشمند</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>پایانه Windows</value>
+    <value>پایانه هوشمند</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>پایانه</value>
+    <value>پایانه هوشمند</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>پایانه Windows جدید</value>
+    <value>ترمینال مبتنی بر هوش مصنوعی از پایه — عامل‌ها می‌توانند گردش‌کارهای ترمینال را درک، رفع اشکال و خودکار کنند</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>پایانه Windows با پیش‌نمایش ویژگی‌های آتی</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>باز کردن در &amp;پایانه</value>
+    <value>باز کردن در &amp;پایانه هوشمند</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/fa-IR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fa-IR/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>باز کردن در پایانه &amp;پیش‌نمایش</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>باز کردن در پایانه هوشمند(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/fa-IR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fa-IR/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>باز کردن در &amp;پایانه هوشمند</value>
+    <value>باز کردن در پایانه هوشمند(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/fa-IR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fa-IR/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>باز کردن در پایانه &amp;پیش‌نمایش</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>باز کردن در پایانه هوشمند(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/fi-FI/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fi-FI/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Pääte</value>
+    <value>Älykäs Pääte</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows-pääte</value>
+    <value>Älykäs Pääte</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Pääte</value>
+    <value>Älykäs Pääte</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Uusi Windows-pääte</value>
+    <value>Tekoälypohjainen pääte — agentit voivat ymmärtää, korjata ja automatisoida päätetyönkulkuja</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows-pääte ja tulevien ominaisuuksien esikatselu</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Avaa &amp;Päätteessä</value>
+    <value>Avaa Älykkäässä &amp;Päätteessä</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/fi-FI/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fi-FI/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Avaa Päätteen &amp;esikatselussa</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Avaa Älykkäässä Päätteessä(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/fi-FI/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fi-FI/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Avaa Älykkäässä &amp;Päätteessä</value>
+    <value>Avaa Älykkäässä Päätteessä(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/fi-FI/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fi-FI/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Avaa Päätteen &amp;esikatselussa</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Avaa Älykkäässä Päätteessä(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/fil-PH/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fil-PH/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Matalinong Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>Matalinong Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Matalinong Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Ang Bagong Windows Terminal</value>
+    <value>AI-native na terminal — kayang unawain, ayusin, at i-automate ng mga AI agent ang mga workflow sa terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows Terminal na may preview ng mga paparating na tampok</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Buksan sa &amp;Terminal</value>
+    <value>Buksan sa Matalinong &amp;Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/fil-PH/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fil-PH/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Buksan sa Terminal &amp;Preview</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Buksan sa Matalinong Terminal(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/fil-PH/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fil-PH/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Buksan sa Matalinong &amp;Terminal</value>
+    <value>Buksan sa Matalinong Terminal(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/fil-PH/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fil-PH/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Buksan sa Terminal &amp;Preview</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Buksan sa Matalinong Terminal(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/fr-CA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fr-CA/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Intelligent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminal Windows</value>
+    <value>Terminal Intelligent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Intelligent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Nouveau Terminal Windows</value>
+    <value>Terminal conçu nativement pour l’IA — les agents peuvent comprendre, corriger et automatiser les flux de travail du terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminal Windows avec un aperçu des fonctionnalités à venir</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Ouvrir dans le &amp;Terminal</value>
+    <value>Ouvrir dans le &amp;Terminal Intelligent</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/fr-CA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fr-CA/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Ouvrir dans le &amp;Terminal Intelligent</value>
+    <value>Ouvrir dans le Terminal &amp;Intelligent</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/fr-CA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fr-CA/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Ouvrir dans la &amp;préversion du Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Ouvrir dans le Terminal &amp;Intelligent</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/fr-CA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fr-CA/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Ouvrir dans la &amp;préversion du Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Ouvrir dans le Terminal &amp;Intelligent</value>

--- a/src/cascadia/CascadiaPackage/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fr-FR/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Intelligent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminal Windows</value>
+    <value>Terminal Intelligent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Intelligent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Nouveau terminal Windows</value>
+    <value>Terminal conçu nativement pour l’IA — les agents peuvent comprendre, corriger et automatiser les flux de travail du terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminal Windows avec un aperçu des fonctionnalités à venir</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Ouvrir dans le &amp;Terminal</value>
+    <value>Ouvrir dans le &amp;Terminal Intelligent</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fr-FR/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Ouvrir dans le &amp;Terminal Intelligent</value>
+    <value>Ouvrir dans le Terminal &amp;Intelligent</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fr-FR/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Ouvrir dans la &amp;préversion du Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Ouvrir dans le Terminal &amp;Intelligent</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/fr-FR/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Ouvrir dans la &amp;préversion du Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Ouvrir dans le Terminal &amp;Intelligent</value>

--- a/src/cascadia/CascadiaPackage/Resources/ga-IE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ga-IE/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Teirminéal</value>
+    <value>Teirminéal Cliste</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Teirminéal Windows</value>
+    <value>Teirminéal Cliste</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Teirminéal</value>
+    <value>Teirminéal Cliste</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>An Teirminéal Windows Nua</value>
+    <value>Teirminéal dúchasach AI — is féidir le gníomhairí sreafaí oibre teirminéil a thuiscint, a cheartú agus a uathobriú</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Teirminéal Windows ina bhfuil réamhamharc ar ghnéithe atá ag teacht aníos</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Oscail i &amp;dTeirminéal</value>
+    <value>Oscail i &amp;dTeirminéal Cliste</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ga-IE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ga-IE/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Oscail i dTeirminéal &amp;Réamhamharc</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Oscail i dTeirminéal Cliste(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ga-IE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ga-IE/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Oscail i &amp;dTeirminéal Cliste</value>
+    <value>Oscail i dTeirminéal Cliste(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ga-IE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ga-IE/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Oscail i dTeirminéal &amp;Réamhamharc</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Oscail i dTeirminéal Cliste(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/gd-gb/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/gd-gb/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Tèirmineal</value>
+    <value>Tèirmineal Glic</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Tèirmineal Windows</value>
+    <value>Tèirmineal Glic</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Tèirmineal</value>
+    <value>Tèirmineal Glic</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>An tèirmineal Windows ùr</value>
+    <value>Teirmineal le AI aig a chridhe — faodaidh àidseantan sruthan-obrach an teirmineil a thuigsinn, a chàradh agus an dèanamh fèin-obrachail</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Tèirmineal Windows le ro-shealladh de ghleusan ri thighinn</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Fosgail san &amp;tèirmineal</value>
+    <value>Fosgail san &amp;tèirmineal glic</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/gd-gb/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/gd-gb/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>&amp;Fosgail ann an ro-shealladh an tèirmineil</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Fosgail san tèirmineal glic(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/gd-gb/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/gd-gb/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>&amp;Fosgail ann an ro-shealladh an tèirmineil</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Fosgail san tèirmineal glic(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/gd-gb/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/gd-gb/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Fosgail san &amp;tèirmineal glic</value>
+    <value>Fosgail san tèirmineal glic(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/gl-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/gl-ES/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Intelixente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminal Windows</value>
+    <value>Terminal Intelixente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Intelixente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>A nova Terminal Windows</value>
+    <value>Terminal nativo de IA — os axentes poden comprender, corrixir e automatizar fluxos de traballo do terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminal Windows cunha previsualización de futuras funcionalidades</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Abrir na &amp;Terminal</value>
+    <value>Abrir na &amp;Terminal Intelixente</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/gl-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/gl-ES/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Abrir na &amp;Previsualización da terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Abrir na Terminal &amp;Intelixente</value>

--- a/src/cascadia/CascadiaPackage/Resources/gl-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/gl-ES/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Abrir na &amp;Previsualización da terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Abrir na Terminal &amp;Intelixente</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/gl-ES/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/gl-ES/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Abrir na &amp;Terminal Intelixente</value>
+    <value>Abrir na Terminal &amp;Intelixente</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/gu-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/gu-IN/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>ટર્મિનલ</value>
+    <value>ઇન્ટેલિજન્ટ ટર્મિનલ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows ટર્મિનલ</value>
+    <value>ઇન્ટેલિજન્ટ ટર્મિનલ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>ટર્મિનલ</value>
+    <value>ઇન્ટેલિજન્ટ ટર્મિનલ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>નવું Windows ટર્મિનલ</value>
+    <value>AI-નેટિવ ટર્મિનલ — એજન્ટો ટર્મિનલ વર્કફ્લોને સમજી શકે છે, ઠીક કરી શકે છે અને સ્વચાલિત બનાવી શકે છે</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>આગામી સુવિધાઓના એક પૂર્વાવલોકન સાથે Windows ટર્મિનલ</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;ટર્મિનલમાં ખોલો</value>
+    <value>ઇન્ટેલિજન્ટ &amp;ટર્મિનલમાં ખોલો</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/gu-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/gu-IN/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>ઇન્ટેલિજન્ટ &amp;ટર્મિનલમાં ખોલો</value>
+    <value>ઇન્ટેલિજન્ટ ટર્મિનલમાં ખોલો(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/gu-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/gu-IN/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>&amp;ટર્મિનલ પૂર્વાવલોકનમાં ખોલો</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ઇન્ટેલિજન્ટ ટર્મિનલમાં ખોલો(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/gu-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/gu-IN/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>&amp;ટર્મિનલ પૂર્વાવલોકનમાં ખોલો</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ઇન્ટેલિજન્ટ ટર્મિનલમાં ખોલો(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/he-IL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/he-IL/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>מסוף</value>
+    <value>מסוף חכם</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>מסוף Windows</value>
+    <value>מסוף חכם</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>מסוף</value>
+    <value>מסוף חכם</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>מסוף Windows החדש</value>
+    <value>מסוף מבוסס בינה מלאכותית במהותו — סוכנים יכולים להבין, לתקן ולאוטמט תהליכי עבודה בטרמינל</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>מסוף Windows עם תצוגה מקדימה של תכונות קרובות</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>פתח &amp;במסוף</value>
+    <value>פתח ב&amp;מסוף חכם</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/he-IL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/he-IL/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>פתח &amp;בתצוגה מקדימה של מסוף</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>פתח במסוף חכם(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/he-IL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/he-IL/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>פתח &amp;בתצוגה מקדימה של מסוף</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>פתח במסוף חכם(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/he-IL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/he-IL/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>פתח ב&amp;מסוף חכם</value>
+    <value>פתח במסוף חכם(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/hi-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hi-IN/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Windows टर्मिनल</value>
+    <value>इंटेलिजेंट टर्मिनल</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows टर्मिनल</value>
+    <value>इंटेलिजेंट टर्मिनल</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Windows टर्मिनल</value>
+    <value>इंटेलिजेंट टर्मिनल</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>नया Windows टर्मिनल</value>
+    <value>AI-नेटिव टर्मिनल — एजेंट टर्मिनल वर्कષ्लो को समझ सकते हैं, ठीक कर सकते हैं और स्वचालित कर सकते हैं</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>आगामी सुविधाओं के पूर्वावलोकन के साथ Windows टर्मिनल</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;टर्मिनल में खोलें</value>
+    <value>इंटेलिजेंट &amp;टर्मिनल में खोलें</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/hi-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hi-IN/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>&amp;टर्मिनल प्रीव्यू में खोलें</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>इंटेलिजेंट टर्मिनल में खोलें(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/hi-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hi-IN/Resources.resw
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>AI-नेटिव टर्मिनल — एजेंट टर्मिनल वर्कષ्लो को समझ सकते हैं, ठीक कर सकते हैं और स्वचालित कर सकते हैं</value>
+    <value>AI-नेटिव टर्मिनल — एजेंट टर्मिनल वर्कफ़्लो को समझ सकते हैं, ठीक कर सकते हैं और स्वचालित कर सकते हैं</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>आगामी सुविधाओं के पूर्वावलोकन के साथ Windows टर्मिनल</value>

--- a/src/cascadia/CascadiaPackage/Resources/hi-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hi-IN/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>इंटेलिजेंट &amp;टर्मिनल में खोलें</value>
+    <value>इंटेलिजेंट टर्मिनल में खोलें(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/hi-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hi-IN/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>&amp;टर्मिनल प्रीव्यू में खोलें</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>इंटेलिजेंट टर्मिनल में खोलें(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/hr-HR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hr-HR/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Inteligentni Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminal sustava Windows</value>
+    <value>Inteligentni Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Inteligentni Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Novi Terminal za sustav Windows</value>
+    <value>Terminal izgrađen na AI-ju — agenti mogu razumjeti, ispraviti i automatizirati tijekove rada u terminalu</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminal za sustav Windows s pretpregledom nadolazećih značajki</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Otvori u &amp;terminalu</value>
+    <value>Otvori u Inteligentnom &amp;Terminalu</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/hr-HR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hr-HR/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Otvori u terminalu &amp;Pretpregled</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Otvori u &amp;Inteligentnom Terminalu</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/hr-HR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hr-HR/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Otvori u terminalu &amp;Pretpregled</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Otvori u &amp;Inteligentnom Terminalu</value>

--- a/src/cascadia/CascadiaPackage/Resources/hr-HR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hr-HR/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Otvori u Inteligentnom &amp;Terminalu</value>
+    <value>Otvori u &amp;Inteligentnom Terminalu</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/hu-HU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hu-HU/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminál</value>
+    <value>Intelligens Terminál</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows terminál</value>
+    <value>Intelligens Terminál</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminál</value>
+    <value>Intelligens Terminál</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Az új Windows terminál</value>
+    <value>AI-alapokra épített terminál — az ágensek képesek megérteni, kijavítani és automatizálni a terminálos munkafolyamatokat</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows terminál a hamarosan megjelenő funkciók előzetes verziójával</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Megnyitás a &amp;terminálban</value>
+    <value>Megnyitás az Intelligens &amp;Terminálban</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/hu-HU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hu-HU/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Megnyitás terminálban - &amp;előzetes verzió</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Megnyitás az &amp;Intelligens Terminálban</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/hu-HU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hu-HU/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Megnyitás az Intelligens &amp;Terminálban</value>
+    <value>Megnyitás az &amp;Intelligens Terminálban</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/hu-HU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hu-HU/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Megnyitás terminálban - &amp;előzetes verzió</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Megnyitás az &amp;Intelligens Terminálban</value>

--- a/src/cascadia/CascadiaPackage/Resources/hy-AM/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hy-AM/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Հեռասարք</value>
+    <value>Խելացի տերմինալ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Հեռասարք</value>
+    <value>Խելացի տերմինալ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Հեռասարք</value>
+    <value>Խելացի տերմինալ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Նոր Windows Հեռասարք</value>
+    <value>Արհեստական բանականության հիմքով տերմինալ — գործակալները կարող են հասկանալ, շտկել և ավտոմատացնել տերմինալի աշխատանքային հոսքերը</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows Հեռասարք՝ առաջիկա առանձնահատկությունների նախատեսքով</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Բացել &amp;Հեռասարքում</value>
+    <value>Բացել &amp;խելացի տերմինալում</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/hy-AM/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hy-AM/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Բացել &amp;խելացի տերմինալում</value>
+    <value>Բացել խելացի տերմինալում(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/hy-AM/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hy-AM/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Բացել Windows Հեռասարքի &amp;Նախատեսքում</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Բացել խելացի տերմինալում(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/hy-AM/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/hy-AM/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Բացել Windows Հեռասարքի &amp;Նախատեսքում</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Բացել խելացի տերմինալում(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/id-ID/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/id-ID/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Cerdas</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminal Windows</value>
+    <value>Terminal Cerdas</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Cerdas</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Terminal Windows Baru</value>
+    <value>Terminal yang dibangun dengan AI sebagai inti — agen AI dapat memahami, memperbaiki, dan mengotomatiskan alur kerja terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminal Windows dengan pratinjau fitur mendatang</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Buka di &amp;Terminal</value>
+    <value>Buka di &amp;Terminal Cerdas</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/id-ID/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/id-ID/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Buka di Terminal &amp;Pratinjau</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Buka di Terminal Cerdas(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/id-ID/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/id-ID/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Buka di &amp;Terminal Cerdas</value>
+    <value>Buka di Terminal Cerdas(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/id-ID/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/id-ID/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Buka di Terminal &amp;Pratinjau</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Buka di Terminal Cerdas(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/is-IS/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/is-IS/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Útstöð</value>
+    <value>Snjallútstöð</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows-útstöð</value>
+    <value>Snjallútstöð</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Útstöð</value>
+    <value>Snjallútstöð</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Nýja Windows-útstöðin</value>
+    <value>Gervigreindardrifinn terminal — agentar geta skilið, lagað og sjálfvirknivaett verkflæði í terminalnum</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows-útstöð með sýnishorn af væntanlegum eiginleikum</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Opna í &amp;endastöð</value>
+    <value>Opna í &amp;Snjallútstöð</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/is-IS/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/is-IS/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Opna í &amp;Snjallútstöð</value>
+    <value>Opna í Snjallútstöð(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/is-IS/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/is-IS/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Opna í forskoðun &amp;endastöðvar</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Opna í Snjallútstöð(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/is-IS/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/is-IS/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Opna í forskoðun &amp;endastöðvar</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Opna í Snjallútstöð(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/it-IT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/it-IT/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminale</value>
+    <value>Terminale Intelligente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminale Windows</value>
+    <value>Terminale Intelligente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminale</value>
+    <value>Terminale Intelligente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Il nuovo Terminale Windows</value>
+    <value>Terminale nativo per l’IA — gli agenti possono comprendere, correggere e automatizzare i flussi di lavoro del terminale</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminale Windows con un'anteprima delle funzionalità in arrivo</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Apri nel &amp;Terminale</value>
+    <value>Apri nel &amp;Terminale Intelligente</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/it-IT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/it-IT/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Apri nel &amp;Terminale Intelligente</value>
+    <value>Apri nel Terminale &amp;Intelligente</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/it-IT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/it-IT/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Apri nell’Anteprima &amp;terminale</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Apri nel Terminale &amp;Intelligente</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/it-IT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/it-IT/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Apri nell’Anteprima &amp;terminale</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Apri nel Terminale &amp;Intelligente</value>

--- a/src/cascadia/CascadiaPackage/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ja-JP/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>ターミナル</value>
+    <value>インテリジェント ターミナル</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows ターミナル</value>
+    <value>インテリジェント ターミナル</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>ターミナル</value>
+    <value>インテリジェント ターミナル</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>新しい Windows ターミナル</value>
+    <value>AIネイティブなターミナル — エージェントがターミナルのワークフローを理解し、修正し、自動化</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows ターミナルと予定されている機能のプレビュー</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>ターミナルで開く(&amp;T)</value>
+    <value>インテリジェント ターミナルで開く(&amp;T)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ja-JP/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>ターミナル プレビューで開く(&amp;P)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>インテリジェント ターミナルで開く(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ja-JP/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>ターミナル プレビューで開く(&amp;P)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>インテリジェント ターミナルで開く(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ja-JP/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>インテリジェント ターミナルで開く(&amp;T)</value>
+    <value>インテリジェント ターミナルで開く(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ka-GE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ka-GE/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>ტერმინალი</value>
+    <value>ჭკვიანი ტერმინალი</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows-ის ტერმინალი</value>
+    <value>ჭკვიანი ტერმინალი</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>ტერმინალი</value>
+    <value>ჭკვიანი ტერმინალი</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Windows-ის ახალი ტერმინალი</value>
+    <value>AI-ის ბირთვზე აგებული ტერმინალი — აგენტებს შეუძლიათ ტერმინალის სამუშაო ნაკადების გაგება, გამოსწორება და ავტომატიზაცია</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows-ის ტერმინალი მომავალი ფუნქციების გადახედვით</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;ტერმინალში გახსნა</value>
+    <value>ჭკვიან &amp;ტერმინალში გახსნა</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ka-GE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ka-GE/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>ტერმინალის &amp;გადახედვაში გახსნა</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ჭკვიან ტერმინალში გახსნა(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ka-GE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ka-GE/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>ტერმინალის &amp;გადახედვაში გახსნა</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ჭკვიან ტერმინალში გახსნა(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/ka-GE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ka-GE/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>ჭკვიან &amp;ტერმინალში გახსნა</value>
+    <value>ჭკვიან ტერმინალში გახსნა(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/kk-KZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/kk-KZ/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Терминал</value>
+    <value>Зияткер терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows терминалы</value>
+    <value>Зияткер терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Терминал</value>
+    <value>Зияткер терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Жаңа Windows терминалы</value>
+    <value>ЖИ өзегіне құрылған терминал — агенттер терминалдағы жұмыс ағындарын түсініп, түзетіп және автоматтандыра алады</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Алдағы мүмкіндіктерді алдын ала қарап алу мүмкіндігі бар Windows терминалы</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;Терминалда ашу</value>
+    <value>&amp;Зияткер терминалда ашу</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/kk-KZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/kk-KZ/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Терминалда және алдын ала қарау нұсқасында ашу</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Зияткер терминалда ашу(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/kk-KZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/kk-KZ/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;Зияткер терминалда ашу</value>
+    <value>Зияткер терминалда ашу(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/kk-KZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/kk-KZ/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Терминалда және алдын ала қарау нұсқасында ашу</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Зияткер терминалда ашу(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/km-KH/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/km-KH/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>ស្ថានីយ</value>
+    <value>ស្ថានីយឆ្លាតវៃ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>ស្ថានីយ Windows</value>
+    <value>ស្ថានីយឆ្លាតវៃ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>ស្ថានីយ</value>
+    <value>ស្ថានីយឆ្លាតវៃ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>ស្ថានីយ Windows ថ្មី</value>
+    <value>តីរ្មីណាល់ដែលបង្កើតឡើងដោយមាន AI ជាស្នូល — ភ្នាក់ងារ AI អាចយល់ ជួសជុល និងធ្វើស្វ័យប្រវត្តិកម្មលំហូរការងារនៅក្នុងតីរ្មីណាល់</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>ស្ថានីយ Windows ដែលមានការសាកល្បងមុខងារដែលនឹងមានក្នុងពេលឆាប់ៗ</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>បើកក្នុង&amp;ធើមីណល</value>
+    <value>បើកក្នុ &amp;ស្ថានីយឆ្លាតវៃ</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/km-KH/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/km-KH/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>បើកក្នុងធើមីណល &amp;សាក​ល្បង</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>បើកក្នុ ស្ថានីយឆ្លាតវៃ(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/km-KH/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/km-KH/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>បើកក្នុ &amp;ស្ថានីយឆ្លាតវៃ</value>
+    <value>បើកក្នុ ស្ថានីយឆ្លាតវៃ(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/km-KH/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/km-KH/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>បើកក្នុងធើមីណល &amp;សាក​ល្បង</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>បើកក្នុ ស្ថានីយឆ្លាតវៃ(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/kn-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/kn-IN/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>ಟರ್ಮಿನಲ್</value>
+    <value>ಇಂಟೆಲಿಜೆಂಟ್ ಟರ್ಮಿನಲ್</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows ಟರ್ಮಿನಲ್</value>
+    <value>ಇಂಟೆಲಿಜೆಂಟ್ ಟರ್ಮಿನಲ್</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>ಟರ್ಮಿನಲ್</value>
+    <value>ಇಂಟೆಲಿಜೆಂಟ್ ಟರ್ಮಿನಲ್</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>ಹೊಸ Windows ಟರ್ಮಿನಲ್</value>
+    <value>AI-ನೇಟಿವ್ ಟರ್ಮಿನಲ್ — ಏಜೆಂಟ್‌ಗಳು ಟರ್ಮಿನಲ್ ವರ್ಕ್‌ಫ್ಲೋಗಳನ್ನು ಅರ್ಥಮಾಡುಕುನಿ, ಸರಿಪಡಿಸಿ, ಸ್ವಯಂಚಾಲಿತಗೊಳಿಸಬಹುದು</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>ಮುಂಬರುವ ವೈಶಿಷ್ಟ್ಯಗಳ ಮುನ್ನೋಟದೊಂದಿಗೆ Windows ಟರ್ಮಿನಲ್</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;ಟರ್ಮಿನಲ್ ನಲ್ಲಿ ತೆರೆಯಿರಿ</value>
+    <value>ಇಂಟೆಲಿಜೆಂಟ್ &amp;ಟರ್ಮಿನಲ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/kn-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/kn-IN/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>ಟರ್ಮಿನಲ್ ನಲ್ಲಿ ತೆರೆಯಿರಿ &amp;ಪೂರ್ವವೀಕ್ಷಣೆ ಮಾಡಿ</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ಇಂಟೆಲಿಜೆಂಟ್ ಟರ್ಮಿನಲ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/kn-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/kn-IN/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>ಇಂಟೆಲಿಜೆಂಟ್ &amp;ಟರ್ಮಿನಲ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ</value>
+    <value>ಇಂಟೆಲಿಜೆಂಟ್ ಟರ್ಮಿನಲ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/kn-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/kn-IN/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>ಟರ್ಮಿನಲ್ ನಲ್ಲಿ ತೆರೆಯಿರಿ &amp;ಪೂರ್ವವೀಕ್ಷಣೆ ಮಾಡಿ</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ಇಂಟೆಲಿಜೆಂಟ್ ಟರ್ಮಿನಲ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ko-KR/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>터미널</value>
+    <value>지능형 터미널</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows 터미널</value>
+    <value>지능형 터미널</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>터미널</value>
+    <value>지능형 터미널</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>새 Windows 터미널</value>
+    <value>AI 네이티브 터미널 — 에이전트가 터미널 워크플로를 이해하고, 수정하고, 자동화합니다</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>예정된 기능에 대한 미리 보기가 포함된 Windows 터미널</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>터미널에서 열기(&amp;T)</value>
+    <value>지능형 터미널에서 열기(&amp;T)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ko-KR/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>지능형 터미널에서 열기(&amp;T)</value>
+    <value>지능형 터미널에서 열기(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ko-KR/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>터미널 미리 보기에서 열기(&amp;P)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>지능형 터미널에서 열기(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ko-KR/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>터미널 미리 보기에서 열기(&amp;P)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>지능형 터미널에서 열기(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/kok-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/kok-IN/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>टर्मिनल</value>
+    <value>इंटेलिजंट टर्मिनल</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows टर्मिनल</value>
+    <value>इंटेलिजंट टर्मिनल</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>टर्मिनल</value>
+    <value>इंटेलिजंट टर्मिनल</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>नवो Windows टर्मिनल</value>
+    <value>AI-नेटिव टर्मिनल — एजंट टर्मिनल वर्कफ्लो समजूंक, दुरुस्त करूंक आनी स्वयंचलित करूंक शकतात</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>येवपी खाशेलपणांच्या पूर्वदेखाव्यासयत Windows टर्मिनल </value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>टर्मिनलांत उगडचें</value>
+    <value>इंटेलिजंट &amp;टर्मिनलांत उघडचें</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/kok-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/kok-IN/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>टर्मिनल पूर्वदेखावांंत उगडचें</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>इंटेलिजंट टर्मिनलांत उघडचें(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/kok-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/kok-IN/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>इंटेलिजंट &amp;टर्मिनलांत उघडचें</value>
+    <value>इंटेलिजंट टर्मिनलांत उघडचें(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/kok-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/kok-IN/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>टर्मिनल पूर्वदेखावांंत उगडचें</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>इंटेलिजंट टर्मिनलांत उघडचें(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/lb-LU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lb-LU/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligenten Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows-Terminal</value>
+    <value>Intelligenten Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligenten Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Den neie Windows-Terminal</value>
+    <value>AI-nativen Terminal — Agenten kënnen Terminal-Workflows verstoen, behiewen an automatiséieren</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows-Terminal mat enger Virusiicht vu kommende Funktiounen</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Am &amp;Terminal opmaachen</value>
+    <value>Am Intelligenten &amp;Terminal opmaachen</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/lb-LU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lb-LU/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Am Intelligenten &amp;Terminal opmaachen</value>
+    <value>Am &amp;Intelligenten Terminal opmaachen</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/lb-LU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lb-LU/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>An der Terminal-&amp;Virusiicht opmaachen</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Am &amp;Intelligenten Terminal opmaachen</value>

--- a/src/cascadia/CascadiaPackage/Resources/lb-LU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lb-LU/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>An der Terminal-&amp;Virusiicht opmaachen</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Am &amp;Intelligenten Terminal opmaachen</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/lo-LA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lo-LA/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>ເທີມິນາລ</value>
+    <value>ເທອຮ໌ມິນັລອັດຊະລິຍະ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>ເທອຮ໌ມິນັລອັດຊະລິຍະ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>ເທີມິນາລ</value>
+    <value>ເທອຮ໌ມິນັລອັດຊະລິຍະ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Windows Terminal ໃໝ່</value>
+    <value>ເທີມິນອນທີ່ສ້າງຂຶ້ນໂດຍໃຫ້ AI ເປັນແກນກາງ — ເອເຈນ AI ສາມາດເຂົ້າໃຈ ແກ້ໄຂ ແລະເຮັດໃຫ້ຂັ້ນຕອນການເຮັດວຽກໃນເທີມິນອນເປັນອັດຕະໂນມັດ</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows Terminal ກັບຕົວຢ່າງຂອງຄຸນສົມບັດທີ່ຈະມາເຖິງ</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>ເປີດໃນ &amp;ເທີມີນໍ</value>
+    <value>ເປີດໃນ &amp;ເທອຮ໌ມິນັລອັດຊະລິຍະ</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/lo-LA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lo-LA/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>ເປີດໃນ &amp;ເທອຮ໌ມິນັລອັດຊະລິຍະ</value>
+    <value>ເປີດໃນ ເທອຮ໌ມິນັລອັດຊະລິຍະ(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/lo-LA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lo-LA/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>ເປີດໃນ ເທີມີນໍ ແລະ ເບິ່ງຕົວຢ່າງ</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ເປີດໃນ ເທອຮ໌ມິນັລອັດຊະລິຍະ(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/lo-LA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lo-LA/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>ເປີດໃນ ເທີມີນໍ ແລະ ເບິ່ງຕົວຢ່າງ</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ເປີດໃນ ເທອຮ໌ມິນັລອັດຊະລິຍະ(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/lt-LT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lt-LT/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminalas</value>
+    <value>Išmanusis Terminalas</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>„Windows“ terminalas</value>
+    <value>Išmanusis Terminalas</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminalas</value>
+    <value>Išmanusis Terminalas</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Naujasis „Windows“ terminalas</value>
+    <value>AI pagrindu sukurtas terminalas — agentai gali suprasti, taisyti ir automatizuoti terminalo darbo eigas</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>„Windows“ terminalas su būsimų funkcijų peržiūra</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Atidaryti naudojant &amp;terminalą</value>
+    <value>Atidaryti naudojant Išmanųjį &amp;Terminalą</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/lt-LT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lt-LT/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Atidaryti naudojant terminalo &amp;peržiūrą</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Atidaryti naudojant &amp;Išmanųjį Terminalą</value>

--- a/src/cascadia/CascadiaPackage/Resources/lt-LT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lt-LT/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Atidaryti naudojant Išmanųjį &amp;Terminalą</value>
+    <value>Atidaryti naudojant &amp;Išmanųjį Terminalą</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/lt-LT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lt-LT/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Atidaryti naudojant terminalo &amp;peržiūrą</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Atidaryti naudojant &amp;Išmanųjį Terminalą</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/lv-LV/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lv-LV/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminālis</value>
+    <value>Viedais Terminālis</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows terminālis</value>
+    <value>Viedais Terminālis</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminālis</value>
+    <value>Viedais Terminālis</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Jaunais Windows terminālis</value>
+    <value>Ar AI izstrādāts terminālis — aģenti var izprast, labot un automatizēt termināļa darbplūsmas</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows terminālis ar gaidāmo līdzekļu priekšskatījumu</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Atvērt &amp;terminālī</value>
+    <value>Atvērt Viedajā &amp;Terminālī</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/lv-LV/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lv-LV/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Atvērt termināļa &amp;priekšskatījumā</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Atvērt Viedajā Terminālī(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/lv-LV/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lv-LV/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Atvērt Viedajā &amp;Terminālī</value>
+    <value>Atvērt Viedajā Terminālī(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/lv-LV/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/lv-LV/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Atvērt termināļa &amp;priekšskatījumā</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Atvērt Viedajā Terminālī(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/mi-NZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mi-NZ/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Iho</value>
+    <value>Iho Atamai</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Iho Windows</value>
+    <value>Iho Atamai</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Iho</value>
+    <value>Iho Atamai</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Te Iho Windows Hōu</value>
+    <value>He kāpeka hangaia me te AI hei pūtake — ka taea e ngā āpiha AI te mārama, te whakatika, me te whakaaunoa i ngā rerengamahi kāpeka</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Iho Windows me tētahi arokite o ngā āhuahira e haramai ana</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Whakatuwhera rō &amp;Iho Windows</value>
+    <value>Whakatuwhera ki te &amp;Iho Atamai</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/mi-NZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mi-NZ/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Whakatuwhera rō Iho Windows &amp;Arokite</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Whakatuwhera ki te Iho Atamai(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/mi-NZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mi-NZ/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Whakatuwhera rō Iho Windows &amp;Arokite</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Whakatuwhera ki te Iho Atamai(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/mi-NZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mi-NZ/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Whakatuwhera ki te &amp;Iho Atamai</value>
+    <value>Whakatuwhera ki te Iho Atamai(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/mk-MK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mk-MK/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Терминал</value>
+    <value>Интелигентен Терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Терминал на Windows</value>
+    <value>Интелигентен Терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Терминал</value>
+    <value>Интелигентен Терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Новиот Терминал на Windows</value>
+    <value>Терминал изграден со AI во својата основа — агентите можат да разбираат, поправаат и автоматизираат работни текови во терминалот</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Терминал на Windows со преглед на претстојните карактеристики</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Отвори во &amp;терминалот</value>
+    <value>Отвори во Интелигентниот &amp;Терминал</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/mk-MK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mk-MK/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Отвори во Интелигентниот &amp;Терминал</value>
+    <value>Отвори во Интелигентниот Терминал(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/mk-MK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mk-MK/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Отвори во &amp;преглед на терминалот</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Отвори во Интелигентниот Терминал(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/mk-MK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mk-MK/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Отвори во &amp;преглед на терминалот</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Отвори во Интелигентниот Терминал(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/ml-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ml-IN/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>ടെർമിനൽ</value>
+    <value>ഇന്റലിജന്റ് ടെർമിനൽ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows ടെർമിനൽ</value>
+    <value>ഇന്റലിജന്റ് ടെർമിനൽ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>ടെർമിനൽ</value>
+    <value>ഇന്റലിജന്റ് ടെർമിനൽ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>പുതിയ Windows ടെര്‍മിനല്‍</value>
+    <value>AI-നേറ്റീവ് ടെർമിനൽ — ഏജന്റുകൾക്ക് ടെർമിനൽ വർക്ക്‌ഫ്ലോകൾ മനസ്സിലാക്കാനും, പരിഹരിക്കാനും, ഓട്ടോമേറ്റ് ചെയ്യാനും കഴിയും</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>വരാനിരിക്കുന്ന സവിശേഷതകളുടെ പ്രിവ്യൂ ഉള്ള Windows ടെർമിനൽ</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;ടെർമിനലിൽ തുറക്കുക</value>
+    <value>ഇന്റലിജന്റ് &amp;ടെർമിനലിൽ തുറക്കുക</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ml-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ml-IN/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>ഇന്റലിജന്റ് &amp;ടെർമിനലിൽ തുറക്കുക</value>
+    <value>ഇന്റലിജന്റ് ടെർമിനലിൽ തുറക്കുക(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ml-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ml-IN/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>ടെർമിനൽ &amp;പ്രിവ്യൂവിൽ തുറക്കുക</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ഇന്റലിജന്റ് ടെർമിനലിൽ തുറക്കുക(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/ml-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ml-IN/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>ടെർമിനൽ &amp;പ്രിവ്യൂവിൽ തുറക്കുക</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ഇന്റലിജന്റ് ടെർമിനലിൽ തുറക്കുക(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/mr-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mr-IN/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>टर्मीनल</value>
+    <value>इंटेलिजंट टर्मिनल</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows टर्मीनल</value>
+    <value>इंटेलिजंट टर्मिनल</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>टर्मीनल</value>
+    <value>इंटेलिजंट टर्मिनल</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>नवीन Windows टर्मीनल</value>
+    <value>AI-नेटिव्ह टर्मिनल — एजंट्स टर्मिनल वर्कफ्लो समजू शकतात, दुरुस्त करू शकतात आणि स्वयंचलित करू शकतात</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>आगामी वैशिष्ट्यांच्या पूर्वावलोकनासह Windows टर्मीनल</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;टर्मिनलमध्ये उघडा</value>
+    <value>इंटेलिजंट &amp;टर्मिनलमध्ये उघडा</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/mr-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mr-IN/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>टर्मिनल &amp;पूर्वावलोकनामध्ये उघडा</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>इंटेलिजंट टर्मिनलमध्ये उघडा(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/mr-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mr-IN/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>इंटेलिजंट &amp;टर्मिनलमध्ये उघडा</value>
+    <value>इंटेलिजंट टर्मिनलमध्ये उघडा(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/mr-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mr-IN/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>टर्मिनल &amp;पूर्वावलोकनामध्ये उघडा</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>इंटेलिजंट टर्मिनलमध्ये उघडा(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/ms-MY/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ms-MY/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Pintar</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminal Windows</value>
+    <value>Terminal Pintar</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Pintar</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Terminal Windows Baharu</value>
+    <value>Terminal yang dibina dengan AI sebagai teras — ejen AI boleh memahami, membetulkan dan mengautomasikan aliran kerja terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminal Windows dengan pratonton ciri-ciri akan datang</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Buka dalam &amp;Terminal</value>
+    <value>Buka dalam &amp;Terminal Pintar</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ms-MY/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ms-MY/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Buka dalam &amp;Terminal Pintar</value>
+    <value>Buka dalam Terminal Pintar(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ms-MY/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ms-MY/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Buka dalam Terminal &amp;Pratonton</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Buka dalam Terminal Pintar(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/ms-MY/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ms-MY/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Buka dalam Terminal &amp;Pratonton</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Buka dalam Terminal Pintar(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/mt-MT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mt-MT/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Intelliġenti</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>Terminal Intelliġenti</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Intelliġenti</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>It-Terminal ta' Windows il-Ġdid</value>
+    <value>Terminal ibbażat fuq l-AI — l-aġenti jistgħu jifhmu, isewwu u jawtomatizzaw il-flussi tax-xogħol tat-terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>It-Terminal ta' Windows bi previżjoni tal-karatteristiċi li ġejjin</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Iftaħ fit-&amp;Terminal</value>
+    <value>Iftaħ fit-&amp;Terminal Intelliġenti</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/mt-MT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mt-MT/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Iftaħ fit-&amp;Terminal Intelliġenti</value>
+    <value>Iftaħ fit-Terminal &amp;Intelliġenti</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/mt-MT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mt-MT/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Iftaħ fil-Previżjoni tat-&amp;Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Iftaħ fit-Terminal &amp;Intelliġenti</value>

--- a/src/cascadia/CascadiaPackage/Resources/mt-MT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/mt-MT/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Iftaħ fil-Previżjoni tat-&amp;Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Iftaħ fit-Terminal &amp;Intelliġenti</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/nb-NO/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/nb-NO/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Nye Windows Terminal</value>
+    <value>AI-nativ terminal — agenter kan forstå, fikse og automatisere terminalarbeidsflyter</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows Terminal med en forsmak av kommende funksjoner</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Åpne i &amp;Terminal</value>
+    <value>Åpne i Intelligent &amp;Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/nb-NO/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/nb-NO/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Åpne i Intelligent &amp;Terminal</value>
+    <value>Åpne i &amp;Intelligent Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/nb-NO/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/nb-NO/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Åpne i &amp;forhåndsversjonen av Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Åpne i &amp;Intelligent Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/nb-NO/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/nb-NO/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Åpne i &amp;forhåndsversjonen av Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Åpne i &amp;Intelligent Terminal</value>

--- a/src/cascadia/CascadiaPackage/Resources/ne-NP/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ne-NP/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>टर्मिनल</value>
+    <value>इन्टेलिजेन्ट टर्मिनल</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows टर्मिनल</value>
+    <value>इन्टेलिजेन्ट टर्मिनल</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>टर्मिनल</value>
+    <value>इन्टेलिजेन्ट टर्मिनल</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>नयाँ Windows टर्मिनल</value>
+    <value>AI-नेटिभ टर्मिनल — एजेन्टहरूले टर्मिनल कार्यप्रवाहहरू बुझ्न, ठीक गर्न र स्वचालित बनाउन सक्छन्</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>आगामी सुविधाहरूको पूर्वावलोकनको साथ Windows टर्मिनल</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;टर्मिनलमा खोल्नुहोस्</value>
+    <value>इन्टेलिजेन्ट &amp;टर्मिनलमा खोल्नुहोस्</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ne-NP/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ne-NP/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>टर्मिनल &amp;पूर्वावलोकनमा खोल्नुहोस्</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>इन्टेलिजेन्ट टर्मिनलमा खोल्नुहोस्(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/ne-NP/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ne-NP/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>टर्मिनल &amp;पूर्वावलोकनमा खोल्नुहोस्</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>इन्टेलिजेन्ट टर्मिनलमा खोल्नुहोस्(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ne-NP/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ne-NP/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>इन्टेलिजेन्ट &amp;टर्मिनलमा खोल्नुहोस्</value>
+    <value>इन्टेलिजेन्ट टर्मिनलमा खोल्नुहोस्(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/nl-NL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/nl-NL/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligente Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>Intelligente Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligente Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>De nieuwe Windows Terminal</value>
+    <value>AI-native terminal — agents kunnen terminalworkflows begrijpen, oplossen en automatiseren</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows Terminal met een preview van toekomstige functies</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Openen in &amp;Terminal</value>
+    <value>Openen in Intelligente &amp;Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/nl-NL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/nl-NL/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Openen in Intelligente &amp;Terminal</value>
+    <value>Openen in &amp;Intelligente Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/nl-NL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/nl-NL/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Openen in Terminal &amp;Preview</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Openen in &amp;Intelligente Terminal</value>

--- a/src/cascadia/CascadiaPackage/Resources/nl-NL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/nl-NL/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Openen in Terminal &amp;Preview</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Openen in &amp;Intelligente Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/nn-NO/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/nn-NO/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Den nye Windows Terminal</value>
+    <value>AI-nativ terminal — agentar kan forstå, fikse og automatisere terminalarbeidsflytar</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows Terminal med ein prøveversjon av komande funksjonar</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Opne i &amp;Terminal</value>
+    <value>Opne i Intelligent &amp;Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/nn-NO/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/nn-NO/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Opne i prøveversjon av &amp;Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Opne i &amp;Intelligent Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/nn-NO/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/nn-NO/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Opne i Intelligent &amp;Terminal</value>
+    <value>Opne i &amp;Intelligent Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/nn-NO/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/nn-NO/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Opne i prøveversjon av &amp;Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Opne i &amp;Intelligent Terminal</value>

--- a/src/cascadia/CascadiaPackage/Resources/or-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/or-IN/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>ଟର୍ମିନଲ୍</value>
+    <value>ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନାଲ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows ଟର୍ମିନଲ୍</value>
+    <value>ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନାଲ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>ଟର୍ମିନଲ୍</value>
+    <value>ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନାଲ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>ନୂତନ Windows ଟର୍ମିନଲ୍</value>
+    <value>AI-ନେଟିଭ୍ ଟର୍ମିନାଲ — ଏଜେଣ୍ଟମାନେ ଟର୍ମିନାଲ ୱର୍କଫ୍ଲୋକୁ ବୁଝିପାରନ୍ତି, ସଠିକ୍ କରିପାରନ୍ତି ଏବଂ ସ୍ୱୟଂଚାଳିତ କରିପାରନ୍ତି</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>ଆଗାମୀ ବୈଶିଷ୍ଟ୍ୟଗୁଡିକର ପୂର୍ବାବଲୋକନ ସହିତ Windows ଟର୍ମିନଲ୍</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;ଟର୍ମିନାଲରେ ଖୋଲନ୍ତୁ</value>
+    <value>ଇଣ୍ଟେଲିଜେଣ୍ଟ &amp;ଟର୍ମିନାଲରେ ଖୋଲନ୍ତୁ</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/or-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/or-IN/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>ଟର୍ମିନାଲ୍ &amp;ପୂର୍ବାବଲୋକନରେ ଖୋଲନ୍ତୁ</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନାଲରେ ଖୋଲନ୍ତୁ(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/or-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/or-IN/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>ଇଣ୍ଟେଲିଜେଣ୍ଟ &amp;ଟର୍ମିନାଲରେ ଖୋଲନ୍ତୁ</value>
+    <value>ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନାଲରେ ଖୋଲନ୍ତୁ(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/or-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/or-IN/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>ଟର୍ମିନାଲ୍ &amp;ପୂର୍ବାବଲୋକନରେ ଖୋଲନ୍ତୁ</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନାଲରେ ଖୋଲନ୍ତୁ(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/pa-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pa-IN/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>ਟਰਮੀਨਲ</value>
+    <value>ਇੰਟੈਲੀਜੈਂਟ ਟਰਮੀਨਲ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows ਟਰਮੀਨਲ</value>
+    <value>ਇੰਟੈਲੀਜੈਂਟ ਟਰਮੀਨਲ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>ਟਰਮੀਨਲ</value>
+    <value>ਇੰਟੈਲੀਜੈਂਟ ਟਰਮੀਨਲ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>ਨਵਾਂ Windows ਟਰਮੀਨਲ</value>
+    <value>AI-ਨੇਟਿਵ ਟਰਮੀਨਲ — ਏਜੰਟ ਟਰਮੀਨਲ ਵਰਕਫਲੋ ਨੂੰ ਸਮਝ ਸਕਦੇ ਹਨ, ਠੀਕ ਕਰ ਸਕਦੇ ਹਨ ਅਤੇ ਸਵੈਚਾਲਿਤ ਕਰ ਸਕਦੇ ਹਨ</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>ਆਉਣ ਵਾਲੀਆਂ ਵਿਸ਼ੇਸ਼ਤਾਵਾਂ ਦੇ ਪੂਰਵਦਰਸ਼ਨ ਦੇ ਨਾਲ Windows ਟਰਮੀਨਲ</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;ਟਰਮੀਨਲ ਵਿੱਚ ਖੋਲ੍ਹੋ</value>
+    <value>ਇੰਟੈਲੀਜੈਂਟ &amp;ਟਰਮੀਨਲ ਵਿੱਚ ਖੋਲ੍ਹੋ</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/pa-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pa-IN/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>ਟਰਮੀਨਲ &amp;ਪੂਰਵਦਰਸ਼ਨ ਵਿੱਚ ਖੋਲ੍ਹੋ</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ਇੰਟੈਲੀਜੈਂਟ ਟਰਮੀਨਲ ਵਿੱਚ ਖੋਲ੍ਹੋ(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/pa-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pa-IN/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>ਇੰਟੈਲੀਜੈਂਟ &amp;ਟਰਮੀਨਲ ਵਿੱਚ ਖੋਲ੍ਹੋ</value>
+    <value>ਇੰਟੈਲੀਜੈਂਟ ਟਰਮੀਨਲ ਵਿੱਚ ਖੋਲ੍ਹੋ(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/pa-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pa-IN/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>ਟਰਮੀਨਲ &amp;ਪੂਰਵਦਰਸ਼ਨ ਵਿੱਚ ਖੋਲ੍ਹੋ</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ਇੰਟੈਲੀਜੈਂਟ ਟਰਮੀਨਲ ਵਿੱਚ ਖੋਲ੍ਹੋ(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/pl-PL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pl-PL/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Inteligentny Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminal Windows</value>
+    <value>Inteligentny Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Inteligentny Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Nowy Terminal Windows</value>
+    <value>Terminal z AI w swojej podstawie — agenci potrafią rozumieć, naprawiać i automatyzować przepływy pracy w terminalu</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminal Windows z podglądem nadchodzących funkcji</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Otwórz w &amp;Terminalu</value>
+    <value>Otwórz w Inteligentnym &amp;Terminalu</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/pl-PL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pl-PL/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Otwórz w &amp;Podglądzie terminalu</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Otwórz w &amp;Inteligentnym Terminalu</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/pl-PL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pl-PL/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Otwórz w Inteligentnym &amp;Terminalu</value>
+    <value>Otwórz w &amp;Inteligentnym Terminalu</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/pl-PL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pl-PL/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Otwórz w &amp;Podglądzie terminalu</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Otwórz w &amp;Inteligentnym Terminalu</value>

--- a/src/cascadia/CascadiaPackage/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pt-BR/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Inteligente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminal do Windows</value>
+    <value>Terminal Inteligente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Inteligente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>O novo terminal do Windows</value>
+    <value>Terminal nativo de IA — os agentes podem entender, corrigir e automatizar fluxos de trabalho do terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminal do Windows com uma visualização dos próximos recursos</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Abrir no &amp;Terminal</value>
+    <value>Abrir no &amp;Terminal Inteligente</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pt-BR/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Abrir no Terminal &amp;Visualizar</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Abrir no Terminal &amp;Inteligente</value>

--- a/src/cascadia/CascadiaPackage/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pt-BR/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Abrir no &amp;Terminal Inteligente</value>
+    <value>Abrir no Terminal &amp;Inteligente</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pt-BR/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Abrir no Terminal &amp;Visualizar</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Abrir no Terminal &amp;Inteligente</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/pt-PT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pt-PT/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Inteligente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminal do Windows</value>
+    <value>Terminal Inteligente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Inteligente</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>O Novo Terminal do Windows</value>
+    <value>Terminal nativo de IA — os agentes podem compreender, corrigir e automatizar fluxos de trabalho do terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminal do Windows com uma pré-visualização das funcionalidades futuras</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Abrir no &amp;Terminal</value>
+    <value>Abrir no &amp;Terminal Inteligente</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/pt-PT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pt-PT/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Abrir no &amp;Terminal Inteligente</value>
+    <value>Abrir no Terminal &amp;Inteligente</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/pt-PT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pt-PT/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Abrir na &amp;Pré-visualização do Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Abrir no Terminal &amp;Inteligente</value>

--- a/src/cascadia/CascadiaPackage/Resources/pt-PT/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/pt-PT/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Abrir na &amp;Pré-visualização do Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Abrir no Terminal &amp;Inteligente</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-ploc/Resources.resw
@@ -189,7 +189,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Όрèп ìņ Ţêŕmїŉåļ &amp;Рѓзνι℮ω !!! !!! !</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Θρēņ ïη &amp;Intelligent Terminal !!! !!! !</value>

--- a/src/cascadia/CascadiaPackage/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-ploc/Resources.resw
@@ -192,7 +192,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Open in &amp;Intelligent Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <value>Θρēņ ïη &amp;Intelligent Terminal !!! !!! !</value>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key. {Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
 </root>

--- a/src/cascadia/CascadiaPackage/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-ploc/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameDev" xml:space="preserve">
@@ -134,7 +134,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameDev" xml:space="preserve">
@@ -150,7 +150,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameDev" xml:space="preserve">
@@ -192,7 +192,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Óрêп ìл &amp;Ťěѓmιиåĺ !!! !!</value>
+    <value>Open in &amp;Intelligent Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>

--- a/src/cascadia/CascadiaPackage/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-ploc/Resources.resw
@@ -189,10 +189,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Όрèп ìņ Ţêŕmїŉåļ &amp;Рѓзνι℮ω !!! !!! !</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Open in &amp;Intelligent Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>

--- a/src/cascadia/CascadiaPackage/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-ploca/Resources.resw
@@ -189,7 +189,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Όрèп ìņ Ţêŕmїŉåļ &amp;Рѓзνι℮ω !!! !!! !</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Θρēņ ïη &amp;Intelligent Terminal !!! !!! !</value>

--- a/src/cascadia/CascadiaPackage/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-ploca/Resources.resw
@@ -192,7 +192,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Open in &amp;Intelligent Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <value>Θρēņ ïη &amp;Intelligent Terminal !!! !!! !</value>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key. {Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
 </root>

--- a/src/cascadia/CascadiaPackage/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-ploca/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameDev" xml:space="preserve">
@@ -134,7 +134,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameDev" xml:space="preserve">
@@ -150,7 +150,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameDev" xml:space="preserve">
@@ -192,7 +192,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Óрêп ìл &amp;Ťěѓmιиåĺ !!! !!</value>
+    <value>Open in &amp;Intelligent Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>

--- a/src/cascadia/CascadiaPackage/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-ploca/Resources.resw
@@ -189,10 +189,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Όрèп ìņ Ţêŕmїŉåļ &amp;Рѓзνι℮ω !!! !!! !</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Open in &amp;Intelligent Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>

--- a/src/cascadia/CascadiaPackage/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-plocm/Resources.resw
@@ -189,7 +189,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Όрèп ìņ Ţêŕmїŉåļ &amp;Рѓзνι℮ω !!! !!! !</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Θρēņ ïη &amp;Intelligent Terminal !!! !!! !</value>

--- a/src/cascadia/CascadiaPackage/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-plocm/Resources.resw
@@ -192,7 +192,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Open in &amp;Intelligent Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <value>Θρēņ ïη &amp;Intelligent Terminal !!! !!! !</value>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key. {Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
 </root>

--- a/src/cascadia/CascadiaPackage/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-plocm/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameDev" xml:space="preserve">
@@ -134,7 +134,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameDev" xml:space="preserve">
@@ -150,7 +150,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameDev" xml:space="preserve">
@@ -192,7 +192,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Óрêп ìл &amp;Ťěѓmιиåĺ !!! !!</value>
+    <value>Open in &amp;Intelligent Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>

--- a/src/cascadia/CascadiaPackage/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-plocm/Resources.resw
@@ -189,10 +189,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Όрèп ìņ Ţêŕmїŉåļ &amp;Рѓзνι℮ω !!! !!! !</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Open in &amp;Intelligent Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>

--- a/src/cascadia/CascadiaPackage/Resources/quz-PE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/quz-PE/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Yuyaysapa Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>Yuyaysapa Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Yuyaysapa Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Musuq Windows Terminal</value>
+    <value>IA nisqapi sayasqa terminal — agente-kunaqa terminalpa llamkana puriyninkunata hamut’an, allinchan hinaspa kikillanmanta rurachin</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows Terminal hamuq imayna kasqanniyuqkuna</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Terminal kaqpi &amp;Kichasqa</value>
+    <value>Yuyaysapa Terminal kaqpi &amp;Kichasqa</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/quz-PE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/quz-PE/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Terminal &amp;Ñawpaq qawarina kaqpi kichay</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Yuyaysapa Terminal kaqpi Kichasqa(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/quz-PE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/quz-PE/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Yuyaysapa Terminal kaqpi &amp;Kichasqa</value>
+    <value>Yuyaysapa Terminal kaqpi Kichasqa(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/quz-PE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/quz-PE/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Terminal &amp;Ñawpaq qawarina kaqpi kichay</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Yuyaysapa Terminal kaqpi Kichasqa(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ro-RO/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ro-RO/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Inteligent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminal Windows</value>
+    <value>Terminal Inteligent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Inteligent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Noul Terminal Windows</value>
+    <value>Terminal nativ AI — agenții pot înțelege, remedia și automatiza fluxurile de lucru din terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminal Windows cu o previzualizare a caracteristicilor viitoare</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Deschideți în &amp;Terminal</value>
+    <value>Deschideți în &amp;Terminal Inteligent</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ro-RO/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ro-RO/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Deschideți în Terminal &amp;Preview</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Deschideți în Terminal &amp;Inteligent</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ro-RO/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ro-RO/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Deschideți în &amp;Terminal Inteligent</value>
+    <value>Deschideți în Terminal &amp;Inteligent</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ro-RO/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ro-RO/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Deschideți în Terminal &amp;Preview</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Deschideți în Terminal &amp;Inteligent</value>

--- a/src/cascadia/CascadiaPackage/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ru-RU/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Терминал</value>
+    <value>Интеллектуальный Терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Терминал Windows</value>
+    <value>Интеллектуальный Терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Терминал</value>
+    <value>Интеллектуальный Терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Новый Терминал Windows</value>
+    <value>Терминал с AI в основе — агенты могут понимать, исправлять и автоматизировать рабочие процессы в терминале</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Терминал Windows с обзором будущих функций</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Открыть в &amp;Терминале</value>
+    <value>Открыть в Интеллектуальном &amp;Терминале</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ru-RU/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Открыть в &amp;предварительной версии терминала</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Открыть в Интеллектуальном Терминале(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ru-RU/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Открыть в Интеллектуальном &amp;Терминале</value>
+    <value>Открыть в Интеллектуальном Терминале(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ru-RU/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Открыть в &amp;предварительной версии терминала</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Открыть в Интеллектуальном Терминале(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sk-SK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sk-SK/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminál</value>
+    <value>Inteligentný Terminál</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminál</value>
+    <value>Inteligentný Terminál</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminál</value>
+    <value>Inteligentný Terminál</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Nový Windows Terminál</value>
+    <value>Terminál postavený na AI — agenti dokážu rozumieť pracovným postupom v termináli, opravovať ich a automatizovať</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows Terminál s ukážkou nadchádzajúcich funkcií</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Otvoriť v službe &amp;Terminal</value>
+    <value>Otvoriť v Inteligentnom &amp;Termináli</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sk-SK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sk-SK/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Otvoriť v Inteligentnom &amp;Termináli</value>
+    <value>Otvoriť v &amp;Inteligentnom Termináli</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sk-SK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sk-SK/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Otvoriť v službe Terminal (&amp;verzia preview)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Otvoriť v &amp;Inteligentnom Termináli</value>

--- a/src/cascadia/CascadiaPackage/Resources/sk-SK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sk-SK/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Otvoriť v službe Terminal (&amp;verzia preview)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Otvoriť v &amp;Inteligentnom Termináli</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sl-SI/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sl-SI/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Inteligentni Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Terminal Windows</value>
+    <value>Inteligentni Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Inteligentni Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Novi terminal Windows</value>
+    <value>Terminal, zasnovan na AI — agenti lahko razumejo poteke dela v terminalu, jih popravijo in avtomatizirajo</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminal Windows s predogledom prihajajočih funkcij</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Odpri v &amp;terminalu</value>
+    <value>Odpri v Inteligentnem &amp;Terminalu</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sl-SI/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sl-SI/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Odpri v &amp;predogledu terminala</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Odpri v &amp;Inteligentnem Terminalu</value>

--- a/src/cascadia/CascadiaPackage/Resources/sl-SI/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sl-SI/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Odpri v Inteligentnem &amp;Terminalu</value>
+    <value>Odpri v &amp;Inteligentnem Terminalu</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sl-SI/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sl-SI/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Odpri v &amp;predogledu terminala</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Odpri v &amp;Inteligentnem Terminalu</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sq-AL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sq-AL/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminali</value>
+    <value>Terminali inteligjent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>Terminali inteligjent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminali</value>
+    <value>Terminali inteligjent</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Terminali i ri i Windows</value>
+    <value>Terminal i ndërtuar mbi AI — agjentët mund të kuptojnë, të rregullojnë dhe të automatizojnë rrjedhat e punës në terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Terminali i Windows me një paraafishim të tipareve të ardhshme</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Hap në &amp;Terminal</value>
+    <value>Hap në &amp;Terminalin inteligjent</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sq-AL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sq-AL/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Hap në &amp;paraafishimin e Terminalit</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Hap në Terminalin &amp;inteligjent</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sq-AL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sq-AL/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Hap në &amp;Terminalin inteligjent</value>
+    <value>Hap në Terminalin &amp;inteligjent</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sq-AL/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sq-AL/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Hap në &amp;paraafishimin e Terminalit</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Hap në Terminalin &amp;inteligjent</value>

--- a/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-BA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-BA/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Терминал</value>
+    <value>Интелигентни Терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Терминал</value>
+    <value>Интелигентни Терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Терминал</value>
+    <value>Интелигентни Терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Нови Windows терминал</value>
+    <value>Терминал изграђен на AI-ју — агенти могу да разумеју, исправљају и аутоматизују токове рада у терминалу</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows терминал са прегледом предстојећих функција</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Отвори у &amp;Терминалу</value>
+    <value>Отвори у Интелигентном &amp;Терминалу</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-BA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-BA/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Отвори у Интелигентном &amp;Терминалу</value>
+    <value>Отвори у Интелигентном Терминалу(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-BA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-BA/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Отвори у Терминалу &amp;Прегледу</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Отвори у Интелигентном Терминалу(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-BA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-BA/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Отвори у Терминалу &amp;Прегледу</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Отвори у Интелигентном Терминалу(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-RS/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Терминал</value>
+    <value>Интелигентни Терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows терминал</value>
+    <value>Интелигентни Терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Терминал</value>
+    <value>Интелигентни Терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Нови Windows терминал</value>
+    <value>Терминал изграђен на AI-ју — агенти могу да разумеју, исправљају и аутоматизују токове рада у терминалу</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows терминал са прегледом предстојећих функција</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Отвори у апликацији &amp;Windows терминал</value>
+    <value>Отвори у Интелигентном &amp;Терминалу</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-RS/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Отвори у &amp;верзији за преглед апликације Windows терминал</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Отвори у Интелигентном Терминалу(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-RS/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Отвори у Интелигентном &amp;Терминалу</value>
+    <value>Отвори у Интелигентном Терминалу(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sr-Cyrl-RS/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Отвори у &amp;верзији за преглед апликације Windows терминал</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Отвори у Интелигентном Терминалу(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sr-Latn-RS/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sr-Latn-RS/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Inteligentni Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows terminal</value>
+    <value>Inteligentni Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Inteligentni Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Novi Windows terminal</value>
+    <value>Terminal izgrađen na AI-ju — agenti mogu da razumeju, ispravljaju i automatizuju tokove rada u terminalu</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows terminal sa pregledom predstojećih funkcija</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;Otvori u terminalu</value>
+    <value>Otvori u Inteligentnom &amp;Terminalu</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sr-Latn-RS/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sr-Latn-RS/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>&amp;Otvori u pregledu terminala</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Otvori u &amp;Inteligentnom Terminalu</value>

--- a/src/cascadia/CascadiaPackage/Resources/sr-Latn-RS/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sr-Latn-RS/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>&amp;Otvori u pregledu terminala</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Otvori u &amp;Inteligentnom Terminalu</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sr-Latn-RS/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sr-Latn-RS/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Otvori u Inteligentnom &amp;Terminalu</value>
+    <value>Otvori u &amp;Inteligentnom Terminalu</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sv-SE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sv-SE/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows-terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Intelligent Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Den nya Windows-terminalen</value>
+    <value>AI-nativ terminal — agenter kan förstå, åtgärda och automatisera terminalarbetsflöden</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows-terminal med en förhandsversion av kommande funktioner</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Öppna i Terminal</value>
+    <value>Öppna i Intelligent &amp;Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sv-SE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sv-SE/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Öppna i Terminal och förhandsversion</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Öppna i &amp;Intelligent Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/sv-SE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sv-SE/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Öppna i Terminal och förhandsversion</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Öppna i &amp;Intelligent Terminal</value>

--- a/src/cascadia/CascadiaPackage/Resources/sv-SE/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/sv-SE/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Öppna i Intelligent &amp;Terminal</value>
+    <value>Öppna i &amp;Intelligent Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ta-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ta-IN/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>முனையம்</value>
+    <value>அறிவாண் முனையம்</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows நிலையம்</value>
+    <value>அறிவாண் முனையம்</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>முனையம்</value>
+    <value>அறிவாண் முனையம்</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>புதிய Windows முனையம்</value>
+    <value>AI-நேட்டிவ் டெர்மினல் — ஏஜென்ட்கள் டெர்மினல் வேலைப்போக்குகளை புரிந்து கொண்டு, சரிசெய்து, தானியக்கமாக்க முடியும்</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>வரவிருக்கும் அம்சங்களின் முன்னோட்டத்துடன் Windows முனையம்</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;முனையத்தில் திற</value>
+    <value>அறிவாண் &amp;முனையத்தில் திற</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ta-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ta-IN/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>அறிவாண் &amp;முனையத்தில் திற</value>
+    <value>அறிவாண் முனையத்தில் திற(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ta-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ta-IN/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>முனையம் &amp;முன்னோட்டத்தில் திற</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>அறிவாண் முனையத்தில் திற(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/ta-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ta-IN/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>முனையம் &amp;முன்னோட்டத்தில் திற</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>அறிவாண் முனையத்தில் திற(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/te-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/te-IN/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>టెర్మినల్</value>
+    <value>ఇంటెలిజెంట్ టెర్మినల్</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows టెర్మినల్</value>
+    <value>ఇంటెలిజెంట్ టెర్మినల్</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>టెర్మినల్</value>
+    <value>ఇంటెలిజెంట్ టెర్మినల్</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>కొత్త Windows టెర్మినల్</value>
+    <value>AI-నేటివ్ టెర్మినల్ — ఏజెంట్లు టెర్మినల్ వర్క్‌ఫ్లోలను అర్థం చేసుకుని, సరిచేసి, స్వయంచాలకంగా మార్చగలరు</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>రాబోయే ఫీచర్ల ప్రివ్యూతో Windows టెర్మినల్</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;టెర్మినల్‌లో తెరవండి</value>
+    <value>ఇంటెలిజెంట్ &amp;టెర్మినల్‌లో తెరవండి</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/te-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/te-IN/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>ఇంటెలిజెంట్ &amp;టెర్మినల్‌లో తెరవండి</value>
+    <value>ఇంటెలిజెంట్ టెర్మినల్‌లో తెరవండి(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/te-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/te-IN/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>టెర్మినల్ &amp;పరిదృశ్యంలో తెరవండి</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ఇంటెలిజెంట్ టెర్మినల్‌లో తెరవండి(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/te-IN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/te-IN/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>టెర్మినల్ &amp;పరిదృశ్యంలో తెరవండి</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ఇంటెలిజెంట్ టెర్మినల్‌లో తెరవండి(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/th-TH/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/th-TH/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>เทอร์มินัล</value>
+    <value>เทอร์มินัลอัจฉริยะ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>เทอร์มินัล Windows</value>
+    <value>เทอร์มินัลอัจฉริยะ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>เทอร์มินัล</value>
+    <value>เทอร์มินัลอัจฉริยะ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>เทอร์มินัล Windows ใหม่</value>
+    <value>เทอร์มินัลที่มี AI เป็นแกนหลัก — เอเจนต์ AI สามารถเข้าใจ แก้ไข และทำให้เวิร์กโฟลว์เทอร์มินัลเป็นอัตโนมัติ</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>เทอร์มินัล Windows ที่มีพรีวิวฟีเจอร์ที่กําลังจะมาถึง</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>เปิดใน&amp;เทอร์มินัล</value>
+    <value>เปิดใน&amp;เทอร์มินัลอัจฉริยะ</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/th-TH/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/th-TH/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>เปิดในเทอร์มินัล&amp;พรีวิว</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>เปิดในเทอร์มินัลอัจฉริยะ(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/th-TH/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/th-TH/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>เปิดในเทอร์มินัล&amp;พรีวิว</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>เปิดในเทอร์มินัลอัจฉริยะ(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/th-TH/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/th-TH/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>เปิดใน&amp;เทอร์มินัลอัจฉริยะ</value>
+    <value>เปิดในเทอร์มินัลอัจฉริยะ(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/tr-TR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/tr-TR/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Akıllı Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows Terminal</value>
+    <value>Akıllı Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Akıllı Terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Yeni Windows Terminal</value>
+    <value>Özünde yapay zekâlı terminal — ajanlar terminal iş akışlarını anlayabilir, düzeltebilir ve otomatikleştirebilir</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Yakında kullanıma sunulacak özelliklerin önizlemesini içeren Windows Terminal</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;Terminalde Aç</value>
+    <value>&amp;Akıllı Terminalde Aç</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/tr-TR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/tr-TR/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;Akıllı Terminalde Aç</value>
+    <value>Akıllı Terminalde Aç(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/tr-TR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/tr-TR/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Terminal Önizlemesinde &amp;Aç</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Akıllı Terminalde Aç(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/tr-TR/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/tr-TR/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Terminal Önizlemesinde &amp;Aç</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Akıllı Terminalde Aç(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/tt-RU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/tt-RU/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Терминал</value>
+    <value>Акыллы терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows терминалы</value>
+    <value>Акыллы терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Терминал</value>
+    <value>Акыллы терминал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Яңа Windows терминалы</value>
+    <value>ЯИ нигезендә төзелгән терминал — агентлар терминал эш агымнарын аңлый, төзәтә һәм автоматлаштыра ала</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Киләчәк функцияләрне алдан карау белән Windows терминалы</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;Терминал кушымтасында ачу</value>
+    <value>&amp;Акыллы терминалда ачу</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/tt-RU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/tt-RU/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;Акыллы терминалда ачу</value>
+    <value>Акыллы терминалда ачу(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/tt-RU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/tt-RU/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Терминал кушымтасының &amp;карап алу версиясендә ачу</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Акыллы терминалда ачу(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/tt-RU/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/tt-RU/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Терминал кушымтасының &amp;карап алу версиясендә ачу</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Акыллы терминалда ачу(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/ug-CN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ug-CN/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>تېرمىنال</value>
+    <value>ئەقلىي تېرمىنال</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows تېرمىنالى</value>
+    <value>ئەقلىي تېرمىنال</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>تېرمىنال</value>
+    <value>ئەقلىي تېرمىنال</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>يېڭى Windows تېرمىنالى</value>
+    <value>سۈنئىي ئەقىلنى ئاساس قىلغان تېرمىنال — ئاگېنتلار تېرمىنال خىزمەت ئېقىنلىرىنى چۈشىنىپ، تۈزىتىپ ۋە ئاپتوماتلاشتۇرالايدۇ</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>تېرمىنال Windows ۋە كەلگۈسىدىكى ئالاھىدىلىكلەر كۆرىكى</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>تېرمىنال &amp;دا ئېچىش</value>
+    <value>ئەقلىي &amp;تېرمىنالدا ئېچىش</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ug-CN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ug-CN/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>تېرمىنال &amp;كۆرەكتە ئېچىش</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ئەقلىي تېرمىنالدا ئېچىش(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/ug-CN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ug-CN/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>ئەقلىي &amp;تېرمىنالدا ئېچىش</value>
+    <value>ئەقلىي تېرمىنالدا ئېچىش(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ug-CN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ug-CN/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>تېرمىنال &amp;كۆرەكتە ئېچىش</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ئەقلىي تېرمىنالدا ئېچىش(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/uk-UA/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Термінал</value>
+    <value>Інтелектуальний Термінал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Термінал Windows</value>
+    <value>Інтелектуальний Термінал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Термінал</value>
+    <value>Інтелектуальний Термінал</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Новий Термінал Windows</value>
+    <value>Термінал, створений на основі AI — агенти можуть розуміти, виправляти й автоматизувати робочі процеси в терміналі</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Термінал Windows з попереднім переглядом майбутніх функцій</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Відкрити в &amp;Terminal</value>
+    <value>Відкрити в Інтелектуальному &amp;Терміналі</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/uk-UA/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Відкрити в Інтелектуальному &amp;Терміналі</value>
+    <value>Відкрити в Інтелектуальному Терміналі(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/uk-UA/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Відкрити в &amp;підготовчій версії Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Відкрити в Інтелектуальному Терміналі(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/uk-UA/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Відкрити в &amp;підготовчій версії Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Відкрити в Інтелектуальному Терміналі(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ur-PK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ur-PK/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>ٹرمینل</value>
+    <value>ذہین ٹرمینل</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows ٹرمینل</value>
+    <value>ذہین ٹرمینل</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>ٹرمینل</value>
+    <value>ذہین ٹرمینل</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>نئی Windows ٹرمینل</value>
+    <value>AI-نیٹو ٹرمینل — ایجنٹس ٹرمینل ورک فلو کو سمجھ سکتے ہیں، درست کر سکتے ہیں، اور خودکار بنا سکتے ہیں</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>آئندہ آنے والے فیچرز کے پیش منظر کے ساتھ Windows ٹرمینل</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;Terminal میں کھولیں</value>
+    <value>ذہین &amp;ٹرمینل میں کھولیں</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ur-PK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ur-PK/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Terminal کے &amp;پیش منظر میں کھولیں</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ذہین ٹرمینل میں کھولیں(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ur-PK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ur-PK/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>ذہین &amp;ٹرمینل میں کھولیں</value>
+    <value>ذہین ٹرمینل میں کھولیں(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/ur-PK/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/ur-PK/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Terminal کے &amp;پیش منظر میں کھولیں</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>ذہین ٹرمینل میں کھولیں(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/uz-Latn-UZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/uz-Latn-UZ/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Aqlli terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows terminal</value>
+    <value>Aqlli terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Aqlli terminal</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Yangi Windows Terminal</value>
+    <value>Sun’iy intellekt asosida yaratilgan terminal — agentlar terminal ish jarayonlarini tushunishi, tuzatishi va avtomatlashtirishi mumkin</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Kelgusi xususiyatlarni dastlabki ko‘rinish bilan Windows Terminal</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;Terminalda ochish</value>
+    <value>&amp;Aqlli terminalda ochish</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/uz-Latn-UZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/uz-Latn-UZ/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Terminal &amp;razm solishda ochish</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Aqlli terminalda ochish(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/uz-Latn-UZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/uz-Latn-UZ/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>&amp;Aqlli terminalda ochish</value>
+    <value>Aqlli terminalda ochish(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/uz-Latn-UZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/uz-Latn-UZ/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Terminal &amp;razm solishda ochish</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Aqlli terminalda ochish(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/vi-VN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/vi-VN/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Đầu cuối</value>
+    <value>Đầu cuối thông minh</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Bảng điều khiển Windows</value>
+    <value>Đầu cuối thông minh</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>Đầu cuối</value>
+    <value>Đầu cuối thông minh</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Bảng điều khiển Windows mới</value>
+    <value>Terminal được xây dựng với AI làm cốt lõi — các tác nhân AI có thể hiểu, khắc phục và tự động hóa quy trình làm việc trên terminal</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Bảng điều khiển Windows với bản xem trước các tính năng sắp ra mắt</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Mở trong &amp;Bảng điều khiển</value>
+    <value>Mở trong &amp;Đầu cuối thông minh</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/vi-VN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/vi-VN/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Mở trong Bản xem trước &amp;Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Mở trong Đầu cuối thông minh(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/vi-VN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/vi-VN/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Mở trong Bản xem trước &amp;Terminal</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>Mở trong Đầu cuối thông minh(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/vi-VN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/vi-VN/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Mở trong &amp;Đầu cuối thông minh</value>
+    <value>Mở trong Đầu cuối thông minh(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/zh-CN/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>终端</value>
+    <value>智能终端</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows 终端</value>
+    <value>智能终端</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>终端</value>
+    <value>智能终端</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>新的 Windows 终端</value>
+    <value>AI 原生终端 — 智能体可理解、修复和自动化终端工作流</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>拥有即将推出功能的 Windows 终端</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>在终端中打开(&amp;T)</value>
+    <value>在智能终端中打开(&amp;T)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/zh-CN/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>在终端预览中打开(&amp;P)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>在智能终端中打开(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/zh-CN/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>在智能终端中打开(&amp;T)</value>
+    <value>在智能终端中打开(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/zh-CN/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>在终端预览中打开(&amp;P)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>在智能终端中打开(&amp;I)</value>

--- a/src/cascadia/CascadiaPackage/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/zh-TW/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>終端機</value>
+    <value>智慧終端機</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameCan" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreName" xml:space="preserve">
-    <value>Windows 終端機</value>
+    <value>智慧終端機</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameCan" xml:space="preserve">
@@ -142,7 +142,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortName" xml:space="preserve">
-    <value>終端機</value>
+    <value>智慧終端機</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameCan" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>新的 Windows 終端機</value>
+    <value>AI 原生終端機 — 智慧代理可理解、修復和自動化終端機工作流程</value>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>具有預定功能預覽的 Windows 終端機</value>
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>在終端中開啟(&amp;T)</value>
+    <value>在智慧終端機中開啟(&amp;T)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/zh-TW/Resources.resw
@@ -165,10 +165,10 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>在終端機預覽中開啟(&amp;P)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>在智慧終端機中開啟(&amp;I)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/zh-TW/Resources.resw
@@ -168,7 +168,7 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>在智慧終端機中開啟(&amp;T)</value>
+    <value>在智慧終端機中開啟(&amp;I)</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 <data name="AppDescriptionDev" xml:space="preserve"><value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppDescriptionCan" xml:space="preserve"><value>The Windows Terminal (Canary build)</value><comment>{Locked}</comment></data><data name="AppNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppShortNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="AppStoreNameDev" xml:space="preserve"><value>Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data><data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve"><value>Open in Intelligent Terminal</value><comment>{Locked} The dev build will never be seen in multiple languages</comment></data></root>

--- a/src/cascadia/CascadiaPackage/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/zh-TW/Resources.resw
@@ -165,7 +165,7 @@
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>在終端機預覽中開啟(&amp;P)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
     <value>在智慧終端機中開啟(&amp;I)</value>

--- a/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
@@ -959,8 +959,8 @@
   <data name="InitShellIntegrationErrorMessage" xml:space="preserve"><value>Die Shellintegration konnte nicht initialisiert werden. Der Pfad zu Ihrem PowerShell-Profil konnte nicht ermittelt werden. Stellen Sie sicher, dass die Ziel-Shell installiert ist.</value><comment>{Locked="PowerShell"}</comment></data>
   <data name="AgentNotConfiguredTitle" xml:space="preserve"><value>KI-Agent ist nicht verfügbar</value></data>
   <data name="AgentNotConfiguredSubtitle" xml:space="preserve"><value>Es konnte kein KI-Agent gefunden werden. Installieren Sie eine Agent-CLI (z. B. copilot, gemini) und stellen Sie sicher, dass sie sich in Ihrem PATH befindet, oder konfigurieren Sie eine unter Einstellungen &gt; Agenten.</value><comment>{Locked="CLI","PATH","copilot","gemini"}</comment></data>
-  <data name="FreOverlay_Title" xml:space="preserve"><value>Neu in Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
-  <data name="FreOverlay_Card1Title" xml:space="preserve"><value>Willkommen bei Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_Title" xml:space="preserve"><value>Neu in Intelligentem Terminal</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
+  <data name="FreOverlay_Card1Title" xml:space="preserve"><value>Willkommen bei Intelligentem Terminal</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_Card1Description" xml:space="preserve"><value>Richten Sie Ihren integrierten KI-Agenten ein, damit er Ihnen direkt bei der Arbeit hilft</value></data>
   <data name="FreOverlay_Card2Title" xml:space="preserve"><value>Automatische Fehlererkennung</value></data>
   <data name="FreOverlay_Card2Description" xml:space="preserve"><value>Der Agentbereich hat immer Kontext und ist mit Ihrer bevorzugten Agent-CLI einsatzbereit</value><comment>{Locked="CLI"}</comment></data>
@@ -968,7 +968,7 @@
   <data name="FreOverlay_Card3Description" xml:space="preserve"><value>Die Sitzungsverwaltung hilft Ihnen dabei, Agenten nachzuverfolgen und zu früheren Sitzungen zurückzukehren</value></data>
   <data name="FreOverlay_Card4Title" xml:space="preserve"><value>Schnelle Agentbefehle</value></data>
   <data name="FreOverlay_Card4Description" xml:space="preserve"><value>Mit der Befehlspalette lassen sich Registerkarten im Hintergrund starten</value></data>
-  <data name="FreOverlay_DetailTitle" xml:space="preserve"><value>Willkommen bei Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_DetailTitle" xml:space="preserve"><value>Willkommen bei Intelligentem Terminal</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_DetailDescription" xml:space="preserve"><value>Richten Sie Ihren integrierten KI-Agenten ein, damit er Ihnen direkt bei der Arbeit hilft, Fehler zu erklären, Befehle zu entwerfen und Aufgaben wieder in Gang zu bringen.</value></data>
   <data name="FreOverlay_Detail2Title" xml:space="preserve"><value>Automatische Fehlererkennung</value></data>
   <data name="FreOverlay_Detail2Description" xml:space="preserve"><value>Der Agentbereich hat immer Kontext und ist mit Ihrer bevorzugten Agent-CLI einsatzbereit.</value><comment>{Locked="CLI"}</comment></data>
@@ -976,6 +976,6 @@
   <data name="FreOverlay_Detail3Description" xml:space="preserve"><value>Die Sitzungsverwaltung hilft Ihnen dabei, Agenten nachzuverfolgen und zu früheren Sitzungen zurückzukehren.</value></data>
   <data name="FreOverlay_Detail4Title" xml:space="preserve"><value>Schnelle Agentbefehle</value></data>
   <data name="FreOverlay_Detail4Description" xml:space="preserve"><value>Verwenden Sie die Befehlspalette, um agentengestützte Aufgaben von überall in Ihrem Terminal aus schnell auszuführen.</value></data>
-  <data name="FreOverlay_DetailLink" xml:space="preserve"><value>Erfahren Sie mehr über Intelligent Terminal.</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_DetailLink" xml:space="preserve"><value>Erfahren Sie mehr über Intelligentes Terminal.</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_NextButton" xml:space="preserve"><value>Jetzt entdecken</value></data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1013,11 +1013,11 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="FreOverlay_Title" xml:space="preserve">
     <value>New in Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_Card1Title" xml:space="preserve">
     <value>Welcome to Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_Card1Description" xml:space="preserve">
     <value>Set up your built-in assistant to help you right where you work</value>
@@ -1044,7 +1044,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
   <data name="FreOverlay_DetailTitle" xml:space="preserve">
     <value>Welcome to Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_DetailDescription" xml:space="preserve">
     <value>Set up your built-in assistant to help you explain errors, draft commands, and unblock tasks right where you work.</value>
@@ -1071,7 +1071,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
   <data name="FreOverlay_DetailLink" xml:space="preserve">
     <value>Learn more about Intelligent Terminal.</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_NextButton" xml:space="preserve">
     <value>Start exploring</value>

--- a/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
@@ -956,8 +956,8 @@
   <data name="InitShellIntegrationErrorMessage" xml:space="preserve"><value>No se pudo inicializar la integración del shell. No se pudo determinar la ruta del perfil de PowerShell. Asegúrese de que el shell de destino esté instalado.</value><comment>{Locked="PowerShell"}</comment></data>
   <data name="AgentNotConfiguredTitle" xml:space="preserve"><value>El agente de IA no está disponible</value></data>
   <data name="AgentNotConfiguredSubtitle" xml:space="preserve"><value>No se ha encontrado ningún agente de IA. Instale una CLI de agente (p. ej., copilot, gemini) y asegúrese de que esté en PATH, o configure un agente en Configuración &gt; Agentes de IA.</value><comment>{Locked="CLI","PATH","copilot","gemini"}</comment></data>
-  <data name="FreOverlay_Title" xml:space="preserve"><value>Novedades de Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
-  <data name="FreOverlay_Card1Title" xml:space="preserve"><value>Bienvenido a Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_Title" xml:space="preserve"><value>Novedades de Terminal Inteligente</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
+  <data name="FreOverlay_Card1Title" xml:space="preserve"><value>Bienvenido a Terminal Inteligente</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_Card1Description" xml:space="preserve"><value>Configura tu agente integrado para que te ayude justo donde trabajas</value></data>
   <data name="FreOverlay_Card2Title" xml:space="preserve"><value>Detección automática de errores</value></data>
   <data name="FreOverlay_Card2Description" xml:space="preserve"><value>El panel del agente siempre tiene contexto y está listo con tu CLI de agente favorita</value><comment>{Locked="CLI"}</comment></data>
@@ -965,7 +965,7 @@
   <data name="FreOverlay_Card3Description" xml:space="preserve"><value>La gestión de sesiones te ayuda a hacer un seguimiento de los agentes y a volver a sesiones anteriores</value></data>
   <data name="FreOverlay_Card4Title" xml:space="preserve"><value>Comandos rápidos del agente</value></data>
   <data name="FreOverlay_Card4Description" xml:space="preserve"><value>La paleta de comandos puede iniciar pestañas en segundo plano</value></data>
-  <data name="FreOverlay_DetailTitle" xml:space="preserve"><value>Bienvenido a Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_DetailTitle" xml:space="preserve"><value>Bienvenido a Terminal Inteligente</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_DetailDescription" xml:space="preserve"><value>Configura tu agente integrado para que te ayude a explicar errores, redactar comandos y desbloquear tareas justo donde trabajas.</value></data>
   <data name="FreOverlay_Detail2Title" xml:space="preserve"><value>Detección automática de errores</value></data>
   <data name="FreOverlay_Detail2Description" xml:space="preserve"><value>El panel del agente siempre tiene contexto y está listo con tu CLI de agente favorita.</value><comment>{Locked="CLI"}</comment></data>
@@ -973,6 +973,6 @@
   <data name="FreOverlay_Detail3Description" xml:space="preserve"><value>La gestión de sesiones te ayuda a hacer un seguimiento de los agentes y a volver a sesiones anteriores.</value></data>
   <data name="FreOverlay_Detail4Title" xml:space="preserve"><value>Comandos rápidos del agente</value></data>
   <data name="FreOverlay_Detail4Description" xml:space="preserve"><value>Usa la paleta de comandos para ejecutar rápidamente tareas impulsadas por agentes desde cualquier lugar del terminal.</value></data>
-  <data name="FreOverlay_DetailLink" xml:space="preserve"><value>Más información sobre Intelligent Terminal.</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_DetailLink" xml:space="preserve"><value>Más información sobre Terminal Inteligente.</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_NextButton" xml:space="preserve"><value>Empezar a explorar</value></data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
@@ -957,8 +957,8 @@
   <data name="InitShellIntegrationErrorMessage" xml:space="preserve"><value>Échec de l'initialisation de l'intégration du shell. Impossible de déterminer le chemin de votre profil PowerShell. Assurez-vous que le shell cible est installé.</value><comment>{Locked="PowerShell"}</comment></data>
   <data name="AgentNotConfiguredTitle" xml:space="preserve"><value>L'agent IA n'est pas disponible</value></data>
   <data name="AgentNotConfiguredSubtitle" xml:space="preserve"><value>Aucun agent IA n'a été trouvé. Installez une CLI d'agent (par exemple copilot, gemini) et assurez-vous qu'elle se trouve dans votre PATH, ou configurez-en une dans Paramètres &gt; Agents IA.</value><comment>{Locked="CLI","PATH","copilot","gemini"}</comment></data>
-  <data name="FreOverlay_Title" xml:space="preserve"><value>Nouveautés dans Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
-  <data name="FreOverlay_Card1Title" xml:space="preserve"><value>Bienvenue dans Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_Title" xml:space="preserve"><value>Nouveautés dans Terminal Intelligent</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
+  <data name="FreOverlay_Card1Title" xml:space="preserve"><value>Bienvenue dans Terminal Intelligent</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_Card1Description" xml:space="preserve"><value>Configurez votre agent IA intégré pour obtenir de l'aide directement là où vous travaillez</value></data>
   <data name="FreOverlay_Card2Title" xml:space="preserve"><value>Détection automatique des erreurs</value></data>
   <data name="FreOverlay_Card2Description" xml:space="preserve"><value>Le volet de l'agent conserve le contexte et est prêt à fonctionner avec votre CLI d'agent préférée</value><comment>{Locked="CLI"}</comment></data>
@@ -966,7 +966,7 @@
   <data name="FreOverlay_Card3Description" xml:space="preserve"><value>La gestion des sessions vous aide à suivre les agents et à revenir à des sessions précédentes</value></data>
   <data name="FreOverlay_Card4Title" xml:space="preserve"><value>Commandes rapides pour l'agent</value></data>
   <data name="FreOverlay_Card4Description" xml:space="preserve"><value>La palette de commandes permet de lancer des onglets en arrière-plan</value></data>
-  <data name="FreOverlay_DetailTitle" xml:space="preserve"><value>Bienvenue dans Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_DetailTitle" xml:space="preserve"><value>Bienvenue dans Terminal Intelligent</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_DetailDescription" xml:space="preserve"><value>Configurez votre agent IA intégré pour vous aider à expliquer les erreurs, rédiger des commandes et débloquer des tâches directement là où vous travaillez.</value></data>
   <data name="FreOverlay_Detail2Title" xml:space="preserve"><value>Détection automatique des erreurs</value></data>
   <data name="FreOverlay_Detail2Description" xml:space="preserve"><value>Le volet de l'agent conserve le contexte et est prêt à fonctionner avec votre CLI d'agent préférée.</value><comment>{Locked="CLI"}</comment></data>
@@ -974,6 +974,6 @@
   <data name="FreOverlay_Detail3Description" xml:space="preserve"><value>La gestion des sessions vous aide à suivre les agents et à revenir à des sessions précédentes.</value></data>
   <data name="FreOverlay_Detail4Title" xml:space="preserve"><value>Commandes rapides pour l'agent</value></data>
   <data name="FreOverlay_Detail4Description" xml:space="preserve"><value>Utilisez la palette de commandes pour exécuter rapidement des tâches pilotées par agent depuis n'importe où dans votre terminal.</value></data>
-  <data name="FreOverlay_DetailLink" xml:space="preserve"><value>En savoir plus sur Intelligent Terminal.</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_DetailLink" xml:space="preserve"><value>En savoir plus sur Terminal Intelligent.</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_NextButton" xml:space="preserve"><value>Commencer l'exploration</value></data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
@@ -956,8 +956,8 @@
   <data name="InitShellIntegrationErrorMessage" xml:space="preserve"><value>Impossibile inizializzare l'integrazione della shell. Non è stato possibile determinare il percorso del profilo di PowerShell. Assicurati che la shell di destinazione sia installata.</value><comment>{Locked="PowerShell"}</comment></data>
   <data name="AgentNotConfiguredTitle" xml:space="preserve"><value>Agente AI non disponibile</value></data>
   <data name="AgentNotConfiguredSubtitle" xml:space="preserve"><value>Nessun agente AI trovato. Installa una CLI per agenti (ad es. copilot, gemini) e assicurati che sia nel PATH, oppure configurane una in Impostazioni &gt; Agenti AI.</value><comment>{Locked="CLI","PATH","copilot","gemini"}</comment></data>
-  <data name="FreOverlay_Title" xml:space="preserve"><value>Novità di Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
-  <data name="FreOverlay_Card1Title" xml:space="preserve"><value>Benvenuto in Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_Title" xml:space="preserve"><value>Novità di Terminale Intelligente</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
+  <data name="FreOverlay_Card1Title" xml:space="preserve"><value>Benvenuto in Terminale Intelligente</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_Card1Description" xml:space="preserve"><value>Configura il tuo agente integrato per ricevere aiuto direttamente dove lavori</value></data>
   <data name="FreOverlay_Card2Title" xml:space="preserve"><value>Rilevamento automatico degli errori</value></data>
   <data name="FreOverlay_Card2Description" xml:space="preserve"><value>Il riquadro agente ha sempre il contesto giusto ed è pronto con la tua CLI per agenti preferita</value><comment>{Locked="CLI"}</comment></data>
@@ -965,7 +965,7 @@
   <data name="FreOverlay_Card3Description" xml:space="preserve"><value>La gestione delle sessioni ti aiuta a tenere traccia degli agenti e a tornare alle sessioni precedenti</value></data>
   <data name="FreOverlay_Card4Title" xml:space="preserve"><value>Comandi rapidi dell'agente</value></data>
   <data name="FreOverlay_Card4Description" xml:space="preserve"><value>Il riquadro comandi può avviare schede in background</value></data>
-  <data name="FreOverlay_DetailTitle" xml:space="preserve"><value>Benvenuto in Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_DetailTitle" xml:space="preserve"><value>Benvenuto in Terminale Intelligente</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_DetailDescription" xml:space="preserve"><value>Configura il tuo agente integrato per aiutarti a spiegare gli errori, scrivere comandi e sbloccare le attività direttamente dove lavori.</value></data>
   <data name="FreOverlay_Detail2Title" xml:space="preserve"><value>Rilevamento automatico degli errori</value></data>
   <data name="FreOverlay_Detail2Description" xml:space="preserve"><value>Il riquadro agente ha sempre il contesto giusto ed è pronto con la tua CLI per agenti preferita.</value><comment>{Locked="CLI"}</comment></data>
@@ -973,6 +973,6 @@
   <data name="FreOverlay_Detail3Description" xml:space="preserve"><value>La gestione delle sessioni ti aiuta a tenere traccia degli agenti e a tornare alle sessioni precedenti.</value></data>
   <data name="FreOverlay_Detail4Title" xml:space="preserve"><value>Comandi rapidi dell'agente</value></data>
   <data name="FreOverlay_Detail4Description" xml:space="preserve"><value>Usa il riquadro comandi per eseguire rapidamente attività basate su agenti da qualsiasi punto del terminale.</value></data>
-  <data name="FreOverlay_DetailLink" xml:space="preserve"><value>Scopri di più su Intelligent Terminal.</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_DetailLink" xml:space="preserve"><value>Scopri di più su Terminale Intelligente.</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_NextButton" xml:space="preserve"><value>Inizia a esplorare</value></data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
@@ -957,8 +957,8 @@
   <data name="InitShellIntegrationErrorMessage" xml:space="preserve"><value>シェル統合を初期化できませんでした。PowerShell プロファイルのパスを特定できませんでした。対象のシェルがインストールされていることを確認してください。</value><comment>{Locked="PowerShell"}</comment></data>
   <data name="AgentNotConfiguredTitle" xml:space="preserve"><value>AI エージェントは利用できません</value></data>
   <data name="AgentNotConfiguredSubtitle" xml:space="preserve"><value>AI エージェントが見つかりませんでした。エージェント CLI (例: copilot、gemini) をインストールし、それが PATH に含まれていることを確認するか、[設定] &gt; [AI エージェント] で構成してください。</value><comment>{Locked="CLI","PATH","copilot","gemini"}</comment></data>
-  <data name="FreOverlay_Title" xml:space="preserve"><value>Intelligent Terminal の新機能</value><comment>{Locked="Intelligent Terminal"}</comment></data>
-  <data name="FreOverlay_Card1Title" xml:space="preserve"><value>Intelligent Terminal へようこそ</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_Title" xml:space="preserve"><value>インテリジェント ターミナルの新機能</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
+  <data name="FreOverlay_Card1Title" xml:space="preserve"><value>インテリジェント ターミナルへようこそ</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_Card1Description" xml:space="preserve"><value>作業しながらその場で支援してくれる組み込みアシスタントを設定します</value></data>
   <data name="FreOverlay_Card2Title" xml:space="preserve"><value>自動エラー検出</value></data>
   <data name="FreOverlay_Card2Description" xml:space="preserve"><value>エージェント ペインは常にコンテキストを保持し、お好みのエージェント CLI をすぐに利用できます</value><comment>{Locked="CLI"}</comment></data>
@@ -966,7 +966,7 @@
   <data name="FreOverlay_Card3Description" xml:space="preserve"><value>セッション管理により、エージェントを追跡し、以前のセッションに戻れます</value></data>
   <data name="FreOverlay_Card4Title" xml:space="preserve"><value>クイック エージェント コマンド</value></data>
   <data name="FreOverlay_Card4Description" xml:space="preserve"><value>コマンド パレットからバックグラウンド タブを起動できます</value></data>
-  <data name="FreOverlay_DetailTitle" xml:space="preserve"><value>Intelligent Terminal へようこそ</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_DetailTitle" xml:space="preserve"><value>インテリジェント ターミナルへようこそ</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_DetailDescription" xml:space="preserve"><value>作業しながらその場で、エラーの説明やコマンドの下書き、行き詰まったタスクの打開を手伝ってくれる組み込みアシスタントを設定します。</value></data>
   <data name="FreOverlay_Detail2Title" xml:space="preserve"><value>自動エラー検出</value></data>
   <data name="FreOverlay_Detail2Description" xml:space="preserve"><value>エージェント ペインは常にコンテキストを保持し、お好みのエージェント CLI をすぐに利用できます。</value><comment>{Locked="CLI"}</comment></data>
@@ -974,6 +974,6 @@
   <data name="FreOverlay_Detail3Description" xml:space="preserve"><value>セッション管理により、エージェントを追跡し、以前のセッションに戻れます。</value></data>
   <data name="FreOverlay_Detail4Title" xml:space="preserve"><value>クイック エージェント コマンド</value></data>
   <data name="FreOverlay_Detail4Description" xml:space="preserve"><value>コマンド パレットを使うと、ターミナル内のどこからでもエージェントを使ったタスクをすばやく実行できます。</value></data>
-  <data name="FreOverlay_DetailLink" xml:space="preserve"><value>Intelligent Terminal の詳細を見る</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_DetailLink" xml:space="preserve"><value>インテリジェント ターミナルの詳細を見る</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_NextButton" xml:space="preserve"><value>使ってみる</value></data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
@@ -1021,12 +1021,12 @@
     <comment>{Locked="CLI","PATH","copilot","gemini"}</comment>
   </data>
   <data name="FreOverlay_Title" xml:space="preserve">
-    <value>Intelligent Terminal의 새로운 기능</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>지능형 터미널의 새로운 기능</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_Card1Title" xml:space="preserve">
-    <value>Intelligent Terminal에 오신 것을 환영합니다</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>지능형 터미널에 오신 것을 환영합니다</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_Card1Description" xml:space="preserve">
     <value>작업하는 곳에서 바로 도움을 받을 수 있도록 기본 제공 어시스턴트를 설정하세요</value>
@@ -1051,8 +1051,8 @@
     <value>명령 팔레트에서 백그라운드 탭을 시작할 수 있습니다</value>
   </data>
   <data name="FreOverlay_DetailTitle" xml:space="preserve">
-    <value>Intelligent Terminal에 오신 것을 환영합니다</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>지능형 터미널에 오신 것을 환영합니다</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_DetailDescription" xml:space="preserve">
     <value>작업하는 곳에서 바로 오류를 설명하고, 명령을 작성하고, 막힌 작업을 해결할 수 있도록 기본 제공 어시스턴트를 설정하세요.</value>
@@ -1077,8 +1077,8 @@
     <value>명령 팔레트를 사용해 터미널 어디에서나 에이전트 기반 작업을 빠르게 실행하세요.</value>
   </data>
   <data name="FreOverlay_DetailLink" xml:space="preserve">
-    <value>Intelligent Terminal에 대해 자세히 알아보기.</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>지능형 터미널에 대해 자세히 알아보기.</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_NextButton" xml:space="preserve">
     <value>둘러보기 시작</value>

--- a/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
@@ -1015,12 +1015,12 @@
     <comment>{Locked="CLI","PATH","copilot","gemini"}</comment>
   </data>
   <data name="FreOverlay_Title" xml:space="preserve">
-    <value>Novidades no Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>Novidades no Terminal Inteligente</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_Card1Title" xml:space="preserve">
-    <value>Boas-vindas ao Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>Boas-vindas ao Terminal Inteligente</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_Card1Description" xml:space="preserve">
     <value>Configure seu agente integrado para ajudar você exatamente onde trabalha.</value>
@@ -1045,8 +1045,8 @@
     <value>A paleta de comandos pode iniciar guias em segundo plano</value>
   </data>
   <data name="FreOverlay_DetailTitle" xml:space="preserve">
-    <value>Boas-vindas ao Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>Boas-vindas ao Terminal Inteligente</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_DetailDescription" xml:space="preserve">
     <value>Configure seu agente integrado para ajudar você a explicar erros, redigir comandos e destravar tarefas exatamente onde trabalha.</value>
@@ -1071,8 +1071,8 @@
     <value>Use a paleta de comandos para executar rapidamente tarefas com agentes de qualquer lugar do terminal.</value>
   </data>
   <data name="FreOverlay_DetailLink" xml:space="preserve">
-    <value>Saiba mais sobre o Intelligent Terminal.</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>Saiba mais sobre o Terminal Inteligente.</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_NextButton" xml:space="preserve">
     <value>Começar a explorar</value>

--- a/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
@@ -1015,12 +1015,12 @@
     <comment>{Locked="CLI","PATH","copilot","gemini"}</comment>
   </data>
   <data name="FreOverlay_Title" xml:space="preserve">
-    <value>Новое в Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>Новое в Интеллектуальном Терминале</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_Card1Title" xml:space="preserve">
-    <value>Добро пожаловать в Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>Добро пожаловать в Интеллектуальный Терминал</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_Card1Description" xml:space="preserve">
     <value>Настройте встроенного ИИ-агента, чтобы он помогал вам прямо во время работы</value>
@@ -1045,8 +1045,8 @@
     <value>Из палитры команд можно запускать фоновые вкладки</value>
   </data>
   <data name="FreOverlay_DetailTitle" xml:space="preserve">
-    <value>Добро пожаловать в Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>Добро пожаловать в Интеллектуальный Терминал</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_DetailDescription" xml:space="preserve">
     <value>Настройте встроенного ИИ-агента, чтобы он помогал объяснять ошибки, составлять команды и решать задачи прямо во время работы.</value>
@@ -1071,8 +1071,8 @@
     <value>Используйте палитру команд, чтобы быстро запускать задачи с помощью агента из любой точки терминала.</value>
   </data>
   <data name="FreOverlay_DetailLink" xml:space="preserve">
-    <value>Подробнее об Intelligent Terminal.</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>Узнайте больше об Интеллектуальном Терминале.</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_NextButton" xml:space="preserve">
     <value>Начать знакомство</value>

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
@@ -997,11 +997,11 @@
     <value>Ниједан ВИ агент није пронађен. Инсталирајте CLI агента (нпр. copilot, gemini) и уверите се да је на вашем PATH-у или га конфигуришите у одељку Подешавања &gt; ВИ агенти.</value>
     <comment>{Locked="CLI","PATH","copilot","gemini"}</comment>
   </data><data name="FreOverlay_Title" xml:space="preserve">
-    <value>Ново у Intelligent Terminal-у</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>Ново у Интелигентном Терминалу</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data><data name="FreOverlay_Card1Title" xml:space="preserve">
-    <value>Добро дошли у Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>Добро дошли у Интелигентни Терминал</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data><data name="FreOverlay_Card1Description" xml:space="preserve">
     <value>Подесите уграђеног агента да вам помаже тамо где радите</value>
   </data><data name="FreOverlay_Card2Title" xml:space="preserve">
@@ -1018,8 +1018,8 @@
   </data><data name="FreOverlay_Card4Description" xml:space="preserve">
     <value>Палета команди може брзо да покрене агентске задатке у позадини</value>
   </data><data name="FreOverlay_DetailTitle" xml:space="preserve">
-    <value>Добро дошли у Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>Добро дошли у Интелигентни Терминал</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data><data name="FreOverlay_DetailDescription" xml:space="preserve">
     <value>Подесите уграђеног агента да вам помогне да објасните грешке, саставите команде и решите блокаде у задацима тамо где радите.</value>
   </data><data name="FreOverlay_Detail2Title" xml:space="preserve">
@@ -1036,8 +1036,8 @@
   </data><data name="FreOverlay_Detail4Description" xml:space="preserve">
     <value>Помоћу палете команди можете брзо да покрећете задатке које покреће агент са било ког места у терминалу.</value>
   </data><data name="FreOverlay_DetailLink" xml:space="preserve">
-    <value>Сазнајте више о Intelligent Terminal-у.</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>Сазнајте више о Интелигентном Терминалу.</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data><data name="FreOverlay_NextButton" xml:space="preserve">
     <value>Почните да истражујете</value>
   </data>

--- a/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
@@ -1009,8 +1009,8 @@
   <data name="InitShellIntegrationErrorMessage" xml:space="preserve"><value>Не вдалося ініціалізувати інтеграцію оболонки. Не вдалося визначити шлях до вашого профілю PowerShell. Переконайтеся, що цільову оболонку встановлено.</value><comment>{Locked="PowerShell"}</comment></data>
   <data name="AgentNotConfiguredTitle" xml:space="preserve"><value>Агент ШІ недоступний</value></data>
   <data name="AgentNotConfiguredSubtitle" xml:space="preserve"><value>Не вдалося знайти жодного агента ШІ. Установіть CLI агента (наприклад, copilot або gemini) і переконайтеся, що його додано до PATH, або налаштуйте його в Налаштування &gt; Агенти.</value><comment>{Locked="CLI","PATH","copilot","gemini"}</comment></data>
-  <data name="FreOverlay_Title" xml:space="preserve"><value>Нове в Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
-  <data name="FreOverlay_Card1Title" xml:space="preserve"><value>Ласкаво просимо до Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_Title" xml:space="preserve"><value>Нове в Інтелектуальному Терміналі</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
+  <data name="FreOverlay_Card1Title" xml:space="preserve"><value>Ласкаво просимо до Інтелектуального Терміналу</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_Card1Description" xml:space="preserve"><value>Налаштуйте вбудованого агента ШІ, щоб він допомагав вам саме там, де ви працюєте</value></data>
   <data name="FreOverlay_Card2Title" xml:space="preserve"><value>Автовиявлення помилок</value></data>
   <data name="FreOverlay_Card2Description" xml:space="preserve"><value>Панель агента завжди має контекст і готова до роботи з вашим улюбленим CLI</value><comment>{Locked="CLI"}</comment></data>
@@ -1018,7 +1018,7 @@
   <data name="FreOverlay_Card3Description" xml:space="preserve"><value>Керування сеансами допомагає відстежувати агентів і повертатися до попередніх сеансів</value></data>
   <data name="FreOverlay_Card4Title" xml:space="preserve"><value>Швидкі команди агента</value></data>
   <data name="FreOverlay_Card4Description" xml:space="preserve"><value>Палітра команд дає змогу запускати завдання агента у фонових вкладках</value></data>
-  <data name="FreOverlay_DetailTitle" xml:space="preserve"><value>Ласкаво просимо до Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_DetailTitle" xml:space="preserve"><value>Ласкаво просимо до Інтелектуального Терміналу</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_DetailDescription" xml:space="preserve"><value>Налаштуйте вбудованого агента ШІ, щоб він допомагав вам пояснювати помилки, складати команди та розблоковувати завдання саме там, де ви працюєте.</value></data>
   <data name="FreOverlay_Detail2Title" xml:space="preserve"><value>Автовиявлення помилок</value></data>
   <data name="FreOverlay_Detail2Description" xml:space="preserve"><value>Панель агента завжди має контекст і готова до роботи з вашим улюбленим CLI.</value><comment>{Locked="CLI"}</comment></data>
@@ -1026,6 +1026,6 @@
   <data name="FreOverlay_Detail3Description" xml:space="preserve"><value>Керування сеансами допомагає відстежувати агентів і повертатися до попередніх сеансів.</value></data>
   <data name="FreOverlay_Detail4Title" xml:space="preserve"><value>Швидкі команди агента</value></data>
   <data name="FreOverlay_Detail4Description" xml:space="preserve"><value>Використовуйте палітру команд, щоб швидко запускати завдання за участю агента з будь-якого місця у вашому терміналі.</value></data>
-  <data name="FreOverlay_DetailLink" xml:space="preserve"><value>Дізнайтеся більше про Intelligent Terminal.</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_DetailLink" xml:space="preserve"><value>Дізнатися більше про Інтелектуальний Термінал.</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_NextButton" xml:space="preserve"><value>Почати знайомство</value></data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
@@ -1024,12 +1024,12 @@
     <comment>{Locked="CLI","PATH","copilot","gemini"}</comment>
   </data>
   <data name="FreOverlay_Title" xml:space="preserve">
-    <value>Intelligent Terminal 的新增功能</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>智能终端的新功能</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_Card1Title" xml:space="preserve">
-    <value>欢迎使用 Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>欢迎使用智能终端</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_Card1Description" xml:space="preserve">
     <value>设置内置智能体，让它在你的工作环境中直接为你提供帮助</value>
@@ -1054,8 +1054,8 @@
     <value>命令面板可快速启动后台标签页</value>
   </data>
   <data name="FreOverlay_DetailTitle" xml:space="preserve">
-    <value>欢迎使用 Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>欢迎使用智能终端</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_DetailDescription" xml:space="preserve">
     <value>设置内置智能体，让它在你的工作环境中帮助你解释错误、起草命令并扫清任务阻碍。</value>
@@ -1080,8 +1080,8 @@
     <value>使用命令面板可从终端中的任意位置快速运行由智能体驱动的任务。</value>
   </data>
   <data name="FreOverlay_DetailLink" xml:space="preserve">
-    <value>详细了解 Intelligent Terminal。</value>
-    <comment>{Locked="Intelligent Terminal"}</comment>
+    <value>详细了解智能终端。</value>
+    <comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment>
   </data>
   <data name="FreOverlay_NextButton" xml:space="preserve">
     <value>开始探索</value>

--- a/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
@@ -956,8 +956,8 @@
   <data name="InitShellIntegrationErrorMessage" xml:space="preserve"><value>初始化 Shell 整合失敗。無法判斷您的 PowerShell 設定檔路徑。請確認已安裝目標 Shell。</value><comment>{Locked="PowerShell"}</comment></data>
   <data name="AgentNotConfiguredTitle" xml:space="preserve"><value>AI 代理無法使用</value></data>
   <data name="AgentNotConfiguredSubtitle" xml:space="preserve"><value>找不到任何 AI 代理。請安裝代理 CLI（例如 copilot、gemini），並確認它位於您的 PATH 中，或在 [設定] &gt; [AI 代理] 中進行設定。</value><comment>{Locked="CLI","PATH","copilot","gemini"}</comment></data>
-  <data name="FreOverlay_Title" xml:space="preserve"><value>Intelligent Terminal 的新功能</value><comment>{Locked="Intelligent Terminal"}</comment></data>
-  <data name="FreOverlay_Card1Title" xml:space="preserve"><value>歡迎使用 Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_Title" xml:space="preserve"><value>智慧終端機的新功能</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
+  <data name="FreOverlay_Card1Title" xml:space="preserve"><value>歡迎使用智慧終端機</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_Card1Description" xml:space="preserve"><value>設定您的內建助理，直接在您的工作環境中提供協助</value></data>
   <data name="FreOverlay_Card2Title" xml:space="preserve"><value>自動錯誤偵測</value></data>
   <data name="FreOverlay_Card2Description" xml:space="preserve"><value>AI 代理窗格一律具備內容脈絡，並已準備好搭配您最愛的 AI 代理 CLI 使用</value><comment>{Locked="CLI"}</comment></data>
@@ -965,7 +965,7 @@
   <data name="FreOverlay_Card3Description" xml:space="preserve"><value>工作階段管理可協助您追蹤 AI 代理，並快速返回先前的工作階段</value></data>
   <data name="FreOverlay_Card4Title" xml:space="preserve"><value>快速 AI 代理命令</value></data>
   <data name="FreOverlay_Card4Description" xml:space="preserve"><value>可從命令選擇區啟動背景索引標籤</value></data>
-  <data name="FreOverlay_DetailTitle" xml:space="preserve"><value>歡迎使用 Intelligent Terminal</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_DetailTitle" xml:space="preserve"><value>歡迎使用智慧終端機</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_DetailDescription" xml:space="preserve"><value>設定您的內建助理，讓它直接在您的工作環境中協助您說明錯誤、草擬命令，以及排除工作阻礙。</value></data>
   <data name="FreOverlay_Detail2Title" xml:space="preserve"><value>自動錯誤偵測</value></data>
   <data name="FreOverlay_Detail2Description" xml:space="preserve"><value>AI 代理窗格一律具備內容脈絡，並已準備好搭配您最愛的 AI 代理 CLI 使用。</value><comment>{Locked="CLI"}</comment></data>
@@ -973,6 +973,6 @@
   <data name="FreOverlay_Detail3Description" xml:space="preserve"><value>工作階段管理可協助您追蹤 AI 代理，並快速返回先前的工作階段。</value></data>
   <data name="FreOverlay_Detail4Title" xml:space="preserve"><value>快速 AI 代理命令</value></data>
   <data name="FreOverlay_Detail4Description" xml:space="preserve"><value>使用命令選擇區，從終端機中的任何位置快速執行由 AI 代理支援的工作。</value></data>
-  <data name="FreOverlay_DetailLink" xml:space="preserve"><value>深入了解 Intelligent Terminal。</value><comment>{Locked="Intelligent Terminal"}</comment></data>
+  <data name="FreOverlay_DetailLink" xml:space="preserve"><value>深入了解智慧終端機。</value><comment>"Intelligent Terminal" is the product name. Translate it if a localized product name exists for this language.</comment></data>
   <data name="FreOverlay_NextButton" xml:space="preserve"><value>開始探索</value></data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -318,7 +318,7 @@
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
     <value>Die Terminalanwendung, die gestartet wird, wenn eine Befehlszeilenanwendung ohne vorhandene Sitzung gestartet wird, beispielsweise vom Startmenü oder über das Dialogfeld "Ausführen".</value>
-    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
+    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Intelligentes Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
     <value>Grafik-API</value>
@@ -358,7 +358,7 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>Dadurch wird geändert, wie eingehender Text in Zellen gruppiert wird. Die Option "Grapheme clusters" ist die moderne und unicode-korrekte Methode, während "wcswidth" ein gängiger Ansatz für UNIX ist und "Windows-Konsole" die für die Arbeit unter Windows verwendete Methode repliziert. Das Ändern dieser Einstellung erfordert einen Neustart von Windows-Terminal und gilt nur für Anwendungen, die innerhalb der Einstellung gestartet werden.</value>
+    <value>Dadurch wird geändert, wie eingehender Text in Zellen gruppiert wird. Die Option "Grapheme clusters" ist die moderne und unicode-korrekte Methode, während "wcswidth" ein gängiger Ansatz für UNIX ist und "Windows-Konsole" die für die Arbeit unter Windows verwendete Methode repliziert. Das Ändern dieser Einstellung erfordert einen Neustart von Intelligentes Terminal und gilt nur für Anwendungen, die innerhalb der Einstellung gestartet werden.</value>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>Graphemcluster</value>
@@ -376,7 +376,7 @@
     <comment>A label for a drop down selector, referring to the East Asian Ambiguous Width Unicode specification.</comment>
   </data>
   <data name="Globals_AmbiguousWidth.HelpText" xml:space="preserve">
-    <value>Legt die Breite fest, die für ostasiatische mehrdeutige Zeichen verwendet wird. „Eng“ (Standard) priorisiert die Kompatibilität, während „Weit“ die Lesbarkeit mit vielen CJK-Schriftarten priorisiert. Im Modus „Breit“ funktionieren einige Anwendungen möglicherweise nicht ordnungsgemäß und verursachen eine erratische Cursorbewegung. Das Ändern dieser Einstellung erfordert einen Neustart von Windows-Terminal und gilt nur für Anwendungen, die von dort aus gestartet werden.</value>
+    <value>Legt die Breite fest, die für ostasiatische mehrdeutige Zeichen verwendet wird. „Eng“ (Standard) priorisiert die Kompatibilität, während „Weit“ die Lesbarkeit mit vielen CJK-Schriftarten priorisiert. Im Modus „Breit“ funktionieren einige Anwendungen möglicherweise nicht ordnungsgemäß und verursachen eine erratische Cursorbewegung. Das Ändern dieser Einstellung erfordert einen Neustart von Intelligentes Terminal und gilt nur für Anwendungen, die von dort aus gestartet werden.</value>
   </data>
   <data name="Globals_AmbiguousWidth_Narrow.Text" xml:space="preserve">
     <value>Schmal</value>
@@ -574,8 +574,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>Ausführung von Windows Terminal im Hintergrund zulassen</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <value>Ausführung von Intelligentes Terminal im Hintergrund zulassen</value>
+    <comment>Header for a control to toggle support for Intelligentes Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>Debugfeatures aktivieren</value>
@@ -896,7 +896,7 @@
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
     <value>Automatisch</value>
-    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
+    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Intelligentes Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>Farbschema</value>
@@ -2223,7 +2223,7 @@
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Windows-Terminal wird im portablen Modus ausgeführt.</value>
+    <value>Intelligentes Terminal wird im portablen Modus ausgeführt.</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">
@@ -2578,7 +2578,7 @@
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>Zeigt ein Schild in der Titelleiste an, wenn Windows Terminal als Administrator ausgeführt wird.</value>
+    <value>Zeigt ein Schild in der Titelleiste an, wenn Intelligentes Terminal als Administrator ausgeführt wird.</value>
     <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -358,7 +358,7 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>This changes the way incoming text is grouped into cells. The "Grapheme clusters" option is the most modern and Unicode-correct way to do so, while "wcswidth" is a common approach on UNIX, and "Windows Console" replicates the way it used to work on Windows. Changing this setting requires a restart of Windows Terminal and it only applies to applications launched from within it.</value>
+    <value>This changes the way incoming text is grouped into cells. The "Grapheme clusters" option is the most modern and Unicode-correct way to do so, while "wcswidth" is a common approach on UNIX, and "Windows Console" replicates the way it used to work on Windows. Changing this setting requires a restart of Intelligent Terminal and it only applies to applications launched from within it.</value>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>Grapheme clusters</value>
@@ -376,7 +376,7 @@
     <comment>A label for a drop down selector, referring to the East Asian Ambiguous Width Unicode specification.</comment>
   </data>
   <data name="Globals_AmbiguousWidth.HelpText" xml:space="preserve">
-    <value>Sets the width used for East Asian Ambiguous characters. "Narrow" (default) prioritizes compatibility, while "Wide" prioritizes readability with many CJK fonts. In "Wide" mode, some applications may not work correctly and cause erratic cursor movement. Changing this setting requires a restart of Windows Terminal and it only applies to applications launched from within it.</value>
+    <value>Sets the width used for East Asian Ambiguous characters. "Narrow" (default) prioritizes compatibility, while "Wide" prioritizes readability with many CJK fonts. In "Wide" mode, some applications may not work correctly and cause erratic cursor movement. Changing this setting requires a restart of Intelligent Terminal and it only applies to applications launched from within it.</value>
   </data>
   <data name="Globals_AmbiguousWidth_Narrow.Text" xml:space="preserve">
     <value>Narrow</value>
@@ -574,8 +574,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>Allow Windows Terminal to run in the background</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <value>Allow Intelligent Terminal to run in the background</value>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>Enable debugging features</value>
@@ -2334,7 +2334,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Windows Terminal is running in portable mode.</value>
+    <value>Intelligent Terminal is running in portable mode.</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
@@ -2693,7 +2693,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>Display a shield in the title bar when Windows Terminal is running as Administrator</value>
+    <value>Display a shield in the title bar when Intelligent Terminal is running as Administrator</value>
     <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -2335,7 +2335,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
     <value>Intelligent Terminal is running in portable mode.</value>
-    <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
+    <comment>A disclaimer that indicates that Intelligent Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
     <value>https://aka.ms/intelligentterminal/portable-mode</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -318,7 +318,7 @@
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
     <value>Aplicación de terminal que se inicia cuando se ejecuta una aplicación de línea de comandos sin una sesión existente, como en el menú Inicio o en el cuadro de diálogo Ejecutar.</value>
-    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
+    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Intelligent Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
     <value>API de gráficos</value>
@@ -358,7 +358,7 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>Esto cambia la forma en que el texto entrante se agrupa en celdas. La opción "Grapheme clusters" es la forma más moderna y correcta de hacerlo, mientras que "wcswidth" es un enfoque común en UNIX y "Consola de Windows" replica la forma en que se utiliza para trabajar en Windows. Para cambiar esta configuración, es necesario reiniciar Terminal Windows y solo se aplica a las aplicaciones iniciadas desde ella.</value>
+    <value>Esto cambia la forma en que el texto entrante se agrupa en celdas. La opción "Grapheme clusters" es la forma más moderna y correcta de hacerlo, mientras que "wcswidth" es un enfoque común en UNIX y "Consola de Windows" replica la forma en que se utiliza para trabajar en Windows. Para cambiar esta configuración, es necesario reiniciar Terminal Inteligente y solo se aplica a las aplicaciones iniciadas desde ella.</value>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>Clústeres de Grapheme</value>
@@ -376,7 +376,7 @@
     <comment>A label for a drop down selector, referring to the East Asian Ambiguous Width Unicode specification.</comment>
   </data>
   <data name="Globals_AmbiguousWidth.HelpText" xml:space="preserve">
-    <value>Establece el ancho usado para los caracteres ambiguos de Asia Oriental. "Estrecho" (valor predeterminado) da prioridad a la compatibilidad, mientras que "Ancho" da prioridad a la legibilidad con muchas fuentes CJK. En el modo "Ancho", es posible que algunas aplicaciones no funcionen correctamente y provoquen un movimiento errático del cursor. Cambiar esta configuración requiere un reinicio de Terminal Windows y solo se aplica a las aplicaciones que se inician desde dentro de ella.</value>
+    <value>Establece el ancho usado para los caracteres ambiguos de Asia Oriental. "Estrecho" (valor predeterminado) da prioridad a la compatibilidad, mientras que "Ancho" da prioridad a la legibilidad con muchas fuentes CJK. En el modo "Ancho", es posible que algunas aplicaciones no funcionen correctamente y provoquen un movimiento errático del cursor. Cambiar esta configuración requiere un reinicio de Terminal Inteligente y solo se aplica a las aplicaciones que se inician desde dentro de ella.</value>
   </data>
   <data name="Globals_AmbiguousWidth_Narrow.Text" xml:space="preserve">
     <value>Estrecho</value>
@@ -574,8 +574,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>Permitir que Terminal Windows se ejecuten en segundo plano</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <value>Permitir que Terminal Inteligente se ejecuten en segundo plano</value>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>Habilitar características de depuración</value>
@@ -896,7 +896,7 @@
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
     <value>Automático</value>
-    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
+    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Intelligent Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>Combinación de colores</value>
@@ -2223,7 +2223,7 @@
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Terminal Windows se ejecuta en modo portátil.</value>
+    <value>Terminal Inteligente se ejecuta en modo portátil.</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">
@@ -2578,7 +2578,7 @@
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>Mostrar un escudo en la barra de título cuando Terminal Windows se ejecute como administrador</value>
+    <value>Mostrar un escudo en la barra de título cuando Terminal Inteligente se ejecute como administrador</value>
     <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -318,7 +318,7 @@
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
     <value>L’application Terminal qui se lance lorsqu’une application de ligne de commande est exécutée sans session existante, par exemple à partir du menu Démarrer ou de la boîte de dialogue Exécuter.</value>
-    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
+    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Intelligent Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
     <value>Graphics API</value>
@@ -358,7 +358,7 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>Cela modifie la façon dont le texte entrant est regroupé en cellules. L'option « Clusters de graphèmes » est la méthode la plus moderne et la plus conforme à Unicode, tandis que « wcswidth » est une approche courante sous UNIX et la « Console Windows » reproduit la manière dont cela fonctionnait sous Windows. La modification de ce paramètre nécessite le redémarrage du Terminal Windows et ne s'applique qu'aux applications lancées à partir de celui-ci.</value>
+    <value>Cela modifie la façon dont le texte entrant est regroupé en cellules. L'option « Clusters de graphèmes » est la méthode la plus moderne et la plus conforme à Unicode, tandis que « wcswidth » est une approche courante sous UNIX et la « Console Windows » reproduit la manière dont cela fonctionnait sous Windows. La modification de ce paramètre nécessite le redémarrage du Terminal Intelligent et ne s'applique qu'aux applications lancées à partir de celui-ci.</value>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>Clusters de graphèmes</value>
@@ -376,7 +376,7 @@
     <comment>A label for a drop down selector, referring to the East Asian Ambiguous Width Unicode specification.</comment>
   </data>
   <data name="Globals_AmbiguousWidth.HelpText" xml:space="preserve">
-    <value>Définit la largeur utilisée pour les caractères ambigus d’Asie de l’Est. « Narrow » (par défaut) privilégie la compatibilité, tandis que « Wide » favorise la lisibilité avec de nombreuses polices CJK. En mode « Wide », certaines applications peuvent ne pas fonctionner correctement et provoquer un déplacement erratique du curseur. La modification de ce paramètre nécessite le redémarrage du Terminal Windows et ne s’applique qu’aux applications lancées à partir de celui-ci.</value>
+    <value>Définit la largeur utilisée pour les caractères ambigus d’Asie de l’Est. « Narrow » (par défaut) privilégie la compatibilité, tandis que « Wide » favorise la lisibilité avec de nombreuses polices CJK. En mode « Wide », certaines applications peuvent ne pas fonctionner correctement et provoquer un déplacement erratique du curseur. La modification de ce paramètre nécessite le redémarrage du Terminal Intelligent et ne s’applique qu’aux applications lancées à partir de celui-ci.</value>
   </data>
   <data name="Globals_AmbiguousWidth_Narrow.Text" xml:space="preserve">
     <value>Étroites</value>
@@ -574,8 +574,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>Autoriser Terminal Windows à s’exécuter en arrière-plan</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <value>Autoriser Terminal Intelligent à s’exécuter en arrière-plan</value>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>Activer les fonctionnalités de débogage</value>
@@ -896,7 +896,7 @@
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
     <value>Automatique</value>
-    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
+    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Intelligent Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>Jeu de couleurs</value>
@@ -2223,7 +2223,7 @@
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Terminal Windows s’exécute en mode portable.</value>
+    <value>Terminal Intelligent s’exécute en mode portable.</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">
@@ -2578,7 +2578,7 @@
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>Afficher un bouclier dans la barre de titre lorsque Terminal Windows s’exécute en tant qu’administrateur</value>
+    <value>Afficher un bouclier dans la barre de titre lorsque Terminal Intelligent s’exécute en tant qu’administrateur</value>
     <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -318,7 +318,7 @@
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
     <value>L'applicazione terminale che viene avviata quando viene eseguita un'applicazione della riga di comando senza una sessione esistente, ad esempio dalla finestra di dialogo menu Start o Esegui.</value>
-    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
+    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Intelligent Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
     <value>API grafica</value>
@@ -358,7 +358,7 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>Cambia il modo in cui il testo in arrivo viene raggruppato in celle. L'opzione "Cluster Grapheme" è il modo più moderno e corretto per Unicode, mentre "wcswidth" è un approccio comune su UNIX e "Console di Windows" replica il modo in cui funzionava in Windows. La modifica di questa impostazione richiede il riavvio di Terminale Windows e si applica solo alle applicazioni avviate da essa.</value>
+    <value>Cambia il modo in cui il testo in arrivo viene raggruppato in celle. L'opzione "Cluster Grapheme" è il modo più moderno e corretto per Unicode, mentre "wcswidth" è un approccio comune su UNIX e "Console di Windows" replica il modo in cui funzionava in Windows. La modifica di questa impostazione richiede il riavvio di Terminale Intelligente e si applica solo alle applicazioni avviate da essa.</value>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>Cluster grapheme</value>
@@ -376,7 +376,7 @@
     <comment>A label for a drop down selector, referring to the East Asian Ambiguous Width Unicode specification.</comment>
   </data>
   <data name="Globals_AmbiguousWidth.HelpText" xml:space="preserve">
-    <value>Imposta la larghezza usata per i caratteri ambigui dell'Asia orientale. "Narrow" (impostazione predefinita) privilegia la compatibilità, mentre "Wide" privilegia la leggibilità con molti tipi di carattere CJK. In modalità "Wide", alcune applicazioni potrebbero non funzionare correttamente e causare movimenti irregolari del cursore. Per applicare questa modifica è necessario riavviare Terminale Windows e si applica solo alle applicazioni avviate all'interno.</value>
+    <value>Imposta la larghezza usata per i caratteri ambigui dell'Asia orientale. "Narrow" (impostazione predefinita) privilegia la compatibilità, mentre "Wide" privilegia la leggibilità con molti tipi di carattere CJK. In modalità "Wide", alcune applicazioni potrebbero non funzionare correttamente e causare movimenti irregolari del cursore. Per applicare questa modifica è necessario riavviare Terminale Intelligente e si applica solo alle applicazioni avviate all'interno.</value>
   </data>
   <data name="Globals_AmbiguousWidth_Narrow.Text" xml:space="preserve">
     <value>Stretti</value>
@@ -574,8 +574,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>Consenti l'esecuzione di Terminale Windows in background</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <value>Consenti l'esecuzione di Terminale Intelligente in background</value>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>Abilita funzionalità di debug</value>
@@ -896,7 +896,7 @@
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
     <value>Automatico</value>
-    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
+    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Intelligent Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>Combinazione colori</value>
@@ -2223,7 +2223,7 @@
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Terminale Windows è in esecuzione in modalità portatile.</value>
+    <value>Terminale Intelligente è in esecuzione in modalità portatile.</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">
@@ -2578,7 +2578,7 @@
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>Visualizza uno scudo nella barra del titolo quando Terminale Windows viene eseguito come amministratore</value>
+    <value>Visualizza uno scudo nella barra del titolo quando Terminale Intelligente viene eseguito come amministratore</value>
     <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -318,7 +318,7 @@
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
     <value>[スタート] メニューや [ファイル名を指定して実行] ダイアログなど、既存のセッションなしでコマンドライン アプリケーションを実行したときに起動するターミナル アプリケーション。</value>
-    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
+    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Intelligent Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
     <value>グラフィックス API</value>
@@ -358,7 +358,7 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>入力したテキストをセルにグループ化する方法を変更します。"Grapheme clusters" オプションは最も新しく Unicode で正しい方法ですが、UNIX では "wcswidth" は一般的な方法であり、"Windows コンソール" は Windows での動作方法をレプリケートします。この設定を変更するには、Windows ターミナルの再起動が必要です。この設定は、その中から起動されたアプリケーションにのみ適用されます。</value>
+    <value>入力したテキストをセルにグループ化する方法を変更します。"Grapheme clusters" オプションは最も新しく Unicode で正しい方法ですが、UNIX では "wcswidth" は一般的な方法であり、"Windows コンソール" は Windows での動作方法をレプリケートします。この設定を変更するには、インテリジェント ターミナルの再起動が必要です。この設定は、その中から起動されたアプリケーションにのみ適用されます。</value>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>書記素クラスター</value>
@@ -376,7 +376,7 @@
     <comment>A label for a drop down selector, referring to the East Asian Ambiguous Width Unicode specification.</comment>
   </data>
   <data name="Globals_AmbiguousWidth.HelpText" xml:space="preserve">
-    <value>東アジアのあいまいな文字に使用する幅を設定します。[幅を狭くする] (既定) は互換性を優先し、[幅を広くする] は多くの CJK フォントでの読みやすさを優先します。[幅を広くする] モードでは、一部のアプリケーションが正しく動作せず、カーソルの動きが不安定になることがあります。この設定を変更するには、Windows ターミナルの再起動が必要で、Windows ターミナル内から起動したアプリケーションにのみ適用されます。</value>
+    <value>東アジアのあいまいな文字に使用する幅を設定します。[幅を狭くする] (既定) は互換性を優先し、[幅を広くする] は多くの CJK フォントでの読みやすさを優先します。[幅を広くする] モードでは、一部のアプリケーションが正しく動作せず、カーソルの動きが不安定になることがあります。この設定を変更するには、インテリジェント ターミナルの再起動が必要で、インテリジェント ターミナル内から起動したアプリケーションにのみ適用されます。</value>
   </data>
   <data name="Globals_AmbiguousWidth_Narrow.Text" xml:space="preserve">
     <value>狭い</value>
@@ -574,8 +574,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>Windows ターミナルのバックグラウンドでの実行を許可する</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <value>インテリジェント ターミナルのバックグラウンドでの実行を許可する</value>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>デバッグ機能を有効にする</value>
@@ -896,7 +896,7 @@
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
     <value>自動</value>
-    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
+    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Intelligent Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>配色</value>
@@ -2223,7 +2223,7 @@
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Windows ターミナルはポータブル モードで実行されています。</value>
+    <value>インテリジェント ターミナルはポータブル モードで実行されています。</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">
@@ -2578,7 +2578,7 @@
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>Windows ターミナルが管理者として実行されているときにタイトル バーにシールドを表示する</value>
+    <value>インテリジェント ターミナルが管理者として実行されているときにタイトル バーにシールドを表示する</value>
     <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -318,7 +318,7 @@
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
     <value>시작 메뉴나 실행 대화 상자와 같이 기존 세션이 없으면 명령 줄 응용 프로그램을 실행하고 있는 터미널 응용 프로그램입니다.</value>
-    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
+    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Intelligent Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
     <value>Graphics API</value>
@@ -358,7 +358,7 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>들어오는 텍스트가 셀로 그룹화되는 방식을 변경합니다. "Grapheme 클러스터" 옵션은 가장 최신이며 유니코드로 올바른 방법이며, "wcswidth"는 UNIX에서 일반적인 접근 방식이며 "Windows 콘솔"은 Windows에서 작동하는 방식을 복제합니다. 이 설정을 변경하려면 Windows 터미널 다시 시작해야 하며 이 설정 내에서 시작된 애플리케이션에만 적용됩니다.</value>
+    <value>들어오는 텍스트가 셀로 그룹화되는 방식을 변경합니다. "Grapheme 클러스터" 옵션은 가장 최신이며 유니코드로 올바른 방법이며, "wcswidth"는 UNIX에서 일반적인 접근 방식이며 "Windows 콘솔"은 Windows에서 작동하는 방식을 복제합니다. 이 설정을 변경하려면 지능형 터미널 다시 시작해야 하며 이 설정 내에서 시작된 애플리케이션에만 적용됩니다.</value>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>Grapheme 클러스터</value>
@@ -376,7 +376,7 @@
     <comment>A label for a drop down selector, referring to the East Asian Ambiguous Width Unicode specification.</comment>
   </data>
   <data name="Globals_AmbiguousWidth.HelpText" xml:space="preserve">
-    <value>동아시아의 모호한 문자에 사용되는 너비를 설정하세요. "좁게"(기본값)는 호환성을 우선시하고, "넓게"는 많은 CJK 글꼴에서 가독성을 우선시합니다. "넓게" 모드에서는 일부 애플리케이션이 제대로 작동하지 않아 커서가 이상하게 움직일 수 있습니다. 이 설정을 변경하려면 Windows 터미널을 다시 시작해야 하며, 이 설정은 Windows 터미널 내에서 실행된 애플리케이션에만 적용됩니다.</value>
+    <value>동아시아의 모호한 문자에 사용되는 너비를 설정하세요. "좁게"(기본값)는 호환성을 우선시하고, "넓게"는 많은 CJK 글꼴에서 가독성을 우선시합니다. "넓게" 모드에서는 일부 애플리케이션이 제대로 작동하지 않아 커서가 이상하게 움직일 수 있습니다. 이 설정을 변경하려면 지능형 터미널을 다시 시작해야 하며, 이 설정은 지능형 터미널 내에서 실행된 애플리케이션에만 적용됩니다.</value>
   </data>
   <data name="Globals_AmbiguousWidth_Narrow.Text" xml:space="preserve">
     <value>좁게</value>
@@ -574,8 +574,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>Windows 터미널 백그라운드에서 실행하도록 허용</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <value>지능형 터미널 백그라운드에서 실행하도록 허용</value>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>디버깅 기능 사용</value>
@@ -896,7 +896,7 @@
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
     <value>자동</value>
-    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
+    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Intelligent Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>색 구성표</value>
@@ -2223,7 +2223,7 @@
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Windows 터미널이 이식 가능 모드에서 실행되고 있습니다.</value>
+    <value>지능형 터미널이 이식 가능 모드에서 실행되고 있습니다.</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">
@@ -2578,7 +2578,7 @@
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>Windows 터미널 관리자 권한으로 실행 중일 때 제목 표시줄에 실드 표시</value>
+    <value>지능형 터미널 관리자 권한으로 실행 중일 때 제목 표시줄에 실드 표시</value>
     <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -318,7 +318,7 @@
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
     <value>O aplicativo de terminal que é iniciado quando um aplicativo de linha de comando é executado sem uma sessão existente, como no menu iniciar ou na caixa de diálogo Executar.</value>
-    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
+    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Intelligent Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
     <value>API de Gráficos</value>
@@ -358,7 +358,7 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>Isso altera a maneira como o texto de entrada é agrupado em células. A opção "Clusters do Grapheme" é a maneira mais moderna e correta de fazer isso, enquanto "wcswidth" é uma abordagem comum no UNIX e o "Console do Windows" replica a maneira como ele funciona no Windows. Alterar essa configuração requer uma reinicialização Terminal do Windows e aplica-se somente a aplicativos iniciados de dentro dela.</value>
+    <value>Isso altera a maneira como o texto de entrada é agrupado em células. A opção "Clusters do Grapheme" é a maneira mais moderna e correta de fazer isso, enquanto "wcswidth" é uma abordagem comum no UNIX e o "Console do Windows" replica a maneira como ele funciona no Windows. Alterar essa configuração requer uma reinicialização Terminal Inteligente e aplica-se somente a aplicativos iniciados de dentro dela.</value>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>Clusters do Grapheme</value>
@@ -376,7 +376,7 @@
     <comment>A label for a drop down selector, referring to the East Asian Ambiguous Width Unicode specification.</comment>
   </data>
   <data name="Globals_AmbiguousWidth.HelpText" xml:space="preserve">
-    <value>Define a largura usada para caracteres ambíguos do Leste Asiático. "Estreito" (padrão) prioriza a compatibilidade, enquanto "Amplo" prioriza a legibilidade com muitas fontes CJK. No modo "Amplo", alguns aplicativos podem não funcionar corretamente e provocar movimento irregular do cursor. Alterar essa configuração exige reiniciar o Terminal do Windows e vale só para aplicativos iniciados dentro dele.</value>
+    <value>Define a largura usada para caracteres ambíguos do Leste Asiático. "Estreito" (padrão) prioriza a compatibilidade, enquanto "Amplo" prioriza a legibilidade com muitas fontes CJK. No modo "Amplo", alguns aplicativos podem não funcionar corretamente e provocar movimento irregular do cursor. Alterar essa configuração exige reiniciar o Terminal Inteligente e vale só para aplicativos iniciados dentro dele.</value>
   </data>
   <data name="Globals_AmbiguousWidth_Narrow.Text" xml:space="preserve">
     <value>Estreita</value>
@@ -574,8 +574,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>Permitir Terminal do Windows ser executado em segundo plano</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <value>Permitir Terminal Inteligente ser executado em segundo plano</value>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>Habilitar recursos de depuração</value>
@@ -896,7 +896,7 @@
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
     <value>Automático</value>
-    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
+    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Intelligent Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>Esquema de cores</value>
@@ -2223,7 +2223,7 @@
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>O terminal do Windows está em execução no modo portátil.</value>
+    <value>O Terminal Inteligente está em execução no modo portátil.</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">
@@ -2578,7 +2578,7 @@
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>Exibir um escudo na barra de título quando o Terminal do Windows estiver sendo executado como Administrador</value>
+    <value>Exibir um escudo na barra de título quando o Terminal Inteligente estiver sendo executado como Administrador</value>
     <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -318,7 +318,7 @@
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
     <value>Ťђě ţэřмīηãĺ ǻφφℓï¢ǻтΐбň ŧђáт łáůйčĥēś ẅĥэп ā сöмmǻńđ-ľіŉэ ăρρĺįċāτΐôⁿ ϊš яųñ шíţћöυţ ªņ ĕхϊŝŧĭñğ şěŝѕïŏπ, ŀĩĸė ƒѓом ţћĕ Ŝτáґт Μęπü бг Яųņ ďīäℓöğ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
+    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Intelligent Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
     <value>Ĝŗäрђΐсѕ ÃРΪ !!! </value>
@@ -575,7 +575,7 @@
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
     <value>Ǻℓĺŏщ Ẁιйđòώѕ Тёŗмїⁿàļ тǿ řϋŋ ϊň тђě ьąςќġѓőůήď !!! !!! !!! !!! !!</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>Єлάвĺé ðèъûġğįñģ ƒέàŧµřэš !!! !!! !</value>
@@ -896,7 +896,7 @@
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
     <value>Ãµťøмäтïč !!!</value>
-    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
+    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Intelligent Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>Çŏłőг ŝćнĕмε !!! </value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -358,7 +358,8 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>Тђíš ċћǻήğэś ťћз ŵàγ ΐń¢ŏmίлġ ŧę×ţ īŝ ģгõųрέď ìŉтб çзŀľś. Ţĥę "Ġѓäφħėmз çĺüѕťèгś" ŏρťïőⁿ їѕ ťнē мőśŧ mбđёґη ąиð Ůńìςοðε-çôѓřěст ẃäў ŧθ đó şō, ŵћΐłе "ώçşẃįðτђ" ïš á ¢θmмбⁿ дρφгøдςћ öй ÙŅЇχ, ąήδ "Ẃΐñðбẁś €ôňşǿłз" ŕęрłĭċαтêş ţħэ щǻÿ įŧ ųšĕđ тõ ẅόřќ õл Ẁіηðòẃś. Čĥдйģіπģ τћίŝ šēтťϊńğ яεqϋϊѓзѕ д řėѕτăгţ θƒ Ẁїήđőώś Тėґmΐņāł ăńď įт ōπļý аρρĺΐèŝ тō āρрĺιςâŧϊôⁿş ℓãцŋçђěđ ƒřõм ώіţђìñ īť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Тђíš ċћǻήğэś ťћз ŵàγ ΐń¢ŏmίлġ ŧę×ţ īŝ ģгõųрέď ìŉтб çзŀľś. Ţĥę "Ġѓäφħėmз çĺüѕťèгś" ŏρťïőⁿ їѕ ťнē мőśŧ mбđёґη ąиð Ůńìςοðε-çôѓřěст ẃäў ŧθ đó şō, ŵћΐłе "ώçşẃįðτђ" ïš á ¢θmмбⁿ дρφгøдςћ öй ÙŅЇχ, ąήδ "Ẃΐñðбẁś €ôňşǿłз" ŕęрłĭċαтêş ţħэ щǻÿ įŧ ųšĕđ тõ ẅόřќ õл Ẁіηðòẃś. Čĥдйģіπģ τћίŝ šēтťϊńğ яεqϋϊѓзѕ д řėѕτăгţ θƒ Intelligent Terminal ăńď įт ōπļý аρρĺΐèŝ тō āρрĺιςâŧϊôⁿş ℓãцŋçђěđ ƒřõм ώіţђìñ īť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>Ġядφђêmé ¢łµѕţ℮ŗѕ !!! !!</value>
@@ -376,7 +377,8 @@
     <comment>A label for a drop down selector, referring to the East Asian Ambiguous Width Unicode specification.</comment>
   </data>
   <data name="Globals_AmbiguousWidth.HelpText" xml:space="preserve">
-    <value>Šеŧѕ тĥé ẃίďтн цšеď ƒθŕ Ёāѕť Дѕїāπ Δmъìĝůόųş ¢ĥǻŕǻćτєŗş. "Νǻяѓòш" (đéƒåųĺţ) ρґΐõѓіŧīźéѕ ċǿmραťĭвĭľΐτŷ, ẃђίļė "Ẁîδ℮" рŕīόŕïтϊźĕş гèáðàвіℓīτў ẁìτн мâйý ČЈК ƒблťś. Ĩл "Шϊďε" mőδє, şõmе áρφļĭĉªτιόņś мąу ⁿõт ẃóѓк çθřŕзçτłў αŋδ čäűѕє ℮ŗѓāŧíć ςŭѓşοґ mòνėmĕŋť. Ċђªŋĝϊйġ тнϊş śэттĩņģ ŕêqůįŗëš å ř℮ŝţâгŧ ōƒ Ẁίήďôωş Ţёŕмĭиàĺ ąηδ îт öŉłý ãφрŀįέѕ τő ąρрļĭсатįŏлŝ ℓаϋⁿćћ℮ð ƒřом шìтħїή îť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Šеŧѕ тĥé ẃίďтн цšеď ƒθŕ Ёāѕť Дѕїāπ Δmъìĝůόųş ¢ĥǻŕǻćτєŗş. "Νǻяѓòш" (đéƒåųĺţ) ρґΐõѓіŧīźéѕ ċǿmραťĭвĭľΐτŷ, ẃђίļė "Ẁîδ℮" рŕīόŕïтϊźĕş гèáðàвіℓīτў ẁìτн мâйý ČЈК ƒблťś. Ĩл "Шϊďε" mőδє, şõmе áρφļĭĉªτιόņś мąу ⁿõт ẃóѓк çθřŕзçτłў αŋδ čäűѕє ℮ŗѓāŧíć ςŭѓşοґ mòνėmĕŋť. Ċђªŋĝϊйġ тнϊş śэттĩņģ ŕêqůįŗëš å ř℮ŝţâгŧ ōƒ Intelligent Terminal ąηδ îт öŉłý ãφрŀįέѕ τő ąρрļĭсатįŏлŝ ℓаϋⁿćћ℮ð ƒřом шìтħїή îť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
   <data name="Globals_AmbiguousWidth_Narrow.Text" xml:space="preserve">
     <value>Ŋǻŕґŏш !</value>
@@ -574,8 +576,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>Ǻℓĺŏщ Ẁιйđòώѕ Тёŗмїⁿàļ тǿ řϋŋ ϊň тђě ьąςќġѓőůήď !!! !!! !!! !!! !!</value>
-    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
+    <value>Ǻℓĺŏщ Intelligent Terminal тǿ řϋŋ ϊň тђě ьąςќġѓőůήď !!! !!! !!! !!! !!</value>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background. {Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>Єлάвĺé ðèъûġğįñģ ƒέàŧµřэš !!! !!! !</value>
@@ -2223,8 +2225,8 @@
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Ẅїηðσшѕ Ţеřmíńăľ īѕ ґϋййïŉģ ĭņ рόѓťáъℓė mōďе. !!! !!! !!! !!! !</value>
-    <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
+    <value>Intelligent Terminal īѕ ґϋййïŉģ ĭņ рόѓťáъℓė mōďе. !!! !!! !!! !!! !</value>
+    <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder. {Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
     <value>https://aka.ms/intelligentterminal/portable-mode</value>
@@ -2582,8 +2584,8 @@
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>Đįŝрļãу ã ŝħĭěļð ίπ ŧђê ţîťłë ъãѓ щћэπ Ẅīήđθщş Ţĕřмïńāľ ίѕ ŕůπŉïηģ åš Àδмιήίŝтяàтοґ !!! !!! !!! !!! !!! !!! !!! !!! </value>
-    <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
+    <value>Đįŝрļãу ã ŝħĭěļð ίπ ŧђê ţîťłë ъãѓ щћэπ Intelligent Terminal ίѕ ŕůπŉïηģ åš Àδмιήίŝтяàтοґ !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin" {Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">
     <value>Şĥбω ťãьŝ іή ƒūļℓ šĉґééл !!! !!! !</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -318,7 +318,7 @@
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
     <value>Ťђě ţэřмīηãĺ ǻφφℓï¢ǻтΐбň ŧђáт łáůйčĥēś ẅĥэп ā сöмmǻńđ-ľіŉэ ăρρĺįċāτΐôⁿ ϊš яųñ шíţћöυţ ªņ ĕхϊŝŧĭñğ şěŝѕïŏπ, ŀĩĸė ƒѓом ţћĕ Ŝτáґт Μęπü бг Яųņ ďīäℓöğ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
+    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Intelligent Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
     <value>Ĝŗäрђΐсѕ ÃРΪ !!! </value>
@@ -575,7 +575,7 @@
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
     <value>Ǻℓĺŏщ Ẁιйđòώѕ Тёŗмїⁿàļ тǿ řϋŋ ϊň тђě ьąςќġѓőůήď !!! !!! !!! !!! !!</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>Єлάвĺé ðèъûġğįñģ ƒέàŧµřэš !!! !!! !</value>
@@ -896,7 +896,7 @@
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
     <value>Ãµťøмäтïč !!!</value>
-    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
+    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Intelligent Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>Çŏłőг ŝćнĕмε !!! </value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -358,7 +358,8 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>Тђíš ċћǻήğэś ťћз ŵàγ ΐń¢ŏmίлġ ŧę×ţ īŝ ģгõųрέď ìŉтб çзŀľś. Ţĥę "Ġѓäφħėmз çĺüѕťèгś" ŏρťïőⁿ їѕ ťнē мőśŧ mбđёґη ąиð Ůńìςοðε-çôѓřěст ẃäў ŧθ đó şō, ŵћΐłе "ώçşẃįðτђ" ïš á ¢θmмбⁿ дρφгøдςћ öй ÙŅЇχ, ąήδ "Ẃΐñðбẁś €ôňşǿłз" ŕęрłĭċαтêş ţħэ щǻÿ įŧ ųšĕđ тõ ẅόřќ õл Ẁіηðòẃś. Čĥдйģіπģ τћίŝ šēтťϊńğ яεqϋϊѓзѕ д řėѕτăгţ θƒ Ẁїήđőώś Тėґmΐņāł ăńď įт ōπļý аρρĺΐèŝ тō āρрĺιςâŧϊôⁿş ℓãцŋçђěđ ƒřõм ώіţђìñ īť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Тђíš ċћǻήğэś ťћз ŵàγ ΐń¢ŏmίлġ ŧę×ţ īŝ ģгõųрέď ìŉтб çзŀľś. Ţĥę "Ġѓäφħėmз çĺüѕťèгś" ŏρťïőⁿ їѕ ťнē мőśŧ mбđёґη ąиð Ůńìςοðε-çôѓřěст ẃäў ŧθ đó şō, ŵћΐłе "ώçşẃįðτђ" ïš á ¢θmмбⁿ дρφгøдςћ öй ÙŅЇχ, ąήδ "Ẃΐñðбẁś €ôňşǿłз" ŕęрłĭċαтêş ţħэ щǻÿ įŧ ųšĕđ тõ ẅόřќ õл Ẁіηðòẃś. Čĥдйģіπģ τћίŝ šēтťϊńğ яεqϋϊѓзѕ д řėѕτăгţ θƒ Intelligent Terminal ăńď įт ōπļý аρρĺΐèŝ тō āρрĺιςâŧϊôⁿş ℓãцŋçђěđ ƒřõм ώіţђìñ īť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>Ġядφђêmé ¢łµѕţ℮ŗѕ !!! !!</value>
@@ -376,7 +377,8 @@
     <comment>A label for a drop down selector, referring to the East Asian Ambiguous Width Unicode specification.</comment>
   </data>
   <data name="Globals_AmbiguousWidth.HelpText" xml:space="preserve">
-    <value>Šеŧѕ тĥé ẃίďтн цšеď ƒθŕ Ёāѕť Дѕїāπ Δmъìĝůόųş ¢ĥǻŕǻćτєŗş. "Νǻяѓòш" (đéƒåųĺţ) ρґΐõѓіŧīźéѕ ċǿmραťĭвĭľΐτŷ, ẃђίļė "Ẁîδ℮" рŕīόŕïтϊźĕş гèáðàвіℓīτў ẁìτн мâйý ČЈК ƒблťś. Ĩл "Шϊďε" mőδє, şõmе áρφļĭĉªτιόņś мąу ⁿõт ẃóѓк çθřŕзçτłў αŋδ čäűѕє ℮ŗѓāŧíć ςŭѓşοґ mòνėmĕŋť. Ċђªŋĝϊйġ тнϊş śэттĩņģ ŕêqůįŗëš å ř℮ŝţâгŧ ōƒ Ẁίήďôωş Ţёŕмĭиàĺ ąηδ îт öŉłý ãφрŀįέѕ τő ąρрļĭсатįŏлŝ ℓаϋⁿćћ℮ð ƒřом шìтħїή îť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Šеŧѕ тĥé ẃίďтн цšеď ƒθŕ Ёāѕť Дѕїāπ Δmъìĝůόųş ¢ĥǻŕǻćτєŗş. "Νǻяѓòш" (đéƒåųĺţ) ρґΐõѓіŧīźéѕ ċǿmραťĭвĭľΐτŷ, ẃђίļė "Ẁîδ℮" рŕīόŕïтϊźĕş гèáðàвіℓīτў ẁìτн мâйý ČЈК ƒблťś. Ĩл "Шϊďε" mőδє, şõmе áρφļĭĉªτιόņś мąу ⁿõт ẃóѓк çθřŕзçτłў αŋδ čäűѕє ℮ŗѓāŧíć ςŭѓşοґ mòνėmĕŋť. Ċђªŋĝϊйġ тнϊş śэттĩņģ ŕêqůįŗëš å ř℮ŝţâгŧ ōƒ Intelligent Terminal ąηδ îт öŉłý ãφрŀįέѕ τő ąρрļĭсатįŏлŝ ℓаϋⁿćћ℮ð ƒřом шìтħїή îť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
   <data name="Globals_AmbiguousWidth_Narrow.Text" xml:space="preserve">
     <value>Ŋǻŕґŏш !</value>
@@ -574,8 +576,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>Ǻℓĺŏщ Ẁιйđòώѕ Тёŗмїⁿàļ тǿ řϋŋ ϊň тђě ьąςќġѓőůήď !!! !!! !!! !!! !!</value>
-    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
+    <value>Ǻℓĺŏщ Intelligent Terminal тǿ řϋŋ ϊň тђě ьąςќġѓőůήď !!! !!! !!! !!! !!</value>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background. {Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>Єлάвĺé ðèъûġğįñģ ƒέàŧµřэš !!! !!! !</value>
@@ -2223,8 +2225,8 @@
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Ẅїηðσшѕ Ţеřmíńăľ īѕ ґϋййïŉģ ĭņ рόѓťáъℓė mōďе. !!! !!! !!! !!! !</value>
-    <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
+    <value>Intelligent Terminal īѕ ґϋййïŉģ ĭņ рόѓťáъℓė mōďе. !!! !!! !!! !!! !</value>
+    <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder. {Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
     <value>https://aka.ms/intelligentterminal/portable-mode</value>
@@ -2582,8 +2584,8 @@
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>Đįŝрļãу ã ŝħĭěļð ίπ ŧђê ţîťłë ъãѓ щћэπ Ẅīήđθщş Ţĕřмïńāľ ίѕ ŕůπŉïηģ åš Àδмιήίŝтяàтοґ !!! !!! !!! !!! !!! !!! !!! !!! </value>
-    <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
+    <value>Đįŝрļãу ã ŝħĭěļð ίπ ŧђê ţîťłë ъãѓ щћэπ Intelligent Terminal ίѕ ŕůπŉïηģ åš Àδмιήίŝтяàтοґ !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin" {Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">
     <value>Şĥбω ťãьŝ іή ƒūļℓ šĉґééл !!! !!! !</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -318,7 +318,7 @@
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
     <value>Ťђě ţэřмīηãĺ ǻφφℓï¢ǻтΐбň ŧђáт łáůйčĥēś ẅĥэп ā сöмmǻńđ-ľіŉэ ăρρĺįċāτΐôⁿ ϊš яųñ шíţћöυţ ªņ ĕхϊŝŧĭñğ şěŝѕïŏπ, ŀĩĸė ƒѓом ţћĕ Ŝτáґт Μęπü бг Яųņ ďīäℓöğ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
+    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Intelligent Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
     <value>Ĝŗäрђΐсѕ ÃРΪ !!! </value>
@@ -575,7 +575,7 @@
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
     <value>Ǻℓĺŏщ Ẁιйđòώѕ Тёŗмїⁿàļ тǿ řϋŋ ϊň тђě ьąςќġѓőůήď !!! !!! !!! !!! !!</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>Єлάвĺé ðèъûġğįñģ ƒέàŧµřэš !!! !!! !</value>
@@ -896,7 +896,7 @@
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
     <value>Ãµťøмäтïč !!!</value>
-    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
+    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Intelligent Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>Çŏłőг ŝćнĕмε !!! </value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -358,7 +358,8 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>Тђíš ċћǻήğэś ťћз ŵàγ ΐń¢ŏmίлġ ŧę×ţ īŝ ģгõųрέď ìŉтб çзŀľś. Ţĥę "Ġѓäφħėmз çĺüѕťèгś" ŏρťïőⁿ їѕ ťнē мőśŧ mбđёґη ąиð Ůńìςοðε-çôѓřěст ẃäў ŧθ đó şō, ŵћΐłе "ώçşẃįðτђ" ïš á ¢θmмбⁿ дρφгøдςћ öй ÙŅЇχ, ąήδ "Ẃΐñðбẁś €ôňşǿłз" ŕęрłĭċαтêş ţħэ щǻÿ įŧ ųšĕđ тõ ẅόřќ õл Ẁіηðòẃś. Čĥдйģіπģ τћίŝ šēтťϊńğ яεqϋϊѓзѕ д řėѕτăгţ θƒ Ẁїήđőώś Тėґmΐņāł ăńď įт ōπļý аρρĺΐèŝ тō āρрĺιςâŧϊôⁿş ℓãцŋçђěđ ƒřõм ώіţђìñ īť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Тђíš ċћǻήğэś ťћз ŵàγ ΐń¢ŏmίлġ ŧę×ţ īŝ ģгõųрέď ìŉтб çзŀľś. Ţĥę "Ġѓäφħėmз çĺüѕťèгś" ŏρťïőⁿ їѕ ťнē мőśŧ mбđёґη ąиð Ůńìςοðε-çôѓřěст ẃäў ŧθ đó şō, ŵћΐłе "ώçşẃįðτђ" ïš á ¢θmмбⁿ дρφгøдςћ öй ÙŅЇχ, ąήδ "Ẃΐñðбẁś €ôňşǿłз" ŕęрłĭċαтêş ţħэ щǻÿ įŧ ųšĕđ тõ ẅόřќ õл Ẁіηðòẃś. Čĥдйģіπģ τћίŝ šēтťϊńğ яεqϋϊѓзѕ д řėѕτăгţ θƒ Intelligent Terminal ăńď įт ōπļý аρρĺΐèŝ тō āρрĺιςâŧϊôⁿş ℓãцŋçђěđ ƒřõм ώіţђìñ īť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>Ġядφђêmé ¢łµѕţ℮ŗѕ !!! !!</value>
@@ -376,7 +377,8 @@
     <comment>A label for a drop down selector, referring to the East Asian Ambiguous Width Unicode specification.</comment>
   </data>
   <data name="Globals_AmbiguousWidth.HelpText" xml:space="preserve">
-    <value>Šеŧѕ тĥé ẃίďтн цšеď ƒθŕ Ёāѕť Дѕїāπ Δmъìĝůόųş ¢ĥǻŕǻćτєŗş. "Νǻяѓòш" (đéƒåųĺţ) ρґΐõѓіŧīźéѕ ċǿmραťĭвĭľΐτŷ, ẃђίļė "Ẁîδ℮" рŕīόŕïтϊźĕş гèáðàвіℓīτў ẁìτн мâйý ČЈК ƒблťś. Ĩл "Шϊďε" mőδє, şõmе áρφļĭĉªτιόņś мąу ⁿõт ẃóѓк çθřŕзçτłў αŋδ čäűѕє ℮ŗѓāŧíć ςŭѓşοґ mòνėmĕŋť. Ċђªŋĝϊйġ тнϊş śэттĩņģ ŕêqůįŗëš å ř℮ŝţâгŧ ōƒ Ẁίήďôωş Ţёŕмĭиàĺ ąηδ îт öŉłý ãφрŀįέѕ τő ąρрļĭсатįŏлŝ ℓаϋⁿćћ℮ð ƒřом шìтħїή îť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Šеŧѕ тĥé ẃίďтн цšеď ƒθŕ Ёāѕť Дѕїāπ Δmъìĝůόųş ¢ĥǻŕǻćτєŗş. "Νǻяѓòш" (đéƒåųĺţ) ρґΐõѓіŧīźéѕ ċǿmραťĭвĭľΐτŷ, ẃђίļė "Ẁîδ℮" рŕīόŕïтϊźĕş гèáðàвіℓīτў ẁìτн мâйý ČЈК ƒблťś. Ĩл "Шϊďε" mőδє, şõmе áρφļĭĉªτιόņś мąу ⁿõт ẃóѓк çθřŕзçτłў αŋδ čäűѕє ℮ŗѓāŧíć ςŭѓşοґ mòνėmĕŋť. Ċђªŋĝϊйġ тнϊş śэттĩņģ ŕêqůįŗëš å ř℮ŝţâгŧ ōƒ Intelligent Terminal ąηδ îт öŉłý ãφрŀįέѕ τő ąρрļĭсатįŏлŝ ℓаϋⁿćћ℮ð ƒřом шìтħїή îť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
   <data name="Globals_AmbiguousWidth_Narrow.Text" xml:space="preserve">
     <value>Ŋǻŕґŏш !</value>
@@ -574,8 +576,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>Ǻℓĺŏщ Ẁιйđòώѕ Тёŗмїⁿàļ тǿ řϋŋ ϊň тђě ьąςќġѓőůήď !!! !!! !!! !!! !!</value>
-    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
+    <value>Ǻℓĺŏщ Intelligent Terminal тǿ řϋŋ ϊň тђě ьąςќġѓőůήď !!! !!! !!! !!! !!</value>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background. {Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>Єлάвĺé ðèъûġğįñģ ƒέàŧµřэš !!! !!! !</value>
@@ -2223,8 +2225,8 @@
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Ẅїηðσшѕ Ţеřmíńăľ īѕ ґϋййïŉģ ĭņ рόѓťáъℓė mōďе. !!! !!! !!! !!! !</value>
-    <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
+    <value>Intelligent Terminal īѕ ґϋййïŉģ ĭņ рόѓťáъℓė mōďе. !!! !!! !!! !!! !</value>
+    <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder. {Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
     <value>https://aka.ms/intelligentterminal/portable-mode</value>
@@ -2582,8 +2584,8 @@
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>Đįŝрļãу ã ŝħĭěļð ίπ ŧђê ţîťłë ъãѓ щћэπ Ẅīήđθщş Ţĕřмïńāľ ίѕ ŕůπŉïηģ åš Àδмιήίŝтяàтοґ !!! !!! !!! !!! !!! !!! !!! !!! </value>
-    <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
+    <value>Đįŝрļãу ã ŝħĭěļð ίπ ŧђê ţîťłë ъãѓ щћэπ Intelligent Terminal ίѕ ŕůπŉïηģ åš Àδмιήίŝтяàтοґ !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin" {Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" should not be pseudo-localized.</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">
     <value>Şĥбω ťãьŝ іή ƒūļℓ šĉґééл !!! !!! !</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -318,7 +318,7 @@
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
     <value>Приложение терминала, запускаемое при запуске приложения командной строки без существующего сеанса, например из меню "Пуск" или из диалогового окна "Выполнить".</value>
-    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
+    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Intelligent Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
     <value>API графики</value>
@@ -358,7 +358,7 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>Это меняет способ группирования входящего текста в ячейки. Параметр "Кластеры Grapheme" — это самый современный и правильный для Unicode способ сделать это, в то время как "wcswidth" является распространенным подходом в UNIX, а "Консоль Windows" повторяет способ работы в Windows. Изменение этого параметра требует перезапуска терминала Windows и применяется только к приложениям, запущенным из него.</value>
+    <value>Это меняет способ группирования входящего текста в ячейки. Параметр "Кластеры Grapheme" — это самый современный и правильный для Unicode способ сделать это, в то время как "wcswidth" является распространенным подходом в UNIX, а "Консоль Windows" повторяет способ работы в Windows. Изменение этого параметра требует перезапуска Интеллектуального Терминала и применяется только к приложениям, запущенным из него.</value>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>Кластеры Grapheme</value>
@@ -574,8 +574,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>Разрешить запуск терминала Windows в фоновом режиме</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <value>Разрешить запуск Интеллектуального Терминала в фоновом режиме</value>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>Включить функции отладки</value>
@@ -896,7 +896,7 @@
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
     <value>Автоматически</value>
-    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
+    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Intelligent Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>Цветовая схема</value>
@@ -2223,7 +2223,7 @@
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Терминал Windows работает в переносном режиме.</value>
+    <value>Интеллектуальный Терминал работает в переносном режиме.</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">
@@ -2578,7 +2578,7 @@
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>Отображать экран в заголовке, когда Терминал Windows от имени администратора</value>
+    <value>Отображать экран в заголовке, когда Интеллектуальный Терминал от имени администратора</value>
     <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -318,7 +318,7 @@
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
     <value>Терминалска апликација која се покреће када се апликација из командне линије покрене без постојеће сесије, као, на пример, из Старт менија или из дијалога Покрени.</value>
-    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
+    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Intelligent Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
     <value>Графички API</value>
@@ -358,7 +358,7 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>Ово мења начин на који се долазни текст распоређује у ћелије. Опција „Скупине графема” је најсавременији и Unicode-исправан начин за то, док је „wcswidth” уобичајен приступ на UNIX системима, а „Windows Console” опонаша начин на који је то некада радило у Windows-у. Измена овог подешавања захтева поновно покретање програма Windows Терминал и примењује се само на апликације покренуте из њега.</value>
+    <value>Ово мења начин на који се долазни текст распоређује у ћелије. Опција „Скупине графема” је најсавременији и Unicode-исправан начин за то, док је „wcswidth” уобичајен приступ на UNIX системима, а „Windows Console” опонаша начин на који је то некада радило у Windows-у. Измена овог подешавања захтева поновно покретање програма Интелигентни Терминал и примењује се само на апликације покренуте из њега.</value>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>Скупине графема</value>
@@ -374,7 +374,7 @@
     <value>Ширина двосмислених знакова</value>
     <comment>A label for a drop down selector, referring to the East Asian Ambiguous Width Unicode specification.</comment>
   </data><data name="Globals_AmbiguousWidth.HelpText" xml:space="preserve">
-    <value>Подешава ширину која се користи за источноазијске знакове двосмислене ширине. „Уско” (подразумевано) даје предност компатибилности, док „Широко” даје предност читљивости са многим CJK фонтовима. У режиму „Широко” неке апликације можда неће радити исправно и могу изазвати непредвидљиво померање курсора. Измена овог подешавања захтева поновно покретање програма Windows Терминал и примењује се само на апликације покренуте из њега.</value>
+    <value>Подешава ширину која се користи за источноазијске знакове двосмислене ширине. „Уско” (подразумевано) даје предност компатибилности, док „Широко” даје предност читљивости са многим CJK фонтовима. У режиму „Широко” неке апликације можда неће радити исправно и могу изазвати непредвидљиво померање курсора. Измена овог подешавања захтева поновно покретање програма Интелигентни Терминал и примењује се само на апликације покренуте из њега.</value>
   </data><data name="Globals_AmbiguousWidth_Narrow.Text" xml:space="preserve">
     <value>Уско</value>
     <comment>As in "narrow width". Refers to the East Asian Ambiguous Width Unicode specification.</comment>
@@ -574,8 +574,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>Дозволи да се Windows Терминал извршава у позадини</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <value>Дозволи да се Интелигентни Терминал извршава у позадини</value>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>Укључи функције за отклањање грешака</value>
@@ -972,7 +972,7 @@
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
     <value>Аутоматски</value>
-    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
+    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Intelligent Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>Шема боја</value>
@@ -2323,7 +2323,7 @@
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Windows Терминал се извршава у преносном режиму.</value>
+    <value>Интелигентни Терминал се извршава у преносном режиму.</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
@@ -2682,7 +2682,7 @@
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>Прикажи штит у насловној линији када се Windows Терминал извршава као Администратор</value>
+    <value>Прикажи штит у насловној линији када се Интелигентни Терминал извршава као Администратор</value>
     <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -328,7 +328,7 @@
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
     <value>Програма терміналу, яка запускається, коли програма командного рядка запускається без наявного сеансу, наприклад із меню "Пуск" або діалогового вікна "Виконати".</value>
-    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
+    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Intelligent Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
     <value>Графічний API</value>
@@ -368,7 +368,7 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>Це змінює спосіб групування вхідного тексту в клітинки. Параметр "Кластери графем" є найсучаснішим і правильним для Unicode способом зробити це, тоді як "wcswidth" є поширеним підходом у UNIX, а "Консоль Windows" повторює спосіб, яким він працював у Windows. Зміна цього параметра потребує перезапуску терміналу Windows, і це стосується лише програм, запущених із нього.</value>
+    <value>Це змінює спосіб групування вхідного тексту в клітинки. Параметр "Кластери графем" є найсучаснішим і правильним для Unicode способом зробити це, тоді як "wcswidth" є поширеним підходом у UNIX, а "Консоль Windows" повторює спосіб, яким він працював у Windows. Зміна цього параметра потребує перезапуску Інтелектуальному Терміналу, і це стосується лише програм, запущених із нього.</value>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>Кластери графем</value>
@@ -581,8 +581,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>Дозволити терміналу Windows працювати у фоновому режимі</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <value>Дозволити Інтелектуальному Терміналу працювати у фоновому режимі</value>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>Увімкнути функції налагодження</value>
@@ -896,7 +896,7 @@
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
     <value>Автоматично</value>
-    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
+    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Intelligent Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>Колірна схема</value>
@@ -1954,7 +1954,7 @@
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Термінал Windows працює в портативному режимі.</value>
+    <value>Інтелектуальний Термінал працює в портативному режимі.</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
@@ -2321,7 +2321,7 @@
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>Відображати щит у рядку заголовка, коли термінал Windows запущено від імені Адміністратора</value>
+    <value>Відображати щит у рядку заголовка, коли Інтелектуальний Термінал запущено від імені Адміністратора</value>
     <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -318,7 +318,7 @@
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
     <value>当命令行应用程序在没有现有会话(例如从“开始菜单”或“运行”对话框)运行时启动的终端应用程序。</value>
-    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
+    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Intelligent Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
     <value>图形 API</value>
@@ -358,7 +358,7 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>这会更改传入文本分组到单元格中的方式。“Grapheme 群集”选项是执行此操作的最新式和 Unicode 正确的方法，而“wcswidth”是 UNIX 上的常见方法，“Windows 控制台”复制了它在 Windows 上的工作方式。更改此设置需要重启Windows 终端且仅适用于从其内部启动的应用程序。</value>
+    <value>这会更改传入文本分组到单元格中的方式。“Grapheme 群集”选项是执行此操作的最新式和 Unicode 正确的方法，而“wcswidth”是 UNIX 上的常见方法，“Windows 控制台”复制了它在 Windows 上的工作方式。更改此设置需要重启智能终端且仅适用于从其内部启动的应用程序。</value>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>Grapheme 群集</value>
@@ -376,7 +376,7 @@
     <comment>A label for a drop down selector, referring to the East Asian Ambiguous Width Unicode specification.</comment>
   </data>
   <data name="Globals_AmbiguousWidth.HelpText" xml:space="preserve">
-    <value>设置东亚模糊字符的宽度。"窄"模式(默认)优先考虑兼容性，而"宽"模式优先考虑很多中日韩字体的可读性。在"宽"模式下，某些应用程序可能无法正常工作，并导致光标不规则移动。更改此设置需要重启 Windows 终端，而且仅适用于从终端中启动的应用程序。</value>
+    <value>设置东亚模糊字符的宽度。"窄"模式(默认)优先考虑兼容性，而"宽"模式优先考虑很多中日韩字体的可读性。在"宽"模式下，某些应用程序可能无法正常工作，并导致光标不规则移动。更改此设置需要重启 智能终端，而且仅适用于从终端中启动的应用程序。</value>
   </data>
   <data name="Globals_AmbiguousWidth_Narrow.Text" xml:space="preserve">
     <value>窄</value>
@@ -574,8 +574,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>允许Windows 终端在后台运行</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <value>允许智能终端在后台运行</value>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>启用调试功能</value>
@@ -896,7 +896,7 @@
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
     <value>自动</value>
-    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
+    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Intelligent Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>配色方案</value>
@@ -2223,7 +2223,7 @@
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Windows 终端正在便携模式下运行。</value>
+    <value>智能终端正在便携模式下运行。</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">
@@ -2578,7 +2578,7 @@
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>当 Windows 终端以管理员身份运行时，在标题栏中显示一个盾牌图标</value>
+    <value>当 智能终端以管理员身份运行时，在标题栏中显示一个盾牌图标</value>
     <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -318,7 +318,7 @@
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
     <value>當執行命令列應用程式且不使用現有工作模式而啟動的終端機應用程式 (例如從 [開始] 功能表或 [執行] 對話方塊)。</value>
-    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
+    <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Intelligent Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
     <value>圖形 API</value>
@@ -358,7 +358,7 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_TextMeasurement.HelpText" xml:space="preserve">
-    <value>這會變更內送文字群組到儲存格的方式。[Grapheme 叢集] 選項是最新式且更正確的 Unicode 方法，而 “wcswidth” 是 UNIX 的常見方法，而 [Windows 控制台] 則會復寫它在 Windows 上運作的方式。變更此設定需要重新啟動Windows 終端機，且只適用於從其中啟動的應用程式。</value>
+    <value>這會變更內送文字群組到儲存格的方式。[Grapheme 叢集] 選項是最新式且更正確的 Unicode 方法，而 “wcswidth” 是 UNIX 的常見方法，而 [Windows 控制台] 則會復寫它在 Windows 上運作的方式。變更此設定需要重新啟動智慧終端機，且只適用於從其中啟動的應用程式。</value>
   </data>
   <data name="Globals_TextMeasurement_Graphemes.Text" xml:space="preserve">
     <value>Grapheme 叢集</value>
@@ -376,7 +376,7 @@
     <comment>A label for a drop down selector, referring to the East Asian Ambiguous Width Unicode specification.</comment>
   </data>
   <data name="Globals_AmbiguousWidth.HelpText" xml:space="preserve">
-    <value>設定東亞模糊字元的寬度。「窄」(預設) 以相容性為優先，而「寬」則以多數中日韓字型的可讀性為優先。在「寬」模式下，部分應用程式可能無法正常運作，導致游標移動異常。變更此設定後，需重新啟動 Windows 終端機，且僅適用於從 Windows 終端機內啟動的應用程式。</value>
+    <value>設定東亞模糊字元的寬度。「窄」(預設) 以相容性為優先，而「寬」則以多數中日韓字型的可讀性為優先。在「寬」模式下，部分應用程式可能無法正常運作，導致游標移動異常。變更此設定後，需重新啟動 智慧終端機，且僅適用於從 智慧終端機內啟動的應用程式。</value>
   </data>
   <data name="Globals_AmbiguousWidth_Narrow.Text" xml:space="preserve">
     <value>窄</value>
@@ -522,7 +522,7 @@
     <comment>Header for a control to toggle whether the terminal's title is shown as the application title, or not.</comment>
   </data>
   <data name="Globals_ShowTitleInTitlebar.HelpText" xml:space="preserve">
-    <value>停用時，標題列會是 [Windows 終端機]。</value>
+    <value>停用時，標題列會是 [智慧終端機]。</value>
     <comment>A description for what the "show title in titlebar" setting does. Presented near "Globals_ShowTitleInTitlebar.Header".{Locked="Windows"}</comment>
   </data>
   <data name="Globals_SnapToGridOnResize.Header" xml:space="preserve">
@@ -574,8 +574,8 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
-    <value>允許 Windows 終端機 在背景執行</value>
-    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+    <value>允許 智慧終端機 在背景執行</value>
+    <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
     <value>啟用偵錯功能</value>
@@ -896,7 +896,7 @@
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
     <value>自動</value>
-    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
+    <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Intelligent Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>色彩配置</value>
@@ -1218,7 +1218,7 @@
     <comment>A supplementary setting to the "starting directory" setting. "Parent" refers to the parent process of the current process.</comment>
   </data>
   <data name="Profile_StartingDirectoryUseParentCheckbox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>如果啟用，這個設定檔將會在啟動 Windows 終端機的目錄中產生。</value>
+    <value>如果啟用，這個設定檔將會在啟動 智慧終端機的目錄中產生。</value>
     <comment>A description for what the supplementary "use parent process directory" setting does. Presented near "Profile_StartingDirectoryUseParentCheckbox".</comment>
   </data>
   <data name="Profile_SuppressApplicationTitle.Header" xml:space="preserve">
@@ -2223,7 +2223,7 @@
     <comment>As in: Always VS Never</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Windows 終端機正以可攜式模式執行。</value>
+    <value>智慧終端機正以可攜式模式執行。</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">
@@ -2578,7 +2578,7 @@
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>當 Windows 終端機 以系統管理員身分執行時，在標題欄中顯示遮罩</value>
+    <value>當 智慧終端機 以系統管理員身分執行時，在標題欄中顯示遮罩</value>
     <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
   </data>
   <data name="Globals_ShowTabsFullscreen.Header" xml:space="preserve">


### PR DESCRIPTION
This pull request updates localization and translation handling for the "Intelligent Terminal" product name across multiple languages. The main changes ensure that the new product name is properly localized (and locked for pseudo-locales only) in both CascadiaPackage and TerminalSettingsEditor resources.

**Localization and Translation Updates:**
- Updated the product name from "Terminal"/"Windows Terminal" to locale-specific translations of "Intelligent Terminal" across 89 locales in CascadiaPackage Resources (AppName, AppStoreName, AppShortName, AppDescription, ShellExtension menu items)
- Updated TerminalSettingsEditor Resources across 15 locales to replace "Windows Terminal" references with locale-appropriate "Intelligent Terminal" translations
- Changed accelerator key from &T to &I across all locales to avoid conflict with Windows Terminal
- Pseudo-locales (qps-ploc/ploca/plocm) use locked "Intelligent Terminal" with pseudo-localized surrounding text
- Preview/Canary builds retain "Windows Terminal" branding (separate SKUs)
- Updated translator instructions to clarify that "Intelligent Terminal" should be translated for real locales but locked for pseudo-locales