### PR TITLE
Fix GetWtExePath to resolve wtai.exe instead of stale wt.exe/wtd.exe

### DIFF
--- a/src/cascadia/WinRTUtils/inc/WtExeUtils.h
+++ b/src/cascadia/WinRTUtils/inc/WtExeUtils.h
@@ -3,8 +3,13 @@
 
 #pragma once
 
-constexpr std::wstring_view WtExe{ L"wt.exe" };
-constexpr std::wstring_view WtdExe{ L"wtd.exe" };
+// The packaging step (CascadiaPackage.wapproj) renames both wt.exe and wtd.exe
+// to wtai.exe inside the appx, and the appExecutionAlias registered in
+// Package*.appxmanifest is wtai.exe. So the alias dropped in
+// %LOCALAPPDATA%\Microsoft\WindowsApps\<pfn>\ is always wtai.exe regardless of
+// dev/preview/release flavor.
+constexpr std::wstring_view WtExe{ L"wtai.exe" };
+constexpr std::wstring_view WtdExe{ L"wtai.exe" };
 constexpr std::wstring_view WindowsTerminalExe{ L"WindowsTerminal.exe" };
 constexpr std::wstring_view LocalAppDataAppsPath{ L"%LOCALAPPDATA%\\Microsoft\\WindowsApps\\" };
 constexpr std::wstring_view ElevateShimExe{ L"elevate-shim.exe" };


### PR DESCRIPTION
## Summary

- `CascadiaPackage.wapproj` already renames `wt.exe`/`wtd.exe` → `wtai.exe` in the packaged output (line 183), and `Package*.appxmanifest` registers `wtai.exe` as the sole `appExecutionAlias`. The alias dropped under `%LOCALAPPDATA%\Microsoft\WindowsApps\<pfn>\` is therefore always `wtai.exe`.
- But `WtExeUtils.h` still defined `WtExe = L"wt.exe"` / `WtdExe = L"wtd.exe"`, so `GetWtExePath()` built a path to a file that does not exist in the package.
- Every caller of `GetWtExePath()` was affected: `Ctrl+Shift+N` new-window (`_OpenNewWindow` in `AppActionHandlers.cpp`), jumplist shell links (`Jumplist.cpp`), and `CascadiaSettings` metadata path resolution. `ShellExecute` either silently failed or accidentally fell back to whatever `wt.exe` lived on `%PATH%` (often the official Windows Terminal install) instead of our build.
- Fix: point both `WtExe` and `WtdExe` at `wtai.exe` to match what's actually deployed.

Other `"wt.exe"` literals in the tree (`AppCommandlineArgs.h::PlaceholderExeName`, `AppCommandlineArgs.cpp:1148`'s `args.emplace_back(L"wt.exe")`, and various comments) are internal argv[0] placeholders / historical docs — not call sites — and are intentionally left alone.

## Test plan

- [ ] Build `CascadiaPackage` from VS (F5), launch Terminal
- [ ] Press `Ctrl+Shift+N` — should open a second window of **this** Intelligent Terminal build (not the system-installed `wt.exe`)
- [ ] Taskbar jumplist: right-click Terminal icon → click a profile → new window opens with that profile
- [ ] If you have an official Windows Terminal installed on `%PATH%`, verify the new window is ours, not the official one

🤖 Generated with [Claude Code](https://claude.com/claude-code)