### PR TITLE
wta: redact event bodies from logs

### DIFF
--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -1568,7 +1568,6 @@ async fn run_acp_app(
                 let wt_event_tx = event_tx.clone();
                 tokio::task::spawn_local(async move {
                     while let Some(event_json) = wt_rx.recv().await {
-                        tracing::debug!(event = %event_json, "wt_event_rx: received event");
                         let method = event_json
                             .get("method")
                             .and_then(|v| v.as_str())
@@ -1609,6 +1608,15 @@ async fn run_acp_app(
                             .get("tab_id")
                             .and_then(|v| v.as_str())
                             .map(str::to_string);
+                        let body_bytes = serde_json::to_string(&params)
+                            .map(|s| s.len())
+                            .unwrap_or(0);
+                        tracing::debug!(
+                            method = %method,
+                            pane_id = %pane_id,
+                            bytes = body_bytes,
+                            "wt_event_rx: received event"
+                        );
                         let _ = wt_event_tx.send(app::AppEvent::WtEvent {
                             method,
                             pane_id,


### PR DESCRIPTION
## Why

wta-main.log was growing huge and leaking sensitive content. Two symptoms:

1. gent.tool.finished lines dumped the full hook payload — including `tool_result.text_result_for_llm` (the model-bound grep/read output, often multi-KB).
2. `vt_sequence` lines contained OSC titles carrying user prompts typed in *other* WT panes (the COM server broadcasts vt sequences to all subscribers).

Root cause: `tools/wta/src/main.rs` did `tracing::debug!(event = %event_json, ...)`, writing every received WT event JSON verbatim. With the default filter `WTA_LOG=debug` (applied unconditionally in both debug and release), every user kept getting full bodies in their logs.

## What

Replace the verbatim dump with a structured DEBUG line containing only `method`, `pane_id`, and `bytes`. The raw body is **not** written at any level — no TRACE escape hatch, because privacy is a wrapper-level concern, not a log-level knob.

## Verification

- Built clean (cargo build --target x86_64-pc-windows-msvc).
- Fresh `code-review` sub-agent pass: HIGH confidence on correctness, no-leakage, comment accuracy, and behavior preservation.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>