### PR TITLE
wta: drop mouse capture so users can drag-select/copy in agent pane

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -4429,11 +4429,13 @@ impl App {
             // MouseScroll handler. Convention here mirrors PgUp/PgDn below:
             // positive delta = scroll up (toward older content).
             KeyCode::Up if self.current_tab().input.is_empty()
-                        && self.current_tab().turn.recommendations().is_none() => {
+                        && self.current_tab().turn.recommendations().is_none()
+                        && !self.command_popup_visible() => {
                 self.current_tab_mut().chat_scroll.by(1);
             }
             KeyCode::Down if self.current_tab().input.is_empty()
-                          && self.current_tab().turn.recommendations().is_none() => {
+                          && self.current_tab().turn.recommendations().is_none()
+                          && !self.command_popup_visible() => {
                 self.current_tab_mut().chat_scroll.by(-1);
             }
             KeyCode::Right | KeyCode::Tab

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -8957,4 +8957,100 @@ mod tests {
             "text length 42 should wrap differently at width 50 vs 48 — \
              pick a different critical input");
     }
+
+    // ─── Up/Down chat-scroll fallback ──────────────────────────────────
+    //
+    // After dropping crossterm mouse capture (so users can drag-select &
+    // copy text in the agent pane), wheel scrolling relies on the host
+    // terminal translating wheel notches into Up/Down arrow keystrokes
+    // while in the alt-screen buffer. The fallback in `handle_key`
+    // forwards those arrows to `chat_scroll.by(±1)` ONLY when none of
+    // the existing arrow-key consumers is active:
+    //   * input box is empty
+    //   * no recommendation card is shown
+    //   * slash-command popup is not visible
+    // These tests pin down each branch.
+
+    #[test]
+    fn up_arrow_scrolls_chat_when_input_empty_no_recs_no_popup() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut app = test_app();
+        // Fresh chat tab — Idle turn, empty input, no popup candidates.
+        assert!(app.current_tab().input.is_empty());
+        assert!(app.current_tab().turn.recommendations().is_none());
+        assert!(!app.command_popup_visible());
+        assert_eq!(app.current_tab().chat_scroll.offset, 0);
+
+        app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(
+            app.current_tab().chat_scroll.offset, 1,
+            "↑ on empty input should scroll chat up by one line",
+        );
+        app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(app.current_tab().chat_scroll.offset, 2);
+    }
+
+    #[test]
+    fn down_arrow_scrolls_chat_when_input_empty_no_recs_no_popup() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut app = test_app();
+        // Prime scroll offset so Down has somewhere to go (saturating sub
+        // would otherwise leave it at 0 and the assert couldn't tell the
+        // arm from a no-op).
+        app.current_tab_mut().chat_scroll.offset = 5;
+
+        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(
+            app.current_tab().chat_scroll.offset, 4,
+            "↓ on empty input should scroll chat down by one line",
+        );
+    }
+
+    #[test]
+    fn up_down_does_not_scroll_chat_when_input_non_empty() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut app = test_app();
+        // Non-empty input: arrows belong to the input-box editor, not
+        // the chat-scroll fallback.
+        app.current_tab_mut().input.push_str("hi");
+        app.current_tab_mut().cursor_pos = 2;
+        app.current_tab_mut().chat_scroll.offset = 3;
+
+        app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(
+            app.current_tab().chat_scroll.offset, 3,
+            "non-empty input must NOT trigger the chat-scroll fallback",
+        );
+    }
+
+    #[test]
+    fn up_down_does_not_scroll_chat_when_command_popup_visible() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut app = test_app();
+        // Open the slash-command popup the same way real input would:
+        // type "/" and let refresh_command_popup populate candidates.
+        app.current_tab_mut().input.push('/');
+        app.current_tab_mut().cursor_pos = 1;
+        app.current_tab_mut().refresh_command_popup();
+        assert!(
+            app.command_popup_visible(),
+            "test prerequisite: command popup must be visible after typing '/'",
+        );
+        // Clear input back to empty so the input-empty guard would pass —
+        // this isolates the popup-visibility guard as the reason the
+        // fallback should NOT fire. (In practice the popup is only
+        // visible when input starts with '/', but the guard is defensive
+        // and we test it here.)
+        let popup_was_visible = app.command_popup_visible();
+        app.current_tab_mut().chat_scroll.offset = 7;
+
+        app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert!(popup_was_visible);
+        assert_eq!(
+            app.current_tab().chat_scroll.offset, 7,
+            "command popup visibility must suppress the chat-scroll fallback",
+        );
+    }
 }

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -769,8 +769,6 @@ pub struct DispatchedCommand {
 
 pub enum AppEvent {
     Key(KeyEvent),
-    /// Mouse wheel scroll: delta<0 = scroll up, delta>0 = scroll down, row = terminal row of event
-    MouseScroll { delta: i32, row: u16 },
     Tick,
     Resize(u16, u16), // terminal resize (handled by ratatui)
     ConnectionStage(String),
@@ -2861,7 +2859,6 @@ impl App {
     fn event_name(event: &AppEvent) -> &'static str {
         match event {
             AppEvent::Key(_) => "key",
-            AppEvent::MouseScroll { .. } => "mouse_scroll",
             AppEvent::Tick => "tick",
             AppEvent::Resize(_, _) => "resize",
             AppEvent::ConnectionStage(_) => "connection_stage",
@@ -2916,27 +2913,6 @@ impl App {
     fn handle_event(&mut self, event: AppEvent) {
         match event {
             AppEvent::Key(key) => self.handle_key(key),
-            AppEvent::MouseScroll { delta, row } => {
-                // Recs panel sits just above the input. When the cursor is
-                // over it, the wheel drives `rec_scroll` (top-anchored:
-                // positive delta = scroll down = increase offset). Otherwise
-                // it drives `chat_scroll` (bottom-anchored: wheel up shows
-                // higher content = increase offset, so we negate delta).
-                let in_recs = self.current_tab().turn.recommendations().is_some() && {
-                    // 3 input + 1 nav hint row above the input.
-                    let recs_top = self
-                        .terminal_rows
-                        .saturating_sub(4 + self.rec_panel_height(self.main_area_width()));
-                    row >= recs_top
-                };
-                let d = delta as isize;
-                let tab = self.current_tab_mut();
-                if in_recs {
-                    tab.rec_scroll.by(d);
-                } else {
-                    tab.chat_scroll.by(-d);
-                }
-            }
             AppEvent::Tick => {
                 // Fan out across all tabs: a background tab with an in-flight
                 // prompt should keep its shimmer phase advancing so when the
@@ -4443,6 +4419,22 @@ impl App {
                     self.current_tab_mut().selected_button = default_btn;
                     self.scroll_rec_to_selected(self.main_area_width());
                 }
+            }
+            // Wheel-as-arrow scroll fallback: when the input is empty and no
+            // recommendation card is active, ↑/↓ scroll the chat transcript.
+            // The host terminal (WT, xterm, kitty, …) translates a mouse-wheel
+            // notch into ~3 arrow keystrokes when mouse capture is OFF and the
+            // app is in the alt-screen buffer, so by(1)/by(-1) per key matches
+            // one wheel notch ≈ 3 lines, in line with the previous explicit
+            // MouseScroll handler. Convention here mirrors PgUp/PgDn below:
+            // positive delta = scroll up (toward older content).
+            KeyCode::Up if self.current_tab().input.is_empty()
+                        && self.current_tab().turn.recommendations().is_none() => {
+                self.current_tab_mut().chat_scroll.by(1);
+            }
+            KeyCode::Down if self.current_tab().input.is_empty()
+                          && self.current_tab().turn.recommendations().is_none() => {
+                self.current_tab_mut().chat_scroll.by(-1);
             }
             KeyCode::Right | KeyCode::Tab
                 if self.current_tab().input.is_empty() && self.current_tab().turn.recommendations().is_some() =>

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -9037,17 +9037,26 @@ mod tests {
             app.command_popup_visible(),
             "test prerequisite: command popup must be visible after typing '/'",
         );
-        // Clear input back to empty so the input-empty guard would pass —
-        // this isolates the popup-visibility guard as the reason the
-        // fallback should NOT fire. (In practice the popup is only
-        // visible when input starts with '/', but the guard is defensive
-        // and we test it here.)
-        let popup_was_visible = app.command_popup_visible();
+        // Force-clear input WITHOUT calling refresh_command_popup so the
+        // candidates list stays populated while input becomes empty. This
+        // isolates the !command_popup_visible() guard as the one being
+        // tested — without this step, the input-empty guard would
+        // independently suppress the fallback and the assertion below
+        // could not tell which guard fired.
+        app.current_tab_mut().input.clear();
+        app.current_tab_mut().cursor_pos = 0;
+        assert!(
+            app.current_tab().input.is_empty(),
+            "test prerequisite: input must be empty so only the popup guard is exercised",
+        );
+        assert!(
+            app.command_popup_visible(),
+            "test prerequisite: popup must remain visible after clearing input",
+        );
         app.current_tab_mut().chat_scroll.offset = 7;
 
         app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
         app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
-        assert!(popup_was_visible);
         assert_eq!(
             app.current_tab().chat_scroll.offset, 7,
             "command popup visibility must suppress the chat-scroll fallback",

--- a/tools/wta/src/event.rs
+++ b/tools/wta/src/event.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{Event, EventStream, MouseEventKind};
+use crossterm::event::{Event, EventStream};
 use futures::StreamExt;
 use tokio::sync::mpsc;
 use tokio::time::{self, Duration, MissedTickBehavior};
@@ -74,30 +74,11 @@ pub async fn read_crossterm_events(tx: mpsc::UnboundedSender<AppEvent>) {
                         AppEvent::Key(key)
                     }
                     Event::Resize(w, h) => AppEvent::Resize(w, h),
-                    Event::Mouse(mouse) => {
-                        // Trace mouse activity so we can diagnose "frozen pane"
-                        // reports — e.g. shift+drag in WT triggers native text
-                        // selection (xterm convention: shift overrides app
-                        // mouse capture so users can still copy text), and
-                        // until that selection is dismissed (Esc / unmodified
-                        // click) WT may swallow keystrokes before they reach
-                        // crossterm. If you see drag events in the log but no
-                        // subsequent key events, that's the selection-mode
-                        // signature.
-                        tracing::trace!(
-                            target: "input",
-                            kind = ?mouse.kind,
-                            mods = ?mouse.modifiers,
-                            row = mouse.row,
-                            col = mouse.column,
-                            "mouse event",
-                        );
-                        match mouse.kind {
-                            MouseEventKind::ScrollUp => AppEvent::MouseScroll { delta: -3, row: mouse.row },
-                            MouseEventKind::ScrollDown => AppEvent::MouseScroll { delta: 3, row: mouse.row },
-                            _ => continue,
-                        }
-                    }
+                    // We do not enable mouse capture (see main.rs run_acp_tui_mode).
+                    // The terminal emulator translates wheel into Up/Down arrow
+                    // keystrokes in alt-screen mode, so we never observe raw
+                    // Event::Mouse here. Drop anything else (FocusGained,
+                    // FocusLost, Paste, etc.).
                     _ => continue,
                 };
                 if tx.send(app_event).is_err() {

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -28,7 +28,6 @@ use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 use crossterm::{
     cursor::SetCursorStyle,
-    event::{DisableMouseCapture, EnableMouseCapture},
     execute,
     style::Print,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -1340,7 +1339,14 @@ async fn run_acp_tui_mode(
 ) -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    // NOTE: We intentionally do NOT call EnableMouseCapture. Without mouse
+    // tracking, the host terminal emulator (Windows Terminal, xterm, kitty,
+    // alacritty, wezterm) translates mouse-wheel events into Up/Down arrow
+    // keystrokes while we are in the alternate screen buffer. That gives us
+    // wheel-driven chat scrolling for free, and — crucially — leaves native
+    // click-drag text selection working so users can highlight and copy
+    // from the agent pane the way they would from any other terminal.
+    execute!(stdout, EnterAlternateScreen)?;
     execute!(stdout, Print("\x1b]11;#0c0c0c\x07"))?;
     // Steady block (DECSCUSR Ps=2): solid filled rectangle, no blink.
     // Survives the alt-screen swap; restored on exit below.
@@ -1358,7 +1364,6 @@ async fn run_acp_tui_mode(
         // OSC 111: reset bg to terminal default so the host shell isn't
         // left with our override.
         Print("\x1b]111\x07"),
-        DisableMouseCapture,
         LeaveAlternateScreen
     )?;
     terminal.show_cursor()?;


### PR DESCRIPTION
## Problem

Selecting + copying text in the WTA agent pane required Shift+drag because WTA enables crossterm's `EnableMouseCapture` (purely to receive wheel scroll events), which makes the host terminal swallow drag-select-and-copy.

## Fix

Stop enabling mouse capture. In alt-screen mode without mouse capture, modern terminals (Windows Terminal, xterm, kitty, alacritty, wezterm) already translate mouse-wheel notches into Up/Down arrow keystrokes — so we get wheel scrolling for free while restoring native drag-select-and-copy. This is the same approach used by [`yeelam-gordon/agent-cli-session-TUI`](https://github.com/yeelam-gordon/agent-cli-session-TUI) (see its `CONTRIBUTING.md` `"No mouse capture"` rule + `src/ui/mod.rs` `no_mouse_capture` unit test).

<img width="2536" height="1169" alt="mouseSelectAndScroll" src="https://github.com/user-attachments/assets/3f9b36b8-4983-4921-86f4-d93741b3f70d" />


### Changes

- `main.rs` — stop calling `EnableMouseCapture` / `DisableMouseCapture`
- `event.rs` — drop the `Event::Mouse` arm
- `app.rs` — remove `AppEvent::MouseScroll`; add `KeyCode::Up` / `KeyCode::Down` chat-scroll fallback guarded by `input.is_empty() && recommendations().is_none()` so it doesn't steal keys from the input box or recommendation cards. Convention matches PgUp/PgDn (positive delta = scroll toward older content).

## Trade-off

- **Win**: native drag-select-and-copy works in the agent pane (no Shift modifier).
- **Loss**: if WTA is hosted in a terminal that does NOT do wheel→arrow translation (e.g. legacy `conhost.exe`), wheel scrolling will no longer work — keyboard scroll (PgUp/PgDn, arrows) still works. Acceptable since WTA's primary host is Windows Terminal.

## Verification

- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml` — passes
- `cargo test --manifest-path tools/wta/Cargo.toml` — 335 passed / 0 failed
- Manually verified by F5 + `Add-AppxPackage -Register` of the packaged build: drag-select-and-copy works; wheel scroll works