### PR TITLE
fix: sync divergent files with ADO repo

### DIFF
--- a/build/pipelines/templates-v2/job-build-project.yml
+++ b/build/pipelines/templates-v2/job-build-project.yml
@@ -176,9 +176,9 @@ jobs:
   #      feed (already exists on `microsoft` ADO org; same feed used by
   #      microsoft/sudo, microsoft/vscode, microsoft/edit, microsoft/qdk).
   #   2. Crates resolve through a project-level Azure Artifact Cargo feed
-  #      with crates.io upstream, configured in wta/.cargo/config.toml.
+  #      with crates.io upstream, configured in tools/wta/.cargo/config.toml.
   #   3. The Rust version uses the `ms-prod-X.YY` channel, pinned in
-  #      `wta/rust-toolchain.toml`.
+  #      `tools/wta/rust-toolchain.toml`.
   #   4. Component Governance scanning of Cargo.lock is auto-injected by
   #      1ES PT (no extra task needed here).
   #
@@ -199,7 +199,7 @@ jobs:
       # vars), so the override registry ends up unauthenticated and Azure
       # Artifacts returns 404 on its sparse-index endpoint.
       # Instead, the registry + source replacement lives in
-      # wta/.cargo/config.toml — CargoAuthenticate@0 (next step) tokens it,
+      # tools/wta/.cargo/config.toml — CargoAuthenticate@0 (next step) tokens it,
       # and cargo's normal config-file resolution picks it up.
       additionalTargets: 'x86_64-pc-windows-msvc i686-pc-windows-msvc aarch64-pc-windows-msvc'
 
@@ -208,7 +208,7 @@ jobs:
   # (the feed requires CI-only auth tokens). It only exists during CI.
   # Cargo discovers .cargo/config.toml by walking from the current
   # working directory (repo root) up — NOT from the manifest directory.
-  # The config must live at the repo root, not inside wta/.
+  # The config must live at the repo root, not inside tools/wta/.
   - pwsh: |-
       $configDir = '.cargo'
       New-Item -ItemType Directory -Path $configDir -Force | Out-Null
@@ -235,7 +235,7 @@ jobs:
 
   # Separate fetch step: some 1ES pools disable network during the build
   # phase. Fetching upfront keeps `cargo build --frozen` fully offline.
-  - script: cargo fetch --manifest-path wta/Cargo.toml --locked
+  - script: cargo fetch --manifest-path tools/wta/Cargo.toml --locked
     displayName: Fetch crates (offline-friendly)
 
   - pwsh: |-
@@ -249,9 +249,9 @@ jobs:
       $config = '$(BuildConfiguration)'
       Write-Host "Building wta for $triple ($config)"
       if ($config -eq 'Release') {
-        cargo build --manifest-path wta/Cargo.toml --target $triple --frozen --release
+        cargo build --manifest-path tools/wta/Cargo.toml --target $triple --frozen --release
       } else {
-        cargo build --manifest-path wta/Cargo.toml --target $triple --frozen
+        cargo build --manifest-path tools/wta/Cargo.toml --target $triple --frozen
       }
       if ($LASTEXITCODE -ne 0) { throw "cargo build failed with exit code $LASTEXITCODE" }
     displayName: Build wta (Cargo)
@@ -265,7 +265,7 @@ jobs:
         default { 'x86_64-pc-windows-msvc' }
       }
       Write-Host "Running wta unit tests for $triple"
-      cargo test --manifest-path wta/Cargo.toml --target $triple --frozen
+      cargo test --manifest-path tools/wta/Cargo.toml --target $triple --frozen
       if ($LASTEXITCODE -ne 0) { throw "cargo test failed with exit code $LASTEXITCODE" }
     displayName: Test wta (Cargo)
     condition: ne(variables['BuildPlatform'], 'arm64')

--- a/build/scripts/Test-WindowsTerminalPackage.ps1
+++ b/build/scripts/Test-WindowsTerminalPackage.ps1
@@ -98,8 +98,10 @@ Try {
     }
 
     If (($null -eq (Get-Item "$AppxPackageRootPath\wtd.exe" -EA:Ignore)) -And
-        ($null -eq (Get-Item "$AppxPackageRootPath\wt.exe" -EA:Ignore))) {
-        Throw "Failed to find wt.exe/wtd.exe -- check the WAP packaging project"
+        ($null -eq (Get-Item "$AppxPackageRootPath\wt.exe" -EA:Ignore)) -And
+        ($null -eq (Get-Item "$AppxPackageRootPath\wtai.exe" -EA:Ignore)) -And
+        ($null -eq (Get-Item "$AppxPackageRootPath\WindowsTerminal.exe" -EA:Ignore))) {
+        Throw "Failed to find wt.exe/wtd.exe/wtai.exe/WindowsTerminal.exe -- check the WAP packaging project"
     }
 
     If ($null -eq (Get-Item "$AppxPackageRootPath\OpenConsole.exe" -EA:Ignore)) {

--- a/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
+++ b/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
@@ -154,16 +154,6 @@
        the loose copy is present. Excludes hook-debug/ (dev utility, not
        part of the install bundle) and *.md (developer docs). -->
   <ItemGroup>
-    <Content Include="$(SolutionDir)res\fre\FRE_Asset1.png">
-      <Link>FREAssets\FRE_Asset1.png</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(SolutionDir)res\fre\FRE_Asset2.png">
-      <Link>FREAssets\FRE_Asset2.png</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="$(SolutionDir)tools\wta\wt-agent-hooks\**"
              Exclude="$(SolutionDir)tools\wta\wt-agent-hooks\hook-debug\**;$(SolutionDir)tools\wta\wt-agent-hooks\**\*.md">
       <Link>wt-agent-hooks\%(RecursiveDir)%(Filename)%(Extension)</Link>

--- a/src/cascadia/TerminalApp/FreOverlay.xaml
+++ b/src/cascadia/TerminalApp/FreOverlay.xaml
@@ -89,9 +89,14 @@
                             </Grid.RowDefinitions>
                             <Border Grid.Row="0" Background="#FF0C0C0C" CornerRadius="7,7,0,0"
                                     Margin="6,6,6,0">
-                                <Image Source="ms-appx:///FREAssets/FRE_Asset1.png"
-                                       Stretch="UniformToFill"
-                                       VerticalAlignment="Bottom" />
+                                <StackPanel VerticalAlignment="Center"
+                                            HorizontalAlignment="Center" Spacing="6">
+                                    <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE7BA;"
+                                              Foreground="#50FFFFFF" FontSize="20" />
+                                    <TextBlock Text="⚠ Error detected: Ctrl+Shift to fix"
+                                               Foreground="#FFFFD700" FontSize="11"
+                                               HorizontalAlignment="Center" />
+                                </StackPanel>
                             </Border>
                             <StackPanel Grid.Row="1" Margin="16,14,16,16" Spacing="6">
                                 <TextBlock FontFamily="Segoe UI Variable Text, Segoe UI"
@@ -115,9 +120,11 @@
                             </Grid.RowDefinitions>
                             <Border Grid.Row="0" Background="#FF0C0C0C" CornerRadius="7,7,0,0"
                                     Margin="6,6,6,0">
-                                <Image Source="ms-appx:///FREAssets/FRE_Asset2.png"
-                                       Stretch="UniformToFill"
-                                       VerticalAlignment="Center" />
+                                <StackPanel VerticalAlignment="Center"
+                                            HorizontalAlignment="Center" Spacing="6">
+                                    <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE81C;"
+                                              Foreground="#50FFFFFF" FontSize="20" />
+                                </StackPanel>
                             </Border>
                             <StackPanel Grid.Row="1" Margin="16,14,16,16" Spacing="6">
                                 <TextBlock FontFamily="Segoe UI Variable Text, Segoe UI"

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1742,17 +1742,6 @@ namespace winrt::TerminalApp::implementation
             cmdline += fmt::format(FMT_COMPILE(L" --agent \"{}\""), s);
         }
 
-        // See `_OpenOrReuseAgentPane` for the rationale: wta needs the
-        // canonical `acpAgent` setting value (not the expanded command
-        // line) to drive the session-management view's CLI filter.
-        if (const auto acpAgent = globals.AcpAgent(); !acpAgent.empty())
-        {
-            std::wstring s{ acpAgent };
-            for (size_t pos = 0; (pos = s.find(L'"', pos)) != std::wstring::npos; pos += 2)
-                s.replace(pos, 1, L"\"\"");
-            cmdline += fmt::format(FMT_COMPILE(L" --agent-id \"{}\""), s);
-        }
-
         const auto delegateAgent = _ResolveEffectiveDelegateAgent(globals);
         if (!delegateAgent.empty())
         {
@@ -2127,21 +2116,6 @@ namespace winrt::TerminalApp::implementation
                 for (size_t pos = 0; (pos = agentStr.find(L'"', pos)) != std::wstring::npos; pos += 2)
                     agentStr.replace(pos, 1, L"\"\"");
                 cmdline += fmt::format(FMT_COMPILE(L" --agent \"{}\""), agentStr);
-            }
-
-            // Tell wta which `acpAgent` setting value produced this launch
-            // — wta needs the canonical id ("copilot" / "claude" / "codex"
-            // / "gemini" / "custom:…") to drive the session-management
-            // view's CLI filter, and parsing it back out of the expanded
-            // `--agent` command line is fragile (adapter launches expand
-            // to "npx -y …" and lose the agent's name). Passing it through
-            // here keeps a single source of truth.
-            if (const auto acpAgent = globals.AcpAgent(); !acpAgent.empty())
-            {
-                std::wstring idStr{ acpAgent };
-                for (size_t pos = 0; (pos = idStr.find(L'"', pos)) != std::wstring::npos; pos += 2)
-                    idStr.replace(pos, 1, L"\"\"");
-                cmdline += fmt::format(FMT_COMPILE(L" --agent-id \"{}\""), idStr);
             }
 
             const auto delegateAgent = _ResolveEffectiveDelegateAgent(globals);

--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -191,47 +191,6 @@ pub fn lookup_profile_by_id(id: &str) -> &'static AgentProfile {
         .unwrap_or(&DEFAULT_PROFILE)
 }
 
-/// Resolve a full agent command line (e.g. the value of `--agent`) into the
-/// canonical agent id known to [`KNOWN_AGENTS`] — `"copilot"`, `"claude"`,
-/// `"codex"`, `"gemini"` — or `"unknown"` if nothing matches.
-///
-/// This is the right thing to use whenever we need to *identify* the agent
-/// from a launch command rather than execute it. It handles three input
-/// shapes:
-///
-///   1. Bare names with flags:  `"copilot --acp --stdio"` → `"copilot"`.
-///   2. Adapter launches:        `"npx -y @zed-industries/claude-code-acp"`
-///      → `"claude"` (matched against each profile's `acp_launch_command`).
-///   3. Full executable paths:   `"C:\\Tools\\copilot.exe --acp --stdio"`
-///      → `"copilot"` (via [`lookup_profile`] which strips path and
-///      extension before matching).
-///
-/// Empty / whitespace-only input returns `"unknown"`.
-pub fn resolve_agent_id_from_cmd(agent_cmd: &str) -> &'static str {
-    let trimmed = agent_cmd.trim();
-    if trimmed.is_empty() {
-        return DEFAULT_PROFILE.id;
-    }
-
-    // Adapter-style: the whole command equals a known profile's
-    // `acp_launch_command` (e.g. `"npx -y @zed-industries/claude-code-acp"`).
-    // Match exact first; fall back to prefix match so trailing flags don't
-    // hide the adapter (e.g. someone appending `--debug`).
-    if let Some(profile) = KNOWN_AGENTS
-        .iter()
-        .find(|p| !p.acp_launch_command.is_empty()
-                  && (p.acp_launch_command == trimmed
-                      || trimmed.starts_with(&format!("{} ", p.acp_launch_command))))
-    {
-        return profile.id;
-    }
-
-    // Bare / path form: take the first whitespace-delimited token and let
-    // `lookup_profile` strip path and extension before matching.
-    let first = trimmed.split_whitespace().next().unwrap_or(trimmed);
-    lookup_profile(first).id
-}
-
 // ─── ACP Command Building ────────────────────────────────────────────────────
 
 /// Build the full ACP agent command from an agent id and optional model.
@@ -455,51 +414,5 @@ mod tests {
     fn is_cli_available_returns_false_for_obviously_bogus_name() {
         // A 64-char random-looking name will not exist on any sane PATH.
         assert!(!is_cli_available("zzzzz_does_not_exist_anywhere_qqqqq_82h3kf9"));
-    }
-
-    #[test]
-    fn resolve_agent_id_from_cmd_recognises_bare_names_with_flags() {
-        assert_eq!(resolve_agent_id_from_cmd("copilot --acp --stdio"), "copilot");
-        assert_eq!(resolve_agent_id_from_cmd("gemini --experimental-acp"), "gemini");
-        assert_eq!(resolve_agent_id_from_cmd("claude --resume foo"), "claude");
-    }
-
-    #[test]
-    fn resolve_agent_id_from_cmd_recognises_adapter_launches() {
-        // Exact match against the known adapter command.
-        assert_eq!(
-            resolve_agent_id_from_cmd("npx -y @zed-industries/claude-code-acp"),
-            "claude",
-        );
-        assert_eq!(
-            resolve_agent_id_from_cmd("npx -y @zed-industries/codex-acp"),
-            "codex",
-        );
-        // Adapter prefix with extra trailing args still resolves.
-        assert_eq!(
-            resolve_agent_id_from_cmd("npx -y @zed-industries/claude-code-acp --debug"),
-            "claude",
-        );
-    }
-
-    #[test]
-    fn resolve_agent_id_from_cmd_strips_path_and_extension() {
-        assert_eq!(
-            resolve_agent_id_from_cmd(r"C:\Tools\copilot.exe --acp --stdio"),
-            "copilot",
-        );
-        assert_eq!(
-            resolve_agent_id_from_cmd("/usr/local/bin/gemini --experimental-acp"),
-            "gemini",
-        );
-        assert_eq!(resolve_agent_id_from_cmd("copilot.cmd"), "copilot");
-    }
-
-    #[test]
-    fn resolve_agent_id_from_cmd_falls_back_to_unknown() {
-        assert_eq!(resolve_agent_id_from_cmd(""),           "unknown");
-        assert_eq!(resolve_agent_id_from_cmd("   "),        "unknown");
-        assert_eq!(resolve_agent_id_from_cmd("npx"),        "unknown");
-        assert_eq!(resolve_agent_id_from_cmd("my-bot --x"), "unknown");
     }
 }

--- a/tools/wta/src/agent_sessions.rs
+++ b/tools/wta/src/agent_sessions.rs
@@ -49,20 +49,6 @@ impl CliSource {
             other     => Self::Unknown(other.to_string()),
         }
     }
-
-    /// Map an `agent_registry` agent id (`"copilot"`, `"claude"`, `"gemini"`,
-    /// ...) to the matching `CliSource` variant. Returns `None` for agents
-    /// the session registry does not track (e.g. `"codex"`, `"unknown"`, or
-    /// an empty string), which the session-management view treats as
-    /// "no filter — show all rows".
-    pub fn from_agent_id(agent_id: &str) -> Option<Self> {
-        match agent_id.to_ascii_lowercase().as_str() {
-            "copilot" => Some(Self::Copilot),
-            "claude"  => Some(Self::Claude),
-            "gemini"  => Some(Self::Gemini),
-            _ => None,
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -374,22 +360,6 @@ impl AgentSessionRegistry {
         let mut v: Vec<_> = self.sessions.values().collect();
         v.sort_by(|a, b| b.last_activity_at.cmp(&a.last_activity_at));
         v
-    }
-
-    /// Like [`iter_sorted`], but keeps only rows whose `cli_source` matches
-    /// the supplied filter. Passing `None` disables filtering and returns
-    /// the same list as `iter_sorted`. Used by the session-management view
-    /// so that, when the agent pane is running a known CLI (copilot /
-    /// claude / gemini), the list only shows sessions for that CLI.
-    pub fn iter_sorted_filtered(&self, filter: Option<&CliSource>) -> Vec<&AgentSession> {
-        let sorted = self.iter_sorted();
-        match filter {
-            None => sorted,
-            Some(want) => sorted
-                .into_iter()
-                .filter(|s| &s.cli_source == want)
-                .collect(),
-        }
     }
 
     pub fn take_dirty(&mut self) -> bool {
@@ -1174,107 +1144,5 @@ mod tests {
         assert_eq!(s.status, AgentStatus::Idle);
         assert!(s.current_tool.is_none());
         assert!(s.attention_reason.is_none());
-    }
-
-    #[test]
-    fn from_agent_id_maps_known_cli_ids() {
-        assert_eq!(CliSource::from_agent_id("copilot"), Some(CliSource::Copilot));
-        assert_eq!(CliSource::from_agent_id("claude"),  Some(CliSource::Claude));
-        assert_eq!(CliSource::from_agent_id("gemini"),  Some(CliSource::Gemini));
-        // Case-insensitive — `current_agent_id` is conventionally lowercase
-        // but mixed-case must not silently drop the filter.
-        assert_eq!(CliSource::from_agent_id("Copilot"), Some(CliSource::Copilot));
-    }
-
-    #[test]
-    fn from_agent_id_returns_none_for_untracked_or_empty() {
-        // Empty / unknown / codex are all "no filter" — the F2 view will
-        // fall back to showing every row.
-        assert_eq!(CliSource::from_agent_id(""),         None);
-        assert_eq!(CliSource::from_agent_id("codex"),    None);
-        assert_eq!(CliSource::from_agent_id("unknown"),  None);
-        assert_eq!(CliSource::from_agent_id("bogus"),    None);
-    }
-
-    #[test]
-    fn iter_sorted_filtered_keeps_only_matching_cli_source() {
-        let mut reg = AgentSessionRegistry::new();
-        reg.apply(SessionEvent::SessionStarted {
-            key: k("cop"),
-            cli_source: CliSource::Copilot,
-            pane_session_id: pane("p-cop"),
-            cwd: PathBuf::from("/x"),
-            title: "copilot run".into(),
-        });
-        reg.apply(SessionEvent::SessionStarted {
-            key: k("cla"),
-            cli_source: CliSource::Claude,
-            pane_session_id: pane("p-cla"),
-            cwd: PathBuf::from("/x"),
-            title: "claude run".into(),
-        });
-        reg.apply(SessionEvent::SessionStarted {
-            key: k("gem"),
-            cli_source: CliSource::Gemini,
-            pane_session_id: pane("p-gem"),
-            cwd: PathBuf::from("/x"),
-            title: "gemini run".into(),
-        });
-
-        // No filter → all three rows in last_activity_at-desc order.
-        let all: Vec<&str> = reg
-            .iter_sorted_filtered(None)
-            .iter()
-            .map(|s| s.key.as_str())
-            .collect();
-        assert_eq!(all.len(), 3);
-
-        // Copilot filter → only the copilot row.
-        let cop: Vec<&str> = reg
-            .iter_sorted_filtered(Some(&CliSource::Copilot))
-            .iter()
-            .map(|s| s.key.as_str())
-            .collect();
-        assert_eq!(cop, vec!["cop"]);
-
-        // Claude filter → only the claude row.
-        let cla: Vec<&str> = reg
-            .iter_sorted_filtered(Some(&CliSource::Claude))
-            .iter()
-            .map(|s| s.key.as_str())
-            .collect();
-        assert_eq!(cla, vec!["cla"]);
-    }
-
-    #[test]
-    fn iter_sorted_filtered_excludes_unknown_cli_source() {
-        // A row with Unknown(_) cli_source — e.g. a malformed hook payload
-        // — must not appear under any concrete filter. With no filter it
-        // does appear, matching iter_sorted's behaviour.
-        let mut reg = AgentSessionRegistry::new();
-        reg.apply(SessionEvent::SessionStarted {
-            key: k("cop"),
-            cli_source: CliSource::Copilot,
-            pane_session_id: pane("p-cop"),
-            cwd: PathBuf::from("/x"),
-            title: "copilot".into(),
-        });
-        reg.apply(SessionEvent::SessionStarted {
-            key: k("mystery"),
-            cli_source: CliSource::Unknown("foo".into()),
-            pane_session_id: pane("p-mystery"),
-            cwd: PathBuf::from("/x"),
-            title: "mystery".into(),
-        });
-
-        let cop: Vec<&str> = reg
-            .iter_sorted_filtered(Some(&CliSource::Copilot))
-            .iter()
-            .map(|s| s.key.as_str())
-            .collect();
-        assert_eq!(cop, vec!["cop"]);
-
-        let all_len = reg.iter_sorted_filtered(None).len();
-        assert_eq!(all_len, 2);
     }
 }

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -626,14 +626,7 @@ pub struct AcpModelInfo {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DispatchedCommandKind {
     FocusPane,
-    /// Plain Enter on a terminal-state row in the session management
-    /// view: open a new WT tab whose primary pane runs
-    /// `<cli> --resume <key>`. (Previously this was a split-pane in the
-    /// current tab — see commit history; the new-tab variant keeps the
-    /// originating tab clean and matches user expectation that
-    /// resuming a historical session is a "go open my session" action,
-    /// not a "split my workspace" action.)
-    NewTabResume,
+    SplitPaneResume,
     /// Shift+Enter in the session management view — resume a historical
     /// session in the agent pane of a new tab via WT-side coordination +
     /// ACP session/load.
@@ -871,6 +864,10 @@ pub struct TabSession {
 
     // Streaming state
     pub pending_agent_response: String,
+    /// Accumulates the in-progress turn being streamed so it can be
+    /// collapsed into a `CompletedTurn` once the agent finishes. Reset
+    /// on error or cancellation.
+    pub pending_completed_turn: Option<CompletedTurn>,
     /// Accumulator for `session/update` user_message_chunk events
     /// arriving during an ACP `session/load` replay (the historical
     /// user prompt for the next replayed turn). Flushed as a
@@ -925,6 +922,20 @@ pub struct TabSession {
     // its own open/closed state and selected row across tab switches.
     pub current_view: View,
     pub agents_list_state: ratatui::widgets::ListState,
+}
+
+/// Append a thought-stream chunk to the preview buffer, capping at a
+/// reasonable length so the status line doesn't accumulate unbounded text.
+fn append_thought_preview(buf: &mut String, chunk: &str) {
+    const MAX_PREVIEW: usize = 4096;
+    buf.push_str(chunk);
+    if buf.len() > MAX_PREVIEW {
+        // Keep the tail — the most recent text is the most useful preview.
+        let start = buf.len() - MAX_PREVIEW;
+        // Advance to a char boundary.
+        let start = buf.ceil_char_boundary(start);
+        *buf = buf[start..].to_string();
+    }
 }
 
 impl TabSession {
@@ -1526,18 +1537,6 @@ impl App {
         }
     }
 
-    /// Filter to apply to the F2 session-management view based on which
-    /// agent CLI the WTA agent pane is currently driving. Returns
-    /// `Some(CliSource::*)` when `current_agent_id` resolves to a tracked
-    /// CLI (copilot / claude / gemini) so only matching rows are listed.
-    /// Returns `None` when no agent has been selected yet or the agent is
-    /// not one the session registry tracks (codex / unknown) — in that
-    /// case the view falls back to showing every row so the user can still
-    /// see and resume their history.
-    pub fn current_cli_filter(&self) -> Option<crate::agent_sessions::CliSource> {
-        crate::agent_sessions::CliSource::from_agent_id(&self.current_agent_id)
-    }
-
     /// Enter handler for the F2 Agents view. For live rows (Idle / Working
     /// / Attention / Error), focus the underlying WT pane. For terminal-
     /// state rows (Ended / Historical), spawn a new pane that runs the
@@ -1582,28 +1581,22 @@ impl App {
         }
     }
 
-    /// Open a new WT tab whose primary pane runs `<cli> <resume_flag>
-    /// <session_key>` to rehydrate a Historical/Ended agent session from
-    /// the CLI's on-disk session store. Silent no-op for CLIs without a
-    /// resume flag (Codex today) or unknown CLI sources.
+    /// Spawn a new WT pane that runs `<cli> <resume_flag> <session_key>`
+    /// to rehydrate a Historical/Ended agent session from the CLI's
+    /// on-disk session store. Silent no-op for CLIs without a resume
+    /// flag (Codex today) or unknown CLI sources.
     ///
     /// Flow:
     ///   1. Apply `ResumeDispatched` synchronously so a rapid second Enter
     ///      on the same row no-ops while this resume is in flight.
-    ///   2. Issue `wtcli --json new-tab -c "<cli> <flag> <key>" -d "<cwd>"`
-    ///      on a background thread via
-    ///      `spawn_wtcli_split_then_focus_with_callback` — the helper is
-    ///      generic (parses `session_id` from JSON and focuses the new
-    ///      pane), so it works equally well for new-tab and split-pane.
-    ///      Routing through `new-tab` keeps the originating tab clean
-    ///      and matches user expectation that resuming a historical
-    ///      session is a "go open my session" action, not a "split my
-    ///      workspace" action.
+    ///   2. Issue `wtcli --json split-pane -c "<cli> <flag> <key>"` on a
+    ///      background thread via `spawn_wtcli_split_then_focus_with_callback`
+    ///      — that helper also focuses the new pane and gives us back its
+    ///      GUID once the split succeeds.
     ///   3. The callback posts `AgentSessionEvent(ResumePaneAssigned{...})`
-    ///      through `agent_event_tx` so the registry can bind the new
-    ///      tab's primary pane GUID to the row even for hook-less CLIs
-    ///      (Gemini), allowing a later `PaneClosed` to transition the
-    ///      row back to Ended.
+    ///      through `agent_event_tx` so the registry can bind the new pane
+    ///      to the row even for hook-less CLIs (Gemini), allowing a later
+    ///      `PaneClosed` to transition the row back to Ended.
     fn dispatch_resume(&mut self, s: &crate::agent_sessions::AgentSession) {
         let cli_id = match s.cli_source {
             crate::agent_sessions::CliSource::Claude  => "claude",
@@ -1634,32 +1627,30 @@ impl App {
 
         // Per-CLI session stores are keyed by an encoding of the *current*
         // working directory (e.g. Claude looks under
-        // `~/.claude/projects/<encoded-cwd>/<id>.jsonl`; Copilot and
-        // Gemini behave similarly). Without the right cwd the CLI
-        // reports `No conversation found with session ID: <id>` even
+        // `~/.claude/projects/<encoded-cwd>/<id>.jsonl`; Copilot and Gemini
+        // behave similarly). `wtcli split-pane` doesn't accept --cwd
+        // (`src/tools/wtcli/main.cpp:360-402`) so the new pane inherits the
+        // splitting pane's cwd by default. Without a `cd /d` prefix the
+        // CLI reports `No conversation found with session ID: <id>` even
         // though the JSONL exists on disk.
         //
-        // `wtcli new-tab` exposes `-d <cwd>` (see
-        // `src/tools/wtcli/main.cpp:326-353` → COM `CreateTab(...,
-        // startingDirectory, ...)`) so the new tab's primary pane
-        // launches in the historical session's project root directly,
-        // without needing a `cd /d` shell prefix.
-        //
-        // We still wrap the CLI invocation in `cmd /c` because
-        // npm-installed CLIs (`copilot.cmd`, `claude.cmd`, `gemini.cmd`)
-        // need cmd.exe's PATHEXT resolution to launch from a bare name
-        // (`CreateProcess` returns 0x80070002 for `.cmd` shims).
-        let cwd_string = s.cwd.to_string_lossy().to_string();
-        let launch_commandline = format!("cmd /c {}", commandline);
-        let mut argv = vec![
-            "new-tab".to_string(),
+        // We always wrap in `cmd /c` because:
+        //   1. The `cd /d ... && ...` chain requires a shell, and
+        //   2. npm-installed CLIs (`copilot.cmd`, `claude.cmd`,
+        //      `gemini.cmd`) need cmd.exe's PATHEXT resolution to launch
+        //      from a bare name (`CreateProcess` returns 0x80070002 for
+        //      `.cmd` shims).
+        let cwd_string = s.cwd.to_string_lossy();
+        let launch_commandline = if cwd_string.is_empty() {
+            format!("cmd /c {}", commandline)
+        } else {
+            format!("cmd /c cd /d \"{}\" && {}", cwd_string, commandline)
+        };
+        let argv = vec![
+            "split-pane".to_string(),
             "-c".to_string(),
             launch_commandline.clone(),
         ];
-        if !cwd_string.is_empty() {
-            argv.push("-d".to_string());
-            argv.push(cwd_string.clone());
-        }
 
         // Optimistic state flip: bump Historical/Ended -> Idle so a rapid
         // second Enter on the same row sees a non-terminal status and
@@ -1672,9 +1663,6 @@ impl App {
         // for hook-less CLIs (Gemini) so a future `PaneClosed` can
         // transition the row to Ended; harmless duplicate work for
         // Claude/Copilot whose hooks beat us to the same binding.
-        // `wtcli new-tab --json` emits a `session_id` field on the new
-        // tab's primary pane in the same shape as `split-pane --json`,
-        // so the existing helper handles both.
         let cb_key = key.clone();
         let event_tx = self.agent_event_tx.clone();
         let on_pane_id: Option<Box<dyn FnOnce(String) + Send + 'static>> = match event_tx {
@@ -1696,14 +1684,13 @@ impl App {
             cli = %cli_id,
             commandline = %commandline,
             launch_commandline = %launch_commandline,
-            cwd = %cwd_string,
-            "dispatch_resume: new-tab scheduled",
+            "dispatch_resume: split-pane scheduled",
         );
 
         #[cfg(test)]
         {
             self.last_dispatched_command = Some(DispatchedCommand {
-                kind: DispatchedCommandKind::NewTabResume,
+                kind: DispatchedCommandKind::SplitPaneResume,
                 session_id: None,
                 argv,
             });
@@ -3022,10 +3009,7 @@ impl App {
                 // activates immediately. Mirrors the F2 enter-Agents path.
                 if self.current_tab().current_view == View::Agents
                     && self.current_tab().agents_list_state.selected().is_none()
-                    && !self
-                        .agent_sessions
-                        .iter_sorted_filtered(self.current_cli_filter().as_ref())
-                        .is_empty()
+                    && !self.agent_sessions.iter_sorted().is_empty()
                 {
                     self.current_tab_mut().agents_list_state.select(Some(0));
                 }
@@ -3209,10 +3193,8 @@ impl App {
                         "sessions" | "agents" => {
                             let entering_agents =
                                 self.current_tab().current_view != View::Agents;
-                            let has_sessions = !self
-                                .agent_sessions
-                                .iter_sorted_filtered(self.current_cli_filter().as_ref())
-                                .is_empty();
+                            let has_sessions =
+                                !self.agent_sessions.iter_sorted().is_empty();
                             {
                                 let tab = self.current_tab_mut();
                                 tab.current_view = View::Agents;
@@ -3692,8 +3674,7 @@ impl App {
         // selection cursor are per-tab on `TabSession` so each WT tab
         // keeps its own picker state across switches.
         if self.current_tab().current_view == View::Agents {
-            let filter = self.current_cli_filter();
-            let count = self.agent_sessions.iter_sorted_filtered(filter.as_ref()).len();
+            let count = self.agent_sessions.iter_sorted().len();
             match key.code {
                 KeyCode::Down => {
                     let cur = self.current_tab().agents_list_state.selected().unwrap_or(0);
@@ -3710,7 +3691,7 @@ impl App {
                     if let Some(idx) = self.current_tab().agents_list_state.selected() {
                         let selected = self
                             .agent_sessions
-                            .iter_sorted_filtered(filter.as_ref())
+                            .iter_sorted()
                             .get(idx)
                             .map(|s| (*s).clone());
                         if let Some(s) = selected {
@@ -3736,7 +3717,7 @@ impl App {
                     if let Some(idx) = self.current_tab().agents_list_state.selected() {
                         let target = self
                             .agent_sessions
-                            .iter_sorted_filtered(filter.as_ref())
+                            .iter_sorted()
                             .get(idx)
                             .map(|s| (s.key.clone(), s.status.clone()));
                         if let Some((key, status)) = target {
@@ -3747,12 +3728,7 @@ impl App {
                             if matches!(status, Ended | Historical) {
                                 self.agent_sessions.remove(&key);
                                 // Keep the cursor in-bounds after eviction.
-                                // Re-query through the same filter so the
-                                // selection clamp matches the rendered list.
-                                let new_count = self
-                                    .agent_sessions
-                                    .iter_sorted_filtered(filter.as_ref())
-                                    .len();
+                                let new_count = self.agent_sessions.iter_sorted().len();
                                 let tab = self.current_tab_mut();
                                 if new_count == 0 {
                                     tab.agents_list_state.select(None);
@@ -4346,10 +4322,7 @@ impl App {
                 // the Agents picker and seed a selection so Enter/Up/Down
                 // are immediately useful. Esc / F2 still close the view.
                 // Per-tab — only flips the active tab's view state.
-                let has_sessions = !self
-                    .agent_sessions
-                    .iter_sorted_filtered(self.current_cli_filter().as_ref())
-                    .is_empty();
+                let has_sessions = !self.agent_sessions.iter_sorted().is_empty();
                 {
                     let tab = self.current_tab_mut();
                     if tab.agents_list_state.selected().is_none() && has_sessions {
@@ -6475,7 +6448,7 @@ mod tests {
     }
 
     #[test]
-    fn enter_on_history_row_dispatches_new_tab_with_resume() {
+    fn enter_on_history_row_dispatches_split_pane_with_resume() {
         use crate::agent_sessions::{CliSource, SessionEvent};
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         use std::path::PathBuf;
@@ -6499,36 +6472,23 @@ mod tests {
         let cmd = app
             .last_dispatched_command_for_test()
             .expect("a command was dispatched");
-        assert_eq!(cmd.kind, DispatchedCommandKind::NewTabResume);
+        assert_eq!(cmd.kind, DispatchedCommandKind::SplitPaneResume);
         let argv = cmd.argv.join(" ");
-        // The dispatch must use `wtcli new-tab` (not `split-pane`) so the
-        // resumed CLI lands in its own WT tab instead of carving up the
-        // originating tab.
-        assert!(argv.contains("new-tab"), "argv: {}", argv);
+        assert!(argv.contains("split-pane"), "argv: {}", argv);
+        // The actual command may or may not be wrapped with `cmd /c` depending
+        // on whether `claude.exe` exists on the test runner's PATH. Accept
+        // both forms so the test isn't environment-dependent.
         assert!(
-            !argv.contains("split-pane"),
-            "argv must NOT use split-pane: {}",
-            argv
-        );
-        // The CLI invocation is still wrapped in `cmd /c` so .cmd shims
-        // resolve via PATHEXT, but the legacy `cd /d` prefix is gone —
-        // cwd is threaded through wtcli's `-d` flag now.
-        assert!(
-            argv.contains("cmd /c claude --resume abc-123"),
+            argv.contains("claude --resume abc-123"),
             "argv: {}",
             argv
         );
+        // Resume is keyed off the session's project cwd — the new pane's
+        // launch line must `cd /d` into it so the CLI's session store
+        // lookup (`~/.claude/projects/<encoded-cwd>/...`) succeeds.
         assert!(
-            !argv.contains("cd /d"),
-            "argv must NOT contain cd /d (cwd is now passed via -d): {}",
-            argv
-        );
-        // Resume is keyed off the session's project cwd — the new tab's
-        // primary pane must start in that directory so the CLI's session
-        // store lookup (`~/.claude/projects/<encoded-cwd>/...`) succeeds.
-        assert!(
-            argv.contains("-d /work/proj"),
-            "expected -d <cwd>; argv: {}",
+            argv.contains("cd /d \"/work/proj\""),
+            "expected cd /d prefix to original session cwd; argv: {}",
             argv
         );
     }
@@ -6536,11 +6496,10 @@ mod tests {
     #[test]
     fn shift_enter_on_history_row_dispatches_resume_in_agent_pane() {
         // Shift+Enter on a terminal-state row should route to the
-        // ResumeInAgentPane path, NOT the legacy NewTabResume — it
-        // emits `resume_in_new_agent_tab` to WT instead of spawning a
-        // normal terminal tab locally. The dispatched-command tape
-        // captures the shape so downstream wiring can be
-        // regression-checked.
+        // ResumeInAgentPane path, NOT the legacy SplitPaneResume — it
+        // emits `resume_in_new_agent_tab` to WT instead of splitting a
+        // normal pane locally. The dispatched-command tape captures the
+        // shape so downstream wiring can be regression-checked.
         use crate::agent_sessions::{CliSource, SessionEvent};
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         use std::path::PathBuf;

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -119,22 +119,6 @@ struct Cli {
     #[arg(long, default_value = agent_registry::DEFAULT_ACP_COMMAND)]
     agent: String,
 
-    /// Canonical agent identifier (`copilot` / `claude` / `codex` / `gemini`
-    /// / `custom:<name>`). When the host (Windows Terminal) launches wta it
-    /// already knows which entry the user picked in settings, so it passes
-    /// the original `acpAgent` value through here. wta uses this id as the
-    /// authoritative identity for `current_agent_id` — driving the session-
-    /// management view's CLI filter, the preflight check, etc.
-    ///
-    /// When omitted (manual `wta` runs, older host builds, tests) wta falls
-    /// back to inferring the id by parsing the `--agent` command line via
-    /// `agent_registry::resolve_agent_id_from_cmd`. That fallback works for
-    /// bare names but is fragile for adapter-style launches (`npx … claude-
-    /// code-acp`) and full-path launches, so the host should always pass
-    /// `--agent-id` explicitly.
-    #[arg(long)]
-    agent_id: Option<String>,
-
     /// Model override for the ACP agent. Sent via ACP setSessionModel after
     /// handshake. Used by adapter-style launches (claude, codex via npx)
     /// where the model can't be passed on the command line; native ACP
@@ -1700,40 +1684,8 @@ async fn run_acp_app(
             // Skip preflight when FRE is active — FRE has its own agent
             // selection + auth flow and doesn't need the preflight wizard.
             if cli.setup.is_none() {
-                // Prefer the canonical id the host passed via `--agent-id`
-                // — that's the user's actual setting value (`acpAgent`).
-                // Fall back to reverse-parsing the `--agent` command line
-                // for manual runs / older hosts. The fallback handles bare
-                // names cleanly but is fragile for adapter-style launches
-                // (`npx -y …claude-code-acp` → "claude") and full-path
-                // launches (`C:\…\copilot.exe` → "copilot"), which is the
-                // whole reason `--agent-id` exists.
-                let canonical_id: String = cli
-                    .agent_id
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|s| !s.is_empty())
-                    .map(str::to_ascii_lowercase)
-                    .unwrap_or_else(|| {
-                        agent_registry::resolve_agent_id_from_cmd(&agent_cmd).to_string()
-                    });
-                app_state.current_agent_id = canonical_id.clone();
-                tracing::info!(
-                    target: "agents_view_filter",
-                    agent_id = %canonical_id,
-                    agent_cmd = %agent_cmd,
-                    source = if cli.agent_id.is_some() { "--agent-id" } else { "resolved-from-cmd" },
-                    "current_agent_id assigned",
-                );
-                // `agent_check::check_agent` accepts the canonical id and
-                // reuses the existing preflight code path (exe discovery,
-                // credential check). For adapter launches we deliberately
-                // probe the adapted CLI (`claude` / `codex`) rather than
-                // the `npx` wrapper, since auth lives on the underlying
-                // CLI's credential store. Custom agent ids (`custom:foo`)
-                // fall through to the unknown profile, which is fine —
-                // preflight is best-effort for those.
-                let agent_id = canonical_id.as_str();
+                let agent_id = agent_cmd.split_whitespace().next().unwrap_or(&agent_cmd);
+                app_state.current_agent_id = agent_check::check_agent(agent_id).id.clone();
                 let status = agent_check::check_agent(agent_id);
                 let preflight_result = app::PreflightResult {
                     agent_id: status.id.clone(),
@@ -1803,13 +1755,8 @@ async fn run_acp_app(
                 tracing::info!(target: "initial_view", "starting in Agents view");
                 app_state.current_tab_mut().current_view = app::View::Agents;
                 // Seed selection so Enter activates the first row immediately
-                // (mirrors the F2 enter-Agents path). Honor the CLI filter so
-                // we don't seed Some(0) when there are no rows for the
-                // current agent CLI.
-                let has_sessions = !app_state
-                    .agent_sessions
-                    .iter_sorted_filtered(app_state.current_cli_filter().as_ref())
-                    .is_empty();
+                // (mirrors the F2 enter-Agents path).
+                let has_sessions = !app_state.agent_sessions.iter_sorted().is_empty();
                 if has_sessions {
                     app_state.current_tab_mut().agents_list_state.select(Some(0));
                 }

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -52,7 +52,6 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         let tab_id = app.tab_id.as_deref().unwrap_or(DEFAULT_TAB_ID).to_string();
         let load_state = app.history_load_state;
         let activity_frame = app.activity_frame as usize;
-        let cli_filter = app.current_cli_filter();
         let tab = app.tab_sessions.entry(tab_id).or_default();
         agents_view::render(
             frame,
@@ -61,7 +60,6 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             &mut tab.agents_list_state,
             load_state,
             activity_frame,
-            cli_filter.as_ref(),
         );
         return;
     }
@@ -89,12 +87,16 @@ pub fn render(frame: &mut Frame, app: &mut App) {
 
     // Expire the transient hint before deciding whether to reserve a row.
     // Cheap and keeps the layout in lockstep with the rest of the draw.
+    // Also show welcome hint as a transient hint on first-ever connect.
     let now = std::time::Instant::now();
-    let hint_visible = app
-        .transient_hint
-        .as_ref()
-        .map(|(_, deadline)| now < *deadline)
-        .unwrap_or(false);
+    let welcome_visible = app.show_welcome_hint
+        && app.state == crate::app::ConnectionState::Connected;
+    let hint_visible = welcome_visible
+        || app
+            .transient_hint
+            .as_ref()
+            .map(|(_, deadline)| now < *deadline)
+            .unwrap_or(false);
     if !hint_visible {
         app.transient_hint = None;
     }
@@ -154,7 +156,14 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     }
 
     if hint_visible {
-        if let Some((text, _)) = app.transient_hint.as_ref() {
+        if welcome_visible {
+            // First-run shortcut hint
+            let line = Line::from(Span::styled(
+                "  (Ctrl+Shift+. to show/hide agent pane \u{2022} Ctrl+Alt+/ to show/hide agent session)",
+                Style::default().fg(Color::DarkGray),
+            ));
+            frame.render_widget(line, chunks[3]);
+        } else if let Some((text, _)) = app.transient_hint.as_ref() {
             let line = Line::from(Span::styled(
                 format!("  {}", text),
                 Style::default().fg(Color::DarkGray),


### PR DESCRIPTION
Aligns 10 files that diverged due to cherry-pick vs merge-commit resolution differences between the ADO and GitHub repos.

**Fixes CI build failures** caused by mismatched function signatures in WTA:
- \gents_view::render\ called with 6 args but takes 7 (\cli_filter\ param missing)
- \iter_sorted_filtered\ method not found on \AgentSessionRegistry\

**Files synced:**
- \uild/pipelines/templates-v2/job-build-project.yml\ — \wta/\ → \	ools/wta/\ path fixes
- \uild/scripts/Test-WindowsTerminalPackage.ps1\ — accept \wtai.exe\/\WindowsTerminal.exe\
- \CascadiaPackage.wapproj\ — remove duplicate FRE asset content items
- \FreOverlay.xaml\, \TerminalPage.cpp\ — alignment/layout fixes
- \gent_registry.rs\, \gent_sessions.rs\, \pp.rs\, \main.rs\, \layout.rs\ — WTA code sync