### PR TITLE
Add "Report a bug" command palette entry that zips diagnostic logs

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1749,6 +1749,87 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
+    // Bundle WTA / Intelligent Terminal diagnostic logs into a timestamped zip on the
+    // Desktop, then pop Explorer with the new file selected so the user can drag it
+    // straight into a bug report. Runs entirely on a background thread — the UI is
+    // never blocked even if the logs dir is large.
+    static safe_void_coroutine _CreateBugReportZipAsync()
+    {
+        co_await winrt::resume_background();
+
+        wil::unique_cotaskmem_string desktopRaw;
+        if (FAILED(SHGetKnownFolderPath(FOLDERID_Desktop, 0, nullptr, &desktopRaw)) || !desktopRaw)
+        {
+            co_return;
+        }
+        wil::unique_cotaskmem_string localAppDataRaw;
+        if (FAILED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localAppDataRaw)) || !localAppDataRaw)
+        {
+            co_return;
+        }
+
+        const std::filesystem::path desktop{ desktopRaw.get() };
+        const std::filesystem::path logsDir = std::filesystem::path(localAppDataRaw.get()) / L"IntelligentTerminal" / L"logs";
+
+        // create_directories is a no-op if the path already exists. We do this so
+        // tar always has *something* to archive, even on a brand-new install where
+        // no logs have been written yet.
+        std::error_code ec;
+        std::filesystem::create_directories(logsDir, ec);
+
+        SYSTEMTIME st{};
+        GetLocalTime(&st);
+        const auto zipName = fmt::format(L"intelligent-terminal-logs-{:04d}{:02d}{:02d}-{:02d}{:02d}{:02d}.zip",
+                                          st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+        const auto zipPath = desktop / zipName;
+
+        // tar.exe ships with Windows 10 1803+ (libarchive). `-a` picks the archive
+        // format from the .zip extension; `-C <parent>` keeps a clean top-level
+        // `logs/` folder inside the archive instead of leaking an absolute path.
+        auto cmdline = fmt::format(LR"(tar.exe -a -c -f "{}" -C "{}" logs)",
+                                    zipPath.wstring(), logsDir.parent_path().wstring());
+
+        STARTUPINFOW si{};
+        si.cb = sizeof(si);
+        si.dwFlags = STARTF_USESHOWWINDOW;
+        si.wShowWindow = SW_HIDE;
+        PROCESS_INFORMATION pi{};
+        if (!CreateProcessW(nullptr, cmdline.data(), nullptr, nullptr, FALSE,
+                            CREATE_NO_WINDOW, nullptr, nullptr, &si, &pi))
+        {
+            co_return;
+        }
+        WaitForSingleObject(pi.hProcess, 60000); // 60s — generous for huge log dirs
+        DWORD exitCode = 1;
+        GetExitCodeProcess(pi.hProcess, &exitCode);
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+
+        if (exitCode != 0 || !std::filesystem::exists(zipPath, ec))
+        {
+            co_return;
+        }
+
+        // Reveal the zip in Explorer (file pre-selected) so the user can drag it
+        // into a GitHub issue or email immediately.
+        auto selectArgs = fmt::format(LR"(/select,"{}")", zipPath.wstring());
+        SHELLEXECUTEINFOW seInfo{ 0 };
+        seInfo.cbSize = sizeof(seInfo);
+        seInfo.fMask = SEE_MASK_NOASYNC;
+        seInfo.lpVerb = L"open";
+        seInfo.lpFile = L"explorer.exe";
+        seInfo.lpParameters = selectArgs.c_str();
+        seInfo.nShow = SW_SHOWNORMAL;
+        LOG_IF_WIN32_BOOL_FALSE(ShellExecuteExW(&seInfo));
+    }
+
+    void TerminalPage::_HandleBugReport(const IInspectable& /*sender*/,
+                                        const ActionEventArgs& args)
+    {
+        _CreateBugReportZipAsync();
+        args.Handled(true);
+    }
+
     void TerminalPage::_HandleShowProtocolInfo(const IInspectable& /*sender*/,
                                                const ActionEventArgs& args)
     {

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1783,25 +1783,53 @@ namespace winrt::TerminalApp::implementation
                                           st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
         const auto zipPath = desktop / zipName;
 
-        // tar.exe ships with Windows 10 1803+ (libarchive). `-a` picks the archive
-        // format from the .zip extension; `-C <parent>` keeps a clean top-level
-        // `logs/` folder inside the archive instead of leaking an absolute path.
-        auto cmdline = fmt::format(LR"(tar.exe -a -c -f "{}" -C "{}" logs)",
-                                    zipPath.wstring(), logsDir.parent_path().wstring());
+        // Resolve absolute paths to tar.exe and explorer.exe up-front so we
+        // never rely on PATH / current-directory lookup (binary-planting hardening).
+        // tar.exe ships in System32 on Windows 10 1803+ (libarchive); explorer.exe
+        // lives in the Windows directory.
+        wchar_t systemDir[MAX_PATH]{};
+        wchar_t windowsDir[MAX_PATH]{};
+        if (!GetSystemDirectoryW(systemDir, ARRAYSIZE(systemDir)) ||
+            !GetWindowsDirectoryW(windowsDir, ARRAYSIZE(windowsDir)))
+        {
+            co_return;
+        }
+        const std::filesystem::path tarExe = std::filesystem::path{ systemDir } / L"tar.exe";
+        const std::filesystem::path explorerExe = std::filesystem::path{ windowsDir } / L"explorer.exe";
+
+        // `-a` picks the archive format from the .zip extension; `-C <parent>`
+        // keeps a clean top-level `logs/` folder inside the archive instead of
+        // leaking an absolute path. argv[0] must still be present in lpCommandLine
+        // even though lpApplicationName provides the executable.
+        auto cmdline = fmt::format(LR"("{}" -a -c -f "{}" -C "{}" logs)",
+                                    tarExe.wstring(), zipPath.wstring(), logsDir.parent_path().wstring());
 
         STARTUPINFOW si{};
         si.cb = sizeof(si);
         si.dwFlags = STARTF_USESHOWWINDOW;
         si.wShowWindow = SW_HIDE;
         PROCESS_INFORMATION pi{};
-        if (!CreateProcessW(nullptr, cmdline.data(), nullptr, nullptr, FALSE,
+        if (!CreateProcessW(tarExe.c_str(), cmdline.data(), nullptr, nullptr, FALSE,
                             CREATE_NO_WINDOW, nullptr, nullptr, &si, &pi))
         {
             co_return;
         }
-        WaitForSingleObject(pi.hProcess, 60000); // 60s — generous for huge log dirs
+
+        // Be strict about the wait result: on timeout or failure, kill the child
+        // so a runaway tar.exe can't outlive this action. We're already on a
+        // background thread, so 60s is a soft cap — anything longer almost
+        // certainly means tar is stuck on a permission/handle issue.
+        const DWORD waitResult = WaitForSingleObject(pi.hProcess, 60000);
         DWORD exitCode = 1;
-        GetExitCodeProcess(pi.hProcess, &exitCode);
+        if (waitResult == WAIT_OBJECT_0)
+        {
+            GetExitCodeProcess(pi.hProcess, &exitCode);
+        }
+        else
+        {
+            TerminateProcess(pi.hProcess, 1);
+            WaitForSingleObject(pi.hProcess, 5000); // reap, best-effort
+        }
         CloseHandle(pi.hProcess);
         CloseHandle(pi.hThread);
 
@@ -1817,7 +1845,7 @@ namespace winrt::TerminalApp::implementation
         seInfo.cbSize = sizeof(seInfo);
         seInfo.fMask = SEE_MASK_NOASYNC;
         seInfo.lpVerb = L"open";
-        seInfo.lpFile = L"explorer.exe";
+        seInfo.lpFile = explorerExe.c_str();
         seInfo.lpParameters = selectArgs.c_str();
         seInfo.nShow = SW_SHOWNORMAL;
         LOG_IF_WIN32_BOOL_FALSE(ShellExecuteExW(&seInfo));

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -107,6 +107,7 @@ static constexpr std::string_view FocusAgentPaneKey{ "focusAgentPane" };
 static constexpr std::string_view OpenAgentSessionsKey{ "openAgentSessions" };
 static constexpr std::string_view TriggerAutofixKey{ "triggerAutofix" };
 static constexpr std::string_view ShowProtocolInfoKey{ "showProtocolInfo" };
+static constexpr std::string_view BugReportKey{ "bugReport" };
 
 static constexpr std::string_view ActionKey{ "action" };
 

--- a/src/cascadia/TerminalSettingsModel/ActionMap.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.cpp
@@ -75,6 +75,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 { ShortcutAction::AdjustFontSize, USES_RESOURCE(L"AdjustFontSizeCommandKey") },
                 { ShortcutAction::AdjustOpacity, USES_RESOURCE(L"AdjustOpacity") },
                 { ShortcutAction::BreakIntoDebugger, USES_RESOURCE(L"BreakIntoDebuggerCommandKey") },
+                { ShortcutAction::BugReport, USES_RESOURCE(L"BugReportCommandKey") },
                 { ShortcutAction::ClearAllMarks, USES_RESOURCE(L"ClearAllMarksCommandKey") },
                 { ShortcutAction::ClearBuffer, USES_RESOURCE(L"ClearBuffer") },
                 { ShortcutAction::ClearMark, USES_RESOURCE(L"ClearMarkCommandKey") },

--- a/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
+++ b/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
@@ -119,7 +119,8 @@
     ON_ALL_ACTIONS(FocusAgentPane)          \
     ON_ALL_ACTIONS(OpenAgentSessions)       \
     ON_ALL_ACTIONS(TriggerAutofix)          \
-    ON_ALL_ACTIONS(ShowProtocolInfo)
+    ON_ALL_ACTIONS(ShowProtocolInfo)        \
+    ON_ALL_ACTIONS(BugReport)
 
 #define ALL_SHORTCUT_ACTIONS_WITH_ARGS             \
     ON_ALL_ACTIONS_WITH_ARGS(AdjustFontSize)       \

--- a/src/cascadia/TerminalSettingsModel/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/de-DE/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -983,4 +983,5 @@
   <data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>KI-Agent-Sitzungsliste öffnen</value></data>
   <data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Autofix auslösen</value></data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data>
+  <data name="BugReportCommandKey" xml:space="preserve"><value>Fehler melden (Protokolle sammeln)</value></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -738,6 +738,10 @@
     <value>Open about dialog</value>
     <comment>This will open the "about" dialog, to display version info and other documentation</comment>
   </data>
+  <data name="BugReportCommandKey" xml:space="preserve">
+    <value>Report a bug (collect logs)</value>
+    <comment>Command palette entry that collects diagnostic log files into a zip archive on the user's Desktop, for attaching to a bug report.</comment>
+  </data>
   <data name="SaveSnippetNamePrefix" xml:space="preserve">
     <value>Save Snippet</value>
   </data>

--- a/src/cascadia/TerminalSettingsModel/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/es-ES/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -983,4 +983,5 @@
   <data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Abrir lista de sesiones del agente de IA</value></data>
   <data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Ejecutar corrección automática</value></data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Consulta</value></data>
+  <data name="BugReportCommandKey" xml:space="preserve"><value>Informar de un error (recopilar registros)</value></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/fr-FR/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -984,4 +984,5 @@
   <data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Ouvrir la liste des sessions de l'agent IA</value></data>
   <data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Déclencher la correction automatique</value></data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data>
+  <data name="BugReportCommandKey" xml:space="preserve"><value>Signaler un bug (collecter les journaux)</value></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/it-IT/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -983,4 +983,5 @@
   <data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Apri elenco sessioni dell'agente AI</value></data>
   <data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Esegui correzione automatica</value></data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data>
+  <data name="BugReportCommandKey" xml:space="preserve"><value>Segnala un bug (raccogli i log)</value></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/ja-JP/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -983,4 +983,5 @@
   <data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>AI エージェント セッション一覧を開く</value></data>
   <data name="TriggerAutofixCommandKey" xml:space="preserve"><value>自動修正を実行する</value></data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve"><value>プロンプト</value></data>
+  <data name="BugReportCommandKey" xml:space="preserve"><value>バグを報告 (ログを収集)</value></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/ko-KR/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -997,5 +997,8 @@
   </data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve">
     <value>프롬프트</value>
+  </data>
+  <data name="BugReportCommandKey" xml:space="preserve">
+    <value>버그 보고(로그 수집)</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/pt-BR/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -997,5 +997,8 @@
   </data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve">
     <value>Solicitação</value>
+  </data>
+  <data name="BugReportCommandKey" xml:space="preserve">
+    <value>Relatar um bug (coletar logs)</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-ploc/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -976,4 +976,4 @@
   <data name="SplitSizeActionArgumentLocalized" xml:space="preserve">
     <value>Šрļϊŧ ѕìžє !!!</value>
   </data>
-<data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data></root>
+<data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data></root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-ploca/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -976,4 +976,4 @@
   <data name="SplitSizeActionArgumentLocalized" xml:space="preserve">
     <value>Šрļϊŧ ѕìžє !!!</value>
   </data>
-<data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data></root>
+<data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data></root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-plocm/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -976,4 +976,4 @@
   <data name="SplitSizeActionArgumentLocalized" xml:space="preserve">
     <value>Šрļϊŧ ѕìžє !!!</value>
   </data>
-<data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data></root>
+<data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data></root>

--- a/src/cascadia/TerminalSettingsModel/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/ru-RU/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -997,5 +997,8 @@
   </data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve">
     <value>Запрос</value>
+  </data>
+  <data name="BugReportCommandKey" xml:space="preserve">
+    <value>Сообщить об ошибке (собрать журналы)</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/sr-Cyrl-RS/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -998,4 +998,7 @@
     <value>Упит</value>
   </data>
 
+  <data name="BugReportCommandKey" xml:space="preserve">
+    <value>Пријави грешку (прикупи евиденције)</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/uk-UA/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -983,4 +983,5 @@
   <data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Відкрити список сеансів агента ШІ</value></data>
   <data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Запустити автовиправлення</value></data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Запит</value></data>
+  <data name="BugReportCommandKey" xml:space="preserve"><value>Повідомити про помилку (зібрати журнали)</value></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/zh-CN/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -997,5 +997,8 @@
   </data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve">
     <value>提示词</value>
+  </data>
+  <data name="BugReportCommandKey" xml:space="preserve">
+    <value>报告问题（收集日志）</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/zh-TW/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -983,4 +983,5 @@
   <data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>開啟 AI 代理工作階段清單</value></data>
   <data name="TriggerAutofixCommandKey" xml:space="preserve"><value>觸發自動修正</value></data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve"><value>提示</value></data>
+  <data name="BugReportCommandKey" xml:space="preserve"><value>回報問題（收集記錄）</value></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -560,6 +560,7 @@
         { "command": "focusAgentPane", "id": "Terminal.FocusAgentPane" },
         { "command": "openAgentSessions", "id": "Terminal.OpenAgentSessions" },
         { "command": "triggerAutofix", "id": "Terminal.TriggerAutofix" },
+        { "command": "bugReport", "id": "Terminal.BugReport" },
         // Tab Management
         // "command": "closeTab" is unbound by default.
         //   The closeTab command closes a tab without confirmation, even if it has multiple panes.


### PR DESCRIPTION
Adds a new bugReport ShortcutAction surfaced in the command palette (Ctrl+Shift+P). When invoked, it bundles %LOCALAPPDATA%\IntelligentTerminal\ logs\ into a timestamped zip on the user's Desktop via tar.exe and reveals the file in Explorer.

Wired through the standard X-macro action pipeline (AllShortcutActions, ActionAndArgs, ActionMap, defaults.json) with a localizable BugReportCommandKey resource string.

## Summary of the Pull Request

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
