### PR TITLE
Fix C++ build break: std::regex_constants::multiline not in MSVC STL

### DIFF
--- a/src/cascadia/inc/ShellIntegration.h
+++ b/src/cascadia/inc/ShellIntegration.h
@@ -152,23 +152,38 @@ if (-not $Global:__ShellInteg_Installed) {
     // script — current (shell-integration_vN.ps1) AND legacy (shell-integration.ps1)
     // — so upgrades can rewrite the line in place.
     //
-    // Pattern (multiline): line begins with `.` + whitespace + a quoted path
-    // whose FINAL filename component is `shell-integration*.ps1`. The path
-    // component check (preceded by `/`, `\`, or the opening quote; followed
-    // only by non-separator chars before `.ps1`) avoids false matches on
-    // directories that happen to contain "shell-integration" or on trailing
-    // comments after an unrelated dot-source line.
+    // Pattern: line begins with `.` + whitespace + a quoted path whose
+    // FINAL filename component is `shell-integration*.ps1`. The path
+    // component check (preceded by `/`, `\`, or the opening quote;
+    // followed only by non-separator chars before `.ps1`) avoids false
+    // matches on directories that happen to contain "shell-integration"
+    // or on trailing comments after an unrelated dot-source line.
+    //
+    // `(^|\n)` substitutes for the C++17 `multiline` flag — MSVC's
+    // STL does NOT define `std::regex_constants::multiline` (only the
+    // basic POSIX flags + icase/nosubs/optimize/collate), so the
+    // documented C++17 spelling does not compile here. We instead match
+    // start-of-string OR a literal newline, and trim the consumed `\n`
+    // out of the returned range so callers still see only the
+    // dot-source line itself.
     inline std::pair<size_t, size_t> FindShellIntegrationDotSourceLine(std::string_view contents)
     {
         static const std::regex pattern{
-            R"(^[ \t]*\.[ \t]+"(?:[^"]*[\\/])?shell-integration[^"\\/]*\.ps1".*)",
-            std::regex_constants::ECMAScript | std::regex_constants::multiline
+            R"((^|\n)[ \t]*\.[ \t]+"(?:[^"]*[\\/])?shell-integration[^"\\/]*\.ps1".*)",
+            std::regex_constants::ECMAScript
         };
         std::cmatch m;
         if (std::regex_search(contents.data(), contents.data() + contents.size(), m, pattern))
         {
-            const size_t start = static_cast<size_t>(m.position());
+            size_t start = static_cast<size_t>(m.position());
             size_t end = start + static_cast<size_t>(m.length());
+            // If the alternation matched `\n` (non-first-line case), the
+            // newline is at `contents[start]`; advance past it so the
+            // returned range starts on the dot-source line proper.
+            if (start < contents.size() && contents[start] == '\n')
+            {
+                ++start;
+            }
             // `.` doesn't match `\n`, so the match naturally stops at end-of-line.
             // For CRLF input a trailing `\r` may remain in the captured range — strip it.
             while (end > start && contents[end - 1] == '\r')


### PR DESCRIPTION
## Summary

PR #64 (`c02d88117`) introduced `FindShellIntegrationDotSourceLine` in `src/cascadia/inc/ShellIntegration.h` using `std::regex_constants::multiline`. cppreference lists this flag as C++17, but **MSVC's STL never implemented it** — its `<regex>` `syntax_option_type` enum only contains the POSIX flags + ECMAScript + `icase / nosubs / optimize / collate`. Verified against MSVC 14.44.35207 headers.

Any translation unit that pulls this header in (`AppActionHandlers.cpp`, `FreOverlay.cpp`) fails the local C++ build with:

```
error C2065: 'multiline': undeclared identifier
std::regex_constants::ECMAScript | std::regex_constants::multiline
                                                          ^
```

## Fix

Replace the `multiline` flag with an explicit `(^|\n)` alternation in the regex:

- Match start-of-string OR a literal newline.
- After a match, if the alternation consumed a leading `\n` (non-first-line case), advance the returned range past that newline so callers still see only the dot-source line itself.

Behavior is equivalent to the original `multiline`-flagged pattern for the inputs this function handles (PowerShell `$PROFILE` content, LF or CRLF terminated).

## How did this land on main?

Unclear — presumably PR #64's CI ran the Rust/lint/spell-check pipeline but did not do a full MSBuild of the C++ side that includes `AppActionHandlers.cpp`. Worth a follow-up to make sure a full C++ build is gating.

## Test plan

- [x] Local incremental F5 build with VS 2022 Enterprise 17.x (MSVC 14.44.35207) compiles cleanly after this change.
- [ ] CI: confirm the full MSBuild step compiles `AppActionHandlers.cpp` and `FreOverlay.cpp`.
- [ ] Functional: install shell integration into a `$PROFILE` that already has a legacy `. "...\shell-integration.ps1"` line and verify it's replaced in-place (matches original `multiline` behavior).

Generated with Claude Code.