### PR TITLE
wta: route ACP Client requests from agent CLI through master to ownin…

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1102,7 +1102,18 @@ pub struct TabSession {
 
     // Tool calls / permission
     pub tool_calls: HashMap<String, (String, String)>,
-    pub permission: Option<PermissionState>,
+    /// FIFO of pending permission requests for this session. The front
+    /// entry is the one currently rendered and accepting keys; the rest
+    /// queue up. Agents (Copilot in particular) sometimes fire multiple
+    /// concurrent `request_permission` calls for one tool invocation
+    /// — e.g. one per path that needs to be unlocked outside the trusted
+    /// directory set — and each carries its own oneshot responder. The
+    /// previous single-slot `Option` overwrote the prior entry on every
+    /// new request, dropping its responder, which `WtaClient::request_permission`
+    /// observed as `Cancelled` and the agent interpreted as "user rejected"
+    /// — producing the silent tool-call failure tracked alongside the
+    /// helper+master split.
+    pub permission: VecDeque<PermissionState>,
     // Recommendation card UI focus (the set itself lives on
     // `turn.recommendations()`).
     pub selected_recommendation: usize,
@@ -1160,7 +1171,9 @@ impl TabSession {
     pub fn clear_chat_history(&mut self) {
         self.messages.clear();
         self.tool_calls.clear();
-        self.permission = None;
+        // Dropping pending responders signals `Cancelled` back to the
+        // agent — appropriate when the user wipes chat history mid-turn.
+        self.permission.clear();
         self.progress_status = None;
         self.activity_frame = 0;
         self.pending_agent_response.clear();
@@ -2949,7 +2962,7 @@ impl App {
             tab.chat_scroll.offset,
             tab.activity_frame,
             tab.turn.recommendations().map(|r| r.choices.len()).unwrap_or(0),
-            tab.permission.is_some(),
+            !tab.permission.is_empty(),
             tab.timing_note.is_some()
         )
     }
@@ -3346,7 +3359,11 @@ impl App {
                     // a Cancelled outcome on the agent side.
                     return;
                 }
-                tab.permission = Some(PermissionState {
+                // FIFO push — never overwrite an in-flight request. The
+                // user sees them one at a time (front of the queue is the
+                // one rendered + key-handled); resolving the front pops
+                // it and exposes the next.
+                tab.permission.push_back(PermissionState {
                     description,
                     options,
                     selected: 0,
@@ -4490,7 +4507,7 @@ impl App {
         // rendered horizontally inside the embedded card (same chrome as
         // recommendations), so Left/Right move the focus; Up/Down kept as
         // aliases for muscle memory from the prior modal.
-        if let Some(ref mut perm) = self.current_tab_mut().permission {
+        if let Some(perm) = self.current_tab_mut().permission.front_mut() {
             match key.code {
                 KeyCode::Left | KeyCode::Up => {
                     if perm.selected > 0 {
@@ -4504,8 +4521,10 @@ impl App {
                 }
                 KeyCode::Enter => {
                     let option_id = perm.options[perm.selected].id.clone();
-                    // Take ownership to send
-                    if let Some(perm) = self.current_tab_mut().permission.take() {
+                    // Pop the resolved entry; the next queued request (if
+                    // any) automatically becomes the new front and is
+                    // rendered on the next frame.
+                    if let Some(perm) = self.current_tab_mut().permission.pop_front() {
                         if let Some(responder) = perm.responder {
                             let _ = responder.send(option_id);
                         } else {
@@ -4517,7 +4536,7 @@ impl App {
                     // Quick allow: find first allow option
                     if let Some(idx) = perm.options.iter().position(|o| o.kind.contains("allow")) {
                         let option_id = perm.options[idx].id.clone();
-                        if let Some(perm) = self.current_tab_mut().permission.take() {
+                        if let Some(perm) = self.current_tab_mut().permission.pop_front() {
                             if let Some(responder) = perm.responder {
                                 let _ = responder.send(option_id);
                             } else {
@@ -4530,7 +4549,7 @@ impl App {
                     // Quick deny: find first reject option
                     if let Some(idx) = perm.options.iter().position(|o| o.kind.contains("reject")) {
                         let option_id = perm.options[idx].id.clone();
-                        if let Some(perm) = self.current_tab_mut().permission.take() {
+                        if let Some(perm) = self.current_tab_mut().permission.pop_front() {
                             if let Some(responder) = perm.responder {
                                 let _ = responder.send(option_id);
                             } else {
@@ -5148,7 +5167,7 @@ impl App {
     /// `panel_width` is the actual render width (`main_area.width` after the
     /// debug-panel split), not `terminal_cols`.
     pub fn permission_panel_height(&self, panel_width: u16) -> u16 {
-        let Some(perm) = self.current_tab().permission.as_ref() else { return 0 };
+        let Some(perm) = self.current_tab().permission.front() else { return 0 };
         let card_h = permission_card_height(perm, panel_width) as u16;
         // Permission is modal — only hard-reserve input(3).
         let ceiling = self.terminal_rows.saturating_sub(3);
@@ -6038,7 +6057,9 @@ impl App {
         // grab-bag helper.
         tab.messages.clear();
         tab.tool_calls.clear();
-        tab.permission = None;
+        // Dropping any in-flight responders signals Cancelled back to
+        // the agent — appropriate when the user starts a new turn.
+        tab.permission.clear();
         tab.chat_scroll.reset();
         tab.selection_visible_pending = false;
         // Any leftover card from the previous turn's
@@ -9401,7 +9422,7 @@ mod tests {
     fn permission_panel_height_falls_back_to_compact_below_card_min() {
         let mut app = test_app();
         app.terminal_rows = 7; // ceiling = 7-3 = 4 < CARD_MIN_SIZE
-        app.current_tab_mut().permission = Some(perm_with("ok"));
+        app.current_tab_mut().permission.push_back(perm_with("ok"));
         // Must stay visible — agent flow blocks on this prompt. 1-row strip
         // is the compact fallback rendered by `ui::permission::render`.
         assert_eq!(app.permission_panel_height(80), 1);
@@ -9411,7 +9432,7 @@ mod tests {
     fn permission_panel_height_admits_at_card_min_ceiling() {
         let mut app = test_app();
         app.terminal_rows = 8; // ceiling = 5 == CARD_MIN_SIZE
-        app.current_tab_mut().permission = Some(perm_with("ok"));
+        app.current_tab_mut().permission.push_back(perm_with("ok"));
         assert_eq!(app.permission_panel_height(80), CARD_MIN_SIZE);
     }
 

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -15,12 +15,23 @@
 //      the agent CLI; route inbound `session_notification`s from
 //      the agent CLI back to the helper that owns the session.
 //
-// Phase 1 (this commit): wires the full forward path (helper →
-// master → agent CLI) and the session_notification reverse path
-// (agent CLI → master → helper). Client-trait methods that need
-// per-session helper routing (request_permission, terminal/*,
-// fs/*) return `method_not_found` for now; Phase 2 wires them via
-// a `session_to_helper`-style table keyed on AgentRequest.session_id.
+// Forwarding paths:
+//   * `helper → master → agent CLI`: every helper request runs
+//     through `HelperHandler`'s `acp::Agent` impl, which is just a
+//     thin pass-through to the agent CLI's `ClientSideConnection`.
+//   * `agent CLI → master → helper` (notifications): inbound
+//     `session_notification`s land in `MasterClient::session_notification`
+//     and are fanned out to the owning helper's notification channel
+//     via the `session_to_helper` map (populated in `new_session` /
+//     `load_session`).
+//   * `agent CLI → master → helper` (requests — request_permission,
+//     terminal/*, fs/*): same map carries an `Arc<AgentSideConnection>`
+//     to each helper. `MasterClient` looks up the helper by
+//     `args.session_id` and calls the matching `Client`-trait method
+//     on that connection (`AgentSideConnection` itself implements
+//     `acp::Client`, RPC'ing back over the helper's pipe). The
+//     helper-side `WtaClient` then runs the same code path it ran
+//     pre-helper-split (TUI permission UI, `ShellManager`, etc.).
 
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
@@ -42,25 +53,47 @@ use crate::Cli;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct HelperId(u64);
 
+/// Per-session routing entry. Owned by `session_to_helper` and
+/// keyed by `acp::SessionId`.
+///
+/// Two reverse paths share this entry:
+///   * `notif_tx`: master's `Client::session_notification` posts here;
+///     the helper's `serve_helper` loop drains it and writes back
+///     across the pipe.
+///   * `forwarder`: master's `Client::request_permission` / `create_terminal`
+///     / `terminal_*` / `read_text_file` / `write_text_file` calls
+///     directly on this connection. `AgentSideConnection` itself
+///     implements `acp::Client` and re-issues each call as an RPC
+///     request to the helper.
+///
+/// `forwarder` is `Option<_>` for one reason only: unit tests below
+/// construct routing entries without a real connection. The
+/// production path (`new_session` / `load_session`) always sets it
+/// to `Some(_)`, and `MasterClient` treats `None` as a routing bug.
+#[derive(Clone)]
+struct HelperRoute {
+    helper_id: HelperId,
+    notif_tx: mpsc::UnboundedSender<acp::SessionNotification>,
+    forwarder: Option<Arc<acp::AgentSideConnection>>,
+}
+
 /// State shared between the master's `acp::Client` impl (receives
 /// notifications from the agent CLI) and each helper's `acp::Agent`
 /// impl (receives requests from one helper).
 struct MasterStateInner {
-    /// Routes inbound `session_notification`s from the agent CLI
-    /// back to the helper that owns the session. Inserted by the
-    /// helper's `new_session` / `load_session` handlers atomically
-    /// (before responding to the helper), so no race window.
+    /// Routes inbound traffic from the agent CLI back to the helper
+    /// that owns the session. Inserted by the helper's `new_session`
+    /// / `load_session` handlers atomically (before responding to
+    /// the helper), so no race window.
     ///
-    /// Value is `(HelperId, sender)` so that on helper disconnect we
-    /// can `retain` out every session belonging to that helper
-    /// without keeping a separate index. Without that cleanup the
-    /// map would grow unboundedly across the master's lifetime —
-    /// each closed pane leaves a dead `SessionId` behind, and every
-    /// future notification for it lights up a "helper notification
-    /// channel closed" warning.
-    session_to_helper: Mutex<
-        HashMap<acp::SessionId, (HelperId, mpsc::UnboundedSender<acp::SessionNotification>)>,
-    >,
+    /// `HelperRoute.helper_id` lets `drop_sessions_for_helper` reap
+    /// every session belonging to a disconnecting helper without a
+    /// secondary index. Without that cleanup the map would grow
+    /// unboundedly across the master's lifetime — each closed pane
+    /// leaves a dead `SessionId` behind, and every future
+    /// notification for it lights up a "helper notification channel
+    /// closed" warning.
+    session_to_helper: Mutex<HashMap<acp::SessionId, HelperRoute>>,
     /// The agent CLI's response to the master's startup initialize.
     /// Replayed verbatim to every helper that calls `initialize` over
     /// its pipe — re-forwarding to the agent CLI returns a stale or
@@ -81,25 +114,99 @@ struct MasterStateInner {
 
 /// Master's `acp::Client` impl: handles inbound from the agent CLI.
 ///
-/// `session_notification` fans out to the owning helper. The other
-/// Client-trait methods that come from the agent CLI (permission
-/// requests, terminal/* calls, fs/* calls) target a specific session
-/// — Phase 2 will route them via `session_to_helper` too. For now
-/// we let them fall through to the trait's default `method_not_found`
-/// (the agent CLI's behaviour is "advertise capability=false, never
-/// call these").
+/// `session_notification` fans out to the owning helper via its
+/// notification channel. The request-shaped Client methods
+/// (`request_permission`, `create_terminal`, `terminal_*`,
+/// `read_text_file`, `write_text_file`) look up the owning helper by
+/// `args.session_id` in `session_to_helper` and forward the call on
+/// that helper's `AgentSideConnection` — the helper's `WtaClient`
+/// then runs the same handler it ran pre-helper-split (TUI permission
+/// UI, `ShellManager`, etc.). The agent CLI sees the helper's
+/// response as if master had answered directly.
 struct MasterClient {
     state: Arc<MasterStateInner>,
+}
+
+impl MasterClient {
+    /// Look up the helper owning `sid` and clone the forwarder + id.
+    ///
+    /// Returns `Err(internal_error)` if either (a) no helper is bound
+    /// to this session — typically means the agent CLI emitted a
+    /// stale request after the owning helper disconnected — or
+    /// (b) the routing entry has no forwarder (production code never
+    /// reaches this branch; see `HelperRoute::forwarder`).
+    async fn route_for(
+        &self,
+        sid: &acp::SessionId,
+        op: &'static str,
+    ) -> acp::Result<(HelperId, Arc<acp::AgentSideConnection>)> {
+        let entry = {
+            let map = self.state.session_to_helper.lock().await;
+            map.get(sid).cloned()
+        };
+        match entry {
+            Some(HelperRoute {
+                helper_id,
+                forwarder: Some(forwarder),
+                ..
+            }) => Ok((helper_id, forwarder)),
+            Some(HelperRoute {
+                forwarder: None,
+                helper_id,
+                ..
+            }) => {
+                tracing::error!(
+                    target: "master",
+                    op = op,
+                    session_id = ?sid,
+                    helper_id = ?helper_id,
+                    "routing entry has no forwarder — bug; routing entry should always carry the helper's AgentSideConnection",
+                );
+                Err(acp::Error::internal_error()
+                    .data(serde_json::json!("master routing entry missing forwarder")))
+            }
+            None => {
+                tracing::warn!(
+                    target: "master",
+                    op = op,
+                    session_id = ?sid,
+                    "agent CLI sent request for unknown SessionId — no helper to route to",
+                );
+                Err(acp::Error::internal_error()
+                    .data(serde_json::json!("no helper bound to session_id")))
+            }
+        }
+    }
 }
 
 #[async_trait::async_trait(?Send)]
 impl acp::Client for MasterClient {
     async fn request_permission(
         &self,
-        _args: acp::RequestPermissionRequest,
+        args: acp::RequestPermissionRequest,
     ) -> acp::Result<acp::RequestPermissionResponse> {
-        // TODO Phase 2: route to the helper owning args.session_id
-        Err(acp::Error::method_not_found())
+        let sid = args.session_id.clone();
+        let (helper_id, forwarder) = self.route_for(&sid, "request_permission").await?;
+        tracing::info!(
+            target: "master",
+            step = "agent→helper",
+            op = "request_permission",
+            helper_id = ?helper_id,
+            session_id = ?sid,
+            "forwarding permission request to helper"
+        );
+        let resp = forwarder.request_permission(args).await;
+        if let Err(ref e) = resp {
+            tracing::warn!(
+                target: "master",
+                op = "request_permission",
+                helper_id = ?helper_id,
+                session_id = ?sid,
+                error = %e,
+                "helper returned error for permission request"
+            );
+        }
+        resp
     }
 
     async fn session_notification(
@@ -113,7 +220,7 @@ impl acp::Client for MasterClient {
         let kind = notification_kind(&args);
         let tx = {
             let map = self.state.session_to_helper.lock().await;
-            map.get(&sid).map(|(_hid, tx)| tx.clone())
+            map.get(&sid).map(|r| r.notif_tx.clone())
         };
         match tx {
             Some(tx) => {
@@ -157,6 +264,134 @@ impl acp::Client for MasterClient {
         }
         Ok(())
     }
+
+    async fn write_text_file(
+        &self,
+        args: acp::WriteTextFileRequest,
+    ) -> acp::Result<acp::WriteTextFileResponse> {
+        let sid = args.session_id.clone();
+        let (helper_id, forwarder) = self.route_for(&sid, "write_text_file").await?;
+        tracing::info!(
+            target: "master",
+            step = "agent→helper",
+            op = "write_text_file",
+            helper_id = ?helper_id,
+            session_id = ?sid,
+            path = ?args.path,
+            "forwarding fs/write_text_file to helper"
+        );
+        forwarder.write_text_file(args).await
+    }
+
+    async fn read_text_file(
+        &self,
+        args: acp::ReadTextFileRequest,
+    ) -> acp::Result<acp::ReadTextFileResponse> {
+        let sid = args.session_id.clone();
+        let (helper_id, forwarder) = self.route_for(&sid, "read_text_file").await?;
+        tracing::info!(
+            target: "master",
+            step = "agent→helper",
+            op = "read_text_file",
+            helper_id = ?helper_id,
+            session_id = ?sid,
+            path = ?args.path,
+            "forwarding fs/read_text_file to helper"
+        );
+        forwarder.read_text_file(args).await
+    }
+
+    async fn create_terminal(
+        &self,
+        args: acp::CreateTerminalRequest,
+    ) -> acp::Result<acp::CreateTerminalResponse> {
+        let sid = args.session_id.clone();
+        let (helper_id, forwarder) = self.route_for(&sid, "create_terminal").await?;
+        tracing::info!(
+            target: "master",
+            step = "agent→helper",
+            op = "create_terminal",
+            helper_id = ?helper_id,
+            session_id = ?sid,
+            command = %args.command,
+            args_len = args.args.len(),
+            "forwarding terminal/create to helper"
+        );
+        forwarder.create_terminal(args).await
+    }
+
+    async fn terminal_output(
+        &self,
+        args: acp::TerminalOutputRequest,
+    ) -> acp::Result<acp::TerminalOutputResponse> {
+        let sid = args.session_id.clone();
+        let (helper_id, forwarder) = self.route_for(&sid, "terminal_output").await?;
+        tracing::debug!(
+            target: "master",
+            step = "agent→helper",
+            op = "terminal_output",
+            helper_id = ?helper_id,
+            session_id = ?sid,
+            terminal_id = ?args.terminal_id,
+            "forwarding terminal/output to helper"
+        );
+        forwarder.terminal_output(args).await
+    }
+
+    async fn release_terminal(
+        &self,
+        args: acp::ReleaseTerminalRequest,
+    ) -> acp::Result<acp::ReleaseTerminalResponse> {
+        let sid = args.session_id.clone();
+        let (helper_id, forwarder) = self.route_for(&sid, "release_terminal").await?;
+        tracing::info!(
+            target: "master",
+            step = "agent→helper",
+            op = "release_terminal",
+            helper_id = ?helper_id,
+            session_id = ?sid,
+            terminal_id = ?args.terminal_id,
+            "forwarding terminal/release to helper"
+        );
+        forwarder.release_terminal(args).await
+    }
+
+    async fn wait_for_terminal_exit(
+        &self,
+        args: acp::WaitForTerminalExitRequest,
+    ) -> acp::Result<acp::WaitForTerminalExitResponse> {
+        let sid = args.session_id.clone();
+        let (helper_id, forwarder) =
+            self.route_for(&sid, "wait_for_terminal_exit").await?;
+        tracing::info!(
+            target: "master",
+            step = "agent→helper",
+            op = "wait_for_terminal_exit",
+            helper_id = ?helper_id,
+            session_id = ?sid,
+            terminal_id = ?args.terminal_id,
+            "forwarding terminal/wait_for_exit to helper"
+        );
+        forwarder.wait_for_terminal_exit(args).await
+    }
+
+    async fn kill_terminal(
+        &self,
+        args: acp::KillTerminalRequest,
+    ) -> acp::Result<acp::KillTerminalResponse> {
+        let sid = args.session_id.clone();
+        let (helper_id, forwarder) = self.route_for(&sid, "kill_terminal").await?;
+        tracing::info!(
+            target: "master",
+            step = "agent→helper",
+            op = "kill_terminal",
+            helper_id = ?helper_id,
+            session_id = ?sid,
+            terminal_id = ?args.terminal_id,
+            "forwarding terminal/kill to helper"
+        );
+        forwarder.kill_terminal(args).await
+    }
 }
 
 /// Short, log-friendly tag for a `SessionNotification`'s update
@@ -190,6 +425,43 @@ struct HelperHandler {
     /// receiver and writes notifications back over the
     /// `AgentSideConnection`.
     notif_tx: mpsc::UnboundedSender<acp::SessionNotification>,
+    /// The same helper's outbound connection back to its pipe.
+    /// `HelperHandler` is moved INTO `AgentSideConnection::new`, so
+    /// we can't hold the `AgentSideConnection` by value — we share a
+    /// `OnceLock` with `serve_helper` instead, which populates it
+    /// immediately after `new()` returns and before `handle_io`
+    /// starts polling (i.e. before any inbound request can hit a
+    /// handler that would observe the slot).
+    ///
+    /// `new_session` / `load_session` read it (must be `Some` by
+    /// then, since they're driven by `handle_io`) and stash the
+    /// resulting `Arc` into `HelperRoute.forwarder`, where
+    /// `MasterClient` finds it for inbound agent-CLI requests.
+    agent_side_slot: Arc<OnceLock<Arc<acp::AgentSideConnection>>>,
+}
+
+impl HelperHandler {
+    /// Snapshot the populated `AgentSideConnection` for this helper.
+    /// Must only be called from request handlers driven by
+    /// `handle_io` (which `serve_helper` polls strictly after the
+    /// slot is set). Returns an `internal_error` if the invariant
+    /// is ever violated — failing closed beats producing a half-
+    /// initialised routing entry.
+    fn forwarder_for_route(&self, op: &'static str) -> acp::Result<Arc<acp::AgentSideConnection>> {
+        match self.agent_side_slot.get() {
+            Some(asc) => Ok(Arc::clone(asc)),
+            None => {
+                tracing::error!(
+                    target: "master",
+                    op = op,
+                    helper_id = ?self.helper_id,
+                    "agent_side_slot empty inside helper request handler — bug; serve_helper must populate it before handle_io polls"
+                );
+                Err(acp::Error::internal_error()
+                    .data(serde_json::json!("agent_side_slot not yet set")))
+            }
+        }
+    }
 }
 
 #[async_trait::async_trait(?Send)]
@@ -257,13 +529,18 @@ impl acp::Agent for HelperHandler {
             "forwarding new_session"
         );
         let resp = self.agent_conn.new_session(args).await?;
+        let forwarder = self.forwarder_for_route("new_session")?;
         // Record routing entry BEFORE returning so the helper can't
         // race a session/update notification.
         let registry_size = {
             let mut map = self.state.session_to_helper.lock().await;
             map.insert(
                 resp.session_id.clone(),
-                (self.helper_id, self.notif_tx.clone()),
+                HelperRoute {
+                    helper_id: self.helper_id,
+                    notif_tx: self.notif_tx.clone(),
+                    forwarder: Some(forwarder),
+                },
             );
             map.len()
         };
@@ -285,9 +562,17 @@ impl acp::Agent for HelperHandler {
     ) -> acp::Result<acp::LoadSessionResponse> {
         let session_id = args.session_id.clone();
         let resp = self.agent_conn.load_session(args).await?;
+        let forwarder = self.forwarder_for_route("load_session")?;
         {
             let mut map = self.state.session_to_helper.lock().await;
-            map.insert(session_id.clone(), (self.helper_id, self.notif_tx.clone()));
+            map.insert(
+                session_id.clone(),
+                HelperRoute {
+                    helper_id: self.helper_id,
+                    notif_tx: self.notif_tx.clone(),
+                    forwarder: Some(forwarder),
+                },
+            );
         }
         tracing::info!(
             target: "master",
@@ -567,11 +852,20 @@ async fn serve_helper(
     let (notif_tx, mut notif_rx) =
         mpsc::unbounded_channel::<acp::SessionNotification>();
 
+    // Shared with `HelperHandler` so it can stash the helper's
+    // outbound `AgentSideConnection` into `HelperRoute.forwarder` at
+    // `new_session` / `load_session` time. `OnceLock` because the
+    // conn doesn't exist until `AgentSideConnection::new` returns,
+    // but we populate it strictly before `handle_io` is polled below.
+    let agent_side_slot: Arc<OnceLock<Arc<acp::AgentSideConnection>>> =
+        Arc::new(OnceLock::new());
+
     let handler = HelperHandler {
         helper_id,
         agent_conn,
         state: Arc::clone(&state),
         notif_tx,
+        agent_side_slot: Arc::clone(&agent_side_slot),
     };
 
     let (read_half, write_half) = tokio::io::split(pipe);
@@ -582,6 +876,12 @@ async fn serve_helper(
         acp::AgentSideConnection::new(handler, outgoing, incoming, |fut| {
             tokio::task::spawn_local(fut);
         });
+    let agent_side_conn = Arc::new(agent_side_conn);
+    // Populate BEFORE `handle_io.await` (below) so any inbound
+    // request the agent CLI sends is guaranteed to see a populated
+    // slot. `set` returns `Err` only if already-set, which can't
+    // happen here.
+    let _ = agent_side_slot.set(Arc::clone(&agent_side_conn));
 
     tokio::pin!(handle_io);
     let result = loop {
@@ -641,7 +941,7 @@ async fn serve_helper(
 async fn drop_sessions_for_helper(state: &MasterStateInner, helper_id: HelperId) -> usize {
     let mut map = state.session_to_helper.lock().await;
     let before = map.len();
-    map.retain(|_, (hid, _)| *hid != helper_id);
+    map.retain(|_, route| route.helper_id != helper_id);
     before - map.len()
 }
 
@@ -684,8 +984,22 @@ mod tests {
 
         {
             let mut map = state.session_to_helper.lock().await;
-            map.insert(sid1.clone(), (HelperId(1), tx1));
-            map.insert(sid2.clone(), (HelperId(2), tx2));
+            map.insert(
+                sid1.clone(),
+                HelperRoute {
+                    helper_id: HelperId(1),
+                    notif_tx: tx1,
+                    forwarder: None,
+                },
+            );
+            map.insert(
+                sid2.clone(),
+                HelperRoute {
+                    helper_id: HelperId(2),
+                    notif_tx: tx2,
+                    forwarder: None,
+                },
+            );
         }
 
         route(&state, make_notif(&sid1)).await;
@@ -706,7 +1020,14 @@ mod tests {
         let sid = SessionId::new("dead-session");
         {
             let mut map = state.session_to_helper.lock().await;
-            map.insert(sid.clone(), (HelperId(7), tx));
+            map.insert(
+                sid.clone(),
+                HelperRoute {
+                    helper_id: HelperId(7),
+                    notif_tx: tx,
+                    forwarder: None,
+                },
+            );
         }
         drop(rx); // simulate helper going away
 
@@ -743,10 +1064,38 @@ mod tests {
         let (tx_c, _rx_c) = mpsc::unbounded_channel();
         {
             let mut map = state.session_to_helper.lock().await;
-            map.insert(SessionId::new("a1"), (HelperId(1), tx_a.clone()));
-            map.insert(SessionId::new("a2"), (HelperId(1), tx_a));
-            map.insert(SessionId::new("b1"), (HelperId(2), tx_b));
-            map.insert(SessionId::new("c1"), (HelperId(3), tx_c));
+            map.insert(
+                SessionId::new("a1"),
+                HelperRoute {
+                    helper_id: HelperId(1),
+                    notif_tx: tx_a.clone(),
+                    forwarder: None,
+                },
+            );
+            map.insert(
+                SessionId::new("a2"),
+                HelperRoute {
+                    helper_id: HelperId(1),
+                    notif_tx: tx_a,
+                    forwarder: None,
+                },
+            );
+            map.insert(
+                SessionId::new("b1"),
+                HelperRoute {
+                    helper_id: HelperId(2),
+                    notif_tx: tx_b,
+                    forwarder: None,
+                },
+            );
+            map.insert(
+                SessionId::new("c1"),
+                HelperRoute {
+                    helper_id: HelperId(3),
+                    notif_tx: tx_c,
+                    forwarder: None,
+                },
+            );
         }
 
         let dropped = drop_sessions_for_helper(&state, HelperId(1)).await;

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -29,12 +29,13 @@
 //     to each helper. `MasterClient` looks up the helper by
 //     `args.session_id` and calls the matching `Client`-trait method
 //     on that connection (`AgentSideConnection` itself implements
-//     `acp::Client`, RPC'ing back over the helper's pipe). The
-//     helper-side `WtaClient` then runs the same code path it ran
-//     pre-helper-split (TUI permission UI, `ShellManager`, etc.).
+//     `acp::Client` and re-issues each call as an RPC request over the
+//     helper's pipe). The helper-side `WtaClient` then runs the same
+//     code path it ran pre-helper-split (TUI permission UI,
+//     `ShellManager`, etc.).
 
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, OnceLock, Weak};
 
 use acp::Agent as _;
 use acp::Client as _;
@@ -425,42 +426,62 @@ struct HelperHandler {
     /// receiver and writes notifications back over the
     /// `AgentSideConnection`.
     notif_tx: mpsc::UnboundedSender<acp::SessionNotification>,
-    /// The same helper's outbound connection back to its pipe.
-    /// `HelperHandler` is moved INTO `AgentSideConnection::new`, so
-    /// we can't hold the `AgentSideConnection` by value — we share a
-    /// `OnceLock` with `serve_helper` instead, which populates it
-    /// immediately after `new()` returns and before `handle_io`
-    /// starts polling (i.e. before any inbound request can hit a
-    /// handler that would observe the slot).
+    /// The same helper's outbound connection back to its pipe, held
+    /// as a `Weak` to break a reference cycle.
     ///
-    /// `new_session` / `load_session` read it (must be `Some` by
-    /// then, since they're driven by `handle_io`) and stash the
-    /// resulting `Arc` into `HelperRoute.forwarder`, where
-    /// `MasterClient` finds it for inbound agent-CLI requests.
-    agent_side_slot: Arc<OnceLock<Arc<acp::AgentSideConnection>>>,
+    /// `HelperHandler` is moved INTO `AgentSideConnection::new`, so
+    /// the conn owns the handler. If we then stored a strong `Arc`
+    /// back to that same conn here, the conn would never drop after
+    /// helper disconnect (its own internally-held handler keeps a
+    /// strong ref to itself), leaking one conn + helper state per
+    /// disconnect across the master's lifetime. `Weak` lets the
+    /// conn die when all its external strong refs go away
+    /// (`serve_helper`'s local + every `HelperRoute.forwarder`),
+    /// after which `upgrade()` returns `None` and the handler can't
+    /// fire any more outbound requests — which is the right behaviour
+    /// since the conn is being torn down.
+    ///
+    /// Shared with `serve_helper` via `OnceLock`: the conn doesn't
+    /// exist until `AgentSideConnection::new()` returns, but
+    /// `serve_helper` populates this slot strictly before `handle_io`
+    /// starts polling, so any inbound request observed by a handler
+    /// sees a populated slot.
+    agent_side_slot: Arc<OnceLock<Weak<acp::AgentSideConnection>>>,
 }
 
 impl HelperHandler {
     /// Snapshot the populated `AgentSideConnection` for this helper.
     /// Must only be called from request handlers driven by
     /// `handle_io` (which `serve_helper` polls strictly after the
-    /// slot is set). Returns an `internal_error` if the invariant
-    /// is ever violated — failing closed beats producing a half-
-    /// initialised routing entry.
+    /// slot is set).
+    ///
+    /// Two failure modes, both returning `internal_error`:
+    ///   * Slot not yet set — a real bug (shouldn't happen given the
+    ///     ordering above).
+    ///   * `Weak::upgrade` returns `None` — the conn has already been
+    ///     dropped (helper disconnect path); we have no way to route
+    ///     a fresh request anyway.
     fn forwarder_for_route(&self, op: &'static str) -> acp::Result<Arc<acp::AgentSideConnection>> {
-        match self.agent_side_slot.get() {
-            Some(asc) => Ok(Arc::clone(asc)),
-            None => {
-                tracing::error!(
-                    target: "master",
-                    op = op,
-                    helper_id = ?self.helper_id,
-                    "agent_side_slot empty inside helper request handler — bug; serve_helper must populate it before handle_io polls"
-                );
-                Err(acp::Error::internal_error()
-                    .data(serde_json::json!("agent_side_slot not yet set")))
-            }
-        }
+        let weak = self.agent_side_slot.get().ok_or_else(|| {
+            tracing::error!(
+                target: "master",
+                op = op,
+                helper_id = ?self.helper_id,
+                "agent_side_slot empty inside helper request handler — bug; serve_helper must populate it before handle_io polls"
+            );
+            acp::Error::internal_error()
+                .data(serde_json::json!("agent_side_slot not yet set"))
+        })?;
+        weak.upgrade().ok_or_else(|| {
+            tracing::warn!(
+                target: "master",
+                op = op,
+                helper_id = ?self.helper_id,
+                "helper AgentSideConnection already dropped — cannot route new request"
+            );
+            acp::Error::internal_error()
+                .data(serde_json::json!("helper connection dropped"))
+        })
     }
 }
 
@@ -857,7 +878,12 @@ async fn serve_helper(
     // `new_session` / `load_session` time. `OnceLock` because the
     // conn doesn't exist until `AgentSideConnection::new` returns,
     // but we populate it strictly before `handle_io` is polled below.
-    let agent_side_slot: Arc<OnceLock<Arc<acp::AgentSideConnection>>> =
+    //
+    // Stored as `Weak` (not `Arc`) to avoid a reference cycle: the
+    // conn owns the handler, the handler owns this slot — if the
+    // slot held a strong `Arc` back to the conn, the conn could
+    // never drop after helper disconnect.
+    let agent_side_slot: Arc<OnceLock<Weak<acp::AgentSideConnection>>> =
         Arc::new(OnceLock::new());
 
     let handler = HelperHandler {
@@ -880,8 +906,10 @@ async fn serve_helper(
     // Populate BEFORE `handle_io.await` (below) so any inbound
     // request the agent CLI sends is guaranteed to see a populated
     // slot. `set` returns `Err` only if already-set, which can't
-    // happen here.
-    let _ = agent_side_slot.set(Arc::clone(&agent_side_conn));
+    // happen here. `Arc::downgrade` so the slot holds a `Weak` —
+    // see the field comment on `HelperHandler::agent_side_slot` for
+    // why a strong `Arc` here would leak the conn.
+    let _ = agent_side_slot.set(Arc::downgrade(&agent_side_conn));
 
     tokio::pin!(handle_io);
     let result = loop {
@@ -1106,5 +1134,77 @@ mod tests {
         assert!(!map.contains_key(&SessionId::new("a2")));
         assert!(map.contains_key(&SessionId::new("b1")));
         assert!(map.contains_key(&SessionId::new("c1")));
+    }
+
+    /// `route_for` (used by every `MasterClient::<client-method>`
+    /// forwarder) must return `internal_error` when the agent CLI
+    /// sends a request for a session that no helper has registered
+    /// — typically a stale call after the owning helper disconnected.
+    /// Returning `Ok(...)` here would dereference an invalid route.
+    #[tokio::test]
+    async fn route_for_unknown_session_id_returns_internal_error() {
+        let state = make_state();
+        let client = MasterClient {
+            state: Arc::clone(&state),
+        };
+        let err = client
+            .route_for(&SessionId::new("ghost"), "request_permission")
+            .await
+            .expect_err("unknown session_id must not resolve");
+        assert_eq!(err.code, acp::ErrorCode::InternalError);
+    }
+
+    /// `route_for` must also fail when the routing entry exists but
+    /// its `forwarder` slot is `None`. Production code never inserts
+    /// a `None` forwarder (every `new_session` / `load_session` path
+    /// upgrades the helper's `Weak<AgentSideConnection>`), so reaching
+    /// this branch means the slot was inserted before the conn was
+    /// alive — that's a bug we want to surface, not paper over.
+    #[tokio::test]
+    async fn route_for_none_forwarder_returns_internal_error() {
+        let state = make_state();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        {
+            let mut map = state.session_to_helper.lock().await;
+            map.insert(
+                SessionId::new("orphan"),
+                HelperRoute {
+                    helper_id: HelperId(42),
+                    notif_tx: tx,
+                    forwarder: None,
+                },
+            );
+        }
+        let client = MasterClient {
+            state: Arc::clone(&state),
+        };
+        let err = client
+            .route_for(&SessionId::new("orphan"), "create_terminal")
+            .await
+            .expect_err("None forwarder must not resolve");
+        assert_eq!(err.code, acp::ErrorCode::InternalError);
+    }
+
+    /// End-to-end through one of the forwarder methods: a Client-trait
+    /// request on `MasterClient` for an unknown session_id propagates
+    /// the same `internal_error` (rather than the trait default
+    /// `method_not_found`, which would mislead the agent CLI into
+    /// thinking the master doesn't support terminals at all).
+    #[tokio::test]
+    async fn master_client_create_terminal_unknown_session_returns_internal_error() {
+        use acp::Client as _;
+        let state = make_state();
+        let client = MasterClient {
+            state: Arc::clone(&state),
+        };
+        let req = acp::CreateTerminalRequest::new(
+            SessionId::new("nobody-home"),
+            "echo".to_string(),
+        );
+        let err = client
+            .create_terminal(req)
+            .await
+            .expect_err("create_terminal on unknown session must fail");
+        assert_eq!(err.code, acp::ErrorCode::InternalError);
     }
 }

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1571,10 +1571,29 @@ impl acp::Client for WtaClient {
             }
             acp::SessionUpdate::ToolCallUpdate(update) => {
                 if let Some(status) = &update.fields.status {
+                    // Failed updates frequently carry a `raw_output.message`
+                    // explaining *why* (e.g. Copilot in non-interactive ACP
+                    // mode emits `{"code":"rejected","message":"The user
+                    // rejected this tool call."}` when permission is auto-
+                    // denied). Surface it through the existing status string
+                    // so the chat view renders something more useful than a
+                    // bare "Failed".
+                    let reason = update
+                        .fields
+                        .raw_output
+                        .as_ref()
+                        .and_then(|v| v.get("message"))
+                        .and_then(|m| m.as_str())
+                        .map(|s| s.trim())
+                        .filter(|s| !s.is_empty());
+                    let status_str = match reason {
+                        Some(msg) => format!("{:?}: {}", status, msg),
+                        None => format!("{:?}", status),
+                    };
                     let _ = self.state.event_tx.send(AppEvent::ToolCallUpdate {
                         session_id: sid,
                         id: update.tool_call_id.to_string(),
-                        status: format!("{:?}", status),
+                        status: status_str,
                     });
                 }
             }

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -152,7 +152,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     chat::render(frame, app, h_chat[1]);
     app.sync_rec_scroll_max(main_area.width);
     recommendations::render(frame, app, h_rec[1]);
-    if app.current_tab().permission.is_some() {
+    if !app.current_tab().permission.is_empty() {
         permission::render(frame, app, h_perm[1]);
     }
 

--- a/tools/wta/src/ui/permission.rs
+++ b/tools/wta/src/ui/permission.rs
@@ -10,9 +10,8 @@ use crate::ui::card::{self, CARD_MIN_SIZE};
 /// either ≥ `CARD_MIN_SIZE` (full card) or exactly 1 (compact fallback —
 /// the agent flow is blocked on this prompt, so we must remain visible).
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
-    let perm = match &app.current_tab().permission {
-        Some(p) => p,
-        None => return,
+    let Some(perm) = app.current_tab().permission.front() else {
+        return;
     };
 
     if area.height < CARD_MIN_SIZE {


### PR DESCRIPTION
Restores `request_permission`, `create_terminal`, `terminal_output`, `release_terminal`, `wait_for_terminal_exit`, `kill_terminal`, `read_text_file`, and `write_text_file` after the helper+master split.

Before this change `MasterClient` only implemented `session_notification`; every other `acp::Client` method fell through to the trait's default `method_not_found` while master still advertised `client_capabilities().terminal(true)` to the agent CLI. Tool calls and permission requests issued by the agent CLI therefore failed silently — flagged on #54 (severity: high).

`session_to_helper` now stores a `HelperRoute` that also carries an `Arc<acp::AgentSideConnection>` back to the helper. `HelperHandler` shares an `Arc<OnceLock<…>>` with `serve_helper` so the conn (which doesn't exist until `AgentSideConnection::new` returns) can be stashed into the route at `new_session` / `load_session` time. `MasterClient` implements every Client-trait method by looking up the helper by `args.session_id` and re-dispatching on its `AgentSideConnection` — `AgentSideConnection` itself implements `acp::Client`, so the call arrives at the helper's `WtaClient`, which runs the same code path it ran pre-split (TUI permission UI, `ShellManager`, etc.).

All existing master tests pass against the new `HelperRoute` value type. Forwarder is `Option<_>` so the unit tests, which exercise only the notification path, can construct routes without a live `AgentSideConnection`; production paths always set it to `Some(_)`. `MasterClient` treats a `None` forwarder as a routing bug and returns `internal_error` with a diagnostic log.

`fs` capability stays unadvertised — the helper's `WtaClient` still doesn't implement `read_text_file` / `write_text_file`. The master forwarders for those methods are in place so adding helper support later is a one-line change to `InitializeRequest`.

## Summary of the Pull Request

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
