### PR TITLE
Adds a config file defining our cargo feed for our Rust crates, for compliance purposes

### DIFF
--- a/wta/.cargo/intelligent_terminal_feed.toml
+++ b/wta/.cargo/intelligent_terminal_feed.toml
@@ -1,0 +1,11 @@
+global-credential-providers = [
+    "artifacts-cargo-credprovider",
+    "cargo:token",
+    "cargo:wincred",
+]
+
+[registries.intelligent_terminal_public_packages]
+index = "sparse+https://microsoft.pkgs.visualstudio.com/Dart/_packaging/intelligent_terminal_public_packages/Cargo/index/"
+
+[source.crates-io]
+replace-with = "intelligent_terminal_public_packages"


### PR DESCRIPTION
## Summary of the Pull Request
As part of https://microsoft.visualstudio.com/OS/_workitems/edit/62007366, we have to make sure our Rust crates go through our custom feed. This PR adds the config file necessary to make that happen (the custom feed has already been set up [here](https://microsoft.visualstudio.com/Dart/_artifacts/feed/intelligent_terminal_public_packages))

## Validation Steps Performed
Able to build `wta` locally with the command `cargo build --config .cargo/intelligent_terminal_feed.toml` (FYI `msrustup` might be required to make sure this works for you)

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
