### PR TITLE
Add filename-based v1 versioning to shell integration

### DIFF
--- a/src/cascadia/inc/ShellIntegration.h
+++ b/src/cascadia/inc/ShellIntegration.h
@@ -19,6 +19,8 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <string_view>
+#include <utility>
 #include <ShlObj.h>
 
 namespace Microsoft::Terminal::ShellIntegration
@@ -57,6 +59,13 @@ namespace Microsoft::Terminal::ShellIntegration
         return profilePath.wstring();
     }
 
+    // Versioned filename for the script we ship. To roll out a new version,
+    // bump the `_vN` suffix here and update the embedded `$Global:__ShellInteg_Version`
+    // literal in ScriptContent below. Install() looks for any prior version of
+    // this file (or the legacy unversioned name) in $PROFILE and rewrites the
+    // line in place; older script files left on disk are inert.
+    inline constexpr std::wstring_view kShellIntegrationScriptFileName = L"shell-integration_v1.ps1";
+
     // The shell integration script content.
     inline constexpr std::wstring_view ScriptContent{
         LR"(# Shell Integration — non-invasive prompt wrapper
@@ -64,12 +73,15 @@ namespace Microsoft::Terminal::ShellIntegration
 # sequences WITHOUT altering the visual appearance of the user's prompt.
 #
 # USAGE: dot-source this AFTER the user's profile has loaded:
-#   . "path\to\shell-integration.ps1"
+#   . "path\to\shell-integration_v1.ps1"
 #
 # Compatible with Windows PowerShell 5.1+ and PowerShell 7+.
 # Safe to source multiple times (idempotent guard).
 
 if (-not $Global:__ShellInteg_Installed) {
+
+    # Version sentinel — bump in lockstep with kShellIntegrationScriptFileName.
+    $Global:__ShellInteg_Version = 1
 
     # ── Escape characters (PS 5.1 doesn't support `e / `a literals) ──
     $Global:__ShellInteg_ESC = [char]0x1B   # ESC
@@ -127,9 +139,62 @@ if (-not $Global:__ShellInteg_Installed) {
 )"
     };
 
+    // Locates an existing `. "...shell-integration*.ps1"` dot-source line in `contents`.
+    // Returns the [start, end) byte range of the line (CR/LF excluded), or
+    // { npos, npos } when no such line is present. Matches any version of our
+    // script — current (shell-integration_v1.ps1) AND legacy (shell-integration.ps1)
+    // — so upgrades can rewrite the line in place.
+    inline std::pair<size_t, size_t> FindShellIntegrationDotSourceLine(std::string_view contents)
+    {
+        size_t pos = 0;
+        while (pos < contents.size())
+        {
+            size_t eol = contents.find('\n', pos);
+            if (eol == std::string_view::npos)
+            {
+                eol = contents.size();
+            }
+            size_t lineEnd = eol;
+            while (lineEnd > pos && (contents[lineEnd - 1] == '\n' || contents[lineEnd - 1] == '\r'))
+            {
+                --lineEnd;
+            }
+            const std::string_view line(contents.data() + pos, lineEnd - pos);
+
+            // PowerShell dot-source: leading whitespace, '.', whitespace, then a path
+            // containing "shell-integration" and ending with `.ps1"`.
+            size_t i = 0;
+            while (i < line.size() && (line[i] == ' ' || line[i] == '\t'))
+            {
+                ++i;
+            }
+            if (i < line.size() && line[i] == '.' &&
+                i + 1 < line.size() && (line[i + 1] == ' ' || line[i + 1] == '\t') &&
+                line.find("shell-integration") != std::string_view::npos &&
+                line.find(".ps1\"") != std::string_view::npos)
+            {
+                return { pos, lineEnd };
+            }
+            pos = eol < contents.size() ? eol + 1 : eol;
+        }
+        return { std::string_view::npos, std::string_view::npos };
+    }
+
     // Install shell integration for a given PowerShell profile path.
-    // Writes shell-integration.ps1 next to the profile and appends a
-    // dot-source line to the profile. Idempotent — skips if already configured.
+    // Writes the versioned script (kShellIntegrationScriptFileName) next to the
+    // profile and ensures $PROFILE dot-sources it. Idempotent — returns
+    // alreadyInstalled=true when the existing dot-source line already references
+    // the current script and the script file is on disk.
+    //
+    // Flow (one pass, file-not-exists case collapses into the existing-file case):
+    //   1. Ensure profile dir + file exist (touch an empty file if missing).
+    //   2. Read profile contents.
+    //   3. Find any existing `. "...shell-integration*.ps1"` line.
+    //   4. If it already matches the desired line and the script is on disk → no-op.
+    //   5. Backup profile (non-fatal), write the versioned script.
+    //   6. Replace the existing line in place, OR append a new line at the bottom.
+    //   7. Write the profile back.
+    //
     // Synchronous — call from a background thread.
     inline InstallResult Install(const std::wstring& profilePathW)
     {
@@ -140,45 +205,45 @@ if (-not $Global:__ShellInteg_Installed) {
 
         const std::filesystem::path profilePath{ profilePathW };
         const auto profileDir = profilePath.parent_path();
-        const auto scriptPath = profileDir / L"shell-integration.ps1";
+        const auto scriptPath = profileDir / std::wstring{ kShellIntegrationScriptFileName };
 
-        // Check if already configured
-        if (std::filesystem::exists(profilePath))
-        {
-            std::ifstream profileIn(profilePath, std::ios::binary);
-            if (profileIn)
-            {
-                std::string contents((std::istreambuf_iterator<char>(profileIn)),
-                                      std::istreambuf_iterator<char>());
-                profileIn.close();
-                if (contents.find("shell-integration.ps1") != std::string::npos)
-                {
-                    return { true, true, {} }; // already configured
-                }
-            }
-        }
-
-        // Ensure profile directory exists
+        // 1. Ensure profile dir + file exist. A freshly-touched file is just
+        //    empty content — the rest of the flow handles it identically.
         std::error_code ec;
         std::filesystem::create_directories(profileDir, ec);
         if (ec)
         {
             return { false, false, L"Failed to create profile directory" };
         }
-
-        // Write shell-integration.ps1
+        if (!std::filesystem::exists(profilePath))
         {
-            std::ofstream scriptOut(scriptPath, std::ios::binary | std::ios::trunc);
-            if (!scriptOut)
-            {
-                return { false, false, L"Failed to write shell-integration.ps1" };
-            }
-            const auto scriptUtf8 = til::u16u8(ScriptContent);
-            scriptOut.write(scriptUtf8.data(), scriptUtf8.size());
+            std::ofstream{ profilePath, std::ios::binary }; // touch
         }
 
-        // Back up existing $PROFILE before modifying
-        if (std::filesystem::exists(profilePath))
+        // 2. Read profile contents.
+        std::string contents;
+        {
+            std::ifstream in{ profilePath, std::ios::binary };
+            contents.assign(std::istreambuf_iterator<char>(in),
+                            std::istreambuf_iterator<char>());
+        }
+
+        // 3. Find any existing dot-source line (current or legacy version).
+        const auto desiredLine = til::u16u8(
+            fmt::format(FMT_COMPILE(L". \"{}\""), scriptPath.wstring()));
+        const auto [lineStart, lineEnd] = FindShellIntegrationDotSourceLine(contents);
+        const bool found = lineStart != std::string::npos;
+
+        // 4. No-op when the existing line already matches AND the script is on disk.
+        if (found &&
+            std::string_view(contents.data() + lineStart, lineEnd - lineStart) == desiredLine &&
+            std::filesystem::exists(scriptPath))
+        {
+            return { true, true, {} };
+        }
+
+        // 5a. Backup $PROFILE before modifying (non-fatal if it fails).
+        if (!contents.empty())
         {
             const auto now = std::chrono::system_clock::now();
             const auto tt = std::chrono::system_clock::to_time_t(now);
@@ -187,38 +252,47 @@ if (-not $Global:__ShellInteg_Installed) {
             wchar_t timeBuf[32]{};
             wcsftime(timeBuf, std::size(timeBuf), L"%Y%m%d-%H%M%S", &tm);
 
-            std::ifstream backupIn(profilePath, std::ios::binary);
-            std::string backupContent((std::istreambuf_iterator<char>(backupIn)),
-                                      std::istreambuf_iterator<char>());
-            backupIn.close();
-            const auto contentHash = std::hash<std::string>{}(backupContent);
-
+            const auto contentHash = std::hash<std::string>{}(contents);
             auto backupPath = profilePath.wstring() +
                 L".bak." + timeBuf + L"." +
                 fmt::format(FMT_COMPILE(L"{:08x}"), contentHash & 0xFFFFFFFF);
             std::filesystem::copy_file(profilePath, backupPath,
                                        std::filesystem::copy_options::overwrite_existing, ec);
-            // Non-fatal if backup fails
         }
 
-        // Append dot-source line to $PROFILE
-        auto dotSourceLine = fmt::format(
-            FMT_COMPILE(L"\n# Shell integration \u2014 emit OSC 133 (exit code) + OSC 9;9 (CWD) without\n"
-                        L"# altering the visual prompt.  Must load LAST so it can wrap whatever\n"
-                        L"# prompt function exists at this point.\n"
-                        L". \"{}\""),
-            scriptPath.wstring());
-
+        // 5b. Write (or refresh) the versioned script next to the profile.
         {
-            std::ofstream profileOut(profilePath, std::ios::binary | std::ios::app);
-            if (!profileOut)
+            std::ofstream scriptOut{ scriptPath, std::ios::binary | std::ios::trunc };
+            if (!scriptOut)
             {
-                return { false, false, L"Failed to append to PowerShell profile" };
+                return { false, false, L"Failed to write shell-integration script" };
             }
-            const auto lineUtf8 = til::u16u8(dotSourceLine);
-            profileOut.write(lineUtf8.data(), lineUtf8.size());
+            const auto scriptUtf8 = til::u16u8(ScriptContent);
+            scriptOut.write(scriptUtf8.data(), scriptUtf8.size());
         }
 
+        // 6. Update existing line in place, or append a new line at the bottom.
+        if (found)
+        {
+            contents.replace(lineStart, lineEnd - lineStart, desiredLine);
+        }
+        else
+        {
+            if (!contents.empty() && contents.back() != '\n')
+            {
+                contents += '\n';
+            }
+            contents += desiredLine;
+            contents += '\n';
+        }
+
+        // 7. Write the profile back.
+        std::ofstream profileOut{ profilePath, std::ios::binary | std::ios::trunc };
+        if (!profileOut)
+        {
+            return { false, false, L"Failed to write PowerShell profile" };
+        }
+        profileOut.write(contents.data(), contents.size());
         return { true, false, {} };
     }
 

--- a/src/cascadia/inc/ShellIntegration.h
+++ b/src/cascadia/inc/ShellIntegration.h
@@ -147,22 +147,35 @@ if (-not $Global:__ShellInteg_Installed) {
         };
     }
 
+    // Result of locating an existing `. "...shell-integration*.ps1"` dot-source
+    // line. When `found()`, [start, end) is the byte range of the matched line
+    // (CR/LF excluded) and `referencedPath` is the quoted path (without the
+    // surrounding quotes) — useful for path-equivalence checks even when the
+    // line has trailing comments or extra whitespace.
+    struct DotSourceMatch
+    {
+        size_t start = std::string::npos;
+        size_t end = std::string::npos;
+        std::string referencedPath;
+
+        bool found() const noexcept { return start != std::string::npos; }
+    };
+
     // Locates an existing `. "...shell-integration*.ps1"` dot-source line in `contents`.
-    // Returns the [start, end) byte range of the line (CR/LF excluded), or
-    // { npos, npos } when no such line is present. Matches any version of our
-    // script — current (shell-integration_vN.ps1) AND legacy (shell-integration.ps1)
-    // — so upgrades can rewrite the line in place.
+    // Matches any version of our script — current (shell-integration_vN.ps1) AND
+    // legacy (shell-integration.ps1) — so upgrades can rewrite the line in place.
     //
     // Pattern (multiline): line begins with `.` + whitespace + a quoted path
     // whose FINAL filename component is `shell-integration*.ps1`. The path
     // component check (preceded by `/`, `\`, or the opening quote; followed
     // only by non-separator chars before `.ps1`) avoids false matches on
     // directories that happen to contain "shell-integration" or on trailing
-    // comments after an unrelated dot-source line.
-    inline std::pair<size_t, size_t> FindShellIntegrationDotSourceLine(std::string_view contents)
+    // comments after an unrelated dot-source line. Capture group 1 yields the
+    // quoted path itself (without the surrounding quotes).
+    inline DotSourceMatch FindShellIntegrationDotSourceLine(std::string_view contents)
     {
         static const std::regex pattern{
-            R"(^[ \t]*\.[ \t]+"(?:[^"]*[\\/])?shell-integration[^"\\/]*\.ps1".*)",
+            R"(^[ \t]*\.[ \t]+"((?:[^"]*[\\/])?shell-integration[^"\\/]*\.ps1)".*)",
             std::regex_constants::ECMAScript | std::regex_constants::multiline
         };
         std::cmatch m;
@@ -175,9 +188,9 @@ if (-not $Global:__ShellInteg_Installed) {
             {
                 --end;
             }
-            return { start, end };
+            return { start, end, m[1].str() };
         }
-        return { std::string_view::npos, std::string_view::npos };
+        return {};
     }
 
     // Install shell integration for a given PowerShell profile path.
@@ -243,14 +256,17 @@ if (-not $Global:__ShellInteg_Installed) {
             : std::string_view{ "\n" };
 
         // 3. Find any existing dot-source line (current or legacy version).
+        const auto desiredPath = til::u16u8(scriptPath.wstring());
         const auto desiredLine = til::u16u8(
             fmt::format(FMT_COMPILE(L". \"{}\""), scriptPath.wstring()));
-        const auto [lineStart, lineEnd] = FindShellIntegrationDotSourceLine(contents);
-        const bool found = lineStart != std::string::npos;
+        const auto match = FindShellIntegrationDotSourceLine(contents);
 
-        // 4. No-op when the existing line already matches AND the script is on disk.
-        if (found &&
-            std::string_view(contents.data() + lineStart, lineEnd - lineStart) == desiredLine &&
+        // 4. No-op when the existing line already references the current script
+        //    AND the script is on disk. Compare the captured path (not the entire
+        //    line) so that trailing user comments or extra whitespace on a
+        //    correct line don't trigger a needless rewrite.
+        if (match.found() &&
+            match.referencedPath == desiredPath &&
             std::filesystem::exists(scriptPath))
         {
             return { true, true, {} };
@@ -283,12 +299,17 @@ if (-not $Global:__ShellInteg_Installed) {
             }
             const auto scriptUtf8 = til::u16u8(ShellIntegrationScriptContent());
             scriptOut.write(scriptUtf8.data(), scriptUtf8.size());
+            scriptOut.close();
+            if (!scriptOut)
+            {
+                return { false, false, L"Failed to write shell-integration script (write/close failed)" };
+            }
         }
 
         // 6. Update existing line in place, or append a new line at the bottom.
-        if (found)
+        if (match.found())
         {
-            contents.replace(lineStart, lineEnd - lineStart, desiredLine);
+            contents.replace(match.start, match.end - match.start, desiredLine);
         }
         else
         {
@@ -300,13 +321,21 @@ if (-not $Global:__ShellInteg_Installed) {
             contents += eol;
         }
 
-        // 7. Write the profile back.
+        // 7. Write the profile back. Check write/close — opening with `trunc`
+        //    means a silent mid-stream failure would leave the profile
+        //    truncated or partial. Surface any failure so callers don't
+        //    report a successful install over a corrupt profile.
         std::ofstream profileOut{ profilePath, std::ios::binary | std::ios::trunc };
         if (!profileOut)
         {
             return { false, false, L"Failed to write PowerShell profile" };
         }
         profileOut.write(contents.data(), contents.size());
+        profileOut.close();
+        if (!profileOut)
+        {
+            return { false, false, L"Failed to write PowerShell profile (write/close failed)" };
+        }
         return { true, false, {} };
     }
 

--- a/src/cascadia/inc/ShellIntegration.h
+++ b/src/cascadia/inc/ShellIntegration.h
@@ -20,6 +20,7 @@
 #include <regex>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <ShlObj.h>
 
 namespace Microsoft::Terminal::ShellIntegration
@@ -145,35 +146,22 @@ if (-not $Global:__ShellInteg_Installed) {
         };
     }
 
-    // Result of locating an existing `. "...shell-integration*.ps1"` dot-source
-    // line. When `found()`, [start, end) is the byte range of the matched line
-    // (CR/LF excluded) and `referencedPath` is the quoted path (without the
-    // surrounding quotes) — useful for path-equivalence checks even when the
-    // line has trailing comments or extra whitespace.
-    struct DotSourceMatch
-    {
-        size_t start = std::string::npos;
-        size_t end = std::string::npos;
-        std::string referencedPath;
-
-        bool found() const noexcept { return start != std::string::npos; }
-    };
-
     // Locates an existing `. "...shell-integration*.ps1"` dot-source line in `contents`.
-    // Matches any version of our script — current (shell-integration_vN.ps1) AND
-    // legacy (shell-integration.ps1) — so upgrades can rewrite the line in place.
+    // Returns the [start, end) byte range of the line (CR/LF excluded), or
+    // { npos, npos } when no such line is present. Matches any version of our
+    // script — current (shell-integration_vN.ps1) AND legacy (shell-integration.ps1)
+    // — so upgrades can rewrite the line in place.
     //
     // Pattern (multiline): line begins with `.` + whitespace + a quoted path
     // whose FINAL filename component is `shell-integration*.ps1`. The path
     // component check (preceded by `/`, `\`, or the opening quote; followed
     // only by non-separator chars before `.ps1`) avoids false matches on
     // directories that happen to contain "shell-integration" or on trailing
-    // comments after an unrelated dot-source line. Capture group 1 yields the
-    // quoted path itself (without the surrounding quotes).
-    inline DotSourceMatch FindShellIntegrationDotSourceLine(std::string_view contents)
+    // comments after an unrelated dot-source line.
+    inline std::pair<size_t, size_t> FindShellIntegrationDotSourceLine(std::string_view contents)
     {
         static const std::regex pattern{
-            R"(^[ \t]*\.[ \t]+"((?:[^"]*[\\/])?shell-integration[^"\\/]*\.ps1)".*)",
+            R"(^[ \t]*\.[ \t]+"(?:[^"]*[\\/])?shell-integration[^"\\/]*\.ps1".*)",
             std::regex_constants::ECMAScript | std::regex_constants::multiline
         };
         std::cmatch m;
@@ -187,9 +175,9 @@ if (-not $Global:__ShellInteg_Installed) {
             {
                 --end;
             }
-            return { start, end, m[1].str() };
+            return { start, end };
         }
-        return {};
+        return { std::string::npos, std::string::npos };
     }
 
     // Install shell integration for a given PowerShell profile path.
@@ -255,17 +243,14 @@ if (-not $Global:__ShellInteg_Installed) {
             : std::string_view{ "\n" };
 
         // 3. Find any existing dot-source line (current or legacy version).
-        const auto desiredPath = til::u16u8(scriptPath.wstring());
         const auto desiredLine = til::u16u8(
             fmt::format(FMT_COMPILE(L". \"{}\""), scriptPath.wstring()));
-        const auto match = FindShellIntegrationDotSourceLine(contents);
+        const auto [lineStart, lineEnd] = FindShellIntegrationDotSourceLine(contents);
+        const bool found = lineStart != std::string::npos;
 
-        // 4. No-op when the existing line already references the current script
-        //    AND the script is on disk. Compare the captured path (not the entire
-        //    line) so that trailing user comments or extra whitespace on a
-        //    correct line don't trigger a needless rewrite.
-        if (match.found() &&
-            match.referencedPath == desiredPath &&
+        // 4. No-op when the existing line already matches AND the script is on disk.
+        if (found &&
+            std::string_view(contents.data() + lineStart, lineEnd - lineStart) == desiredLine &&
             std::filesystem::exists(scriptPath))
         {
             return { true, true, {} };
@@ -306,9 +291,9 @@ if (-not $Global:__ShellInteg_Installed) {
         }
 
         // 6. Update existing line in place, or append a new line at the bottom.
-        if (match.found())
+        if (found)
         {
-            contents.replace(match.start, match.end - match.start, desiredLine);
+            contents.replace(lineStart, lineEnd - lineStart, desiredLine);
         }
         else
         {

--- a/src/cascadia/inc/ShellIntegration.h
+++ b/src/cascadia/inc/ShellIntegration.h
@@ -17,6 +17,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -59,29 +60,43 @@ namespace Microsoft::Terminal::ShellIntegration
         return profilePath.wstring();
     }
 
-    // Versioned filename for the script we ship. To roll out a new version,
-    // bump the `_vN` suffix here and update the embedded `$Global:__ShellInteg_Version`
-    // literal in ScriptContent below. Install() looks for any prior version of
-    // this file (or the legacy unversioned name) in $PROFILE and rewrites the
-    // line in place; older script files left on disk are inert.
-    inline constexpr std::wstring_view kShellIntegrationScriptFileName = L"shell-integration_v1.ps1";
+    // ───────────────────────────────────────────────────────────────────
+    // SINGLE SOURCE OF TRUTH for shell-integration script versioning.
+    // To roll out a new version, bump this integer — the filename
+    // (`shell-integration_vN.ps1`) and the embedded
+    // `$Global:__ShellInteg_Version = N` literal are derived from it.
+    // Install() looks for any prior version of this script (or the
+    // legacy unversioned name) in $PROFILE and rewrites the line in
+    // place; older script files left on disk are inert.
+    // ───────────────────────────────────────────────────────────────────
+    inline constexpr int kShellIntegrationVersion = 1;
 
-    // The shell integration script content.
-    inline constexpr std::wstring_view ScriptContent{
-        LR"(# Shell Integration — non-invasive prompt wrapper
+    // Versioned filename — derived from kShellIntegrationVersion.
+    inline std::wstring ShellIntegrationScriptFileName()
+    {
+        return L"shell-integration_v" + std::to_wstring(kShellIntegrationVersion) + L".ps1";
+    }
+
+    // The shell integration script content. The literal `__VERSION__` token
+    // is substituted with kShellIntegrationVersion at runtime so the version
+    // appears in exactly one place in source.
+    inline std::wstring ShellIntegrationScriptContent()
+    {
+        constexpr std::wstring_view kTemplate{
+            LR"(# Shell Integration — non-invasive prompt wrapper
 # Emits OSC 133 (command marks / exit code) and OSC 9;9 (CWD) escape
 # sequences WITHOUT altering the visual appearance of the user's prompt.
 #
 # USAGE: dot-source this AFTER the user's profile has loaded:
-#   . "path\to\shell-integration_v1.ps1"
+#   . "path\to\shell-integration_v__VERSION__.ps1"
 #
 # Compatible with Windows PowerShell 5.1+ and PowerShell 7+.
 # Safe to source multiple times (idempotent guard).
 
 if (-not $Global:__ShellInteg_Installed) {
 
-    # Version sentinel — bump in lockstep with kShellIntegrationScriptFileName.
-    $Global:__ShellInteg_Version = 1
+    # Version sentinel — derived from kShellIntegrationVersion in C++ source.
+    $Global:__ShellInteg_Version = __VERSION__
 
     # ── Escape characters (PS 5.1 doesn't support `e / `a literals) ──
     $Global:__ShellInteg_ESC = [char]0x1B   # ESC
@@ -137,54 +152,53 @@ if (-not $Global:__ShellInteg_Installed) {
     }
 }
 )"
-    };
+        };
+        std::wstring result{ kTemplate };
+        const auto versionStr = std::to_wstring(kShellIntegrationVersion);
+        for (size_t pos = 0; (pos = result.find(L"__VERSION__", pos)) != std::wstring::npos;)
+        {
+            result.replace(pos, 11, versionStr);
+            pos += versionStr.size();
+        }
+        return result;
+    }
 
     // Locates an existing `. "...shell-integration*.ps1"` dot-source line in `contents`.
     // Returns the [start, end) byte range of the line (CR/LF excluded), or
     // { npos, npos } when no such line is present. Matches any version of our
-    // script — current (shell-integration_v1.ps1) AND legacy (shell-integration.ps1)
+    // script — current (shell-integration_vN.ps1) AND legacy (shell-integration.ps1)
     // — so upgrades can rewrite the line in place.
+    //
+    // Pattern: leading whitespace, '.', whitespace, then a quoted path whose
+    // contents include "shell-integration" and end with `.ps1"`, then anything
+    // up to end-of-line. Uses std::regex with the multiline flag so `^`/`$`
+    // anchor at line boundaries.
     inline std::pair<size_t, size_t> FindShellIntegrationDotSourceLine(std::string_view contents)
     {
-        size_t pos = 0;
-        while (pos < contents.size())
+        static const std::regex pattern{
+            R"(^[ \t]*\.[ \t]+"[^"]*shell-integration[^"]*\.ps1".*)",
+            std::regex_constants::ECMAScript | std::regex_constants::multiline
+        };
+        std::cmatch m;
+        if (std::regex_search(contents.data(), contents.data() + contents.size(), m, pattern))
         {
-            size_t eol = contents.find('\n', pos);
-            if (eol == std::string_view::npos)
+            const size_t start = static_cast<size_t>(m.position());
+            size_t end = start + static_cast<size_t>(m.length());
+            // Multiline `$` stops before `\n`; trailing `\r` from CRLF may remain — strip it.
+            while (end > start && contents[end - 1] == '\r')
             {
-                eol = contents.size();
+                --end;
             }
-            size_t lineEnd = eol;
-            while (lineEnd > pos && (contents[lineEnd - 1] == '\n' || contents[lineEnd - 1] == '\r'))
-            {
-                --lineEnd;
-            }
-            const std::string_view line(contents.data() + pos, lineEnd - pos);
-
-            // PowerShell dot-source: leading whitespace, '.', whitespace, then a path
-            // containing "shell-integration" and ending with `.ps1"`.
-            size_t i = 0;
-            while (i < line.size() && (line[i] == ' ' || line[i] == '\t'))
-            {
-                ++i;
-            }
-            if (i < line.size() && line[i] == '.' &&
-                i + 1 < line.size() && (line[i + 1] == ' ' || line[i + 1] == '\t') &&
-                line.find("shell-integration") != std::string_view::npos &&
-                line.find(".ps1\"") != std::string_view::npos)
-            {
-                return { pos, lineEnd };
-            }
-            pos = eol < contents.size() ? eol + 1 : eol;
+            return { start, end };
         }
         return { std::string_view::npos, std::string_view::npos };
     }
 
     // Install shell integration for a given PowerShell profile path.
-    // Writes the versioned script (kShellIntegrationScriptFileName) next to the
-    // profile and ensures $PROFILE dot-sources it. Idempotent — returns
-    // alreadyInstalled=true when the existing dot-source line already references
-    // the current script and the script file is on disk.
+    // Writes the versioned script (named via ShellIntegrationScriptFileName())
+    // next to the profile and ensures $PROFILE dot-sources it. Idempotent —
+    // returns alreadyInstalled=true when the existing dot-source line already
+    // references the current script and the script file is on disk.
     //
     // Flow (one pass, file-not-exists case collapses into the existing-file case):
     //   1. Ensure profile dir + file exist (touch an empty file if missing).
@@ -205,7 +219,7 @@ if (-not $Global:__ShellInteg_Installed) {
 
         const std::filesystem::path profilePath{ profilePathW };
         const auto profileDir = profilePath.parent_path();
-        const auto scriptPath = profileDir / std::wstring{ kShellIntegrationScriptFileName };
+        const auto scriptPath = profileDir / ShellIntegrationScriptFileName();
 
         // 1. Ensure profile dir + file exist. A freshly-touched file is just
         //    empty content — the rest of the flow handles it identically.
@@ -267,7 +281,7 @@ if (-not $Global:__ShellInteg_Installed) {
             {
                 return { false, false, L"Failed to write shell-integration script" };
             }
-            const auto scriptUtf8 = til::u16u8(ScriptContent);
+            const auto scriptUtf8 = til::u16u8(ShellIntegrationScriptContent());
             scriptOut.write(scriptUtf8.data(), scriptUtf8.size());
         }
 

--- a/src/cascadia/inc/ShellIntegration.h
+++ b/src/cascadia/inc/ShellIntegration.h
@@ -169,14 +169,16 @@ if (-not $Global:__ShellInteg_Installed) {
     // script — current (shell-integration_vN.ps1) AND legacy (shell-integration.ps1)
     // — so upgrades can rewrite the line in place.
     //
-    // Pattern: leading whitespace, '.', whitespace, then a quoted path whose
-    // contents include "shell-integration" and end with `.ps1"`, then anything
-    // up to end-of-line. Uses std::regex with the multiline flag so `^`/`$`
-    // anchor at line boundaries.
+    // Pattern (multiline): line begins with `.` + whitespace + a quoted path
+    // whose FINAL filename component is `shell-integration*.ps1`. The path
+    // component check (preceded by `/`, `\`, or the opening quote; followed
+    // only by non-separator chars before `.ps1`) avoids false matches on
+    // directories that happen to contain "shell-integration" or on trailing
+    // comments after an unrelated dot-source line.
     inline std::pair<size_t, size_t> FindShellIntegrationDotSourceLine(std::string_view contents)
     {
         static const std::regex pattern{
-            R"(^[ \t]*\.[ \t]+"[^"]*shell-integration[^"]*\.ps1".*)",
+            R"(^[ \t]*\.[ \t]+"(?:[^"]*[\\/])?shell-integration[^"\\/]*\.ps1".*)",
             std::regex_constants::ECMAScript | std::regex_constants::multiline
         };
         std::cmatch m;
@@ -238,9 +240,23 @@ if (-not $Global:__ShellInteg_Installed) {
         std::string contents;
         {
             std::ifstream in{ profilePath, std::ios::binary };
+            if (!in)
+            {
+                return { false, false, L"Failed to open PowerShell profile for reading" };
+            }
             contents.assign(std::istreambuf_iterator<char>(in),
                             std::istreambuf_iterator<char>());
+            if (in.bad())
+            {
+                return { false, false, L"Failed to read PowerShell profile" };
+            }
         }
+
+        // Detect existing line-ending style so the appended line matches.
+        // If the profile contains any CRLF, treat it as a CRLF file.
+        const std::string_view eol = contents.find("\r\n") != std::string::npos
+            ? std::string_view{ "\r\n" }
+            : std::string_view{ "\n" };
 
         // 3. Find any existing dot-source line (current or legacy version).
         const auto desiredLine = til::u16u8(
@@ -294,10 +310,10 @@ if (-not $Global:__ShellInteg_Installed) {
         {
             if (!contents.empty() && contents.back() != '\n')
             {
-                contents += '\n';
+                contents += eol;
             }
             contents += desiredLine;
-            contents += '\n';
+            contents += eol;
         }
 
         // 7. Write the profile back.

--- a/src/cascadia/inc/ShellIntegration.h
+++ b/src/cascadia/inc/ShellIntegration.h
@@ -62,12 +62,11 @@ namespace Microsoft::Terminal::ShellIntegration
 
     // ───────────────────────────────────────────────────────────────────
     // SINGLE SOURCE OF TRUTH for shell-integration script versioning.
-    // To roll out a new version, bump this integer — the filename
-    // (`shell-integration_vN.ps1`) and the embedded
-    // `$Global:__ShellInteg_Version = N` literal are derived from it.
-    // Install() looks for any prior version of this script (or the
-    // legacy unversioned name) in $PROFILE and rewrites the line in
-    // place; older script files left on disk are inert.
+    // The version is carried by the filename (`shell-integration_vN.ps1`)
+    // — Install() detects any prior `shell-integration*.ps1` dot-source
+    // line in $PROFILE and rewrites it to point at the current version.
+    // Older script files left on disk are inert (never referenced).
+    // To roll out a new version, bump this integer.
     // ───────────────────────────────────────────────────────────────────
     inline constexpr int kShellIntegrationVersion = 1;
 
@@ -77,26 +76,19 @@ namespace Microsoft::Terminal::ShellIntegration
         return L"shell-integration_v" + std::to_wstring(kShellIntegrationVersion) + L".ps1";
     }
 
-    // The shell integration script content. The literal `__VERSION__` token
-    // is substituted with kShellIntegrationVersion at runtime so the version
-    // appears in exactly one place in source.
+    // The shell integration script content. The version is carried by the
+    // filename, not embedded inside the script body.
     inline std::wstring ShellIntegrationScriptContent()
     {
-        constexpr std::wstring_view kTemplate{
+        return std::wstring{
             LR"(# Shell Integration — non-invasive prompt wrapper
 # Emits OSC 133 (command marks / exit code) and OSC 9;9 (CWD) escape
 # sequences WITHOUT altering the visual appearance of the user's prompt.
-#
-# USAGE: dot-source this AFTER the user's profile has loaded:
-#   . "path\to\shell-integration_v__VERSION__.ps1"
 #
 # Compatible with Windows PowerShell 5.1+ and PowerShell 7+.
 # Safe to source multiple times (idempotent guard).
 
 if (-not $Global:__ShellInteg_Installed) {
-
-    # Version sentinel — derived from kShellIntegrationVersion in C++ source.
-    $Global:__ShellInteg_Version = __VERSION__
 
     # ── Escape characters (PS 5.1 doesn't support `e / `a literals) ──
     $Global:__ShellInteg_ESC = [char]0x1B   # ESC
@@ -153,14 +145,6 @@ if (-not $Global:__ShellInteg_Installed) {
 }
 )"
         };
-        std::wstring result{ kTemplate };
-        const auto versionStr = std::to_wstring(kShellIntegrationVersion);
-        for (size_t pos = 0; (pos = result.find(L"__VERSION__", pos)) != std::wstring::npos;)
-        {
-            result.replace(pos, 11, versionStr);
-            pos += versionStr.size();
-        }
-        return result;
     }
 
     // Locates an existing `. "...shell-integration*.ps1"` dot-source line in `contents`.

--- a/src/cascadia/inc/ShellIntegration.h
+++ b/src/cascadia/inc/ShellIntegration.h
@@ -18,10 +18,8 @@
 #include <filesystem>
 #include <fstream>
 #include <regex>
-#include <sstream>
 #include <string>
 #include <string_view>
-#include <utility>
 #include <ShlObj.h>
 
 namespace Microsoft::Terminal::ShellIntegration
@@ -183,7 +181,8 @@ if (-not $Global:__ShellInteg_Installed) {
         {
             const size_t start = static_cast<size_t>(m.position());
             size_t end = start + static_cast<size_t>(m.length());
-            // Multiline `$` stops before `\n`; trailing `\r` from CRLF may remain — strip it.
+            // `.` doesn't match `\n`, so the match naturally stops at end-of-line.
+            // For CRLF input a trailing `\r` may remain in the captured range — strip it.
             while (end > start && contents[end - 1] == '\r')
             {
                 --end;


### PR DESCRIPTION
## Summary

Adds filename-based v1 versioning to the PowerShell shell integration script (`shell-integration.ps1` → `shell-integration_v1.ps1`) so a future build can detect and replace older installs.

## Why

The previous installer had no version marker. Detection was a substring search for `"shell-integration.ps1"` in `$PROFILE`. If we ever needed to ship a fix to the script, there was no way to tell "this user has the old version" from "this user is already up-to-date" — an upgrade would either skip everyone or rewrite everyone''s profile every time.

## Approach

**Filename = version.** Self-documenting, trivially diffable, zero parsing.

A single `kShellIntegrationVersion` integer in `ShellIntegration.h` is the only place the version lives. The filename is derived from it via `ShellIntegrationScriptFileName()` (`shell-integration_v{N}.ps1`). The script content itself does NOT carry an in-script version sentinel — detection is purely filename-based, so embedding a duplicate version in the script body would just be another thing to keep in sync.

To ship a new version, bump `kShellIntegrationVersion`. Done.

## Install() flow

The file-not-exists case collapses into the file-exists case by touching an empty file first, so there is one linear path through the function:

1. **Ensure profile dir + file exist** (touch empty file if missing).
2. **Read** profile contents.
3. **Find** any existing `. "...shell-integration*.ps1"` line (matches current OR legacy unversioned name).
4. **Match?** If the existing line already references the current script AND the script file is on disk → no-op, return `alreadyInstalled=true`. The check compares the captured path inside the quotes, so trailing user comments / extra whitespace on a correct line are preserved verbatim.
5. **Backup** `$PROFILE` (non-fatal), **write** the versioned script next to it (with explicit close + state check).
6. **Replace** the existing line in place, OR **append** a new line at the bottom (using detected CRLF/LF style).
7. **Write** the profile back (with explicit close + state check — `trunc`-mode silent failures are surfaced as errors instead of corrupting the profile).

## Legacy migration

Implicit. A pre-v1 install matches step 3 (the old line referenced `shell-integration.ps1`), fails step 4 (filename differs), and gets rewritten in place at step 6. The legacy `shell-integration.ps1` script file stays on disk as a rollback artifact — once `$PROFILE` no longer references it, it''s inert.

## Risk

Low. Single header change. API unchanged — both callers (`FreOverlay.cpp` FRE wizard, `AppActionHandlers.cpp` Settings UI action) work as-is. The install path runs only on explicit user opt-in, not on every Terminal startup.

## Verification scenarios

After F5 with `CascadiaPackage` as startup project, run the Settings UI "Install shell integration" action on each starting state:

1. **No `$PROFILE` file** → dir + empty file created, then the not-found path appends a single dot-source line.
2. **Profile has v1 line + script file present** → no-op, returns `alreadyInstalled=true`.
3. **Profile has legacy unversioned install** → the legacy dot-source line is rewritten in place to point at `shell-integration_v1.ps1`; `shell-integration.ps1` left on disk.
4. **Profile has v1 line but script file deleted by user** → falls through and refreshes both.

CRLF and LF line endings both round-trip. User-authored content outside the matched line is preserved byte-for-byte. Trailing user comments on a correct dot-source line are preserved (path-equivalence check, not byte-exact line match).

Also covered by a local PowerShell E2E harness (62 assertions, 12 scenarios — not checked in) including CRLF/LF, legacy upgrade, lookalike-content false-match rejection, trailing-comment no-op, and live dot-source crash test on both `pwsh.exe` and `powershell.exe`.

## Related future work (separate PR)

Agent hooks have a JSON `version` field already (`0.1.0` in plugin/marketplace/gemini-extension manifests) but `ensure_installed()` in `tools/wta/src/agent_hooks_installer.rs` reinstalls unconditionally — the version is never used for gating. Follow-up: bump manifests to `1.0.0`, extend `StatusReport` to schema v4 with `bundle_version`/`installed_version`, and gate `ensure_installed` on mismatch.