### PR TITLE
fix(l10n): align localization comments and fix agent translations across all locales

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -15,6 +15,7 @@
 (?:^|/|\b)requirements(?:-dev|-doc|-test|)\.txt$
 ignore$
 Resources/(?!en)
+^tools/wta/locales/(?!en-US\.yml)
 [^/]\.vsdx$
 -lock\.yaml$
 \.a$

--- a/.github/instructions/rust-localization.instructions.md
+++ b/.github/instructions/rust-localization.instructions.md
@@ -46,15 +46,15 @@ Since YAML has no structured comment system like `.resw`, we use `#` comments wi
 ### Section-level (applies to all strings in a group)
 
 ```yaml
-# {Locked="Intelligent Terminal"} - product name, do not translate
-setup.title.first_run: "Welcome to Intelligent Terminal!"
-setup.title.agent_missing: "Agent not found"
+# {Locked="Copilot","CLI"} - these tokens must stay in English
+agent.status.connected: "Connected to Copilot CLI"
+agent.status.disconnected: "Disconnected from agent"
 ```
 
 ### Line-level (applies to one specific string)
 
 ```yaml
-setup.title.first_run: "Welcome to Intelligent Terminal!"  # {Locked="Intelligent Terminal"}
+hint.confirm: "Press Enter to confirm"  # {Locked="Enter"} keyboard key name
 ```
 
 ### Rules
@@ -63,6 +63,8 @@ setup.title.first_run: "Welcome to Intelligent Terminal!"  # {Locked="Intelligen
 - **Line-level** `{Locked}` comment → applies only to that line
 - Multiple locked tokens: `# {Locked="Copilot","CLI"}`
 - Full lock (entire value must not be translated): `# {Locked}`
+- Pseudo-locale-only lock (real locales translate, pseudo-locales keep English): `# {Locked=qps-ploc,qps-ploca,qps-plocm}`
+  - Use this for product names like "Intelligent Terminal" that real locales should translate but pseudo-locales should not mangle. This mirrors the `.resw` `{Locked=qps-ploc,qps-ploca,qps-plocm}` convention.
 - **Translation rule:** Locked tokens must appear **verbatim** (in English) in all locale files. This matches the `.resw` `{Locked}` convention — see `.github/instructions/localization.instructions.md` for the full list of non-translatable terms.
 
 ## Terminology Alignment

--- a/.github/instructions/rust-localization.instructions.md
+++ b/.github/instructions/rust-localization.instructions.md
@@ -82,7 +82,7 @@ hint.confirm: "Press Enter to confirm"  # {Locked="Enter"} keyboard key name
 - Full lock (entire value must not be translated): `# {Locked}`
 - Pseudo-locale-only lock (real locales translate, pseudo-locales keep English): `# {Locked=qps-ploc,qps-ploca,qps-plocm}`
   - Use this for product names like "Intelligent Terminal" that real locales should translate but pseudo-locales should not mangle. This mirrors the `.resw` `{Locked=qps-ploc,qps-ploca,qps-plocm}` convention.
-- **Translation rule:** Locked tokens must appear **verbatim** (in English) in all locale files. This matches the `.resw` `{Locked}` convention — see `.github/instructions/localization.instructions.md` for the full list of non-translatable terms.
+- **Translation rule:** Tokens marked with `{Locked}` (full lock) or `{Locked="token"}` (token lock) must appear **verbatim** (in English) in all locale files. Tokens marked with `{Locked=qps-ploc,qps-ploca,qps-plocm}` (pseudo-locale-only lock) must be kept verbatim only in pseudo-locale files — real locales should translate them. See `.github/instructions/localization.instructions.md` for the full list of non-translatable terms.
 
 ## Context Comments for Ambiguous Strings (REQUIRED)
 

--- a/.github/instructions/rust-localization.instructions.md
+++ b/.github/instructions/rust-localization.instructions.md
@@ -41,14 +41,30 @@ When adding new strings:
 
 ## Non-Translatable Token Rules
 
-Since YAML has no structured comment system like `.resw`, we use `#` comments with `{Locked}` syntax borrowed from .resw:
+Since YAML has no structured comment system like `.resw`, we use `#` comments with `{Locked}` syntax borrowed from .resw. There are three scope levels:
+
+### File-level (top of file, applies to everything)
+
+Place at the very top of the file, before any section headers. These define constraints that apply to **every string** in the file.
+
+```yaml
+# ── File-level locks ─────────────────────────────────────────────────────────
+# {Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name
+# "Agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human representative or proxy
+
+# ── Setup screen titles ─────────────────────────────────────────────────────
+setup.title.first_run: "Welcome to Intelligent Terminal!"
+```
 
 ### Section-level (applies to all strings in a group)
 
+Place immediately before a group of related strings. Applies until the next section comment.
+
 ```yaml
-# {Locked="Copilot","CLI"} - these tokens must stay in English
-agent.status.connected: "Connected to Copilot CLI"
-agent.status.disconnected: "Disconnected from agent"
+# ── Hooks status output ─────────────────────────────────────────────────────
+# {Locked="CLI","PATH","wt-agent-hooks","wta"} - tool/CLI names, env vars
+hooks.cli_not_on_path: "✗ CLI not on PATH"
+hooks.installed: "✓ installed"
 ```
 
 ### Line-level (applies to one specific string)
@@ -59,6 +75,7 @@ hint.confirm: "Press Enter to confirm"  # {Locked="Enter"} keyboard key name
 
 ### Rules
 
+- **File-level** `{Locked}` comment → applies to all strings in the entire file
 - **Section-level** `{Locked}` comment → applies to all strings below until the next section comment
 - **Line-level** `{Locked}` comment → applies only to that line
 - Multiple locked tokens: `# {Locked="Copilot","CLI"}`
@@ -66,6 +83,53 @@ hint.confirm: "Press Enter to confirm"  # {Locked="Enter"} keyboard key name
 - Pseudo-locale-only lock (real locales translate, pseudo-locales keep English): `# {Locked=qps-ploc,qps-ploca,qps-plocm}`
   - Use this for product names like "Intelligent Terminal" that real locales should translate but pseudo-locales should not mangle. This mirrors the `.resw` `{Locked=qps-ploc,qps-ploca,qps-plocm}` convention.
 - **Translation rule:** Locked tokens must appear **verbatim** (in English) in all locale files. This matches the `.resw` `{Locked}` convention — see `.github/instructions/localization.instructions.md` for the full list of non-translatable terms.
+
+## Context Comments for Ambiguous Strings (REQUIRED)
+
+Short strings (1–2 words) and strings with unclear context **must** have a comment explaining when and where the label is shown to the user. Without context, translators will guess — and guesses lead to mistranslations that can be politically embarrassing or internationally offensive.
+
+### When is a context comment required?
+
+A context comment is **mandatory** when ANY of these are true:
+
+- The value is **1–2 words** and is not `{Locked}` (e.g., `"installed"`, `"Switch agent"`)
+- The value is **ambiguous out of context** — the same word means different things in different domains (e.g., "Agent" = AI agent vs. spy vs. broker vs. proxy)
+- The value contains **domain-specific jargon** that a general translator may not recognize (e.g., `"bundle source"`, `"marketplace path stale"`)
+- The value contains **UI actions** that need spatial/interaction context (e.g., is "Switch" a noun label or a verb command?)
+
+### Format
+
+```yaml
+hooks.installed: "✓ installed"  # Shown when a shell hook is successfully installed
+action.retry: "Retry"  # Button label — retry a failed AI agent connection
+status.stale: "stale"  # Badge in hooks-status table when the install path is outdated
+```
+
+### ⚠️ Mistranslation Risk Table
+
+When writing or reviewing strings, assess the **mistranslation risk** if context is missing. Use this table to prioritize adding comments:
+
+| Risk level | Confidence the translation will go wrong | When to worry | Examples |
+|------------|------------------------------------------|---------------|----------|
+| 🔴 **Critical** | >90% — the word has a dominant meaning in most languages that is **wrong** for this context | The word is a false friend, or its primary meaning is political, military, or socially sensitive | "Agent" (= spy in many languages), "Execute" (= kill), "Abort" (= politically charged in some cultures), "Master/Slave" (= offensive) |
+| 🟠 **High** | 70–90% — the word is ambiguous and translators will likely pick the **more common but wrong** sense | The word has 2+ common meanings and no surrounding sentence to disambiguate | "Terminal" (= airport terminal vs. CLI), "Host" (= party host vs. server), "Shell" (= seashell vs. command shell), "Port" (= harbor vs. network port) |
+| 🟡 **Medium** | 40–70% — the word is technical jargon that a **general translator** may not know | Domain-specific terms that don't appear in everyday language | "Hook" (= fishing hook vs. shell hook), "Bundle" (= package vs. software bundle), "Pane" (= window pane vs. UI pane) |
+| 🟢 **Low** | <40% — the word is clear enough or already a global loanword | Common tech terms that most translators handle correctly | "Error", "OK", "Settings", "Profile" |
+
+**Rule of thumb:** If a string scores 🔴 or 🟠, a missing context comment is a **bug** — treat it the same as a missing `{Locked}` directive. Fix it before shipping.
+
+### Real-world examples of what goes wrong
+
+| String | Missing context | What happens |
+|--------|----------------|--------------|
+| `"Agent not found"` | No comment explaining AI agent | zh-TW translated as "proxy not found" (代理), el-GR as "spy not found" (πράκτορας) |
+| `"Switch agent"` | No comment explaining it's a UI action | Could be translated as a noun phrase ("agent switch/toggle device") instead of a verb command |
+| `"installed"` | No comment explaining it's a hook status | Could be translated as past tense ("was installed") vs. adjective state ("currently installed") |
+| `"stale"` | No comment explaining marketplace path | Could be translated as "old bread" or "not fresh" instead of "outdated" in tech sense |
+
+### Applying to existing strings
+
+When adding new strings or reviewing existing ones, scan for any that lack comments and score 🟡 or above. Add context comments proactively — it is far cheaper to write a 10-word comment now than to debug a politically embarrassing mistranslation across 85+ locales later.
 
 ## Terminology Alignment
 

--- a/.github/instructions/rust-localization.instructions.md
+++ b/.github/instructions/rust-localization.instructions.md
@@ -86,7 +86,7 @@ hint.confirm: "Press Enter to confirm"  # {Locked="Enter"} keyboard key name
 
 ## Context Comments for Ambiguous Strings (REQUIRED)
 
-Short strings (1–2 words) and strings with unclear context **must** have a comment explaining when and where the label is shown to the user. Without context, translators will guess — and guesses lead to mistranslations that can be politically embarrassing or internationally offensive.
+Short strings (1–2 words) and strings with unclear context **must** have a comment explaining when and where the label is shown to the user. Without context, translators will guess — and guesses lead to translation errors that can be politically embarrassing or internationally offensive.
 
 ### When is a context comment required?
 
@@ -129,7 +129,7 @@ When writing or reviewing strings, assess the **mistranslation risk** if context
 
 ### Applying to existing strings
 
-When adding new strings or reviewing existing ones, scan for any that lack comments and score 🟡 or above. Add context comments proactively — it is far cheaper to write a 10-word comment now than to debug a politically embarrassing mistranslation across 85+ locales later.
+When adding new strings or reviewing existing ones, scan for any that lack comments and score 🟡 or above. Add context comments early — it is far cheaper to write a 10-word comment now than to debug a politically embarrassing translation error across 85+ locales later.
 
 ## Terminology Alignment
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -128,4 +128,7 @@
         "**/packages/**": true,
     },
     "sarif-viewer.connectToGithubCodeScanning": "on",
+    "C_Cpp.default.configurationProvider": "microsoft.vscode-nmake-tools",
+    "C_Cpp.formatting": "clang-format",
+    "editor.formatOnType": true,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -128,7 +128,4 @@
         "**/packages/**": true,
     },
     "sarif-viewer.connectToGithubCodeScanning": "on",
-    "C_Cpp.default.configurationProvider": "microsoft.vscode-nmake-tools",
-    "C_Cpp.formatting": "clang-format",
-    "editor.formatOnType": true,
 }

--- a/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
@@ -119,7 +119,7 @@
   </resheader>
   <data name="AppName" xml:space="preserve">
     <value>Intelligent Terminal</value>
-    <comment>{Locked} Product name — do not translate.</comment>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppNameDev" xml:space="preserve">
     <value>Intelligent Terminal</value>
@@ -135,7 +135,7 @@
   </data>
   <data name="AppStoreName" xml:space="preserve">
     <value>Intelligent Terminal</value>
-    <comment>{Locked} Product name — do not translate.</comment>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppStoreNameDev" xml:space="preserve">
     <value>Intelligent Terminal</value>
@@ -151,7 +151,7 @@
   </data>
   <data name="AppShortName" xml:space="preserve">
     <value>Intelligent Terminal</value>
-    <comment>{Locked} Product name — do not translate.</comment>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppShortNameDev" xml:space="preserve">
     <value>Intelligent Terminal</value>

--- a/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
@@ -167,7 +167,8 @@
   </data>
   <data name="AppDescription" xml:space="preserve">
     <value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value>
-  <comment>"agents" here means AI agents (Copilot, Claude, Gemini), not human representatives. "terminal" means a command-line terminal application, not an airport terminal. This is the app store description shown to users.</comment></data>
+    <comment>"agents" here means AI agents (Copilot, Claude, Gemini), not human representatives. "terminal" means a command-line terminal application, not an airport terminal. This is the app store description shown to users.</comment>
+  </data>
   <data name="AppDescriptionDev" xml:space="preserve">
     <value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>
@@ -178,7 +179,8 @@
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows Terminal with a preview of upcoming features</value>
-  <comment>"Terminal" means a command-line terminal application. "Preview" means a pre-release version with upcoming features. This is the app store description for the Preview build.</comment></data>
+    <comment>"Terminal" means a command-line terminal application. "Preview" means a pre-release version with upcoming features. This is the app store description for the Preview build.</comment>
+  </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve">
     <value>Open in Intelligent Terminal</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>

--- a/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -167,7 +167,7 @@
   </data>
   <data name="AppDescription" xml:space="preserve">
     <value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value>
-  </data>
+  <comment>"agents" here means AI agents (Copilot, Claude, Gemini), not human representatives. "terminal" means a command-line terminal application, not an airport terminal. This is the app store description shown to users.</comment></data>
   <data name="AppDescriptionDev" xml:space="preserve">
     <value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>
@@ -178,14 +178,14 @@
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
     <value>Windows Terminal with a preview of upcoming features</value>
-  </data>
+  <comment>"Terminal" means a command-line terminal application. "Preview" means a pre-release version with upcoming features. This is the app store description for the Preview build.</comment></data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve">
     <value>Open in Intelligent Terminal</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Canary" xml:space="preserve">
     <value>Open in Terminal (&amp;Canary)</value>
-    <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Canary version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
+    <comment>"Canary" means an unstable or nightly build of the software, not the bird. This is a menu item in Windows File Explorer that launches the Canary version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
     <value>Open in Terminal &amp;Preview</value>

--- a/src/cascadia/CascadiaPackage/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-ploc/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -169,7 +169,7 @@
     <value>Τĥз Йéщ Ẃįńđôẃѕ Тéѓmĩиâļ !!! !!! !</value>
   </data>
   <data name="AppDescriptionDev" xml:space="preserve">
-    <value>The Windows Terminal, but Unofficial</value>
+    <value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>
   </data>
   <data name="AppDescriptionCan" xml:space="preserve">
@@ -180,7 +180,7 @@
     <value>Щΐňδόŵѕ Ŧęřмĭŉäℓ ẅîťħ à φřеνίëẃ θƒ џрсøмΐŉğ ƒĕāŧųřэś !!! !!! !!! !!! !!! </value>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve">
-    <value>Open in Terminal (&amp;Dev)</value>
+    <value>Open in Intelligent Terminal</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Canary" xml:space="preserve">

--- a/src/cascadia/CascadiaPackage/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-ploca/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -169,7 +169,7 @@
     <value>Τĥз Йéщ Ẃįńđôẃѕ Тéѓmĩиâļ !!! !!! !</value>
   </data>
   <data name="AppDescriptionDev" xml:space="preserve">
-    <value>The Windows Terminal, but Unofficial</value>
+    <value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>
   </data>
   <data name="AppDescriptionCan" xml:space="preserve">
@@ -180,7 +180,7 @@
     <value>Щΐňδόŵѕ Ŧęřмĭŉäℓ ẅîťħ à φřеνίëẃ θƒ џрсøмΐŉğ ƒĕāŧųřэś !!! !!! !!! !!! !!! </value>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve">
-    <value>Open in Terminal (&amp;Dev)</value>
+    <value>Open in Intelligent Terminal</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Canary" xml:space="preserve">

--- a/src/cascadia/CascadiaPackage/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-plocm/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -169,7 +169,7 @@
     <value>Τĥз Йéщ Ẃįńđôẃѕ Тéѓmĩиâļ !!! !!! !</value>
   </data>
   <data name="AppDescriptionDev" xml:space="preserve">
-    <value>The Windows Terminal, but Unofficial</value>
+    <value>AI-native terminal — agents can understand, fix, and automate terminal workflows</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>
   </data>
   <data name="AppDescriptionCan" xml:space="preserve">
@@ -180,7 +180,7 @@
     <value>Щΐňδόŵѕ Ŧęřмĭŉäℓ ẅîťħ à φřеνίëẃ θƒ џрсøмΐŉğ ƒĕāŧųřэś !!! !!! !!! !!! !!! </value>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve">
-    <value>Open in Terminal (&amp;Dev)</value>
+    <value>Open in Intelligent Terminal</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Canary" xml:space="preserve">

--- a/tools/wta/locales/af-ZA.yml
+++ b/tools/wta/locales/af-ZA.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Welkom by Intelligent Terminal!"
+setup.title.first_run: "Welkom by Intelligente Terminaal!"
 setup.title.agent_missing: "Agent nie gevind nie"
 setup.title.agent_error: "Agentverbinding het misluk"
 setup.title.switch_agent: "Wissel agent"

--- a/tools/wta/locales/am-ET.yml
+++ b/tools/wta/locales/am-ET.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "እንኳን ወደ Intelligent Terminal በደህና መጡ!"
+setup.title.first_run: "እንኳን ወደ ብልህ ተርሚናል በደህና መጡ!"
 setup.title.agent_missing: "ኤጅንት አልተገኘም"
 setup.title.agent_error: "ኤጅንት ግንኙነት አልተሳካም"
 setup.title.switch_agent: "ኤጅንትን ቀይር"

--- a/tools/wta/locales/ar-SA.yml
+++ b/tools/wta/locales/ar-SA.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "مرحبًا بك في الوحدة الطرفية الذكية!"
-setup.title.agent_missing: "لم يتم العثور على الوكيل"
-setup.title.agent_error: "فشل الاتصال بالوكيل"
-setup.title.switch_agent: "تبديل الوكيل"
+setup.title.agent_missing: "لم يتم العثور على عامل الذكاء الاصطناعي"
+setup.title.agent_error: "فشل الاتصال بعامل الذكاء الاصطناعي"
+setup.title.switch_agent: "تبديل عامل الذكاء الاصطناعي"

--- a/tools/wta/locales/ar-SA.yml
+++ b/tools/wta/locales/ar-SA.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "مرحبًا بك في Intelligent Terminal!"
+setup.title.first_run: "مرحبًا بك في الوحدة الطرفية الذكية!"
 setup.title.agent_missing: "لم يتم العثور على الوكيل"
 setup.title.agent_error: "فشل الاتصال بالوكيل"
 setup.title.switch_agent: "تبديل الوكيل"

--- a/tools/wta/locales/ar-SA.yml
+++ b/tools/wta/locales/ar-SA.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "مرحبًا بك في الوحدة الطرفية الذكية!"
-setup.title.agent_missing: "لم يتم العثور على عامل الذكاء الاصطناعي"
-setup.title.agent_error: "فشل الاتصال بعامل الذكاء الاصطناعي"
-setup.title.switch_agent: "تبديل عامل الذكاء الاصطناعي"
+setup.title.agent_missing: "لم يتم العثور على وكيل الذكاء الاصطناعي"
+setup.title.agent_error: "فشل الاتصال بوكيل الذكاء الاصطناعي"
+setup.title.switch_agent: "بدّل وكيل الذكاء الاصطناعي"

--- a/tools/wta/locales/as-IN.yml
+++ b/tools/wta/locales/as-IN.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "ইন্টেলিজেণ্ট টাৰ্মিনেললৈ স্বাগতম!"
+setup.title.first_run: "ইন্টেলিজেন্ট টাৰ্মিনেললৈ স্বাগতম!"
 setup.title.agent_missing: "এজেণ্ট পোৱা নগল"
 setup.title.agent_error: "এজেণ্ট সংযোগ বিফল হল"
 setup.title.switch_agent: "এজেণ্ট সলনি কৰক"

--- a/tools/wta/locales/az-Latn-AZ.yml
+++ b/tools/wta/locales/az-Latn-AZ.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Ağıllı Terminal-a xoş gəlmisiniz!"
+setup.title.first_run: "Ağıllı Terminal tətbiqinə xoş gəlmisiniz!"
 setup.title.agent_missing: "Agent tapılmadı"
 setup.title.agent_error: "Agent bağlantısı uğursuz oldu"
 setup.title.switch_agent: "Agenti dəyiş"

--- a/tools/wta/locales/az-Latn-AZ.yml
+++ b/tools/wta/locales/az-Latn-AZ.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Intelligent Terminal-a xoş gəlmisiniz!"
+setup.title.first_run: "Ağıllı Terminal-a xoş gəlmisiniz!"
 setup.title.agent_missing: "Agent tapılmadı"
 setup.title.agent_error: "Agent bağlantısı uğursuz oldu"
 setup.title.switch_agent: "Agenti dəyiş"

--- a/tools/wta/locales/bg-BG.yml
+++ b/tools/wta/locales/bg-BG.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Добре дошли в Intelligent Terminal!"
+setup.title.first_run: "Добре дошли в Интелигентен Терминал!"
 setup.title.agent_missing: "Агентът не е намерен"
 setup.title.agent_error: "Връзката с агента е неуспешна"
 setup.title.switch_agent: "Смяна на агента"

--- a/tools/wta/locales/bg-BG.yml
+++ b/tools/wta/locales/bg-BG.yml
@@ -2,4 +2,4 @@
 setup.title.first_run: "Добре дошли в Интелигентен Терминал!"
 setup.title.agent_missing: "Агентът не е намерен"
 setup.title.agent_error: "Връзката с агента е неуспешна"
-setup.title.switch_agent: "Смяна на агента"
+setup.title.switch_agent: "Сменете агента"

--- a/tools/wta/locales/bs-Latn-BA.yml
+++ b/tools/wta/locales/bs-Latn-BA.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Dobrodošli u Intelligent Terminal!"
+setup.title.first_run: "Dobrodošli u Inteligentni Terminal!"
 setup.title.agent_missing: "Agent nije pronađen"
 setup.title.agent_error: "Povezivanje s agentom nije uspjelo"
 setup.title.switch_agent: "Promijeni agenta"

--- a/tools/wta/locales/ca-ES.yml
+++ b/tools/wta/locales/ca-ES.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Us donem la benvinguda a l'Terminal Intel·ligent!"
+setup.title.first_run: "Us donem la benvinguda al Terminal Intel·ligent!"
 setup.title.agent_missing: "No s'ha trobat l'agent"
 setup.title.agent_error: "No s'ha pogut connectar amb l'agent"
 setup.title.switch_agent: "Canvia d'agent"

--- a/tools/wta/locales/ca-ES.yml
+++ b/tools/wta/locales/ca-ES.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Us donem la benvinguda a l'Intelligent Terminal!"
+setup.title.first_run: "Us donem la benvinguda a l'Terminal Intel·ligent!"
 setup.title.agent_missing: "No s'ha trobat l'agent"
 setup.title.agent_error: "No s'ha pogut connectar amb l'agent"
 setup.title.switch_agent: "Canvia d'agent"

--- a/tools/wta/locales/ca-Es-VALENCIA.yml
+++ b/tools/wta/locales/ca-Es-VALENCIA.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Vos donem la benvinguda a l'Terminal Intel·ligent!"
+setup.title.first_run: "Vos donem la benvinguda al Terminal Intel·ligent!"
 setup.title.agent_missing: "No s'ha trobat l'agent"
 setup.title.agent_error: "No s'ha pogut connectar amb l'agent"
 setup.title.switch_agent: "Canvia d'agent"

--- a/tools/wta/locales/ca-Es-VALENCIA.yml
+++ b/tools/wta/locales/ca-Es-VALENCIA.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Vos donem la benvinguda a l'Intelligent Terminal!"
+setup.title.first_run: "Vos donem la benvinguda a l'Terminal Intel·ligent!"
 setup.title.agent_missing: "No s'ha trobat l'agent"
 setup.title.agent_error: "No s'ha pogut connectar amb l'agent"
 setup.title.switch_agent: "Canvia d'agent"

--- a/tools/wta/locales/cs-CZ.yml
+++ b/tools/wta/locales/cs-CZ.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Vítejte v Intelligent Terminal!"
+setup.title.first_run: "Vítejte v Inteligentní Terminál!"
 setup.title.agent_missing: "Agenta se nepodařilo najít"
 setup.title.agent_error: "Připojení k agentovi se nezdařilo"
 setup.title.switch_agent: "Přepnout agenta"

--- a/tools/wta/locales/cs-CZ.yml
+++ b/tools/wta/locales/cs-CZ.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Vítejte v Inteligentní Terminál!"
+setup.title.first_run: "Vítejte v aplikaci Inteligentní Terminál!"
 setup.title.agent_missing: "Agenta se nepodařilo najít"
 setup.title.agent_error: "Připojení k agentovi se nezdařilo"
-setup.title.switch_agent: "Přepnout agenta"
+setup.title.switch_agent: "Přepněte agenta"

--- a/tools/wta/locales/cy-GB.yml
+++ b/tools/wta/locales/cy-GB.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Croeso i Intelligent Terminal!"
+setup.title.first_run: "Croeso i Terfynell Ddeallus!"
 setup.title.agent_missing: "Ni chanfuwyd yr asiant"
 setup.title.agent_error: "Methwyd â chysylltu â'r asiant"
 setup.title.switch_agent: "Newid asiant"

--- a/tools/wta/locales/de-DE.yml
+++ b/tools/wta/locales/de-DE.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Willkommen bei Intelligent Terminal!"
+setup.title.first_run: "Willkommen bei Intelligentes Terminal!"
 setup.title.agent_missing: "Agent nicht gefunden"
 setup.title.agent_error: "Verbindung zum Agenten fehlgeschlagen"
 setup.title.switch_agent: "Agent wechseln"

--- a/tools/wta/locales/de-DE.yml
+++ b/tools/wta/locales/de-DE.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Willkommen bei Intelligentes Terminal!"
+setup.title.first_run: "Willkommen beim Intelligenten Terminal!"
 setup.title.agent_missing: "Agent nicht gefunden"
 setup.title.agent_error: "Verbindung zum Agenten fehlgeschlagen"
 setup.title.switch_agent: "Agent wechseln"

--- a/tools/wta/locales/el-GR.yml
+++ b/tools/wta/locales/el-GR.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "Καλως ήρθατε στο Έξυπνο Τερματικό!"
-setup.title.agent_missing: "Δεν βρέθηκε ο πράκτορας"
-setup.title.agent_error: "Η σύνδεση με τον πράκτορα απέτυχε"
-setup.title.switch_agent: "Αλλαγή πράκτορα"
+setup.title.agent_missing: "Δεν βρέθηκε ο παράγοντας"
+setup.title.agent_error: "Η σύνδεση με τον παράγοντα απέτυχε"
+setup.title.switch_agent: "Αλλαγή παράγοντα"

--- a/tools/wta/locales/el-GR.yml
+++ b/tools/wta/locales/el-GR.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Καλως ήρθατε στο Έξυπνο Τερματικό!"
+setup.title.first_run: "Καλώς ήρθατε στο Έξυπνο Τερματικό!"
 setup.title.agent_missing: "Δεν βρέθηκε ο παράγοντας"
 setup.title.agent_error: "Η σύνδεση με τον παράγοντα απέτυχε"
 setup.title.switch_agent: "Αλλαγή παράγοντα"

--- a/tools/wta/locales/el-GR.yml
+++ b/tools/wta/locales/el-GR.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Καλως ήρθατε στο Intelligent Terminal!"
+setup.title.first_run: "Καλως ήρθατε στο Έξυπνο Τερματικό!"
 setup.title.agent_missing: "Δεν βρέθηκε ο πράκτορας"
 setup.title.agent_error: "Η σύνδεση με τον πράκτορα απέτυχε"
 setup.title.switch_agent: "Αλλαγή πράκτορα"

--- a/tools/wta/locales/en-US.yml
+++ b/tools/wta/locales/en-US.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-# {Locked="Intelligent Terminal"} - product name, do not translate
+# {Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name
 setup.title.first_run: "Welcome to Intelligent Terminal!"
 setup.title.agent_missing: "Agent not found"
 setup.title.agent_error: "Agent connection failed"

--- a/tools/wta/locales/en-US.yml
+++ b/tools/wta/locales/en-US.yml
@@ -1,6 +1,9 @@
-# Setup screen titles
+# ── File-level locks ─────────────────────────────────────────────────────────
 # {Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name
-setup.title.first_run: "Welcome to Intelligent Terminal!"
-setup.title.agent_missing: "Agent not found"
-setup.title.agent_error: "Agent connection failed"
-setup.title.switch_agent: "Switch agent"
+# "Agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human representative or proxy
+
+# ── Setup screen titles ─────────────────────────────────────────────────────
+setup.title.first_run: "Welcome to Intelligent Terminal!"  # Title shown on first launch setup screen
+setup.title.agent_missing: "Agent not found"  # Title when the configured AI agent binary cannot be located on disk
+setup.title.agent_error: "Agent connection failed"  # Title when the AI agent process fails to start or connect
+setup.title.switch_agent: "Switch agent"  # Button label — verb command to change which AI agent is active

--- a/tools/wta/locales/es-ES.yml
+++ b/tools/wta/locales/es-ES.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "¡Bienvenido a Intelligent Terminal!"
+setup.title.first_run: "¡Bienvenido a Terminal Inteligente!"
 setup.title.agent_missing: "No se ha encontrado el agente"
 setup.title.agent_error: "Error al conectar con el agente"
 setup.title.switch_agent: "Cambiar agente"

--- a/tools/wta/locales/es-MX.yml
+++ b/tools/wta/locales/es-MX.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "¡Bienvenido a Intelligent Terminal!"
+setup.title.first_run: "¡Bienvenido a Terminal Inteligente!"
 setup.title.agent_missing: "No se encontró el agente"
 setup.title.agent_error: "No se pudo conectar con el agente"
 setup.title.switch_agent: "Cambiar de agente"

--- a/tools/wta/locales/et-EE.yml
+++ b/tools/wta/locales/et-EE.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Tere tulemast Nutikas Terminali!"
+setup.title.first_run: "Tere tulemast rakendusse „Nutikas Terminal“!"
 setup.title.agent_missing: "Agenti ei leitud"
 setup.title.agent_error: "Agendiga ühenduse loomine nurjus"
 setup.title.switch_agent: "Vaheta agenti"

--- a/tools/wta/locales/et-EE.yml
+++ b/tools/wta/locales/et-EE.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Tere tulemast Intelligent Terminali!"
+setup.title.first_run: "Tere tulemast Nutikas Terminali!"
 setup.title.agent_missing: "Agenti ei leitud"
 setup.title.agent_error: "Agendiga ühenduse loomine nurjus"
 setup.title.switch_agent: "Vaheta agenti"

--- a/tools/wta/locales/eu-ES.yml
+++ b/tools/wta/locales/eu-ES.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Ongi etorri Intelligent Terminal-era!"
+setup.title.first_run: "Ongi etorri Terminal Adimenduna-era!"
 setup.title.agent_missing: "Agentea ez da aurkitu"
 setup.title.agent_error: "Agentearekin konektatzeak huts egin du"
 setup.title.switch_agent: "Aldatu agentea"

--- a/tools/wta/locales/fa-IR.yml
+++ b/tools/wta/locales/fa-IR.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "به Intelligent Terminal خوش آمدید!"
+setup.title.first_run: "به پایانه هوشمند خوش آمدید!"
 setup.title.agent_missing: "عامل یافت نشد"
 setup.title.agent_error: "اتصال به عامل ناموفق بود"
 setup.title.switch_agent: "تغییر عامل"

--- a/tools/wta/locales/fa-IR.yml
+++ b/tools/wta/locales/fa-IR.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "به پایانه هوشمند خوش آمدید!"
-setup.title.agent_missing: "عامل یافت نشد"
-setup.title.agent_error: "اتصال به عامل ناموفق بود"
-setup.title.switch_agent: "تغییر عامل"
+setup.title.agent_missing: "عامل هوش مصنوعی یافت نشد"
+setup.title.agent_error: "اتصال به عامل هوش مصنوعی ناموفق بود"
+setup.title.switch_agent: "تغییر عامل هوش مصنوعی"

--- a/tools/wta/locales/fa-IR.yml
+++ b/tools/wta/locales/fa-IR.yml
@@ -2,4 +2,4 @@
 setup.title.first_run: "به پایانه هوشمند خوش آمدید!"
 setup.title.agent_missing: "عامل هوش مصنوعی یافت نشد"
 setup.title.agent_error: "اتصال به عامل هوش مصنوعی ناموفق بود"
-setup.title.switch_agent: "تغییر عامل هوش مصنوعی"
+setup.title.switch_agent: "عامل هوش مصنوعی را تغییر دهید"

--- a/tools/wta/locales/fi-FI.yml
+++ b/tools/wta/locales/fi-FI.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Tervetuloa Älykäs Pääteiin!"
+setup.title.first_run: "Tervetuloa Älykäs Pääte -sovellukseen!"
 setup.title.agent_missing: "Agenttia ei löytynyt"
 setup.title.agent_error: "Yhteys agenttiin epäonnistui"
 setup.title.switch_agent: "Vaihda agentti"

--- a/tools/wta/locales/fi-FI.yml
+++ b/tools/wta/locales/fi-FI.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Tervetuloa Intelligent Terminaliin!"
+setup.title.first_run: "Tervetuloa Älykäs Pääteiin!"
 setup.title.agent_missing: "Agenttia ei löytynyt"
 setup.title.agent_error: "Yhteys agenttiin epäonnistui"
 setup.title.switch_agent: "Vaihda agentti"

--- a/tools/wta/locales/fil-PH.yml
+++ b/tools/wta/locales/fil-PH.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "Maligayang pagdating sa Matalinong Terminal!"
-setup.title.agent_missing: "Hindi nahanap ang agent"
-setup.title.agent_error: "Nabigo ang koneksyon sa agent"
-setup.title.switch_agent: "Palitan ang agent"
+setup.title.agent_missing: "Hindi nahanap ang AI agent"
+setup.title.agent_error: "Nabigo ang koneksyon sa AI agent"
+setup.title.switch_agent: "Palitan ang AI agent"

--- a/tools/wta/locales/fil-PH.yml
+++ b/tools/wta/locales/fil-PH.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Maligayang pagdating sa Intelligent Terminal!"
+setup.title.first_run: "Maligayang pagdating sa Matalinong Terminal!"
 setup.title.agent_missing: "Hindi nahanap ang agent"
 setup.title.agent_error: "Nabigo ang koneksyon sa agent"
 setup.title.switch_agent: "Palitan ang agent"

--- a/tools/wta/locales/fr-CA.yml
+++ b/tools/wta/locales/fr-CA.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Bienvenue dans Intelligent Terminal !"
+setup.title.first_run: "Bienvenue dans Terminal Intelligent !"
 setup.title.agent_missing: "Agent introuvable"
 setup.title.agent_error: "Impossible de se connecter à l'agent"
 setup.title.switch_agent: "Changer d'agent"

--- a/tools/wta/locales/fr-FR.yml
+++ b/tools/wta/locales/fr-FR.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Bienvenue dans Intelligent Terminal !"
+setup.title.first_run: "Bienvenue dans Terminal Intelligent !"
 setup.title.agent_missing: "Agent introuvable"
 setup.title.agent_error: "Échec de la connexion à l'agent"
 setup.title.switch_agent: "Changer d'agent"

--- a/tools/wta/locales/ga-IE.yml
+++ b/tools/wta/locales/ga-IE.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Fáilte go Intelligent Terminal!"
+setup.title.first_run: "Fáilte go Teirminéal Cliste!"
 setup.title.agent_missing: "Nír aimsíodh an gníomhaire"
 setup.title.agent_error: "Theip ar cheangal an ghníomhaire"
 setup.title.switch_agent: "Athraigh gníomhaire"

--- a/tools/wta/locales/ga-IE.yml
+++ b/tools/wta/locales/ga-IE.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "Fáilte go Teirminéal Cliste!"
-setup.title.agent_missing: "Nír aimsíodh an gníomhaire"
-setup.title.agent_error: "Theip ar cheangal an ghníomhaire"
+setup.title.agent_missing: "Níor aimsíodh an gníomhaire"
+setup.title.agent_error: "Theip ar an gceangal leis an ngníomhaire"
 setup.title.switch_agent: "Athraigh gníomhaire"

--- a/tools/wta/locales/gd-gb.yml
+++ b/tools/wta/locales/gd-gb.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "Fàilte gu Tèirmineal Glic!"
-setup.title.agent_missing: "Cha deach an neach-gníomha a lorg"
-setup.title.agent_error: "Dh’fhàillig ceangal an neach-ghníomha"
-setup.title.switch_agent: "Atharraich neach-gníomha"
+setup.title.agent_missing: "Cha deach an t-àidseant a lorg"
+setup.title.agent_error: "Dh’fhàillig ceangal ris an àidseant"
+setup.title.switch_agent: "Atharraich àidseant"

--- a/tools/wta/locales/gd-gb.yml
+++ b/tools/wta/locales/gd-gb.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Fàilte gu Intelligent Terminal!"
+setup.title.first_run: "Fàilte gu Tèirmineal Glic!"
 setup.title.agent_missing: "Cha deach an neach-gníomha a lorg"
 setup.title.agent_error: "Dh’fhàillig ceangal an neach-ghníomha"
 setup.title.switch_agent: "Atharraich neach-gníomha"

--- a/tools/wta/locales/gl-ES.yml
+++ b/tools/wta/locales/gl-ES.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Benvido a Intelligent Terminal!"
+setup.title.first_run: "Benvido a Terminal Intelixente!"
 setup.title.agent_missing: "Non se atopou o axente"
 setup.title.agent_error: "Non se puido conectar co axente"
 setup.title.switch_agent: "Cambiar de axente"

--- a/tools/wta/locales/he-IL.yml
+++ b/tools/wta/locales/he-IL.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "ברוכים הבאים ל-מסוף חכם!"
-setup.title.agent_missing: "הסוכן לא נמצא"
-setup.title.agent_error: "החיבור לסוכן נכשל"
-setup.title.switch_agent: "החלף סוכן"
+setup.title.first_run: "ברוכים הבאים למסוף חכם!"
+setup.title.agent_missing: "סוכן AI לא נמצא"
+setup.title.agent_error: "החיבור לסוכן AI נכשל"
+setup.title.switch_agent: "החלף סוכן AI"

--- a/tools/wta/locales/he-IL.yml
+++ b/tools/wta/locales/he-IL.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "ברוכים הבאים ל-Intelligent Terminal!"
+setup.title.first_run: "ברוכים הבאים ל-מסוף חכם!"
 setup.title.agent_missing: "הסוכן לא נמצא"
 setup.title.agent_error: "החיבור לסוכן נכשל"
 setup.title.switch_agent: "החלף סוכן"

--- a/tools/wta/locales/hr-HR.yml
+++ b/tools/wta/locales/hr-HR.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Dobro došli u Intelligent Terminal!"
+setup.title.first_run: "Dobro došli u Inteligentni Terminal!"
 setup.title.agent_missing: "Agent nije pronađen"
 setup.title.agent_error: "Povezivanje s agentom nije uspjelo"
 setup.title.switch_agent: "Promijeni agenta"

--- a/tools/wta/locales/hu-HU.yml
+++ b/tools/wta/locales/hu-HU.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Üdvözli az Intelligent Terminal!"
+setup.title.first_run: "Üdvözli az Intelligens Terminál!"
 setup.title.agent_missing: "Az ügynök nem található"
 setup.title.agent_error: "Az ügynökhöz való kapcsolódás sikertelen"
 setup.title.switch_agent: "Ügynök váltása"

--- a/tools/wta/locales/hy-AM.yml
+++ b/tools/wta/locales/hy-AM.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Բարի գալուստ Խելացի տերմինալ!"
+setup.title.first_run: "Բարի գալուստ «Խելացի տերմինալ»!"
 setup.title.agent_missing: "Ագենտը չի գտնվել"
 setup.title.agent_error: "Ագենտին միանալը ձախողվել է"
 setup.title.switch_agent: "Փոխել ագենտը"

--- a/tools/wta/locales/hy-AM.yml
+++ b/tools/wta/locales/hy-AM.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Բարի գալուստ Intelligent Terminal!"
+setup.title.first_run: "Բարի գալուստ Խելացի տերմինալ!"
 setup.title.agent_missing: "Գործակալը չի գտնվել"
 setup.title.agent_error: "Գործակալին միանալը ձախողվել է"
 setup.title.switch_agent: "Փոխել գործակալը"

--- a/tools/wta/locales/hy-AM.yml
+++ b/tools/wta/locales/hy-AM.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "Բարի գալուստ Խելացի տերմինալ!"
-setup.title.agent_missing: "Գործակալը չի գտնվել"
-setup.title.agent_error: "Գործակալին միանալը ձախողվել է"
-setup.title.switch_agent: "Փոխել գործակալը"
+setup.title.agent_missing: "Ագենտը չի գտնվել"
+setup.title.agent_error: "Ագենտին միանալը ձախողվել է"
+setup.title.switch_agent: "Փոխել ագենտը"

--- a/tools/wta/locales/id-ID.yml
+++ b/tools/wta/locales/id-ID.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "Selamat datang di Terminal Cerdas!"
-setup.title.agent_missing: "Agen tidak ditemukan"
-setup.title.agent_error: "Koneksi agen gagal"
-setup.title.switch_agent: "Ganti agen"
+setup.title.agent_missing: "Agen AI tidak ditemukan"
+setup.title.agent_error: "Koneksi ke agen AI gagal"
+setup.title.switch_agent: "Ganti agen AI"

--- a/tools/wta/locales/id-ID.yml
+++ b/tools/wta/locales/id-ID.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Selamat datang di Intelligent Terminal!"
+setup.title.first_run: "Selamat datang di Terminal Cerdas!"
 setup.title.agent_missing: "Agen tidak ditemukan"
 setup.title.agent_error: "Koneksi agen gagal"
 setup.title.switch_agent: "Ganti agen"

--- a/tools/wta/locales/is-IS.yml
+++ b/tools/wta/locales/is-IS.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Velkomin í Intelligent Terminal!"
+setup.title.first_run: "Velkomin í Snjallútstöð!"
 setup.title.agent_missing: "Agent fannst ekki"
 setup.title.agent_error: "Tenging við agent mistókst"
 setup.title.switch_agent: "Skipta um agent"

--- a/tools/wta/locales/is-IS.yml
+++ b/tools/wta/locales/is-IS.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "Velkomin í Snjallútstöð!"
-setup.title.agent_missing: "Agent fannst ekki"
-setup.title.agent_error: "Tenging við agent mistókst"
-setup.title.switch_agent: "Skipta um agent"
+setup.title.agent_missing: "AI-agent fannst ekki"
+setup.title.agent_error: "Tenging við AI-agent mistókst"
+setup.title.switch_agent: "Skipta um AI-agent"

--- a/tools/wta/locales/it-IT.yml
+++ b/tools/wta/locales/it-IT.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Benvenuto in Intelligent Terminal!"
+setup.title.first_run: "Benvenuto in Terminale Intelligente!"
 setup.title.agent_missing: "Agente non trovato"
 setup.title.agent_error: "Connessione all'agente non riuscita"
 setup.title.switch_agent: "Cambia agente"

--- a/tools/wta/locales/ja-JP.yml
+++ b/tools/wta/locales/ja-JP.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Intelligent Terminal へようこそ"
+setup.title.first_run: "インテリジェント ターミナル へようこそ"
 setup.title.agent_missing: "エージェントが見つかりません"
 setup.title.agent_error: "エージェントへの接続に失敗しました"
 setup.title.switch_agent: "エージェントを切り替える"

--- a/tools/wta/locales/ka-GE.yml
+++ b/tools/wta/locales/ka-GE.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Intelligent Terminal-ში მოგესალმებით!"
+setup.title.first_run: "ჭკვიანი ტერმინალი-ში მოგესალმებით!"
 setup.title.agent_missing: "აგენტი ვერ მოიძებნა"
 setup.title.agent_error: "აგენტთან კავშირი ვერ შედგა"
 setup.title.switch_agent: "აგენტის შეცვლა"

--- a/tools/wta/locales/ka-GE.yml
+++ b/tools/wta/locales/ka-GE.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "ჭკვიანი ტერმინალი-ში მოგესალმებით!"
+setup.title.first_run: "მოგესალმებით ჭკვიან ტერმინალში!"
 setup.title.agent_missing: "აგენტი ვერ მოიძებნა"
 setup.title.agent_error: "აგენტთან კავშირი ვერ შედგა"
 setup.title.switch_agent: "აგენტის შეცვლა"

--- a/tools/wta/locales/kk-KZ.yml
+++ b/tools/wta/locales/kk-KZ.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Зияткер терминал-ға қош келдіңіз!"
+setup.title.first_run: "«Зияткер терминал» қолданбасына қош келдіңіз!"
 setup.title.agent_missing: "Агент табылмады"
 setup.title.agent_error: "Агентке қосылу сәтсіз аяқталды"
-setup.title.switch_agent: "Агентті ауыстыру"
+setup.title.switch_agent: "Агентті ауыстыр"

--- a/tools/wta/locales/kk-KZ.yml
+++ b/tools/wta/locales/kk-KZ.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Intelligent Terminal-ға қош келдіңіз!"
+setup.title.first_run: "Зияткер терминал-ға қош келдіңіз!"
 setup.title.agent_missing: "Агент табылмады"
 setup.title.agent_error: "Агентке қосылу сәтсіз аяқталды"
 setup.title.switch_agent: "Агентті ауыстыру"

--- a/tools/wta/locales/km-KH.yml
+++ b/tools/wta/locales/km-KH.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "សូមស្វាគម្ន៍មកកាន់ ស្ថានីយឆ្លាតវៃ!"
-setup.title.agent_missing: "រកមិនឃើញភ្នាក់ងារ"
-setup.title.agent_error: "ការតភ្ជាប់ទៅភ្នាក់ងារបានបរាជ័យ"
-setup.title.switch_agent: "ប្តូរភ្នាក់ងារ"
+setup.title.agent_missing: "រកមិនឃើញ AI អេជេនต์"
+setup.title.agent_error: "ការតភ្ជាប់ទៅ AI អេជេនต์ បានបរាជ័យ"
+setup.title.switch_agent: "ប្តូរ AI អេជេនต์"

--- a/tools/wta/locales/km-KH.yml
+++ b/tools/wta/locales/km-KH.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "សូមស្វាគម្ន៍មកកាន់ Intelligent Terminal!"
+setup.title.first_run: "សូមស្វាគម្ន៍មកកាន់ ស្ថានីយឆ្លាតវៃ!"
 setup.title.agent_missing: "រកមិនឃើញភ្នាក់ងារ"
 setup.title.agent_error: "ការតភ្ជាប់ទៅភ្នាក់ងារបានបរាជ័យ"
 setup.title.switch_agent: "ប្តូរភ្នាក់ងារ"

--- a/tools/wta/locales/ko-KR.yml
+++ b/tools/wta/locales/ko-KR.yml
@@ -2,4 +2,4 @@
 setup.title.first_run: "지능형 터미널에 오신 것을 환영합니다!"
 setup.title.agent_missing: "에이전트를 찾을 수 없음"
 setup.title.agent_error: "에이전트 연결 실패"
-setup.title.switch_agent: "에이전트 전환"
+setup.title.switch_agent: "에이전트 변경"

--- a/tools/wta/locales/ko-KR.yml
+++ b/tools/wta/locales/ko-KR.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Intelligent Terminal에 오신 것을 환영합니다!"
+setup.title.first_run: "지능형 터미널에 오신 것을 환영합니다!"
 setup.title.agent_missing: "에이전트를 찾을 수 없음"
 setup.title.agent_error: "에이전트 연결 실패"
 setup.title.switch_agent: "에이전트 전환"

--- a/tools/wta/locales/kok-IN.yml
+++ b/tools/wta/locales/kok-IN.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "इंटेलिजेंट टर्मिनलांत आपलें स्वागत!"
+setup.title.first_run: "इंटेलिजंट टर्मिनलांत आपलें स्वागत!"
 setup.title.agent_missing: "एजेंट मेळलो ना"
 setup.title.agent_error: "एजेंट कनेक्शन अपेशी जालें"
 setup.title.switch_agent: "एजेंट बदल"

--- a/tools/wta/locales/lb-LU.yml
+++ b/tools/wta/locales/lb-LU.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Wëllkomm am Intelligent Terminal!"
+setup.title.first_run: "Wëllkomm am Intelligenten Terminal!"
 setup.title.agent_missing: "Agent net fonnt"
 setup.title.agent_error: "Verbindung mam Agent ass gescheitert"
 setup.title.switch_agent: "Agent wiesselen"

--- a/tools/wta/locales/lo-LA.yml
+++ b/tools/wta/locales/lo-LA.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "ຍິນດີຕ້ອນຮັບສູ່ ເທອຮ໌ມິນັລອັດຊະລິຍະ!"
-setup.title.agent_missing: "ບໍ່ພົບ agent"
-setup.title.agent_error: "ການເຊື່ອມຕໍ່ agent ລົ້ມເຫລວ"
-setup.title.switch_agent: "ປ່ຽນ agent"
+setup.title.agent_missing: "ບໍ່ພົບເອເຈນ AI"
+setup.title.agent_error: "ການເຊື່ອມຕໍ່ເອເຈນ AI ລົ້ມເຫລວ"
+setup.title.switch_agent: "ປ່ຽນເອເຈນ AI"

--- a/tools/wta/locales/lo-LA.yml
+++ b/tools/wta/locales/lo-LA.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "ຍິນດີຕ້ອນຮັບສູ່ Intelligent Terminal!"
+setup.title.first_run: "ຍິນດີຕ້ອນຮັບສູ່ ເທອຮ໌ມິນັລອັດຊະລິຍະ!"
 setup.title.agent_missing: "ບໍ່ພົບ agent"
 setup.title.agent_error: "ການເຊື່ອມຕໍ່ agent ລົ້ມເຫລວ"
 setup.title.switch_agent: "ປ່ຽນ agent"

--- a/tools/wta/locales/lt-LT.yml
+++ b/tools/wta/locales/lt-LT.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Sveiki atvykę į Išmanusis Terminalas!"
+setup.title.first_run: "Sveiki atvykę į „Išmanusis Terminalas“ programą!"
 setup.title.agent_missing: "Agentas nerastas"
 setup.title.agent_error: "Nepavyko prisijungti prie agento"
-setup.title.switch_agent: "Pakeisti agentą"
+setup.title.switch_agent: "Pakeiskite agentą"

--- a/tools/wta/locales/lt-LT.yml
+++ b/tools/wta/locales/lt-LT.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Sveiki atvykę į Intelligent Terminal!"
+setup.title.first_run: "Sveiki atvykę į Išmanusis Terminalas!"
 setup.title.agent_missing: "Agentas nerastas"
 setup.title.agent_error: "Nepavyko prisijungti prie agento"
 setup.title.switch_agent: "Pakeisti agentą"

--- a/tools/wta/locales/lv-LV.yml
+++ b/tools/wta/locales/lv-LV.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Laipni lūdzam Intelligent Terminal!"
+setup.title.first_run: "Laipni lūdzam Viedais Terminālis!"
 setup.title.agent_missing: "Aģents nav atrasts"
 setup.title.agent_error: "Neizdevās izveidot savienojumu ar aģentu"
 setup.title.switch_agent: "Mainīt aģentu"

--- a/tools/wta/locales/lv-LV.yml
+++ b/tools/wta/locales/lv-LV.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Laipni lūdzam Viedais Terminālis!"
+setup.title.first_run: "Laipni lūdzam lietotnē „Viedais Terminālis“!"
 setup.title.agent_missing: "Aģents nav atrasts"
 setup.title.agent_error: "Neizdevās izveidot savienojumu ar aģentu"
-setup.title.switch_agent: "Mainīt aģentu"
+setup.title.switch_agent: "Maini aģentu"

--- a/tools/wta/locales/mi-NZ.yml
+++ b/tools/wta/locales/mi-NZ.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Nāu mai ki Intelligent Terminal!"
+setup.title.first_run: "Nāu mai ki Iho Atamai!"
 setup.title.agent_missing: "Kāore i kitea te agent"
 setup.title.agent_error: "I rahua te hononga agent"
 setup.title.switch_agent: "Huri agent"

--- a/tools/wta/locales/mk-MK.yml
+++ b/tools/wta/locales/mk-MK.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Добродојдовте во Intelligent Terminal!"
+setup.title.first_run: "Добродојдовте во Интелигентен Терминал!"
 setup.title.agent_missing: "Агентот не е пронајден"
 setup.title.agent_error: "Поврзувањето со агентот не успеа"
 setup.title.switch_agent: "Промени агент"

--- a/tools/wta/locales/mr-IN.yml
+++ b/tools/wta/locales/mr-IN.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "इंटेलिजेंट टर्मिनलमध्ये आपले स्वागत आहे!"
+setup.title.first_run: "इंटेलिजंट टर्मिनलमध्ये आपले स्वागत आहे!"
 setup.title.agent_missing: "एजंट आढळला नाही"
 setup.title.agent_error: "एजंट कनेक्शन अयशस्वी झाले"
 setup.title.switch_agent: "एजंट बदला"

--- a/tools/wta/locales/ms-MY.yml
+++ b/tools/wta/locales/ms-MY.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Selamat datang ke Intelligent Terminal!"
+setup.title.first_run: "Selamat datang ke Terminal Pintar!"
 setup.title.agent_missing: "Ejen tidak ditemui"
 setup.title.agent_error: "Sambungan ejen gagal"
 setup.title.switch_agent: "Tukar ejen"

--- a/tools/wta/locales/ms-MY.yml
+++ b/tools/wta/locales/ms-MY.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "Selamat datang ke Terminal Pintar!"
-setup.title.agent_missing: "Ejen tidak ditemui"
-setup.title.agent_error: "Sambungan ejen gagal"
-setup.title.switch_agent: "Tukar ejen"
+setup.title.agent_missing: "Ejen AI tidak ditemui"
+setup.title.agent_error: "Sambungan ejen AI gagal"
+setup.title.switch_agent: "Tukar ejen AI"

--- a/tools/wta/locales/mt-MT.yml
+++ b/tools/wta/locales/mt-MT.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Merħba fl-Intelligent Terminal!"
+setup.title.first_run: "Merħba fl-Terminal Intelliġenti!"
 setup.title.agent_missing: "L-aġent ma nstabx"
 setup.title.agent_error: "Il-konnessjoni mal-aġent falliet"
 setup.title.switch_agent: "Ibdel l-aġent"

--- a/tools/wta/locales/ne-NP.yml
+++ b/tools/wta/locales/ne-NP.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Intelligent Terminal मा स्वागत छ!"
+setup.title.first_run: "इन्टेलिजेन्ट टर्मिनल मा स्वागत छ!"
 setup.title.agent_missing: "एजेन्ट भेटिएन"
 setup.title.agent_error: "एजेन्ट जडान विफल भयो"
 setup.title.switch_agent: "एजेन्ट बदल्नुहोस्"

--- a/tools/wta/locales/nl-NL.yml
+++ b/tools/wta/locales/nl-NL.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Welkom bij Intelligent Terminal!"
+setup.title.first_run: "Welkom bij Intelligente Terminal!"
 setup.title.agent_missing: "Agent niet gevonden"
 setup.title.agent_error: "Verbinding met agent mislukt"
 setup.title.switch_agent: "Van agent wisselen"

--- a/tools/wta/locales/nl-NL.yml
+++ b/tools/wta/locales/nl-NL.yml
@@ -2,4 +2,4 @@
 setup.title.first_run: "Welkom bij Intelligente Terminal!"
 setup.title.agent_missing: "Agent niet gevonden"
 setup.title.agent_error: "Verbinding met agent mislukt"
-setup.title.switch_agent: "Van agent wisselen"
+setup.title.switch_agent: "Agent wisselen"

--- a/tools/wta/locales/or-IN.yml
+++ b/tools/wta/locales/or-IN.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନଲ୍‌କୁ ସ୍ୱାଗତ!"
+setup.title.first_run: "ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନାଲକୁ ସ୍ୱାଗତ!"
 setup.title.agent_missing: "ଏଜେଣ୍ଟ ମିଳିଲା ନାହିଁ"
 setup.title.agent_error: "ଏଜେଣ୍ଟ ସଂଯୋଗ ବିଫଳ ହେଲା"
 setup.title.switch_agent: "ଏଜେଣ୍ଟ ବଦଳାନ୍ତୁ"

--- a/tools/wta/locales/pl-PL.yml
+++ b/tools/wta/locales/pl-PL.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Witamy w Intelligent Terminal!"
+setup.title.first_run: "Witamy w Inteligentny Terminal!"
 setup.title.agent_missing: "Nie znaleziono agenta"
 setup.title.agent_error: "Połączenie z agentem nie powiodło się"
 setup.title.switch_agent: "Zmień agenta"

--- a/tools/wta/locales/pl-PL.yml
+++ b/tools/wta/locales/pl-PL.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Witamy w Inteligentny Terminal!"
+setup.title.first_run: "Witamy w aplikacji Inteligentny Terminal!"
 setup.title.agent_missing: "Nie znaleziono agenta"
 setup.title.agent_error: "Połączenie z agentem nie powiodło się"
 setup.title.switch_agent: "Zmień agenta"

--- a/tools/wta/locales/pt-BR.yml
+++ b/tools/wta/locales/pt-BR.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Bem-vindo ao Intelligent Terminal!"
+setup.title.first_run: "Bem-vindo ao Terminal Inteligente!"
 setup.title.agent_missing: "Agente não encontrado"
 setup.title.agent_error: "Falha na conexão com o agente"
 setup.title.switch_agent: "Trocar agente"

--- a/tools/wta/locales/pt-PT.yml
+++ b/tools/wta/locales/pt-PT.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Bem-vindo ao Intelligent Terminal!"
+setup.title.first_run: "Bem-vindo ao Terminal Inteligente!"
 setup.title.agent_missing: "Agente não encontrado"
 setup.title.agent_error: "Falha na ligação ao agente"
 setup.title.switch_agent: "Mudar de agente"

--- a/tools/wta/locales/qps-ploc.yml
+++ b/tools/wta/locales/qps-ploc.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "[Ŵéĺçöḿé ţö Intelligent Terminal!!]"
-setup.title.agent_missing: "[Àğéñţ ñöţ ƒöûñď!!]"
-setup.title.agent_error: "[Àğéñţ çöññéçţïöñ ƒåïĺéď!!]"
-setup.title.switch_agent: "[Ŝŵïţçĥ åğéñţ!!]"
+setup.title.agent_missing: "[Agent ñöţ ƒöûñď!!]"
+setup.title.agent_error: "[Agent çöññéçţïöñ ƒåïĺéď!!]"
+setup.title.switch_agent: "[Ŝŵïţçĥ agent!!]"

--- a/tools/wta/locales/qps-ploc.yml
+++ b/tools/wta/locales/qps-ploc.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "[Ŵéĺçöḿé ţö Îñţéĺĺïğéñţ Ţéŕḿïñåĺ!!]"
+setup.title.first_run: "[Ŵéĺçöḿé ţö Intelligent Terminal!!]"
 setup.title.agent_missing: "[Àğéñţ ñöţ ƒöûñď!!]"
 setup.title.agent_error: "[Àğéñţ çöññéçţïöñ ƒåïĺéď!!]"
 setup.title.switch_agent: "[Ŝŵïţçĥ åğéñţ!!]"

--- a/tools/wta/locales/qps-ploca.yml
+++ b/tools/wta/locales/qps-ploca.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "[‫!!‬_مرحبًا Intelligent Terminal_‫!!‬]"
-setup.title.agent_missing: "[‫!!‬_الوكيل غير موجود_‫!!‬]"
-setup.title.agent_error: "[‫!!‬_فشل اتصال الوكيل_‫!!‬]"
-setup.title.switch_agent: "[‫!!‬_تبديل الوكيل_‫!!‬]"
+setup.title.agent_missing: "[‫!!‬_Agent غير موجود_‫!!‬]"
+setup.title.agent_error: "[‫!!‬_فشل اتصال Agent_‫!!‬]"
+setup.title.switch_agent: "[‫!!‬_تبديل agent_‫!!‬]"

--- a/tools/wta/locales/qps-plocm.yml
+++ b/tools/wta/locales/qps-plocm.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "[¡¡ Ŵẽĺçømẽ ŧø Îñŧẽĺĺįğẽñŧ Ţẽŕmįñåĺ! ¡¡]"
+setup.title.first_run: "[¡¡ Ŵẽĺçømẽ ŧø Intelligent Terminal! ¡¡]"
 setup.title.agent_missing: "[¡¡ Åğẽñŧ ñøŧ ƒøůñđ ¡¡]"
 setup.title.agent_error: "[¡¡ Åğẽñŧ çøññẽçŧįøñ ƒåįĺẽđ ¡¡]"
 setup.title.switch_agent: "[¡¡ Ŝŵįŧçĥ åğẽñŧ ¡¡]"

--- a/tools/wta/locales/qps-plocm.yml
+++ b/tools/wta/locales/qps-plocm.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "[¡¡ Ŵẽĺçømẽ ŧø Intelligent Terminal! ¡¡]"
-setup.title.agent_missing: "[¡¡ Åğẽñŧ ñøŧ ƒøůñđ ¡¡]"
-setup.title.agent_error: "[¡¡ Åğẽñŧ çøññẽçŧįøñ ƒåįĺẽđ ¡¡]"
-setup.title.switch_agent: "[¡¡ Ŝŵįŧçĥ åğẽñŧ ¡¡]"
+setup.title.agent_missing: "[¡¡ Agent ñøŧ ƒøůñđ ¡¡]"
+setup.title.agent_error: "[¡¡ Agent çøññẽçŧįøñ ƒåįĺẽđ ¡¡]"
+setup.title.switch_agent: "[¡¡ Ŝŵįŧçĥ agent ¡¡]"

--- a/tools/wta/locales/quz-PE.yml
+++ b/tools/wta/locales/quz-PE.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Allillanchu Intelligent Terminal!"
+setup.title.first_run: "Allillanchu Yuyaysapa Terminal!"
 setup.title.agent_missing: "Mana agente tarikusqachu"
 setup.title.agent_error: "Agente t'inkiynin mana allinchu"
 setup.title.switch_agent: "Agente t'ikray"

--- a/tools/wta/locales/ro-RO.yml
+++ b/tools/wta/locales/ro-RO.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Bun venit la Intelligent Terminal!"
+setup.title.first_run: "Bun venit la Terminal Inteligent!"
 setup.title.agent_missing: "Agentul nu a fost găsit"
 setup.title.agent_error: "Conectarea la agent a eșuat"
 setup.title.switch_agent: "Schimbă agentul"

--- a/tools/wta/locales/ru-RU.yml
+++ b/tools/wta/locales/ru-RU.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Добро пожаловать в Intelligent Terminal!"
+setup.title.first_run: "Добро пожаловать в Интеллектуальный Терминал!"
 setup.title.agent_missing: "Агент не найден"
 setup.title.agent_error: "Сбой подключения к агенту"
 setup.title.switch_agent: "Сменить агента"

--- a/tools/wta/locales/ru-RU.yml
+++ b/tools/wta/locales/ru-RU.yml
@@ -2,4 +2,4 @@
 setup.title.first_run: "Добро пожаловать в Интеллектуальный Терминал!"
 setup.title.agent_missing: "Агент не найден"
 setup.title.agent_error: "Сбой подключения к агенту"
-setup.title.switch_agent: "Сменить агента"
+setup.title.switch_agent: "Смените агента"

--- a/tools/wta/locales/sk-SK.yml
+++ b/tools/wta/locales/sk-SK.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Vitajte v Intelligent Terminal!"
+setup.title.first_run: "Vitajte v Inteligentný Terminál!"
 setup.title.agent_missing: "Agenta sa nepodarilo nájsť"
 setup.title.agent_error: "Pripojenie k agentovi zlyhalo"
 setup.title.switch_agent: "Prepnúť agenta"

--- a/tools/wta/locales/sk-SK.yml
+++ b/tools/wta/locales/sk-SK.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Vitajte v Inteligentný Terminál!"
+setup.title.first_run: "Vitajte v aplikácii Inteligentný Terminál!"
 setup.title.agent_missing: "Agenta sa nepodarilo nájsť"
 setup.title.agent_error: "Pripojenie k agentovi zlyhalo"
-setup.title.switch_agent: "Prepnúť agenta"
+setup.title.switch_agent: "Prepnite agenta"

--- a/tools/wta/locales/sl-SI.yml
+++ b/tools/wta/locales/sl-SI.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Dobrodošli v Intelligent Terminal!"
+setup.title.first_run: "Dobrodošli v Inteligentni Terminal!"
 setup.title.agent_missing: "Agenta ni mogoče najti"
 setup.title.agent_error: "Povezava z agentom ni uspela"
 setup.title.switch_agent: "Spremeni agenta"

--- a/tools/wta/locales/sq-AL.yml
+++ b/tools/wta/locales/sq-AL.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Mirë se vini në Terminali inteligjent!"
+setup.title.first_run: "Mirë se vini në Terminalin inteligjent!"
 setup.title.agent_missing: "Agjenti nuk u gjet"
 setup.title.agent_error: "Lidhja me agjentin dështoi"
 setup.title.switch_agent: "Ndrysho agjentin"

--- a/tools/wta/locales/sq-AL.yml
+++ b/tools/wta/locales/sq-AL.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Mirë se vini në Intelligent Terminal!"
+setup.title.first_run: "Mirë se vini në Terminali inteligjent!"
 setup.title.agent_missing: "Agjenti nuk u gjet"
 setup.title.agent_error: "Lidhja me agjentin dështoi"
 setup.title.switch_agent: "Ndrysho agjentin"

--- a/tools/wta/locales/sr-Cyrl-BA.yml
+++ b/tools/wta/locales/sr-Cyrl-BA.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Добродошли у Intelligent Terminal!"
+setup.title.first_run: "Добродошли у Интелигентни Терминал!"
 setup.title.agent_missing: "Агент није пронађен"
 setup.title.agent_error: "Повезивање са агентом није успјело"
 setup.title.switch_agent: "Промијени агента"

--- a/tools/wta/locales/sr-Cyrl-RS.yml
+++ b/tools/wta/locales/sr-Cyrl-RS.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Добродошли у Intelligent Terminal!"
+setup.title.first_run: "Добродошли у Интелигентни Терминал!"
 setup.title.agent_missing: "Агент није пронађен"
 setup.title.agent_error: "Повезивање са агентом није успело"
 setup.title.switch_agent: "Промени агента"

--- a/tools/wta/locales/sr-Latn-RS.yml
+++ b/tools/wta/locales/sr-Latn-RS.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Dobrodošli u Intelligent Terminal!"
+setup.title.first_run: "Dobrodošli u Inteligentni Terminal!"
 setup.title.agent_missing: "Agent nije pronađen"
 setup.title.agent_error: "Povezivanje sa agentom nije uspelo"
 setup.title.switch_agent: "Promeni agenta"

--- a/tools/wta/locales/ta-IN.yml
+++ b/tools/wta/locales/ta-IN.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "அறிவாண் முனையம்-க்கு வரவேற்கிறோம்!"
-setup.title.agent_missing: "முகவர் கிடைக்கவில்லை"
-setup.title.agent_error: "முகவர் இணைப்பு தோல்வியடைந்தது"
-setup.title.switch_agent: "முகவரை மாற்று"
+setup.title.agent_missing: "ஏஜெண்ட் கிடைக்கவில்லை"
+setup.title.agent_error: "ஏஜெண்ட் இணைப்பு தோல்வியடைந்தது"
+setup.title.switch_agent: "ஏஜெண்டை மாற்று"

--- a/tools/wta/locales/ta-IN.yml
+++ b/tools/wta/locales/ta-IN.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Intelligent Terminal-க்கு வரவேற்கிறோம்!"
+setup.title.first_run: "அறிவாண் முனையம்-க்கு வரவேற்கிறோம்!"
 setup.title.agent_missing: "முகவர் கிடைக்கவில்லை"
 setup.title.agent_error: "முகவர் இணைப்பு தோல்வியடைந்தது"
 setup.title.switch_agent: "முகவரை மாற்று"

--- a/tools/wta/locales/th-TH.yml
+++ b/tools/wta/locales/th-TH.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "ยินดีต้อนรับสู่ Intelligent Terminal!"
+setup.title.first_run: "ยินดีต้อนรับสู่ เทอร์มินัลอัจฉริยะ!"
 setup.title.agent_missing: "ไม่พบเอเจนต์"
 setup.title.agent_error: "การเชื่อมต่อเอเจนต์ล้มเหลว"
 setup.title.switch_agent: "สลับเอเจนต์"

--- a/tools/wta/locales/tr-TR.yml
+++ b/tools/wta/locales/tr-TR.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Intelligent Terminal'e hoş geldiniz!"
+setup.title.first_run: "Akıllı Terminal'e hoş geldiniz!"
 setup.title.agent_missing: "Aracı bulunamadı"
 setup.title.agent_error: "Aracı bağlantısı başarısız oldu"
 setup.title.switch_agent: "Aracı değiştir"

--- a/tools/wta/locales/tr-TR.yml
+++ b/tools/wta/locales/tr-TR.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "Akıllı Terminal'e hoş geldiniz!"
-setup.title.agent_missing: "Aracı bulunamadı"
-setup.title.agent_error: "Aracı bağlantısı başarısız oldu"
-setup.title.switch_agent: "Aracı değiştir"
+setup.title.agent_missing: "Ajan bulunamadı"
+setup.title.agent_error: "Ajan bağlantısı başarısız oldu"
+setup.title.switch_agent: "Ajanı değiştir"

--- a/tools/wta/locales/tt-RU.yml
+++ b/tools/wta/locales/tt-RU.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Intelligent Terminal-га рәхим итегез!"
+setup.title.first_run: "Акыллы терминал-га рәхим итегез!"
 setup.title.agent_missing: "Агент табылмады"
 setup.title.agent_error: "Агентка тоташу уңышсыз булды"
 setup.title.switch_agent: "Агентны алыштыру"

--- a/tools/wta/locales/tt-RU.yml
+++ b/tools/wta/locales/tt-RU.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Акыллы терминал-га рәхим итегез!"
+setup.title.first_run: "«Акыллы терминал» кушымтасына рәхим итегез!"
 setup.title.agent_missing: "Агент табылмады"
-setup.title.agent_error: "Агентка тоташу уңышсыз булды"
-setup.title.switch_agent: "Агентны алыштыру"
+setup.title.agent_error: "Агент белән тоташу уңышсыз булды"
+setup.title.switch_agent: "Агентны алыштыр"

--- a/tools/wta/locales/ug-CN.yml
+++ b/tools/wta/locales/ug-CN.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Intelligent Terminal هە خوش كەلدىڭىز!"
+setup.title.first_run: "ئەقلىي تېرمىنال هە خوش كەلدىڭىز!"
 setup.title.agent_missing: "ۋەكىل تېپىلمىدى"
 setup.title.agent_error: "ۋەكىل بىلەن باغلىنىش مەغلۇب بولدى"
 setup.title.switch_agent: "ۋەكىلنى الماشتۇرۇش"

--- a/tools/wta/locales/ug-CN.yml
+++ b/tools/wta/locales/ug-CN.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "ئەقلىي تېرمىنال هە خوش كەلدىڭىز!"
-setup.title.agent_missing: "ۋەكىل تېپىلمىدى"
-setup.title.agent_error: "ۋەكىل بىلەن باغلىنىش مەغلۇب بولدى"
-setup.title.switch_agent: "ۋەكىلنى الماشتۇرۇش"
+setup.title.agent_missing: "AI ئاگېنتى تېپىلمىدى"
+setup.title.agent_error: "AI ئاگېنتى بىلەن باغلىنىش مەغلۇپ بولدى"
+setup.title.switch_agent: "AI ئاگېنتىنى ئالماشتۇرۇش"

--- a/tools/wta/locales/ug-CN.yml
+++ b/tools/wta/locales/ug-CN.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "ئەقلىي تېرمىنال هە خوش كەلدىڭىز!"
+setup.title.first_run: "ئەقلىي تېرمىنالغا خۇش كەلدىڭىز!"
 setup.title.agent_missing: "AI ئاگېنتى تېپىلمىدى"
-setup.title.agent_error: "AI ئاگېنتى بىلەن باغلىنىش مەغلۇپ بولدى"
-setup.title.switch_agent: "AI ئاگېنتىنى ئالماشتۇرۇش"
+setup.title.agent_error: "AI ئاگېنتىغا ئۇلىنىش مەغلۇپ بولدى"
+setup.title.switch_agent: "AI ئاگېنتىنى ئالماشتۇرۇڭ"

--- a/tools/wta/locales/uk-UA.yml
+++ b/tools/wta/locales/uk-UA.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Ласкаво просимо до Intelligent Terminal!"
+setup.title.first_run: "Ласкаво просимо до Інтелектуальний Термінал!"
 setup.title.agent_missing: "Агент не знайдено"
 setup.title.agent_error: "Не вдалося підключитися до агента"
 setup.title.switch_agent: "Змінити агента"

--- a/tools/wta/locales/uk-UA.yml
+++ b/tools/wta/locales/uk-UA.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Ласкаво просимо до Інтелектуальний Термінал!"
-setup.title.agent_missing: "Агент не знайдено"
+setup.title.first_run: "Ласкаво просимо до програми «Інтелектуальний Термінал»!"
+setup.title.agent_missing: "Агента не знайдено"
 setup.title.agent_error: "Не вдалося підключитися до агента"
-setup.title.switch_agent: "Змінити агента"
+setup.title.switch_agent: "Змініть агента"

--- a/tools/wta/locales/ur-PK.yml
+++ b/tools/wta/locales/ur-PK.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Intelligent Terminal میں خوش آمدید!"
+setup.title.first_run: "ذہین ٹرمینل میں خوش آمدید!"
 setup.title.agent_missing: "ایجنٹ نہیں ملا"
 setup.title.agent_error: "ایجنٹ کنیکشن ناکام"
 setup.title.switch_agent: "ایجنٹ تبدیل کریں"

--- a/tools/wta/locales/ur-PK.yml
+++ b/tools/wta/locales/ur-PK.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "ذہین ٹرمینل میں خوش آمدید!"
-setup.title.agent_missing: "ایجنٹ نہیں ملا"
-setup.title.agent_error: "ایجنٹ کنیکشن ناکام"
-setup.title.switch_agent: "ایجنٹ تبدیل کریں"
+setup.title.agent_missing: "AI ایجنٹ نہیں ملا"
+setup.title.agent_error: "AI ایجنٹ سے رابطہ ناکام ہوگیا"
+setup.title.switch_agent: "AI ایجنٹ تبدیل کریں"

--- a/tools/wta/locales/uz-Latn-UZ.yml
+++ b/tools/wta/locales/uz-Latn-UZ.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Aqlli terminal-ga xush kelibsiz!"
+setup.title.first_run: "«Aqlli terminal» ilovasiga xush kelibsiz!"
 setup.title.agent_missing: "Agent topilmadi"
 setup.title.agent_error: "Agentga ulanish amalga oshmadi"
-setup.title.switch_agent: "Agentni almashtirish"
+setup.title.switch_agent: "Agentni almashtir"

--- a/tools/wta/locales/uz-Latn-UZ.yml
+++ b/tools/wta/locales/uz-Latn-UZ.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Intelligent Terminal-ga xush kelibsiz!"
+setup.title.first_run: "Aqlli terminal-ga xush kelibsiz!"
 setup.title.agent_missing: "Agent topilmadi"
 setup.title.agent_error: "Agentga ulanish amalga oshmadi"
 setup.title.switch_agent: "Agentni almashtirish"

--- a/tools/wta/locales/vi-VN.yml
+++ b/tools/wta/locales/vi-VN.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "Chào mừng bạn đến Đầu cuối thông minh!"
-setup.title.agent_missing: "Không tìm thấy tác tử"
-setup.title.agent_error: "Kết nối tới tác tử thất bại"
-setup.title.switch_agent: "Chuyển tác tử"
+setup.title.agent_missing: "Không tìm thấy tác nhân AI"
+setup.title.agent_error: "Kết nối tới tác nhân AI thất bại"
+setup.title.switch_agent: "Chuyển tác nhân AI"

--- a/tools/wta/locales/vi-VN.yml
+++ b/tools/wta/locales/vi-VN.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Chào mừng bạn đến Đầu cuối thông minh!"
+setup.title.first_run: "Chào mừng bạn đến với Đầu cuối thông minh!"
 setup.title.agent_missing: "Không tìm thấy tác nhân AI"
 setup.title.agent_error: "Kết nối tới tác nhân AI thất bại"
 setup.title.switch_agent: "Chuyển tác nhân AI"

--- a/tools/wta/locales/vi-VN.yml
+++ b/tools/wta/locales/vi-VN.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "Chào mừng bạn đến Intelligent Terminal!"
+setup.title.first_run: "Chào mừng bạn đến Đầu cuối thông minh!"
 setup.title.agent_missing: "Không tìm thấy tác tử"
 setup.title.agent_error: "Kết nối tới tác tử thất bại"
 setup.title.switch_agent: "Chuyển tác tử"

--- a/tools/wta/locales/zh-CN.yml
+++ b/tools/wta/locales/zh-CN.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "欢迎使用 Intelligent Terminal！"
+setup.title.first_run: "欢迎使用 智能终端！"
 setup.title.agent_missing: "未找到智能体"
 setup.title.agent_error: "智能体连接失败"
 setup.title.switch_agent: "切换智能体"

--- a/tools/wta/locales/zh-TW.yml
+++ b/tools/wta/locales/zh-TW.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
 setup.title.first_run: "歡迎使用 智慧終端機！"
-setup.title.agent_missing: "找不到代理"
-setup.title.agent_error: "代理連線失敗"
-setup.title.switch_agent: "切換代理"
+setup.title.agent_missing: "找不到智慧代理"
+setup.title.agent_error: "智慧代理連線失敗"
+setup.title.switch_agent: "切換智慧代理"

--- a/tools/wta/locales/zh-TW.yml
+++ b/tools/wta/locales/zh-TW.yml
@@ -1,5 +1,5 @@
 # Setup screen titles
-setup.title.first_run: "歡迎使用 Intelligent Terminal！"
+setup.title.first_run: "歡迎使用 智慧終端機！"
 setup.title.agent_missing: "找不到代理"
 setup.title.agent_error: "代理連線失敗"
 setup.title.switch_agent: "切換代理"


### PR DESCRIPTION
## Summary

Fix localization comments and translations for the **Intelligent Terminal** product name and **Agent** terminology across all 85+ locales in both \.resw\ and Rust \.yml\ files.

## Problem

1. Product name comments used \{Locked}\ (fully locked) instead of \{Locked=qps-ploc,qps-ploca,qps-plocm}\ (pseudo-locale-only lock), preventing real locales from translating
2. \Agent\ was mistranslated as spy/proxy/broker in 12+ locales (e.g. zh-TW \代理\, el-GR \πράκτορας\, ar-SA \الوكيل\)
3. No context comments on ambiguous strings, causing translators to guess wrong
4. Pseudo-locale files had stale \Windows Terminal\ values
5. Rust localization instruction lacked documentation for file-level comments and mistranslation risk assessment

## Changes

### Comments & Instructions
- **en-US resw**: Changed 3 product name comments from \{Locked}\ → \{Locked=qps-ploc,qps-ploca,qps-plocm}\
- **en-US resw**: Added context comments to \AppDescription\, \AppDescriptionPre\, \ShellExtension_OpenInTerminalMenuItem_Canary\
- **en-US yml**: Added file-level locks and per-string context comments explaining where each label is shown
- **rust-localization.instructions.md**: Documented 3-level comment scopes (file/section/line), added **Mistranslation Risk Table** (🔴🟠🟡🟢) and mandatory context comment rules

### Translation Fixes
- **12 locales**: Fixed \Agent\ mistranslation (zh-TW, ar-SA, fa-IR, ug-CN, el-GR, ta-IN, vi-VN, id-ID, ms-MY, km-KH, gd-gb, hy-AM)
- **69 locale yml files**: Translated product name in \setup.title.first_run\ to match resw \AppName\
- **3 pseudo-locale resw**: Fixed stale Dev variant values
- **3 pseudo-locale yml**: Fixed mangled product names + kept \Agent\ verbatim
- **40 locale yml files**: Context-aware review pass — fixed imperative verb forms, product name alignment, naturalness

## Testing
- Full audit script verified all locales pass (product names match resw, no stale values, pseudo-locales correct)
- \cargo build --target x86_64-pc-windows-msvc\ succeeds
