### PR TITLE
Fix cmdpal `?<prompt>` delegate: --language must precede subcommand

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1173,8 +1173,20 @@ namespace winrt::TerminalApp::implementation
             return L"\"" + escaped + L"\"";
         };
 
-        // Build: wta delegate --agent <agent> --delegate-agent <delegate> "<prompt>"
-        std::wstring cmdline = quoteArg(wtaPath) + L" delegate";
+        // Build: wta [--language <lang>] delegate --agent <agent> --delegate-agent <delegate> "<prompt>"
+        //
+        // `--language` is a top-level Cli flag, so it must appear *before* the
+        // `delegate` subcommand — otherwise clap rejects it and the process
+        // exits before `logging::init("delegate")` runs (silent failure, no
+        // wta-delegate.log, no new tab).
+        std::wstring cmdline = quoteArg(wtaPath);
+
+        if (const auto lang = _ResolveEffectiveLanguage(globals); !lang.empty())
+        {
+            cmdline += L" --language " + quoteArg(std::wstring_view{ lang });
+        }
+
+        cmdline += L" delegate";
 
         if (!agentCliPath.empty())
         {
@@ -1190,11 +1202,6 @@ namespace winrt::TerminalApp::implementation
         if (!delegateModel.empty())
         {
             cmdline += L" --delegate-model " + quoteArg(std::wstring_view{ delegateModel });
-        }
-
-        if (const auto lang = _ResolveEffectiveLanguage(globals); !lang.empty())
-        {
-            cmdline += L" --language " + quoteArg(std::wstring_view{ lang });
         }
 
         // Pass CWD from the active pane.


### PR DESCRIPTION
## Summary

- `?<prompt>` in the command palette (and the Alt+Shift+? shortcut) silently failed to open a new tab. Root cause: PR #33 added `--language` to the `wta delegate` command line but placed it *after* the `delegate` subcommand token. `--language` is a top-level `Cli` flag (see `tools/wta/src/main.rs:175-181`), not a flag on the `Delegate` subcommand, so clap rejected it with `unexpected argument '--language' found` and the process exited before `logging::init("delegate")` ran — no `wta-delegate.log`, no new tab.
- Fix: build the cmdline as `wta [--language <lang>] delegate ...` so clap parses `--language` as the top-level flag it actually is. Added a comment explaining the ordering requirement so this doesn't get re-broken.

Note: PR #33 added `--language` in three places in `TerminalPage.cpp`. Only the `delegate` path was broken — the other two launch `wta` without a subcommand, where the ordering is moot.

## Test plan

- [ ] Rebuild Terminal (no WTA rebuild needed; its argument parsing is already correct).
- [ ] In the command palette, type `?spin up a new cpp project here` and press Enter — a new tab should open running the delegate agent.
- [ ] Verify `%LOCALAPPDATA%\IntelligentTerminal\logs\wta-delegate.log` is created and shows `run_delegate started`.
- [ ] Trigger via Alt+Shift+? as well to confirm both entry points work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)