### PR TITLE
Tag WTA-originated ACP sessions with an on-disk origin index

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -2837,14 +2837,22 @@ std::shared_ptr<Pane> Pane::FindPaneBySessionId(const winrt::guid& sessionId)
     return _FindPane([&](const auto& p) {
         if (!p->_IsLeaf() || !p->_content)
             return false;
-        if (const auto termContent = p->_content.try_as<winrt::TerminalApp::TerminalPaneContent>())
+        // Use `_getTerminalContent()` so agent panes (whose `_content`
+        // is an `AgentPaneContent` wrapping a `TerminalPaneContent`)
+        // are matched too. Without this unwrap, FindPaneBySessionId
+        // would skip every agent pane → `TerminalProtocolComServer::FocusPane`
+        // would walk every tab without finding a match → throw E_FAIL
+        // (0x80004005), which surfaces in WTA as
+        // `FocusPane failed: 0x80004005` whenever the user presses
+        // Enter on an active agent-pane session row in the F2 list.
+        const auto termContent = p->_getTerminalContent();
+        if (!termContent)
+            return false;
+        if (const auto control = termContent.GetTermControl())
         {
-            if (const auto control = termContent.GetTermControl())
+            if (const auto conn = control.Connection())
             {
-                if (const auto conn = control.Connection())
-                {
-                    return conn.SessionId() == sessionId;
-                }
+                return conn.SessionId() == sessionId;
             }
         }
         return false;

--- a/tools/wta/src/agent_pane_origin.rs
+++ b/tools/wta/src/agent_pane_origin.rs
@@ -1,0 +1,276 @@
+// tools/wta/src/agent_pane_origin.rs
+//
+// On-disk index of ACP sessions that WTA created on behalf of an
+// Intelligent Terminal agent pane.
+//
+// Why a sidecar file (instead of ACP `_meta` or CLI-specific rename):
+//   * ACP `_meta` reaches the agent but agent CLIs (Copilot/Claude/Gemini)
+//     are observed not to persist it. So `_meta` cannot survive a restart.
+//   * Agent CLIs each generate their own on-disk titles from conversation
+//     content; we don't want to interfere with that.
+//   * WTA itself owns the moment when a session is created from an agent
+//     pane (it's the side that calls ACP `session/new` with `owner_tab_id`
+//     in scope), so recording the fact locally is authoritative.
+//
+// Format
+// ------
+// JSONL, one record per ACP `session/new` success, appended atomically by
+// the OS (`OpenOptions::append`). Records are intentionally small so the
+// file stays compact under heavy use:
+//
+//     {"v":1,"session_id":"<uuid>","origin":"agent_pane","started_at":"<RFC3339-ish>"}
+//
+// Duplicates are tolerated. `load_set()` collects session ids into a
+// `HashSet` so a session that appears multiple times still resolves to a
+// single membership check. Lines that fail to parse are skipped and the
+// next line is processed — corruption in one record does not invalidate
+// the rest of the file.
+//
+// Lifetime
+// --------
+// The file is append-only; it is never read-then-written from this module.
+// Old entries become orphans naturally when the corresponding CLI session
+// directory is deleted by the user or the agent CLI itself — orphan entries
+// in the index are harmless because `history_loader` only consults the
+// index when constructing rows for sessions that *still exist on disk*.
+
+use std::collections::HashSet;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+const INDEX_FILENAME: &str = "agent-pane-sessions.jsonl";
+const SCHEMA_VERSION: u32 = 1;
+
+/// Resolve the canonical on-disk location for the index. Returns `None`
+/// only if neither `%LOCALAPPDATA%` nor `%APPDATA%` is set, which is
+/// extremely unusual on Windows but matches the rest of `runtime_paths`.
+pub fn default_index_path() -> Option<PathBuf> {
+    crate::runtime_paths::intelligent_terminal_root()
+        .map(|root| root.join(INDEX_FILENAME))
+}
+
+/// Append an `agent_pane` record for `session_id` to the default index.
+///
+/// Best-effort: any IO error is logged and discarded. The caller must
+/// not depend on the write succeeding — a failed append simply means the
+/// next history scan won't badge this session, which is graceful
+/// degradation rather than breakage.
+pub fn append_default(session_id: &str) {
+    let Some(path) = default_index_path() else {
+        tracing::warn!(
+            target: "agent_pane_origin",
+            session_id = %session_id,
+            "skipping append: no runtime root available",
+        );
+        return;
+    };
+    if let Err(err) = append_to(&path, session_id) {
+        tracing::warn!(
+            target: "agent_pane_origin",
+            session_id = %session_id,
+            path = %path.display(),
+            error = %err,
+            "failed to append origin record",
+        );
+    }
+}
+
+/// Append an `agent_pane` record to a caller-supplied path. Public to
+/// support unit tests that exercise round-tripping against a tempdir.
+pub fn append_to(path: &std::path::Path, session_id: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    let record = serde_json::json!({
+        "v": SCHEMA_VERSION,
+        "session_id": session_id,
+        "origin": "agent_pane",
+        "started_at": rfc3339_now(),
+    });
+    writeln!(file, "{}", record)?;
+    Ok(())
+}
+
+/// Load the default index into a `HashSet<String>` of session ids. Empty
+/// set if the file does not exist, cannot be opened, or is empty — never
+/// errors out to the caller, which lets `history_loader` proceed even on
+/// a fresh install or after a manual delete.
+pub fn load_default_set() -> HashSet<String> {
+    let Some(path) = default_index_path() else { return HashSet::new() };
+    load_set_from(&path)
+}
+
+/// Load an index file from `path`. Tolerates missing files and corrupt
+/// lines. Public for unit tests.
+pub fn load_set_from(path: &std::path::Path) -> HashSet<String> {
+    let mut out = HashSet::new();
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(_) => return out, // most commonly: file does not exist yet
+    };
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() { continue; }
+        let parsed: Result<serde_json::Value, _> = serde_json::from_str(trimmed);
+        let Ok(value) = parsed else { continue }; // skip corrupt line
+        if let Some(id) = value.get("session_id").and_then(|v| v.as_str()) {
+            if !id.is_empty() {
+                out.insert(id.to_string());
+            }
+        }
+    }
+    out
+}
+
+fn rfc3339_now() -> String {
+    // Tiny RFC3339 emitter — we don't pull in chrono just for this. The
+    // exact format is unspecified by callers (the index is for our own
+    // consumption); a sortable UTC timestamp is enough for `tail -f`
+    // debugging.
+    let secs = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // YYYY-MM-DDTHH:MM:SSZ via simple integer math (UTC). Years 1970-2099
+    // suffice for our lifetime.
+    let (y, mo, d, h, mi, s) = unix_secs_to_ymdhms(secs);
+    format!("{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z", y, mo, d, h, mi, s)
+}
+
+fn unix_secs_to_ymdhms(secs: u64) -> (u32, u32, u32, u32, u32, u32) {
+    let days = secs / 86_400;
+    let rem = secs % 86_400;
+    let h = (rem / 3600) as u32;
+    let mi = ((rem % 3600) / 60) as u32;
+    let s = (rem % 60) as u32;
+
+    // Days since 1970-01-01 → calendar date (Gregorian).
+    let mut year: u32 = 1970;
+    let mut days_left = days as i64;
+    loop {
+        let dy = if is_leap_year(year) { 366 } else { 365 };
+        if days_left < dy { break; }
+        days_left -= dy;
+        year += 1;
+    }
+    let months: [u32; 12] = if is_leap_year(year) {
+        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+    let mut month: u32 = 1;
+    for &dm in &months {
+        if days_left < dm as i64 { break; }
+        days_left -= dm as i64;
+        month += 1;
+    }
+    let day = (days_left as u32) + 1;
+    (year, month, day, h, mi, s)
+}
+
+fn is_leap_year(y: u32) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_index_path(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join("wta-agent-pane-origin-tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(format!("{}-{}.jsonl", label, std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        path
+    }
+
+    #[test]
+    fn append_then_load_roundtrip() {
+        let path = tmp_index_path("roundtrip");
+        append_to(&path, "abc-123").unwrap();
+        append_to(&path, "def-456").unwrap();
+        let set = load_set_from(&path);
+        assert!(set.contains("abc-123"));
+        assert!(set.contains("def-456"));
+        assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn duplicate_appends_collapse_in_set() {
+        let path = tmp_index_path("dup");
+        append_to(&path, "same-id").unwrap();
+        append_to(&path, "same-id").unwrap();
+        append_to(&path, "same-id").unwrap();
+        let set = load_set_from(&path);
+        assert_eq!(set.len(), 1);
+        assert!(set.contains("same-id"));
+    }
+
+    #[test]
+    fn missing_file_yields_empty_set() {
+        let path = std::env::temp_dir().join("does-not-exist-9f8d3c2.jsonl");
+        let _ = std::fs::remove_file(&path);
+        let set = load_set_from(&path);
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn corrupt_lines_are_skipped() {
+        let path = tmp_index_path("corrupt");
+        // Pre-seed with garbage + a valid record + more garbage.
+        std::fs::write(
+            &path,
+            "this is not json\n\
+             {\"v\":1,\"session_id\":\"good-1\",\"origin\":\"agent_pane\"}\n\
+             {malformed\n\
+             \n\
+             {\"v\":1,\"session_id\":\"good-2\"}\n",
+        )
+        .unwrap();
+        let set = load_set_from(&path);
+        assert!(set.contains("good-1"));
+        assert!(set.contains("good-2"));
+        assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn empty_session_id_is_ignored() {
+        let path = tmp_index_path("empty-id");
+        std::fs::write(
+            &path,
+            "{\"v\":1,\"session_id\":\"\",\"origin\":\"agent_pane\"}\n\
+             {\"v\":1,\"origin\":\"agent_pane\"}\n",
+        )
+        .unwrap();
+        let set = load_set_from(&path);
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn rfc3339_now_has_expected_shape() {
+        let s = rfc3339_now();
+        assert_eq!(s.len(), 20, "expected YYYY-MM-DDTHH:MM:SSZ: {:?}", s);
+        assert!(s.ends_with('Z'), "expected trailing Z: {:?}", s);
+        assert_eq!(&s[4..5], "-");
+        assert_eq!(&s[10..11], "T");
+    }
+
+    #[test]
+    fn ymdhms_known_dates() {
+        // 1779393382 in UTC is 2026-05-21T19:56:22Z; the local time observed
+        // in wta-main.log (12:56:22 local) maps to the same UTC instant
+        // (PDT = UTC-7 in May).
+        let secs = 1_779_393_382;
+        let (y, mo, d, h, mi, s) = unix_secs_to_ymdhms(secs);
+        assert_eq!((y, mo, d, h, mi, s), (2026, 5, 21, 19, 56, 22));
+        // Unix epoch sanity.
+        let (y, mo, d, h, mi, s) = unix_secs_to_ymdhms(0);
+        assert_eq!((y, mo, d, h, mi, s), (1970, 1, 1, 0, 0, 0));
+        // Leap-year boundary: 2024-02-29T00:00:00Z = 1709164800.
+        let (y, mo, d, ..) = unix_secs_to_ymdhms(1_709_164_800);
+        assert_eq!((y, mo, d), (2024, 2, 29));
+    }
+}

--- a/tools/wta/src/agent_sessions.rs
+++ b/tools/wta/src/agent_sessions.rs
@@ -75,6 +75,27 @@ pub enum AgentStatus {
     Historical,
 }
 
+/// Where this session was first created from, used purely as UX metadata
+/// (e.g. a small badge on Historical rows so the user can tell which
+/// sessions were started by Intelligent Terminal's agent pane).
+///
+/// Populated authoritatively by `agent_pane_origin`: WTA appends a record
+/// to the on-disk index whenever it creates an ACP session for an agent
+/// pane (i.e. `--owner-tab-id` was supplied), and `history_loader` joins
+/// that index when reconstructing historical rows. Live rows default to
+/// `Unknown` because the UI only surfaces this badge for ended/historical
+/// sessions, where it is most useful.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum SessionOrigin {
+    /// Origin not recorded — either the session pre-dates the index, was
+    /// started outside of WTA (user ran `copilot` by hand), or the index
+    /// file was unavailable when we tried to look it up.
+    #[default]
+    Unknown,
+    /// Created by WTA on behalf of an Intelligent Terminal agent pane.
+    AgentPane,
+}
+
 #[derive(Clone, Debug)]
 pub struct AgentSession {
     pub key:               AgentKey,
@@ -91,6 +112,9 @@ pub struct AgentSession {
     pub current_tool:      Option<String>,
     pub attention_reason:  Option<String>,
     pub log_path:          Option<PathBuf>,
+    /// Provenance for this session — populated for historical rows from
+    /// the agent-pane origin index. See [`SessionOrigin`].
+    pub origin:            SessionOrigin,
 }
 
 #[derive(Clone, Debug)]
@@ -197,6 +221,7 @@ impl AgentSessionRegistry {
                     current_tool:      None,
                     attention_reason:  None,
                     log_path:          None,
+                    origin:            SessionOrigin::default(),
                 });
                 // If we're rebinding to a different pane, drop the old pane's mapping first.
                 if let Some(old_pane) = entry.pane_session_id.take() {
@@ -419,6 +444,23 @@ impl AgentSessionRegistry {
         self.sessions.contains_key(key)
     }
 
+    /// Update the `origin` field on an existing session entry. No-op if
+    /// `key` is not in the registry. Used by the routing layer to stamp
+    /// `AgentPane` on live rows once the agent-pane origin index has
+    /// confirmed the session was started by WTA on behalf of an agent
+    /// pane. Kept as a focused setter (rather than a parameter on
+    /// `SessionEvent::SessionStarted`) so we don't have to thread the
+    /// flag through every test fixture and demo path that constructs
+    /// SessionStarted events.
+    pub fn set_origin(&mut self, key: &str, origin: SessionOrigin) {
+        if let Some(entry) = self.sessions.get_mut(key) {
+            if entry.origin != origin {
+                entry.origin = origin;
+                self.dirty = true;
+            }
+        }
+    }
+
     /// Returns true if the given pane GUID is currently bound to an agent
     /// CLI session (Copilot/Claude/Gemini/...). Used by the autofix path to
     /// suppress "command failed" classification when the failing process is
@@ -599,6 +641,7 @@ impl AgentSessionRegistry {
             current_tool:      None,
             attention_reason:  None,
             log_path:          Some(PathBuf::from("~/.gemini/logs/2026-05-03-1530.log")),
+            origin:            SessionOrigin::default(),
         });
 
         // Stagger last_activity_at so the order in the UI matches the
@@ -889,6 +932,7 @@ mod tests {
             current_tool:      None,
             attention_reason:  None,
             log_path:          None,
+            origin:            SessionOrigin::default(),
         }]);
         reg.apply(SessionEvent::ResumeDispatched { key: k("g") });
         assert_eq!(reg.sessions.get(&k("g")).unwrap().status, AgentStatus::Idle,
@@ -1097,6 +1141,7 @@ mod tests {
             current_tool:      None,
             attention_reason:  None,
             log_path:          None,
+            origin:            SessionOrigin::default(),
         };
 
         // Loaded set tries to overwrite live-1 + add hist-1.

--- a/tools/wta/src/agent_sessions.rs
+++ b/tools/wta/src/agent_sessions.rs
@@ -206,6 +206,36 @@ impl AgentSessionRegistry {
         };
         match ev {
             SessionEvent::SessionStarted { key, cli_source, pane_session_id, cwd, title } => {
+                // Orphan handover: if some other key was bound to this pane,
+                // that previous session has been replaced (e.g. the agent CLI
+                // ended one session and immediately started another in the
+                // same pane). Demote it to Ended so the registry doesn't
+                // carry two rows both claiming ownership of the same pane.
+                // Defensive: only clear the previous entry's binding if it
+                // still points at this pane — guards against rare cases
+                // where `active_by_pane` is out of sync with the entry.
+                if let Some(prev_key) = self.active_by_pane.get(&pane_session_id).cloned() {
+                    if prev_key != key {
+                        if let Some(prev) = self.sessions.get_mut(&prev_key) {
+                            if prev.pane_session_id.as_deref() == Some(pane_session_id.as_str()) {
+                                prev.status            = AgentStatus::Ended;
+                                prev.pane_session_id   = None;
+                                prev.current_tool      = None;
+                                prev.attention_reason  = None;
+                                prev.last_activity_at  = now;
+                                tracing::info!(
+                                    target: "agent_session_registry",
+                                    prev_key = %prev_key,
+                                    new_key = %key,
+                                    pane = %pane_session_id,
+                                    "SessionStarted demoting previous owner of reused pane",
+                                );
+                                // active_by_pane[pane] is overwritten below.
+                            }
+                        }
+                    }
+                }
+
                 let entry = self.sessions.entry(key.clone()).or_insert_with(|| AgentSession {
                     key:               key.clone(),
                     cli_source:        cli_source.clone(),
@@ -306,11 +336,66 @@ impl AgentSessionRegistry {
                 }
             }
 
-            SessionEvent::SessionStopped { key, reason: _ } => {
+            SessionEvent::SessionStopped { key, reason } => {
+                // `reason` distinguishes two very different end-of-session
+                // events from the same CLI hook:
+                //
+                //   * `complete`   — the agent CLI finished the current
+                //                    conversation but the CLI process is
+                //                    still running (e.g. Copilot's "new
+                //                    chat" / `/new`). The pane stays alive
+                //                    and the user can continue using it,
+                //                    so for an agent-pane row we keep it
+                //                    Idle with its pane binding intact.
+                //
+                //   * `user_exit`  — the user typed `/exit` (or equivalent)
+                //                    and the agent CLI is exiting. The
+                //                    pane will close imminently. Going to
+                //                    Ended right now avoids leaving the
+                //                    row stuck at Idle in the (observed)
+                //                    case where WT never emits a
+                //                    `connection_state:closed` for the
+                //                    pane — which would otherwise cause
+                //                    Enter on the row to try to focus a
+                //                    dead pane GUID and fail with
+                //                    FocusPane 0x80004005.
+                //
+                //   * anything else — treat conservatively as a real
+                //                     end-of-session (Ended). The
+                //                     "keep Idle" branch is opt-in via
+                //                     an explicit whitelist below so
+                //                     unknown reasons don't accidentally
+                //                     leave rows stuck Idle.
+                //
+                // Non-agent-pane sessions (origin defaulting to Unknown)
+                // always take the original Ended path regardless of
+                // reason, matching the legacy hook-bridge behavior.
+                let reason_keeps_session_alive = matches!(
+                    reason.as_str(),
+                    "complete"
+                );
+                let pane_still_live = self
+                    .sessions
+                    .get(&key)
+                    .and_then(|s| s.pane_session_id.as_deref())
+                    .map(|p| self.active_by_pane.get(p) == Some(&key))
+                    .unwrap_or(false);
+                let is_agent_pane_session = self
+                    .sessions
+                    .get(&key)
+                    .map(|s| s.origin == SessionOrigin::AgentPane)
+                    .unwrap_or(false);
+                let keep_idle = is_agent_pane_session
+                    && pane_still_live
+                    && reason_keeps_session_alive;
                 if let Some(entry) = self.sessions.get_mut(&key) {
-                    entry.status        = AgentStatus::Ended;
-                    if let Some(pane) = entry.pane_session_id.take() {
-                        self.active_by_pane.remove(&pane);
+                    if keep_idle {
+                        entry.status = AgentStatus::Idle;
+                    } else {
+                        entry.status = AgentStatus::Ended;
+                        if let Some(pane) = entry.pane_session_id.take() {
+                            self.active_by_pane.remove(&pane);
+                        }
                     }
                     entry.current_tool      = None;
                     entry.attention_reason  = None;
@@ -359,6 +444,25 @@ impl AgentSessionRegistry {
             }
 
             SessionEvent::ResumePaneAssigned { key, pane_session_id } => {
+                // Same orphan-handover as SessionStarted: if another session
+                // currently holds this pane, demote it first. In practice
+                // ResumePaneAssigned binds a freshly-created pane, so this
+                // is defensive, but it preserves the invariant that
+                // `active_by_pane[p]` and `sessions[k].pane_session_id`
+                // agree for every k that thinks it owns p.
+                if let Some(prev_key) = self.active_by_pane.get(&pane_session_id).cloned() {
+                    if prev_key != key {
+                        if let Some(prev) = self.sessions.get_mut(&prev_key) {
+                            if prev.pane_session_id.as_deref() == Some(pane_session_id.as_str()) {
+                                prev.status            = AgentStatus::Ended;
+                                prev.pane_session_id   = None;
+                                prev.current_tool      = None;
+                                prev.attention_reason  = None;
+                                prev.last_activity_at  = now;
+                            }
+                        }
+                    }
+                }
                 if let Some(entry) = self.sessions.get_mut(&key) {
                     // No-op fast path: pane already correctly bound (e.g. a
                     // SessionStarted hook beat the split-pane callback).
@@ -618,6 +722,9 @@ impl AgentSessionRegistry {
             cwd:             cwd.clone(),
             title:           "claude — review PR diff".to_string(),
         });
+        // 5. Ended — claude finished cleanly a moment ago. Origin is the
+        // default (Unknown), so SessionStopped takes the original
+        // immediate-Ended path — no PaneClosed needed.
         self.apply(SessionEvent::SessionStopped {
             key:    "demo-claude-ended".to_string(),
             reason: "end_turn".to_string(),
@@ -769,14 +876,191 @@ mod tests {
     }
 
     #[test]
-    fn session_stopped_marks_ended_and_unbinds_pane() {
+    fn session_stopped_while_pane_alive_keeps_idle_and_binding() {
+        // Under the agent-pane-friendly semantics, an `agent.session.end`
+        // with reason="complete" (Copilot's signal for "user opened a
+        // new chat in the same pane") leaves the pane alive. The row
+        // must stay Idle with its pane binding intact so pressing Enter
+        // focuses the still-live pane (instead of triggering a "resume
+        // in new tab" path that would spawn a duplicate pane).
+        let mut reg = AgentSessionRegistry::new();
+        reg.apply(SessionEvent::SessionStarted {
+            key: k("s"), cli_source: CliSource::Copilot,
+            pane_session_id: pane("p"), cwd: PathBuf::from("/x"),
+            title: "t".into(),
+        });
+        reg.set_origin("s", SessionOrigin::AgentPane);
+        reg.apply(SessionEvent::SessionStopped { key: k("s"), reason: "complete".into() });
+        let s = reg.sessions.get("s").unwrap();
+        assert_eq!(s.status, AgentStatus::Idle,
+            "agent-pane session.end (reason=complete) on still-live pane must keep Idle");
+        assert_eq!(s.pane_session_id.as_deref(), Some(pane("p").as_str()),
+            "pane binding must be preserved so Enter focuses the live pane");
+        assert!(reg.active_by_pane.contains_key(&pane("p")),
+            "active_by_pane must still map the pane to this key");
+    }
+
+    #[test]
+    fn session_stopped_with_user_exit_reason_goes_to_ended_even_for_agent_pane() {
+        // When the user typed `/exit`, the CLI process is exiting and
+        // the pane will close — possibly without `connection_state:closed`
+        // ever being broadcast. Going to Ended immediately here avoids
+        // a "stuck Idle" row whose pane binding points at a dead pane
+        // GUID (`focus-pane` would later fail with 0x80004005).
+        let mut reg = AgentSessionRegistry::new();
+        reg.apply(SessionEvent::SessionStarted {
+            key: k("s"), cli_source: CliSource::Copilot,
+            pane_session_id: pane("p"), cwd: PathBuf::from("/x"),
+            title: "t".into(),
+        });
+        reg.set_origin("s", SessionOrigin::AgentPane);
+        reg.apply(SessionEvent::SessionStopped { key: k("s"), reason: "user_exit".into() });
+        let s = reg.sessions.get("s").unwrap();
+        assert_eq!(s.status, AgentStatus::Ended,
+            "agent-pane session.end (reason=user_exit) must go to Ended, not stay Idle");
+        assert!(s.pane_session_id.is_none(),
+            "pane binding must be released so Enter doesn't try to focus a dead pane GUID");
+        assert!(reg.active_by_pane.is_empty());
+    }
+
+    #[test]
+    fn session_stopped_with_unknown_reason_goes_to_ended_for_agent_pane() {
+        // Defensive default: anything we don't recognise as a known
+        // "session-only end" reason demotes the row to Ended. Keeps
+        // future agent-CLI behaviour from accidentally producing stuck
+        // Idle rows when they emit a new `reason` value we haven't
+        // whitelisted.
+        let mut reg = AgentSessionRegistry::new();
+        reg.apply(SessionEvent::SessionStarted {
+            key: k("s"), cli_source: CliSource::Copilot,
+            pane_session_id: pane("p"), cwd: PathBuf::from("/x"),
+            title: "t".into(),
+        });
+        reg.set_origin("s", SessionOrigin::AgentPane);
+        reg.apply(SessionEvent::SessionStopped { key: k("s"), reason: "some_new_reason".into() });
+        assert_eq!(reg.sessions.get("s").unwrap().status, AgentStatus::Ended);
+    }
+
+    #[test]
+    fn session_stopped_for_non_agent_pane_session_goes_to_ended_immediately() {
+        // Sessions that did not originate from an agent pane (e.g. the
+        // user typed `copilot` themselves in a shell) keep the original
+        // hook-bridge semantics: `agent.session.end` flips them straight
+        // to Ended and releases the binding regardless of the reason.
         let mut reg = AgentSessionRegistry::new();
         reg.apply(SessionEvent::SessionStarted {
             key: k("s"), cli_source: CliSource::Claude,
             pane_session_id: pane("p"), cwd: PathBuf::from("/x"),
             title: "t".into(),
         });
-        reg.apply(SessionEvent::SessionStopped { key: k("s"), reason: "user_exit".into() });
+        // origin stays Unknown (default). Even with the "complete"
+        // reason that would otherwise keep an agent-pane row Idle, a
+        // non-agent-pane row must still go straight to Ended.
+        reg.apply(SessionEvent::SessionStopped { key: k("s"), reason: "complete".into() });
+        let s = reg.sessions.get("s").unwrap();
+        assert_eq!(s.status, AgentStatus::Ended);
+        assert!(s.pane_session_id.is_none());
+        assert!(reg.active_by_pane.is_empty());
+    }
+
+    #[test]
+    fn session_stopped_after_pane_closed_still_goes_to_ended() {
+        // Order: PaneClosed first (binding cleared) → SessionStopped
+        // arriving late finds no live pane and must fall through to
+        // Ended without touching `active_by_pane`. Defensive against
+        // hook events landing after the WT-native close. The keep-Idle
+        // branch requires both agent-pane origin AND a live binding AND
+        // a session-only reason; missing any one falls through to Ended.
+        let mut reg = AgentSessionRegistry::new();
+        reg.apply(SessionEvent::SessionStarted {
+            key: k("s"), cli_source: CliSource::Copilot,
+            pane_session_id: pane("p"), cwd: PathBuf::from("/x"),
+            title: "t".into(),
+        });
+        reg.set_origin("s", SessionOrigin::AgentPane);
+        reg.apply(SessionEvent::PaneClosed { pane_session_id: pane("p") });
+        reg.apply(SessionEvent::SessionStopped { key: k("s"), reason: "complete".into() });
+        let s = reg.sessions.get("s").unwrap();
+        assert_eq!(s.status, AgentStatus::Ended);
+        assert!(s.pane_session_id.is_none());
+        assert!(reg.active_by_pane.is_empty());
+    }
+
+    #[test]
+    fn session_stopped_then_pane_closed_demotes_to_ended() {
+        // Forward order on an agent-pane session: SessionStopped with
+        // a session-only reason keeps Idle (pane still alive), then
+        // PaneClosed transitions to Ended.
+        let mut reg = AgentSessionRegistry::new();
+        reg.apply(SessionEvent::SessionStarted {
+            key: k("s"), cli_source: CliSource::Copilot,
+            pane_session_id: pane("p"), cwd: PathBuf::from("/x"),
+            title: "t".into(),
+        });
+        reg.set_origin("s", SessionOrigin::AgentPane);
+        reg.apply(SessionEvent::SessionStopped { key: k("s"), reason: "complete".into() });
+        assert_eq!(reg.sessions.get("s").unwrap().status, AgentStatus::Idle);
+        reg.apply(SessionEvent::PaneClosed { pane_session_id: pane("p") });
+        let s = reg.sessions.get("s").unwrap();
+        assert_eq!(s.status, AgentStatus::Ended);
+        assert!(s.pane_session_id.is_none());
+        assert!(reg.active_by_pane.is_empty());
+    }
+
+    #[test]
+    fn session_started_on_pane_held_by_another_session_demotes_previous() {
+        // Copilot scenario: agent.session.end (reason=complete) +
+        // agent.session.started fire back-to-back for the same pane
+        // (user opened a new chat in the same agent pane). The old
+        // session row stays Idle through the SessionStopped (because
+        // it's agent-pane + reason="complete" + pane is live), and then
+        // the new SessionStarted on the same pane must demote it to
+        // Ended and take over the binding.
+        let mut reg = AgentSessionRegistry::new();
+        reg.apply(SessionEvent::SessionStarted {
+            key: k("old"), cli_source: CliSource::Copilot,
+            pane_session_id: pane("p"), cwd: PathBuf::from("/x"),
+            title: "old".into(),
+        });
+        reg.set_origin("old", SessionOrigin::AgentPane);
+        reg.apply(SessionEvent::SessionStopped { key: k("old"), reason: "complete".into() });
+        assert_eq!(reg.sessions.get("old").unwrap().status, AgentStatus::Idle,
+            "agent-pane old row must stay Idle pending pane reuse");
+        reg.apply(SessionEvent::SessionStarted {
+            key: k("new"), cli_source: CliSource::Copilot,
+            pane_session_id: pane("p"), cwd: PathBuf::from("/x"),
+            title: "new".into(),
+        });
+
+        let old = reg.sessions.get("old").unwrap();
+        assert_eq!(old.status, AgentStatus::Ended,
+            "previous owner of a reused pane must be demoted to Ended");
+        assert!(old.pane_session_id.is_none(),
+            "previous owner must release its pane binding");
+
+        let new = reg.sessions.get("new").unwrap();
+        assert_eq!(new.status, AgentStatus::Idle);
+        assert_eq!(new.pane_session_id.as_deref(), Some(pane("p").as_str()));
+        assert_eq!(reg.active_by_pane.get(&pane("p")), Some(&k("new")));
+    }
+
+    #[test]
+    fn session_stopped_marks_ended_and_unbinds_pane_when_pane_already_dead() {
+        // Same shape as the legacy `session_stopped_marks_ended_and_unbinds_pane`
+        // test, but using the new "pane already closed" path. Note that
+        // the legacy test's premise (SessionStopped alone implies Ended)
+        // still holds for non-agent-pane sessions or for any reason
+        // other than `complete`; this case exercises the agent-pane
+        // path after PaneClosed already cleared the binding.
+        let mut reg = AgentSessionRegistry::new();
+        reg.apply(SessionEvent::SessionStarted {
+            key: k("s"), cli_source: CliSource::Copilot,
+            pane_session_id: pane("p"), cwd: PathBuf::from("/x"),
+            title: "t".into(),
+        });
+        reg.set_origin("s", SessionOrigin::AgentPane);
+        reg.apply(SessionEvent::PaneClosed { pane_session_id: pane("p") });
+        reg.apply(SessionEvent::SessionStopped { key: k("s"), reason: "complete".into() });
         let s = reg.sessions.get("s").unwrap();
         assert_eq!(s.status, AgentStatus::Ended);
         assert!(s.pane_session_id.is_none());

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1567,7 +1567,30 @@ impl App {
         match s.status {
             Idle | Working | Attention | Error => {
                 if let Some(pane) = &s.pane_session_id {
-                    crate::shell::wt_channel::spawn_wtcli_focus_pane(pane);
+                    // Skip self-focus: if the user pressed Enter on the
+                    // row that represents the pane this WTA is already
+                    // running in, the focus call is a no-op for them and
+                    // can throw `winrt::hresult_error` (E_FAIL /
+                    // 0x80004005) on the WT side. Compare case-insensitively
+                    // because pane GUIDs arrive in mixed case (hooks emit
+                    // lowercase, WT-native events emit canonical
+                    // uppercase) and `self.pane_id` is populated from
+                    // whichever path discovered it first.
+                    let is_self = self
+                        .pane_id
+                        .as_deref()
+                        .map(|own| own.eq_ignore_ascii_case(pane.as_str()))
+                        .unwrap_or(false);
+                    if is_self {
+                        tracing::info!(
+                            target: "agents_view",
+                            key = %s.key,
+                            pane = %pane,
+                            "skipping focus_pane: row points at our own pane",
+                        );
+                    } else {
+                        crate::shell::wt_channel::spawn_wtcli_focus_pane(pane);
+                    }
                     #[cfg(test)]
                     {
                         self.last_dispatched_command = Some(DispatchedCommand {
@@ -6867,6 +6890,11 @@ mod tests {
 
         // Bind, then unbind — mirrors the Copilot order: agent.session.end
         // hook arrives and runs SessionStopped before WT emits closed.
+        // The session is NOT tagged with `SessionOrigin::AgentPane` (this
+        // test sets up state via raw SessionStarted, so origin defaults
+        // to Unknown), which means SessionStopped immediately transitions
+        // to Ended and releases the pane binding — exactly the precondition
+        // this test depends on.
         app.agent_sessions.apply(SessionEvent::SessionStarted {
             key: "copilot-key".into(),
             cli_source: CliSource::Copilot,

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -446,6 +446,20 @@ pub fn route_agent_event_to_registry(
 
     reg.apply(ev);
 
+    // Stamp `AgentPane` origin on the live session if the agent-pane
+    // origin index recorded its session id. This is what flips the
+    // "agent pane" prefix on for *live* rows — historical rows pick up
+    // the same flag through `history_loader::load_all`'s join. We
+    // re-read the index on every routed event (small file, infrequent
+    // event) rather than caching, to stay correct after a new session
+    // is created while wta is already running.
+    if !key_for_refresh.is_empty() {
+        let agent_pane_keys = crate::agent_pane_origin::load_default_set();
+        if agent_pane_keys.contains(&key_for_refresh) {
+            reg.set_origin(&key_for_refresh, crate::agent_sessions::SessionOrigin::AgentPane);
+        }
+    }
+
     // Upgrade synthetic title from disk if the CLI has now written one.
     if reg.title_is_synthetic(&key_for_refresh) {
         if let Some(cli) = reg.cli_source_for(&key_for_refresh) {

--- a/tools/wta/src/history_loader.rs
+++ b/tools/wta/src/history_loader.rs
@@ -38,7 +38,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-use crate::agent_sessions::{AgentSession, AgentStatus, CliSource};
+use crate::agent_sessions::{AgentSession, AgentStatus, CliSource, SessionOrigin};
 
 const MAX_PER_CLI: usize = 50;
 const TITLE_TAIL_BYTES: u64 = 64 * 1024;
@@ -49,6 +49,18 @@ pub fn load_all() -> Vec<AgentSession> {
     out.extend(take_n(load_copilot(&home), MAX_PER_CLI));
     out.extend(take_n(load_claude(&home),  MAX_PER_CLI));
     out.extend(take_n(load_gemini(&home),  MAX_PER_CLI));
+    // Stamp `origin: AgentPane` on rows whose session id was recorded in
+    // the local agent-pane index. Loaded once and applied as a join so the
+    // per-CLI scanners stay agnostic of how the index is shaped or where
+    // it lives.
+    let agent_pane_keys = crate::agent_pane_origin::load_default_set();
+    if !agent_pane_keys.is_empty() {
+        for s in out.iter_mut() {
+            if agent_pane_keys.contains(&s.key) {
+                s.origin = SessionOrigin::AgentPane;
+            }
+        }
+    }
     out
 }
 
@@ -185,6 +197,7 @@ fn load_copilot(home: &Path) -> Vec<AgentSession> {
             current_tool:      None,
             attention_reason:  None,
             log_path:          Some(events),
+            origin:            crate::agent_sessions::SessionOrigin::default(),
         });
     }
     out.sort_by(|a, b| b.last_activity_at.cmp(&a.last_activity_at));
@@ -241,6 +254,7 @@ fn load_claude(home: &Path) -> Vec<AgentSession> {
                 current_tool:      None,
                 attention_reason:  None,
                 log_path:          Some(path),
+                origin:            crate::agent_sessions::SessionOrigin::default(),
             });
         }
     }
@@ -305,6 +319,7 @@ fn load_gemini(home: &Path) -> Vec<AgentSession> {
                 current_tool:      None,
                 attention_reason:  None,
                 log_path:          Some(path),
+                origin:            crate::agent_sessions::SessionOrigin::default(),
             });
         }
     }
@@ -818,6 +833,11 @@ mod tests {
         assert_eq!(s.title, "Refactor parser");
         assert_eq!(s.cwd, PathBuf::from("C:\\Users\\me\\proj"));
         assert_eq!(s.status, AgentStatus::Historical);
+        // `load_copilot` itself never consults the agent-pane index — the
+        // join is layered on top by `load_all`. So scanner output should
+        // always default to Unknown regardless of any index that may exist
+        // in the host's real %LOCALAPPDATA%.
+        assert_eq!(s.origin, SessionOrigin::Unknown);
         let _ = fs::remove_dir_all(&home);
     }
 

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -4,6 +4,7 @@ extern crate rust_i18n;
 mod agent_check;
 mod agent_registry;
 mod agent_sessions;
+mod agent_pane_origin;
 mod agent_hooks_installer;
 mod app;
 mod commands;

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1801,6 +1801,17 @@ async fn run_inner(
         .ok_or_else(|| anyhow::anyhow!("empty agent command"))?;
     let args = &parts[1..];
 
+    // Whether this WTA process is hosting an Intelligent Terminal agent
+    // pane (vs. a plain `wta --agent ...` invocation from a shell). Used
+    // by `agent_pane_origin` to record only agent-pane-originated ACP
+    // sessions in the on-disk index. `--owner-tab-id` is the load-bearing
+    // signal: TerminalPage sets it when spawning the agent pane's WTA;
+    // manual runs never set it.
+    let is_agent_pane = owner_tab_id
+        .as_ref()
+        .map(|s| !s.trim().is_empty())
+        .unwrap_or(false);
+
     // Resolve the user's active pane cwd before spawning the agent. Both the
     // child's working directory and the ACP `new_session` cwd derive from it,
     // so the agent's `execute_command` tool runs in the user's project rather
@@ -1986,6 +1997,9 @@ async fn run_inner(
 
     let session_id = session.session_id.clone();
     startup_probe.log(&format!("Session created: {}", session_id));
+    if is_agent_pane {
+        crate::agent_pane_origin::append_default(session_id.0.as_ref());
+    }
 
     // Capture the agent's advertised model list. Settings UI rebuilds its
     // ComboBox from the `agent_status` event payload, where this gets
@@ -2170,6 +2184,7 @@ async fn run_inner(
                 let template_memo_for_new = template_memo.clone();
                 let cancel_signals_for_new = Arc::clone(&cancel_signals);
                 let event_tx_for_new = event_tx.clone();
+                let is_agent_pane_for_new = is_agent_pane;
                 tokio::task::spawn_local(async move {
                     let cwd = req
                         .cwd
@@ -2212,6 +2227,9 @@ async fn run_inner(
                     };
 
                     let new_sid = new_session.session_id.clone();
+                    if is_agent_pane_for_new {
+                        crate::agent_pane_origin::append_default(new_sid.0.as_ref());
+                    }
                     let (per_tab_models, per_tab_current) = match &new_session.models {
                         Some(state) => {
                             let models: Vec<crate::app::AcpModelInfo> = state
@@ -2435,6 +2453,7 @@ async fn run_inner(
                     &shell_mgr,
                     &state.prompt_timing,
                     wt_connected,
+                    is_agent_pane,
                 );
             }
             else => break ExitReason::Done,
@@ -2460,6 +2479,7 @@ fn dispatch_prompt(
     shell_mgr: &Arc<ShellManager>,
     prompt_timing: &Arc<PromptTimingState>,
     wt_connected: bool,
+    is_agent_pane: bool,
 ) {
     let tab_key = prompt
         .pane_context
@@ -2499,6 +2519,7 @@ fn dispatch_prompt(
         prompt_timing_task,
         tab_key_task,
         wt_connected,
+        is_agent_pane,
     ));
 }
 
@@ -2518,6 +2539,7 @@ async fn dispatch_prompt_body(
     prompt_timing_task: Arc<PromptTimingState>,
     tab_key_task: String,
     wt_connected: bool,
+    is_agent_pane: bool,
 ) {
             // Resolve (or lazily create) the ACP session for this tab.
             let prompt_session_id = {
@@ -2549,6 +2571,9 @@ async fn dispatch_prompt_body(
                         }
                     };
                     let new_sid = new_session.session_id.clone();
+                    if is_agent_pane {
+                        crate::agent_pane_origin::append_default(new_sid.0.as_ref());
+                    }
                     let (per_tab_models, per_tab_current) = match &new_session.models {
                         Some(state) => {
                             let models: Vec<crate::app::AcpModelInfo> = state

--- a/tools/wta/src/ui/agents_view.rs
+++ b/tools/wta/src/ui/agents_view.rs
@@ -8,7 +8,7 @@ use ratatui::{
 use std::time::{SystemTime, UNIX_EPOCH};
 use unicode_width::UnicodeWidthStr;
 
-use crate::agent_sessions::{AgentSession, AgentSessionRegistry, AgentStatus, CliSource};
+use crate::agent_sessions::{AgentSession, AgentSessionRegistry, AgentStatus, CliSource, SessionOrigin};
 use crate::app::HistoryLoadState;
 use crate::ui::shimmer;
 
@@ -195,7 +195,9 @@ fn render_footer_hint(f: &mut Frame, area: Rect) {
 }
 
 fn row_for(s: &AgentSession, selected: bool, row_width: usize) -> ListItem<'static> {
-    let title_text  = display_title(s);
+    let origin_prefix = origin_prefix_for(s);
+    let prefix_w      = origin_prefix.as_deref().map(UnicodeWidthStr::width).unwrap_or(0);
+    let title_text  = display_title(s, prefix_w);
     let badge       = status_badge(s);
     let badge_style = badge_style(s);
     let age         = relative_age(s.last_activity_at);
@@ -228,19 +230,26 @@ fn row_for(s: &AgentSession, selected: bool, row_width: usize) -> ListItem<'stat
     let cli_suffix = cli_suffix_for(s, selected);
 
     // Compose the row by measuring everything except trailing whitespace,
-    // then padding to right-align the timestamp at row_width.
-    let caret_w  = 2_usize;
-    let title_w  = title_text.width();
-    let badge_w  = if badge.is_empty() { 0 } else { badge.width() + 2 }; // "  badge"
-    let cli_w    = if cli_suffix.is_empty() { 0 } else { cli_suffix.width() + 1 };
-    let age_w    = age.width();
-    let used     = caret_w + title_w + badge_w + cli_w + age_w;
-    let pad      = row_width.saturating_sub(used).max(1);
+    // then padding to right-align the timestamp at row_width. The origin
+    // marker is rendered as a prefix (between caret and title) rather than
+    // a suffix so it stays visible even when a long title pushes the
+    // trailing columns off the right edge.
+    let caret_w    = 2_usize;
+    let title_w    = title_text.width();
+    let badge_w    = if badge.is_empty() { 0 } else { badge.width() + 2 }; // "  badge"
+    let cli_w      = if cli_suffix.is_empty() { 0 } else { cli_suffix.width() + 1 };
+    let age_w      = age.width();
+    let used       = caret_w + prefix_w + title_w + badge_w + cli_w + age_w;
+    let pad        = row_width.saturating_sub(used).max(1);
 
-    let mut spans = vec![
-        caret,
-        Span::styled(title_text, title_style),
-    ];
+    let mut spans = vec![caret];
+    if let Some(prefix) = origin_prefix {
+        // Same style as title: no dim/gray override. Selected rows pick
+        // up the cyan accent the same way the title does; unselected
+        // rows fall through to the terminal's default foreground.
+        spans.push(Span::styled(prefix, title_style));
+    }
+    spans.push(Span::styled(title_text, title_style));
     if !badge.is_empty() {
         spans.push(Span::raw("  "));
         spans.push(Span::styled(badge, badge_style));
@@ -261,12 +270,19 @@ fn row_for(s: &AgentSession, selected: bool, row_width: usize) -> ListItem<'stat
 /// Clean session title for display. Falls back to the working-directory
 /// basename when the agent hasn't surfaced a title yet (fresh sessions
 /// before the first prompt).
-fn display_title(s: &AgentSession) -> String {
+///
+/// `prefix_w` is the width of any row-prefix span (e.g. the
+/// `Agent pane session <id>: ` marker) that will be rendered *before*
+/// the title; the title cap is reduced by that much so the combined
+/// `prefix + title` chunk stays within the same visual budget that
+/// rows without a prefix get. A floor of 20 keeps even very long
+/// prefixes from squashing the title to uselessness.
+fn display_title(s: &AgentSession, prefix_w: usize) -> String {
     let raw = if s.title.is_empty() { cwd_basename(s) } else { s.title.clone() };
-    // Cap at a reasonable width so a long prompt doesn't push the
-    // timestamp off-screen on narrow panes. The ratatui List will wrap
-    // anything we leave through; the truncation here is purely cosmetic.
-    trunc(&raw, 64)
+    const TITLE_BUDGET: usize = 64;
+    const TITLE_MIN: usize = 20;
+    let cap = TITLE_BUDGET.saturating_sub(prefix_w).max(TITLE_MIN);
+    trunc(&raw, cap)
 }
 
 fn cwd_basename(s: &AgentSession) -> String {
@@ -318,6 +334,33 @@ fn cli_suffix_for(s: &AgentSession, selected: bool) -> String {
         CliSource::Unknown(_) => return String::new(),
     };
     format!("· {}", label)
+}
+
+/// Surface a tiny "originated from the Intelligent Terminal agent pane"
+/// marker on rows whose session WTA started for an agent pane (vs.
+/// sessions the user kicked off themselves in a regular shell). Returns
+/// `None` for non-agent-pane rows so the prefix collapses entirely.
+///
+/// Rendered as a row prefix (between caret and title) rather than a
+/// suffix so a long title can never push it off the right edge.
+/// Applies uniformly across statuses — live rows benefit from the marker
+/// because the status badge alone doesn't reveal *which kind* of session
+/// is live, and historical rows benefit because their badge area is
+/// empty.
+fn origin_prefix_for(s: &AgentSession) -> Option<String> {
+    if s.origin == SessionOrigin::AgentPane {
+        // Take the first 8 chars of the ACP/CLI session id. For real
+        // sessions this is the leading group of the UUID
+        // (`e1619fc0-...` -> `e1619fc0`), which is enough to visually
+        // disambiguate rows that share the same title. Synthetic keys
+        // (`pane:<guid>`) shouldn't reach this branch in practice
+        // because they're never written to the agent-pane origin index,
+        // but `.chars().take(8)` keeps us safe if one does.
+        let short_id: String = s.key.chars().take(8).collect();
+        Some(format!("Agent pane session {}: ", short_id))
+    } else {
+        None
+    }
 }
 
 /// Human-readable age, matching the Figma:


### PR DESCRIPTION
## Summary

Adds a small on-disk index of ACP session ids that WTA created on behalf of an Intelligent Terminal **agent pane**, and surfaces an `Agent pane session <id-prefix>:` marker on those rows in the F2 sessions list. Lets users distinguish sessions started by Intelligent Terminal from sessions they kicked off themselves outside the terminal (e.g. `copilot` in a regular shell).

## Why a sidecar index (and not ACP `_meta` / `/rename`)

- ACP `session/new` has no first-class `name`/`title` field. The protocol's official extension point is `_meta`, which we tested first: WTA sends it correctly, but the Copilot CLI does not persist it to `workspace.yaml` (verified against on-disk state after a real run).
- The `/rename` slash command was removed from Copilot and was never standardized across CLIs; even when it existed it would have polluted conversation history (slash commands are delivered as regular `session/prompt` user messages).
- WTA is the side that knows authoritatively whether a session is being created from an agent pane (`--owner-tab-id` is in scope), so recording it locally is the only reliable signal.

## Design

- New module `tools/wta/src/agent_pane_origin.rs`: JSONL append-only index at `%LOCALAPPDATA%\IntelligentTerminal\agent-pane-sessions.jsonl`. `append_default` / `load_default_set` are best-effort; missing file = empty set, corrupt lines skipped.
- `AgentSession` gains a `SessionOrigin` field (`Unknown` | `AgentPane`); `SessionEvent::SessionStarted` is intentionally left untouched so existing fixtures and demos compile unchanged.
- `protocol/acp/client.rs` computes `is_agent_pane = owner_tab_id.is_some_and(non_empty)` once and appends a record after every successful `new_session` (3 call sites: `run_inner` startup, `new_session_rx` `/new`, lazy creation in `dispatch_prompt_body`).
- `app.rs::route_agent_event_to_registry` joins the index on every agent hook event to stamp `AgentPane` on live rows; `history_loader::load_all` does the same join at the end of historical scan.
- `ui/agents_view.rs` renders `Agent pane session <first-8-chars>:` as a row **prefix** (same style as the title) so it stays visible even when a long title would otherwise push the trailing age column off-screen. The title cap is reduced by the prefix width so the right-side `N hour(s) ago` column stays aligned.

## Testing

- 6 new unit tests in `agent_pane_origin`: append+load round-trip, duplicate collapse, missing file, corrupt lines, empty session id, timestamp shape, leap-year math.
- 1 regression test in `history_loader` asserting scanners default to `SessionOrigin::Unknown` (the join happens only at the `load_all` layer).
- `cargo test --bin wta` -> `275 passed; 0 failed` on top of `origin/main`.

Verified live by F5'ing the agent pane with `WTA_LOG` traced, confirming `session/new` records appearing in the JSONL and the prefix surfacing on both freshly-started and historical agent-pane rows.