### PR TITLE
Add RTL layout support for FRE and WTA agent pane

### DIFF
--- a/.github/actions/spelling/patterns/patterns.txt
+++ b/.github/actions/spelling/patterns/patterns.txt
@@ -236,6 +236,9 @@ ROY\sG\.\sBIV
 # ARM NEON intrinsics like "vsubq_u16"
 \bv\w+_[fsu](?:8|16|32|64)\b
 
+# Win32 SDK LOCALE_* constants (locale-info field identifiers from winnls.h)
+\bLOCALE_[A-Z][A-Z0-9_]+\b
+
 # AppX package
 _\d[0-9a-z]{12}['\.]
 

--- a/doc/specs/rtl-investigation.md
+++ b/doc/specs/rtl-investigation.md
@@ -1,146 +1,91 @@
-# RTL Support Investigation — Intelligent Terminal
+# RTL Support — Design Notes
 
-**Status:** Implemented — see PR adding `src/cascadia/inc/RtlHelper.h`,
-`tools/wta/src/rtl.rs`, and the FRE/WTA wiring. This document is kept
-as a historical design record explaining *why* the fix took the shape
-it did; the "Next steps" checklist below is now mostly complete.
+**Status:** Implemented.
+
+This document explains the right-to-left (RTL) layout work that
+accompanies the localization effort, so that future contributors can
+see *why* the implementation is shaped the way it is. The code lives
+in `src/cascadia/inc/RtlHelper.h` (C++ / FRE) and `tools/wta/src/rtl.rs`
+(Rust / `wta`); this note is the design background.
 
 ## Why this exists
 
-The localization branch (`dev/yeelam/loc-fre-fixes`) translated text for
-Arabic (`ar-SA`), Hebrew (`he-IL`), Farsi (`fa-IR`), Urdu (`ur-PK`),
-Uyghur (`ug-CN`) and other RTL scripts. But translated text is only half
-of RTL support — the **layout** also needs to mirror (right-to-left
-flow, right-aligned columns, save/cancel buttons swap sides, etc.).
+The localization pass translated text for Arabic (`ar-SA`), Hebrew
+(`he-IL`), Persian (`fa-IR`), Urdu (`ur-PK`), `ug-CN`, and other
+right-to-left scripts. Translated text is only half of RTL support —
+the *layout* also needs to mirror (right-to-left flow, right-aligned
+columns, primary buttons swap sides, etc.).
 
-This worktree is for that work. The PR'd loc fix won't address it.
+## RTL locales the product ships
 
-## RTL locales we ship
+`ar-SA`, `he-IL`, `fa-IR`, `ur-PK`, `ug-CN`. Plus the pseudo-locale
+`qps-plocm`, which exists specifically to validate RTL / mirrored
+layouts.
 
-`ar-SA`, `he-IL`, `fa-IR`, `ur-PK`, `ug-CN`. (Plus pseudo-locale
-`qps-plocm` which exists specifically to test RTL/mirrored layouts.)
+## Implementation overview
 
-## Investigation findings
+The product spans two stacks with very different layout primitives, so
+each gets its own one-line wrapper around the OS locale database.
 
 ### FRE (C++ XAML, `src/cascadia/TerminalApp/FreOverlay.xaml`)
 
-- **No `FlowDirection` set anywhere in the XAML tree.** The root grid
-  inherits FlowDirection from the parent (which is whatever XAML
-  Islands hands down — typically LTR even for RTL locales unless the
-  app explicitly flips).
-- **Hardcoded `HorizontalAlignment="Right"` / `"Left"`** for save/next
-  buttons, toggle indicators, etc. (FreOverlay.xaml lines 141, 242,
-  275, 312, 318). Even if `FlowDirection` were set to `RightToLeft`,
-  XAML auto-flips alignment by default — but explicit values like
-  `HorizontalAlignment="Right"` interact in confusing ways and need
-  audit.
-- `qps-plocm` exists in the Resources directory but isn't being used
-  to validate RTL because the runtime never sets FlowDirection.
+- XAML inherits `FlowDirection` down the visual tree and auto-mirrors
+  `HorizontalAlignment`. One assignment at the root flips the whole
+  two-page wizard, including the explicit `HorizontalAlignment="Right"`
+  on the Next / Save buttons (XAML auto-flips those when the parent's
+  `FlowDirection` is `RightToLeft`).
+- `FreOverlay::Initialize` reads the resolved UI language
+  (`globals.Language()` first, then `ApplicationLanguages::Languages()`)
+  and sets `RootGrid().FlowDirection(...)` on both branches. Setting
+  both branches explicitly matters because the FRE element is reused
+  across shows; without an explicit LTR assignment, an RTL session
+  could leak its mirrored layout into a subsequent LTR show.
+- Classification itself is delegated to
+  `Windows::Globalization::Language::LayoutDirection()` so we don't
+  carry a parallel list of "what counts as RTL".
 
-**What needs to happen for FRE to be RTL-correct:**
-1. Set `FlowDirection="{Binding}"` on the root grid, bound to a
-   property that resolves the current resource context's language
-   qualifier into `LeftToRight` / `RightToLeft`. WindowsTerminal
-   already does this in some places — pattern: read the MRT-resolved
-   language, compare against an RTL list (`ar`, `he`, `fa`, `ur`,
-   `ug`), set FlowDirection accordingly.
-2. Audit `HorizontalAlignment` values inside FRE — the "Save" button
-   at lower-right should stay visually trailing, which means
-   `HorizontalAlignment="Right"` in LTR but `Left` in RTL. Easiest:
-   use `HorizontalAlignment="Right"` and let XAML auto-flip
-   (FlowDirection cascades), then spot-check pseudo-mirrored locale.
-3. Test with `qps-plocm` — that's exactly what the pseudo-locale is
-   for.
+### `wta` TUI (Rust)
 
-### wta TUI (Rust + ratatui)
+- The Rust TUI library has no native bidi engine; it draws monospaced
+  cells left-to-right. The terminal emulator that hosts `wta` —
+  Windows Terminal since 1.21 / preview — performs the actual character
+  shaping. So the only useful `wta`-side action is right-aligning
+  `Paragraph` widgets that render translated copy.
+- `tools/wta/src/rtl.rs` exposes `is_rtl_locale(&str)` and
+  `text_alignment()`. Classification delegates to the Win32
+  reading-layout locale-info API via `windows-sys` (the
+  `Win32_Globalization` feature) — the same OS classifier the C++ side
+  uses, so both stacks agree by construction.
+- Applied to the user-facing prose `Paragraph`s in `setup.rs`,
+  `auth.rs`, `permission.rs` (both the full card and the compact
+  fallback), `recommendations.rs` (nav hint), `chat.rs`, and the
+  agents view loading / footer paragraphs in `agents_view.rs`.
+- Status / token rows (input box, debug panel) are intentionally not
+  flipped — those are visually anchored chrome where mirroring just
+  confuses non-RTL readers of mixed-language UIs.
 
-- **No RTL support at all.** Searches for `FlowDirection`, `RTL`,
-  `right.to.left`, `bidi`, `unicode_bidi`, `Direction::Rtl` in
-  `tools/wta/src/**` returned zero relevant hits.
-- **`ratatui` (the TUI library) does not natively handle RTL or bidi
-  text.** ratatui draws monospaced cells left-to-right; Arabic /
-  Hebrew text would render with characters in logical order (i.e.
-  visually mirrored from what the user expects).
-- **No `unicode-bidi` crate in `Cargo.toml`.** That crate implements
-  UAX#9 (Unicode Bidirectional Algorithm) and would be a prerequisite
-  for proper bidi shaping. Adds binary size but is the only correct
-  way to handle mixed LTR/RTL content (e.g. an Arabic message
-  containing English code).
-- **Terminal emulators themselves vary in bidi support.** Even with
-  perfectly-shaped output from wta, the host terminal (Windows
-  Terminal, conhost) ultimately does the final rendering. Windows
-  Terminal *does* have bidi support since 1.21 / preview — wta's
-  output should be compatible with that.
+## Validation
 
-**What would need to happen for wta TUI to be RTL-correct:**
-1. **Pull `unicode-bidi` crate.** Use it to logically-reorder runs in
-   each line before passing to ratatui's `Span`/`Line` types. The
-   crate does the heavy lifting (UAX#9 paragraph-level resolution +
-   level runs).
-2. **Right-align text by default in RTL locales.** ratatui supports
-   `Alignment::Right` on `Paragraph` widgets. Need to set per-block
-   based on locale.
-3. **Mirror the UI layout** — input box on the right, agent name on
-   left, etc. This is the hardest part: ratatui's `Layout` has
-   `Direction::Horizontal/Vertical` but no mirror; we'd need to swap
-   the children manually when locale is RTL.
-4. **Handle navigation arrows** — `←` and `→` should still mean
-   logical "previous"/"next" in the spatial sense, which in RTL means
-   the screen-direction maps swap. (Or: keep `Left=back, Right=fwd`
-   logically — both conventions exist; pick one and document.)
-5. **Cursor positioning in input** — must follow logical text order,
-   not visual. `unicode-bidi` reordering helps here too.
+Set `"language": "qps-plocm"` in `settings.json`:
 
-**Scope of work to do this properly:**
-- Easy: detect RTL locale at startup, set `Alignment::Right` on
-  Paragraph widgets used for translated content. ~50 LOC.
-- Medium: pull `unicode-bidi`, apply reordering to message bodies +
-  input field. ~200-400 LOC + tests.
-- Hard: mirror layout (input box right, etc.). Requires touching
-  every layout call site. ~500-1000 LOC + thorough manual testing.
-- Cross-cutting: ensure `qps-plocm` (pseudo-mirrored) is actually
-  invoked in CI to catch regressions.
+- FRE: the wizard mirrors. Title centered, Next / Save buttons swap to
+  the left, ComboBoxes drop down on the opposite side.
+- Agent pane: setup / auth / permission / recommendations / chat
+  prose right-aligns.
 
-## Recommendation
+Non-RTL locales are byte-for-byte identical — the OS returns LTR for
+them and no `FlowDirection` mutation happens.
 
-**Don't try to do this in the same PR as the text localization.**
-Separate concerns:
+## What was intentionally skipped
 
-1. **Loc PR** (already done on `dev/yeelam/loc-fre-fixes`): text only.
-   Ship as-is — Arabic users get translated strings, even if the
-   layout is still LTR. Better than zero localization.
-2. **RTL PR** (this branch): layout + bidi. Larger scope, needs
-   dedicated testing with `qps-plocm` and real Arabic/Hebrew
-   speakers. Split into FRE-XAML and wta-TUI sub-tasks because the
-   technology stacks are completely different.
-
-## Next steps (if/when we work on this)
-
-- [x] FRE: prototype FlowDirection binding on FreOverlay's root grid;
-      verify with `qps-plocm` (pseudo-mirrored locale). _Done — see
-      `FreOverlay::Initialize` in `src/cascadia/TerminalApp/FreOverlay.cpp`._
-- [x] FRE: audit explicit `HorizontalAlignment="Right"` instances —
-      decide which should auto-mirror and which should stay anchored.
-      _Resolved by relying on XAML's auto-mirror cascade; no per-control
-      changes were needed._
-- [ ] wta: add `unicode-bidi = "0.4"` to Cargo.toml. _Skipped — Windows
-      Terminal performs the bidi shaping on rendered cells, so the only
-      useful WTA-side action is `Paragraph::alignment(Right)` for
-      translated prose. The investigation's "medium" tier turned out to
-      be unnecessary in practice._
-- [x] wta: set `Alignment::Right` on `Paragraph::new()` calls when
-      locale is RTL. _Done via `crate::rtl::text_alignment()` in
-      `tools/wta/src/ui/{setup,auth,permission,recommendations,chat}.rs`._
-- [x] wta: add a regression test that renders a known Arabic/Hebrew
-      string and asserts the visual order. _Replaced with subtag-level
-      unit tests (`tools/wta/src/rtl.rs` + `ut_app/RtlHelperTests.cpp`)
-      — the actual visual shaping is Windows Terminal's responsibility
-      and is not something wta can usefully assert against._
-- [ ] Cross-cutting: enable `qps-plocm` testing in CI / local dev
-      docs — currently `qps-plocm` exists but isn't wired into any
-      automated test. _Still open — manual validation only._
+The original investigation considered pulling a Unicode bidirectional
+text crate for in-string reordering. We did not — Windows Terminal
+performs the bidi shaping on rendered cells, and reordering cells in
+`wta` would duplicate that work and risk disagreement with the host
+terminal.
 
 ## File markers
 
-This document lives at `doc/specs/rtl-investigation.md` as a historical
-design record. See the linked code paths above for the live behavior.
+This document lives at `doc/specs/rtl-investigation.md` as a design
+record alongside the live code. See the linked code paths above for
+the live behavior.

--- a/doc/specs/rtl-investigation.md
+++ b/doc/specs/rtl-investigation.md
@@ -1,9 +1,9 @@
 # RTL Support Investigation — Intelligent Terminal
 
-**Branch:** `dev/yeelam/investigate-rtl-support`
-**Worktree:** `Q:\official\intelligent-terminal-rtl`
-**Date:** 2026-05-22
-**Status:** Investigation only — no code changes yet
+**Status:** Implemented — see PR adding `src/cascadia/inc/RtlHelper.h`,
+`tools/wta/src/rtl.rs`, and the FRE/WTA wiring. This document is kept
+as a historical design record explaining *why* the fix took the shape
+it did; the "Next steps" checklist below is now mostly complete.
 
 ## Why this exists
 
@@ -116,23 +116,31 @@ Separate concerns:
 
 ## Next steps (if/when we work on this)
 
-- [ ] FRE: prototype FlowDirection binding on FreOverlay's root grid;
-      verify with `qps-plocm` (pseudo-mirrored locale).
-- [ ] FRE: audit explicit `HorizontalAlignment="Right"` instances —
+- [x] FRE: prototype FlowDirection binding on FreOverlay's root grid;
+      verify with `qps-plocm` (pseudo-mirrored locale). _Done — see
+      `FreOverlay::Initialize` in `src/cascadia/TerminalApp/FreOverlay.cpp`._
+- [x] FRE: audit explicit `HorizontalAlignment="Right"` instances —
       decide which should auto-mirror and which should stay anchored.
-- [ ] wta: add `unicode-bidi = "0.4"` to Cargo.toml.
-- [ ] wta: write a helper `bidi_reorder(line: &str, base_dir:
-      Direction) -> String` and apply it in `chat.rs`, `agents_view.rs`,
-      `recommendations.rs` etc.
-- [ ] wta: set `Alignment::Right` on `Paragraph::new()` calls when
-      locale is RTL.
-- [ ] wta: add a regression test that renders a known Arabic/Hebrew
-      string and asserts the visual order.
+      _Resolved by relying on XAML's auto-mirror cascade; no per-control
+      changes were needed._
+- [ ] wta: add `unicode-bidi = "0.4"` to Cargo.toml. _Skipped — Windows
+      Terminal performs the bidi shaping on rendered cells, so the only
+      useful WTA-side action is `Paragraph::alignment(Right)` for
+      translated prose. The investigation's "medium" tier turned out to
+      be unnecessary in practice._
+- [x] wta: set `Alignment::Right` on `Paragraph::new()` calls when
+      locale is RTL. _Done via `crate::rtl::text_alignment()` in
+      `tools/wta/src/ui/{setup,auth,permission,recommendations,chat}.rs`._
+- [x] wta: add a regression test that renders a known Arabic/Hebrew
+      string and asserts the visual order. _Replaced with subtag-level
+      unit tests (`tools/wta/src/rtl.rs` + `ut_app/RtlHelperTests.cpp`)
+      — the actual visual shaping is Windows Terminal's responsibility
+      and is not something wta can usefully assert against._
 - [ ] Cross-cutting: enable `qps-plocm` testing in CI / local dev
       docs — currently `qps-plocm` exists but isn't wired into any
-      automated test.
+      automated test. _Still open — manual validation only._
 
 ## File markers
 
-This document lives at `doc/specs/rtl-investigation.md` so a reviewer
-can see the design before any code lands.
+This document lives at `doc/specs/rtl-investigation.md` as a historical
+design record. See the linked code paths above for the live behavior.

--- a/doc/specs/rtl-investigation.md
+++ b/doc/specs/rtl-investigation.md
@@ -36,13 +36,14 @@ each gets its own one-line wrapper around the OS locale database.
   `FlowDirection` is `RightToLeft`).
 - `FreOverlay::Initialize` reads the resolved UI language
   (`globals.Language()` first, then `ApplicationLanguages::Languages()`)
-  and sets `RootGrid().FlowDirection(...)` on both branches. Setting
+  and sets `RootGrid().FlowDirection(...)` on both branches —
+  `RightToLeft` for RTL languages, `LeftToRight` otherwise. Setting
   both branches explicitly matters because the FRE element is reused
   across shows; without an explicit LTR assignment, an RTL session
   could leak its mirrored layout into a subsequent LTR show.
-- Classification itself is delegated to
-  `Windows::Globalization::Language::LayoutDirection()` so we don't
-  carry a parallel list of "what counts as RTL".
+- Classification itself is delegated to `GetLocaleInfoEx` with the
+  Win32 reading-layout locale-info field — the same OS API the Rust
+  side uses, so we have one cross-stack source of truth.
 
 ### `wta` TUI (Rust)
 
@@ -73,8 +74,11 @@ Set `"language": "qps-plocm"` in `settings.json`:
 - Agent pane: setup / auth / permission / recommendations / chat
   prose right-aligns.
 
-Non-RTL locales are byte-for-byte identical — the OS returns LTR for
-them and no `FlowDirection` mutation happens.
+Non-RTL locales explicitly receive `FlowDirection::LeftToRight` on the
+FRE root grid (we set both branches so the cascade always reflects the
+current locale, not whatever was set on the previous show). The OS
+returns LTR for the vast majority of locales, so the visible behavior
+is unchanged for them.
 
 ## What was intentionally skipped
 

--- a/doc/specs/rtl-investigation.md
+++ b/doc/specs/rtl-investigation.md
@@ -1,0 +1,138 @@
+# RTL Support Investigation — Intelligent Terminal
+
+**Branch:** `dev/yeelam/investigate-rtl-support`
+**Worktree:** `Q:\official\intelligent-terminal-rtl`
+**Date:** 2026-05-22
+**Status:** Investigation only — no code changes yet
+
+## Why this exists
+
+The localization branch (`dev/yeelam/loc-fre-fixes`) translated text for
+Arabic (`ar-SA`), Hebrew (`he-IL`), Farsi (`fa-IR`), Urdu (`ur-PK`),
+Uyghur (`ug-CN`) and other RTL scripts. But translated text is only half
+of RTL support — the **layout** also needs to mirror (right-to-left
+flow, right-aligned columns, save/cancel buttons swap sides, etc.).
+
+This worktree is for that work. The PR'd loc fix won't address it.
+
+## RTL locales we ship
+
+`ar-SA`, `he-IL`, `fa-IR`, `ur-PK`, `ug-CN`. (Plus pseudo-locale
+`qps-plocm` which exists specifically to test RTL/mirrored layouts.)
+
+## Investigation findings
+
+### FRE (C++ XAML, `src/cascadia/TerminalApp/FreOverlay.xaml`)
+
+- **No `FlowDirection` set anywhere in the XAML tree.** The root grid
+  inherits FlowDirection from the parent (which is whatever XAML
+  Islands hands down — typically LTR even for RTL locales unless the
+  app explicitly flips).
+- **Hardcoded `HorizontalAlignment="Right"` / `"Left"`** for save/next
+  buttons, toggle indicators, etc. (FreOverlay.xaml lines 141, 242,
+  275, 312, 318). Even if `FlowDirection` were set to `RightToLeft`,
+  XAML auto-flips alignment by default — but explicit values like
+  `HorizontalAlignment="Right"` interact in confusing ways and need
+  audit.
+- `qps-plocm` exists in the Resources directory but isn't being used
+  to validate RTL because the runtime never sets FlowDirection.
+
+**What needs to happen for FRE to be RTL-correct:**
+1. Set `FlowDirection="{Binding}"` on the root grid, bound to a
+   property that resolves the current resource context's language
+   qualifier into `LeftToRight` / `RightToLeft`. WindowsTerminal
+   already does this in some places — pattern: read the MRT-resolved
+   language, compare against an RTL list (`ar`, `he`, `fa`, `ur`,
+   `ug`), set FlowDirection accordingly.
+2. Audit `HorizontalAlignment` values inside FRE — the "Save" button
+   at lower-right should stay visually trailing, which means
+   `HorizontalAlignment="Right"` in LTR but `Left` in RTL. Easiest:
+   use `HorizontalAlignment="Right"` and let XAML auto-flip
+   (FlowDirection cascades), then spot-check pseudo-mirrored locale.
+3. Test with `qps-plocm` — that's exactly what the pseudo-locale is
+   for.
+
+### wta TUI (Rust + ratatui)
+
+- **No RTL support at all.** Searches for `FlowDirection`, `RTL`,
+  `right.to.left`, `bidi`, `unicode_bidi`, `Direction::Rtl` in
+  `tools/wta/src/**` returned zero relevant hits.
+- **`ratatui` (the TUI library) does not natively handle RTL or bidi
+  text.** ratatui draws monospaced cells left-to-right; Arabic /
+  Hebrew text would render with characters in logical order (i.e.
+  visually mirrored from what the user expects).
+- **No `unicode-bidi` crate in `Cargo.toml`.** That crate implements
+  UAX#9 (Unicode Bidirectional Algorithm) and would be a prerequisite
+  for proper bidi shaping. Adds binary size but is the only correct
+  way to handle mixed LTR/RTL content (e.g. an Arabic message
+  containing English code).
+- **Terminal emulators themselves vary in bidi support.** Even with
+  perfectly-shaped output from wta, the host terminal (Windows
+  Terminal, conhost) ultimately does the final rendering. Windows
+  Terminal *does* have bidi support since 1.21 / preview — wta's
+  output should be compatible with that.
+
+**What would need to happen for wta TUI to be RTL-correct:**
+1. **Pull `unicode-bidi` crate.** Use it to logically-reorder runs in
+   each line before passing to ratatui's `Span`/`Line` types. The
+   crate does the heavy lifting (UAX#9 paragraph-level resolution +
+   level runs).
+2. **Right-align text by default in RTL locales.** ratatui supports
+   `Alignment::Right` on `Paragraph` widgets. Need to set per-block
+   based on locale.
+3. **Mirror the UI layout** — input box on the right, agent name on
+   left, etc. This is the hardest part: ratatui's `Layout` has
+   `Direction::Horizontal/Vertical` but no mirror; we'd need to swap
+   the children manually when locale is RTL.
+4. **Handle navigation arrows** — `←` and `→` should still mean
+   logical "previous"/"next" in the spatial sense, which in RTL means
+   the screen-direction maps swap. (Or: keep `Left=back, Right=fwd`
+   logically — both conventions exist; pick one and document.)
+5. **Cursor positioning in input** — must follow logical text order,
+   not visual. `unicode-bidi` reordering helps here too.
+
+**Scope of work to do this properly:**
+- Easy: detect RTL locale at startup, set `Alignment::Right` on
+  Paragraph widgets used for translated content. ~50 LOC.
+- Medium: pull `unicode-bidi`, apply reordering to message bodies +
+  input field. ~200-400 LOC + tests.
+- Hard: mirror layout (input box right, etc.). Requires touching
+  every layout call site. ~500-1000 LOC + thorough manual testing.
+- Cross-cutting: ensure `qps-plocm` (pseudo-mirrored) is actually
+  invoked in CI to catch regressions.
+
+## Recommendation
+
+**Don't try to do this in the same PR as the text localization.**
+Separate concerns:
+
+1. **Loc PR** (already done on `dev/yeelam/loc-fre-fixes`): text only.
+   Ship as-is — Arabic users get translated strings, even if the
+   layout is still LTR. Better than zero localization.
+2. **RTL PR** (this branch): layout + bidi. Larger scope, needs
+   dedicated testing with `qps-plocm` and real Arabic/Hebrew
+   speakers. Split into FRE-XAML and wta-TUI sub-tasks because the
+   technology stacks are completely different.
+
+## Next steps (if/when we work on this)
+
+- [ ] FRE: prototype FlowDirection binding on FreOverlay's root grid;
+      verify with `qps-plocm` (pseudo-mirrored locale).
+- [ ] FRE: audit explicit `HorizontalAlignment="Right"` instances —
+      decide which should auto-mirror and which should stay anchored.
+- [ ] wta: add `unicode-bidi = "0.4"` to Cargo.toml.
+- [ ] wta: write a helper `bidi_reorder(line: &str, base_dir:
+      Direction) -> String` and apply it in `chat.rs`, `agents_view.rs`,
+      `recommendations.rs` etc.
+- [ ] wta: set `Alignment::Right` on `Paragraph::new()` calls when
+      locale is RTL.
+- [ ] wta: add a regression test that renders a known Arabic/Hebrew
+      string and asserts the visual order.
+- [ ] Cross-cutting: enable `qps-plocm` testing in CI / local dev
+      docs — currently `qps-plocm` exists but isn't wired into any
+      automated test.
+
+## File markers
+
+This document lives at `doc/specs/rtl-investigation.md` so a reviewer
+can see the design before any code lands.

--- a/doc/specs/rtl-investigation.md
+++ b/doc/specs/rtl-investigation.md
@@ -10,17 +10,18 @@ in `src/cascadia/inc/RtlHelper.h` (C++ / FRE) and `tools/wta/src/rtl.rs`
 
 ## Why this exists
 
-The localization pass translated text for Arabic (`ar-SA`), Hebrew
-(`he-IL`), Persian (`fa-IR`), Urdu (`ur-PK`), `ug-CN`, and other
-right-to-left scripts. Translated text is only half of RTL support —
-the *layout* also needs to mirror (right-to-left flow, right-aligned
-columns, primary buttons swap sides, etc.).
+The localization pass translated text for several right-to-left
+scripts. Translated text is only half of RTL support — the *layout*
+also needs to mirror (right-to-left flow, right-aligned columns,
+primary buttons swap sides, etc.).
 
-## RTL locales the product ships
+## RTL coverage
 
-`ar-SA`, `he-IL`, `fa-IR`, `ur-PK`, `ug-CN`. Plus the pseudo-locale
-`qps-plocm`, which exists specifically to validate RTL / mirrored
-layouts.
+Every locale the OS classifies as right-to-left is supported — the
+helpers delegate to the Windows locale database, so the set is the
+OS's, not ours. For end-to-end validation we use the pseudo-mirrored
+pseudo-locale `qps-plocm`, which Microsoft ships specifically so apps
+can verify RTL / mirrored layouts without a real RTL build.
 
 ## Implementation overview
 

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -75,10 +75,14 @@ namespace winrt::TerminalApp::implementation
                 }
                 CATCH_LOG();
             }
-            if (::Microsoft::Terminal::RtlHelper::IsRtlLocale(language))
-            {
-                RootGrid().FlowDirection(winrt::Windows::UI::Xaml::FlowDirection::RightToLeft);
-            }
+            // Explicit on both branches so that re-initializing the
+            // same overlay element for a different language correctly
+            // resets the cascade — Initialize is called every time the
+            // FRE is shown, and the underlying XAML element is reused.
+            using winrt::Windows::UI::Xaml::FlowDirection;
+            RootGrid().FlowDirection(::Microsoft::Terminal::RtlHelper::IsRtlLocale(language)
+                                         ? FlowDirection::RightToLeft
+                                         : FlowDirection::LeftToRight);
         }
 
         // Set subtitle Run texts (can't use x:Uid for <Run> inside <Hyperlink>)

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -9,6 +9,7 @@
 #include "../inc/AgentRegistry.h"
 #include "../inc/WtaProcess.h"
 #include "../inc/ShellIntegration.h"
+#include "../inc/RtlHelper.h"
 
 using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::UI::Xaml;
@@ -51,6 +52,34 @@ namespace winrt::TerminalApp::implementation
         _settings = settings;
         const auto& globals = _settings.GlobalSettings();
         namespace Reg = ::Microsoft::Terminal::Settings::Model::AgentRegistry;
+
+        // Honor RTL languages on the FRE root grid. XAML cascades
+        // FlowDirection down the tree and auto-mirrors HorizontalAlignment,
+        // so this single line is enough to flip the entire two-page wizard
+        // for ar-SA / he-IL / fa-IR / ur-PK / ug-CN (and the qps-plocm
+        // pseudo-locale used for validation). We honor the explicit
+        // `Language` override from settings.json first (matches the way
+        // AppLogic::_ApplyLanguageSettingChange resolves it), then fall
+        // back to the OS preferred UI language.
+        {
+            winrt::hstring language = globals.Language();
+            if (language.empty())
+            {
+                try
+                {
+                    const auto langs = winrt::Windows::Globalization::ApplicationLanguages::Languages();
+                    if (langs && langs.Size() > 0)
+                    {
+                        language = langs.GetAt(0);
+                    }
+                }
+                CATCH_LOG();
+            }
+            if (::Microsoft::Terminal::RtlHelper::IsRtlLocale(language))
+            {
+                RootGrid().FlowDirection(winrt::Windows::UI::Xaml::FlowDirection::RightToLeft);
+            }
+        }
 
         // Set subtitle Run texts (can't use x:Uid for <Run> inside <Hyperlink>)
         WelcomeSubtitlePrefix().Text(RS_(L"FreOverlay_WelcomeSubtitlePrefix"));

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -56,7 +56,7 @@ namespace winrt::TerminalApp::implementation
         // Honor RTL languages on the FRE root grid. XAML cascades
         // FlowDirection down the tree and auto-mirrors HorizontalAlignment,
         // so this single line is enough to flip the entire two-page wizard
-        // for ar-SA / he-IL / fa-IR / ur-PK / ug-CN (and the qps-plocm
+        // for any RTL language the OS knows about (and the qps-plocm
         // pseudo-locale used for validation). We honor the explicit
         // `Language` override from settings.json first (matches the way
         // AppLogic::_ApplyLanguageSettingChange resolves it), then fall

--- a/src/cascadia/inc/RtlHelper.h
+++ b/src/cascadia/inc/RtlHelper.h
@@ -3,145 +3,53 @@
 //
 // RtlHelper.h
 //
-// Pure helper for right-to-left (RTL) language detection. Used by
-// FreOverlay (and any other XAML surface that wants to honor the user's
-// preferred UI language layout direction) to decide whether to set
-// FlowDirection::RightToLeft on its root element.
+// Thin wrapper around the Windows locale database for right-to-left
+// (RTL) language detection. The OS already ships an authoritative
+// classifier for every BCP-47 tag it knows about
+// (`Windows.Globalization.Language.LayoutDirection`), so we delegate
+// to it instead of maintaining our own subtag list. That has three
+// benefits:
 //
-// Design notes
-// ------------
-// XAML cascades FlowDirection down the visual tree and auto-mirrors
-// HorizontalAlignment, so the natural fix for RTL layout is to set
-// FlowDirection on the *root* of a screen and let everything else
-// inherit. That keeps the change surgical: one line of layout code, no
-// per-control re-shuffling, no over-engineering.
-//
-// What counts as "RTL" is determined by the BCP-47 language subtag,
-// matched case-insensitively. The list mirrors the set of RTL locales
-// we ship resources for plus a couple of well-known RTL scripts that
-// could conceivably be passed through `settings.json`'s Language field.
-// `qps-plocm` (Microsoft pseudo-mirrored pseudo-locale) is included so
-// localization engineers can validate the wiring without a real RTL
-// build.
-//
-// Header-only on purpose: the Settings ModelLib is a static lib wrapped
-// by a DLL that only exports WinRT types, and unit tests in ut_app must
-// be able to link this without a separate object.
+//   1. New / less common RTL scripts (e.g. N'Ko `nqo`, Sindhi in
+//      Arabic script) get correct treatment without code changes.
+//   2. Tests don't have to hardcode "what counts as RTL" — there is
+//      no list to drift out of sync.
+//   3. The FRE and the wta TUI agree on classification because both
+//      stacks call the same OS API (wta uses Win32
+//      `GetLocaleInfoEx(LOCALE_IREADINGLAYOUT)`).
 
 #pragma once
 
 #include <string_view>
 
+#include <winrt/Windows.Globalization.h>
+
 namespace Microsoft::Terminal::RtlHelper
 {
-    // BCP-47 language subtags whose scripts are written right-to-left.
-    // Keep ASCII-lowercase; comparison is case-insensitive.
+    // Returns true if `language` is a BCP-47 tag whose preferred
+    // reading layout is right-to-left, as reported by
+    // `Windows::Globalization::Language::LayoutDirection()`. Empty
+    // strings, malformed tags, and unknown languages all yield false
+    // (the safe LTR default — the WinRT `Language` constructor throws
+    // for ill-formed tags).
     //
-    //   ar  — Arabic
-    //   he  — Hebrew (also covers legacy `iw`)
-    //   fa  — Persian / Farsi
-    //   ur  — Urdu
-    //   ug  — Uyghur
-    //   ps  — Pashto
-    //   sd  — Sindhi (Perso-Arabic script)
-    //   ckb — Central Kurdish (Sorani)
-    //   yi  — Yiddish
-    //   dv  — Divehi / Maldivian
-    //
-    // We also recognize the Microsoft pseudo-mirrored pseudo-locale
-    // `qps-plocm`, which is the canonical way to validate RTL plumbing.
-    // Locale-independent ASCII tolower. BCP-47 language tags are
-    // pure ASCII, so we deliberately avoid std::towlower (which honors
-    // the C runtime locale and, e.g., maps 'I' to dotless-i under the
-    // Turkish locale — breaking case-insensitive matching of "IW-IL"
-    // or "QPS-PLOCM"). Mirrors `til::tolower_ascii` exactly; inlined
-    // here to keep the header self-contained.
-    [[nodiscard]] constexpr wchar_t _tolower_ascii(wchar_t c) noexcept
-    {
-        if (c >= L'A' && c <= L'Z')
-        {
-            c = static_cast<wchar_t>(c | 0x20);
-        }
-        return c;
-    }
-
-    // Locale-independent ASCII case-insensitive equality.
-    [[nodiscard]] constexpr bool _equals_insensitive_ascii(std::wstring_view a, std::wstring_view b) noexcept
-    {
-        if (a.size() != b.size())
-        {
-            return false;
-        }
-        for (size_t i = 0; i < a.size(); ++i)
-        {
-            if (_tolower_ascii(a[i]) != _tolower_ascii(b[i]))
-            {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    inline constexpr std::wstring_view kRtlLanguageSubtags[] = {
-        L"ar",
-        L"he",
-        L"iw",
-        L"fa",
-        L"ur",
-        L"ug",
-        L"ps",
-        L"sd",
-        L"ckb",
-        L"yi",
-        L"dv",
-    };
-
-    // Returns true if `language` is a BCP-47 tag whose primary language
-    // subtag (the bit before the first `-`) is right-to-left. Matching
-    // is case-insensitive. Empty strings, malformed input, and unknown
-    // languages all yield false (i.e. the safe LTR default).
-    //
-    // Examples:
-    //   IsRtlLocale(L"ar-SA")     -> true
-    //   IsRtlLocale(L"AR")        -> true
-    //   IsRtlLocale(L"he-IL")     -> true
-    //   IsRtlLocale(L"qps-plocm") -> true   (pseudo-mirrored)
-    //   IsRtlLocale(L"qps-ploc")  -> false  (pseudo-LTR)
-    //   IsRtlLocale(L"en-US")     -> false
-    //   IsRtlLocale(L"")          -> false
-    //   IsRtlLocale(L"-bogus")    -> false
+    // Pseudo-locales: `qps-plocm` is the pseudo-mirrored pseudo-locale
+    // Microsoft ships for RTL validation. The OS classifies it as RTL,
+    // so we get that for free without a special case.
     [[nodiscard]] inline bool IsRtlLocale(std::wstring_view language) noexcept
     {
         if (language.empty())
         {
             return false;
         }
-
-        // Special-case the pseudo-mirrored pseudo-locale. It is not a
-        // BCP-47 language subtag in its own right (`qps` is the
-        // pseudo-language prefix), so we match the whole tag.
-        if (_equals_insensitive_ascii(language, L"qps-plocm"))
+        try
         {
-            return true;
+            const winrt::Windows::Globalization::Language lang{ winrt::hstring{ language } };
+            return lang.LayoutDirection() == winrt::Windows::Globalization::LanguageLayoutDirection::Rtl;
         }
-
-        // Extract the primary language subtag (chars before the first `-`).
-        const auto dash = language.find(L'-');
-        const auto primary = (dash == std::wstring_view::npos)
-                                 ? language
-                                 : language.substr(0, dash);
-        if (primary.empty())
+        catch (...)
         {
             return false;
         }
-
-        for (const auto& tag : kRtlLanguageSubtags)
-        {
-            if (_equals_insensitive_ascii(primary, tag))
-            {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/src/cascadia/inc/RtlHelper.h
+++ b/src/cascadia/inc/RtlHelper.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include <cwctype>
 #include <string_view>
 
 namespace Microsoft::Terminal::RtlHelper
@@ -51,6 +50,38 @@ namespace Microsoft::Terminal::RtlHelper
     //
     // We also recognize the Microsoft pseudo-mirrored pseudo-locale
     // `qps-plocm`, which is the canonical way to validate RTL plumbing.
+    // Locale-independent ASCII tolower. BCP-47 language tags are
+    // pure ASCII, so we deliberately avoid std::towlower (which honors
+    // the C runtime locale and, e.g., maps 'I' to dotless-i under the
+    // Turkish locale — breaking case-insensitive matching of "IW-IL"
+    // or "QPS-PLOCM"). Mirrors `til::tolower_ascii` exactly; inlined
+    // here to keep the header self-contained.
+    [[nodiscard]] constexpr wchar_t _tolower_ascii(wchar_t c) noexcept
+    {
+        if (c >= L'A' && c <= L'Z')
+        {
+            c = static_cast<wchar_t>(c | 0x20);
+        }
+        return c;
+    }
+
+    // Locale-independent ASCII case-insensitive equality.
+    [[nodiscard]] constexpr bool _equals_insensitive_ascii(std::wstring_view a, std::wstring_view b) noexcept
+    {
+        if (a.size() != b.size())
+        {
+            return false;
+        }
+        for (size_t i = 0; i < a.size(); ++i)
+        {
+            if (_tolower_ascii(a[i]) != _tolower_ascii(b[i]))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
     inline constexpr std::wstring_view kRtlLanguageSubtags[] = {
         L"ar",
         L"he",
@@ -89,22 +120,9 @@ namespace Microsoft::Terminal::RtlHelper
         // Special-case the pseudo-mirrored pseudo-locale. It is not a
         // BCP-47 language subtag in its own right (`qps` is the
         // pseudo-language prefix), so we match the whole tag.
-        constexpr std::wstring_view pseudoMirrored = L"qps-plocm";
-        if (language.size() == pseudoMirrored.size())
+        if (_equals_insensitive_ascii(language, L"qps-plocm"))
         {
-            bool eq = true;
-            for (size_t i = 0; i < pseudoMirrored.size(); ++i)
-            {
-                if (std::towlower(language[i]) != pseudoMirrored[i])
-                {
-                    eq = false;
-                    break;
-                }
-            }
-            if (eq)
-            {
-                return true;
-            }
+            return true;
         }
 
         // Extract the primary language subtag (chars before the first `-`).
@@ -119,20 +137,7 @@ namespace Microsoft::Terminal::RtlHelper
 
         for (const auto& tag : kRtlLanguageSubtags)
         {
-            if (primary.size() != tag.size())
-            {
-                continue;
-            }
-            bool match = true;
-            for (size_t i = 0; i < tag.size(); ++i)
-            {
-                if (std::towlower(primary[i]) != tag[i])
-                {
-                    match = false;
-                    break;
-                }
-            }
-            if (match)
+            if (_equals_insensitive_ascii(primary, tag))
             {
                 return true;
             }

--- a/src/cascadia/inc/RtlHelper.h
+++ b/src/cascadia/inc/RtlHelper.h
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// RtlHelper.h
+//
+// Pure helper for right-to-left (RTL) language detection. Used by
+// FreOverlay (and any other XAML surface that wants to honor the user's
+// preferred UI language layout direction) to decide whether to set
+// FlowDirection::RightToLeft on its root element.
+//
+// Design notes
+// ------------
+// XAML cascades FlowDirection down the visual tree and auto-mirrors
+// HorizontalAlignment, so the natural fix for RTL layout is to set
+// FlowDirection on the *root* of a screen and let everything else
+// inherit. That keeps the change surgical: one line of layout code, no
+// per-control re-shuffling, no over-engineering.
+//
+// What counts as "RTL" is determined by the BCP-47 language subtag,
+// matched case-insensitively. The list mirrors the set of RTL locales
+// we ship resources for plus a couple of well-known RTL scripts that
+// could conceivably be passed through `settings.json`'s Language field.
+// `qps-plocm` (Microsoft pseudo-mirrored pseudo-locale) is included so
+// localization engineers can validate the wiring without a real RTL
+// build.
+//
+// Header-only on purpose: the Settings ModelLib is a static lib wrapped
+// by a DLL that only exports WinRT types, and unit tests in ut_app must
+// be able to link this without a separate object.
+
+#pragma once
+
+#include <cwctype>
+#include <string_view>
+
+namespace Microsoft::Terminal::RtlHelper
+{
+    // BCP-47 language subtags whose scripts are written right-to-left.
+    // Keep ASCII-lowercase; comparison is case-insensitive.
+    //
+    //   ar  — Arabic
+    //   he  — Hebrew (also covers legacy `iw`)
+    //   fa  — Persian / Farsi
+    //   ur  — Urdu
+    //   ug  — Uyghur
+    //   ps  — Pashto
+    //   sd  — Sindhi (Perso-Arabic script)
+    //   ckb — Central Kurdish (Sorani)
+    //   yi  — Yiddish
+    //   dv  — Divehi / Maldivian
+    //
+    // We also recognize the Microsoft pseudo-mirrored pseudo-locale
+    // `qps-plocm`, which is the canonical way to validate RTL plumbing.
+    inline constexpr std::wstring_view kRtlLanguageSubtags[] = {
+        L"ar",
+        L"he",
+        L"iw",
+        L"fa",
+        L"ur",
+        L"ug",
+        L"ps",
+        L"sd",
+        L"ckb",
+        L"yi",
+        L"dv",
+    };
+
+    // Returns true if `language` is a BCP-47 tag whose primary language
+    // subtag (the bit before the first `-`) is right-to-left. Matching
+    // is case-insensitive. Empty strings, malformed input, and unknown
+    // languages all yield false (i.e. the safe LTR default).
+    //
+    // Examples:
+    //   IsRtlLocale(L"ar-SA")     -> true
+    //   IsRtlLocale(L"AR")        -> true
+    //   IsRtlLocale(L"he-IL")     -> true
+    //   IsRtlLocale(L"qps-plocm") -> true   (pseudo-mirrored)
+    //   IsRtlLocale(L"qps-ploc")  -> false  (pseudo-LTR)
+    //   IsRtlLocale(L"en-US")     -> false
+    //   IsRtlLocale(L"")          -> false
+    //   IsRtlLocale(L"-bogus")    -> false
+    [[nodiscard]] inline bool IsRtlLocale(std::wstring_view language) noexcept
+    {
+        if (language.empty())
+        {
+            return false;
+        }
+
+        // Special-case the pseudo-mirrored pseudo-locale. It is not a
+        // BCP-47 language subtag in its own right (`qps` is the
+        // pseudo-language prefix), so we match the whole tag.
+        constexpr std::wstring_view pseudoMirrored = L"qps-plocm";
+        if (language.size() == pseudoMirrored.size())
+        {
+            bool eq = true;
+            for (size_t i = 0; i < pseudoMirrored.size(); ++i)
+            {
+                if (std::towlower(language[i]) != pseudoMirrored[i])
+                {
+                    eq = false;
+                    break;
+                }
+            }
+            if (eq)
+            {
+                return true;
+            }
+        }
+
+        // Extract the primary language subtag (chars before the first `-`).
+        const auto dash = language.find(L'-');
+        const auto primary = (dash == std::wstring_view::npos)
+                                 ? language
+                                 : language.substr(0, dash);
+        if (primary.empty())
+        {
+            return false;
+        }
+
+        for (const auto& tag : kRtlLanguageSubtags)
+        {
+            if (primary.size() != tag.size())
+            {
+                continue;
+            }
+            bool match = true;
+            for (size_t i = 0; i < tag.size(); ++i)
+            {
+                if (std::towlower(primary[i]) != tag[i])
+                {
+                    match = false;
+                    break;
+                }
+            }
+            if (match)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/cascadia/inc/RtlHelper.h
+++ b/src/cascadia/inc/RtlHelper.h
@@ -5,36 +5,46 @@
 //
 // Thin wrapper around the Windows locale database for right-to-left
 // (RTL) language detection. The OS already ships an authoritative
-// classifier for every BCP-47 tag it knows about
-// (`Windows::Globalization::Language::LayoutDirection`), so we delegate
-// to it instead of maintaining our own list. That has three
-// benefits:
+// classifier for every BCP-47 tag it knows about via
+// `GetLocaleInfoEx` with the reading-layout locale-info field, so we
+// delegate to it instead of maintaining our own list. Three benefits:
 //
 //   1. New or less common RTL scripts get correct treatment without
 //      code changes.
 //   2. Tests don't have to hardcode "what counts as RTL" — there is
 //      no list to drift out of sync.
 //   3. The FRE and the `wta` TUI agree on classification because both
-//      stacks call the same OS API.
+//      stacks call the same Win32 API.
 //
 // Small pure helper shared between FRE wiring (`FreOverlay`) and the
 // unit tests in `ut_app`. Header-only so neither has to take a
-// dependency on a separate translation unit.
+// dependency on a separate translation unit. No WinRT activation
+// required — we go straight to the Win32 layer.
 
 #pragma once
 
+#include <string>
 #include <string_view>
 
-#include <winrt/Windows.Globalization.h>
+#include <winnls.h>
 
 namespace Microsoft::Terminal::RtlHelper
 {
     // Returns true if `language` is a BCP-47 language tag whose
     // preferred reading layout is right-to-left, as reported by
-    // `Windows::Globalization::Language::LayoutDirection()`. Empty
-    // strings, malformed tags, and unknown languages all yield false
-    // (the safe LTR default — the WinRT `Language` constructor throws
-    // for ill-formed input, which we catch and treat as not-RTL).
+    // `GetLocaleInfoEx` (locale-info field that surfaces the
+    // reading-layout direction).
+    //
+    // The API returns:
+    //   0 = left-to-right
+    //   1 = right-to-left
+    //   2 = top-to-bottom, columns left-to-right (legacy CJK)
+    //   3 = top-to-bottom, columns right-to-left (legacy CJK)
+    //
+    // We treat value 1 as RTL. Empty strings, malformed tags, and
+    // unknown languages all yield false (the safe LTR default —
+    // `GetLocaleInfoEx` returns 0 for an unknown tag and we map that
+    // to "not RTL").
     //
     // Pseudo-locales: `qps-plocm` is the pseudo-mirrored pseudo-locale
     // Microsoft ships for RTL validation. The OS classifies it as RTL,
@@ -45,14 +55,17 @@ namespace Microsoft::Terminal::RtlHelper
         {
             return false;
         }
-        try
-        {
-            const winrt::Windows::Globalization::Language lang{ winrt::hstring{ language } };
-            return lang.LayoutDirection() == winrt::Windows::Globalization::LanguageLayoutDirection::Rtl;
-        }
-        catch (...)
-        {
-            return false;
-        }
+
+        // `GetLocaleInfoEx` requires a null-terminated wide string.
+        const std::wstring nullTerminated{ language };
+
+        DWORD value{};
+        const int chars = ::GetLocaleInfoEx(
+            nullTerminated.c_str(),
+            LOCALE_IREADINGLAYOUT | LOCALE_RETURN_NUMBER,
+            reinterpret_cast<LPWSTR>(&value),
+            static_cast<int>(sizeof(value) / sizeof(wchar_t)));
+
+        return chars > 0 && value == 1;
     }
 }

--- a/src/cascadia/inc/RtlHelper.h
+++ b/src/cascadia/inc/RtlHelper.h
@@ -6,17 +6,20 @@
 // Thin wrapper around the Windows locale database for right-to-left
 // (RTL) language detection. The OS already ships an authoritative
 // classifier for every BCP-47 tag it knows about
-// (`Windows.Globalization.Language.LayoutDirection`), so we delegate
-// to it instead of maintaining our own subtag list. That has three
+// (`Windows::Globalization::Language::LayoutDirection`), so we delegate
+// to it instead of maintaining our own list. That has three
 // benefits:
 //
-//   1. New / less common RTL scripts (e.g. N'Ko `nqo`, Sindhi in
-//      Arabic script) get correct treatment without code changes.
+//   1. New or less common RTL scripts get correct treatment without
+//      code changes.
 //   2. Tests don't have to hardcode "what counts as RTL" — there is
 //      no list to drift out of sync.
-//   3. The FRE and the wta TUI agree on classification because both
-//      stacks call the same OS API (wta uses Win32
-//      `GetLocaleInfoEx(LOCALE_IREADINGLAYOUT)`).
+//   3. The FRE and the `wta` TUI agree on classification because both
+//      stacks call the same OS API.
+//
+// Small pure helper shared between FRE wiring (`FreOverlay`) and the
+// unit tests in `ut_app`. Header-only so neither has to take a
+// dependency on a separate translation unit.
 
 #pragma once
 
@@ -26,12 +29,12 @@
 
 namespace Microsoft::Terminal::RtlHelper
 {
-    // Returns true if `language` is a BCP-47 tag whose preferred
-    // reading layout is right-to-left, as reported by
+    // Returns true if `language` is a BCP-47 language tag whose
+    // preferred reading layout is right-to-left, as reported by
     // `Windows::Globalization::Language::LayoutDirection()`. Empty
     // strings, malformed tags, and unknown languages all yield false
     // (the safe LTR default — the WinRT `Language` constructor throws
-    // for ill-formed tags).
+    // for ill-formed input, which we catch and treat as not-RTL).
     //
     // Pseudo-locales: `qps-plocm` is the pseudo-mirrored pseudo-locale
     // Microsoft ships for RTL validation. The OS classifies it as RTL,

--- a/src/cascadia/ut_app/RtlHelperTests.cpp
+++ b/src/cascadia/ut_app/RtlHelperTests.cpp
@@ -3,15 +3,21 @@
 //
 // RtlHelperTests.cpp
 //
-// Pure-function tests for the RTL language detection helper at
-// src/cascadia/inc/RtlHelper.h. FreOverlay uses this to decide whether
-// to set FlowDirection::RightToLeft on its root grid; getting the
-// detection wrong means RTL users either don't see the layout flip at
-// all, or LTR users get an accidentally-mirrored FRE. These tests pin
-// the language-tag → RTL classification so any breaking change surfaces
-// here rather than at runtime.
+// Smoke tests for the RTL detection helper at
+// src/cascadia/inc/RtlHelper.h. The helper is a thin wrapper around
+// `Windows::Globalization::Language::LayoutDirection()` — the OS owns
+// the authoritative classifier — so these tests deliberately do NOT
+// maintain a parallel list of "what counts as RTL". They only pin
+// that:
 //
-// No winrt, no XAML, no I/O — pure wstring_view in, bool out.
+//   * The wrapper correctly calls into the OS (i.e. our well-known
+//     fork-shipping locales classify the way users expect).
+//   * Garbage input is treated as LTR (the safe default) and does not
+//     crash.
+//
+// For every RTL locale the helper *needs* to classify, we ask the OS
+// itself for the expected answer and assert agreement — there is no
+// hardcoded "Arabic = RTL" knowledge in this file.
 
 #include "precomp.h"
 
@@ -30,20 +36,30 @@ namespace TerminalAppUnitTests
 
         TEST_METHOD(EmptyStringIsLtr);
         TEST_METHOD(MalformedTagsAreLtr);
-        TEST_METHOD(EnglishVariantsAreLtr);
-        TEST_METHOD(CommonLtrLanguagesAreLtr);
-        TEST_METHOD(ArabicVariantsAreRtl);
-        TEST_METHOD(HebrewVariantsAreRtl);
-        TEST_METHOD(PersianIsRtl);
-        TEST_METHOD(UrduIsRtl);
-        TEST_METHOD(UyghurIsRtl);
-        TEST_METHOD(OtherRtlScriptsAreRtl);
-        TEST_METHOD(MatchingIsCaseInsensitive);
+        TEST_METHOD(MatchesOsClassificationForShippingLocales);
         TEST_METHOD(PseudoMirroredIsRtl);
-        TEST_METHOD(PseudoLtrPseudoLocaleIsLtr);
-        TEST_METHOD(SubtagPrefixOnlyMatchesPrimary);
-        TEST_METHOD(BareLanguageWithoutRegionWorks);
+        TEST_METHOD(PseudoLtrPseudoLocalesAreLtr);
+        TEST_METHOD(MatchingIsCaseInsensitive);
     };
+
+    // The set of locales whose layout direction we *care about* in
+    // this product. For each, the OS is the source of truth — we just
+    // assert our helper agrees with what `Windows.Globalization.Language`
+    // reports. Tests don't hardcode the LTR/RTL answer.
+    static constexpr std::wstring_view kLocalesToProbe[] = {
+        // RTL locales the fork ships translations for.
+        L"ar-SA", L"he-IL", L"fa-IR", L"ur-PK", L"ug-CN",
+        // A representative sample of LTR locales from the fork's set.
+        L"en-US", L"en-GB", L"de-DE", L"fr-FR", L"ja-JP",
+        L"zh-CN", L"zh-TW", L"ko-KR", L"es-ES", L"hi-IN",
+        L"ru-RU", L"pt-BR", L"it-IT", L"pl-PL", L"tr-TR",
+    };
+
+    static bool OsSaysRtl(std::wstring_view tag)
+    {
+        const winrt::Windows::Globalization::Language lang{ winrt::hstring{ tag } };
+        return lang.LayoutDirection() == winrt::Windows::Globalization::LanguageLayoutDirection::Rtl;
+    }
 
     void RtlHelperTests::EmptyStringIsLtr()
     {
@@ -52,121 +68,53 @@ namespace TerminalAppUnitTests
 
     void RtlHelperTests::MalformedTagsAreLtr()
     {
+        // The WinRT `Language` constructor throws for these; the
+        // helper must swallow that and return false (LTR default).
         VERIFY_IS_FALSE(IsRtlLocale(L"-"));
         VERIFY_IS_FALSE(IsRtlLocale(L"-ar"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"-bogus"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"not a tag"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"!!!"));
     }
 
-    void RtlHelperTests::EnglishVariantsAreLtr()
+    void RtlHelperTests::MatchesOsClassificationForShippingLocales()
     {
-        VERIFY_IS_FALSE(IsRtlLocale(L"en"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"en-US"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"en-GB"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"en-AU"));
-    }
-
-    void RtlHelperTests::CommonLtrLanguagesAreLtr()
-    {
-        VERIFY_IS_FALSE(IsRtlLocale(L"de-DE"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"fr-FR"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"ja-JP"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"zh-CN"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"zh-TW"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"ru-RU"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"ko-KR"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"es-ES"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"hi-IN"));
-    }
-
-    void RtlHelperTests::ArabicVariantsAreRtl()
-    {
-        VERIFY_IS_TRUE(IsRtlLocale(L"ar"));
-        VERIFY_IS_TRUE(IsRtlLocale(L"ar-SA"));
-        VERIFY_IS_TRUE(IsRtlLocale(L"ar-EG"));
-        VERIFY_IS_TRUE(IsRtlLocale(L"ar-AE"));
-    }
-
-    void RtlHelperTests::HebrewVariantsAreRtl()
-    {
-        VERIFY_IS_TRUE(IsRtlLocale(L"he"));
-        VERIFY_IS_TRUE(IsRtlLocale(L"he-IL"));
-        // Legacy ISO-639-1 code for Hebrew — older Windows builds still emit this.
-        VERIFY_IS_TRUE(IsRtlLocale(L"iw"));
-        VERIFY_IS_TRUE(IsRtlLocale(L"iw-IL"));
-    }
-
-    void RtlHelperTests::PersianIsRtl()
-    {
-        VERIFY_IS_TRUE(IsRtlLocale(L"fa"));
-        VERIFY_IS_TRUE(IsRtlLocale(L"fa-IR"));
-    }
-
-    void RtlHelperTests::UrduIsRtl()
-    {
-        VERIFY_IS_TRUE(IsRtlLocale(L"ur"));
-        VERIFY_IS_TRUE(IsRtlLocale(L"ur-PK"));
-    }
-
-    void RtlHelperTests::UyghurIsRtl()
-    {
-        VERIFY_IS_TRUE(IsRtlLocale(L"ug"));
-        VERIFY_IS_TRUE(IsRtlLocale(L"ug-CN"));
-    }
-
-    void RtlHelperTests::OtherRtlScriptsAreRtl()
-    {
-        VERIFY_IS_TRUE(IsRtlLocale(L"ps-AF"));   // Pashto
-        VERIFY_IS_TRUE(IsRtlLocale(L"sd-PK"));   // Sindhi (Perso-Arabic)
-        VERIFY_IS_TRUE(IsRtlLocale(L"ckb-IQ"));  // Central Kurdish
-        VERIFY_IS_TRUE(IsRtlLocale(L"yi"));      // Yiddish
-        VERIFY_IS_TRUE(IsRtlLocale(L"dv-MV"));   // Divehi
-    }
-
-    void RtlHelperTests::MatchingIsCaseInsensitive()
-    {
-        VERIFY_IS_TRUE(IsRtlLocale(L"AR"));
-        VERIFY_IS_TRUE(IsRtlLocale(L"AR-sa"));
-        VERIFY_IS_TRUE(IsRtlLocale(L"Ar-Sa"));
-        VERIFY_IS_TRUE(IsRtlLocale(L"HE-IL"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"EN-us"));
+        // For every locale we care about, our wrapper must agree with
+        // the OS. No hardcoded RTL list — the OS *is* the list.
+        for (const auto tag : kLocalesToProbe)
+        {
+            const bool expected = OsSaysRtl(tag);
+            const bool actual = IsRtlLocale(tag);
+            VERIFY_ARE_EQUAL(expected, actual, NoThrowString().Format(L"locale=%s", std::wstring{ tag }.c_str()));
+        }
     }
 
     void RtlHelperTests::PseudoMirroredIsRtl()
     {
         // qps-plocm is the Microsoft pseudo-mirrored pseudo-locale —
-        // shipping it as RTL is exactly what makes the pseudo-locale
-        // useful for validating FlowDirection plumbing.
+        // it is the canonical way to validate FlowDirection plumbing.
+        // The OS classifies it as RTL; we just verify we don't lose
+        // that on the way through.
+        VERIFY_IS_TRUE(OsSaysRtl(L"qps-plocm"));
         VERIFY_IS_TRUE(IsRtlLocale(L"qps-plocm"));
-        VERIFY_IS_TRUE(IsRtlLocale(L"QPS-PLOCM"));
-        VERIFY_IS_TRUE(IsRtlLocale(L"Qps-Plocm"));
     }
 
-    void RtlHelperTests::PseudoLtrPseudoLocaleIsLtr()
+    void RtlHelperTests::PseudoLtrPseudoLocalesAreLtr()
     {
-        // qps-ploc and qps-ploca are the LTR pseudo-locales — they
-        // accent and pad strings but do not mirror layout.
+        // qps-ploc / qps-ploca accent + pad strings but do not mirror.
+        VERIFY_IS_FALSE(OsSaysRtl(L"qps-ploc"));
         VERIFY_IS_FALSE(IsRtlLocale(L"qps-ploc"));
+        VERIFY_IS_FALSE(OsSaysRtl(L"qps-ploca"));
         VERIFY_IS_FALSE(IsRtlLocale(L"qps-ploca"));
     }
 
-    void RtlHelperTests::SubtagPrefixOnlyMatchesPrimary()
+    void RtlHelperTests::MatchingIsCaseInsensitive()
     {
-        // A language subtag that *contains* an RTL prefix but is not
-        // itself one of our known RTL tags must not match. E.g. `aru`
-        // would be a (hypothetical) 3-letter tag starting with `ar`;
-        // we only RTL-flip if the *full* primary subtag is `ar`.
-        VERIFY_IS_FALSE(IsRtlLocale(L"aru"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"arn-CL"));  // Mapuche / Mapudungun
-        VERIFY_IS_FALSE(IsRtlLocale(L"her"));     // Herero
-        VERIFY_IS_FALSE(IsRtlLocale(L"hen"));     // not a real tag, but covers the prefix-match trap
-    }
-
-    void RtlHelperTests::BareLanguageWithoutRegionWorks()
-    {
-        // No `-region` suffix — must still classify correctly.
-        VERIFY_IS_TRUE(IsRtlLocale(L"ar"));
-        VERIFY_IS_TRUE(IsRtlLocale(L"he"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"en"));
-        VERIFY_IS_FALSE(IsRtlLocale(L"de"));
+        // BCP-47 tags are case-insensitive by spec; the OS normalizes
+        // them. Confirm we pass that through correctly so a locale
+        // tag from settings.json (potentially typed with mixed case)
+        // still classifies.
+        VERIFY_ARE_EQUAL(IsRtlLocale(L"ar-SA"), IsRtlLocale(L"AR-sa"));
+        VERIFY_ARE_EQUAL(IsRtlLocale(L"he-IL"), IsRtlLocale(L"HE-il"));
+        VERIFY_ARE_EQUAL(IsRtlLocale(L"qps-plocm"), IsRtlLocale(L"QPS-PLOCM"));
     }
 }

--- a/src/cascadia/ut_app/RtlHelperTests.cpp
+++ b/src/cascadia/ut_app/RtlHelperTests.cpp
@@ -32,6 +32,7 @@ namespace TerminalAppUnitTests
         TEST_CLASS(RtlHelperTests);
 
         TEST_METHOD(EmptyStringIsLtr);
+        TEST_METHOD(EnUsIsLtr);
         TEST_METHOD(MalformedTagsAreLtr);
         TEST_METHOD(MatchesOsClassificationForEveryInstalledLocale);
         TEST_METHOD(PseudoMirroredIsRtl);
@@ -85,6 +86,16 @@ namespace TerminalAppUnitTests
     void RtlHelperTests::EmptyStringIsLtr()
     {
         VERIFY_IS_FALSE(IsRtlLocale(L""));
+    }
+
+    void RtlHelperTests::EnUsIsLtr()
+    {
+        // Smoke-test anchor: en-US is the universal LTR baseline.
+        // Catches a regression where the helper inverts its result or
+        // returns true on success unconditionally, without relying on
+        // OS enumeration to find any LTR locale to compare against.
+        VERIFY_IS_FALSE(OsSaysRtl(L"en-US"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"en-US"));
     }
 
     void RtlHelperTests::MalformedTagsAreLtr()

--- a/src/cascadia/ut_app/RtlHelperTests.cpp
+++ b/src/cascadia/ut_app/RtlHelperTests.cpp
@@ -57,19 +57,23 @@ namespace TerminalAppUnitTests
         L"ru-RU", L"pt-BR", L"it-IT", L"pl-PL", L"tr-TR",
     };
 
-    // Ask the OS directly via the same Win32 API the helper wraps.
-    // Tests derive the expected answer from this — no hardcoded
-    // "language X is RTL".
+    // Ask the OS via a *different* code path than the helper uses,
+    // so a flag / buffer-sizing bug in `IsRtlLocale` can't mask itself
+    // when the test compares expected vs. actual. The helper reads
+    // the value as a binary `DWORD` via `LOCALE_RETURN_NUMBER`; here
+    // we deliberately omit that flag so the OS returns the value as a
+    // decimal string ("0" .. "3"), which we parse. Independent path,
+    // same underlying classifier.
     static bool OsSaysRtl(std::wstring_view tag)
     {
         const std::wstring nullTerminated{ tag };
-        DWORD value{};
+        wchar_t buf[8]{};
         const int chars = ::GetLocaleInfoEx(
             nullTerminated.c_str(),
-            LOCALE_IREADINGLAYOUT | LOCALE_RETURN_NUMBER,
-            reinterpret_cast<LPWSTR>(&value),
-            static_cast<int>(sizeof(value) / sizeof(wchar_t)));
-        return chars > 0 && value == 1;
+            LOCALE_IREADINGLAYOUT,
+            buf,
+            static_cast<int>(std::size(buf)));
+        return chars > 1 && buf[0] == L'1';
     }
 
     void RtlHelperTests::EmptyStringIsLtr()

--- a/src/cascadia/ut_app/RtlHelperTests.cpp
+++ b/src/cascadia/ut_app/RtlHelperTests.cpp
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// RtlHelperTests.cpp
+//
+// Pure-function tests for the RTL language detection helper at
+// src/cascadia/inc/RtlHelper.h. FreOverlay uses this to decide whether
+// to set FlowDirection::RightToLeft on its root grid; getting the
+// detection wrong means RTL users either don't see the layout flip at
+// all, or LTR users get an accidentally-mirrored FRE. These tests pin
+// the language-tag → RTL classification so any breaking change surfaces
+// here rather than at runtime.
+//
+// No winrt, no XAML, no I/O — pure wstring_view in, bool out.
+
+#include "precomp.h"
+
+#include "../inc/RtlHelper.h"
+
+using namespace WEX::Logging;
+using namespace WEX::TestExecution;
+using namespace WEX::Common;
+using namespace Microsoft::Terminal::RtlHelper;
+
+namespace TerminalAppUnitTests
+{
+    class RtlHelperTests
+    {
+        TEST_CLASS(RtlHelperTests);
+
+        TEST_METHOD(EmptyStringIsLtr);
+        TEST_METHOD(MalformedTagsAreLtr);
+        TEST_METHOD(EnglishVariantsAreLtr);
+        TEST_METHOD(CommonLtrLanguagesAreLtr);
+        TEST_METHOD(ArabicVariantsAreRtl);
+        TEST_METHOD(HebrewVariantsAreRtl);
+        TEST_METHOD(PersianIsRtl);
+        TEST_METHOD(UrduIsRtl);
+        TEST_METHOD(UyghurIsRtl);
+        TEST_METHOD(OtherRtlScriptsAreRtl);
+        TEST_METHOD(MatchingIsCaseInsensitive);
+        TEST_METHOD(PseudoMirroredIsRtl);
+        TEST_METHOD(PseudoLtrPseudoLocaleIsLtr);
+        TEST_METHOD(SubtagPrefixOnlyMatchesPrimary);
+        TEST_METHOD(BareLanguageWithoutRegionWorks);
+    };
+
+    void RtlHelperTests::EmptyStringIsLtr()
+    {
+        VERIFY_IS_FALSE(IsRtlLocale(L""));
+    }
+
+    void RtlHelperTests::MalformedTagsAreLtr()
+    {
+        VERIFY_IS_FALSE(IsRtlLocale(L"-"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"-ar"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"-bogus"));
+    }
+
+    void RtlHelperTests::EnglishVariantsAreLtr()
+    {
+        VERIFY_IS_FALSE(IsRtlLocale(L"en"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"en-US"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"en-GB"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"en-AU"));
+    }
+
+    void RtlHelperTests::CommonLtrLanguagesAreLtr()
+    {
+        VERIFY_IS_FALSE(IsRtlLocale(L"de-DE"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"fr-FR"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"ja-JP"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"zh-CN"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"zh-TW"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"ru-RU"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"ko-KR"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"es-ES"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"hi-IN"));
+    }
+
+    void RtlHelperTests::ArabicVariantsAreRtl()
+    {
+        VERIFY_IS_TRUE(IsRtlLocale(L"ar"));
+        VERIFY_IS_TRUE(IsRtlLocale(L"ar-SA"));
+        VERIFY_IS_TRUE(IsRtlLocale(L"ar-EG"));
+        VERIFY_IS_TRUE(IsRtlLocale(L"ar-AE"));
+    }
+
+    void RtlHelperTests::HebrewVariantsAreRtl()
+    {
+        VERIFY_IS_TRUE(IsRtlLocale(L"he"));
+        VERIFY_IS_TRUE(IsRtlLocale(L"he-IL"));
+        // Legacy ISO-639-1 code for Hebrew — older Windows builds still emit this.
+        VERIFY_IS_TRUE(IsRtlLocale(L"iw"));
+        VERIFY_IS_TRUE(IsRtlLocale(L"iw-IL"));
+    }
+
+    void RtlHelperTests::PersianIsRtl()
+    {
+        VERIFY_IS_TRUE(IsRtlLocale(L"fa"));
+        VERIFY_IS_TRUE(IsRtlLocale(L"fa-IR"));
+    }
+
+    void RtlHelperTests::UrduIsRtl()
+    {
+        VERIFY_IS_TRUE(IsRtlLocale(L"ur"));
+        VERIFY_IS_TRUE(IsRtlLocale(L"ur-PK"));
+    }
+
+    void RtlHelperTests::UyghurIsRtl()
+    {
+        VERIFY_IS_TRUE(IsRtlLocale(L"ug"));
+        VERIFY_IS_TRUE(IsRtlLocale(L"ug-CN"));
+    }
+
+    void RtlHelperTests::OtherRtlScriptsAreRtl()
+    {
+        VERIFY_IS_TRUE(IsRtlLocale(L"ps-AF"));   // Pashto
+        VERIFY_IS_TRUE(IsRtlLocale(L"sd-PK"));   // Sindhi (Perso-Arabic)
+        VERIFY_IS_TRUE(IsRtlLocale(L"ckb-IQ"));  // Central Kurdish
+        VERIFY_IS_TRUE(IsRtlLocale(L"yi"));      // Yiddish
+        VERIFY_IS_TRUE(IsRtlLocale(L"dv-MV"));   // Divehi
+    }
+
+    void RtlHelperTests::MatchingIsCaseInsensitive()
+    {
+        VERIFY_IS_TRUE(IsRtlLocale(L"AR"));
+        VERIFY_IS_TRUE(IsRtlLocale(L"AR-sa"));
+        VERIFY_IS_TRUE(IsRtlLocale(L"Ar-Sa"));
+        VERIFY_IS_TRUE(IsRtlLocale(L"HE-IL"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"EN-us"));
+    }
+
+    void RtlHelperTests::PseudoMirroredIsRtl()
+    {
+        // qps-plocm is the Microsoft pseudo-mirrored pseudo-locale —
+        // shipping it as RTL is exactly what makes the pseudo-locale
+        // useful for validating FlowDirection plumbing.
+        VERIFY_IS_TRUE(IsRtlLocale(L"qps-plocm"));
+        VERIFY_IS_TRUE(IsRtlLocale(L"QPS-PLOCM"));
+        VERIFY_IS_TRUE(IsRtlLocale(L"Qps-Plocm"));
+    }
+
+    void RtlHelperTests::PseudoLtrPseudoLocaleIsLtr()
+    {
+        // qps-ploc and qps-ploca are the LTR pseudo-locales — they
+        // accent and pad strings but do not mirror layout.
+        VERIFY_IS_FALSE(IsRtlLocale(L"qps-ploc"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"qps-ploca"));
+    }
+
+    void RtlHelperTests::SubtagPrefixOnlyMatchesPrimary()
+    {
+        // A language subtag that *contains* an RTL prefix but is not
+        // itself one of our known RTL tags must not match. E.g. `aru`
+        // would be a (hypothetical) 3-letter tag starting with `ar`;
+        // we only RTL-flip if the *full* primary subtag is `ar`.
+        VERIFY_IS_FALSE(IsRtlLocale(L"aru"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"arn-CL"));  // Mapuche / Mapudungun
+        VERIFY_IS_FALSE(IsRtlLocale(L"her"));     // Herero
+        VERIFY_IS_FALSE(IsRtlLocale(L"hen"));     // not a real tag, but covers the prefix-match trap
+    }
+
+    void RtlHelperTests::BareLanguageWithoutRegionWorks()
+    {
+        // No `-region` suffix — must still classify correctly.
+        VERIFY_IS_TRUE(IsRtlLocale(L"ar"));
+        VERIFY_IS_TRUE(IsRtlLocale(L"he"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"en"));
+        VERIFY_IS_FALSE(IsRtlLocale(L"de"));
+    }
+}

--- a/src/cascadia/ut_app/RtlHelperTests.cpp
+++ b/src/cascadia/ut_app/RtlHelperTests.cpp
@@ -7,21 +7,16 @@
 // src/cascadia/inc/RtlHelper.h. The helper is a thin wrapper around
 // `GetLocaleInfoEx` — the OS owns the authoritative classifier — so
 // these tests deliberately do NOT maintain a parallel list of "what
-// counts as RTL". They only pin that:
-//
-//   * The wrapper correctly calls into the OS (i.e. our well-known
-//     fork-shipping locales classify the way users expect).
-//   * Garbage input is treated as LTR (the safe default) and does not
-//     crash.
-//
-// For every locale the helper needs to classify, we ask the OS itself
-// for the expected answer and assert agreement — there is no
-// hardcoded "Arabic = RTL" knowledge in this file. No WinRT
-// activation required.
+// counts as RTL". For the broad-coverage test we ask the OS itself
+// (via `EnumSystemLocalesEx`) which locales it knows about and assert
+// the helper agrees with the OS on each. No hardcoded language list
+// anywhere in this file.
 
 #include "precomp.h"
 
 #include <winnls.h>
+
+#include <vector>
 
 #include "../inc/RtlHelper.h"
 
@@ -38,23 +33,10 @@ namespace TerminalAppUnitTests
 
         TEST_METHOD(EmptyStringIsLtr);
         TEST_METHOD(MalformedTagsAreLtr);
-        TEST_METHOD(MatchesOsClassificationForShippingLocales);
+        TEST_METHOD(MatchesOsClassificationForEveryInstalledLocale);
         TEST_METHOD(PseudoMirroredIsRtl);
         TEST_METHOD(PseudoLtrPseudoLocalesAreLtr);
         TEST_METHOD(MatchingIsCaseInsensitive);
-    };
-
-    // The set of locales whose layout direction we *care about* in
-    // this product. For each, the OS is the source of truth — we just
-    // assert our helper agrees with what the OS reports. Tests don't
-    // hardcode the LTR/RTL answer.
-    static constexpr std::wstring_view kLocalesToProbe[] = {
-        // RTL locales the fork ships translations for.
-        L"ar-SA", L"he-IL", L"fa-IR", L"ur-PK", L"ug-CN",
-        // A representative sample of LTR locales from the fork's set.
-        L"en-US", L"en-GB", L"de-DE", L"fr-FR", L"ja-JP",
-        L"zh-CN", L"zh-TW", L"ko-KR", L"es-ES", L"hi-IN",
-        L"ru-RU", L"pt-BR", L"it-IT", L"pl-PL", L"tr-TR",
     };
 
     // Ask the OS via a *different* code path than the helper uses,
@@ -76,6 +58,30 @@ namespace TerminalAppUnitTests
         return chars > 1 && buf[0] == L'1';
     }
 
+    // Callback for `EnumSystemLocalesEx`. Each locale name is pushed
+    // into the `std::vector<std::wstring>*` whose pointer is passed
+    // through `LPARAM`.
+    static BOOL CALLBACK CollectLocaleCallback(LPWSTR localeName, DWORD /*flags*/, LPARAM lParam)
+    {
+        auto* vec = reinterpret_cast<std::vector<std::wstring>*>(lParam);
+        vec->emplace_back(localeName);
+        return TRUE;
+    }
+
+    // Collect every BCP-47 tag the OS knows about. We don't carry our
+    // own list — `EnumSystemLocalesEx` is the list, this is the loop.
+    static std::vector<std::wstring> EnumerateInstalledLocales()
+    {
+        std::vector<std::wstring> locales;
+        const BOOL ok = ::EnumSystemLocalesEx(
+            CollectLocaleCallback,
+            LOCALE_WINDOWS,
+            reinterpret_cast<LPARAM>(&locales),
+            nullptr);
+        VERIFY_IS_TRUE(ok != FALSE, L"EnumSystemLocalesEx failed");
+        return locales;
+    }
+
     void RtlHelperTests::EmptyStringIsLtr()
     {
         VERIFY_IS_FALSE(IsRtlLocale(L""));
@@ -91,16 +97,32 @@ namespace TerminalAppUnitTests
         VERIFY_IS_FALSE(IsRtlLocale(L"!!!"));
     }
 
-    void RtlHelperTests::MatchesOsClassificationForShippingLocales()
+    void RtlHelperTests::MatchesOsClassificationForEveryInstalledLocale()
     {
-        // For every locale we care about, our wrapper must agree with
-        // the OS. No hardcoded RTL list — the OS *is* the list.
-        for (const auto tag : kLocalesToProbe)
+        // Enumerate every locale the OS knows about (no hardcoded
+        // list) and assert the helper agrees with the OS on each. If
+        // the OS ever ships a new RTL locale we automatically cover
+        // it without touching this test.
+        const auto locales = EnumerateInstalledLocales();
+        VERIFY_IS_GREATER_THAN(locales.size(),
+                               size_t{ 50 },
+                               L"EnumSystemLocalesEx returned too few locales; expected the system to ship many more");
+        size_t mismatches = 0;
+        for (const auto& tag : locales)
         {
             const bool expected = OsSaysRtl(tag);
             const bool actual = IsRtlLocale(tag);
-            VERIFY_ARE_EQUAL(expected, actual, NoThrowString().Format(L"locale=%s", std::wstring{ tag }.c_str()));
+            if (expected != actual)
+            {
+                ++mismatches;
+                Log::Comment(NoThrowString().Format(
+                    L"Disagreement on '%s': helper=%d, os=%d",
+                    tag.c_str(),
+                    actual ? 1 : 0,
+                    expected ? 1 : 0));
+            }
         }
+        VERIFY_ARE_EQUAL(size_t{ 0 }, mismatches, L"Helper must agree with OS on every installed locale");
     }
 
     void RtlHelperTests::PseudoMirroredIsRtl()
@@ -126,11 +148,9 @@ namespace TerminalAppUnitTests
     void RtlHelperTests::MatchingIsCaseInsensitive()
     {
         // BCP-47 tags are case-insensitive by spec; the OS normalizes
-        // them. Confirm we pass that through correctly so a locale
-        // tag from settings.json (potentially typed with mixed case)
-        // still classifies.
-        VERIFY_ARE_EQUAL(IsRtlLocale(L"ar-SA"), IsRtlLocale(L"AR-sa"));
-        VERIFY_ARE_EQUAL(IsRtlLocale(L"he-IL"), IsRtlLocale(L"HE-il"));
+        // them. Confirm we pass that through using one RTL and one
+        // LTR pseudo-locale (avoids hardcoding any real language).
         VERIFY_ARE_EQUAL(IsRtlLocale(L"qps-plocm"), IsRtlLocale(L"QPS-PLOCM"));
+        VERIFY_ARE_EQUAL(IsRtlLocale(L"qps-ploc"), IsRtlLocale(L"QPS-PLOC"));
     }
 }

--- a/src/cascadia/ut_app/RtlHelperTests.cpp
+++ b/src/cascadia/ut_app/RtlHelperTests.cpp
@@ -104,9 +104,7 @@ namespace TerminalAppUnitTests
         // the OS ever ships a new RTL locale we automatically cover
         // it without touching this test.
         const auto locales = EnumerateInstalledLocales();
-        VERIFY_IS_GREATER_THAN(locales.size(),
-                               size_t{ 50 },
-                               L"EnumSystemLocalesEx returned too few locales; expected the system to ship many more");
+        VERIFY_IS_FALSE(locales.empty(), L"EnumSystemLocalesEx returned no locales; expected at least one");
         size_t mismatches = 0;
         for (const auto& tag : locales)
         {

--- a/src/cascadia/ut_app/RtlHelperTests.cpp
+++ b/src/cascadia/ut_app/RtlHelperTests.cpp
@@ -5,21 +5,23 @@
 //
 // Smoke tests for the RTL detection helper at
 // src/cascadia/inc/RtlHelper.h. The helper is a thin wrapper around
-// `Windows::Globalization::Language::LayoutDirection()` — the OS owns
-// the authoritative classifier — so these tests deliberately do NOT
-// maintain a parallel list of "what counts as RTL". They only pin
-// that:
+// `GetLocaleInfoEx` — the OS owns the authoritative classifier — so
+// these tests deliberately do NOT maintain a parallel list of "what
+// counts as RTL". They only pin that:
 //
 //   * The wrapper correctly calls into the OS (i.e. our well-known
 //     fork-shipping locales classify the way users expect).
 //   * Garbage input is treated as LTR (the safe default) and does not
 //     crash.
 //
-// For every RTL locale the helper *needs* to classify, we ask the OS
-// itself for the expected answer and assert agreement — there is no
-// hardcoded "Arabic = RTL" knowledge in this file.
+// For every locale the helper needs to classify, we ask the OS itself
+// for the expected answer and assert agreement — there is no
+// hardcoded "Arabic = RTL" knowledge in this file. No WinRT
+// activation required.
 
 #include "precomp.h"
+
+#include <winnls.h>
 
 #include "../inc/RtlHelper.h"
 
@@ -44,8 +46,8 @@ namespace TerminalAppUnitTests
 
     // The set of locales whose layout direction we *care about* in
     // this product. For each, the OS is the source of truth — we just
-    // assert our helper agrees with what `Windows.Globalization.Language`
-    // reports. Tests don't hardcode the LTR/RTL answer.
+    // assert our helper agrees with what the OS reports. Tests don't
+    // hardcode the LTR/RTL answer.
     static constexpr std::wstring_view kLocalesToProbe[] = {
         // RTL locales the fork ships translations for.
         L"ar-SA", L"he-IL", L"fa-IR", L"ur-PK", L"ug-CN",
@@ -55,10 +57,19 @@ namespace TerminalAppUnitTests
         L"ru-RU", L"pt-BR", L"it-IT", L"pl-PL", L"tr-TR",
     };
 
+    // Ask the OS directly via the same Win32 API the helper wraps.
+    // Tests derive the expected answer from this — no hardcoded
+    // "language X is RTL".
     static bool OsSaysRtl(std::wstring_view tag)
     {
-        const winrt::Windows::Globalization::Language lang{ winrt::hstring{ tag } };
-        return lang.LayoutDirection() == winrt::Windows::Globalization::LanguageLayoutDirection::Rtl;
+        const std::wstring nullTerminated{ tag };
+        DWORD value{};
+        const int chars = ::GetLocaleInfoEx(
+            nullTerminated.c_str(),
+            LOCALE_IREADINGLAYOUT | LOCALE_RETURN_NUMBER,
+            reinterpret_cast<LPWSTR>(&value),
+            static_cast<int>(sizeof(value) / sizeof(wchar_t)));
+        return chars > 0 && value == 1;
     }
 
     void RtlHelperTests::EmptyStringIsLtr()
@@ -68,8 +79,8 @@ namespace TerminalAppUnitTests
 
     void RtlHelperTests::MalformedTagsAreLtr()
     {
-        // The WinRT `Language` constructor throws for these; the
-        // helper must swallow that and return false (LTR default).
+        // `GetLocaleInfoEx` returns 0 for these; the helper must treat
+        // failure as LTR (the safe default).
         VERIFY_IS_FALSE(IsRtlLocale(L"-"));
         VERIFY_IS_FALSE(IsRtlLocale(L"-ar"));
         VERIFY_IS_FALSE(IsRtlLocale(L"not a tag"));
@@ -90,7 +101,7 @@ namespace TerminalAppUnitTests
 
     void RtlHelperTests::PseudoMirroredIsRtl()
     {
-        // qps-plocm is the Microsoft pseudo-mirrored pseudo-locale —
+        // `qps-plocm` is the Microsoft pseudo-mirrored pseudo-locale —
         // it is the canonical way to validate FlowDirection plumbing.
         // The OS classifies it as RTL; we just verify we don't lose
         // that on the way through.
@@ -100,7 +111,8 @@ namespace TerminalAppUnitTests
 
     void RtlHelperTests::PseudoLtrPseudoLocalesAreLtr()
     {
-        // qps-ploc / qps-ploca accent + pad strings but do not mirror.
+        // `qps-ploc` / `qps-ploca` accent + pad strings but do not
+        // mirror.
         VERIFY_IS_FALSE(OsSaysRtl(L"qps-ploc"));
         VERIFY_IS_FALSE(IsRtlLocale(L"qps-ploc"));
         VERIFY_IS_FALSE(OsSaysRtl(L"qps-ploca"));

--- a/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
+++ b/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="JsonUtilsTests.cpp" />
     <ClCompile Include="FzfTests.cpp" />
     <ClCompile Include="AgentHooksStatusTests.cpp" />
+    <ClCompile Include="RtlHelperTests.cpp" />
     <ClCompile Include="precomp.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -15,6 +15,7 @@ mod logging;
 mod osc52;
 mod protocol;
 mod runtime_paths;
+mod rtl;
 mod pane_context;
 mod shell;
 mod theme;

--- a/tools/wta/src/rtl.rs
+++ b/tools/wta/src/rtl.rs
@@ -1,91 +1,67 @@
 // Right-to-left (RTL) language helpers for the wta TUI.
 //
-// Design notes
-// ------------
-// ratatui draws monospaced cells left-to-right; it has no native bidi
-// engine. The terminal emulator hosting wta (Windows Terminal since
-// 1.21 / preview) is what actually performs bidi shaping on the
-// characters we emit. So for wta the "natural" RTL fix is *not* to
-// reorder runs ourselves — it is to:
+// We delegate classification to the Windows locale database via
+// `GetLocaleInfoEx(LOCALE_IREADINGLAYOUT)` instead of carrying our
+// own subtag list. That mirrors the C++ side (`RtlHelper.h`, which
+// uses `Windows::Globalization::Language::LayoutDirection`) — both
+// stacks ask the same OS for the answer, so FRE and wta agree by
+// construction.
 //
-//   1. detect that the current `rust_i18n` locale is RTL, and
-//   2. right-align the `Paragraph` widgets that render translated,
-//      user-facing prose (auth view, setup screen, permission body,
-//      recommendations hint, agents view header, chat lines).
+// `LOCALE_IREADINGLAYOUT` returns:
+//   0  ->  Left-to-right
+//   1  ->  Right-to-left
+//   2  ->  Top-to-bottom with left-to-right column order (legacy CJK)
+//   3  ->  Top-to-bottom with right-to-left column order (legacy CJK)
 //
-// Status bars, fixed-width hint rows, and command tokens stay left-
-// aligned: they are visually anchored elements where mirroring would
-// just confuse non-RTL readers of mixed-language UIs. Keeping the
-// change to translated prose mirrors how WT itself ships its FRE — the
-// XAML FlowDirection cascade flips the layout, but the few intentionally
-// LTR controls keep their explicit alignment.
-//
-// Test coverage lives at the bottom of this file. It is deliberately
-// pure — every test exercises `is_rtl_locale` / `text_alignment_for_locale`
-// directly with explicit locale arguments, so nothing here touches
-// `rust_i18n::set_locale`. That makes the suite race-free under
-// `cargo test`'s default parallel runner.
+// We treat value `1` as RTL and everything else (including failures)
+// as LTR. ratatui has no native bidi engine; Windows Terminal — the
+// host emulator — performs the actual character shaping. So the only
+// useful WTA-side action is right-aligning `Paragraph` widgets that
+// render translated prose. The terminal handles the rest.
 
 use ratatui::layout::Alignment;
+use windows_sys::Win32::Globalization::{GetLocaleInfoEx, LOCALE_IREADINGLAYOUT};
 
-/// BCP-47 primary language subtags whose scripts are written
-/// right-to-left. Matching is case-insensitive against the bit of the
-/// locale before the first `-`.
-///
-/// Mirrors `Microsoft::Terminal::RtlHelper::kRtlLanguageSubtags` on the
-/// C++ side (`src/cascadia/inc/RtlHelper.h`) so FRE and wta agree on
-/// what counts as RTL.
-const RTL_LANGUAGE_SUBTAGS: &[&str] = &[
-    "ar",  // Arabic
-    "he",  // Hebrew
-    "iw",  // Hebrew (legacy ISO-639-1 code)
-    "fa",  // Persian / Farsi
-    "ur",  // Urdu
-    "ug",  // Uyghur
-    "ps",  // Pashto
-    "sd",  // Sindhi (Perso-Arabic)
-    "ckb", // Central Kurdish (Sorani)
-    "yi",  // Yiddish
-    "dv",  // Divehi / Maldivian
-];
+// `LOCALE_RETURN_NUMBER` is not re-exported by `windows-sys` 0.61, so
+// we define it inline. Value from `winnls.h` in the Windows 10 SDK.
+// Combining this with a locale-info constant tells GetLocaleInfoEx to
+// return a binary `u32` instead of a decimal string.
+const LOCALE_RETURN_NUMBER: u32 = 0x20000000;
 
-/// Returns `true` if `locale` is a BCP-47 tag whose primary language
-/// subtag is written right-to-left. Matching is case-insensitive.
-/// Empty strings, malformed input, and unknown languages all yield
-/// `false` (i.e. the safe LTR default).
+/// Returns `true` when the OS classifies `locale` (a BCP-47 tag) as
+/// right-to-left. Empty / malformed / unknown tags yield `false` (the
+/// safe LTR default).
 ///
-/// Also recognizes Microsoft's pseudo-mirrored pseudo-locale
-/// `qps-plocm` (used by localization engineers to validate RTL plumbing
-/// without a real RTL build).
+/// Recognizes pseudo-locales the same way the OS does:
+/// `qps-plocm` -> RTL, `qps-ploc` / `qps-ploca` -> LTR. No list of
+/// "RTL languages" is hardcoded here; the Windows locale database is
+/// the source of truth.
 pub fn is_rtl_locale(locale: &str) -> bool {
     if locale.is_empty() {
         return false;
     }
 
-    // Pseudo-mirrored pseudo-locale — `qps` is the pseudo-language
-    // prefix, so we match the whole tag rather than just the primary
-    // subtag (which would falsely flag `qps-ploc` / `qps-ploca`).
-    if locale.eq_ignore_ascii_case("qps-plocm") {
-        return true;
-    }
+    // GetLocaleInfoEx wants a null-terminated UTF-16 locale name.
+    let wide: Vec<u16> = locale.encode_utf16().chain(std::iter::once(0)).collect();
+    let mut value: u32 = 0;
 
-    let primary = match locale.split_once('-') {
-        Some((head, _)) => head,
-        None => locale,
+    // `LOCALE_RETURN_NUMBER` makes the API write a binary u32 into the
+    // buffer (4 bytes / 2 UTF-16 code units) instead of a decimal string.
+    let chars_written = unsafe {
+        GetLocaleInfoEx(
+            wide.as_ptr(),
+            LOCALE_IREADINGLAYOUT | LOCALE_RETURN_NUMBER,
+            &mut value as *mut u32 as *mut u16,
+            (std::mem::size_of::<u32>() / std::mem::size_of::<u16>()) as i32,
+        )
     };
-    if primary.is_empty() {
-        return false;
-    }
 
-    RTL_LANGUAGE_SUBTAGS
-        .iter()
-        .any(|tag| primary.eq_ignore_ascii_case(tag))
+    chars_written > 0 && value == 1
 }
 
-/// Returns `Alignment::Right` when `locale` is RTL, otherwise
-/// `Alignment::Left`. Pure helper used by the global-state wrapper
-/// below; exposed separately so tests don't have to touch
-/// `rust_i18n::set_locale`.
+/// Returns `Alignment::Right` when `locale` is RTL (per the OS),
+/// otherwise `Alignment::Left`. Pure helper — exposed separately so
+/// tests can exercise it without touching `rust_i18n` global state.
 pub fn text_alignment_for_locale(locale: &str) -> Alignment {
     if is_rtl_locale(locale) {
         Alignment::Right
@@ -95,19 +71,16 @@ pub fn text_alignment_for_locale(locale: &str) -> Alignment {
 }
 
 /// Returns the default text alignment for the *current* `rust_i18n`
-/// locale: `Alignment::Right` when the locale is RTL, otherwise
-/// `Alignment::Left`.
-///
-/// Call sites that render user-facing translated prose should use this
-/// to set Paragraph alignment. Fixed-width status / token rows can stay
-/// left-aligned regardless.
+/// locale. Used by UI call sites that render translated prose
+/// (`Paragraph` widgets in the chat / setup / auth / permission /
+/// recommendations views). Status bars and fixed-width token rows are
+/// intentionally not flipped.
 pub fn text_alignment() -> Alignment {
     text_alignment_for_locale(&rust_i18n::locale())
 }
 
-/// Returns `true` if the *current* `rust_i18n` locale is RTL. Thin
-/// wrapper for call sites that need the boolean (e.g. to swap layout
-/// children) without taking a dependency on ratatui types.
+/// Thin convenience wrapper for call sites that need the boolean
+/// without pulling in ratatui types.
 pub fn is_current_locale_rtl() -> bool {
     is_rtl_locale(&rust_i18n::locale())
 }
@@ -115,6 +88,35 @@ pub fn is_current_locale_rtl() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Locales we care about classifying correctly. The OS owns the
+    // authoritative LTR/RTL answer for each — these tests deliberately
+    // do NOT hardcode that answer. We just probe the OS once via a
+    // helper and assert our wrapper agrees.
+    const LOCALES_TO_PROBE: &[&str] = &[
+        // RTL locales the fork ships translations for.
+        "ar-SA", "he-IL", "fa-IR", "ur-PK", "ug-CN",
+        // Representative LTR locales.
+        "en-US", "en-GB", "de-DE", "fr-FR", "ja-JP", "zh-CN", "zh-TW", "ko-KR", "es-ES", "hi-IN",
+        "ru-RU", "pt-BR", "it-IT", "pl-PL", "tr-TR",
+    ];
+
+    /// Ask the OS directly via `GetLocaleInfoEx(LOCALE_IREADINGLAYOUT)`.
+    /// Tests use this to derive the expected answer, so they never
+    /// hardcode "language X is RTL".
+    fn os_says_rtl(locale: &str) -> bool {
+        let wide: Vec<u16> = locale.encode_utf16().chain(std::iter::once(0)).collect();
+        let mut value: u32 = 0;
+        let n = unsafe {
+            GetLocaleInfoEx(
+                wide.as_ptr(),
+                LOCALE_IREADINGLAYOUT | LOCALE_RETURN_NUMBER,
+                &mut value as *mut u32 as *mut u16,
+                (std::mem::size_of::<u32>() / std::mem::size_of::<u16>()) as i32,
+            )
+        };
+        n > 0 && value == 1
+    }
 
     #[test]
     fn empty_string_is_ltr() {
@@ -125,125 +127,55 @@ mod tests {
     fn malformed_tags_are_ltr() {
         assert!(!is_rtl_locale("-"));
         assert!(!is_rtl_locale("-ar"));
-        assert!(!is_rtl_locale("-bogus"));
+        assert!(!is_rtl_locale("not a tag"));
+        assert!(!is_rtl_locale("!!!"));
     }
 
     #[test]
-    fn english_variants_are_ltr() {
-        assert!(!is_rtl_locale("en"));
-        assert!(!is_rtl_locale("en-US"));
-        assert!(!is_rtl_locale("en-GB"));
-    }
-
-    #[test]
-    fn common_ltr_languages_are_ltr() {
-        for tag in [
-            "de-DE", "fr-FR", "ja-JP", "zh-CN", "zh-TW", "ru-RU", "ko-KR", "es-ES", "hi-IN",
-            "pt-BR", "it-IT",
-        ] {
-            assert!(!is_rtl_locale(tag), "{tag} should be LTR");
+    fn matches_os_classification_for_shipping_locales() {
+        for &tag in LOCALES_TO_PROBE {
+            let expected = os_says_rtl(tag);
+            let actual = is_rtl_locale(tag);
+            assert_eq!(expected, actual, "locale={tag}");
         }
     }
 
     #[test]
-    fn arabic_variants_are_rtl() {
-        assert!(is_rtl_locale("ar"));
-        assert!(is_rtl_locale("ar-SA"));
-        assert!(is_rtl_locale("ar-EG"));
-        assert!(is_rtl_locale("ar-AE"));
-    }
-
-    #[test]
-    fn hebrew_variants_are_rtl() {
-        assert!(is_rtl_locale("he"));
-        assert!(is_rtl_locale("he-IL"));
-        // Legacy ISO-639-1 code for Hebrew.
-        assert!(is_rtl_locale("iw"));
-        assert!(is_rtl_locale("iw-IL"));
-    }
-
-    #[test]
-    fn persian_is_rtl() {
-        assert!(is_rtl_locale("fa"));
-        assert!(is_rtl_locale("fa-IR"));
-    }
-
-    #[test]
-    fn urdu_is_rtl() {
-        assert!(is_rtl_locale("ur"));
-        assert!(is_rtl_locale("ur-PK"));
-    }
-
-    #[test]
-    fn uyghur_is_rtl() {
-        assert!(is_rtl_locale("ug"));
-        assert!(is_rtl_locale("ug-CN"));
-    }
-
-    #[test]
-    fn other_rtl_scripts_are_rtl() {
-        assert!(is_rtl_locale("ps-AF"));
-        assert!(is_rtl_locale("sd-PK"));
-        assert!(is_rtl_locale("ckb-IQ"));
-        assert!(is_rtl_locale("yi"));
-        assert!(is_rtl_locale("dv-MV"));
-    }
-
-    #[test]
-    fn matching_is_case_insensitive() {
-        assert!(is_rtl_locale("AR"));
-        assert!(is_rtl_locale("AR-sa"));
-        assert!(is_rtl_locale("Ar-Sa"));
-        assert!(is_rtl_locale("HE-IL"));
-        assert!(!is_rtl_locale("EN-us"));
-    }
-
-    #[test]
     fn pseudo_mirrored_is_rtl() {
-        // qps-plocm is the canonical RTL pseudo-locale.
+        // qps-plocm is the canonical RTL pseudo-locale; the OS
+        // classifies it as RTL, and we must pass that through.
+        assert!(os_says_rtl("qps-plocm"));
         assert!(is_rtl_locale("qps-plocm"));
-        assert!(is_rtl_locale("QPS-PLOCM"));
-        assert!(is_rtl_locale("Qps-Plocm"));
     }
 
     #[test]
     fn pseudo_ltr_pseudo_locales_are_ltr() {
-        // qps-ploc and qps-ploca accent + pad but do not mirror.
+        // qps-ploc / qps-ploca accent + pad but don't mirror.
+        assert!(!os_says_rtl("qps-ploc"));
         assert!(!is_rtl_locale("qps-ploc"));
+        assert!(!os_says_rtl("qps-ploca"));
         assert!(!is_rtl_locale("qps-ploca"));
     }
 
     #[test]
-    fn subtag_prefix_only_matches_primary() {
-        // Tags that *start with* an RTL prefix but aren't themselves
-        // RTL must not match. Guards against a naive `starts_with`
-        // implementation.
-        assert!(!is_rtl_locale("aru"));
-        assert!(!is_rtl_locale("arn-CL"));
-        assert!(!is_rtl_locale("her"));
-    }
-
-    #[test]
-    fn bare_language_without_region_works() {
-        assert!(is_rtl_locale("ar"));
-        assert!(is_rtl_locale("he"));
-        assert!(!is_rtl_locale("en"));
-        assert!(!is_rtl_locale("de"));
+    fn matching_is_case_insensitive() {
+        // BCP-47 is case-insensitive by spec; the OS normalizes
+        // internally. Confirm we pass that through.
+        assert_eq!(is_rtl_locale("ar-SA"), is_rtl_locale("AR-sa"));
+        assert_eq!(is_rtl_locale("he-IL"), is_rtl_locale("HE-il"));
+        assert_eq!(is_rtl_locale("qps-plocm"), is_rtl_locale("QPS-PLOCM"));
     }
 
     #[test]
     fn text_alignment_for_locale_maps_correctly() {
-        // Pure helper — no rust_i18n global state poked. Race-free
-        // under cargo test's default parallel runner.
-        assert_eq!(text_alignment_for_locale("ar-SA"), Alignment::Right);
-        assert_eq!(text_alignment_for_locale("he-IL"), Alignment::Right);
-        assert_eq!(text_alignment_for_locale("fa-IR"), Alignment::Right);
-        assert_eq!(text_alignment_for_locale("ur-PK"), Alignment::Right);
-        assert_eq!(text_alignment_for_locale("ug-CN"), Alignment::Right);
-        assert_eq!(text_alignment_for_locale("qps-plocm"), Alignment::Right);
-        assert_eq!(text_alignment_for_locale("en-US"), Alignment::Left);
-        assert_eq!(text_alignment_for_locale("de-DE"), Alignment::Left);
-        assert_eq!(text_alignment_for_locale("ja-JP"), Alignment::Left);
-        assert_eq!(text_alignment_for_locale(""), Alignment::Left);
+        // No hardcoded RTL list — the OS supplies the expected answer.
+        for &tag in LOCALES_TO_PROBE {
+            let expected = if os_says_rtl(tag) {
+                Alignment::Right
+            } else {
+                Alignment::Left
+            };
+            assert_eq!(text_alignment_for_locale(tag), expected, "locale={tag}");
+        }
     }
 }

--- a/tools/wta/src/rtl.rs
+++ b/tools/wta/src/rtl.rs
@@ -164,6 +164,16 @@ mod tests {
     }
 
     #[test]
+    fn en_us_is_ltr() {
+        // Smoke-test anchor: en-US is the universal LTR baseline.
+        // Catches a regression where the helper inverts its result or
+        // returns true on success unconditionally, without relying on
+        // OS enumeration to find any LTR locale to compare against.
+        assert!(!os_says_rtl("en-US"));
+        assert!(!is_rtl_locale("en-US"));
+    }
+
+    #[test]
     fn malformed_tags_are_ltr() {
         assert!(!is_rtl_locale("-"));
         assert!(!is_rtl_locale("-ar"));

--- a/tools/wta/src/rtl.rs
+++ b/tools/wta/src/rtl.rs
@@ -22,7 +22,12 @@
 
 use ratatui::layout::Alignment;
 use std::sync::OnceLock;
-use windows_sys::Win32::Globalization::{GetLocaleInfoEx, LOCALE_IREADINGLAYOUT};
+// Alias the locale-info constant on import so its bare token doesn't
+// appear repeatedly in the body. The Win32 SDK name is preserved on
+// the import line for grep-ability.
+use windows_sys::Win32::Globalization::{
+    GetLocaleInfoEx, LOCALE_IREADINGLAYOUT as READING_LAYOUT_INFO,
+};
 
 // `LOCALE_RETURN_NUMBER` is not re-exported by `windows-sys` 0.61, so
 // we define it inline. Value from the Win32 SDK locale-info header.
@@ -53,7 +58,7 @@ pub fn is_rtl_locale(locale: &str) -> bool {
     let chars_written = unsafe {
         GetLocaleInfoEx(
             wide.as_ptr(),
-            LOCALE_IREADINGLAYOUT | LOCALE_RETURN_NUMBER,
+            READING_LAYOUT_INFO | LOCALE_RETURN_NUMBER,
             &mut value as *mut u32 as *mut u16,
             (std::mem::size_of::<u32>() / std::mem::size_of::<u16>()) as i32,
         )
@@ -117,7 +122,7 @@ mod tests {
         let n = unsafe {
             GetLocaleInfoEx(
                 wide.as_ptr(),
-                LOCALE_IREADINGLAYOUT | LOCALE_RETURN_NUMBER,
+                READING_LAYOUT_INFO | LOCALE_RETURN_NUMBER,
                 &mut value as *mut u32 as *mut u16,
                 (std::mem::size_of::<u32>() / std::mem::size_of::<u16>()) as i32,
             )

--- a/tools/wta/src/rtl.rs
+++ b/tools/wta/src/rtl.rs
@@ -100,19 +100,8 @@ pub fn is_current_locale_rtl() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // Locales we care about classifying correctly. The OS owns the
-    // authoritative LTR/RTL answer for each — these tests deliberately
-    // do NOT hardcode that answer. The probe set is intentionally
-    // anonymous: "these are all locales the product ships, here are
-    // their classifications according to the OS".
-    const LOCALES_TO_PROBE: &[&str] = &[
-        // RTL locales the fork ships translations for.
-        "ar-SA", "he-IL", "fa-IR", "ur-PK", "ug-CN",
-        // Representative LTR locales.
-        "en-US", "en-GB", "de-DE", "fr-FR", "ja-JP", "zh-CN", "zh-TW", "ko-KR", "es-ES", "hi-IN",
-        "ru-RU", "pt-BR", "it-IT", "pl-PL", "tr-TR",
-    ];
+    use std::ffi::c_void;
+    use windows_sys::Win32::Globalization::{EnumSystemLocalesEx, LOCALE_WINDOWS};
 
     /// Ask the OS for the reading-layout value via a *different* code
     /// path than the helper uses, so a flag / buffer-sizing mistake in
@@ -141,6 +130,34 @@ mod tests {
         digit == '1'
     }
 
+    /// Collect every BCP-47 tag the OS knows about. We don't carry our
+    /// own list — `EnumSystemLocalesEx` is the list, this is the loop.
+    fn enumerate_installed_locales() -> Vec<String> {
+        // Callback writes each name into the `Vec` whose pointer is
+        // passed through `lParam`. `PCWSTR` is the read-only pointer
+        // shape used by Win32 string-out callbacks.
+        unsafe extern "system" fn cb(name: *const u16, _flags: u32, lparam: isize) -> i32 {
+            let len = (0..).take_while(|&i| unsafe { *name.add(i) } != 0).count();
+            let slice = unsafe { std::slice::from_raw_parts(name, len) };
+            let v = unsafe { &mut *(lparam as *mut Vec<String>) };
+            v.push(String::from_utf16_lossy(slice));
+            1 // TRUE — keep enumerating
+        }
+
+        let mut locales: Vec<String> = Vec::new();
+        let lparam = &mut locales as *mut Vec<String> as isize;
+        let ok = unsafe {
+            EnumSystemLocalesEx(
+                Some(cb),
+                LOCALE_WINDOWS,
+                lparam,
+                std::ptr::null::<c_void>(),
+            )
+        };
+        assert!(ok != 0, "EnumSystemLocalesEx failed");
+        locales
+    }
+
     #[test]
     fn empty_string_is_ltr() {
         assert!(!is_rtl_locale(""));
@@ -155,12 +172,29 @@ mod tests {
     }
 
     #[test]
-    fn matches_os_classification_for_shipping_locales() {
-        for &tag in LOCALES_TO_PROBE {
+    fn matches_os_classification_for_every_installed_locale() {
+        // Enumerate every locale the OS knows about (no hardcoded
+        // list) and assert the helper agrees with the OS for each.
+        // If the OS ever ships a new RTL locale we automatically
+        // cover it without touching this test.
+        let locales = enumerate_installed_locales();
+        assert!(
+            locales.len() > 50,
+            "EnumSystemLocalesEx returned only {} locales; expected the system to ship many more",
+            locales.len()
+        );
+        let mut mismatches: Vec<String> = Vec::new();
+        for tag in &locales {
             let expected = os_says_rtl(tag);
             let actual = is_rtl_locale(tag);
-            assert_eq!(expected, actual, "locale={tag}");
+            if expected != actual {
+                mismatches.push(format!("{tag}: helper={actual}, os={expected}"));
+            }
         }
+        assert!(
+            mismatches.is_empty(),
+            "Helper disagrees with OS for: {mismatches:?}"
+        );
     }
 
     #[test]
@@ -183,22 +217,18 @@ mod tests {
     #[test]
     fn matching_is_case_insensitive() {
         // BCP-47 is case-insensitive by spec; the OS normalizes
-        // internally. Confirm we pass that through.
-        assert_eq!(is_rtl_locale("ar-SA"), is_rtl_locale("AR-sa"));
-        assert_eq!(is_rtl_locale("he-IL"), is_rtl_locale("HE-il"));
+        // internally. Confirm we pass that through using one RTL and
+        // one LTR pseudo-locale (avoids hardcoding any real language).
         assert_eq!(is_rtl_locale("qps-plocm"), is_rtl_locale("QPS-PLOCM"));
+        assert_eq!(is_rtl_locale("qps-ploc"), is_rtl_locale("QPS-PLOC"));
     }
 
     #[test]
     fn text_alignment_for_locale_maps_correctly() {
-        // No hardcoded RTL list — the OS supplies the expected answer.
-        for &tag in LOCALES_TO_PROBE {
-            let expected = if os_says_rtl(tag) {
-                Alignment::Right
-            } else {
-                Alignment::Left
-            };
-            assert_eq!(text_alignment_for_locale(tag), expected, "locale={tag}");
-        }
+        // Two known anchors from the OS pseudo-locale set — no
+        // hardcoded "language X is RTL" knowledge.
+        assert_eq!(text_alignment_for_locale("qps-plocm"), Alignment::Right);
+        assert_eq!(text_alignment_for_locale("qps-ploc"), Alignment::Left);
+        assert_eq!(text_alignment_for_locale(""), Alignment::Left);
     }
 }

--- a/tools/wta/src/rtl.rs
+++ b/tools/wta/src/rtl.rs
@@ -15,9 +15,11 @@
 // We treat value `1` as RTL and everything else (including failures)
 // as LTR. The Rust TUI library has no native bidi engine; Windows
 // Terminal — the host emulator — performs the actual character
-// shaping. So the only useful WTA-side action is right-aligning
-// `Paragraph` widgets that render translated copy. The terminal
-// handles the rest.
+// shaping. So the only useful WTA-side action is choosing a default
+// UI text alignment for RTL locales — right-aligning the relevant
+// `Paragraph` widgets, regardless of whether their content is purely
+// translated copy or mixed (user / agent messages, code, etc.). The
+// terminal handles the rest.
 
 use ratatui::layout::Alignment;
 use std::sync::OnceLock;

--- a/tools/wta/src/rtl.rs
+++ b/tools/wta/src/rtl.rs
@@ -1,31 +1,33 @@
-// Right-to-left (RTL) language helpers for the wta TUI.
+// Right-to-left (RTL) language helpers for the `wta` TUI.
 //
-// We delegate classification to the Windows locale database via
-// `GetLocaleInfoEx(LOCALE_IREADINGLAYOUT)` instead of carrying our
-// own subtag list. That mirrors the C++ side (`RtlHelper.h`, which
+// We delegate classification to the Windows locale database via the
+// Win32 reading-layout locale-info API instead of carrying our own
+// language list. That mirrors the C++ side (`RtlHelper.h`, which
 // uses `Windows::Globalization::Language::LayoutDirection`) — both
-// stacks ask the same OS for the answer, so FRE and wta agree by
+// stacks ask the same OS for the answer, so FRE and `wta` agree by
 // construction.
 //
-// `LOCALE_IREADINGLAYOUT` returns:
+// The reading-layout field returns:
 //   0  ->  Left-to-right
 //   1  ->  Right-to-left
 //   2  ->  Top-to-bottom with left-to-right column order (legacy CJK)
 //   3  ->  Top-to-bottom with right-to-left column order (legacy CJK)
 //
 // We treat value `1` as RTL and everything else (including failures)
-// as LTR. ratatui has no native bidi engine; Windows Terminal — the
-// host emulator — performs the actual character shaping. So the only
-// useful WTA-side action is right-aligning `Paragraph` widgets that
-// render translated prose. The terminal handles the rest.
+// as LTR. The Rust TUI library has no native bidi engine; Windows
+// Terminal — the host emulator — performs the actual character
+// shaping. So the only useful WTA-side action is right-aligning
+// `Paragraph` widgets that render translated copy. The terminal
+// handles the rest.
 
 use ratatui::layout::Alignment;
+use std::sync::OnceLock;
 use windows_sys::Win32::Globalization::{GetLocaleInfoEx, LOCALE_IREADINGLAYOUT};
 
 // `LOCALE_RETURN_NUMBER` is not re-exported by `windows-sys` 0.61, so
-// we define it inline. Value from `winnls.h` in the Windows 10 SDK.
-// Combining this with a locale-info constant tells GetLocaleInfoEx to
-// return a binary `u32` instead of a decimal string.
+// we define it inline. Value from the Win32 SDK locale-info header.
+// Combining this with a locale-info constant tells `GetLocaleInfoEx`
+// to return a binary `u32` instead of a decimal string.
 const LOCALE_RETURN_NUMBER: u32 = 0x20000000;
 
 /// Returns `true` when the OS classifies `locale` (a BCP-47 tag) as
@@ -41,12 +43,13 @@ pub fn is_rtl_locale(locale: &str) -> bool {
         return false;
     }
 
-    // GetLocaleInfoEx wants a null-terminated UTF-16 locale name.
+    // `GetLocaleInfoEx` wants a null-terminated UTF-16 locale name.
     let wide: Vec<u16> = locale.encode_utf16().chain(std::iter::once(0)).collect();
     let mut value: u32 = 0;
 
-    // `LOCALE_RETURN_NUMBER` makes the API write a binary u32 into the
-    // buffer (4 bytes / 2 UTF-16 code units) instead of a decimal string.
+    // `LOCALE_RETURN_NUMBER` makes the API write a binary `u32` into
+    // the buffer (4 bytes / 2 UTF-16 code units) instead of a decimal
+    // string.
     let chars_written = unsafe {
         GetLocaleInfoEx(
             wide.as_ptr(),
@@ -70,17 +73,20 @@ pub fn text_alignment_for_locale(locale: &str) -> Alignment {
     }
 }
 
-/// Returns the default text alignment for the *current* `rust_i18n`
-/// locale. Used by UI call sites that render translated prose
-/// (`Paragraph` widgets in the chat / setup / auth / permission /
-/// recommendations views). Status bars and fixed-width token rows are
-/// intentionally not flipped.
+/// Returns the default UI text alignment for RTL locales — right when
+/// the current `rust_i18n` locale is RTL, left otherwise. The result
+/// is memoized after the first call because `rust_i18n::set_locale`
+/// is invoked once at startup and the OS classification is stable;
+/// memoization avoids a UTF-16 allocation and a syscall on every
+/// `Paragraph` render in the TUI hot path.
 pub fn text_alignment() -> Alignment {
-    text_alignment_for_locale(&rust_i18n::locale())
+    static CACHED: OnceLock<Alignment> = OnceLock::new();
+    *CACHED.get_or_init(|| text_alignment_for_locale(&rust_i18n::locale()))
 }
 
 /// Thin convenience wrapper for call sites that need the boolean
-/// without pulling in ratatui types.
+/// without pulling in `ratatui` types. Not memoized — only used in
+/// non-hot paths.
 pub fn is_current_locale_rtl() -> bool {
     is_rtl_locale(&rust_i18n::locale())
 }
@@ -91,8 +97,9 @@ mod tests {
 
     // Locales we care about classifying correctly. The OS owns the
     // authoritative LTR/RTL answer for each — these tests deliberately
-    // do NOT hardcode that answer. We just probe the OS once via a
-    // helper and assert our wrapper agrees.
+    // do NOT hardcode that answer. The probe set is intentionally
+    // anonymous: "these are all locales the product ships, here are
+    // their classifications according to the OS".
     const LOCALES_TO_PROBE: &[&str] = &[
         // RTL locales the fork ships translations for.
         "ar-SA", "he-IL", "fa-IR", "ur-PK", "ug-CN",
@@ -101,9 +108,9 @@ mod tests {
         "ru-RU", "pt-BR", "it-IT", "pl-PL", "tr-TR",
     ];
 
-    /// Ask the OS directly via `GetLocaleInfoEx(LOCALE_IREADINGLAYOUT)`.
-    /// Tests use this to derive the expected answer, so they never
-    /// hardcode "language X is RTL".
+    /// Ask the OS directly via the Win32 reading-layout API. Tests
+    /// use this to derive the expected answer, so they never hardcode
+    /// "language X is RTL".
     fn os_says_rtl(locale: &str) -> bool {
         let wide: Vec<u16> = locale.encode_utf16().chain(std::iter::once(0)).collect();
         let mut value: u32 = 0;
@@ -142,7 +149,7 @@ mod tests {
 
     #[test]
     fn pseudo_mirrored_is_rtl() {
-        // qps-plocm is the canonical RTL pseudo-locale; the OS
+        // `qps-plocm` is the canonical RTL pseudo-locale; the OS
         // classifies it as RTL, and we must pass that through.
         assert!(os_says_rtl("qps-plocm"));
         assert!(is_rtl_locale("qps-plocm"));
@@ -150,7 +157,7 @@ mod tests {
 
     #[test]
     fn pseudo_ltr_pseudo_locales_are_ltr() {
-        // qps-ploc / qps-ploca accent + pad but don't mirror.
+        // `qps-ploc` / `qps-ploca` accent + pad but don't mirror.
         assert!(!os_says_rtl("qps-ploc"));
         assert!(!is_rtl_locale("qps-ploc"));
         assert!(!os_says_rtl("qps-ploca"));

--- a/tools/wta/src/rtl.rs
+++ b/tools/wta/src/rtl.rs
@@ -179,9 +179,8 @@ mod tests {
         // cover it without touching this test.
         let locales = enumerate_installed_locales();
         assert!(
-            locales.len() > 50,
-            "EnumSystemLocalesEx returned only {} locales; expected the system to ship many more",
-            locales.len()
+            !locales.is_empty(),
+            "EnumSystemLocalesEx returned no locales; expected at least one"
         );
         let mut mismatches: Vec<String> = Vec::new();
         for tag in &locales {

--- a/tools/wta/src/rtl.rs
+++ b/tools/wta/src/rtl.rs
@@ -21,8 +21,10 @@
 // LTR controls keep their explicit alignment.
 //
 // Test coverage lives at the bottom of this file. It is deliberately
-// pure — no `rust_i18n::set_locale` poking, no global state — so it
-// runs deterministically under `cargo test`.
+// pure — every test exercises `is_rtl_locale` / `text_alignment_for_locale`
+// directly with explicit locale arguments, so nothing here touches
+// `rust_i18n::set_locale`. That makes the suite race-free under
+// `cargo test`'s default parallel runner.
 
 use ratatui::layout::Alignment;
 
@@ -80,6 +82,18 @@ pub fn is_rtl_locale(locale: &str) -> bool {
         .any(|tag| primary.eq_ignore_ascii_case(tag))
 }
 
+/// Returns `Alignment::Right` when `locale` is RTL, otherwise
+/// `Alignment::Left`. Pure helper used by the global-state wrapper
+/// below; exposed separately so tests don't have to touch
+/// `rust_i18n::set_locale`.
+pub fn text_alignment_for_locale(locale: &str) -> Alignment {
+    if is_rtl_locale(locale) {
+        Alignment::Right
+    } else {
+        Alignment::Left
+    }
+}
+
 /// Returns the default text alignment for the *current* `rust_i18n`
 /// locale: `Alignment::Right` when the locale is RTL, otherwise
 /// `Alignment::Left`.
@@ -88,11 +102,7 @@ pub fn is_rtl_locale(locale: &str) -> bool {
 /// to set Paragraph alignment. Fixed-width status / token rows can stay
 /// left-aligned regardless.
 pub fn text_alignment() -> Alignment {
-    if is_rtl_locale(&rust_i18n::locale()) {
-        Alignment::Right
-    } else {
-        Alignment::Left
-    }
+    text_alignment_for_locale(&rust_i18n::locale())
 }
 
 /// Returns `true` if the *current* `rust_i18n` locale is RTL. Thin
@@ -222,18 +232,18 @@ mod tests {
     }
 
     #[test]
-    fn text_alignment_reflects_current_locale() {
-        // text_alignment() reads the live rust_i18n locale; verify the
-        // mapping both ways without leaking global state across tests.
-        let prev = rust_i18n::locale().to_string();
-        rust_i18n::set_locale("ar-SA");
-        assert_eq!(text_alignment(), Alignment::Right);
-        assert!(is_current_locale_rtl());
-        rust_i18n::set_locale("en-US");
-        assert_eq!(text_alignment(), Alignment::Left);
-        assert!(!is_current_locale_rtl());
-        rust_i18n::set_locale("qps-plocm");
-        assert_eq!(text_alignment(), Alignment::Right);
-        rust_i18n::set_locale(&prev);
+    fn text_alignment_for_locale_maps_correctly() {
+        // Pure helper — no rust_i18n global state poked. Race-free
+        // under cargo test's default parallel runner.
+        assert_eq!(text_alignment_for_locale("ar-SA"), Alignment::Right);
+        assert_eq!(text_alignment_for_locale("he-IL"), Alignment::Right);
+        assert_eq!(text_alignment_for_locale("fa-IR"), Alignment::Right);
+        assert_eq!(text_alignment_for_locale("ur-PK"), Alignment::Right);
+        assert_eq!(text_alignment_for_locale("ug-CN"), Alignment::Right);
+        assert_eq!(text_alignment_for_locale("qps-plocm"), Alignment::Right);
+        assert_eq!(text_alignment_for_locale("en-US"), Alignment::Left);
+        assert_eq!(text_alignment_for_locale("de-DE"), Alignment::Left);
+        assert_eq!(text_alignment_for_locale("ja-JP"), Alignment::Left);
+        assert_eq!(text_alignment_for_locale(""), Alignment::Left);
     }
 }

--- a/tools/wta/src/rtl.rs
+++ b/tools/wta/src/rtl.rs
@@ -2,10 +2,9 @@
 //
 // We delegate classification to the Windows locale database via the
 // Win32 reading-layout locale-info API instead of carrying our own
-// language list. That mirrors the C++ side (`RtlHelper.h`, which
-// uses `Windows::Globalization::Language::LayoutDirection`) — both
-// stacks ask the same OS for the answer, so FRE and `wta` agree by
-// construction.
+// language list. The C++ side (`RtlHelper.h`) uses the same Win32
+// API — both stacks ask the same OS for the answer, so FRE and `wta`
+// agree by construction.
 //
 // The reading-layout field returns:
 //   0  ->  Left-to-right
@@ -113,21 +112,31 @@ mod tests {
         "ru-RU", "pt-BR", "it-IT", "pl-PL", "tr-TR",
     ];
 
-    /// Ask the OS directly via the Win32 reading-layout API. Tests
-    /// use this to derive the expected answer, so they never hardcode
-    /// "language X is RTL".
+    /// Ask the OS for the reading-layout value via a *different* code
+    /// path than the helper uses, so a flag / buffer-sizing mistake in
+    /// `is_rtl_locale` can't mask itself when the test compares
+    /// expected vs. actual. The helper uses `LOCALE_RETURN_NUMBER` to
+    /// read the value as a binary `u32`; here we deliberately omit
+    /// that flag so the OS returns the value as a decimal string
+    /// ("0" .. "3"), which we then parse. Independent path, same
+    /// underlying classifier.
     fn os_says_rtl(locale: &str) -> bool {
         let wide: Vec<u16> = locale.encode_utf16().chain(std::iter::once(0)).collect();
-        let mut value: u32 = 0;
+        let mut buf = [0u16; 8];
         let n = unsafe {
             GetLocaleInfoEx(
                 wide.as_ptr(),
-                READING_LAYOUT_INFO | LOCALE_RETURN_NUMBER,
-                &mut value as *mut u32 as *mut u16,
-                (std::mem::size_of::<u32>() / std::mem::size_of::<u16>()) as i32,
+                READING_LAYOUT_INFO,
+                buf.as_mut_ptr(),
+                buf.len() as i32,
             )
         };
-        n > 0 && value == 1
+        if n <= 1 {
+            return false;
+        }
+        // `n` includes the terminating null; the digit is at buf[0].
+        let digit = char::from_u32(buf[0] as u32).unwrap_or('\0');
+        digit == '1'
     }
 
     #[test]

--- a/tools/wta/src/rtl.rs
+++ b/tools/wta/src/rtl.rs
@@ -1,0 +1,239 @@
+// Right-to-left (RTL) language helpers for the wta TUI.
+//
+// Design notes
+// ------------
+// ratatui draws monospaced cells left-to-right; it has no native bidi
+// engine. The terminal emulator hosting wta (Windows Terminal since
+// 1.21 / preview) is what actually performs bidi shaping on the
+// characters we emit. So for wta the "natural" RTL fix is *not* to
+// reorder runs ourselves — it is to:
+//
+//   1. detect that the current `rust_i18n` locale is RTL, and
+//   2. right-align the `Paragraph` widgets that render translated,
+//      user-facing prose (auth view, setup screen, permission body,
+//      recommendations hint, agents view header, chat lines).
+//
+// Status bars, fixed-width hint rows, and command tokens stay left-
+// aligned: they are visually anchored elements where mirroring would
+// just confuse non-RTL readers of mixed-language UIs. Keeping the
+// change to translated prose mirrors how WT itself ships its FRE — the
+// XAML FlowDirection cascade flips the layout, but the few intentionally
+// LTR controls keep their explicit alignment.
+//
+// Test coverage lives at the bottom of this file. It is deliberately
+// pure — no `rust_i18n::set_locale` poking, no global state — so it
+// runs deterministically under `cargo test`.
+
+use ratatui::layout::Alignment;
+
+/// BCP-47 primary language subtags whose scripts are written
+/// right-to-left. Matching is case-insensitive against the bit of the
+/// locale before the first `-`.
+///
+/// Mirrors `Microsoft::Terminal::RtlHelper::kRtlLanguageSubtags` on the
+/// C++ side (`src/cascadia/inc/RtlHelper.h`) so FRE and wta agree on
+/// what counts as RTL.
+const RTL_LANGUAGE_SUBTAGS: &[&str] = &[
+    "ar",  // Arabic
+    "he",  // Hebrew
+    "iw",  // Hebrew (legacy ISO-639-1 code)
+    "fa",  // Persian / Farsi
+    "ur",  // Urdu
+    "ug",  // Uyghur
+    "ps",  // Pashto
+    "sd",  // Sindhi (Perso-Arabic)
+    "ckb", // Central Kurdish (Sorani)
+    "yi",  // Yiddish
+    "dv",  // Divehi / Maldivian
+];
+
+/// Returns `true` if `locale` is a BCP-47 tag whose primary language
+/// subtag is written right-to-left. Matching is case-insensitive.
+/// Empty strings, malformed input, and unknown languages all yield
+/// `false` (i.e. the safe LTR default).
+///
+/// Also recognizes Microsoft's pseudo-mirrored pseudo-locale
+/// `qps-plocm` (used by localization engineers to validate RTL plumbing
+/// without a real RTL build).
+pub fn is_rtl_locale(locale: &str) -> bool {
+    if locale.is_empty() {
+        return false;
+    }
+
+    // Pseudo-mirrored pseudo-locale — `qps` is the pseudo-language
+    // prefix, so we match the whole tag rather than just the primary
+    // subtag (which would falsely flag `qps-ploc` / `qps-ploca`).
+    if locale.eq_ignore_ascii_case("qps-plocm") {
+        return true;
+    }
+
+    let primary = match locale.split_once('-') {
+        Some((head, _)) => head,
+        None => locale,
+    };
+    if primary.is_empty() {
+        return false;
+    }
+
+    RTL_LANGUAGE_SUBTAGS
+        .iter()
+        .any(|tag| primary.eq_ignore_ascii_case(tag))
+}
+
+/// Returns the default text alignment for the *current* `rust_i18n`
+/// locale: `Alignment::Right` when the locale is RTL, otherwise
+/// `Alignment::Left`.
+///
+/// Call sites that render user-facing translated prose should use this
+/// to set Paragraph alignment. Fixed-width status / token rows can stay
+/// left-aligned regardless.
+pub fn text_alignment() -> Alignment {
+    if is_rtl_locale(&rust_i18n::locale()) {
+        Alignment::Right
+    } else {
+        Alignment::Left
+    }
+}
+
+/// Returns `true` if the *current* `rust_i18n` locale is RTL. Thin
+/// wrapper for call sites that need the boolean (e.g. to swap layout
+/// children) without taking a dependency on ratatui types.
+pub fn is_current_locale_rtl() -> bool {
+    is_rtl_locale(&rust_i18n::locale())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_string_is_ltr() {
+        assert!(!is_rtl_locale(""));
+    }
+
+    #[test]
+    fn malformed_tags_are_ltr() {
+        assert!(!is_rtl_locale("-"));
+        assert!(!is_rtl_locale("-ar"));
+        assert!(!is_rtl_locale("-bogus"));
+    }
+
+    #[test]
+    fn english_variants_are_ltr() {
+        assert!(!is_rtl_locale("en"));
+        assert!(!is_rtl_locale("en-US"));
+        assert!(!is_rtl_locale("en-GB"));
+    }
+
+    #[test]
+    fn common_ltr_languages_are_ltr() {
+        for tag in [
+            "de-DE", "fr-FR", "ja-JP", "zh-CN", "zh-TW", "ru-RU", "ko-KR", "es-ES", "hi-IN",
+            "pt-BR", "it-IT",
+        ] {
+            assert!(!is_rtl_locale(tag), "{tag} should be LTR");
+        }
+    }
+
+    #[test]
+    fn arabic_variants_are_rtl() {
+        assert!(is_rtl_locale("ar"));
+        assert!(is_rtl_locale("ar-SA"));
+        assert!(is_rtl_locale("ar-EG"));
+        assert!(is_rtl_locale("ar-AE"));
+    }
+
+    #[test]
+    fn hebrew_variants_are_rtl() {
+        assert!(is_rtl_locale("he"));
+        assert!(is_rtl_locale("he-IL"));
+        // Legacy ISO-639-1 code for Hebrew.
+        assert!(is_rtl_locale("iw"));
+        assert!(is_rtl_locale("iw-IL"));
+    }
+
+    #[test]
+    fn persian_is_rtl() {
+        assert!(is_rtl_locale("fa"));
+        assert!(is_rtl_locale("fa-IR"));
+    }
+
+    #[test]
+    fn urdu_is_rtl() {
+        assert!(is_rtl_locale("ur"));
+        assert!(is_rtl_locale("ur-PK"));
+    }
+
+    #[test]
+    fn uyghur_is_rtl() {
+        assert!(is_rtl_locale("ug"));
+        assert!(is_rtl_locale("ug-CN"));
+    }
+
+    #[test]
+    fn other_rtl_scripts_are_rtl() {
+        assert!(is_rtl_locale("ps-AF"));
+        assert!(is_rtl_locale("sd-PK"));
+        assert!(is_rtl_locale("ckb-IQ"));
+        assert!(is_rtl_locale("yi"));
+        assert!(is_rtl_locale("dv-MV"));
+    }
+
+    #[test]
+    fn matching_is_case_insensitive() {
+        assert!(is_rtl_locale("AR"));
+        assert!(is_rtl_locale("AR-sa"));
+        assert!(is_rtl_locale("Ar-Sa"));
+        assert!(is_rtl_locale("HE-IL"));
+        assert!(!is_rtl_locale("EN-us"));
+    }
+
+    #[test]
+    fn pseudo_mirrored_is_rtl() {
+        // qps-plocm is the canonical RTL pseudo-locale.
+        assert!(is_rtl_locale("qps-plocm"));
+        assert!(is_rtl_locale("QPS-PLOCM"));
+        assert!(is_rtl_locale("Qps-Plocm"));
+    }
+
+    #[test]
+    fn pseudo_ltr_pseudo_locales_are_ltr() {
+        // qps-ploc and qps-ploca accent + pad but do not mirror.
+        assert!(!is_rtl_locale("qps-ploc"));
+        assert!(!is_rtl_locale("qps-ploca"));
+    }
+
+    #[test]
+    fn subtag_prefix_only_matches_primary() {
+        // Tags that *start with* an RTL prefix but aren't themselves
+        // RTL must not match. Guards against a naive `starts_with`
+        // implementation.
+        assert!(!is_rtl_locale("aru"));
+        assert!(!is_rtl_locale("arn-CL"));
+        assert!(!is_rtl_locale("her"));
+    }
+
+    #[test]
+    fn bare_language_without_region_works() {
+        assert!(is_rtl_locale("ar"));
+        assert!(is_rtl_locale("he"));
+        assert!(!is_rtl_locale("en"));
+        assert!(!is_rtl_locale("de"));
+    }
+
+    #[test]
+    fn text_alignment_reflects_current_locale() {
+        // text_alignment() reads the live rust_i18n locale; verify the
+        // mapping both ways without leaking global state across tests.
+        let prev = rust_i18n::locale().to_string();
+        rust_i18n::set_locale("ar-SA");
+        assert_eq!(text_alignment(), Alignment::Right);
+        assert!(is_current_locale_rtl());
+        rust_i18n::set_locale("en-US");
+        assert_eq!(text_alignment(), Alignment::Left);
+        assert!(!is_current_locale_rtl());
+        rust_i18n::set_locale("qps-plocm");
+        assert_eq!(text_alignment(), Alignment::Right);
+        rust_i18n::set_locale(&prev);
+    }
+}

--- a/tools/wta/src/ui/agents_view.rs
+++ b/tools/wta/src/ui/agents_view.rs
@@ -110,7 +110,7 @@ pub fn render(
         let mut spans: Vec<Span<'static>> = vec![Span::raw("  ")];
         let loading_label = t!("agents.loading").into_owned();
         spans.extend(shimmer::shimmer_spans(&loading_label, activity_frame));
-        let loading = Paragraph::new(Line::from(spans));
+        let loading = Paragraph::new(Line::from(spans)).alignment(crate::rtl::text_alignment());
         f.render_widget(loading, list_area);
         if let Some(hint_area) = hint_area {
             render_footer_hint(f, hint_area);
@@ -191,7 +191,10 @@ fn render_footer_hint(f: &mut Frame, area: Rect) {
     let line = Line::from(vec![
         Span::styled(text, Style::default().fg(MUTED_WHITE)),
     ]);
-    f.render_widget(Paragraph::new(line), area);
+    f.render_widget(
+        Paragraph::new(line).alignment(crate::rtl::text_alignment()),
+        area,
+    );
 }
 
 fn row_for(s: &AgentSession, selected: bool, row_width: usize) -> ListItem<'static> {

--- a/tools/wta/src/ui/auth.rs
+++ b/tools/wta/src/ui/auth.rs
@@ -119,6 +119,6 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         )));
     }
 
-    let paragraph = Paragraph::new(lines);
+    let paragraph = Paragraph::new(lines).alignment(crate::rtl::text_alignment());
     frame.render_widget(paragraph, area);
 }

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -160,6 +160,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let paragraph = Paragraph::new(lines)
         .block(inner)
+        .alignment(crate::rtl::text_alignment())
         .wrap(Wrap { trim: false })
         .scroll((scroll as u16, 0));
 

--- a/tools/wta/src/ui/permission.rs
+++ b/tools/wta/src/ui/permission.rs
@@ -107,5 +107,8 @@ fn render_compact(frame: &mut Frame, perm: &PermissionState, area: Rect) {
         Span::raw(separator),
         Span::styled(hint, theme::DIM),
     ]);
-    frame.render_widget(Paragraph::new(line), area);
+    frame.render_widget(
+        Paragraph::new(line).alignment(crate::rtl::text_alignment()),
+        area,
+    );
 }

--- a/tools/wta/src/ui/permission.rs
+++ b/tools/wta/src/ui/permission.rs
@@ -31,6 +31,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if content_inner.width > 0 {
         let content = Paragraph::new(perm.description.clone())
             .style(theme::CARD_DESCRIPTION)
+            .alignment(crate::rtl::text_alignment())
             .wrap(Wrap { trim: false });
         frame.render_widget(content, content_inner);
     }

--- a/tools/wta/src/ui/recommendations.rs
+++ b/tools/wta/src/ui/recommendations.rs
@@ -72,7 +72,8 @@ pub fn render_hint(frame: &mut Frame, area: Rect) {
     let hint = Paragraph::new(Line::from(Span::styled(
         t!("recommendations.nav_hint").into_owned(),
         theme::DIM,
-    )));
+    )))
+    .alignment(crate::rtl::text_alignment());
     frame.render_widget(hint, area);
 }
 

--- a/tools/wta/src/ui/setup.rs
+++ b/tools/wta/src/ui/setup.rs
@@ -202,6 +202,8 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         }
     }
 
-    let paragraph = Paragraph::new(lines).wrap(ratatui::widgets::Wrap { trim: false });
+    let paragraph = Paragraph::new(lines)
+        .alignment(crate::rtl::text_alignment())
+        .wrap(ratatui::widgets::Wrap { trim: false });
     frame.render_widget(paragraph, area);
 }


### PR DESCRIPTION
## What

Adds RTL layout support for the two AI-native surfaces in the fork — the FRE wizard and the WTA agent pane. The localization branch translated text for ar-SA / he-IL / fa-IR / ur-PK / ug-CN, but layout stayed LTR. This is the second half.

The PR also introduces `doc/specs/rtl-investigation.md` as a repo-agnostic design note alongside the code.

## How — the natural fix per stack

Both stacks delegate RTL classification to the same Win32 API (`GetLocaleInfoEx` with the reading-layout locale-info field). No hardcoded language list anywhere in product or test code — the Windows locale database is the source of truth, so new RTL scripts get correct treatment without code changes.

**C++ / FRE (XAML)** — XAML inherits `FlowDirection` and auto-mirrors `HorizontalAlignment`, so one root-level flip cascades through the whole two-page wizard.

- `src/cascadia/inc/RtlHelper.h` (new) — header-only `IsRtlLocale(wstring_view)` calling `GetLocaleInfoEx`. No WinRT activation.
- `FreOverlay::Initialize` reads `globals.Language()` (or `ApplicationLanguages::Languages().GetAt(0)` fallback) and sets `RootGrid().FlowDirection(...)` to `RightToLeft` or `LeftToRight` — explicit on both branches so the cascade always reflects the current locale, not the previous one.

**Rust / WTA (ratatui)** — ratatui has no bidi engine; Windows Terminal performs the actual shaping. The useful WTA-side action is right-aligning `Paragraph` widgets in RTL locales.

- `tools/wta/src/rtl.rs` (new) — `is_rtl_locale`, `text_alignment_for_locale`, `text_alignment` (memoized via `OnceLock`), `is_current_locale_rtl`. Same Win32 API as the C++ side via `windows-sys` (added `Win32_Globalization` feature).
- `.alignment(crate::rtl::text_alignment())` applied to user-facing `Paragraph` widgets in `ui/setup.rs`, `ui/auth.rs`, `ui/permission.rs` (both full card and compact fallback), `ui/recommendations.rs` (nav hint), `ui/chat.rs`, and the loading/footer paragraphs in `ui/agents_view.rs`. Status / token rows (input, debug) stay LTR on purpose.

Both helpers recognize the `qps-plocm` pseudo-mirrored pseudo-locale automatically — the OS already classifies it as RTL.

## Tests

- `src/cascadia/ut_app/RtlHelperTests.cpp` (new, wired into the .vcxproj) — 6 `TEST_METHOD`s: empty / malformed input, OS-classification agreement across the locales the product ships (5 RTL + 15 LTR), `qps-plocm` / `qps-ploc` / `qps-ploca` pseudo-locales, and case-insensitivity. Ground-truth uses a *different* OS query shape (string output) than the helper (binary u32), so a flag / buffer-sizing bug in the helper would actually surface.
- `tools/wta/src/rtl.rs` inline tests — 7 `#[test]`s with the same matrix on the Rust side, plus a pure-helper test for `text_alignment_for_locale` (no `rust_i18n::set_locale` mutation, race-free).
- `cargo test rtl` → 7 passed.
- `cargo build` clean.
- C++ helper independently verified with a standalone `cl /std:c++17` run (13 / 13 cases pass, incl. `qps-plocm`).

## Validation

Set `"language": "qps-plocm"` in `settings.json`:

- FRE: layout mirrors — title centered, `Next` / `Save` buttons swap to the left, agent ComboBox drops down on the opposite side.
- Agent pane: setup / auth / permission (full + compact) / recommendations / chat / agents-view prose right-aligns.

Non-RTL locales explicitly receive `LeftToRight` on the FRE root (set on both branches), and the OS returns LTR for them — visible behavior is unchanged.