### PR TITLE
wta agent pane: pre-warm helper per tab + fix drag-in autofix state/trigger

### DIFF
--- a/src/cascadia/TerminalApp/AgentPaneContent.cpp
+++ b/src/cascadia/TerminalApp/AgentPaneContent.cpp
@@ -87,6 +87,18 @@ namespace winrt::TerminalApp::implementation
         {
             _refreshLogo();
         }
+        // Match `SetSessionsView` and `ApplyAutofixState`: any bottom-bar-
+        // affecting state mutation on AgentPaneContent must raise
+        // `StateChanged` so subscribers (TerminalPage's bar-refresh
+        // handler) can pick up the change without polling. The bar does
+        // not currently render the agent name itself, but the cross-
+        // window-drag fix path in `TabManagement.cpp` relies on
+        // `_UpdateBottomBarState` running once after the wire-up to
+        // reflect any cached state the helper pushed before the wire
+        // was in place — without the raise here, that catch-up wouldn't
+        // observe agent_status arriving in the same race window. Also
+        // future-proofs the bar against ever displaying agent name.
+        StateChanged.raise(*this, nullptr);
     }
 
     // Swap the bar between two modes:

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -227,11 +227,11 @@ namespace winrt::TerminalApp::implementation
         // tab. The helper conpty child is spawned but the pane is immediately
         // stashed via `Tab::StashAgentPane`, so the user only sees the
         // terminal pane. Toggling the agent pane (`Ctrl+Shift+.` /
-        // `Ctrl+Shift+/` / bottom-bar button) is just an unstash/restash.
+        // `Ctrl+Shift+/` / bottom-bar button) is just a stash/restore.
         // The point of pre-warming is autofix: autofix routes through the
         // agent helper, and gating it on "user has opened the pane at least
-        // once" was a footgun. With pre-warm, autofix works on every tab
-        // from the moment the tab opens.
+        // once" silently broke autofix on every fresh tab. With pre-warm,
+        // autofix works on every tab from the moment the tab opens.
         //
         // The actual spawn is deferred to the same low-priority dispatcher
         // tick as the cross-window drag rename walk below — that way
@@ -694,7 +694,7 @@ namespace winrt::TerminalApp::implementation
         {
             _NotifyAgentTabClosed(closedTabStableId);
 
-            // Pre-existing latent leak (made worse by pre-warm): tab close
+            // Preexisting latent leak (made worse by pre-warm): tab close
             // goes through `Tab::Shutdown` → `Pane::Shutdown`, which only
             // calls `_setPaneContent(nullptr)` on each leaf — it does NOT
             // raise `Pane::Closed`. The agent pane's `Pane::Closed` handler

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -18,6 +18,7 @@
 
 #include "AgentPaneContent.h"
 #include "AgentPaneLog.h"
+#include "SharedWta.h"
 #include "TabRowControl.h"
 #include "DebugTapConnection.h"
 #include "DesktopNotification.h"
@@ -222,8 +223,21 @@ namespace winrt::TerminalApp::implementation
             _tabContent.Children().Append(content);
         }
 
-        // Per-tab model: no auto-create-on-tab-creation. Users open an
-        // agent pane on demand per tab via the keybinding / toolbar.
+        // Per-tab model: pre-warm a stashed agent pane on every new terminal
+        // tab. The helper conpty child is spawned but the pane is immediately
+        // stashed via `Tab::StashAgentPane`, so the user only sees the
+        // terminal pane. Toggling the agent pane (`Ctrl+Shift+.` /
+        // `Ctrl+Shift+/` / bottom-bar button) is just an unstash/restash.
+        // The point of pre-warming is autofix: autofix routes through the
+        // agent helper, and gating it on "user has opened the pane at least
+        // once" was a footgun. With pre-warm, autofix works on every tab
+        // from the moment the tab opens.
+        //
+        // The actual spawn is deferred to the same low-priority dispatcher
+        // tick as the cross-window drag rename walk below — that way
+        // (a) drag-in tabs that arrive with their own agent pane skip the
+        // pre-warm (see the `agentLeavesSeen == 0` guard there), and
+        // (b) tab initialization isn't blocked on conpty + helper spawn.
 
         // Cross-window agent-pane drag — finalize the rename and re-wire
         // bottom-bar events for any agent pane that arrived via the drag-in
@@ -326,6 +340,45 @@ namespace winrt::TerminalApp::implementation
                     winrt::to_string(newTabId) +
                     " isAgentPaneLeaves=" + std::to_string(isAgentPaneLeaves) +
                     " agentLeavesSeen=" + std::to_string(agentLeavesSeen));
+
+                // Pre-warm a stashed agent pane on this tab so the helper is
+                // running from the start (autofix needs it). Skipped if the
+                // tab already arrived with an agent pane via cross-window
+                // drag-in that landed before this deferred tick fired
+                // (`agentLeavesSeen > 0`). `_AutoCreateHiddenAgentPaneShared`
+                // itself short-circuits if wta isn't available or policy
+                // blocks all agents, and the early-return on
+                // `GetActiveTerminalControl() == null` skips the settings tab.
+                //
+                // NOTE on the race with cross-window drag-in: pre-warm fires
+                // here unconditionally (when `agentLeavesSeen == 0`), even
+                // though a drag-in's SplitPane action might land AFTER this
+                // tick and add a second AgentPaneContent on the same tab.
+                // The de-duplication happens on the drag-in side instead:
+                // `_MakeTerminalPane`'s re-wrap path closes any existing
+                // agent pane on the destination tab before installing its
+                // own. That's a per-tab decision (we know FOR SURE the drag
+                // is targeting this specific tab because the focused tab is
+                // its destination), so it doesn't suffer the false-positive
+                // problem a global "is any drag in flight?" check would
+                // have (window-A-drag would erroneously block window-B's
+                // unrelated new-tab pre-warm).
+                if (agentLeavesSeen == 0)
+                {
+                    _agentPaneLog(
+                        std::string{ "_InitializeTab(deferred): pre-warming stashed agent pane on tab " } +
+                        winrt::to_string(newTabId));
+                    self->_AutoCreateHiddenAgentPaneShared(tabImplCom, /*intoSessionsView*/ false, /*autoStash*/ true);
+                }
+                else
+                {
+                    // Cross-window drag-in path: an agent pane arrived from
+                    // another window and we just wired `_WireAgentPaneEvents`
+                    // on it (via the walk above). Refresh the bottom bar
+                    // explicitly so it picks up the autofix-state cache the
+                    // helper already populated on this AgentPaneContent.
+                    self->_UpdateBottomBarState();
+                }
             });
         }
     }
@@ -614,9 +667,23 @@ namespace winrt::TerminalApp::implementation
         // to drop the matching TabSession so a future tab that reuses any
         // index slot starts with a clean conversation.
         winrt::hstring closedTabStableId{};
+        size_t agentPanesOnTab = 0;
         if (const auto tabImpl = _GetTabImpl(tab))
         {
             closedTabStableId = tabImpl->StableId();
+
+            // Count agent panes on this tab BEFORE `tab.Shutdown()` runs.
+            // We need this for the `SharedWta::ReleasePane` decrement
+            // below — see the long comment after `tab.Shutdown()`.
+            if (const auto rootPane = tabImpl->GetRootPane())
+            {
+                rootPane->WalkTree([&agentPanesOnTab](const std::shared_ptr<Pane>& p) -> void {
+                    if (p && p->IsAgentPane())
+                    {
+                        ++agentPanesOnTab;
+                    }
+                });
+            }
         }
 
         // Removing the tab from the collection should destroy its control and disconnect its connection,
@@ -626,6 +693,28 @@ namespace winrt::TerminalApp::implementation
         if (!movingAway)
         {
             _NotifyAgentTabClosed(closedTabStableId);
+
+            // Pre-existing latent leak (made worse by pre-warm): tab close
+            // goes through `Tab::Shutdown` → `Pane::Shutdown`, which only
+            // calls `_setPaneContent(nullptr)` on each leaf — it does NOT
+            // raise `Pane::Closed`. The agent pane's `Pane::Closed` handler
+            // registered in `_AutoCreateHiddenAgentPaneShared` calls
+            // `SharedWta::ReleasePane()`, so without that event firing the
+            // refcount never drops on tab close. With pre-warm every new
+            // tab adds 1 to the refcount; closing tabs never decrements,
+            // so the master process is kept alive past its last live pane
+            // (only `~SharedWta` at process exit truly cleans it up).
+            // Compensate by manually releasing once per agent pane that
+            // was on the tab — equivalent to what the missed `Closed`
+            // events would have done. Skipped for `movingAway` because
+            // the helper survives a cross-window drag (the target window's
+            // re-wrapped pane is the new owner), so decrementing here
+            // would prematurely zero the refcount and tear down the
+            // master that the dragged pane still depends on.
+            for (size_t i = 0; i < agentPanesOnTab; ++i)
+            {
+                winrt::TerminalApp::implementation::SharedWta::Instance().ReleasePane();
+            }
         }
 
         uint32_t mruIndex{};

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -6600,6 +6600,34 @@ namespace winrt::TerminalApp::implementation
                 if (auto wrapped = _WrapInAgentPaneContent(resultPane))
                 {
                     wrapped->IsAgentPane(true);
+
+                    // Mirror the `Pane::Closed` → `SharedWta::ReleasePane`
+                    // wiring that `_AutoCreateHiddenAgentPaneShared`
+                    // installs on the source side. The drag-in pane is a
+                    // freshly-constructed `Pane` object; without this
+                    // handler, any path that calls `pane->Close()` on it
+                    // (Ctrl+C×2 → `OnCloseAgentPaneRequested` →
+                    // `_TeardownAgentPane`, or settings-rebuild via
+                    // `_RebuildAgentStack` → `_TeardownAgentPane`) would
+                    // raise `Closed` without anyone decrementing the
+                    // SharedWta refcount that the source side's
+                    // `AcquirePane()` contributed. The tab-close walk
+                    // in `_RemoveTab` wouldn't catch it either, because
+                    // the pane is already gone from the tree by the time
+                    // the tab finally closes. Net: the master process
+                    // would be kept alive past its last live pane.
+                    //
+                    // No new `AcquirePane()` here — the source side's
+                    // existing refcount carries across the drag (source's
+                    // `_RemoveTab(movingAway=true)` deliberately skips
+                    // `ReleasePane` precisely so the dragged helper has a
+                    // refcount to live on). This `Closed` handler is the
+                    // matching `Release` for that.
+                    wrapped->Closed([](auto&&, auto&&) {
+                        _agentPaneLog("drag-in agent pane closed");
+                        winrt::TerminalApp::implementation::SharedWta::Instance().ReleasePane();
+                    });
+
                     if (const auto agentContent = wrapped->GetContent().try_as<winrt::TerminalApp::AgentPaneContent>())
                     {
                         agentContent.SetAgentPanePosition(_settings.GlobalSettings().AgentPanePosition());

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1464,7 +1464,7 @@ namespace winrt::TerminalApp::implementation
     // wta-master process that the helpers connect to over a named pipe (helper
     // ↔ master speaks ACP JSON-RPC, master owns the single agent CLI subprocess).
     // See doc/specs/Multi-window-agent-pane.md.
-    bool TerminalPage::_AutoCreateHiddenAgentPaneShared(winrt::com_ptr<Tab> tab, bool intoSessionsView)
+    bool TerminalPage::_AutoCreateHiddenAgentPaneShared(winrt::com_ptr<Tab> tab, bool intoSessionsView, bool autoStash)
     {
         if (!tab || !tab->GetActiveTerminalControl())
         {
@@ -1606,6 +1606,17 @@ namespace winrt::TerminalApp::implementation
         {
             helperCmd.append(L" --initial-view sessions");
         }
+        if (autoStash)
+        {
+            // Pre-warm path: the helper is spawned for a pane that C++
+            // will stash immediately. Tell the helper to seed its
+            // `tab.pane_open = false` so the initial `agent_state_changed`
+            // echo matches the stashed C++ state. Without this the
+            // helper defaults to `pane_open = true` (the "user just
+            // opened the pane" assumption), C++ receives the echo on a
+            // stashed pane and restores it — defeating pre-warm.
+            helperCmd.append(L" --start-stashed");
+        }
 
         // Resolve cwd. Priority matches the legacy spawn:
         //   a) VirtualWorkingDirectory (CLI-remoted commands like `wt agent`)
@@ -1679,6 +1690,45 @@ namespace winrt::TerminalApp::implementation
 
         const auto splitDirection = _AgentPanePositionToSplitDirection(globals.AgentPanePosition());
         tab->SplitPaneAtRoot(splitDirection, newPane);
+
+        if (autoStash)
+        {
+            // Pre-warm path: spawn the helper conpty child NOW, then stash
+            // the pane so the user doesn't see it.
+            //
+            // CRITICAL: `connection.Start()` (which spawns the wta-helper
+            // process) is gated on the agent pane's SwapChainPanel firing
+            // its first `LayoutUpdated` event — see
+            // `TermControl.cpp:343-352`. `LayoutUpdated` is raised by XAML
+            // during its layout pass, which runs *after* the UI thread
+            // returns. If we stash synchronously after SplitPaneAtRoot,
+            // `Pane::HidePane` strips the agent pane's border out of the
+            // visual tree *before* layout runs, so `LayoutUpdated` never
+            // fires, `_InitializeTerminal` never runs, `connection.Start()`
+            // never runs, and the helper is never spawned. Pre-warm becomes
+            // a no-op.
+            //
+            // Fix: force a synchronous layout pass via `UpdateLayout()` on
+            // the agent pane's root grid before stashing. `UpdateLayout` is
+            // XAML's official API for running measure+arrange synchronously;
+            // `LayoutUpdated` is raised inside the call, the
+            // TermControl handler runs, `connection.Start()` spawns the
+            // helper. By the time `StashAgentPane` runs on the next line
+            // the helper is already alive — `HidePane` just rewires the
+            // grid while the conpty + helper keep running headlessly.
+            //
+            // Everything stays in one UI-thread tick (no awaits), so XAML
+            // never renders an intermediate frame. The user only sees the
+            // post-stash state: terminal pane filling the tab.
+            if (const auto root = newPane->GetRootElement())
+            {
+                root.UpdateLayout();
+            }
+            tab->StashAgentPane();
+            _UpdateBottomBarState();
+            _agentPaneLog("_AutoCreateHiddenAgentPaneShared: done — helper pre-warmed + stashed");
+            return true;
+        }
 
         // Focus the new agent pane so the helper receives keyboard input.
         // The bookkeeping path (FocusPane) is synchronous; the actual
@@ -2017,7 +2067,18 @@ namespace winrt::TerminalApp::implementation
         winrt::hstring hotkeyHint;
         winrt::hstring suggestionTitle;
         winrt::hstring detectedSummary;
-        if (paneOpen)
+        // Autofix-state read must NOT be gated on pane visibility. The
+        // helper keeps running and detecting command failures even when
+        // the agent pane is stashed (pre-warm path: helper is spawned
+        // and connected from the moment the tab opens, with the pane
+        // hidden). `OnAutofixStateChanged` writes the latest state into
+        // AgentPaneContent's cache regardless of stash, so the bar
+        // should reflect it regardless of stash too. (The toggle-button
+        // highlights above DO gate on `paneOpen` — that's correct, they
+        // mean "which view is currently shown.") Without this, the bar
+        // shows Idle forever until the user opens the pane, which
+        // defeats autofix-without-toggle.
+        if (activeAgent)
         {
             if (const auto impl = winrt::get_self<winrt::TerminalApp::implementation::AgentPaneContent>(activeAgent))
             {
@@ -6496,6 +6557,35 @@ namespace winrt::TerminalApp::implementation
             winrt::hstring oldTabId;
             if (winrt::TerminalApp::implementation::AgentPaneDragStash::Take(contentId, oldTabId))
             {
+                // Drag-in is targeting the focused (destination) tab. If
+                // pre-warm already created an agent pane on this tab (race:
+                // NewTab's deferred dispatcher tick fires ~300ms BEFORE this
+                // SplitPane re-wrap, sees no agent pane yet, and spawns a
+                // pre-warm one), close that pane first so the drag-in pane
+                // is the only AgentPaneContent on the tab. The pre-existing
+                // pre-warm pane's `Pane::Closed` handler releases its
+                // SharedWta refcount and its helper conpty exits via EOF;
+                // the brief wasted helper spawn is the cost of letting
+                // pre-warm fire unconditionally on every new tab (vs.
+                // gating it on an unreliable / over-broad "is any drag in
+                // flight" signal).
+                //
+                // Per-tab dedup: we know the drag-in is targeting THIS
+                // focused tab specifically (NewTab focused it just before
+                // this SplitPane fires), so this only tears down panes on
+                // the right tab — no false-positives in unrelated windows
+                // / tabs.
+                if (const auto focusedTab = _GetFocusedTabImpl())
+                {
+                    if (const auto existingAgentPane = focusedTab->FindAgentPane())
+                    {
+                        _agentPaneLog(
+                            std::string{ "_MakeTerminalPane: drag-in tearing down pre-warm leftover on tab " } +
+                            winrt::to_string(focusedTab->StableId()));
+                        existingAgentPane->Close();
+                    }
+                }
+
                 if (auto wrapped = _WrapInAgentPaneContent(resultPane))
                 {
                     wrapped->IsAgentPane(true);
@@ -6566,6 +6656,27 @@ namespace winrt::TerminalApp::implementation
                             }
                         }
                     }
+                    // Wire `StateChanged` NOW. The deferred walk in
+                    // `_InitializeTab` would normally handle this, but
+                    // cross-window drag-in has a timing problem: the
+                    // SplitPane that calls this `_MakeTerminalPane` re-wrap
+                    // path fires ~300ms AFTER NewTab's deferred dispatcher
+                    // tick has already run. By the time the deferred tick
+                    // walked the tab tree the agent pane wasn't there yet,
+                    // so `_WireAgentPaneEvents` was never invoked. Without
+                    // the StateChanged subscriber the helper's post-
+                    // `tab_renamed` state echo (`ApplyAutofixState` writes
+                    // the cache, raises StateChanged) has nobody listening,
+                    // so the bottom bar never refreshes — the autofix
+                    // pill silently disappears across drag even though
+                    // the helper's TabSession migrated correctly and is
+                    // re-emitting the right state. The `ownerTab` arg is
+                    // unused by `_WireAgentPaneEvents`; pass nullptr.
+                    if (const auto agentContent = wrapped->GetContent().try_as<winrt::TerminalApp::AgentPaneContent>())
+                    {
+                        _WireAgentPaneEvents(agentContent, winrt::com_ptr<Tab>{ nullptr });
+                    }
+
                     _agentPaneLog("_MakeTerminalPane: re-wrapped drag-in pane as AgentPaneContent");
                     return wrapped;
                 }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1620,13 +1620,24 @@ namespace winrt::TerminalApp::implementation
 
         // Resolve cwd. Priority matches the legacy spawn:
         //   a) VirtualWorkingDirectory (CLI-remoted commands like `wt agent`)
-        //   b) Active pane CWD (from shell integration / OSC 9;9)
+        //   b) Active pane CWD of THIS tab (from shell integration / OSC 9;9)
         //   c) Profile's configured starting directory
         //   d) User's home directory
+        //
+        // Use `tab->GetActiveTerminalControl()` rather than the page's
+        // `_GetActiveControl()`: for `openInBackground=true` new tabs the
+        // tab being pre-warmed is NOT the focused one, so reading from the
+        // page-focused control would pick up the foreground tab's cwd and
+        // the helper would start in the wrong directory (autofix and
+        // agent context would attribute to the wrong project). Reading
+        // directly from `tab` resolves to whichever pane is active on
+        // this specific tab. If shell integration hasn't reported a cwd
+        // yet (common for a just-spawned background tab) we fall through
+        // to (c)/(d) below.
         winrt::hstring startingDirectory = _WindowProperties.VirtualWorkingDirectory();
         if (startingDirectory.empty())
         {
-            if (const auto& activeControl = _GetActiveControl())
+            if (const auto activeControl = tab->GetActiveTerminalControl())
             {
                 startingDirectory = activeControl.WorkingDirectory();
             }
@@ -6592,6 +6603,28 @@ namespace winrt::TerminalApp::implementation
                     if (const auto agentContent = wrapped->GetContent().try_as<winrt::TerminalApp::AgentPaneContent>())
                     {
                         agentContent.SetAgentPanePosition(_settings.GlobalSettings().AgentPanePosition());
+
+                        // Wire `StateChanged` BEFORE emitting `tab_renamed`.
+                        // The deferred walk in `_InitializeTab` would normally
+                        // handle this, but cross-window drag-in has a timing
+                        // problem: the SplitPane that calls this re-wrap
+                        // fires ~300ms AFTER NewTab's deferred dispatcher tick
+                        // has already run; at walk time the agent pane wasn't
+                        // in the tree yet, so `_WireAgentPaneEvents` was
+                        // never invoked. We do it here instead.
+                        //
+                        // Ordering matters: `tab_renamed` (emitted a few lines
+                        // below) drives the helper to re-project state, which
+                        // ends up calling `ApplyAutofixState` → `StateChanged`
+                        // on this very `AgentPaneContent`. If the wire happens
+                        // after `tab_renamed`, that `StateChanged` raise has
+                        // nobody listening and the bottom bar stays stale —
+                        // exactly the bug this drag-in path is meant to fix.
+                        // The helper round-trip through wtcli + COM is many
+                        // ms so in practice we always win the race, but the
+                        // synchronous-correct ordering is to wire first.
+                        // (`ownerTab` arg is unused.)
+                        _WireAgentPaneEvents(agentContent, winrt::com_ptr<Tab>{ nullptr });
                     }
                     // Emit `tab_renamed` IMMEDIATELY here. The cross-window
                     // drag flow runs NewTab → SplitPane as serialized actions:
@@ -6656,27 +6689,6 @@ namespace winrt::TerminalApp::implementation
                             }
                         }
                     }
-                    // Wire `StateChanged` NOW. The deferred walk in
-                    // `_InitializeTab` would normally handle this, but
-                    // cross-window drag-in has a timing problem: the
-                    // SplitPane that calls this `_MakeTerminalPane` re-wrap
-                    // path fires ~300ms AFTER NewTab's deferred dispatcher
-                    // tick has already run. By the time the deferred tick
-                    // walked the tab tree the agent pane wasn't there yet,
-                    // so `_WireAgentPaneEvents` was never invoked. Without
-                    // the StateChanged subscriber the helper's post-
-                    // `tab_renamed` state echo (`ApplyAutofixState` writes
-                    // the cache, raises StateChanged) has nobody listening,
-                    // so the bottom bar never refreshes — the autofix
-                    // pill silently disappears across drag even though
-                    // the helper's TabSession migrated correctly and is
-                    // re-emitting the right state. The `ownerTab` arg is
-                    // unused by `_WireAgentPaneEvents`; pass nullptr.
-                    if (const auto agentContent = wrapped->GetContent().try_as<winrt::TerminalApp::AgentPaneContent>())
-                    {
-                        _WireAgentPaneEvents(agentContent, winrt::com_ptr<Tab>{ nullptr });
-                    }
-
                     _agentPaneLog("_MakeTerminalPane: re-wrapped drag-in pane as AgentPaneContent");
                     return wrapped;
                 }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1715,7 +1715,7 @@ namespace winrt::TerminalApp::implementation
             // TermControl handler runs, `connection.Start()` spawns the
             // helper. By the time `StashAgentPane` runs on the next line
             // the helper is already alive — `HidePane` just rewires the
-            // grid while the conpty + helper keep running headlessly.
+            // grid while the conpty + helper keep running in the background.
             //
             // Everything stays in one UI-thread tick (no awaits), so XAML
             // never renders an intermediate frame. The user only sees the
@@ -6562,7 +6562,7 @@ namespace winrt::TerminalApp::implementation
                 // NewTab's deferred dispatcher tick fires ~300ms BEFORE this
                 // SplitPane re-wrap, sees no agent pane yet, and spawns a
                 // pre-warm one), close that pane first so the drag-in pane
-                // is the only AgentPaneContent on the tab. The pre-existing
+                // is the only AgentPaneContent on the tab. The preexisting
                 // pre-warm pane's `Pane::Closed` handler releases its
                 // SharedWta refcount and its helper conpty exits via EOF;
                 // the brief wasted helper spawn is the cost of letting

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -389,8 +389,16 @@ namespace winrt::TerminalApp::implementation
         // `intoSessionsView` is passed through to the helper as
         // `--initial-view sessions`. Called from `_OpenOrReuseAgentPane`
         // user-initiated paths.
+        //
+        // `autoStash=true` is the pre-warm path called from `_InitializeTab`:
+        // the helper conpty is spawned but the pane is immediately stashed
+        // (`Tab::StashAgentPane`) so the user sees only the terminal pane.
+        // Focus stays on the original terminal; no telemetry fires (the
+        // pane wasn't *opened*, just pre-warmed). This is what makes
+        // autofix work without the user ever opening the agent pane.
         bool _AutoCreateHiddenAgentPaneShared(winrt::com_ptr<Tab> tab,
-                                              bool intoSessionsView = false);
+                                              bool intoSessionsView = false,
+                                              bool autoStash = false);
         // Wraps the raw terminal pane's TerminalPaneContent in an
         // AgentPaneContent so the leaf renders the 36px XAML agent bar
         // above the wta TermControl + the bottom-bar below.

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -10,6 +10,7 @@
 
 #include "VirtualDesktopUtils.h"
 #include "WindowEmperor.h"
+#include "TerminalProtocolComServer.h"
 #include "../types/inc/utils.hpp"
 
 using namespace winrt::Windows::UI;
@@ -1174,6 +1175,25 @@ safe_void_coroutine AppHost::_WindowInitializedHandler(const winrt::Windows::Fou
                                                        const winrt::Windows::Foundation::IInspectable& /*arg*/)
 {
     _isWindowInitialized = WindowInitializedState::Initializing;
+
+    // Re-run page-events registration now that the TerminalPage is
+    // actually constructed. `WindowEmperor::CreateNewWindow` already
+    // calls `s_OnWindowAdded` immediately after `host->Initialize()`,
+    // but at that point XAML is still spinning up its UI tree and
+    // `_getPage(host)` returns null, so the registration is silently
+    // skipped for this window. `_ensurePageEventsRegistered` deduplicates
+    // per-page via `s_registered`, so the normal "Subscribe() calls
+    // _ensurePageEventsRegistered" retry path picks the new page up the
+    // next time a wta helper subscribes. For tear-out windows that
+    // sometimes still misses (depending on whether the pre-warm helper
+    // wins the race against the existing-helper rekey), and the new
+    // window's `TerminalPage::ProtocolVtSequenceReceived` never gets
+    // wired into the COM fan-out — events the new window raises (e.g.
+    // `autofix_execute` from the Ctrl+Alt+. handler) end up with no
+    // listener and silently disappear. Retrying registration here, when
+    // we know the page is actually ready, closes that hole. Cheap
+    // (O(n) over a small N) and idempotent.
+    TerminalProtocolComServer::s_OnWindowAdded(this);
 
     // GH#11561: We're totally done being initialized. Resize the window to
     // match the initial settings, and then call ShowWindow to finally make us

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -189,6 +189,18 @@ struct Cli {
     #[arg(long, hide = true)]
     owner_tab_id: Option<String>,
 
+    /// Pre-warm mode: the helper is being spawned for a tab whose agent
+    /// pane is *already stashed* on the C++ side (see TerminalPage::
+    /// _AutoCreateHiddenAgentPaneShared autoStash path). Without this
+    /// flag, the helper's `--owner-tab-id` startup branch seeds
+    /// `tab.pane_open = true` and echoes back `agent_state_changed
+    /// { pane_open: true }`, which C++ interprets as "user opened the
+    /// pane" and unstashes it — defeating pre-warm. With this flag the
+    /// helper seeds `tab.pane_open = false`, matching the C++ stash
+    /// state. Hidden because only WT's pre-warm path should set it.
+    #[arg(long, hide = true)]
+    start_stashed: bool,
+
     // Legacy flags (hidden, backward compat)
     #[arg(long, hide = true)]
     info: bool,
@@ -1932,13 +1944,20 @@ async fn run_acp_app(
             //      stashes the just-spawned agent pane.
             // The full seed block further down (which logs + redundantly
             // sets the same fields) becomes idempotent now.
+            //
+            // `--start-stashed` inverts (2): in the pre-warm path the
+            // C++ side has *already stashed* the pane after spawning the
+            // helper, so the helper must seed `pane_open = false` to
+            // match. Without this, helper echoes `pane_open=true`, C++
+            // sees a stashed pane and a `pane_open=true` echo, and
+            // restores the pane — defeating pre-warm.
             if let Some(ref owner_tab_id) = cli.owner_tab_id {
                 if !owner_tab_id.is_empty() && app_state.tab_id.is_none() {
                     let tab = app_state
                         .tab_sessions
                         .entry(owner_tab_id.clone())
                         .or_default();
-                    tab.pane_open = true;
+                    tab.pane_open = !cli.start_stashed;
                     app_state.tab_id = Some(owner_tab_id.clone());
                     app_state.owner_tab_id = Some(owner_tab_id.clone());
                 }
@@ -2104,11 +2123,12 @@ async fn run_acp_app(
                         .or_default();
                     // wta is the source of truth for "does this tab want
                     // the pane visible". The pane is being spawned right
-                    // now for this owner tab, so the user clearly wants
-                    // it visible here. C++ will pick this up in the
-                    // initial `agent_state_changed` emit below and mirror
-                    // it onto Tab.AgentPaneOpen.
-                    tab.pane_open = true;
+                    // now for this owner tab; under the normal user-
+                    // initiated open the user wants it visible, so default
+                    // pane_open=true. The exception is `--start-stashed`
+                    // (pre-warm path) where C++ has already stashed the
+                    // pane — see comment on the earlier seed block.
+                    tab.pane_open = !cli.start_stashed;
                     app_state.tab_id = Some(owner_tab_id);
                 }
             }


### PR DESCRIPTION
## Summary

Five related fixes around per-tab agent pane lifecycle. The user-visible bugs were "autofix doesn't work until I open the agent pane" and "after dragging a tab to a new window, the autofix bar / hotkey is dead". Underneath those were a chain of races and missed wirings; this PR fixes them in one go.

### What changed

1. **Pre-warm a stashed agent pane on every new terminal tab** so the helper + ACP session are alive from the moment the tab opens — autofix no longer requires the user to manually open the pane first.
   - `TabManagement.cpp::_InitializeTab` deferred tick calls `_AutoCreateHiddenAgentPaneShared(..., autoStash=true)` when the tab has no agent pane.
   - `_AutoCreateHiddenAgentPaneShared` gains an `autoStash` parameter: after `SplitPaneAtRoot` it forces a synchronous `UpdateLayout()` (so `SwapChainPanel.LayoutUpdated` fires inside the call, `connection.Start()` runs, helper conpty actually spawns — without this, stashing immediately would strip the SwapChainPanel from the visual tree before layout, and the helper would never launch), then calls `Tab::StashAgentPane()`.
   - New `--start-stashed` CLI flag on `wta` so the helper seeds `tab.pane_open = false` (instead of `true`) when it knows the pane is pre-warmed in a stashed state. Without this the helper's startup echo of `pane_open=true` would race back to C++ and unstash the pane.

2. **`_UpdateBottomBarState` no longer gates the autofix indicator on `paneOpen`.** The cache (`AgentPaneContent::_autofixState` etc.) is always updated by `OnAutofixStateChanged`; the bar must read it regardless of whether the pane is currently visible. The toggle-button highlights still legitimately depend on `paneOpen` (they indicate which view is currently shown).

3. **Cross-window drag: de-dup pre-warm pane in `_MakeTerminalPane`'s re-wrap path.** When a NewTab+SplitPane sequence drags an agent pane in, NewTab's deferred dispatcher tick fires ~300 ms before the SplitPane's re-wrap, so pre-warm sees an empty tab and creates a pre-warm pane just before the drag-in adds its own pane — duplicate `AgentPaneContent`s on one tab, two helpers fighting over the same `owner_tab_id`, broken autofix routing. The drag-in path now checks `focusedTab->FindAgentPane()` and `Close()`s the pre-warm leftover before installing the dragged pane. The decision is per-tab (the drag's destination is the focused tab in the destination window), so it does not over-restrict.

4. **Wire `StateChanged` on the drag-in's freshly-created `AgentPaneContent`.** Same race as above: the deferred walk in `_InitializeTab` would normally call `_WireAgentPaneEvents`, but at walk time the drag-in pane isn't in the tree yet, so the subscriber is never installed. The result was the helper's post-`tab_renamed` state echo updated the cache (visible if you opened the pane manually) but `StateChanged.raise()` had nobody listening, so the bottom bar never refreshed across drag. The wiring now happens directly inside `_MakeTerminalPane`'s drag-in branch.

5. **`AppHost::_WindowInitializedHandler` re-runs `s_OnWindowAdded`.** `WindowEmperor::CreateNewWindow` calls `s_OnWindowAdded` immediately after `host->Initialize()`, but at that point XAML's UI tree is still being built and `_getPage(host)` returns null, so `_ensurePageEventsRegistered` silently skips this window. The normal "next Subscribe() will retry" recovery does not fire for tear-out windows because no new helper subscribes (the dragged helper kept its existing subscription). Net effect: the new window's `TerminalPage::ProtocolVtSequenceReceived` never gets wired into the COM fan-out, so any event the new window raises (e.g. `autofix_execute` from the Ctrl+Alt+. handler) ends up with no listener and silently disappears. Retrying registration once the window is actually initialized closes that hole.

6. **`AgentPaneContent::UpdateAgentStatus` raises `StateChanged`** to match the contract of `SetSessionsView` / `ApplyAutofixState`. Currently the bottom bar doesn't display agent name, so this has no visible effect today, but it removes a footgun: any future bar element that reads `_agentName` / `_agentVersion` would have silently suffered the same drag-in-race miss as autofix did.

## References and relevant issues

Spec: see the `Multi-window-agent-pane.md` §Z-R8 update (pending in a follow-up commit) for the pre-warm rationale and the `UpdateLayout` race notes.

## Detailed description

See per-section commentary inline in `TerminalPage.cpp` (`_AutoCreateHiddenAgentPaneShared` autoStash branch, `_MakeTerminalPane` drag-in re-wrap), `TabManagement.cpp` (`_InitializeTab` deferred tick), `AppHost.cpp` (`_WindowInitializedHandler`), and `tools/wta/src/main.rs` (`--start-stashed` flag wiring). Each fix has a multi-paragraph comment explaining the race / failure mode and why the fix is shaped the way it is.

Known follow-up: helpers torn down (pre-warm replacement during drag, normal pane close, tab close) leak an ACP session in the agent CLI's memory because we don't currently send `session/stop`. ACP has a `session/stop` method under the `unstable_session_stop` feature flag (currently disabled in this repo). Tracking separately — not part of this PR.

## Validation steps performed

- New terminal tab → autofix should fire on the next failing command without ever opening the agent pane.
- Open agent pane via `Ctrl+Shift+.` → should snap to Connected immediately (helper was pre-warmed; no Connecting flicker).
- In source window, let autofix arm. Drag tab to new window via tear-out. Bottom bar in target window should immediately reflect Armed/Detected without opening the pane.
- In armed state in the target window, press `Ctrl+Alt+.` → autofix should fire (no stray `.` typed, fix command should run).
- `wta-agent-pane.log` after a drag should show `_MakeTerminalPane: drag-in tearing down pre-warm leftover on tab ...` (or no such line if pre-warm's deferred tick happened after drag-in already landed).

## PR checklist

- [ ] Closes #xxx
- [x] Tests added/passed (existing tests; per-tab agent pane lifecycle has no unit-test scaffolding in this repo)
- [ ] Documentation updated (Multi-window-agent-pane.md update pending in a follow-up commit)
- [ ] Schema updated (n/a)