### PR TITLE
fix: escape PowerShell variable in cargo config append step

### DIFF
--- a/build/pipelines/templates-v2/job-build-project.yml
+++ b/build/pipelines/templates-v2/job-build-project.yml
@@ -236,7 +236,7 @@ jobs:
       replace-with = "WindowsTerminalCargo"
       "@
       Add-Content -Path $configPath -Value $registry -Encoding utf8NoBOM
-      Write-Host "Updated $configPath:"
+      Write-Host "Updated ${configPath}:"
       Get-Content $configPath
     displayName: Append Cargo registry config (CI only)
 


### PR DESCRIPTION
The `$configPath:` syntax is invalid PowerShell — the colon after the variable name is interpreted as a drive-qualifier. Wrap in `${}` to delimit the variable name.

Fixes CI build failure in the 'Append Cargo registry config' step introduced by #55.