### PR TITLE
wta: ship user locale in Terminal/Shell Context JSON

### DIFF
--- a/tools/wta/prompts/terminal-agent.md
+++ b/tools/wta/prompts/terminal-agent.md
@@ -154,6 +154,6 @@ Rules:
 The following sections are injected by WTA at runtime:
 
 - supported delegate agents
-- terminal context JSON (fields: `activeTarget`, `window_title`, `cwd`, `profile`, `buffer`)
+- terminal context JSON (fields: `activeTarget`, `window_title`, `cwd`, `profile`, `locale`, `buffer`)
 
 <!-- WTA_RUNTIME_CONTEXT -->

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -18,6 +18,8 @@ mod runtime_paths;
 mod rtl;
 mod pane_context;
 mod shell;
+#[cfg(test)]
+mod test_support;
 mod theme;
 mod ui;
 mod ui_trace;

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1044,17 +1044,15 @@ async fn build_terminal_context_json(shell_mgr: &ShellManager) -> Option<String>
 }
 
 /// User's UI locale as a BCP-47 tag, suitable for embedding in
-/// runtime context JSON shipped to the agent. Pseudo-locales
-/// (`qps-ploc*`) are UI-only and not real BCP-47 tags; map them
-/// to `en-US` so the model sees a real locale. Mirrors the
-/// `qps-*` → `en_US.UTF-8` mapping in `spawn.rs` for `LANG`/`LC_ALL`.
+/// runtime context JSON shipped to the agent.
+///
+/// Pseudo-locales (`qps-ploc*`) are passed through verbatim. Unlike
+/// `LANG`/`LC_ALL` in `spawn.rs` — which feed libc and have to be real
+/// POSIX locales — this field is just metadata for an LLM, which will
+/// either recognise the tag or treat it as opaque text. Either way it's
+/// honest: it reflects exactly what the user picked in the UI.
 fn user_locale_tag() -> String {
-    let raw = rust_i18n::locale().to_string();
-    if raw.is_empty() || raw.starts_with("qps-") {
-        "en-US".to_string()
-    } else {
-        raw
-    }
+    rust_i18n::locale().to_string()
 }
 
 async fn build_prompt_text(
@@ -2723,22 +2721,17 @@ mod tests {
     use tokio::sync::mpsc;
 
     #[test]
-    fn user_locale_tag_maps_pseudo_locales_to_en_us() {
+    fn user_locale_tag_returns_current_locale_verbatim() {
         let _g = crate::test_support::lock_locale();
-        // qps-* are UI-only pseudo-locales — agents won't recognize them.
-        rust_i18n::set_locale("qps-ploc");
-        assert_eq!(user_locale_tag(), "en-US");
-        rust_i18n::set_locale("qps-ploca");
-        assert_eq!(user_locale_tag(), "en-US");
-    }
-
-    #[test]
-    fn user_locale_tag_passes_real_locale_through() {
-        let _g = crate::test_support::lock_locale();
+        // Real locales pass through unchanged.
         rust_i18n::set_locale("zh-CN");
         assert_eq!(user_locale_tag(), "zh-CN");
         rust_i18n::set_locale("en-US");
         assert_eq!(user_locale_tag(), "en-US");
+        // Pseudo-locales are passed through too — agents treat unknown
+        // BCP-47 tags as opaque metadata, so there's no need to remap.
+        rust_i18n::set_locale("qps-ploca");
+        assert_eq!(user_locale_tag(), "qps-ploca");
     }
 
     #[test]

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -2724,6 +2724,7 @@ mod tests {
 
     #[test]
     fn user_locale_tag_maps_pseudo_locales_to_en_us() {
+        let _g = crate::test_support::lock_locale();
         // qps-* are UI-only pseudo-locales — agents won't recognize them.
         rust_i18n::set_locale("qps-ploc");
         assert_eq!(user_locale_tag(), "en-US");
@@ -2733,6 +2734,7 @@ mod tests {
 
     #[test]
     fn user_locale_tag_passes_real_locale_through() {
+        let _g = crate::test_support::lock_locale();
         rust_i18n::set_locale("zh-CN");
         assert_eq!(user_locale_tag(), "zh-CN");
         rust_i18n::set_locale("en-US");

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1037,9 +1037,24 @@ async fn build_terminal_context_json(shell_mgr: &ShellManager) -> Option<String>
         "window_title": target_window_title,
         "cwd": target_cwd,
         "profile": target_profile,
+        "locale": user_locale_tag(),
         "buffer": buffer,
     }))
     .ok()
+}
+
+/// User's UI locale as a BCP-47 tag, suitable for embedding in
+/// runtime context JSON shipped to the agent. Pseudo-locales
+/// (`qps-ploc*`) are UI-only and not real BCP-47 tags; map them
+/// to `en-US` so the model sees a real locale. Mirrors the
+/// `qps-*` → `en_US.UTF-8` mapping in `spawn.rs` for `LANG`/`LC_ALL`.
+fn user_locale_tag() -> String {
+    let raw = rust_i18n::locale().to_string();
+    if raw.is_empty() || raw.starts_with("qps-") {
+        "en-US".to_string()
+    } else {
+        raw
+    }
 }
 
 async fn build_prompt_text(
@@ -1148,6 +1163,7 @@ async fn build_prompt_text(
                     let json = serde_json::to_string(&serde_json::json!({
                         "profile": profile,
                         "cwd": cwd,
+                        "locale": user_locale_tag(),
                     }))
                     .unwrap_or_else(|_| "{}".to_string());
                     runtime_sections.push(format!(
@@ -2700,11 +2716,28 @@ async fn dispatch_prompt_body(
 #[cfg(test)]
 mod tests {
     use super::{
-        complete_prompt_request, requested_model_id, summarize_agent_identity,
+        complete_prompt_request, requested_model_id, summarize_agent_identity, user_locale_tag,
         PromptTimingState,
     };
     use crate::app::AppEvent;
     use tokio::sync::mpsc;
+
+    #[test]
+    fn user_locale_tag_maps_pseudo_locales_to_en_us() {
+        // qps-* are UI-only pseudo-locales — agents won't recognize them.
+        rust_i18n::set_locale("qps-ploc");
+        assert_eq!(user_locale_tag(), "en-US");
+        rust_i18n::set_locale("qps-ploca");
+        assert_eq!(user_locale_tag(), "en-US");
+    }
+
+    #[test]
+    fn user_locale_tag_passes_real_locale_through() {
+        rust_i18n::set_locale("zh-CN");
+        assert_eq!(user_locale_tag(), "zh-CN");
+        rust_i18n::set_locale("en-US");
+        assert_eq!(user_locale_tag(), "en-US");
+    }
 
     #[test]
     fn parses_model_from_separate_flag() {

--- a/tools/wta/src/test_support.rs
+++ b/tools/wta/src/test_support.rs
@@ -1,0 +1,51 @@
+//! Test-only helpers shared across modules.
+//!
+//! These helpers are compiled only under `cfg(test)`. They centralize patterns
+//! that would otherwise have to be duplicated in every `mod tests` block —
+//! most importantly the global-locale lock, which must be a single mutex
+//! shared across the whole crate to actually serialize parallel tests.
+
+#![cfg(test)]
+
+use std::sync::{Mutex, MutexGuard};
+
+/// All tests that read or write `rust_i18n`'s global locale share this lock.
+///
+/// Cargo runs unit tests in parallel by default. Without a single shared
+/// mutex, one test's `rust_i18n::set_locale("zh-CN")` can race with another
+/// test's en-US assertions. Module-local mutexes are NOT sufficient, because
+/// two tests in different modules would hold two different locks and still
+/// race on the global `rust_i18n` state.
+static LOCALE_LOCK: Mutex<()> = Mutex::new(());
+
+/// RAII guard returned by [`lock_locale`].
+///
+/// While alive it (a) holds the crate-wide `LOCALE_LOCK`, serializing all
+/// locale-sensitive tests, and (b) on drop restores whatever locale was
+/// active when the guard was acquired, so the test suite remains
+/// order-independent even when individual tests mutate the global locale.
+pub(crate) struct LocaleGuard {
+    _lock: MutexGuard<'static, ()>,
+    previous: String,
+}
+
+impl Drop for LocaleGuard {
+    fn drop(&mut self) {
+        rust_i18n::set_locale(&self.previous);
+    }
+}
+
+/// Acquire the shared locale lock and capture the current locale for restore.
+///
+/// Any test that calls `rust_i18n::set_locale(...)` — directly or transitively
+/// via code that reads the global locale — must hold the returned guard for
+/// the duration of its assertions.
+pub(crate) fn lock_locale() -> LocaleGuard {
+    // `unwrap` is fine: a poisoned mutex here just means a previous test
+    // panicked while holding it, and we don't care about the `()` payload.
+    let lock = LOCALE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    LocaleGuard {
+        _lock: lock,
+        previous: rust_i18n::locale().to_string(),
+    }
+}

--- a/tools/wta/src/ui/agents_view.rs
+++ b/tools/wta/src/ui/agents_view.rs
@@ -485,26 +485,23 @@ fn trunc(s: &str, n: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
     use std::time::Duration;
 
-    /// All tests that read rust_i18n strings share the global locale.
-    /// Cargo runs tests in parallel by default, so without this mutex
-    /// one test's `set_locale("zh-CN")` is observed by another test
-    /// inside its en-US assertions. Every locale-sensitive test must
-    /// acquire this lock first.
-    static LOCALE_LOCK: Mutex<()> = Mutex::new(());
+    /// All locale-sensitive tests must hold the crate-wide locale guard
+    /// from [`crate::test_support::lock_locale`]. It serializes parallel
+    /// tests on the global `rust_i18n` locale AND restores the previous
+    /// locale on drop, so the suite stays order-independent.
 
     /// Ensure tests use en-US locale so the hardcoded English assertions match
     /// (regardless of what the running shell's locale is). Must be called
-    /// while holding `LOCALE_LOCK`.
+    /// while holding the locale guard.
     fn set_test_locale() {
         rust_i18n::set_locale("en-US");
     }
 
     #[test]
     fn relative_age_just_now_under_a_minute() {
-        let _g = LOCALE_LOCK.lock().unwrap();
+        let _g = crate::test_support::lock_locale();
         set_test_locale();
         let t = SystemTime::now() - Duration::from_secs(5);
         assert_eq!(relative_age(t), "just now");
@@ -512,7 +509,7 @@ mod tests {
 
     #[test]
     fn relative_age_singular_and_plural_minutes() {
-        let _g = LOCALE_LOCK.lock().unwrap();
+        let _g = crate::test_support::lock_locale();
         set_test_locale();
         let t1 = SystemTime::now() - Duration::from_secs(60);
         assert_eq!(relative_age(t1), "1 minute ago");
@@ -522,7 +519,7 @@ mod tests {
 
     #[test]
     fn relative_age_days() {
-        let _g = LOCALE_LOCK.lock().unwrap();
+        let _g = crate::test_support::lock_locale();
         set_test_locale();
         let t = SystemTime::now() - Duration::from_secs(3 * 86_400);
         assert_eq!(relative_age(t), "3 days ago");
@@ -531,7 +528,7 @@ mod tests {
     #[test]
     fn relative_age_falls_back_to_calendar_date_after_a_week() {
         // 8 days ago — must produce a calendar date string, not "8 days ago".
-        let _g = LOCALE_LOCK.lock().unwrap();
+        let _g = crate::test_support::lock_locale();
         set_test_locale();
         let t = SystemTime::now() - Duration::from_secs(8 * 86_400);
         let s = relative_age(t);
@@ -556,7 +553,7 @@ mod tests {
     ///      one digit, and doesn't end with the English literal "ago".
     #[test]
     fn relative_age_covers_representative_locales() {
-        let _g = LOCALE_LOCK.lock().unwrap();
+        let _g = crate::test_support::lock_locale();
         let one_minute = SystemTime::now() - Duration::from_secs(60);
         let many_minutes = SystemTime::now() - Duration::from_secs(180);
         let many_hours = SystemTime::now() - Duration::from_secs(5 * 3600);
@@ -633,7 +630,7 @@ mod tests {
     /// contains digits, and is distinct across locales.
     #[test]
     fn format_calendar_date_locale_smoke() {
-        let _g = LOCALE_LOCK.lock().unwrap();
+        let _g = crate::test_support::lock_locale();
         // 2026-05-22 in UTC.
         let target = UNIX_EPOCH + Duration::from_secs(20_595 * 86_400);
 
@@ -681,7 +678,7 @@ mod tests {
 
     #[test]
     fn format_calendar_date_renders_month_name() {
-        let _g = LOCALE_LOCK.lock().unwrap();
+        let _g = crate::test_support::lock_locale();
         rust_i18n::set_locale("en-US");
         let t = UNIX_EPOCH + Duration::from_secs(20_563 * 86_400);
         let s = format_calendar_date(t);


### PR DESCRIPTION
## Summary

WTA already forwards the user's UI locale to the spawned ACP agent process via `LANG`/`LC_ALL` env vars (`src/protocol/acp/spawn.rs`), but those env vars only reach the **adapter process** — they aren't guaranteed to be propagated to the cloud LLM the adapter talks to. The most reliable channel to the model itself is the prompt text.

ACP 0.10's wire format has no `locale` field on `initialize` / `session/new`, so this PR takes the smallest possible step: ship the user's BCP-47 locale tag as one more field inside the **existing** runtime-context JSON blocks the agent already parses.

## Change

| File | Change |
|---|---|
| `tools/wta/src/protocol/acp/client.rs` | New `user_locale_tag()` helper. Returns the current `rust_i18n::locale()` verbatim — including pseudo-locales (`qps-ploc*`). Unlike `LANG`/`LC_ALL` in `spawn.rs`, which feed libc and must be real POSIX locales, this field is just metadata for an LLM: it either recognises the BCP-47 tag or treats it as opaque text. Added `"locale"` field to the Terminal Context JSON (planner) and Shell Context JSON (auto-fix). |
| `tools/wta/prompts/terminal-agent.md` | One-line doc-list update: `locale` now listed alongside `activeTarget` / `cwd` / `profile` / `buffer`. |
| `tools/wta/src/test_support.rs` (new) | Crate-wide `lock_locale()` RAII guard. Serializes every locale-mutating test on a single shared mutex and restores the previous locale on drop, so the test suite stays order-independent. |
| `tools/wta/src/ui/agents_view.rs` | Migrated existing `LOCALE_LOCK` tests to the shared guard (two separate per-module mutexes wouldn't actually serialize the global `rust_i18n` state). |

### Deliberately not in this PR

- **No `qps-* → en-US` remap in this field.** `spawn.rs` has to remap because libc/POSIX consumers warn or fall back on bogus tags. The ACP context JSON is consumed by an LLM, which has no such constraint, so the field reflects exactly what the user picked in the UI.
- **No new prompt section / instructions.** The model already does the right thing — replies in the user's language, doesn't translate code/paths. Adding "respond in locale X" rules would over-instruct. Treating `locale` as just another context field (like `profile`) keeps the prompt surface clean.
- **No ACP `_meta` plumbing.** It's a viable future extensibility point if adapters start honoring it, but today most ignore it; not worth wiring until there's a consumer.

## Verification

- `cargo build --manifest-path tools/wta/Cargo.toml` → clean
- `cargo test --bin wta -- locale relative_age format_calendar_date` → 12/12 pass (pass-through + all locale-sensitive tests serialized through the shared guard)
- Live end-to-end check on a Chinese chrome (zh-CN): `wta-main.log` shows `"locale":"zh-CN"` inside the Terminal Context JSON, matching the UI language

## Layered story

| Layer | Channel | Status |
|---|---|---|
| 1. Process env | `LANG` / `LC_ALL` (with `qps-* → en_US.UTF-8` remap for libc) | Already in `spawn.rs` |
| 2. Prompt text | `"locale"` in Terminal/Shell Context JSON (verbatim, including `qps-ploc*`) | **This PR** |
| 3. ACP `_meta` | `_meta: { "wta.locale": "..." }` on `initialize` / `session/new` | Future, opt-in when adapters honor it |
