### PR TITLE
wta hooks: drop tool_result/tool_response before forwarding

### DIFF
--- a/tools/wta/wt-agent-hooks/claude/wt-agent-hooks/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/claude/wt-agent-hooks/hooks/send-event.ps1
@@ -158,7 +158,7 @@ try {
     # Drop large model-bound fields wta never reads, so multi-KB tool output
     # doesn't ride the hook -> wtcli -> COM -> wta pipeline for nothing.
     if ($parsed -is [System.Management.Automation.PSCustomObject]) {
-        foreach ($key in @('tool_result', 'tool_response')) {
+        foreach ($key in @('tool_result', 'tool_response', 'tool_output', 'toolResult', 'toolResponse', 'toolOutput')) {
             if ($parsed.PSObject.Properties[$key]) {
                 $parsed.PSObject.Properties.Remove($key)
             }

--- a/tools/wta/wt-agent-hooks/claude/wt-agent-hooks/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/claude/wt-agent-hooks/hooks/send-event.ps1
@@ -155,6 +155,16 @@ try {
     }
     $cliSource = $CliSource
 
+    # Drop large model-bound fields wta never reads, so multi-KB tool output
+    # doesn't ride the hook -> wtcli -> COM -> wta pipeline for nothing.
+    if ($parsed -is [System.Management.Automation.PSCustomObject]) {
+        foreach ($key in @('tool_result', 'tool_response')) {
+            if ($parsed.PSObject.Properties[$key]) {
+                $parsed.PSObject.Properties.Remove($key)
+            }
+        }
+    }
+
     $wrapper = @{
         cli_source       = $cliSource
         agent_session_id = $agentSessionId

--- a/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.ps1
@@ -158,7 +158,7 @@ try {
     # Drop large model-bound fields wta never reads, so multi-KB tool output
     # doesn't ride the hook -> wtcli -> COM -> wta pipeline for nothing.
     if ($parsed -is [System.Management.Automation.PSCustomObject]) {
-        foreach ($key in @('tool_result', 'tool_response')) {
+        foreach ($key in @('tool_result', 'tool_response', 'tool_output', 'toolResult', 'toolResponse', 'toolOutput')) {
             if ($parsed.PSObject.Properties[$key]) {
                 $parsed.PSObject.Properties.Remove($key)
             }

--- a/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.ps1
@@ -155,6 +155,16 @@ try {
     }
     $cliSource = $CliSource
 
+    # Drop large model-bound fields wta never reads, so multi-KB tool output
+    # doesn't ride the hook -> wtcli -> COM -> wta pipeline for nothing.
+    if ($parsed -is [System.Management.Automation.PSCustomObject]) {
+        foreach ($key in @('tool_result', 'tool_response')) {
+            if ($parsed.PSObject.Properties[$key]) {
+                $parsed.PSObject.Properties.Remove($key)
+            }
+        }
+    }
+
     $wrapper = @{
         cli_source       = $cliSource
         agent_session_id = $agentSessionId

--- a/tools/wta/wt-agent-hooks/gemini-extension/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/gemini-extension/hooks/send-event.ps1
@@ -158,7 +158,7 @@ try {
     # Drop large model-bound fields wta never reads, so multi-KB tool output
     # doesn't ride the hook -> wtcli -> COM -> wta pipeline for nothing.
     if ($parsed -is [System.Management.Automation.PSCustomObject]) {
-        foreach ($key in @('tool_result', 'tool_response')) {
+        foreach ($key in @('tool_result', 'tool_response', 'tool_output', 'toolResult', 'toolResponse', 'toolOutput')) {
             if ($parsed.PSObject.Properties[$key]) {
                 $parsed.PSObject.Properties.Remove($key)
             }

--- a/tools/wta/wt-agent-hooks/gemini-extension/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/gemini-extension/hooks/send-event.ps1
@@ -155,6 +155,16 @@ try {
     }
     $cliSource = $CliSource
 
+    # Drop large model-bound fields wta never reads, so multi-KB tool output
+    # doesn't ride the hook -> wtcli -> COM -> wta pipeline for nothing.
+    if ($parsed -is [System.Management.Automation.PSCustomObject]) {
+        foreach ($key in @('tool_result', 'tool_response')) {
+            if ($parsed.PSObject.Properties[$key]) {
+                $parsed.PSObject.Properties.Remove($key)
+            }
+        }
+    }
+
     $wrapper = @{
         cli_source       = $cliSource
         agent_session_id = $agentSessionId


### PR DESCRIPTION
PostToolUse payloads from Claude (and equivalents for other CLIs) can carry multi-KB tool output (file reads, grep results, etc.) in `tool_result` / `tool_response`. wta only consumes small metadata (`tool_name`, `cwd`, `reason`, prompts) and never reads the model-bound result body — but those bytes still ride the full `hook -> wtcli -> COM -> wta` pipeline once per subscriber.

Strip the two keys from the parsed payload before building the wrapper so the wire payload stays bounded regardless of tool output size. All three hook bundles (claude / copilot / gemini-extension) remain byte-identical to each other.