### PR TITLE
Hide bottom agent bar on setting tab

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3965,10 +3965,30 @@ namespace winrt::TerminalApp::implementation
     // The bottom bar is hidden entirely on non-terminal tabs (e.g. Settings).
     void TerminalPage::_UpdateBottomBarState()
     {
-        // Keep the bottom bar (agent pane / session toggle buttons) visible on
-        // every tab type, including non-terminal tabs like Settings — the
-        // buttons are still functional there (they target the shared agent
-        // pane, not the focused tab's content).
+        // Hide the bottom bar on non-terminal tabs (Settings, etc.) — collapsing
+        // it lets TabContent (Grid.Row=2, Height="*") expand to fill the recovered
+        // space automatically. The bar contains terminal-pane-oriented controls
+        // (agent toggle, diagnostics, sessions) that have no meaningful target
+        // when a non-terminal pane is focused.
+        const auto focusedTabImpl = _GetFocusedTabImpl();
+        bool isTerminalTab = true;
+        if (focusedTabImpl)
+        {
+            if (const auto content = focusedTabImpl->GetActiveContent())
+            {
+                const bool isTerm = content.try_as<TerminalApp::TerminalPaneContent>() != nullptr;
+                const bool isAgent = content.try_as<TerminalApp::AgentPaneContent>() != nullptr;
+                isTerminalTab = isTerm || isAgent;
+            }
+        }
+        if (auto barRoot = BottomBarRoot())
+        {
+            barRoot.Visibility(isTerminalTab ? Visibility::Visible : Visibility::Collapsed);
+        }
+        if (!isTerminalTab)
+        {
+            return;
+        }
 
         // Per-tab flag drives the toggle button's lit state — it tracks
         // whether the user wants the agent pane open on the *active* tab,

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -84,7 +84,8 @@
              alpha-blend against the transparent window underneath instead
              of the bar's black. Stacking a 1px Border on top of the
              solid-black outer Border makes the alpha blend correctly. -->
-        <Border Grid.Row="3"
+        <Border x:Name="BottomBarRoot"
+                Grid.Row="3"
                 Background="#000000"
                 VerticalAlignment="Top">
         <Grid>


### PR DESCRIPTION
## Summary
- On Settings (and any future non-terminal pane), the bottom agent toolbar — agent-toggle, diagnostics, sessions buttons — leaves a 41 px black strip with no meaningful target for its controls. This collapses the bar in that case so `TabContent` (Grid.Row=2, Height="*") expands into the recovered space automatically.
- Implementation is in `_UpdateBottomBarState()`: classify the focused tab's active content as terminal (`TerminalPaneContent` / `AgentPaneContent`) or not, and toggle `BottomBarRoot.Visibility` accordingly. Restores the variant of the check that existed before #30, but scoped to genuine non-terminal content rather than a specific tab type.
- XAML side just gives the outer `Border` an `x:Name="BottomBarRoot"` so collapsing folds the entire strip (black background + 1 px divider + 40 px button row), not just the inner button Grid whose row heights are still hardcoded.

## Test plan
- [ ] Open a terminal tab — BottomBar visible.
- [ ] Open Settings (Ctrl+,) — BottomBar collapses, settings page extends to the bottom edge.
- [ ] Switch back to the terminal tab — BottomBar reappears at full height.
- [ ] Open the agent pane on a terminal tab, navigate to Settings, back — agent pane stays mounted; BottomBar visibility tracks the focused tab.
- [ ] Multi-tab: switch between terminal / settings / terminal repeatedly — no flicker, no leftover strip.

<img width="1728" height="916" alt="image" src="https://github.com/user-attachments/assets/db7ccda4-9328-4228-89d6-97ff960b833c" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)