### PR TITLE
version: rebrand to Intelligent Terminal 0.1.x

### DIFF
--- a/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
+++ b/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
@@ -55,7 +55,7 @@ jobs:
           BuildConfiguration: ${{ config }}
   variables:
     ${{ if eq(parameters.branding, 'Release') }}:
-      BundleStemName: Microsoft.WindowsTerminal
+      BundleStemName: Microsoft.IntelligentTerminal
     ${{ elseif eq(parameters.branding, 'Preview') }}:
       BundleStemName: Microsoft.WindowsTerminalPreview
     ${{ elseif eq(parameters.branding, 'Canary') }}:

--- a/build/pipelines/templates-v2/job-publish-symbols-using-symbolrequestprod-api.yml
+++ b/build/pipelines/templates-v2/job-publish-symbols-using-symbolrequestprod-api.yml
@@ -77,7 +77,7 @@ jobs:
       SymbolServerType: 'TeamServices'
       SymbolsProduct: 'Windows Terminal Converged Symbols'
       SymbolsVersion: '$(XES_APPXMANIFESTVERSION)'
-      SymbolsArtifactName: 'WindowsTerminal_$(XES_APPXMANIFESTVERSION)'
+      SymbolsArtifactName: 'IntelligentTerminal_$(XES_APPXMANIFESTVERSION)'
       SymbolExpirationInDays: ${{ parameters.symbolExpiryTime }}
     env:
       LIB: $(Build.SourcesDirectory)
@@ -93,7 +93,7 @@ jobs:
       # Prepare the request
       $expiration = (Get-Date).Add([TimeSpan]::FromDays(${{ parameters.symbolExpiryTime }}))
       $createRequestBody = @{
-        requestName = "WindowsTerminal_$(XES_APPXMANIFESTVERSION)";
+        requestName = "IntelligentTerminal_$(XES_APPXMANIFESTVERSION)";
         expirationTime = $expiration.ToString();
       }
       Write-Host "##[debug]Starting request $($createRequestBody.requestName) with expiration date of $($createRequestBody.expirationTime)"

--- a/build/pipelines/templates-v2/job-submit-windows-vpack.yml
+++ b/build/pipelines/templates-v2/job-submit-windows-vpack.yml
@@ -49,8 +49,8 @@ jobs:
   # Rename to known/fixed name for Windows build system
   - powershell: |-
       # Create vpack directory and place item inside
-      $TargetFolder = New-Item -Type Directory '$(Build.SourcesDirectory)/WindowsTerminal.app'
-      Get-ChildItem bundle/Microsoft.WindowsTerminal_*.msixbundle | Move-Item (Join-Path $TargetFolder.FullName 'Microsoft.WindowsTerminal_8wekyb3d8bbwe.msixbundle') -Verbose
+      $TargetFolder = New-Item -Type Directory '$(Build.SourcesDirectory)/IntelligentTerminal.app'
+      Get-ChildItem bundle/Microsoft.IntelligentTerminal_*.msixbundle | Move-Item (Join-Path $TargetFolder.FullName 'Microsoft.IntelligentTerminal_8wekyb3d8bbwe.msixbundle') -Verbose
     displayName: Stage packages for vpack
 
   - task: PkgESVPack@12
@@ -58,9 +58,9 @@ jobs:
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     inputs:
-      sourceDirectory: '$(Build.SourcesDirectory)/WindowsTerminal.app'
-      description: VPack for the Windows Terminal Application
-      pushPkgName: WindowsTerminal.app
+      sourceDirectory: '$(Build.SourcesDirectory)/IntelligentTerminal.app'
+      description: VPack for the Intelligent Terminal Application
+      pushPkgName: IntelligentTerminal.app
       owner: conhost
       githubToken: $(GitHubTokenForVpackProvenance)
 

--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -198,9 +198,9 @@ extends:
                   ob_createvpack_enabled: ${{ and(parameters.buildTerminal, parameters.createVpack) }}
                   ob_updateOSManifest_enabled: ${{ and(parameters.buildTerminal, parameters.createVpack, parameters.publishVpackToWindows) }}
                   ### If enabled above, these options are in play.
-                  ob_createvpack_packagename: 'WindowsTerminal.app'
+                  ob_createvpack_packagename: 'IntelligentTerminal.app'
                   ob_createvpack_owneralias: 'conhost@microsoft.com'
-                  ob_createvpack_description: 'VPack for the Windows Terminal Application'
+                  ob_createvpack_description: 'VPack for the Intelligent Terminal Application'
                   ob_createvpack_targetDestinationDirectory: '$(Destination)'
                   ob_createvpack_propsFile: false
                   ob_createvpack_provData: true
@@ -236,7 +236,7 @@ extends:
 
                   - ${{ if parameters.createVpack }}:
                     - pwsh: |-
-                        Copy-Item -Verbose -Path "$(MsixBundlePath)" -Destination (Join-Path "$(JobOutputDirectory)/vpack" 'Microsoft.WindowsTerminal_8wekyb3d8bbwe.msixbundle')
+                        Copy-Item -Verbose -Path "$(MsixBundlePath)" -Destination (Join-Path "$(JobOutputDirectory)/vpack" 'Microsoft.IntelligentTerminal_8wekyb3d8bbwe.msixbundle')
                       displayName: Stage msixbundle for vpack
 
           - ${{ if eq(parameters.buildConPTY, true) }}:

--- a/custom.props
+++ b/custom.props
@@ -4,9 +4,9 @@
   <PropertyGroup Label="Version">
     <XesUseOneStoreVersioning>true</XesUseOneStoreVersioning>
     <XesBaseYearForStoreVersion>2026</XesBaseYearForStoreVersion>
-    <VersionMajor>1</VersionMajor>
-    <VersionMinor>26</VersionMinor>
-    <VersionInfoProductName>Windows Terminal</VersionInfoProductName>
+    <VersionMajor>0</VersionMajor>
+    <VersionMinor>1</VersionMinor>
+    <VersionInfoProductName>Intelligent Terminal</VersionInfoProductName>
     <VersionInfoCulture>1033</VersionInfoCulture>
     <!-- The default has a spacing problem -->
     <VersionInfoCopyRight>\xa9 Microsoft Corporation. All rights reserved.</VersionInfoCopyRight>

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -21,7 +21,7 @@
   <Identity
     Name="Microsoft.IntelligentTerminal"
     Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
-    Version="1.0.0.0" />
+    Version="0.1.0.0" />
 
   <Properties>
     <DisplayName>ms-resource:AppStoreName</DisplayName>

--- a/tools/ReleaseEngineering/Draft-TerminalReleases.ps1
+++ b/tools/ReleaseEngineering/Draft-TerminalReleases.ps1
@@ -133,6 +133,7 @@ Class Asset {
 		$this.VersionMoniker = "{0}.{1}" -f ($v.Major, $v.Minor)
 
 		$this.Branding = Switch($this.Name) {
+			"Microsoft.IntelligentTerminal" { [Branding]::Release }
 			"Microsoft.WindowsTerminal" { [Branding]::Release }
 			"Microsoft.WindowsTerminalPreview" { [Branding]::Preview }
 			"Microsoft.WindowsTerminalCanary" { [Branding]::Canary }


### PR DESCRIPTION
This pull request updates the application's branding and versioning to transition from "Windows Terminal" to "Intelligent Terminal" and resets the version number to an initial release. The changes affect build configuration, product naming, and version numbers across the codebase.

Branding updates:

* Renamed all instances of the bundle and product name from "Windows Terminal" to "Intelligent Terminal" in the build pipeline (`job-merge-msix-into-bundle.yml`) and project properties (`custom.props`). [[1]](diffhunk://#diff-7e5aebea696456c44f897a7e390da276770df4161b478d53c2628e2a2a13c02bL58-R64) [[2]](diffhunk://#diff-6ff39b8ad354e908ce47bcc333b41c4cf0c8a65d2eff4764a49254f00df9f24eL7-R9)

Versioning changes:

* Reset the major and minor version numbers from 1.26 to 0.1 in `custom.props` and updated the package version in the manifest from `1.0.0.0` to `0.1.0.0`, reflecting an initial release for the rebranded product. [[1]](diffhunk://#diff-6ff39b8ad354e908ce47bcc333b41c4cf0c8a65d2eff4764a49254f00df9f24eL7-R9) [[2]](diffhunk://#diff-470baec122fb9c32ee1b9d6daecb22b6412c29981e2731312a2826a3e19bfc2fL24-R24)