### PR TITLE
ci: append (not overwrite) .cargo/config.toml to keep wta.exe static-CRT

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,11 @@
+# Static-link the MSVC CRT so wta.exe doesn't import VCRUNTIME140.dll
+# (the package strips Microsoft.VCLibs and ships no VC runtime; missing
+# this flag causes wta.exe to fail to launch on clean machines like
+# Windows Sandbox).
+#
+# CI rewrites this file from scratch to add internal-feed registry
+# routing — keep these target blocks in sync with the version in
+# build/pipelines/templates-v2/job-build-project.yml.
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,10 +2,6 @@
 # (the package strips Microsoft.VCLibs and ships no VC runtime; missing
 # this flag causes wta.exe to fail to launch on clean machines like
 # Windows Sandbox).
-#
-# CI rewrites this file from scratch to add internal-feed registry
-# routing — keep these target blocks in sync with the version in
-# build/pipelines/templates-v2/job-build-project.yml.
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
 

--- a/build/pipelines/templates-v2/job-build-project.yml
+++ b/build/pipelines/templates-v2/job-build-project.yml
@@ -205,54 +205,51 @@ jobs:
       # config-file resolution picks it up.
       additionalTargets: 'x86_64-pc-windows-msvc i686-pc-windows-msvc aarch64-pc-windows-msvc'
 
-  # Inject the Azure Artifacts source replacement into .cargo/config.toml.
-  # The repo's .cargo/config.toml is checked in and carries the
-  # `+crt-static` rustflags that wta.exe needs to start without
-  # VCRUNTIME140.dll on customer machines (the package ships no VC
-  # runtime and strips the Microsoft.VCLibs dependency). Earlier this
-  # step used `Set-Content`, which silently clobbered those rustflags
-  # and produced CI-built wta.exe binaries that imported
-  # VCRUNTIME140.dll and failed to launch in clean environments
-  # (e.g. Windows Sandbox).
+  # Write .cargo/config.toml from scratch. CI owns this file fully —
+  # it bundles both halves of the configuration in a single Set-Content
+  # call so the step is trivially idempotent (re-runs produce the same
+  # file) and never needs to read the existing content back.
   #
-  # The strategy: read the file, locate any previously CI-injected
-  # block via a sentinel marker line, truncate the file at that
-  # marker, then append a fresh canonical CI block. Idempotent by
-  # construction — regardless of starting state, the final file is
-  # always the repo's checked-in content followed by exactly one
-  # canonical CI block. Safe under retries, dirty workspaces, future
-  # URL changes, or hand-edits.
+  # The two halves:
   #
-  # Cargo discovers .cargo/config.toml by walking from the current
-  # working directory (repo root) up — NOT from the manifest directory.
-  # The config must live at the repo root, not inside tools/wta/.
+  #   1. `[target.*-pc-windows-msvc] rustflags = +crt-static` — static-
+  #      link the MSVC CRT so wta.exe doesn't import VCRUNTIME140.dll
+  #      (the package strips Microsoft.VCLibs and ships no VC runtime;
+  #      missing the flag here causes wta.exe to fail to launch on
+  #      clean machines like Windows Sandbox).
+  #
+  #   2. `[registries] / [source.crates-io]` — route Cargo through
+  #      the internal Azure Artifacts feed. CI-only; the public feed
+  #      isn't reachable from the build agents.
+  #
+  # IMPORTANT: the rustflags block MUST stay in sync with the
+  # repo-root `.cargo/config.toml` used by local builds. If you change
+  # one, change the other. Cargo discovers config.toml by walking up
+  # from CWD (repo root), not from --manifest-path, which is why the
+  # local version lives at the repo root and not inside tools/wta/.
   - pwsh: |-
       $configDir = '.cargo'
       $configPath = Join-Path $configDir 'config.toml'
       New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+      @"
+      [target.x86_64-pc-windows-msvc]
+      rustflags = ["-C", "target-feature=+crt-static"]
 
-      $marker = '# === BEGIN: Azure Artifacts source replacement (CI-injected) ==='
-      $existing = if (Test-Path $configPath) { Get-Content $configPath -Raw } else { '' }
-      $markerIdx = $existing.IndexOf($marker)
-      if ($markerIdx -ge 0) {
-        $existing = $existing.Substring(0, $markerIdx)
-      }
-      $existing = $existing.TrimEnd()
+      [target.i686-pc-windows-msvc]
+      rustflags = ["-C", "target-feature=+crt-static"]
 
-      $injection = @"
-      $marker
+      [target.aarch64-pc-windows-msvc]
+      rustflags = ["-C", "target-feature=+crt-static"]
+
       [registries]
       WindowsTerminalCargo = { index = "sparse+https://pkgs.dev.azure.com/microsoft/Dart/_packaging/IntelligentTerminal_Cargo/Cargo/index/" }
 
       [source.crates-io]
       replace-with = "WindowsTerminalCargo"
-      "@
-
-      $final = if ($existing) { "$existing`n`n$injection`n" } else { "$injection`n" }
-      Set-Content -Path $configPath -Value $final -Encoding utf8NoBOM -NoNewline
+      "@ | Set-Content -Path $configPath -Encoding utf8NoBOM
       Write-Host "Wrote $configPath:"
       Get-Content $configPath
-    displayName: Inject Cargo registry config (CI only)
+    displayName: Write Cargo config (CI only)
 
   # CargoAuthenticate issues a Bearer token (using System.AccessToken) for
   # every Azure Artifacts Cargo feed referenced in the config file.

--- a/build/pipelines/templates-v2/job-build-project.yml
+++ b/build/pipelines/templates-v2/job-build-project.yml
@@ -209,11 +209,16 @@ jobs:
   # The repo's .cargo/config.toml is checked in and carries the
   # `+crt-static` rustflags that wta.exe needs to start without
   # VCRUNTIME140.dll on customer machines (the package ships no VC
-  # runtime and strips the Microsoft.VCLibs dependency; see commit
-  # fbbb367c8). Earlier this step used `Set-Content`, which silently
-  # clobbered those rustflags and produced CI-built wta.exe binaries
-  # that imported VCRUNTIME140.dll and failed to launch in clean
-  # environments (e.g. Windows Sandbox).
+  # runtime and strips the Microsoft.VCLibs dependency). Earlier this
+  # step used `Set-Content`, which silently clobbered those rustflags
+  # and produced CI-built wta.exe binaries that imported
+  # VCRUNTIME140.dll and failed to launch in clean environments
+  # (e.g. Windows Sandbox).
+  #
+  # The grep guard makes the step idempotent: if `WindowsTerminalCargo`
+  # is already present (re-run on a dirty workspace, or the repo grows
+  # its own registry entry later), skip the append so we don't produce
+  # a config file with duplicate TOML keys that Cargo refuses to parse.
   #
   # Cargo discovers .cargo/config.toml by walking from the current
   # working directory (repo root) up — NOT from the manifest directory.
@@ -222,7 +227,10 @@ jobs:
       $configDir = '.cargo'
       $configPath = Join-Path $configDir 'config.toml'
       New-Item -ItemType Directory -Path $configDir -Force | Out-Null
-      $registry = @"
+      if ((Test-Path $configPath) -and (Select-String -Path $configPath -Pattern 'WindowsTerminalCargo' -SimpleMatch -Quiet)) {
+        Write-Host "Registry replacement already present in $configPath, skipping append."
+      } else {
+        $registry = @"
 
       [registries]
       WindowsTerminalCargo = { index = "sparse+https://pkgs.dev.azure.com/microsoft/Dart/_packaging/IntelligentTerminal_Cargo/Cargo/index/" }
@@ -230,8 +238,9 @@ jobs:
       [source.crates-io]
       replace-with = "WindowsTerminalCargo"
       "@
-      Add-Content -Path $configPath -Value $registry -Encoding utf8NoBOM
-      Write-Host "Updated $configPath"
+        Add-Content -Path $configPath -Value $registry -Encoding utf8NoBOM
+        Write-Host "Appended registry replacement to $configPath."
+      }
       Get-Content $configPath
     displayName: Append Cargo registry config (CI only)
 

--- a/build/pipelines/templates-v2/job-build-project.yml
+++ b/build/pipelines/templates-v2/job-build-project.yml
@@ -205,25 +205,35 @@ jobs:
       # config-file resolution picks it up.
       additionalTargets: 'x86_64-pc-windows-msvc i686-pc-windows-msvc aarch64-pc-windows-msvc'
 
-  # Create .cargo/config.toml for Azure Artifacts source replacement.
-  # This is NOT checked into the repo because it would break local dev
-  # (the feed requires CI-only auth tokens). It only exists during CI.
+  # Append Azure Artifacts source replacement to .cargo/config.toml.
+  # The repo's .cargo/config.toml is checked in and carries the
+  # `+crt-static` rustflags that wta.exe needs to start without
+  # VCRUNTIME140.dll on customer machines (the package ships no VC
+  # runtime and strips the Microsoft.VCLibs dependency; see commit
+  # fbbb367c8). Earlier this step used `Set-Content`, which silently
+  # clobbered those rustflags and produced CI-built wta.exe binaries
+  # that imported VCRUNTIME140.dll and failed to launch in clean
+  # environments (e.g. Windows Sandbox).
+  #
   # Cargo discovers .cargo/config.toml by walking from the current
   # working directory (repo root) up — NOT from the manifest directory.
   # The config must live at the repo root, not inside tools/wta/.
   - pwsh: |-
       $configDir = '.cargo'
+      $configPath = Join-Path $configDir 'config.toml'
       New-Item -ItemType Directory -Path $configDir -Force | Out-Null
-      @"
+      $registry = @"
+
       [registries]
       WindowsTerminalCargo = { index = "sparse+https://pkgs.dev.azure.com/microsoft/Dart/_packaging/IntelligentTerminal_Cargo/Cargo/index/" }
 
       [source.crates-io]
       replace-with = "WindowsTerminalCargo"
-      "@ | Set-Content "$configDir/config.toml" -Encoding utf8NoBOM
-      Write-Host "Wrote $configDir/config.toml"
-      Get-Content "$configDir/config.toml"
-    displayName: Create Cargo registry config (CI only)
+      "@
+      Add-Content -Path $configPath -Value $registry -Encoding utf8NoBOM
+      Write-Host "Updated $configPath"
+      Get-Content $configPath
+    displayName: Append Cargo registry config (CI only)
 
   # CargoAuthenticate issues a Bearer token (using System.AccessToken) for
   # every Azure Artifacts Cargo feed referenced in the config file.

--- a/build/pipelines/templates-v2/job-build-project.yml
+++ b/build/pipelines/templates-v2/job-build-project.yml
@@ -205,7 +205,7 @@ jobs:
       # config-file resolution picks it up.
       additionalTargets: 'x86_64-pc-windows-msvc i686-pc-windows-msvc aarch64-pc-windows-msvc'
 
-  # Append Azure Artifacts source replacement to .cargo/config.toml.
+  # Inject the Azure Artifacts source replacement into .cargo/config.toml.
   # The repo's .cargo/config.toml is checked in and carries the
   # `+crt-static` rustflags that wta.exe needs to start without
   # VCRUNTIME140.dll on customer machines (the package ships no VC
@@ -215,10 +215,13 @@ jobs:
   # VCRUNTIME140.dll and failed to launch in clean environments
   # (e.g. Windows Sandbox).
   #
-  # The grep guard makes the step idempotent: if `WindowsTerminalCargo`
-  # is already present (re-run on a dirty workspace, or the repo grows
-  # its own registry entry later), skip the append so we don't produce
-  # a config file with duplicate TOML keys that Cargo refuses to parse.
+  # The strategy: read the file, locate any previously CI-injected
+  # block via a sentinel marker line, truncate the file at that
+  # marker, then append a fresh canonical CI block. Idempotent by
+  # construction — regardless of starting state, the final file is
+  # always the repo's checked-in content followed by exactly one
+  # canonical CI block. Safe under retries, dirty workspaces, future
+  # URL changes, or hand-edits.
   #
   # Cargo discovers .cargo/config.toml by walking from the current
   # working directory (repo root) up — NOT from the manifest directory.
@@ -227,22 +230,29 @@ jobs:
       $configDir = '.cargo'
       $configPath = Join-Path $configDir 'config.toml'
       New-Item -ItemType Directory -Path $configDir -Force | Out-Null
-      if ((Test-Path $configPath) -and (Select-String -Path $configPath -Pattern 'WindowsTerminalCargo' -SimpleMatch -Quiet)) {
-        Write-Host "Registry replacement already present in $configPath, skipping append."
-      } else {
-        $registry = @"
 
+      $marker = '# === BEGIN: Azure Artifacts source replacement (CI-injected) ==='
+      $existing = if (Test-Path $configPath) { Get-Content $configPath -Raw } else { '' }
+      $markerIdx = $existing.IndexOf($marker)
+      if ($markerIdx -ge 0) {
+        $existing = $existing.Substring(0, $markerIdx)
+      }
+      $existing = $existing.TrimEnd()
+
+      $injection = @"
+      $marker
       [registries]
       WindowsTerminalCargo = { index = "sparse+https://pkgs.dev.azure.com/microsoft/Dart/_packaging/IntelligentTerminal_Cargo/Cargo/index/" }
 
       [source.crates-io]
       replace-with = "WindowsTerminalCargo"
       "@
-        Add-Content -Path $configPath -Value $registry -Encoding utf8NoBOM
-        Write-Host "Appended registry replacement to $configPath."
-      }
+
+      $final = if ($existing) { "$existing`n`n$injection`n" } else { "$injection`n" }
+      Set-Content -Path $configPath -Value $final -Encoding utf8NoBOM -NoNewline
+      Write-Host "Wrote $configPath:"
       Get-Content $configPath
-    displayName: Append Cargo registry config (CI only)
+    displayName: Inject Cargo registry config (CI only)
 
   # CargoAuthenticate issues a Bearer token (using System.AccessToken) for
   # every Azure Artifacts Cargo feed referenced in the config file.

--- a/build/pipelines/templates-v2/job-build-project.yml
+++ b/build/pipelines/templates-v2/job-build-project.yml
@@ -205,51 +205,40 @@ jobs:
       # config-file resolution picks it up.
       additionalTargets: 'x86_64-pc-windows-msvc i686-pc-windows-msvc aarch64-pc-windows-msvc'
 
-  # Write .cargo/config.toml from scratch. CI owns this file fully —
-  # it bundles both halves of the configuration in a single Set-Content
-  # call so the step is trivially idempotent (re-runs produce the same
-  # file) and never needs to read the existing content back.
+  # Append the Azure Artifacts source replacement to the repo's
+  # checked-in .cargo/config.toml. We append rather than overwrite
+  # because the repo's version carries the `+crt-static` rustflags
+  # that wta.exe needs to start without VCRUNTIME140.dll on customer
+  # machines (the package ships no VC runtime and strips the
+  # Microsoft.VCLibs dependency). The previous version of this step
+  # used `Set-Content`, which silently clobbered those rustflags and
+  # produced CI-built wta.exe binaries that failed to launch in clean
+  # environments (e.g. Windows Sandbox).
   #
-  # The two halves:
+  # 1ES build agents do a fresh checkout per run, so the file always
+  # starts from its git-pristine state — Add-Content's lack of
+  # idempotency on a hypothetical re-used workspace is not a real
+  # concern in this pipeline.
   #
-  #   1. `[target.*-pc-windows-msvc] rustflags = +crt-static` — static-
-  #      link the MSVC CRT so wta.exe doesn't import VCRUNTIME140.dll
-  #      (the package strips Microsoft.VCLibs and ships no VC runtime;
-  #      missing the flag here causes wta.exe to fail to launch on
-  #      clean machines like Windows Sandbox).
-  #
-  #   2. `[registries] / [source.crates-io]` — route Cargo through
-  #      the internal Azure Artifacts feed. CI-only; the public feed
-  #      isn't reachable from the build agents.
-  #
-  # IMPORTANT: the rustflags block MUST stay in sync with the
-  # repo-root `.cargo/config.toml` used by local builds. If you change
-  # one, change the other. Cargo discovers config.toml by walking up
-  # from CWD (repo root), not from --manifest-path, which is why the
-  # local version lives at the repo root and not inside tools/wta/.
+  # Cargo discovers .cargo/config.toml by walking from the current
+  # working directory (repo root) up — NOT from the manifest directory.
+  # The config must live at the repo root, not inside tools/wta/.
   - pwsh: |-
       $configDir = '.cargo'
       $configPath = Join-Path $configDir 'config.toml'
       New-Item -ItemType Directory -Path $configDir -Force | Out-Null
-      @"
-      [target.x86_64-pc-windows-msvc]
-      rustflags = ["-C", "target-feature=+crt-static"]
-
-      [target.i686-pc-windows-msvc]
-      rustflags = ["-C", "target-feature=+crt-static"]
-
-      [target.aarch64-pc-windows-msvc]
-      rustflags = ["-C", "target-feature=+crt-static"]
+      $registry = @"
 
       [registries]
       WindowsTerminalCargo = { index = "sparse+https://pkgs.dev.azure.com/microsoft/Dart/_packaging/IntelligentTerminal_Cargo/Cargo/index/" }
 
       [source.crates-io]
       replace-with = "WindowsTerminalCargo"
-      "@ | Set-Content -Path $configPath -Encoding utf8NoBOM
-      Write-Host "Wrote $configPath:"
+      "@
+      Add-Content -Path $configPath -Value $registry -Encoding utf8NoBOM
+      Write-Host "Updated $configPath:"
       Get-Content $configPath
-    displayName: Write Cargo config (CI only)
+    displayName: Append Cargo registry config (CI only)
 
   # CargoAuthenticate issues a Bearer token (using System.AccessToken) for
   # every Azure Artifacts Cargo feed referenced in the config file.


### PR DESCRIPTION
## Summary

- The CI Rust step in `build/pipelines/templates-v2/job-build-project.yml` used `Set-Content` to inject an Azure Artifacts registry replacement into `.cargo/config.toml`, **silently clobbering** the repo's checked-in `.cargo/config.toml` that carries the `+crt-static` rustflags added in fbbb367c8.
- Result: CI-built `wta.exe` imported `VCRUNTIME140.dll` again and failed to launch in clean environments (e.g. Windows Sandbox installs of the CI-produced MSIX bundle), since the package ships no VC runtime and strips the `Microsoft.VCLibs` dependency.
- Fix: switch to `Add-Content`, preserving the repo's `[target.*]` rustflags while still injecting the CI-only registry replacement.

## Test plan

- [ ] Trigger a CI build on this branch and confirm the produced `wta.exe` (under `tools/wta/target/<triple>/release/`) has **no** `VCRUNTIME140.dll` / `api-ms-win-crt-*` imports — verify with `dumpbin /imports wta.exe`.
- [ ] Install the resulting MSIX bundle in a fresh Windows Sandbox (no VC++ Redist) and confirm `wta.exe` launches (the agent pane / `?<prompt>` delegation works, `%LOCALAPPDATA%\IntelligentTerminal\logs\wta-ensure-host.log` shows no DLL-load failures).
- [ ] Verify the CI log shows the merged `.cargo/config.toml` contains **both** `[target.x86_64-pc-windows-msvc]` and `[registries]` sections (the `Get-Content` echo at the end of the step makes this visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)