### PR TITLE
wta: route card/panel height math through main_area_width

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -4409,7 +4409,7 @@ impl App {
         let Some(recs) = self.current_tab().turn.recommendations() else { return 0 };
         let card_heights = recs.choices.iter().map(|c| rec_card_height(c, panel_width) as u16);
         let total = card_heights.clone().sum::<u16>();
-        let floor = card_heights.max().unwrap_or(ui::card::CARD_MIN_HEIGHT);
+        let floor = card_heights.max().unwrap_or(ui::card::CARD_MIN_SIZE);
         // Reserve: input(3) + chat_min(1) + rec_hint(1) = 5.
         let ceiling = self.terminal_rows.saturating_sub(5);
         total.min(ceiling).max(floor)
@@ -4430,7 +4430,7 @@ impl App {
         // Permission is modal — only hard-reserve input(3).
         let ceiling = self.terminal_rows.saturating_sub(3);
         let h = card_h.min(ceiling);
-        if h >= ui::card::CARD_MIN_HEIGHT { h } else { 1 }
+        if h >= ui::card::CARD_MIN_SIZE { h } else { 1 }
     }
 
     /// Recompute `rec_scroll.max` from the current card heights and the
@@ -5612,8 +5612,8 @@ pub(crate) fn rec_card_height(choice: &RecommendationChoice, panel_width: u16) -
         .sum::<usize>()
         .max(1);
 
-    // CARD_MIN_HEIGHT counts 1 content row; add the wrap-extra rows + 1 gap.
-    ui::card::CARD_MIN_HEIGHT as usize + content_lines.saturating_sub(1) + 1
+    // CARD_MIN_SIZE counts 1 content row; add the wrap-extra rows + 1 gap.
+    ui::card::CARD_MIN_SIZE as usize + content_lines.saturating_sub(1) + 1
 }
 
 /// Computes the rendered height (in terminal rows) of the embedded
@@ -5629,8 +5629,8 @@ pub(crate) fn permission_card_height(perm: &PermissionState, panel_width: u16) -
         })
         .sum::<usize>()
         .max(1);
-    // CARD_MIN_HEIGHT counts 1 content row; add the wrap-extra rows.
-    ui::card::CARD_MIN_HEIGHT as usize + content_lines.saturating_sub(1)
+    // CARD_MIN_SIZE counts 1 content row; add the wrap-extra rows.
+    ui::card::CARD_MIN_SIZE as usize + content_lines.saturating_sub(1)
 }
 
 /// Render a parsed `RecommendationSet` as the agent's "reply" text in chat.
@@ -7265,7 +7265,7 @@ mod tests {
     use crate::coordinator::{
         OpenTarget, RecommendationChoice, RecommendationSet, RecommendedAction,
     };
-    use crate::ui::card::{card_content_width, CARD_H_CHROME, CARD_MIN_HEIGHT};
+    use crate::ui::card::{card_content_width, CARD_H_CHROME, CARD_MIN_SIZE};
 
     fn perm_with(desc: &str) -> PermissionState {
         PermissionState {
@@ -7322,7 +7322,7 @@ mod tests {
         let perm = perm_with("ok");
         assert_eq!(
             permission_card_height(&perm, 80) as u16,
-            CARD_MIN_HEIGHT
+            CARD_MIN_SIZE
         );
     }
 
@@ -7333,13 +7333,13 @@ mod tests {
         let inner_full = 80 - CARD_H_CHROME as usize;
         assert_eq!(
             permission_card_height(&perm, 80),
-            CARD_MIN_HEIGHT as usize + 200_usize.div_ceil(inner_full) - 1
+            CARD_MIN_SIZE as usize + 200_usize.div_ceil(inner_full) - 1
         );
         // Debug panel open: 60% of 80 = 48 → wrap at 40.
         let inner_split = 48 - CARD_H_CHROME as usize;
         assert_eq!(
             permission_card_height(&perm, 48),
-            CARD_MIN_HEIGHT as usize + 200_usize.div_ceil(inner_split) - 1
+            CARD_MIN_SIZE as usize + 200_usize.div_ceil(inner_split) - 1
         );
         // The two should differ — proves the panel_width input matters
         // (the PR #20 reviewer-3 bug).
@@ -7353,13 +7353,13 @@ mod tests {
     fn permission_card_height_treats_blank_lines_as_one_row() {
         let perm = perm_with("line1\n\nline2");
         // 3 logical lines (blank counts as 1).
-        assert_eq!(permission_card_height(&perm, 80), CARD_MIN_HEIGHT as usize + 2);
+        assert_eq!(permission_card_height(&perm, 80), CARD_MIN_SIZE as usize + 2);
     }
 
     #[test]
     fn rec_card_height_includes_inter_card_gap() {
         let h = rec_card_height(&rec_send("ls"), 80);
-        assert_eq!(h as u16, CARD_MIN_HEIGHT + 1);
+        assert_eq!(h as u16, CARD_MIN_SIZE + 1);
     }
 
     #[test]
@@ -7378,7 +7378,7 @@ mod tests {
         };
         let h = rec_card_height(&choice, 80);
         // "New tab (logs) in C:/repo" fits on one row at width 72.
-        assert_eq!(h as u16, CARD_MIN_HEIGHT + 1);
+        assert_eq!(h as u16, CARD_MIN_SIZE + 1);
     }
 
     #[test]
@@ -7391,7 +7391,7 @@ mod tests {
     #[test]
     fn permission_panel_height_falls_back_to_compact_below_card_min() {
         let mut app = test_app();
-        app.terminal_rows = 7; // ceiling = 7-3 = 4 < CARD_MIN_HEIGHT
+        app.terminal_rows = 7; // ceiling = 7-3 = 4 < CARD_MIN_SIZE
         app.current_tab_mut().permission = Some(perm_with("ok"));
         // Must stay visible — agent flow blocks on this prompt. 1-row strip
         // is the compact fallback rendered by `ui::permission::render`.
@@ -7401,9 +7401,9 @@ mod tests {
     #[test]
     fn permission_panel_height_admits_at_card_min_ceiling() {
         let mut app = test_app();
-        app.terminal_rows = 8; // ceiling = 5 == CARD_MIN_HEIGHT
+        app.terminal_rows = 8; // ceiling = 5 == CARD_MIN_SIZE
         app.current_tab_mut().permission = Some(perm_with("ok"));
-        assert_eq!(app.permission_panel_height(80), CARD_MIN_HEIGHT);
+        assert_eq!(app.permission_panel_height(80), CARD_MIN_SIZE);
     }
 
     #[test]
@@ -7440,5 +7440,43 @@ mod tests {
         assert_eq!(app.main_area_width(), 100);
         app.show_debug_panel = true;
         assert_eq!(app.main_area_width(), 60);
+    }
+
+    /// Regression: `ui::recommendations::render` used `area.width` (= `h_rec[1]`
+    /// = `main_area.width - 2`) when calling `rec_card_height`, while
+    /// `rec_panel_height` / `sync_rec_scroll_max` used `main_area.width`. The
+    /// 2-cell desync clipped the bottom card and undercounted scroll bounds
+    /// whenever a card's wrap row count differed between the two widths.
+    ///
+    /// This test pins both code paths to `main_area.width`, and picks a
+    /// text length that lies in the critical window `(W-10, W-8]` so the
+    /// old buggy width (`W-2`, content `W-10`) would wrap to a different
+    /// row count than the correct width (`W`, content `W-8`).
+    #[test]
+    fn rec_card_height_matches_predict_and_render_paths() {
+        let w: u16 = 50;
+        // text length 42 sits exactly at the boundary: fits on 1 row at
+        // inner_width 42 (W=50, chrome=8), but spills to 2 rows at
+        // inner_width 40 (the old buggy basis).
+        let text = "a".repeat(42);
+        let choice = rec_send(&text);
+        let mut app = test_app();
+        app.terminal_cols = w;
+        app.terminal_rows = 30;
+        install_recs(&mut app, vec![choice.clone()]);
+
+        let predict = app.rec_panel_height(app.main_area_width()) as usize;
+        // Same width the renderer now uses (`app.main_area_width()`).
+        let render = rec_card_height(&choice, app.main_area_width());
+        assert_eq!(predict, render);
+
+        // Sanity: confirm the chosen text *is* a sensitive input — i.e. the
+        // old buggy basis (h_rec[1] width = W-2) would have produced a
+        // different height. If this ever fails the test no longer guards
+        // the regression.
+        let buggy = rec_card_height(&choice, app.main_area_width() - 2);
+        assert_ne!(render, buggy,
+            "text length 42 should wrap differently at width 50 vs 48 — \
+             pick a different critical input");
     }
 }

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2581,7 +2581,7 @@ impl App {
                     // 3 input + 1 nav hint row above the input.
                     let recs_top = self
                         .terminal_rows
-                        .saturating_sub(4 + self.rec_panel_height());
+                        .saturating_sub(4 + self.rec_panel_height(self.main_area_width()));
                     row >= recs_top
                 };
                 let d = delta as isize;
@@ -3835,7 +3835,7 @@ impl App {
                 if self.current_tab_mut().selected_recommendation > 0 {
                     self.current_tab_mut().selected_recommendation -= 1;
                     self.current_tab_mut().selected_button = self.default_button_for_selected();
-                    self.scroll_rec_to_selected();
+                    self.scroll_rec_to_selected(self.main_area_width());
                 }
             }
             KeyCode::Down if self.current_tab().input.is_empty() && self.current_tab().turn.recommendations().is_some() => {
@@ -3849,7 +3849,7 @@ impl App {
                     let default_btn = self.default_button_for_selected();
                     self.current_tab_mut().selected_recommendation += 1;
                     self.current_tab_mut().selected_button = default_btn;
-                    self.scroll_rec_to_selected();
+                    self.scroll_rec_to_selected(self.main_area_width());
                 }
             }
             KeyCode::Right | KeyCode::Tab
@@ -4384,58 +4384,63 @@ impl App {
         }
     }
 
+    /// Width of the main area (chat / recs / perm / input) — matches the
+    /// 60/40 horizontal split in `ui::layout::render` when the debug panel is
+    /// open. All card/wrap calculations must root here, not `terminal_cols`.
+    pub fn main_area_width(&self) -> u16 {
+        if self.show_debug_panel {
+            self.terminal_cols.saturating_mul(60) / 100
+        } else {
+            self.terminal_cols
+        }
+    }
+
     /// Height of the recommendations panel — grows to fit content, capped so
-    /// input (3) and chat (≥3) still have room, but floored at
-    /// `tallest_card_h + 1` so any card is fully renderable when scrolled to.
-    /// Using the tallest (not just the recommended) means Down/Up navigation
-    /// never lands on a card too tall for the panel. The floor wins when the
-    /// cap would otherwise hide a card.
-    pub fn rec_panel_height(&self) -> u16 {
+    /// input and chat still have room, but floored at the tallest card's
+    /// height so any card is fully renderable when scrolled to. Using the
+    /// tallest (not just the recommended) means Down/Up navigation never
+    /// lands on a card too tall for the panel.
+    ///
+    /// `panel_width` is the actual render width (`main_area.width` after the
+    /// debug-panel split), not `terminal_cols` — passing the wrong one
+    /// under-counts wrap rows and clips the bottom card when the debug panel
+    /// is open.
+    pub fn rec_panel_height(&self, panel_width: u16) -> u16 {
         let Some(recs) = self.current_tab().turn.recommendations() else { return 0 };
-        let w = self.terminal_cols;
-        let card_heights = recs.choices.iter().map(|c| rec_card_height(c, w) as u16);
+        let card_heights = recs.choices.iter().map(|c| rec_card_height(c, panel_width) as u16);
         let total = card_heights.clone().sum::<u16>();
-        let floor = card_heights.max().unwrap_or(7);
-        // 6 = input (3) + chat min (3); +1 reserves the row layout.rs adds
-        // for the nav hint just above the input.
-        let ceiling = self.terminal_rows.saturating_sub(7);
+        let floor = card_heights.max().unwrap_or(ui::card::CARD_MIN_HEIGHT);
+        // Reserve: input(3) + chat_min(1) + rec_hint(1) = 5.
+        let ceiling = self.terminal_rows.saturating_sub(5);
         total.min(ceiling).max(floor)
     }
 
-    /// Height of the embedded permission card. Returns 0 when no permission
-    /// is pending. Permission is modal-equivalent — the user can't make
-    /// progress without resolving it — so the only hard reserve is the input
-    /// row (3); chat / filler / nav-hint may shrink to make room. When the
-    /// terminal is so short that even the minimum drawable shell (4) won't
-    /// fit, return 0 so layout doesn't reserve unrenderable rows (the card
-    /// shell bails out below 4 in card.rs).
+    /// Height reserved for the embedded permission card. Returns 0 only when
+    /// no permission is pending — when one *is* pending, the user must be
+    /// able to see it (the agent flow is blocked until they answer), so we
+    /// fall back to a 1-row compact strip when the full card can't fit.
+    /// `permission::render` reads the actual reserved height and switches
+    /// between full and compact rendering.
     ///
-    /// `panel_width` must be the actual render width the card will see (i.e.
-    /// `main_area.width` after debug-panel split), not `terminal_cols`.
-    /// Passing the full terminal width would under-count wrap rows when the
-    /// debug panel is visible and clip the description.
+    /// `panel_width` is the actual render width (`main_area.width` after the
+    /// debug-panel split), not `terminal_cols`.
     pub fn permission_panel_height(&self, panel_width: u16) -> u16 {
         let Some(perm) = self.current_tab().permission.as_ref() else { return 0 };
         let card_h = permission_card_height(perm, panel_width) as u16;
+        // Permission is modal — only hard-reserve input(3).
         let ceiling = self.terminal_rows.saturating_sub(3);
         let h = card_h.min(ceiling);
-        if h < 4 { 0 } else { h }
+        if h >= ui::card::CARD_MIN_HEIGHT { h } else { 1 }
     }
 
     /// Recompute `rec_scroll.max` from the current card heights and the
     /// panel's available cards region. Called from layout.rs before
     /// `recommendations::render` so the renderer stays `&App` and any
     /// wheel-driven over-scroll is clamped before paint.
-    ///
-    /// `max = total_cards_h - panel_cards_h` (saturating): when the panel
-    /// grows large enough to fit every card, `max` drops to 0 and `set_max`
-    /// snaps `offset` back to the top — so resizing the pane wider
-    /// "rearranges" the panel without needing a manual scroll.
-    pub fn sync_rec_scroll_max(&mut self) {
-        let w = self.terminal_cols;
-        let panel_cards_h = self.rec_panel_height() as usize;
+    pub fn sync_rec_scroll_max(&mut self, panel_width: u16) {
+        let panel_cards_h = self.rec_panel_height(panel_width) as usize;
         let Some(recs) = self.current_tab().turn.recommendations() else { return };
-        let total: usize = recs.choices.iter().map(|c| rec_card_height(c, w)).sum();
+        let total: usize = recs.choices.iter().map(|c| rec_card_height(c, panel_width)).sum();
         self.current_tab_mut().rec_scroll.set_max(total.saturating_sub(panel_cards_h));
     }
 
@@ -4444,14 +4449,13 @@ impl App {
     }
 
     /// Scroll the rec panel so the selected card's top sits at the panel top.
-    fn scroll_rec_to_selected(&mut self) {
-        let panel_height = self.rec_panel_height() as usize;
-        let w = self.terminal_cols;
+    fn scroll_rec_to_selected(&mut self, panel_width: u16) {
+        let panel_height = self.rec_panel_height(panel_width) as usize;
         let Some(recs) = self.current_tab().turn.recommendations().cloned() else { return };
 
         let mut line_top = 0usize;
         for (idx, choice) in recs.choices.iter().enumerate() {
-            let card_h = rec_card_height(choice, w);
+            let card_h = rec_card_height(choice, panel_width);
             if idx == self.current_tab().selected_recommendation {
                 let tab = self.current_tab_mut();
                 if line_top < tab.rec_scroll.offset
@@ -5572,12 +5576,10 @@ impl App {
 }
 
 /// Computes the rendered height (in terminal rows) of a recommendation card.
+/// Includes one trailing row used as the inter-card gap in the rec panel.
 pub(crate) fn rec_card_height(choice: &RecommendationChoice, panel_width: u16) -> usize {
     use crate::coordinator::RecommendedAction;
-    // h_rec padding (1+1) + side borders (1+1) + inner padding (2+2) = 8. The
-    // card now spans the full h_rec[1] width so its border aligns with the
-    // green-dot column in the chat above (no extra 2-cell outer indent).
-    let inner_width = (panel_width as usize).saturating_sub(8).max(1);
+    let inner_width = ui::card::card_content_width(panel_width);
 
     let text = choice.actions.iter().find_map(|action| match action {
         RecommendedAction::Send { input, .. } => Some(input.clone()),
@@ -5610,31 +5612,25 @@ pub(crate) fn rec_card_height(choice: &RecommendationChoice, panel_width: u16) -
         .sum::<usize>()
         .max(1);
 
-    // top_border + content + divider + buttons + bottom_border + blank = 5 fixed rows.
-    5 + content_lines
+    // CARD_MIN_HEIGHT counts 1 content row; add the wrap-extra rows + 1 gap.
+    ui::card::CARD_MIN_HEIGHT as usize + content_lines.saturating_sub(1) + 1
 }
 
 /// Computes the rendered height (in terminal rows) of the embedded
-/// permission card. Same chrome budget as `rec_card_height` (8-cell
-/// horizontal padding for outer h_perm padding + borders + inner inset),
-/// but without the inter-card gap (only one card is ever shown).
+/// permission card. No inter-card gap — only one card is ever shown.
 pub(crate) fn permission_card_height(perm: &PermissionState, panel_width: u16) -> usize {
-    let inner_width = (panel_width as usize).saturating_sub(8).max(1);
+    let inner_width = ui::card::card_content_width(panel_width);
     let content_lines: usize = perm
         .description
         .lines()
         .map(|line| {
             let chars = line.chars().count();
-            if chars == 0 {
-                1
-            } else {
-                chars.div_ceil(inner_width)
-            }
+            if chars == 0 { 1 } else { chars.div_ceil(inner_width) }
         })
         .sum::<usize>()
         .max(1);
-    // top_border + content + divider + buttons + bottom_border = 4 + content_lines.
-    4 + content_lines
+    // CARD_MIN_HEIGHT counts 1 content row; add the wrap-extra rows.
+    ui::card::CARD_MIN_HEIGHT as usize + content_lines.saturating_sub(1)
 }
 
 /// Render a parsed `RecommendationSet` as the agent's "reply" text in chat.
@@ -7261,5 +7257,188 @@ mod tests {
         // AgentMessageEnd flips end_pending=false.
         app.turn_close(DEFAULT_TAB_ID);
         assert!(app.current_tab().turn.accepts_new_prompt());
+    }
+
+    // ─── card / panel height math ───────────────────────────────────────────
+
+    use crate::app::turn_state::{SubmittedPrompt, TurnOutcome, TurnState};
+    use crate::coordinator::{
+        OpenTarget, RecommendationChoice, RecommendationSet, RecommendedAction,
+    };
+    use crate::ui::card::{card_content_width, CARD_H_CHROME, CARD_MIN_HEIGHT};
+
+    fn perm_with(desc: &str) -> PermissionState {
+        PermissionState {
+            description: desc.to_string(),
+            options: vec![PermOption {
+                id: "allow_once".into(),
+                name: "Allow".into(),
+                kind: "allow_once".into(),
+            }],
+            selected: 0,
+            responder: None,
+        }
+    }
+
+    fn rec_send(input: &str) -> RecommendationChoice {
+        RecommendationChoice {
+            choice: 0,
+            title: "t".into(),
+            rationale: String::new(),
+            actions: vec![RecommendedAction::Send {
+                parent: String::new(),
+                input: input.into(),
+            }],
+        }
+    }
+
+    fn install_recs(app: &mut App, choices: Vec<RecommendationChoice>) {
+        let tab = app.current_tab_mut();
+        tab.turn = TurnState::Surfaced {
+            prompt: SubmittedPrompt {
+                id: 1,
+                text: "p".into(),
+                submitted_at_unix_s: 0.0,
+                autofix: None,
+            },
+            outcome: TurnOutcome::Recommendation(RecommendationSet {
+                recommended_choice: Some(0),
+                choices,
+            }),
+            end_pending: false,
+        };
+    }
+
+    #[test]
+    fn card_content_width_subtracts_chrome_and_floors_at_1() {
+        assert_eq!(card_content_width(80), 80 - CARD_H_CHROME as usize);
+        assert_eq!(card_content_width(CARD_H_CHROME + 1), 1);
+        assert_eq!(card_content_width(CARD_H_CHROME), 1);
+        assert_eq!(card_content_width(0), 1);
+    }
+
+    #[test]
+    fn permission_card_height_single_line_is_card_min() {
+        let perm = perm_with("ok");
+        assert_eq!(
+            permission_card_height(&perm, 80) as u16,
+            CARD_MIN_HEIGHT
+        );
+    }
+
+    #[test]
+    fn permission_card_height_counts_wrap_at_actual_panel_width() {
+        let perm = perm_with(&"a".repeat(200));
+        // Full-width terminal: wrap at 80 - 8 = 72.
+        let inner_full = 80 - CARD_H_CHROME as usize;
+        assert_eq!(
+            permission_card_height(&perm, 80),
+            CARD_MIN_HEIGHT as usize + 200_usize.div_ceil(inner_full) - 1
+        );
+        // Debug panel open: 60% of 80 = 48 → wrap at 40.
+        let inner_split = 48 - CARD_H_CHROME as usize;
+        assert_eq!(
+            permission_card_height(&perm, 48),
+            CARD_MIN_HEIGHT as usize + 200_usize.div_ceil(inner_split) - 1
+        );
+        // The two should differ — proves the panel_width input matters
+        // (the PR #20 reviewer-3 bug).
+        assert_ne!(
+            permission_card_height(&perm, 80),
+            permission_card_height(&perm, 48)
+        );
+    }
+
+    #[test]
+    fn permission_card_height_treats_blank_lines_as_one_row() {
+        let perm = perm_with("line1\n\nline2");
+        // 3 logical lines (blank counts as 1).
+        assert_eq!(permission_card_height(&perm, 80), CARD_MIN_HEIGHT as usize + 2);
+    }
+
+    #[test]
+    fn rec_card_height_includes_inter_card_gap() {
+        let h = rec_card_height(&rec_send("ls"), 80);
+        assert_eq!(h as u16, CARD_MIN_HEIGHT + 1);
+    }
+
+    #[test]
+    fn rec_card_height_handles_open_action_synthesis() {
+        let choice = RecommendationChoice {
+            choice: 0,
+            title: "t".into(),
+            rationale: String::new(),
+            actions: vec![RecommendedAction::Open {
+                target: OpenTarget::Tab,
+                parent: None,
+                cwd: Some("C:/repo".into()),
+                title: Some("logs".into()),
+                direction: None,
+            }],
+        };
+        let h = rec_card_height(&choice, 80);
+        // "New tab (logs) in C:/repo" fits on one row at width 72.
+        assert_eq!(h as u16, CARD_MIN_HEIGHT + 1);
+    }
+
+    #[test]
+    fn permission_panel_height_zero_when_no_permission() {
+        let mut app = test_app();
+        app.terminal_rows = 30;
+        assert_eq!(app.permission_panel_height(80), 0);
+    }
+
+    #[test]
+    fn permission_panel_height_falls_back_to_compact_below_card_min() {
+        let mut app = test_app();
+        app.terminal_rows = 7; // ceiling = 7-3 = 4 < CARD_MIN_HEIGHT
+        app.current_tab_mut().permission = Some(perm_with("ok"));
+        // Must stay visible — agent flow blocks on this prompt. 1-row strip
+        // is the compact fallback rendered by `ui::permission::render`.
+        assert_eq!(app.permission_panel_height(80), 1);
+    }
+
+    #[test]
+    fn permission_panel_height_admits_at_card_min_ceiling() {
+        let mut app = test_app();
+        app.terminal_rows = 8; // ceiling = 5 == CARD_MIN_HEIGHT
+        app.current_tab_mut().permission = Some(perm_with("ok"));
+        assert_eq!(app.permission_panel_height(80), CARD_MIN_HEIGHT);
+    }
+
+    #[test]
+    fn rec_panel_height_floor_lets_tallest_card_render() {
+        let mut app = test_app();
+        app.terminal_rows = 20;
+        let tall = "x".repeat(500);
+        install_recs(&mut app, vec![rec_send(&tall)]);
+        let tall_h = rec_card_height(&app.current_tab().turn.recommendations()
+            .unwrap().choices[0], 80) as u16;
+        // ceiling = 20 - 5 = 15; tall card is much larger; floor wins.
+        assert_eq!(app.rec_panel_height(80), tall_h);
+    }
+
+    #[test]
+    fn rec_panel_height_caps_at_ceiling_when_total_exceeds() {
+        let mut app = test_app();
+        app.terminal_rows = 30;
+        // Three short cards, each h=6 → total 18; ceiling 30-5=25.
+        install_recs(&mut app, vec![rec_send("a"), rec_send("b"), rec_send("c")]);
+        assert_eq!(app.rec_panel_height(80), 18);
+    }
+
+    #[test]
+    fn rec_panel_height_zero_when_no_recs() {
+        let app = test_app();
+        assert_eq!(app.rec_panel_height(80), 0);
+    }
+
+    #[test]
+    fn main_area_width_reflects_debug_panel_split() {
+        let mut app = test_app();
+        app.terminal_cols = 100;
+        assert_eq!(app.main_area_width(), 100);
+        app.show_debug_panel = true;
+        assert_eq!(app.main_area_width(), 60);
     }
 }

--- a/tools/wta/src/ui/card.rs
+++ b/tools/wta/src/ui/card.rs
@@ -10,7 +10,7 @@ pub const CARD_H_CHROME: u16 = 8;
 /// Minimum `area.{width,height}` for `render_card_shell` to paint anything:
 /// 2 borders + content(1) + divider(1) + buttons(1) = 5. Callers reserving
 /// fewer rows than this would leave the card invisible — clamp to 0 instead.
-pub const CARD_MIN_HEIGHT: u16 = 5;
+pub const CARD_MIN_SIZE: u16 = 5;
 
 /// Wrap width inside a card given the outer panel width. Floors at 1 so
 /// `div_ceil` callers don't divide by zero on absurdly narrow terminals.
@@ -29,13 +29,13 @@ pub fn inset_horizontal(r: Rect, n: u16) -> Rect {
 
 /// Paint the card chrome (outer border + middle divider) and return the
 /// inner content/button regions. Returns `None` when `area` is smaller than
-/// `CARD_MIN_HEIGHT` in either dimension.
+/// `CARD_MIN_SIZE` in either dimension.
 pub fn render_card_shell(
     frame: &mut Frame,
     area: Rect,
     border_style: Style,
 ) -> Option<(Rect, Rect)> {
-    if area.width < CARD_MIN_HEIGHT || area.height < CARD_MIN_HEIGHT {
+    if area.width < CARD_MIN_SIZE || area.height < CARD_MIN_SIZE {
         return None;
     }
     let block = Block::default()

--- a/tools/wta/src/ui/card.rs
+++ b/tools/wta/src/ui/card.rs
@@ -3,6 +3,21 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 
 use crate::theme;
 
+/// Horizontal chrome between `main_area.width` and a card's inner text:
+/// 2 (h_rec/h_perm outer padding) + 2 (border) + 4 (inset, 2 each side) = 8.
+pub const CARD_H_CHROME: u16 = 8;
+
+/// Minimum `area.{width,height}` for `render_card_shell` to paint anything:
+/// 2 borders + content(1) + divider(1) + buttons(1) = 5. Callers reserving
+/// fewer rows than this would leave the card invisible — clamp to 0 instead.
+pub const CARD_MIN_HEIGHT: u16 = 5;
+
+/// Wrap width inside a card given the outer panel width. Floors at 1 so
+/// `div_ceil` callers don't divide by zero on absurdly narrow terminals.
+pub fn card_content_width(panel_width: u16) -> usize {
+    (panel_width as usize).saturating_sub(CARD_H_CHROME as usize).max(1)
+}
+
 pub fn inset_horizontal(r: Rect, n: u16) -> Rect {
     Rect {
         x: r.x.saturating_add(n),
@@ -13,15 +28,14 @@ pub fn inset_horizontal(r: Rect, n: u16) -> Rect {
 }
 
 /// Paint the card chrome (outer border + middle divider) and return the
-/// inner content/button regions. Returns `None` when `area` is too small to
-/// fit a usable shell — callers should bail out without painting anything
-/// else, matching the previous per-card "too cramped to draw" guard.
+/// inner content/button regions. Returns `None` when `area` is smaller than
+/// `CARD_MIN_HEIGHT` in either dimension.
 pub fn render_card_shell(
     frame: &mut Frame,
     area: Rect,
     border_style: Style,
 ) -> Option<(Rect, Rect)> {
-    if area.width < 4 || area.height < 4 {
+    if area.width < CARD_MIN_HEIGHT || area.height < CARD_MIN_HEIGHT {
         return None;
     }
     let block = Block::default()
@@ -29,10 +43,6 @@ pub fn render_card_shell(
         .border_style(border_style);
     let inner = block.inner(area);
     frame.render_widget(block, area);
-
-    if inner.height < 3 || inner.width == 0 {
-        return None;
-    }
     let inner_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -77,7 +77,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     };
 
     let rec_panel_h = if app.current_tab().turn.recommendations().is_some() {
-        app.rec_panel_height()
+        app.rec_panel_height(main_area.width)
     } else {
         0
     };
@@ -147,7 +147,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         .split(chunks[2]);
 
     chat::render(frame, app, h_chat[1]);
-    app.sync_rec_scroll_max();
+    app.sync_rec_scroll_max(main_area.width);
     recommendations::render(frame, app, h_rec[1]);
     if app.current_tab().permission.is_some() {
         permission::render(frame, app, h_perm[1]);
@@ -209,7 +209,7 @@ pub fn input_cursor_position(app: &App, area: Rect) -> Option<Position> {
     };
 
     let rec_height = if app.current_tab().turn.recommendations().is_some() {
-        Constraint::Length(app.rec_panel_height())
+        Constraint::Length(app.rec_panel_height(main_area.width))
     } else {
         Constraint::Length(0)
     };

--- a/tools/wta/src/ui/mod.rs
+++ b/tools/wta/src/ui/mod.rs
@@ -1,5 +1,5 @@
 mod auth;
-mod card;
+pub mod card;
 mod chat;
 mod command_popup;
 mod debug_panel;

--- a/tools/wta/src/ui/mod.rs
+++ b/tools/wta/src/ui/mod.rs
@@ -1,5 +1,5 @@
 mod auth;
-pub mod card;
+pub(crate) mod card;
 mod chat;
 mod command_popup;
 mod debug_panel;

--- a/tools/wta/src/ui/permission.rs
+++ b/tools/wta/src/ui/permission.rs
@@ -1,22 +1,29 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Paragraph, Wrap};
 
-use crate::app::App;
+use crate::app::{App, PermissionState};
 use crate::theme;
-use crate::ui::card;
+use crate::ui::card::{self, CARD_MIN_HEIGHT};
 
-/// Render the permission card. Embedded above the input box in the same
-/// chrome as recommendation cards — `layout.rs` reserves the row budget via
-/// `App::permission_panel_height`, so this just paints into the slot.
+/// Render the permission card. Embedded above the input box; `layout.rs`
+/// reserves the row budget via `App::permission_panel_height`, which is
+/// either ≥ `CARD_MIN_HEIGHT` (full card) or exactly 1 (compact fallback —
+/// the agent flow is blocked on this prompt, so we must remain visible).
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     let perm = match &app.current_tab().permission {
         Some(p) => p,
         None => return,
     };
 
+    if area.height < CARD_MIN_HEIGHT {
+        render_compact(frame, perm, area);
+        return;
+    }
+
     let Some((content_area, button_area)) =
         card::render_card_shell(frame, area, theme::CARD_BORDER)
     else {
+        render_compact(frame, perm, area);
         return;
     };
 
@@ -51,4 +58,32 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             .collect();
         card::render_buttons(frame, button_inner, &labels, Some(perm.selected));
     }
+}
+
+/// 1-row fallback when the panel can't fit a full card. Keeps the user
+/// informed that a permission is pending and what to press — the agent is
+/// blocked until they answer, so silently hiding the card would deadlock the
+/// flow.
+fn render_compact(frame: &mut Frame, perm: &PermissionState, area: Rect) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let desc_one_line = perm
+        .description
+        .lines()
+        .next()
+        .unwrap_or("Permission requested");
+    let hint = "[Y/N to answer · resize for full card]";
+    let budget = area.width.saturating_sub(hint.chars().count() as u16 + 4) as usize;
+    let mut desc: String = desc_one_line.chars().take(budget.max(1)).collect();
+    if desc_one_line.chars().count() > budget {
+        desc.push('…');
+    }
+    let line = Line::from(vec![
+        Span::styled("[!] ", theme::BADGE_ACTIONABLE),
+        Span::styled(desc, theme::CARD_DESCRIPTION),
+        Span::raw("  "),
+        Span::styled(hint, theme::DIM),
+    ]);
+    frame.render_widget(Paragraph::new(line), area);
 }

--- a/tools/wta/src/ui/permission.rs
+++ b/tools/wta/src/ui/permission.rs
@@ -3,11 +3,11 @@ use ratatui::widgets::{Paragraph, Wrap};
 
 use crate::app::{App, PermissionState};
 use crate::theme;
-use crate::ui::card::{self, CARD_MIN_HEIGHT};
+use crate::ui::card::{self, CARD_MIN_SIZE};
 
 /// Render the permission card. Embedded above the input box; `layout.rs`
 /// reserves the row budget via `App::permission_panel_height`, which is
-/// either ≥ `CARD_MIN_HEIGHT` (full card) or exactly 1 (compact fallback —
+/// either ≥ `CARD_MIN_SIZE` (full card) or exactly 1 (compact fallback —
 /// the agent flow is blocked on this prompt, so we must remain visible).
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     let perm = match &app.current_tab().permission {
@@ -15,7 +15,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         None => return,
     };
 
-    if area.height < CARD_MIN_HEIGHT {
+    if area.height < CARD_MIN_SIZE {
         render_compact(frame, perm, area);
         return;
     }
@@ -73,16 +73,34 @@ fn render_compact(frame: &mut Frame, perm: &PermissionState, area: Rect) {
         .lines()
         .next()
         .unwrap_or("Permission requested");
+    let prefix = "[!] ";
+    let separator = "  ";
     let hint = "[Y/N to answer · resize for full card]";
-    let budget = area.width.saturating_sub(hint.chars().count() as u16 + 4) as usize;
-    let mut desc: String = desc_one_line.chars().take(budget.max(1)).collect();
-    if desc_one_line.chars().count() > budget {
-        desc.push('…');
-    }
+    // Reserve every non-description column up front (prefix + separator +
+    // hint). Previously we only subtracted prefix+hint and let description
+    // eat the separator — and forced `.max(1)` so 1 char of description
+    // would render even when there was genuinely no room, pushing the hint
+    // off-screen.
+    let overhead =
+        prefix.chars().count() + separator.chars().count() + hint.chars().count();
+    let budget = (area.width as usize).saturating_sub(overhead);
+    let total = desc_one_line.chars().count();
+    let desc: String = if budget == 0 {
+        // No room — show prefix + hint only; the hint must stay visible.
+        String::new()
+    } else if total <= budget {
+        desc_one_line.to_string()
+    } else {
+        // Reserve one column for '…'.
+        let take = budget.saturating_sub(1);
+        let mut s: String = desc_one_line.chars().take(take).collect();
+        s.push('…');
+        s
+    };
     let line = Line::from(vec![
-        Span::styled("[!] ", theme::BADGE_ACTIONABLE),
+        Span::styled(prefix, theme::BADGE_ACTIONABLE),
         Span::styled(desc, theme::CARD_DESCRIPTION),
-        Span::raw("  "),
+        Span::raw(separator),
         Span::styled(hint, theme::DIM),
     ]);
     frame.render_widget(Paragraph::new(line), area);

--- a/tools/wta/src/ui/recommendations.rs
+++ b/tools/wta/src/ui/recommendations.rs
@@ -4,7 +4,7 @@ use ratatui::widgets::{Paragraph, Wrap};
 use crate::app::{rec_card_height, App};
 use crate::coordinator::{OpenTarget, RecommendationChoice, RecommendedAction};
 use crate::theme;
-use crate::ui::card;
+use crate::ui::card::{self, CARD_MIN_HEIGHT};
 
 /// Render the recommendations panel. Pure: callers (layout.rs) must call
 /// `App::sync_rec_scroll_max` first so `rec_scroll.offset` is already clamped
@@ -36,8 +36,8 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             let card_h = h.saturating_sub(1) as u16; // last canvas row is inter-card gap
             let y = area.y + (canvas_top - rec_scroll) as u16;
             let available = cards_bottom.saturating_sub(y);
-            if available < 4 {
-                break; // render_card bails below 4 — nothing useful to draw
+            if available < CARD_MIN_HEIGHT {
+                break; // card shell bails below this — nothing useful to draw
             }
             let render_h = card_h.min(available);
             // Cards use the full h_rec[1] width so their left border sits in
@@ -76,7 +76,7 @@ fn render_card(
     choice: &RecommendationChoice,
     idx: usize,
 ) {
-    if area.width < 4 || area.height < 4 {
+    if area.width < CARD_MIN_HEIGHT || area.height < CARD_MIN_HEIGHT {
         return;
     }
 

--- a/tools/wta/src/ui/recommendations.rs
+++ b/tools/wta/src/ui/recommendations.rs
@@ -4,7 +4,7 @@ use ratatui::widgets::{Paragraph, Wrap};
 use crate::app::{rec_card_height, App};
 use crate::coordinator::{OpenTarget, RecommendationChoice, RecommendedAction};
 use crate::theme;
-use crate::ui::card::{self, CARD_MIN_HEIGHT};
+use crate::ui::card::{self, CARD_MIN_SIZE};
 
 /// Render the recommendations panel. Pure: callers (layout.rs) must call
 /// `App::sync_rec_scroll_max` first so `rec_scroll.offset` is already clamped
@@ -29,14 +29,21 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     let rec_scroll = app.current_tab().rec_scroll.offset;
     let cards_bottom = area.y.saturating_add(area.height);
 
+    // `area` is `h_rec[1]` (post-padding), but `rec_card_height` /
+    // `rec_panel_height` / `sync_rec_scroll_max` all root their wrap math at
+    // `main_area.width` (see `CARD_H_CHROME`). Use the same basis here or
+    // wrap rows go 2 cells narrower at render than at predict, clipping the
+    // bottom card and undercounting `rec_scroll.max`.
+    let panel_width = app.main_area_width();
+
     let mut canvas_top = 0usize;
     for (idx, choice) in recs.choices.iter().enumerate() {
-        let h = rec_card_height(choice, area.width);
+        let h = rec_card_height(choice, panel_width);
         if canvas_top >= rec_scroll {
             let card_h = h.saturating_sub(1) as u16; // last canvas row is inter-card gap
             let y = area.y + (canvas_top - rec_scroll) as u16;
             let available = cards_bottom.saturating_sub(y);
-            if available < CARD_MIN_HEIGHT {
+            if available < CARD_MIN_SIZE {
                 break; // card shell bails below this — nothing useful to draw
             }
             let render_h = card_h.min(available);
@@ -76,7 +83,7 @@ fn render_card(
     choice: &RecommendationChoice,
     idx: usize,
 ) {
-    if area.width < CARD_MIN_HEIGHT || area.height < CARD_MIN_HEIGHT {
+    if area.width < CARD_MIN_SIZE || area.height < CARD_MIN_SIZE {
         return;
     }
 


### PR DESCRIPTION
Card and panel height calculations were using `self.terminal_cols`, which over-counts width when the debug panel is open (60/40 horizontal split). That under-counts text-wrap row counts and clips the bottom recommendation card.

Add `main_area_width()` as the single source of truth for the panel width and thread it through `rec_panel_height`, `permission_panel_height`, and `scroll_rec_to_selected`. Introduce `CARD_MIN_HEIGHT` for a consistent height floor.

## Summary of the Pull Request

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
