### PR TITLE
wta: default log level to warn in release builds

### DIFF
--- a/tools/wta/src/logging.rs
+++ b/tools/wta/src/logging.rs
@@ -1,6 +1,23 @@
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
+/// Returns the default `EnvFilter` directive to use when neither `WTA_LOG` nor
+/// `RUST_LOG` is set.
+///
+/// `debug_assertions` is passed in (rather than read from `cfg!`) so that the
+/// release-build branch can be unit-tested even when the test binary itself is
+/// compiled in debug mode.
+pub(crate) fn default_filter_directive(debug_assertions: bool) -> &'static str {
+    if debug_assertions {
+        // Verbose for developers iterating on the code.
+        "debug"
+    } else {
+        // Quiet in shipping release binaries. Users troubleshooting can opt in
+        // by setting `WTA_LOG=info|debug|trace` or `RUST_LOG=...`.
+        "warn"
+    }
+}
+
 pub fn init(process: &str) -> WorkerGuard {
     let log_dir = crate::runtime_paths::intelligent_terminal_root()
         .map(|r| r.join("logs"))
@@ -11,9 +28,11 @@ pub fn init(process: &str) -> WorkerGuard {
     let appender = tracing_appender::rolling::never(&log_dir, &file_name);
     let (non_blocking, guard) = tracing_appender::non_blocking(appender);
 
+    let default_level = default_filter_directive(cfg!(debug_assertions));
+
     let filter = EnvFilter::try_from_env("WTA_LOG")
         .or_else(|_| EnvFilter::try_from_default_env())
-        .unwrap_or_else(|_| EnvFilter::new("debug"));
+        .unwrap_or_else(|_| EnvFilter::new(default_level));
 
     tracing_subscriber::registry()
         .with(filter)
@@ -27,4 +46,34 @@ pub fn init(process: &str) -> WorkerGuard {
         .init();
 
     guard
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::filter::LevelFilter;
+
+    #[test]
+    fn debug_build_default_is_debug() {
+        assert_eq!(default_filter_directive(true), "debug");
+    }
+
+    #[test]
+    fn release_build_default_is_warn() {
+        assert_eq!(default_filter_directive(false), "warn");
+    }
+
+    #[test]
+    fn release_default_filter_rejects_info_and_below() {
+        // The EnvFilter built from the release default must NOT enable info,
+        // debug, or trace events — only warn and error.
+        let filter = EnvFilter::new(default_filter_directive(false));
+        assert_eq!(filter.max_level_hint(), Some(LevelFilter::WARN));
+    }
+
+    #[test]
+    fn debug_default_filter_enables_debug() {
+        let filter = EnvFilter::new(default_filter_directive(true));
+        assert_eq!(filter.max_level_hint(), Some(LevelFilter::DEBUG));
+    }
 }


### PR DESCRIPTION
## What

Make the default log level in `tools/wta` depend on build type:

- **Debug builds**: `debug` (unchanged — verbose for developers)
- **Release builds**: `warn` (quiet by default; only warnings and errors)

## Why

Previously the fallback was hardcoded to `debug` for every build when neither `WTA_LOG` nor `RUST_LOG` was set, which produces noisy logs in shipping release binaries (info-level lifecycle chatter, etc.).

## Opting back into verbose logging

The env var override chain is unchanged, so users troubleshooting a release build can still enable more detail without rebuilding:

```powershell
$env:WTA_LOG = ""debug""    # or ""info"", ""trace""
$env:WTA_LOG = ""info,wta::protocol::acp=debug""   # per-module also works
```

## Files

- `tools/wta/src/logging.rs` — 1 file, +7/-1