### PR TITLE
Make wta the sole owner of per-tab agent view state

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -13,6 +13,7 @@ consvc
 copyable
 dcs
 deselection
+desync
 diffing
 Dimidium
 downsides

--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -438,7 +438,6 @@ DELAYLOAD
 DELETEONRELEASE
 depersist
 deprioritized
-desync
 devicecode
 Dext
 DFF

--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -438,6 +438,7 @@ DELAYLOAD
 DELETEONRELEASE
 depersist
 deprioritized
+desync
 devicecode
 Dext
 DFF

--- a/src/cascadia/TerminalApp/AgentPaneContent.h
+++ b/src/cascadia/TerminalApp/AgentPaneContent.h
@@ -58,7 +58,7 @@ namespace winrt::TerminalApp::implementation
         winrt::hstring _agentState{};
 
         // When true, the bar replaces "<agent> <version>" with "Agent sessions"
-        // and hides the agent logo. Driven by TerminalPage::OnAgentViewChanged
+        // and hides the agent logo. Driven by TerminalPage::OnAgentStateChanged
         // (the single writer for view-derived UI state).
         bool _isSessionsView{ false };
 

--- a/src/cascadia/TerminalApp/AgentPaneContent.h
+++ b/src/cascadia/TerminalApp/AgentPaneContent.h
@@ -58,7 +58,8 @@ namespace winrt::TerminalApp::implementation
         winrt::hstring _agentState{};
 
         // When true, the bar replaces "<agent> <version>" with "Agent sessions"
-        // and hides the agent logo. Driven by TerminalPage::_BroadcastAgentSetView.
+        // and hides the agent logo. Driven by TerminalPage::OnAgentViewChanged
+        // (the single writer for view-derived UI state).
         bool _isSessionsView{ false };
 
         // Inner content event tokens — forwarded to our own BasicPaneEvents.

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1677,10 +1677,10 @@ namespace winrt::TerminalApp::implementation
         if (visibleOnActiveTab && _agentSessionsViewActive)
         {
             OutputDebugStringW(L"[AgentPane] OpenAgentPane: switch to chat — pane visible and in sessions view\n");
-            // Request only. wta applies the view change and echoes back a
-            // `view_changed` event; `OnAgentViewChanged` is the sole writer
-            // of `_agentSessionsViewActive` for runtime view transitions.
-            _RequestAgentView("chat");
+            // Request only. wta flips its per-tab `current_view` to chat
+            // and echoes back the snapshot via `agent_state_changed`;
+            // `OnAgentStateChanged` is the sole writer of the mirrors.
+            _RequestAgentState("chat", std::nullopt);
             args.Handled(true);
             return;
         }
@@ -1719,27 +1719,23 @@ namespace winrt::TerminalApp::implementation
 
         if (visibleOnActiveTab && _agentSessionsViewActive)
         {
-            // Toggle off: close the pane on the active tab. Mirrors the
-            // closing half of the Ctrl+Shift+. toggle path.
-            //
-            // We don't reset `_agentSessionsViewActive` here — the pane is
-            // about to be hidden, so the bottom-bar gate (`_agentPaneVisible`)
-            // already turns off both chat/session highlights regardless of
-            // the flag. The flag stays at wta's last reported view; when the
-            // pane is re-opened on this tab, the next `view_changed` from
-            // wta corrects it.
+            // Toggle off: ask wta to mark this tab as not wanting the
+            // pane. The resulting `agent_state_changed` snapshot will
+            // flip `Tab.AgentPaneOpen` mirror to false and reconcile
+            // (which hides the pane on this tab). View stays put — when
+            // the user reopens the pane on this tab the previous view
+            // is preserved.
             OutputDebugStringW(L"[AgentPane] OpenAgentSessions: toggle close — pane visible and already in sessions view\n");
-            activeTab->AgentPaneOpen(false);
-            _ReconcileAgentPaneForActiveTab();
-            _UpdateBottomBarState();
+            _RequestAgentState(std::nullopt, /*pane_open*/ false);
             args.Handled(true);
             return;
         }
 
         // Either the pane needs opening/relocating, or it's open in chat
         // view and we want to switch it. Both go through the existing
-        // intoSessionsView=true code path; wta emits `view_changed("sessions")`
-        // back which lands in `OnAgentViewChanged` and flips the flag there.
+        // intoSessionsView=true code path; wta emits `agent_state_changed`
+        // back with `view=sessions, pane_open=true` which lands in
+        // `OnAgentStateChanged`.
         _OpenOrReuseAgentPane(L"", /*intoSessionsView*/ true);
         _UpdateBottomBarState();
         args.Handled(true);

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1677,9 +1677,10 @@ namespace winrt::TerminalApp::implementation
         if (visibleOnActiveTab && _agentSessionsViewActive)
         {
             OutputDebugStringW(L"[AgentPane] OpenAgentPane: switch to chat — pane visible and in sessions view\n");
-            _BroadcastAgentSetView("chat");
-            _agentSessionsViewActive = false;
-            _UpdateBottomBarState();
+            // Request only. wta applies the view change and echoes back a
+            // `view_changed` event; `OnAgentViewChanged` is the sole writer
+            // of `_agentSessionsViewActive` for runtime view transitions.
+            _RequestAgentView("chat");
             args.Handled(true);
             return;
         }
@@ -1720,10 +1721,16 @@ namespace winrt::TerminalApp::implementation
         {
             // Toggle off: close the pane on the active tab. Mirrors the
             // closing half of the Ctrl+Shift+. toggle path.
+            //
+            // We don't reset `_agentSessionsViewActive` here — the pane is
+            // about to be hidden, so the bottom-bar gate (`_agentPaneVisible`)
+            // already turns off both chat/session highlights regardless of
+            // the flag. The flag stays at wta's last reported view; when the
+            // pane is re-opened on this tab, the next `view_changed` from
+            // wta corrects it.
             OutputDebugStringW(L"[AgentPane] OpenAgentSessions: toggle close — pane visible and already in sessions view\n");
             activeTab->AgentPaneOpen(false);
             _ReconcileAgentPaneForActiveTab();
-            _agentSessionsViewActive = false;
             _UpdateBottomBarState();
             args.Handled(true);
             return;
@@ -1731,8 +1738,8 @@ namespace winrt::TerminalApp::implementation
 
         // Either the pane needs opening/relocating, or it's open in chat
         // view and we want to switch it. Both go through the existing
-        // intoSessionsView=true code path, which sets _agentSessionsViewActive
-        // = true on success.
+        // intoSessionsView=true code path; wta emits `view_changed("sessions")`
+        // back which lands in `OnAgentViewChanged` and flips the flag there.
         _OpenOrReuseAgentPane(L"", /*intoSessionsView*/ true);
         _UpdateBottomBarState();
         args.Handled(true);

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -602,9 +602,10 @@ namespace winrt::TerminalApp::implementation
             // 3. When rearranging tabs (GH#7916) _OnTabItemsChanged is suppressed
             const auto tabSwitchMode = _settings.GlobalSettings().TabSwitcherMode();
 
+            winrt::TerminalApp::Tab newSelectedTab{ nullptr };
             if (tabSwitchMode == TabSwitcherMode::MostRecentlyUsed)
             {
-                const auto newSelectedTab = _mruTabs.GetAt(0);
+                newSelectedTab = _mruTabs.GetAt(0);
                 _UpdatedSelectedTab(newSelectedTab);
                 _tabView.SelectedItem(newSelectedTab.TabViewItem());
             }
@@ -625,7 +626,7 @@ namespace winrt::TerminalApp::implementation
                 const auto newSelectedIndex = std::clamp<int32_t>(tabIndex, 0, _tabs.Size() - 1);
                 // _UpdatedSelectedTab will do the work of setting up the new tab as
                 // the focused one, and unfocusing all the others.
-                auto newSelectedTab{ _tabs.GetAt(newSelectedIndex) };
+                newSelectedTab = _tabs.GetAt(newSelectedIndex);
                 _UpdatedSelectedTab(newSelectedTab);
 
                 // Also, we need to _manually_ set the SelectedItem of the tabView
@@ -634,6 +635,16 @@ namespace winrt::TerminalApp::implementation
                 // work correctly.
                 _tabView.SelectedItem(newSelectedTab.TabViewItem());
             }
+
+            // Notify wta of the new active tab. `_OnTabSelectionChanged` is
+            // suppressed by `_removing=true` for the rest of this scope, so
+            // without this explicit call the `tab_changed` event would never
+            // fire — wta would stay routed at the just-dropped tab id until
+            // the user's next manual tab switch. That left wta materialising
+            // DEFAULT_TAB_ID and the agent bar / view stuck on the closed
+            // tab's last state. Cheap and idempotent (deduped by
+            // `_lastNotifiedAgentTabId`).
+            _NotifyAgentTabChanged(_GetTabImpl(newSelectedTab));
         }
 
         // GH#5559 - If we were in the middle of a drag/drop, end it by clearing

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -516,15 +516,17 @@ namespace winrt::TerminalApp::implementation
                     const auto splitDir = _AgentPanePositionToSplitDirection(
                         _settings.GlobalSettings().AgentPanePosition());
                     rescueTab->SplitPaneAtRoot(splitDir, existingPane);
-                    // Keep it hidden in the rescue tab.
-                    if (const auto rescueRoot = rescueTab->GetRootPane())
-                    {
-                        if (!existingPane->IsHidden())
-                        {
-                            rescueRoot->HidePane(existingPane);
-                        }
-                    }
-                    // agent pane rescued from closing tab
+                    // Visibility is decided by `_ReconcileAgentPaneForActiveTab`
+                    // after the rescue tab becomes active: if the rescue tab
+                    // happens to be the new active tab AND wants the pane
+                    // (`Tab.AgentPaneOpen()` mirror == true, set by wta's
+                    // last projection for that tab), reconcile restores the
+                    // pane to visible. If it doesn't want the pane, reconcile
+                    // hides it. Pre-hiding here was wrong: when the rescue
+                    // tab was the user's "originally pane-open" tab, the
+                    // hide stuck because the subsequent reconcile path was
+                    // missing (closed-active-tab flow doesn't go through
+                    // `_OnTabSelectionChanged`).
                 }
             }
         }
@@ -636,15 +638,25 @@ namespace winrt::TerminalApp::implementation
                 _tabView.SelectedItem(newSelectedTab.TabViewItem());
             }
 
-            // Notify wta of the new active tab. `_OnTabSelectionChanged` is
-            // suppressed by `_removing=true` for the rest of this scope, so
-            // without this explicit call the `tab_changed` event would never
-            // fire — wta would stay routed at the just-dropped tab id until
-            // the user's next manual tab switch. That left wta materialising
-            // DEFAULT_TAB_ID and the agent bar / view stuck on the closed
-            // tab's last state. Cheap and idempotent (deduped by
-            // `_lastNotifiedAgentTabId`).
-            _NotifyAgentTabChanged(_GetTabImpl(newSelectedTab));
+            // Run the same reconcile chain that a normal tab switch goes
+            // through, since `_OnTabSelectionChanged` is suppressed by
+            // `_removing=true` for the rest of this scope.
+            // `_ReconcileAgentPaneForActiveTab` internally calls
+            // `_NotifyAgentTabChanged(activeTab)` (deduped via
+            // `_lastNotifiedAgentTabId`), which makes wta switch its
+            // active TabSession and emit an `agent_state_changed`
+            // snapshot for the new active tab. `OnAgentStateChanged`
+            // then mirrors the new `pane_open` onto `Tab.AgentPaneOpen`
+            // and reconciles again — collectively this restores the
+            // rescued (hidden) pane to visible when the rescue tab is
+            // the new active and wants the pane.
+            //
+            // Without this, closing the active tab left wta routed at
+            // DEFAULT_TAB_ID and the rescued pane hidden on the new
+            // active tab, with no event sequence to wake the C++ side
+            // up until the user's next manual tab switch.
+            _FlushPendingAgentRebuild();
+            _ReconcileAgentPaneForActiveTab();
         }
 
         // GH#5559 - If we were in the middle of a drag/drop, end it by clearing

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1690,12 +1690,19 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
-    // Broadcast a `set_view` event to wta so it switches its TUI view
-    // (Chat / Agents). Used by Ctrl+Shift+/ to drive the wta into the
-    // Agents (session list) view when the agent pane is already alive.
-    // For a fresh pane the same effect is achieved via the
-    // `--initial-view` CLI flag passed to wta on spawn.
-    void TerminalPage::_BroadcastAgentSetView(std::string_view view)
+    // Ask wta to switch its TUI view (chat / sessions). One half of a
+    // request/ack pair — wta applies the change and echoes it back via a
+    // `view_changed` event handled by `OnAgentViewChanged`, which is the
+    // sole writer of `_agentSessionsViewActive` and the agent bar's
+    // session/chat label. We do NOT update local view state here; doing so
+    // would defeat the single-owner invariant (wta owns per-tab view; this
+    // is what made `_agentSessionsViewActive` go out of sync with the
+    // active tab's actual view in the multi-tab desync bug).
+    //
+    // For a fresh pane the same effect is achieved via the `--initial-view`
+    // CLI flag passed to wta on spawn — wta then emits the initial
+    // `view_changed` itself once its main loop is up.
+    void TerminalPage::_RequestAgentView(std::string_view view)
     {
         Json::Value evt;
         evt["type"] = "event";
@@ -1709,25 +1716,10 @@ namespace winrt::TerminalApp::implementation
         evt["params"] = params;
         Json::StreamWriterBuilder wb;
         wb["indentation"] = "";
-        _agentPaneLog(std::string{ "broadcasting set_view event: view=" } + std::string{ view });
+        _agentPaneLog(std::string{ "requesting set_view: view=" } + std::string{ view });
         ProtocolVtSequenceReceived.raise(
             *this,
             winrt::to_hstring(Json::writeString(wb, evt)));
-
-        // Mirror the wta-side view switch on the C++ agent bar: in sessions
-        // view, the bar replaces "<agent> <version>" with "Agent sessions"
-        // and hides the agent logo. Tied to _BroadcastAgentSetView (and not
-        // _agentSessionsViewActive directly) because every keyboard- or
-        // icon-driven switch we care about flows through here; the few
-        // remaining `_agentSessionsViewActive = false` sites are pane-closed
-        // paths where the bar is going away anyway.
-        if (const auto pane = _FindAgentPane())
-        {
-            if (const auto agent = pane->GetContent().try_as<winrt::TerminalApp::AgentPaneContent>())
-            {
-                agent.SetSessionsView(view == "sessions");
-            }
-        }
     }
 
     // Reset every tab's AgentPaneOpen() flag. Called when the shared pane is
@@ -2396,9 +2388,10 @@ namespace winrt::TerminalApp::implementation
 
                 // Order matters: tab_changed (raised inside reconcile via
                 // _NotifyAgentTabChanged) must reach wta before set_view so
-                // the view switch lands on the right TabSession.
-                _BroadcastAgentSetView("sessions");
-                _agentSessionsViewActive = true;
+                // the view switch lands on the right TabSession. Request
+                // only — the resulting `view_changed` from wta will land in
+                // `OnAgentViewChanged` and flip `_agentSessionsViewActive`.
+                _RequestAgentView("sessions");
                 _UpdateBottomBarState();
                 return;
             }
@@ -2424,11 +2417,12 @@ namespace winrt::TerminalApp::implementation
                 // hidden, so wta retains its previous view). Without this
                 // the user would press the chat key and still see the
                 // session list.
-                _BroadcastAgentSetView("chat");
+                _RequestAgentView("chat");
             }
-            // Toggle path opens to chat (default) or hides the pane —
-            // either way the sessions view is no longer active.
-            _agentSessionsViewActive = false;
+            // No direct flag write here: `_agentSessionsViewActive` is
+            // managed by `OnAgentViewChanged` (for the open path, wta will
+            // echo `view_changed("chat")`; for the hide path, the flag is
+            // gated out of the bottom bar by `_agentPaneVisible == false`).
             _UpdateBottomBarState();
             return;
         }
@@ -2591,24 +2585,17 @@ namespace winrt::TerminalApp::implementation
         // via --owner-tab-id in the cmdline. Tab switches from here on
         // flow through _ReconcileAgentPaneForActiveTab.
 
-        // New pane: wta starts in whichever view --initial-view requested
-        // (chat by default; sessions when Ctrl+Shift+/ triggered the open).
-        _agentSessionsViewActive = intoSessionsView;
-
-        // Mirror that view on the new agent bar's label so the title reads
-        // "Agent sessions" from the very first frame. Without this the bar
-        // would briefly show "<agent> <version>" before any user input,
-        // which is misleading when the wta TUI below is the session list.
-        if (intoSessionsView)
-        {
-            if (const auto& content{ newPane->GetContent() })
-            {
-                if (const auto agent = content.try_as<winrt::TerminalApp::AgentPaneContent>())
-                {
-                    agent.SetSessionsView(true);
-                }
-            }
-        }
+        // No optimistic write of `_agentSessionsViewActive` here: wta is
+        // the sole owner of view state. wta is starting up with the
+        // `--initial-view` we baked into its cmdline, and it emits the
+        // initial `view_changed` from its main loop (see main.rs's
+        // post-`--initial-view` projection call). That event lands in
+        // `OnAgentViewChanged`, which flips the flag and updates the bar
+        // label. There is a brief visual lag while wta starts up — the
+        // bar shows the default "<agent> <version>" until wta's first
+        // `view_changed` — which is an accepted tradeoff for keeping
+        // the C++ flag's writer set to one (`OnAgentViewChanged`) and
+        // making view-state desync architecturally impossible.
 
         _UpdateBottomBarState();
     }
@@ -3887,9 +3874,13 @@ namespace winrt::TerminalApp::implementation
 
         if (visibleOnActiveTab && _agentSessionsViewActive)
         {
+            // Hide path: pane goes invisible on this tab. The
+            // `_agentPaneVisible` gate in `_UpdateBottomBarState` makes
+            // both chat/sessions highlights drop, so we don't need to
+            // clear `_agentSessionsViewActive` ourselves — wta still
+            // owns the view; on reopen the next `view_changed` corrects it.
             activeTab->AgentPaneOpen(false);
             _ReconcileAgentPaneForActiveTab();
-            _agentSessionsViewActive = false;
             _UpdateBottomBarState();
             return;
         }
@@ -4420,17 +4411,25 @@ namespace winrt::TerminalApp::implementation
 
     // Inbound event from WTA: {method:"view_changed", params:{view}}.
     //
-    // wta is the sole driver for two view transitions C++ can't observe by
-    // itself: Esc out of the Agents picker and the `/sessions` slash command.
-    // Both flip wta's internal `current_view` without going through
-    // `_BroadcastAgentSetView`, so without this echo the agent bar title
-    // would stay on "Agent sessions" after Esc, or fail to switch to it
-    // after `/sessions`, and the bottom bar's sessions/chat highlight (which
-    // reads `_agentSessionsViewActive`) would drift out of sync.
+    // **Single-writer handler** for `_agentSessionsViewActive` and the
+    // agent bar's session/chat title. wta is the sole owner of per-tab
+    // `current_view`, and it pushes this event whenever active-tab view
+    // state changes:
+    //   - On `tab_changed` (active tab swap; via `project_active_tab_state`
+    //     in `switch_tab_session`).
+    //   - On `set_view` (C++-originated request; wta echoes back).
+    //   - On Esc out of Agents view, `/sessions` slash command,
+    //     `load_session`, and once at startup after `--initial-view`.
     //
-    // Critically we do NOT call `_BroadcastAgentSetView` here — that would
-    // emit `set_view` back to wta and create a feedback loop. We only mirror
-    // the new view onto C++ state.
+    // C++ never writes `_agentSessionsViewActive` from its own code paths
+    // (the lone exception is the pane-Closed handler, where wta is dead
+    // and there is no one to send `view_changed`). This is what makes
+    // view-state desync architecturally impossible — a single writer means
+    // the flag can only ever reflect wta's last reported view.
+    //
+    // Don't request anything back here. The flag/bar mutation below is the
+    // terminal state of the round-trip; emitting `set_view` would just
+    // bounce the same view back and waste a hop.
     void TerminalPage::OnAgentViewChanged(hstring eventJson)
     {
         Json::Value evt;

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1690,33 +1690,46 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
-    // Ask wta to switch its TUI view (chat / sessions). One half of a
-    // request/ack pair — wta applies the change and echoes it back via a
-    // `view_changed` event handled by `OnAgentViewChanged`, which is the
-    // sole writer of `_agentSessionsViewActive` and the agent bar's
-    // session/chat label. We do NOT update local view state here; doing so
-    // would defeat the single-owner invariant (wta owns per-tab view; this
-    // is what made `_agentSessionsViewActive` go out of sync with the
-    // active tab's actual view in the multi-tab desync bug).
+    // Single C++ → wta request for changing per-tab agent-pane UI state on
+    // the active tab. Half of a request/ack pair: wta applies the requested
+    // fields, then echoes the full snapshot back via `agent_state_changed`,
+    // which `OnAgentStateChanged` mirrors onto `_agentSessionsViewActive`
+    // and `Tab.AgentPaneOpen`. We never write those mirrors locally — wta
+    // is the sole owner of per-tab UI state, which is what makes desync
+    // architecturally impossible.
     //
-    // For a fresh pane the same effect is achieved via the `--initial-view`
-    // CLI flag passed to wta on spawn — wta then emits the initial
-    // `view_changed` itself once its main loop is up.
-    void TerminalPage::_RequestAgentView(std::string_view view)
+    // Both arguments are optional. Pass only the fields you actually want
+    // to change; the rest are left as-is on wta's side. `std::nullopt` for
+    // both is a no-op (don't call us). For a fresh pane the spawn flow
+    // bakes the initial state into wta's cmdline (`--initial-view`, plus
+    // the owner tab is seeded with `pane_open=true` at startup) — wta
+    // emits the first `agent_state_changed` from its main loop.
+    void TerminalPage::_RequestAgentState(std::optional<std::string_view> view,
+                                          std::optional<bool> paneOpen)
     {
         Json::Value evt;
         evt["type"] = "event";
-        evt["method"] = "set_view";
+        evt["method"] = "set_agent_state";
         Json::Value params;
-        params["view"] = std::string{ view };
         // Scope to this WT window so multi-window users with multiple
         // wta processes don't cross-talk. wta ignores the event when its
         // own window_id is known and doesn't match.
         params["window_id"] = std::to_string(_WindowProperties.WindowId());
+        std::string logSuffix;
+        if (view.has_value())
+        {
+            params["view"] = std::string{ *view };
+            logSuffix += " view=" + std::string{ *view };
+        }
+        if (paneOpen.has_value())
+        {
+            params["pane_open"] = *paneOpen;
+            logSuffix += " pane_open=" + std::string{ *paneOpen ? "true" : "false" };
+        }
         evt["params"] = params;
         Json::StreamWriterBuilder wb;
         wb["indentation"] = "";
-        _agentPaneLog(std::string{ "requesting set_view: view=" } + std::string{ view });
+        _agentPaneLog(std::string{ "requesting set_agent_state:" } + logSuffix);
         ProtocolVtSequenceReceived.raise(
             *this,
             winrt::to_hstring(Json::writeString(wb, evt)));
@@ -2365,18 +2378,17 @@ namespace winrt::TerminalApp::implementation
             if (intoSessionsView)
             {
                 // Open-into-sessions semantics (Ctrl+Shift+/): never toggle
-                // closed. Force the active tab's flag on, reconcile (which
-                // moves the pane to the active tab and emits tab_changed),
-                // focus it, then broadcast set_view so wta switches the
-                // *new* active tab's TabSession into the Agents view.
+                // closed. Ask wta to flip both `view=sessions` and
+                // `pane_open=true` on the active tab. The echoing
+                // `agent_state_changed` lands in `OnAgentStateChanged`,
+                // which sets `Tab.AgentPaneOpen=true` and reconciles
+                // (relocates the shared pane to the active tab + makes
+                // it visible).
                 const auto activeTab = _GetFocusedTabImpl();
                 if (!activeTab)
                 {
                     return;
                 }
-                activeTab->AgentPaneOpen(true);
-                _agentPaneLog("intoSessionsView: forcing active tab AgentPaneOpen=true");
-                _ReconcileAgentPaneForActiveTab();
 
                 if (const auto pane = _FindAgentPane())
                 {
@@ -2386,44 +2398,28 @@ namespace winrt::TerminalApp::implementation
                     }
                 }
 
-                // Order matters: tab_changed (raised inside reconcile via
-                // _NotifyAgentTabChanged) must reach wta before set_view so
-                // the view switch lands on the right TabSession. Request
-                // only — the resulting `view_changed` from wta will land in
-                // `OnAgentViewChanged` and flip `_agentSessionsViewActive`.
-                _RequestAgentView("sessions");
-                _UpdateBottomBarState();
+                _RequestAgentState("sessions", /*pane_open*/ true);
                 return;
             }
 
-            // Empty prompt: per-tab toggle. Flip the active tab's flag, then
-            // reconcile the shared pane against it. The pane follows the
-            // active tab — switching tabs preserves each tab's open/closed
-            // state independently.
+            // Empty prompt: per-tab toggle. We read the local mirror
+            // (last reported by wta) to decide direction; the actual flip
+            // and visible reconcile happen via the `agent_state_changed`
+            // echo. Pane relocation/show/hide flows out of
+            // `OnAgentStateChanged → _ReconcileAgentPaneForActiveTab`.
             const auto activeTab = _GetFocusedTabImpl();
             if (!activeTab)
             {
                 return;
             }
             const bool wantOpen = !activeTab->AgentPaneOpen();
-            activeTab->AgentPaneOpen(wantOpen);
-            _agentPaneLog(std::string{ "toggle: active tab AgentPaneOpen=" } + (wantOpen ? "true" : "false"));
-            _ReconcileAgentPaneForActiveTab();
-            if (wantOpen)
-            {
-                // Transitioning hidden → visible via the chat keybinding
-                // (Ctrl+Shift+.). Force wta into chat view in case it was
-                // last left in the Agents view (the pane stays alive when
-                // hidden, so wta retains its previous view). Without this
-                // the user would press the chat key and still see the
-                // session list.
-                _RequestAgentView("chat");
-            }
-            // No direct flag write here: `_agentSessionsViewActive` is
-            // managed by `OnAgentViewChanged` (for the open path, wta will
-            // echo `view_changed("chat")`; for the hide path, the flag is
-            // gated out of the bottom bar by `_agentPaneVisible == false`).
-            _UpdateBottomBarState();
+            _agentPaneLog(std::string{ "toggle: requesting pane_open=" } + (wantOpen ? "true" : "false"));
+            // When opening via Ctrl+Shift+., also force the view to chat
+            // (pane may have been left in Agents view from a previous
+            // `/sessions` / Ctrl+Shift+/). When closing, leave view as-is
+            // so reopening preserves the user's last view.
+            _RequestAgentState(wantOpen ? std::optional<std::string_view>{ "chat" } : std::nullopt,
+                               wantOpen);
             return;
         }
 
@@ -2578,24 +2574,32 @@ namespace winrt::TerminalApp::implementation
             content.Focus(FocusState::Programmatic);
         }
 
-        // The user explicitly asked to open it on this tab.
+        // Spawn boundary write: wta isn't running yet, so there is no one
+        // to send `agent_state_changed` back. Seed the mirror locally
+        // (`Tab.AgentPaneOpen=true`) so reconcile doesn't immediately
+        // hide the freshly-created pane. wta is being launched with
+        // `--owner-tab-id <this tab>` and seeds its TabSession's
+        // `pane_open=true` for that tab at startup, so when its initial
+        // `agent_state_changed` arrives it confirms (not contradicts)
+        // the value we wrote here. This is the only runtime path where
+        // C++ writes `Tab.AgentPaneOpen` directly; the symmetric pane
+        // teardown boundary is in the pane-Closed handler.
         activeTab->AgentPaneOpen(true);
 
         // No tab_changed needed here — wta was already told its owner tab
         // via --owner-tab-id in the cmdline. Tab switches from here on
         // flow through _ReconcileAgentPaneForActiveTab.
 
-        // No optimistic write of `_agentSessionsViewActive` here: wta is
-        // the sole owner of view state. wta is starting up with the
-        // `--initial-view` we baked into its cmdline, and it emits the
-        // initial `view_changed` from its main loop (see main.rs's
-        // post-`--initial-view` projection call). That event lands in
-        // `OnAgentViewChanged`, which flips the flag and updates the bar
-        // label. There is a brief visual lag while wta starts up — the
-        // bar shows the default "<agent> <version>" until wta's first
-        // `view_changed` — which is an accepted tradeoff for keeping
-        // the C++ flag's writer set to one (`OnAgentViewChanged`) and
-        // making view-state desync architecturally impossible.
+        // `_agentSessionsViewActive` is NOT seeded here. wta is starting
+        // up with the `--initial-view` we baked into its cmdline and
+        // emits the initial `agent_state_changed` from its main loop
+        // (see main.rs's post-`--initial-view` projection call). That
+        // event lands in `OnAgentStateChanged` and flips the flag. There
+        // is a brief visual lag while wta starts up — the bar shows the
+        // default "<agent> <version>" until wta's first
+        // `agent_state_changed` — which is an accepted tradeoff for
+        // keeping the C++ flag's writer set to one (`OnAgentStateChanged`)
+        // and making view-state desync architecturally impossible.
 
         _UpdateBottomBarState();
     }
@@ -3874,14 +3878,11 @@ namespace winrt::TerminalApp::implementation
 
         if (visibleOnActiveTab && _agentSessionsViewActive)
         {
-            // Hide path: pane goes invisible on this tab. The
-            // `_agentPaneVisible` gate in `_UpdateBottomBarState` makes
-            // both chat/sessions highlights drop, so we don't need to
-            // clear `_agentSessionsViewActive` ourselves — wta still
-            // owns the view; on reopen the next `view_changed` corrects it.
-            activeTab->AgentPaneOpen(false);
-            _ReconcileAgentPaneForActiveTab();
-            _UpdateBottomBarState();
+            // Hide path: ask wta to flip pane_open=false on this tab.
+            // wta echoes `agent_state_changed{pane_open:false}` which
+            // lands in `OnAgentStateChanged`, sets the mirror, and
+            // reconciles (hides the pane on this tab).
+            _RequestAgentState(std::nullopt, /*pane_open*/ false);
             return;
         }
 
@@ -4409,28 +4410,33 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
-    // Inbound event from WTA: {method:"view_changed", params:{view}}.
+    // Inbound event from WTA:
+    //   {method:"agent_state_changed", params:{view, pane_open}}
     //
-    // **Single-writer handler** for `_agentSessionsViewActive` and the
-    // agent bar's session/chat title. wta is the sole owner of per-tab
-    // `current_view`, and it pushes this event whenever active-tab view
-    // state changes:
-    //   - On `tab_changed` (active tab swap; via `project_active_tab_state`
+    // **Single-writer handler** for all per-tab agent-pane UI state that
+    // C++ caches as global per-pane state. wta is the sole owner of every
+    // field carried here; we never write the mirrors from any other code
+    // path (the lone exception is the pane-Closed handler, where wta is
+    // dead and there is no one left to send projections). This is what
+    // makes view-state / pane-visibility desync architecturally
+    // impossible — a single writer means the mirrors can only ever
+    // reflect wta's last reported snapshot.
+    //
+    // wta pushes this event whenever active-tab state changes:
+    //   - `tab_changed` (active tab swap; via `project_active_tab_state`
     //     in `switch_tab_session`).
-    //   - On `set_view` (C++-originated request; wta echoes back).
-    //   - On Esc out of Agents view, `/sessions` slash command,
-    //     `load_session`, and once at startup after `--initial-view`.
+    //   - `set_agent_state` (C++-originated request; wta echoes back).
+    //   - Esc out of Agents view, `/sessions` slash command,
+    //     `load_session`, Ctrl+C×2 reset, and once at startup after
+    //     `--initial-view`.
     //
-    // C++ never writes `_agentSessionsViewActive` from its own code paths
-    // (the lone exception is the pane-Closed handler, where wta is dead
-    // and there is no one to send `view_changed`). This is what makes
-    // view-state desync architecturally impossible — a single writer means
-    // the flag can only ever reflect wta's last reported view.
+    // Don't send anything back here. The mirror updates below are the
+    // terminal state of the round-trip; emitting `set_agent_state` would
+    // just bounce the same snapshot back.
     //
-    // Don't request anything back here. The flag/bar mutation below is the
-    // terminal state of the round-trip; emitting `set_view` would just
-    // bounce the same view back and waste a hop.
-    void TerminalPage::OnAgentViewChanged(hstring eventJson)
+    // Future per-tab UI state plugs in as another field on `params` —
+    // parse it here, update its mirror, no new IDL route or handler needed.
+    void TerminalPage::OnAgentStateChanged(hstring eventJson)
     {
         Json::Value evt;
         Json::CharReaderBuilder rb;
@@ -4441,26 +4447,51 @@ namespace winrt::TerminalApp::implementation
             return;
         }
         const auto& params = evt["params"];
-        if (!params.isObject() || !params.isMember("view") || !params["view"].isString())
+        if (!params.isObject())
         {
             return;
         }
-        const auto view = params["view"].asString();
-        const bool sessions = (view == "sessions");
 
-        _agentPaneLog(std::string{ "OnAgentViewChanged: view=" } + view);
+        std::string logSuffix;
 
-        _agentSessionsViewActive = sessions;
-
-        if (const auto pane = _FindAgentPane())
+        // view: drives `_agentSessionsViewActive` and the agent bar
+        // (`AgentPaneContent::SetSessionsView`).
+        if (params.isMember("view") && params["view"].isString())
         {
-            if (const auto agent = pane->GetContent().try_as<winrt::TerminalApp::AgentPaneContent>())
+            const auto view = params["view"].asString();
+            const bool sessions = (view == "sessions");
+            _agentSessionsViewActive = sessions;
+            if (const auto pane = _FindAgentPane())
             {
-                agent.SetSessionsView(sessions);
+                if (const auto agent = pane->GetContent().try_as<winrt::TerminalApp::AgentPaneContent>())
+                {
+                    agent.SetSessionsView(sessions);
+                }
             }
+            logSuffix += " view=" + view;
         }
 
+        // pane_open: drives `Tab.AgentPaneOpen` on the active tab. Then
+        // reconcile so the actual XAML pane visibility / placement
+        // matches the new intent (relocate from another tab, restore
+        // from hidden, or hide on this tab).
+        bool didReconcile = false;
+        if (params.isMember("pane_open") && params["pane_open"].isBool())
+        {
+            const bool open = params["pane_open"].asBool();
+            if (const auto activeTab = _GetFocusedTabImpl())
+            {
+                activeTab->AgentPaneOpen(open);
+            }
+            _ReconcileAgentPaneForActiveTab();
+            didReconcile = true;
+            logSuffix += std::string{ " pane_open=" } + (open ? "true" : "false");
+        }
+
+        _agentPaneLog(std::string{ "OnAgentStateChanged:" } + logSuffix);
+
         _UpdateBottomBarState();
+        (void)didReconcile; // reserved for future "only reconcile when needed" heuristics
     }
 
     // Inbound event from WTA: {method:"close_agent_pane", params:{...}}.
@@ -4529,30 +4560,19 @@ namespace winrt::TerminalApp::implementation
         _agentPaneLog("OnCloseAgentPaneRequested: other tabs still want the pane — hide + reset this tab");
 
         // Tell wta to drop this tab's ACP session + conversation. Fire this
-        // BEFORE flipping AgentPaneOpen so wta sees the reset request while
-        // its tab_to_session for ownerTab is still populated. (Order isn't
-        // strict — the events are queued — but it's the natural sequence.)
+        // BEFORE the pane-open flip so wta sees the reset request while
+        // its tab_to_session for ownerTab is still populated.
         _NotifyAgentTabReset(ownerTab->StableId());
 
-        ownerTab->AgentPaneOpen(false);
-
-        // Only hide if the pane is currently visible on the owner tab. If
-        // it's already hidden (e.g. user switched tabs between Ctrl+C and
-        // this event), the flag-flip above is enough; reconcile will keep
-        // it hidden the next time this tab becomes active.
-        if (!agentPane->IsHidden())
-        {
-            if (const auto rootPane = ownerTab->GetRootPane())
-            {
-                rootPane->HidePane(agentPane);
-                if (const auto target = _FindSourceOfAgentPaneId(rootPane))
-                {
-                    ownerTab->FocusPane(target.value());
-                }
-            }
-        }
-
-        _UpdateBottomBarState();
+        // ownerTab is the tab whose pane TUI raised Ctrl+C×2 — it's the
+        // currently active tab from wta's perspective (the pane is what
+        // had focus to receive the keypress). Ask wta to flip its
+        // pane_open to false; the echoing `agent_state_changed` lands
+        // in `OnAgentStateChanged`, which flips the mirror and reconciles
+        // (hiding the pane on this tab). Don't HidePane locally — that
+        // would race the round-trip and could leave the C++ mirror and
+        // XAML state out of sync if a tab switch happens in between.
+        _RequestAgentState(std::nullopt, /*pane_open*/ false);
     }
 
     // Send {method:"autofix_execute",params:{pane_id}} over the outbound
@@ -4650,8 +4670,14 @@ namespace winrt::TerminalApp::implementation
             return;
         }
 
-        // Step 2: the new tab is now focused. Flip its AgentPaneOpen=true
-        // and reconcile to move the shared agent pane onto it.
+        // Step 2: the new tab is now focused. `_OpenNewTab` triggers a
+        // tab_changed flowing to wta (via reconcile inside
+        // _OnTabSelectionChanged), so wta's active TabSession is now this
+        // new tab — by the time the `set_agent_state` below arrives, wta
+        // routes it to the right TabSession. wta will echo back
+        // `agent_state_changed{pane_open:true}` which lands in
+        // `OnAgentStateChanged`, sets the mirror, and reconciles (moving
+        // the shared agent pane onto the new tab).
         const auto newTab = _GetFocusedTabImpl();
         if (!newTab)
         {
@@ -4664,8 +4690,7 @@ namespace winrt::TerminalApp::implementation
             _agentPaneLog("OnResumeInNewAgentTabRequested: new tab has empty StableId");
             return;
         }
-        newTab->AgentPaneOpen(true);
-        _ReconcileAgentPaneForActiveTab();
+        _RequestAgentState(std::nullopt, /*pane_open*/ true);
 
         // Step 3: publish load_session back to wta with the new tab's
         // StableId. ProtocolVtSequenceReceived fans this out to subscribed

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1715,6 +1715,21 @@ namespace winrt::TerminalApp::implementation
         // wta processes don't cross-talk. wta ignores the event when its
         // own window_id is known and doesn't match.
         params["window_id"] = std::to_string(_WindowProperties.WindowId());
+
+        // Always carry the active tab's StableId so wta routes the
+        // mutation to the right TabSession. Without `tab_id`, wta would
+        // fall back to its own active-tab pointer, which can lag behind
+        // a `tab_changed` we just sent (e.g. resume-in-new-tab fires
+        // tab_changed then set_agent_state back-to-back).
+        if (const auto activeTab = _GetFocusedTabImpl())
+        {
+            const auto stableId = activeTab->StableId();
+            if (!stableId.empty())
+            {
+                params["tab_id"] = winrt::to_string(stableId);
+            }
+        }
+
         std::string logSuffix;
         if (view.has_value())
         {
@@ -4474,7 +4489,9 @@ namespace winrt::TerminalApp::implementation
         // pane_open: drives `Tab.AgentPaneOpen` on the active tab. Then
         // reconcile so the actual XAML pane visibility / placement
         // matches the new intent (relocate from another tab, restore
-        // from hidden, or hide on this tab).
+        // from hidden, or hide on this tab). Reconcile internally calls
+        // `_UpdateBottomBarState`, so skip the redundant call below
+        // when we took the reconcile branch.
         bool didReconcile = false;
         if (params.isMember("pane_open") && params["pane_open"].isBool())
         {
@@ -4490,8 +4507,10 @@ namespace winrt::TerminalApp::implementation
 
         _agentPaneLog(std::string{ "OnAgentStateChanged:" } + logSuffix);
 
-        _UpdateBottomBarState();
-        (void)didReconcile; // reserved for future "only reconcile when needed" heuristics
+        if (!didReconcile)
+        {
+            _UpdateBottomBarState();
+        }
     }
 
     // Inbound event from WTA: {method:"close_agent_pane", params:{...}}.

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -206,7 +206,7 @@ namespace winrt::TerminalApp::implementation
         void OnAutofixStateChanged(hstring eventJson);
         void OnAgentStatusChanged(hstring eventJson);
         void OnCloseAgentPaneRequested(hstring eventJson);
-        void OnAgentViewChanged(hstring eventJson);
+        void OnAgentStateChanged(hstring eventJson);
         void OnResumeInNewAgentTabRequested(hstring eventJson);
 
         til::property_changed_event PropertyChanged;
@@ -678,7 +678,8 @@ namespace winrt::TerminalApp::implementation
         static void NTAPI _OnAgentPaneWtaExit(PVOID context, BOOLEAN timedOut) noexcept;
         void _OpenOrReuseAgentPane(const winrt::hstring& prompt, bool intoSessionsView = false);
         void _FocusAgentPane();
-        void _RequestAgentView(std::string_view view);
+        void _RequestAgentState(std::optional<std::string_view> view,
+                                std::optional<bool> paneOpen);
         void _RepositionAgentPanes();
         static winrt::Microsoft::Terminal::Settings::Model::SplitDirection _AgentPanePositionToSplitDirection(const winrt::hstring& position);
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -678,7 +678,7 @@ namespace winrt::TerminalApp::implementation
         static void NTAPI _OnAgentPaneWtaExit(PVOID context, BOOLEAN timedOut) noexcept;
         void _OpenOrReuseAgentPane(const winrt::hstring& prompt, bool intoSessionsView = false);
         void _FocusAgentPane();
-        void _BroadcastAgentSetView(std::string_view view);
+        void _RequestAgentView(std::string_view view);
         void _RepositionAgentPanes();
         static winrt::Microsoft::Terminal::Settings::Model::SplitDirection _AgentPanePositionToSplitDirection(const winrt::hstring& position);
 

--- a/src/cascadia/TerminalApp/TerminalPage.idl
+++ b/src/cascadia/TerminalApp/TerminalPage.idl
@@ -137,11 +137,14 @@ namespace TerminalApp
         // The page tears down the shared agent pane; wta dies with its ConPty.
         void OnCloseAgentPaneRequested(String eventJson);
 
-        // Inbound event from WTA carrying {method:"view_changed",params:{view}}.
-        // Emitted when the wta TUI flips its internal view (Esc out of Agents,
-        // `/sessions` slash command). Mirrors the new view onto C++ state so
-        // the agent bar title + bottom bar highlight stay in sync.
-        void OnAgentViewChanged(String eventJson);
+        // Inbound event from WTA carrying
+        // {method:"agent_state_changed",params:{view,pane_open}}.
+        // Unified active-tab snapshot of every piece of per-tab agent-pane
+        // UI state that C++ stores as global per-pane state. The single
+        // writer of `_agentSessionsViewActive` and `Tab.AgentPaneOpen` for
+        // the active tab; any future per-tab UI state plugs in as another
+        // field in the same payload, no new IDL route needed.
+        void OnAgentStateChanged(String eventJson);
 
         // Inbound event from WTA carrying
         // {method:"resume_in_new_agent_tab",params:{session_id,cwd}}.

--- a/src/cascadia/TerminalProtocol/ProtocolParsing.h
+++ b/src/cascadia/TerminalProtocol/ProtocolParsing.h
@@ -34,7 +34,7 @@ namespace Microsoft::Terminal::Protocol::Parsing
         AutofixState,         // Direct to TerminalPage, no broadcast
         AgentStatus,          // Direct to TerminalPage, no broadcast
         CloseAgentPane,       // Direct to TerminalPage, no broadcast
-        ViewChanged,          // Direct to TerminalPage, no broadcast
+        AgentState,           // Direct to TerminalPage, no broadcast — unified per-tab agent-pane UI snapshot (view + pane_open + ...)
         ResumeInNewAgentTab,  // Direct to TerminalPage, no broadcast
         Broadcast,            // Normalize envelope + broadcast to all subscribers
         Invalid               // Failed validation
@@ -77,9 +77,9 @@ namespace Microsoft::Terminal::Protocol::Parsing
             {
                 return SendEventRoute::CloseAgentPane;
             }
-            if (method == "view_changed")
+            if (method == "agent_state_changed")
             {
-                return SendEventRoute::ViewChanged;
+                return SendEventRoute::AgentState;
             }
             if (method == "resume_in_new_agent_tab")
             {

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
@@ -686,11 +686,13 @@ void TerminalProtocolComServer::SendEvent(winrt::hstring const& eventJson)
         // thread and tell TerminalPage to tear down the shared agent pane.
         _dispatchCloseAgentPaneToPage(eventJson);
         return;
-    case ProtocolParsing::SendEventRoute::ViewChanged:
-        // wta TUI flipped its internal view (Esc out of session view,
-        // `/sessions` slash command). C++ mirrors the new view onto the
-        // agent bar title + the bottom bar's sessions/chat highlight.
-        _dispatchViewChangedToPage(eventJson);
+    case ProtocolParsing::SendEventRoute::AgentState:
+        // Unified per-tab agent-pane UI snapshot from wta. Drives
+        // `_agentSessionsViewActive` (bar title + bottom-bar highlight)
+        // and `Tab.AgentPaneOpen` (which tab wants the shared pane
+        // visible). One handler, one event, future per-tab state plugs
+        // in as another field on the same payload.
+        _dispatchAgentStateChangedToPage(eventJson);
         return;
     case ProtocolParsing::SendEventRoute::ResumeInNewAgentTab:
         // Session view's Shift+Enter handler in the wta TUI. Carries
@@ -822,7 +824,7 @@ void TerminalProtocolComServer::_dispatchCloseAgentPaneToPage(const winrt::hstri
     }
 }
 
-void TerminalProtocolComServer::_dispatchViewChangedToPage(const winrt::hstring& eventJson)
+void TerminalProtocolComServer::_dispatchAgentStateChangedToPage(const winrt::hstring& eventJson)
 {
     if (!s_emperor)
     {
@@ -830,7 +832,7 @@ void TerminalProtocolComServer::_dispatchViewChangedToPage(const winrt::hstring&
     }
     // Same fan-out shape as the other dispatchers: the agent pane lives in
     // exactly one window, but we don't know which from here, and pages with
-    // no agent pane no-op the call (see OnAgentViewChanged).
+    // no agent pane no-op the call (see OnAgentStateChanged).
     for (const auto& host : s_emperor->GetWindows())
     {
         auto page = _getPage(host.get());
@@ -848,7 +850,7 @@ void TerminalProtocolComServer::_dispatchViewChangedToPage(const winrt::hstring&
             [page, eventJson]() {
                 try
                 {
-                    page.OnAgentViewChanged(eventJson);
+                    page.OnAgentStateChanged(eventJson);
                 }
                 catch (...)
                 {

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.h
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.h
@@ -133,10 +133,11 @@ private:
     // the user presses Ctrl+C twice. TerminalPage tears down the agent pane.
     static void _dispatchCloseAgentPaneToPage(const winrt::hstring& eventJson);
 
-    // Same shape, for {method:"view_changed"} emitted by the wta TUI when its
-    // internal view flips (Esc out of Agents, `/sessions` slash command).
-    // TerminalPage mirrors the new view onto its agent bar + bottom bar state.
-    static void _dispatchViewChangedToPage(const winrt::hstring& eventJson);
+    // Same shape, for {method:"agent_state_changed"} — the unified per-tab
+    // agent-pane UI snapshot from wta. TerminalPage::OnAgentStateChanged
+    // is the single writer of `_agentSessionsViewActive` (view) and
+    // `Tab.AgentPaneOpen` (pane visibility intent) for the active tab.
+    static void _dispatchAgentStateChangedToPage(const winrt::hstring& eventJson);
 
     // Same shape, for {method:"resume_in_new_agent_tab"} emitted by the wta
     // TUI on Shift+Enter in the session view. TerminalPage creates a new

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -3251,12 +3251,10 @@ impl App {
                         "tab_changed event received"
                     );
                     if let Some(new_tab_id) = params.get("tab_id").and_then(|v| v.as_str()) {
+                        // switch_tab_session calls project_active_tab_state
+                        // at its end — that pushes the new tab's view AND
+                        // autofix bar snapshot to C++ in one shot.
                         self.switch_tab_session(new_tab_id.to_string());
-                        // Re-emit the now-active tab's autofix bar
-                        // snapshot so the C++ bottom bar matches the new
-                        // tab (Idle if it has no in-flight autofix, the
-                        // cached state otherwise).
-                        self.project_bar_for_active_tab();
                     } else {
                         tracing::warn!(target: "tab_session", "tab_changed: missing tab_id in params");
                     }
@@ -3344,6 +3342,16 @@ impl App {
                         )));
                         tab.scroll_to_bottom();
                     }
+                    // If the load_session target IS the active tab, push the
+                    // (now Chat) view to C++ so the bar drops the "Agent
+                    // sessions" label that the user was looking at when they
+                    // hit Shift+Enter on a session row. When the target is a
+                    // not-yet-active tab (e.g. WT just created a fresh tab
+                    // and the `tab_changed` race still hasn't landed), the
+                    // imminent `tab_changed` to that tab will project then.
+                    if tab_id == self.active_tab_key() {
+                        self.project_active_tab_state();
+                    }
                     let _ = self.load_session_tx.send(LoadSessionForTab {
                         tab_id: tab_id.to_string(),
                         session_id: session_id.to_string(),
@@ -3352,9 +3360,20 @@ impl App {
                     return;
                 }
 
-                // set_view: WT broadcasts this from Ctrl+Shift+/ (or any
-                // future "open agent pane in <view>" action) to switch the
-                // active TabSession's TUI view. Absolute (not toggle).
+                // set_view: WT sends this from Ctrl+Shift+/ / Ctrl+Shift+.
+                // / agent-bar buttons to request a view switch. Absolute
+                // (not toggle).
+                //
+                // **Round-trip contract**: under the "wta is the sole owner
+                // of view state" architecture, C++ does NOT update its
+                // `_agentSessionsViewActive` flag when it sends set_view —
+                // it waits for the resulting `view_changed` (emitted by
+                // `project_active_tab_state` below) to update the flag,
+                // bar title, and bottom-bar highlight. This deliberately
+                // creates a small visual lag (one IPC round-trip), but in
+                // exchange the C++ flag has a single writer
+                // (`OnAgentViewChanged`) and view-state desync becomes
+                // architecturally impossible.
                 //
                 // Window-scoped: WT includes its own window_id; we ignore
                 // the event when our window_id is known and doesn't match,
@@ -3415,8 +3434,16 @@ impl App {
                         }
                         other => {
                             tracing::warn!(target: "set_view", view = other, "unknown view");
+                            // Unknown view — don't project a fabricated
+                            // state. The active tab's view is unchanged.
+                            return;
                         }
                     }
+                    // Echo the applied view back so C++ can update its
+                    // global flag (it does not write the flag locally
+                    // before sending set_view — see the round-trip
+                    // contract comment above).
+                    self.project_active_tab_state();
                     return;
                 }
 
@@ -4000,7 +4027,7 @@ impl App {
                 }
                 KeyCode::Esc => {
                     self.current_tab_mut().current_view = View::Chat;
-                    self.emit_view_changed("chat");
+                    self.project_active_tab_state();
                 }
                 _ => {}
             }
@@ -4602,7 +4629,7 @@ impl App {
                 // /sessions left the registry empty and rendered a blank view
                 // forever (state stuck at NotStarted, no Loading row, no rows).
                 self.ensure_history_loaded();
-                self.emit_view_changed("sessions");
+                self.project_active_tab_state();
             }
             CommandKind::Restart => {
                 // Full reconnect. Reset every tab: drop session_id (the
@@ -4726,6 +4753,14 @@ impl App {
             "switch_tab_session"
         );
         self.tab_id = Some(new_tab_id);
+
+        // The new active tab's `current_view` (and autofix bar) is now
+        // authoritative for the shared C++ agent pane. Re-emit so the bar
+        // title and bottom-bar highlight match the tab we just switched to;
+        // without this, C++'s global flag stays on the previous tab's view
+        // and the agent bar shows "Agent sessions" while the TUI below
+        // actually renders chat (or vice versa).
+        self.project_active_tab_state();
     }
 
     /// Drop the per-tab state for a tab that WT has just destroyed. Removes
@@ -5061,7 +5096,7 @@ impl App {
     // Per-tab projection: the bar shows the ACTIVE tab's autofix state. Each
     // emit_autofix_state_* stores the new snapshot on the target tab AND
     // only forwards to WT when the target tab is currently active. On
-    // tab_changed, `project_bar_for_active_tab` re-emits the new active
+    // tab_changed, `project_active_tab_state` re-emits the new active
     // tab's snapshot so the bar matches.
 
     fn emit_autofix_state_pending(&mut self, target_tab_id: &str, pane_id: &str, summary: &str) {
@@ -5260,12 +5295,6 @@ impl App {
         if target_tab_id == self.active_tab_key() {
             send_bar_event(&snapshot);
         }
-    }
-
-    /// Re-emit the active tab's bar snapshot to WT. Called after a
-    /// `tab_changed` event so the bar reflects the now-focused tab.
-    fn project_bar_for_active_tab(&self) {
-        send_bar_event(&self.current_tab().autofix.bar_snapshot);
     }
 
     fn armed_fix_preview(rec: &crate::coordinator::RecommendationSet) -> String {
@@ -6147,14 +6176,15 @@ impl App {
         send_wt_protocol_event(evt.to_string());
     }
 
-    /// Notify the host that the wta-internal view changed. C++ owns the
-    /// agent bar's title + the `_agentSessionsViewActive` flag that drives
-    /// the bottom bar; without this push the bar would stay on
-    /// "Agent sessions" after Esc / out of sync after `/sessions`.
+    /// Notify the host that the wta-internal view changed. wta is the sole
+    /// owner of per-tab `current_view`; C++ mirrors it through this event
+    /// onto its global `_agentSessionsViewActive` flag, which drives the
+    /// agent bar's title (`AgentPaneContent::SetSessionsView`) and the
+    /// bottom bar's chat/sessions highlight.
     ///
-    /// Only emit from paths where wta is the sole source of truth (Esc,
-    /// `/sessions`). The C++-originated `set_view` path already knows
-    /// what it asked for and updates its own state directly.
+    /// Prefer `project_active_tab_state` over calling this directly — that
+    /// function also re-emits the autofix bar snapshot and is the canonical
+    /// entry point for "tell C++ what the active tab looks like now".
     fn emit_view_changed(&self, view: &str) {
         let evt = serde_json::json!({
             "type": "event",
@@ -6162,6 +6192,45 @@ impl App {
             "params": { "view": view }
         });
         send_wt_protocol_event(evt.to_string());
+    }
+
+    /// Re-emit every piece of active-tab UI state that C++ stores globally
+    /// (per-pane, not per-tab). Single entry point for "project per-tab
+    /// state onto C++'s global view".
+    ///
+    /// **Architecture contract**: per-tab UI state lives in wta. C++ has
+    /// one shared agent pane and one set of bar flags, so anything that
+    /// could differ across tabs must be re-asserted whenever the active
+    /// tab changes or its state mutates. Without this, switching tabs
+    /// (or `/sessions`, Esc, set_view, load_session) leaves C++'s flag
+    /// stuck on the previous tab's state, producing the classic
+    /// "bar says Agent sessions but the pane shows chat" desync.
+    ///
+    /// Call sites:
+    ///   - `switch_tab_session` end — covers WT `tab_changed`.
+    ///   - `set_view` end — round-trips C++'s request back so C++ updates
+    ///     its flag (we don't write the flag optimistically on the C++ side
+    ///     anymore).
+    ///   - `load_session` after the `current_view = Chat` mutation.
+    ///   - `Esc` out of Agents view, `/sessions` slash command.
+    ///   - Once at startup (after `--initial-view` has been applied) so the
+    ///     bar picks up the requested initial view.
+    ///
+    /// Idempotent — safe to call multiple times in a row.
+    pub fn project_active_tab_state(&self) {
+        // 1. View: chat vs sessions. Drives C++ bar title +
+        //    `_agentSessionsViewActive`.
+        let view = match self.current_tab().current_view {
+            View::Agents => "sessions",
+            View::Chat => "chat",
+        };
+        self.emit_view_changed(view);
+
+        // 2. Autofix bar snapshot. Replaces the standalone
+        //    `project_bar_for_active_tab` — folded in here so every per-tab
+        //    → C++ projection has one entry point and future per-tab UI
+        //    state can be added in one place.
+        send_bar_event(&self.current_tab().autofix.bar_snapshot);
     }
 }
 

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -610,12 +610,12 @@ pub fn classify_wt_event(
                 age_ticks: 0,
             }
         }
-        "set_view" => {
-            // handle_event consumes set_view at the top of WtEvent before
-            // classification runs, so classify normally never sees it.
-            // Add an explicit arm anyway so a future refactor that drops
-            // the early return doesn't surface a stray "Pane: set_view"
-            // banner via the default catch-all.
+        "set_agent_state" => {
+            // handle_event consumes set_agent_state at the top of WtEvent
+            // before classification runs, so classify normally never sees
+            // it. Add an explicit arm anyway so a future refactor that
+            // drops the early return doesn't surface a stray
+            // "Pane: set_agent_state" banner via the default catch-all.
             WtNotification {
                 severity: WtEventSeverity::Informational,
                 pane_id: pane_id.to_string(),
@@ -1023,6 +1023,20 @@ pub struct TabSession {
     // its own open/closed state and selected row across tab switches.
     pub current_view: View,
     pub agents_list_state: ratatui::widgets::ListState,
+
+    // "Does this tab want the agent pane visible?" — per-tab user intent.
+    // Independent of where the (single, shared) XAML pane physically lives:
+    // C++ relocates the pane to whichever active tab has `pane_open == true`
+    // and hides it on tabs where it's `false`. wta owns this state so the
+    // C++ side has one writer (`OnAgentStateChanged`) and the desync that
+    // came from tracking it as a per-Tab.AgentPaneOpen flag on a moving
+    // XAML pane is gone.
+    //
+    // Default false. Seeded to true at startup for the spawn owner tab
+    // (the user just asked to open the pane on that tab). Flipped by
+    // C++-originated `set_agent_state` requests (hotkey/button toggles)
+    // and by wta-internal events like Ctrl+C×2 reset.
+    pub pane_open: bool,
 }
 
 impl TabSession {
@@ -3360,20 +3374,26 @@ impl App {
                     return;
                 }
 
-                // set_view: WT sends this from Ctrl+Shift+/ / Ctrl+Shift+.
-                // / agent-bar buttons to request a view switch. Absolute
-                // (not toggle).
+                // set_agent_state: unified inbound request from C++ to
+                // change one or more pieces of per-tab agent-pane UI state
+                // on the *active* tab. Every field under `params` is
+                // optional — only specified ones are applied, the rest
+                // are left untouched. Always followed by a full
+                // `agent_state_changed` projection so C++ mirrors the new
+                // snapshot.
+                //
+                // Supported fields:
+                //   * `view`: "chat" | "sessions"
+                //   * `pane_open`: bool
                 //
                 // **Round-trip contract**: under the "wta is the sole owner
-                // of view state" architecture, C++ does NOT update its
-                // `_agentSessionsViewActive` flag when it sends set_view —
-                // it waits for the resulting `view_changed` (emitted by
-                // `project_active_tab_state` below) to update the flag,
-                // bar title, and bottom-bar highlight. This deliberately
-                // creates a small visual lag (one IPC round-trip), but in
-                // exchange the C++ flag has a single writer
-                // (`OnAgentViewChanged`) and view-state desync becomes
-                // architecturally impossible.
+                // of agent-pane UI state" architecture, C++ does NOT update
+                // its mirrors (`_agentSessionsViewActive`, `Tab.AgentPaneOpen`)
+                // when it sends `set_agent_state`. It waits for the resulting
+                // `agent_state_changed` emitted by `project_active_tab_state`
+                // below. One IPC round-trip latency, in exchange for the
+                // C++ flags having a single writer (`OnAgentStateChanged`),
+                // which makes desync architecturally impossible.
                 //
                 // Window-scoped: WT includes its own window_id; we ignore
                 // the event when our window_id is known and doesn't match,
@@ -3382,7 +3402,7 @@ impl App {
                 //
                 // Processed BEFORE the own-pane skip below: this is a
                 // global UI command, not a per-pane signal.
-                if method == "set_view" {
+                if method == "set_agent_state" {
                     let target_window = params
                         .get("window_id")
                         .and_then(|v| v.as_str())
@@ -3393,56 +3413,74 @@ impl App {
                         && target_window != our_window
                     {
                         tracing::debug!(
-                            target: "set_view",
+                            target: "set_agent_state",
                             target_window,
                             our_window,
-                            "ignoring set_view for different window"
+                            "ignoring set_agent_state for different window"
                         );
                         return;
                     }
-                    let view_str = params.get("view").and_then(|v| v.as_str()).unwrap_or("");
-                    tracing::info!(target: "set_view", view = view_str, "applying set_view");
-                    match view_str {
-                        "sessions" | "agents" => {
-                            // User entered session management (via shortcut or UI) —
-                            // permanently dismiss the welcome hint.
-                            if self.show_welcome_hint {
-                                self.show_welcome_hint = false;
-                                set_welcome_shown_in_state();
-                            }
-                            let entering_agents =
-                                self.current_tab().current_view != View::Agents;
-                            let has_sessions = !self
-                                .agent_sessions
-                                .iter_sorted_filtered(self.current_cli_filter().as_ref())
-                                .is_empty();
-                            {
-                                let tab = self.current_tab_mut();
-                                tab.current_view = View::Agents;
-                                if tab.agents_list_state.selected().is_none()
-                                    && has_sessions
+
+                    // Apply `view` if present.
+                    if let Some(view_str) = params.get("view").and_then(|v| v.as_str()) {
+                        tracing::info!(
+                            target: "set_agent_state",
+                            view = view_str,
+                            "applying view"
+                        );
+                        match view_str {
+                            "sessions" | "agents" => {
+                                // User entered session management (via shortcut or UI) —
+                                // permanently dismiss the welcome hint.
+                                if self.show_welcome_hint {
+                                    self.show_welcome_hint = false;
+                                    set_welcome_shown_in_state();
+                                }
+                                let entering_agents =
+                                    self.current_tab().current_view != View::Agents;
+                                let has_sessions = !self
+                                    .agent_sessions
+                                    .iter_sorted_filtered(self.current_cli_filter().as_ref())
+                                    .is_empty();
                                 {
-                                    tab.agents_list_state.select(Some(0));
+                                    let tab = self.current_tab_mut();
+                                    tab.current_view = View::Agents;
+                                    if tab.agents_list_state.selected().is_none()
+                                        && has_sessions
+                                    {
+                                        tab.agents_list_state.select(Some(0));
+                                    }
+                                }
+                                if entering_agents {
+                                    self.ensure_history_loaded();
                                 }
                             }
-                            if entering_agents {
-                                self.ensure_history_loaded();
+                            "chat" => {
+                                self.current_tab_mut().current_view = View::Chat;
+                            }
+                            other => {
+                                tracing::warn!(
+                                    target: "set_agent_state",
+                                    view = other,
+                                    "unknown view value — ignoring"
+                                );
                             }
                         }
-                        "chat" => {
-                            self.current_tab_mut().current_view = View::Chat;
-                        }
-                        other => {
-                            tracing::warn!(target: "set_view", view = other, "unknown view");
-                            // Unknown view — don't project a fabricated
-                            // state. The active tab's view is unchanged.
-                            return;
-                        }
                     }
-                    // Echo the applied view back so C++ can update its
-                    // global flag (it does not write the flag locally
-                    // before sending set_view — see the round-trip
-                    // contract comment above).
+
+                    // Apply `pane_open` if present.
+                    if let Some(open) = params.get("pane_open").and_then(|v| v.as_bool()) {
+                        tracing::info!(
+                            target: "set_agent_state",
+                            pane_open = open,
+                            "applying pane_open"
+                        );
+                        self.current_tab_mut().pane_open = open;
+                    }
+
+                    // Echo the resulting snapshot back so C++ mirrors it
+                    // (the C++ side never writes its own mirror locally
+                    // — see the round-trip contract comment above).
                     self.project_active_tab_state();
                     return;
                 }
@@ -6176,61 +6214,67 @@ impl App {
         send_wt_protocol_event(evt.to_string());
     }
 
-    /// Notify the host that the wta-internal view changed. wta is the sole
-    /// owner of per-tab `current_view`; C++ mirrors it through this event
-    /// onto its global `_agentSessionsViewActive` flag, which drives the
-    /// agent bar's title (`AgentPaneContent::SetSessionsView`) and the
-    /// bottom bar's chat/sessions highlight.
+    /// Single outbound projection of the active tab's agent-pane UI state.
     ///
-    /// Prefer `project_active_tab_state` over calling this directly — that
-    /// function also re-emits the autofix bar snapshot and is the canonical
-    /// entry point for "tell C++ what the active tab looks like now".
-    fn emit_view_changed(&self, view: &str) {
-        let evt = serde_json::json!({
-            "type": "event",
-            "method": "view_changed",
-            "params": { "view": view }
-        });
-        send_wt_protocol_event(evt.to_string());
-    }
-
-    /// Re-emit every piece of active-tab UI state that C++ stores globally
-    /// (per-pane, not per-tab). Single entry point for "project per-tab
-    /// state onto C++'s global view".
+    /// **Architecture contract**: per-tab agent-pane UI state lives in wta.
+    /// C++ has one shared agent pane and one set of XAML flags per window,
+    /// so anything that varies across WT tabs must be re-asserted on every
+    /// tab switch or local mutation. Emits one unified `agent_state_changed`
+    /// snapshot — adding a new piece of per-tab UI state in the future is
+    /// a matter of putting another field in the payload, no new IDL route
+    /// or new C++ handler.
     ///
-    /// **Architecture contract**: per-tab UI state lives in wta. C++ has
-    /// one shared agent pane and one set of bar flags, so anything that
-    /// could differ across tabs must be re-asserted whenever the active
-    /// tab changes or its state mutates. Without this, switching tabs
-    /// (or `/sessions`, Esc, set_view, load_session) leaves C++'s flag
-    /// stuck on the previous tab's state, producing the classic
-    /// "bar says Agent sessions but the pane shows chat" desync.
+    /// Payload shape (mirror of the inbound `set_agent_state` request):
+    /// ```json
+    /// {
+    ///   "type": "event",
+    ///   "method": "agent_state_changed",
+    ///   "params": {
+    ///     "view":      "chat" | "sessions",
+    ///     "pane_open": true | false
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// On the C++ side this lands in `TerminalPage::OnAgentStateChanged`,
+    /// which is the single writer of `_agentSessionsViewActive` and
+    /// `Tab.AgentPaneOpen` for the active tab.
+    ///
+    /// Also re-emits the autofix bar snapshot (orthogonal domain — bottom
+    /// bar autofix indicator — kept on its own `autofix_state` route).
     ///
     /// Call sites:
     ///   - `switch_tab_session` end — covers WT `tab_changed`.
-    ///   - `set_view` end — round-trips C++'s request back so C++ updates
-    ///     its flag (we don't write the flag optimistically on the C++ side
-    ///     anymore).
-    ///   - `load_session` after the `current_view = Chat` mutation.
-    ///   - `Esc` out of Agents view, `/sessions` slash command.
-    ///   - Once at startup (after `--initial-view` has been applied) so the
-    ///     bar picks up the requested initial view.
+    ///   - `set_agent_state` handler end — echoes C++'s request back so C++
+    ///     mirrors it (the round-trip the new architecture is built on).
+    ///   - `load_session` after the per-tab mutation.
+    ///   - Esc out of Agents view, `/sessions` slash command, Ctrl+C×2
+    ///     multi-tab reset.
+    ///   - Once at startup (after `--initial-view` has been applied) so
+    ///     the bar and the agent-pane-open flag both pick up the spawn
+    ///     intent.
     ///
     /// Idempotent — safe to call multiple times in a row.
     pub fn project_active_tab_state(&self) {
-        // 1. View: chat vs sessions. Drives C++ bar title +
-        //    `_agentSessionsViewActive`.
-        let view = match self.current_tab().current_view {
+        let tab = self.current_tab();
+        let view = match tab.current_view {
             View::Agents => "sessions",
             View::Chat => "chat",
         };
-        self.emit_view_changed(view);
+        let evt = serde_json::json!({
+            "type": "event",
+            "method": "agent_state_changed",
+            "params": {
+                "view":      view,
+                "pane_open": tab.pane_open,
+            }
+        });
+        send_wt_protocol_event(evt.to_string());
 
-        // 2. Autofix bar snapshot. Replaces the standalone
-        //    `project_bar_for_active_tab` — folded in here so every per-tab
-        //    → C++ projection has one entry point and future per-tab UI
-        //    state can be added in one place.
-        send_bar_event(&self.current_tab().autofix.bar_snapshot);
+        // Autofix bar — different domain (bottom bar), kept on its own
+        // route. Re-emitted here so a `tab_changed` projects both halves
+        // of the per-tab → C++ surface in one call.
+        send_bar_event(&tab.autofix.bar_snapshot);
     }
 }
 

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -3376,15 +3376,30 @@ impl App {
 
                 // set_agent_state: unified inbound request from C++ to
                 // change one or more pieces of per-tab agent-pane UI state
-                // on the *active* tab. Every field under `params` is
+                // for a specific tab. Every field under `params` is
                 // optional — only specified ones are applied, the rest
-                // are left untouched. Always followed by a full
-                // `agent_state_changed` projection so C++ mirrors the new
-                // snapshot.
+                // are left untouched.
                 //
                 // Supported fields:
+                //   * `tab_id`: optional WT StableId of the tab to mutate.
+                //               Falls back to the active tab when absent.
+                //               C++ should always include it: defends
+                //               against `tab_changed`/`set_agent_state`
+                //               ordering ambiguity (e.g. resume-in-new-tab
+                //               creates a new tab and immediately requests
+                //               pane_open=true; with `tab_id` we don't
+                //               depend on `tab_changed` arriving first to
+                //               route to the right TabSession).
                 //   * `view`: "chat" | "sessions"
                 //   * `pane_open`: bool
+                //
+                // **Projection rule**: if the target tab is the currently-
+                // active one, immediately project the new snapshot back to
+                // C++ (`agent_state_changed`). If the target is NOT active,
+                // skip projection — the next `tab_changed` to that tab will
+                // project the now-up-to-date state. C++ mirrors are global
+                // per-pane so they only need refreshing when the active tab
+                // changes (or when a mutation lands on the active tab).
                 //
                 // **Round-trip contract**: under the "wta is the sole owner
                 // of agent-pane UI state" architecture, C++ does NOT update
@@ -3421,10 +3436,22 @@ impl App {
                         return;
                     }
 
+                    // Resolve target tab: explicit `tab_id` wins;
+                    // otherwise fall back to the active tab. The explicit
+                    // path is robust against `tab_changed` ordering races
+                    // (e.g. resume-in-new-tab where C++ creates a tab and
+                    // immediately fires `set_agent_state` for it).
+                    let target_tab = params
+                        .get("tab_id")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| self.active_tab_key().to_string());
+
                     // Apply `view` if present.
                     if let Some(view_str) = params.get("view").and_then(|v| v.as_str()) {
                         tracing::info!(
                             target: "set_agent_state",
+                            tab = %target_tab,
                             view = view_str,
                             "applying view"
                         );
@@ -3436,14 +3463,17 @@ impl App {
                                     self.show_welcome_hint = false;
                                     set_welcome_shown_in_state();
                                 }
-                                let entering_agents =
-                                    self.current_tab().current_view != View::Agents;
+                                let entering_agents = self
+                                    .tab_sessions
+                                    .get(&target_tab)
+                                    .map(|t| t.current_view != View::Agents)
+                                    .unwrap_or(true);
                                 let has_sessions = !self
                                     .agent_sessions
                                     .iter_sorted_filtered(self.current_cli_filter().as_ref())
                                     .is_empty();
                                 {
-                                    let tab = self.current_tab_mut();
+                                    let tab = self.tab_mut(&target_tab);
                                     tab.current_view = View::Agents;
                                     if tab.agents_list_state.selected().is_none()
                                         && has_sessions
@@ -3456,7 +3486,7 @@ impl App {
                                 }
                             }
                             "chat" => {
-                                self.current_tab_mut().current_view = View::Chat;
+                                self.tab_mut(&target_tab).current_view = View::Chat;
                             }
                             other => {
                                 tracing::warn!(
@@ -3472,16 +3502,27 @@ impl App {
                     if let Some(open) = params.get("pane_open").and_then(|v| v.as_bool()) {
                         tracing::info!(
                             target: "set_agent_state",
+                            tab = %target_tab,
                             pane_open = open,
                             "applying pane_open"
                         );
-                        self.current_tab_mut().pane_open = open;
+                        self.tab_mut(&target_tab).pane_open = open;
                     }
 
-                    // Echo the resulting snapshot back so C++ mirrors it
-                    // (the C++ side never writes its own mirror locally
-                    // — see the round-trip contract comment above).
-                    self.project_active_tab_state();
+                    // Only project when the mutation landed on the active
+                    // tab — C++'s mirrors are global per-pane, so a
+                    // non-active mutation has no effect there until the
+                    // next `tab_changed` projects the (now-updated) tab.
+                    if target_tab == self.active_tab_key() {
+                        self.project_active_tab_state();
+                    } else {
+                        tracing::debug!(
+                            target: "set_agent_state",
+                            target = %target_tab,
+                            active = %self.active_tab_key(),
+                            "applied to non-active tab; deferring projection to next tab_changed"
+                        );
+                    }
                     return;
                 }
 

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -1899,10 +1899,17 @@ async fn run_acp_app(
                         tab_id = %owner_tab_id,
                         "seeded app_state.tab_id from --owner-tab-id"
                     );
-                    app_state
+                    let tab = app_state
                         .tab_sessions
                         .entry(owner_tab_id.clone())
                         .or_default();
+                    // wta is the source of truth for "does this tab want
+                    // the pane visible". The pane is being spawned right
+                    // now for this owner tab, so the user clearly wants
+                    // it visible here. C++ will pick this up in the
+                    // initial `agent_state_changed` emit below and mirror
+                    // it onto Tab.AgentPaneOpen.
+                    tab.pane_open = true;
                     app_state.tab_id = Some(owner_tab_id);
                 }
             }

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -1783,9 +1783,9 @@ async fn run_acp_app(
             // the user's first interaction, leaving the bar mislabelled in
             // the `--initial-view sessions` case. Cheap and idempotent.
             //
-            // Safe before `Setup` mode setup below: setup runs its own UI
-            // and doesn't read the view flag; if we end up in setup the
-            // initial "chat" emission is harmless.
+            // Safe before the `Setup` mode block below: that block runs
+            // its own UI and doesn't read the view flag; if we end up in
+            // setup mode the initial "chat" emission is harmless.
             if wt_connected {
                 app_state.project_active_tab_state();
             }

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -1778,10 +1778,13 @@ async fn run_acp_app(
 
             // Project the initial active-tab state to C++ once, after the
             // --initial-view block has had its say. Without this push,
-            // C++'s `_agentSessionsViewActive` flag (single writer, lives in
-            // `OnAgentViewChanged`) would stay on its default `false` until
-            // the user's first interaction, leaving the bar mislabelled in
-            // the `--initial-view sessions` case. Cheap and idempotent.
+            // C++'s `_agentSessionsViewActive` and `Tab.AgentPaneOpen`
+            // mirrors (single writer lives in `OnAgentStateChanged`)
+            // would stay on their defaults until the user's first
+            // interaction, leaving the bar mislabelled in the
+            // `--initial-view sessions` case and the pane-open flag
+            // out of sync with the seeded `pane_open=true` on the
+            // owner tab. Cheap and idempotent.
             //
             // Safe before the `Setup` mode block below: that block runs
             // its own UI and doesn't read the view flag; if we end up in

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -1776,6 +1776,20 @@ async fn run_acp_app(
                 app_state.ensure_history_loaded();
             }
 
+            // Project the initial active-tab state to C++ once, after the
+            // --initial-view block has had its say. Without this push,
+            // C++'s `_agentSessionsViewActive` flag (single writer, lives in
+            // `OnAgentViewChanged`) would stay on its default `false` until
+            // the user's first interaction, leaving the bar mislabelled in
+            // the `--initial-view sessions` case. Cheap and idempotent.
+            //
+            // Safe before `Setup` mode setup below: setup runs its own UI
+            // and doesn't read the view flag; if we end up in setup the
+            // initial "chat" emission is harmless.
+            if wt_connected {
+                app_state.project_active_tab_state();
+            }
+
             // NOTE: historical agent sessions used to be loaded here via
             // `history_loader::load_all()` (later as a `spawn_blocking`).
             // That work is now deferred — the registry is scanned lazily


### PR DESCRIPTION
## Summary

- Agent bar was stuck on "Agent sessions: Copilot" while the TUI below rendered chat — caused by `current_view` being per-tab in wta but `_agentSessionsViewActive` being global in C++ with no re-emit on tab switch. Fixed by making wta the sole owner of view state and having C++ mirror via `view_changed` events only.
- New `App::project_active_tab_state` in wta re-emits the active tab's view + autofix bar snapshot. Called on `switch_tab_session`, `set_view` round-trip, `load_session`, `/sessions`, Esc, and once at startup so `--initial-view` lands in C++.
- C++ becomes a passive mirror: `OnAgentViewChanged` is the single runtime writer of `_agentSessionsViewActive` (pane-Closed handler still clears on teardown). Removed 6 direct flag writes from hotkey / button / spawn paths. Renamed `_BroadcastAgentSetView` → `_RequestAgentView` to reflect request/ack semantics.
- Also closes a long-standing gap in `TabManagement::_RemoveTab`: closing the active tab fired `tab_closed` but no `tab_changed` (XAML `SelectionChanged` is suppressed by `_removing=true`), leaving wta routed at the dropped tab id until the user''s next manual tab switch. Now emits `_NotifyAgentTabChanged(newSelectedTab)` explicitly.

## Architectural contract

| | Before | After |
|---|---|---|
| `_agentSessionsViewActive` writers | 7 sites across hotkey, button, spawn, OnAgentViewChanged, Closed handler | 2: `OnAgentViewChanged` (runtime) + Closed handler (teardown only) |
| Round-trip on `set_view` | C++ writes flag optimistically; wta does NOT echo `view_changed` (loop avoidance) | C++ requests only; wta applies + echoes; C++ mirrors on echo |
| Tab switch propagation | Implicit, relies on no per-tab state actually differing | Explicit `project_active_tab_state` at end of `switch_tab_session` |
| Closing active tab | `tab_closed(A)` sent; no `tab_changed(B)` → wta stuck at DEFAULT_TAB_ID | Both events fire; wta routes correctly |

The user-visible tradeoff: a small one-IPC-round-trip lag when changing view via hotkey / button (request goes to wta, wta acks back). Accepted in exchange for making view-state desync architecturally impossible.

## Test plan

- [ ] **K — fresh tab while in sessions**: Open agent pane in sessions view (Ctrl+Shift+/). `Ctrl+Shift+T` to make a new WT tab. Agent bar should drop the "Agent sessions" label immediately and revert to chat presentation.
- [ ] **L — sticky per-tab view**: Tab A in chat, Tab B in sessions; switch back and forth — bar tracks each tab''s state.
- [ ] **N — close active tab**: With agent pane on Tab A in sessions view, close Tab A. New active tab takes over the bar (Q1 fix).
- [ ] **E/F — set_view round-trip**: With pane open, Ctrl+Shift+/ ↔ Ctrl+Shift+. flips bar between chat and sessions.
- [ ] **G/H — wta-side transitions**: `/sessions` and Esc out of Agents view both update the bar.
- [ ] **P — Ctrl+C×2 multi-tab reset**: Open pane on two tabs, Ctrl+C twice in the pane TUI — pane hides on the owner tab, other tab unaffected.
- [ ] **Q/R — teardown**: Last Ctrl+C×2 / kill wta.exe externally — pane closes, bottom bar dims, flag clears.
- [ ] **S — resume in new agent tab**: Shift+Enter on a session row in sessions view spawns a new tab; bar transitions from "Agent sessions" → chat correctly.
- [ ] `cargo test --manifest-path tools/wta/Cargo.toml` — 282 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)