### PR TITLE
wta agent pane: stop pushing WT events into chat history

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1499,11 +1499,6 @@ pub struct App {
     /// place of a live wtcli; not compiled into release builds.
     #[cfg(test)]
     pub last_dispatched_command: Option<DispatchedCommand>,
-    /// Test hook: prompt last passed to `delegate_to_tab_agent`.
-    /// Lets cross-tab `agent_prompt` filtering be unit-tested without
-    /// actually spawning a `wta delegate` subprocess.
-    #[cfg(test)]
-    pub last_delegated_prompt: Option<String>,
     /// Source pane GUID (set from `WTA_SOURCE_SESSION_ID` env var by the
     /// launching pane). Used by autofix to attribute which pane originated
     /// the failing command we're about to fix.
@@ -1645,8 +1640,6 @@ impl App {
             agent_event_tx: None,
             #[cfg(test)]
             last_dispatched_command: None,
-            #[cfg(test)]
-            last_delegated_prompt: None,
             source_session_id: None,
             source_cwd: None,
             log_agent_events: false,
@@ -3514,21 +3507,6 @@ impl App {
                 if method == "agent_prompt" {
                     // Command palette `?<prompt>` delegation. Not a WT
                     // notification — has nothing to do with banner/queue.
-                    //
-                    // C++ broadcasts to every helper in the window, so
-                    // we must filter here: without this check, N agent
-                    // panes across N tabs would each spawn a `wta
-                    // delegate` subprocess for a single user prompt and
-                    // get N duplicate sub-agent tabs.
-                    if !self.is_event_for_my_tab(tab_id.as_deref()) {
-                        tracing::debug!(
-                            target: "autofix",
-                            event_tab = ?tab_id,
-                            self_tab = ?self.owner_tab_id,
-                            "dropping agent_prompt for different tab"
-                        );
-                        return;
-                    }
                     let prompt = params
                         .get("prompt")
                         .and_then(|v| v.as_str())
@@ -4014,16 +3992,26 @@ impl App {
 
                 // Per-tab filter. WT broadcasts pane-scoped events to every
                 // helper in the window, but another tab's failures are not
-                // this helper's concern.
-                if !self.is_event_for_my_tab(notification.tab_id.as_deref()) {
-                    tracing::debug!(
-                        target: "autofix",
-                        event_tab = ?notification.tab_id,
-                        self_tab = ?self.owner_tab_id,
-                        method = %method,
-                        "dropping cross-tab WT event"
-                    );
-                    return;
+                // this helper's concern. Drop notifications whose tab_id
+                // doesn't match our owner_tab_id; empty/missing tab_id falls
+                // through (no per-tab scope).
+                if let (Some(event_tab), Some(self_tab)) = (
+                    notification.tab_id.as_deref(),
+                    self.owner_tab_id.as_deref(),
+                ) {
+                    if !event_tab.is_empty()
+                        && !self_tab.is_empty()
+                        && event_tab != self_tab
+                    {
+                        tracing::debug!(
+                            target: "autofix",
+                            event_tab,
+                            self_tab,
+                            method = %method,
+                            "dropping cross-tab WT event"
+                        );
+                        return;
+                    }
                 }
 
                 // Surface rule: WT events (connection_state, vt_sequence)
@@ -5540,43 +5528,23 @@ impl App {
     /// Delegate a prompt to a new tab agent by spawning `wta delegate` subprocess.
     /// This is the same path used by the command palette — single code path for
     /// context capture, prompt building, and tab creation.
-    pub fn delegate_to_tab_agent(&mut self, prompt: &str) {
+    pub fn delegate_to_tab_agent(&self, prompt: &str) {
         tracing::info!(target: "autofix", prompt_len = prompt.len(), "delegate_to_tab_agent called");
-        #[cfg(test)]
-        {
-            self.last_delegated_prompt = Some(prompt.to_string());
-            return;
-        }
-        #[cfg(not(test))]
-        {
-            let exe = match std::env::current_exe() {
-                Ok(p) => p,
-                Err(_) => return,
-            };
-            let mut cmd = std::process::Command::new(exe);
-            cmd.arg("delegate").arg(prompt);
-            // The delegate child inherits WT_COM_CLSID from our env; no explicit pass needed.
+        let exe = match std::env::current_exe() {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let mut cmd = std::process::Command::new(exe);
+        cmd.arg("delegate").arg(prompt);
+        // The delegate child inherits WT_COM_CLSID from our env; no explicit pass needed.
 
-            // Fire-and-forget: spawn hidden, don't wait.
-            #[cfg(windows)]
-            {
-                use std::os::windows::process::CommandExt;
-                cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-            }
-            let _ = cmd.spawn();
+        // Fire-and-forget: spawn hidden, don't wait.
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
         }
-    }
-
-    /// True when an inbound WT event whose `tab_id` we trust should be acted on
-    /// by this helper. wta-master broadcasts every event to every helper across
-    /// the window; only the helper whose `owner_tab_id` matches should respond.
-    /// Falls through (returns true) when either side has no tab scope, so
-    /// window-wide events still get processed.
-    fn is_event_for_my_tab(&self, event_tab: Option<&str>) -> bool {
-        match (event_tab, self.owner_tab_id.as_deref()) {
-            (Some(et), Some(st)) if !et.is_empty() && !st.is_empty() => et == st,
-            _ => true,
-        }
+        let _ = cmd.spawn();
     }
 
     /// Auto-fix: when a command fails in another pane, ask the coordinator
@@ -7843,38 +7811,6 @@ mod tests {
         assert!(!app.show_notification_banner);
         assert!(app.wt_notifications.is_empty());
         assert!(app.current_tab().messages.is_empty());
-    }
-
-    #[test]
-    fn agent_prompt_for_my_tab_delegates() {
-        let mut app = test_app();
-        app.owner_tab_id = Some("{tab-A}".to_string());
-        app.handle_event(AppEvent::WtEvent {
-            method: "agent_prompt".to_string(),
-            pane_id: String::new(),
-            tab_id: Some("{tab-A}".to_string()),
-            params: json!({"prompt": "fix the build", "tab_id": "{tab-A}"}),
-        });
-        assert_eq!(
-            app.last_delegated_prompt.as_deref(),
-            Some("fix the build")
-        );
-    }
-
-    #[test]
-    fn agent_prompt_for_other_tab_does_not_delegate() {
-        // C++ broadcasts `agent_prompt` to every helper in the window.
-        // Only the helper whose owner_tab_id matches should spawn the
-        // delegate child — else N agent panes = N duplicate sub-agents.
-        let mut app = test_app();
-        app.owner_tab_id = Some("{tab-A}".to_string());
-        app.handle_event(AppEvent::WtEvent {
-            method: "agent_prompt".to_string(),
-            pane_id: String::new(),
-            tab_id: Some("{tab-B}".to_string()),
-            params: json!({"prompt": "ignore me", "tab_id": "{tab-B}"}),
-        });
-        assert!(app.last_delegated_prompt.is_none());
     }
 
     #[test]

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -3504,6 +3504,20 @@ impl App {
                     return;
                 }
 
+                if method == "agent_prompt" {
+                    // Command palette `?<prompt>` delegation. Not a WT
+                    // notification — has nothing to do with banner/queue.
+                    let prompt = params
+                        .get("prompt")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    tracing::info!(target: "autofix", prompt_len = prompt.len(), "agent_prompt: delegating");
+                    if !prompt.is_empty() {
+                        self.delegate_to_tab_agent(prompt);
+                    }
+                    return;
+                }
+
                 if method == "autofix_enabled_changed" {
                     // C++ pushes this when the user toggles "Auto-suggest
                     // fixes" in settings while WTA is already running.
@@ -3976,54 +3990,43 @@ impl App {
                     classify_wt_event(&method, &pane_id, tab_id.as_deref(), &params);
                 tracing::debug!(target: "autofix", severity = ?notification.severity, summary = %notification.summary, tab_id = ?notification.tab_id, "classified");
 
-                // Always log to chat for critical/actionable events
-                match notification.severity {
-                    WtEventSeverity::Critical => {
-                        self.current_tab_mut().messages
-                            .push(ChatMessage::Error(notification.summary.clone()));
-                        self.show_notification_banner = true;
-                        self.scroll_to_bottom();
+                // Per-tab filter. WT broadcasts pane-scoped events to every
+                // helper in the window, but another tab's failures are not
+                // this helper's concern. Drop notifications whose tab_id
+                // doesn't match our owner_tab_id; empty/missing tab_id falls
+                // through (no per-tab scope).
+                if let (Some(event_tab), Some(self_tab)) = (
+                    notification.tab_id.as_deref(),
+                    self.owner_tab_id.as_deref(),
+                ) {
+                    if !event_tab.is_empty()
+                        && !self_tab.is_empty()
+                        && event_tab != self_tab
+                    {
+                        tracing::debug!(
+                            target: "autofix",
+                            event_tab,
+                            self_tab,
+                            method = %method,
+                            "dropping cross-tab WT event"
+                        );
+                        return;
                     }
-                    WtEventSeverity::Actionable => {
-                        if method == "agent_prompt" {
-                            // Command palette prompt: delegate directly to a new tab agent.
-                            let prompt = params
-                                .get("prompt")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string();
-                            tracing::info!(target: "autofix", prompt_len = prompt.len(), "agent_prompt: delegating");
-                            if !prompt.is_empty() {
-                                self.delegate_to_tab_agent(&prompt);
-                            }
-                            return;
-                        }
+                }
 
+                // Surface rule: WT events (connection_state, vt_sequence)
+                // surface via the bottom bar / `wt_notifications` queue ONLY.
+                // Chat is the agent dialogue surface — only user input and
+                // agent responses go there.
+                match notification.severity {
+                    WtEventSeverity::Critical | WtEventSeverity::Actionable => {
                         self.show_notification_banner = true;
-                        // Only OSC-133;D vt_sequence events carry enough info
-                        // to drive autofix (a per-command exit code from a
-                        // shell-integrated pane whose shell is still alive
-                        // so we can read its buffer). `connection_state:
-                        // closed` is just process termination — no exit
-                        // code, no command context, fires for both exit 0
-                        // and exit 1, and the pane is *gone* so any
-                        // downstream `wt_read_last_prompt(<dead_guid>)`
-                        // throws E_FAIL on the C++ side. Surface those as a
-                        // System message instead.
-                        let is_autofix_candidate = method == "vt_sequence";
-                        if is_autofix_candidate {
-                            // Always run the autofix trigger — when
-                            // auto-suggest is on we Pending+submit; when
-                            // off we just surface the Detected pill so
-                            // the user can opt in. Either way the
-                            // function pushes its own chat message.
+                        // Only OSC-133;D vt_sequence events have the exit
+                        // code + live shell buffer needed to drive autofix.
+                        // `connection_state: closed`/`failed` is just process
+                        // termination — banner-only.
+                        if method == "vt_sequence" {
                             self.maybe_trigger_autofix(&notification);
-                        } else {
-                            // Not an autofix candidate (e.g. connection_state:closed):
-                            // surface the event in chat so the user still sees it.
-                            self.current_tab_mut().messages
-                                .push(ChatMessage::System(notification.summary.clone()));
-                            self.scroll_to_bottom();
                         }
                     }
                     WtEventSeverity::Informational => {
@@ -7725,7 +7728,10 @@ mod tests {
     // ─── App notification state ─────────────────────────────────────────────
 
     #[test]
-    fn wt_event_critical_shows_banner_and_error_message() {
+    fn wt_event_critical_raises_banner_only_no_chat() {
+        // WT events route through the bottom bar / `wt_notifications` queue,
+        // never the agent's chat history. The chat is for agent dialogue;
+        // process-lifecycle noise belongs in the bar.
         let mut app = test_app();
         app.handle_event(AppEvent::WtEvent {
             method: "connection_state".to_string(),
@@ -7736,12 +7742,14 @@ mod tests {
         assert!(app.show_notification_banner);
         assert_eq!(app.wt_notifications.len(), 1);
         assert_eq!(app.wt_notifications[0].severity, WtEventSeverity::Critical);
-        // Should have an Error message in chat
-        assert!(app.current_tab().messages.iter().any(|m| matches!(m, ChatMessage::Error(_))));
+        assert!(
+            app.current_tab().messages.is_empty(),
+            "WT events must not pollute chat history with Error messages"
+        );
     }
 
     #[test]
-    fn wt_event_actionable_shows_banner_and_system_message() {
+    fn wt_event_actionable_raises_banner_only_no_chat() {
         let mut app = test_app();
         app.handle_event(AppEvent::WtEvent {
             method: "connection_state".to_string(),
@@ -7750,7 +7758,10 @@ mod tests {
             params: json!({"session_id": "5", "state": "closed"}),
         });
         assert!(app.show_notification_banner);
-        assert!(app.current_tab().messages.iter().any(|m| matches!(m, ChatMessage::System(_))));
+        assert!(
+            app.current_tab().messages.is_empty(),
+            "WT events must not pollute chat history with System messages"
+        );
     }
 
     #[test]
@@ -7781,6 +7792,45 @@ mod tests {
         assert!(!app.show_notification_banner);
         assert!(app.wt_notifications.is_empty());
         assert!(app.current_tab().messages.is_empty());
+    }
+
+    #[test]
+    fn wt_event_critical_from_other_tab_does_not_surface_in_owner_tab() {
+        // Regression for the cross-tab "Pane …: connection failed" leak:
+        // helper A owns tab A; tab B's Copilot pane fails; WT broadcasts
+        // the `connection_state:failed` event to every helper. Helper A
+        // must drop it instead of writing a red Error into tab A's chat.
+        let mut app = test_app();
+        app.owner_tab_id = Some("{tab-A}".to_string());
+        app.handle_event(AppEvent::WtEvent {
+            method: "connection_state".to_string(),
+            pane_id: "B-PANE".to_string(),
+            tab_id: Some("{tab-B}".to_string()),
+            params: json!({"pane_id": "B-PANE", "state": "failed", "tab_id": "{tab-B}"}),
+        });
+        assert!(!app.show_notification_banner);
+        assert!(app.wt_notifications.is_empty());
+        assert!(app.current_tab().messages.is_empty());
+    }
+
+    #[test]
+    fn wt_event_critical_from_owner_tab_raises_banner_not_chat() {
+        // Same-tab event raises the banner but still does NOT push into chat
+        // — the bar is the user-visible surface for connection failures.
+        let mut app = test_app();
+        app.owner_tab_id = Some("{tab-A}".to_string());
+        app.handle_event(AppEvent::WtEvent {
+            method: "connection_state".to_string(),
+            pane_id: "A-PANE".to_string(),
+            tab_id: Some("{tab-A}".to_string()),
+            params: json!({"pane_id": "A-PANE", "state": "failed", "tab_id": "{tab-A}"}),
+        });
+        assert!(app.show_notification_banner);
+        assert_eq!(app.wt_notifications.len(), 1);
+        assert!(
+            app.current_tab().messages.is_empty(),
+            "WT events must not pollute chat history"
+        );
     }
 
     #[test]
@@ -7941,8 +7991,9 @@ mod tests {
         assert_eq!(app.unacknowledged_count(), 2);
         // Banner should show (due to critical + actionable)
         assert!(app.show_notification_banner);
-        // Chat should have 2 messages (critical error + actionable system msg)
-        assert_eq!(app.current_tab().messages.len(), 2);
+        // Chat must stay empty — WT events surface in the bar/banner, never
+        // in agent dialogue.
+        assert!(app.current_tab().messages.is_empty());
     }
 
     // ─── F2 Agents view: Enter / Delete dispatch ───────────────────────────
@@ -8768,14 +8819,13 @@ mod tests {
             app.current_tab().turn.is_idle(),
             "no autofix prompt should be in-flight"
         );
-        // The user still gets a system message about the pane closing.
+        // The pane-closed event surfaces via the banner / `wt_notifications`,
+        // never in chat. Chat is the agent dialogue surface.
         assert!(
-            app.current_tab()
-                .messages
-                .iter()
-                .any(|m| matches!(m, ChatMessage::System(_))),
-            "the user still gets a system message about the pane closing"
+            app.current_tab().messages.is_empty(),
+            "WT events must not push into chat history"
         );
+        assert!(app.show_notification_banner);
     }
 
     /// Defense-in-depth: a vt_sequence (osc:133;D non-zero) inside an agent

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1499,6 +1499,11 @@ pub struct App {
     /// place of a live wtcli; not compiled into release builds.
     #[cfg(test)]
     pub last_dispatched_command: Option<DispatchedCommand>,
+    /// Test hook: prompt last passed to `delegate_to_tab_agent`.
+    /// Lets cross-tab `agent_prompt` filtering be unit-tested without
+    /// actually spawning a `wta delegate` subprocess.
+    #[cfg(test)]
+    pub last_delegated_prompt: Option<String>,
     /// Source pane GUID (set from `WTA_SOURCE_SESSION_ID` env var by the
     /// launching pane). Used by autofix to attribute which pane originated
     /// the failing command we're about to fix.
@@ -1640,6 +1645,8 @@ impl App {
             agent_event_tx: None,
             #[cfg(test)]
             last_dispatched_command: None,
+            #[cfg(test)]
+            last_delegated_prompt: None,
             source_session_id: None,
             source_cwd: None,
             log_agent_events: false,
@@ -3507,6 +3514,21 @@ impl App {
                 if method == "agent_prompt" {
                     // Command palette `?<prompt>` delegation. Not a WT
                     // notification — has nothing to do with banner/queue.
+                    //
+                    // C++ broadcasts to every helper in the window, so
+                    // we must filter here: without this check, N agent
+                    // panes across N tabs would each spawn a `wta
+                    // delegate` subprocess for a single user prompt and
+                    // get N duplicate sub-agent tabs.
+                    if !self.is_event_for_my_tab(tab_id.as_deref()) {
+                        tracing::debug!(
+                            target: "autofix",
+                            event_tab = ?tab_id,
+                            self_tab = ?self.owner_tab_id,
+                            "dropping agent_prompt for different tab"
+                        );
+                        return;
+                    }
                     let prompt = params
                         .get("prompt")
                         .and_then(|v| v.as_str())
@@ -3992,26 +4014,16 @@ impl App {
 
                 // Per-tab filter. WT broadcasts pane-scoped events to every
                 // helper in the window, but another tab's failures are not
-                // this helper's concern. Drop notifications whose tab_id
-                // doesn't match our owner_tab_id; empty/missing tab_id falls
-                // through (no per-tab scope).
-                if let (Some(event_tab), Some(self_tab)) = (
-                    notification.tab_id.as_deref(),
-                    self.owner_tab_id.as_deref(),
-                ) {
-                    if !event_tab.is_empty()
-                        && !self_tab.is_empty()
-                        && event_tab != self_tab
-                    {
-                        tracing::debug!(
-                            target: "autofix",
-                            event_tab,
-                            self_tab,
-                            method = %method,
-                            "dropping cross-tab WT event"
-                        );
-                        return;
-                    }
+                // this helper's concern.
+                if !self.is_event_for_my_tab(notification.tab_id.as_deref()) {
+                    tracing::debug!(
+                        target: "autofix",
+                        event_tab = ?notification.tab_id,
+                        self_tab = ?self.owner_tab_id,
+                        method = %method,
+                        "dropping cross-tab WT event"
+                    );
+                    return;
                 }
 
                 // Surface rule: WT events (connection_state, vt_sequence)
@@ -5528,23 +5540,43 @@ impl App {
     /// Delegate a prompt to a new tab agent by spawning `wta delegate` subprocess.
     /// This is the same path used by the command palette — single code path for
     /// context capture, prompt building, and tab creation.
-    pub fn delegate_to_tab_agent(&self, prompt: &str) {
+    pub fn delegate_to_tab_agent(&mut self, prompt: &str) {
         tracing::info!(target: "autofix", prompt_len = prompt.len(), "delegate_to_tab_agent called");
-        let exe = match std::env::current_exe() {
-            Ok(p) => p,
-            Err(_) => return,
-        };
-        let mut cmd = std::process::Command::new(exe);
-        cmd.arg("delegate").arg(prompt);
-        // The delegate child inherits WT_COM_CLSID from our env; no explicit pass needed.
-
-        // Fire-and-forget: spawn hidden, don't wait.
-        #[cfg(windows)]
+        #[cfg(test)]
         {
-            use std::os::windows::process::CommandExt;
-            cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+            self.last_delegated_prompt = Some(prompt.to_string());
+            return;
         }
-        let _ = cmd.spawn();
+        #[cfg(not(test))]
+        {
+            let exe = match std::env::current_exe() {
+                Ok(p) => p,
+                Err(_) => return,
+            };
+            let mut cmd = std::process::Command::new(exe);
+            cmd.arg("delegate").arg(prompt);
+            // The delegate child inherits WT_COM_CLSID from our env; no explicit pass needed.
+
+            // Fire-and-forget: spawn hidden, don't wait.
+            #[cfg(windows)]
+            {
+                use std::os::windows::process::CommandExt;
+                cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+            }
+            let _ = cmd.spawn();
+        }
+    }
+
+    /// True when an inbound WT event whose `tab_id` we trust should be acted on
+    /// by this helper. wta-master broadcasts every event to every helper across
+    /// the window; only the helper whose `owner_tab_id` matches should respond.
+    /// Falls through (returns true) when either side has no tab scope, so
+    /// window-wide events still get processed.
+    fn is_event_for_my_tab(&self, event_tab: Option<&str>) -> bool {
+        match (event_tab, self.owner_tab_id.as_deref()) {
+            (Some(et), Some(st)) if !et.is_empty() && !st.is_empty() => et == st,
+            _ => true,
+        }
     }
 
     /// Auto-fix: when a command fails in another pane, ask the coordinator
@@ -7811,6 +7843,38 @@ mod tests {
         assert!(!app.show_notification_banner);
         assert!(app.wt_notifications.is_empty());
         assert!(app.current_tab().messages.is_empty());
+    }
+
+    #[test]
+    fn agent_prompt_for_my_tab_delegates() {
+        let mut app = test_app();
+        app.owner_tab_id = Some("{tab-A}".to_string());
+        app.handle_event(AppEvent::WtEvent {
+            method: "agent_prompt".to_string(),
+            pane_id: String::new(),
+            tab_id: Some("{tab-A}".to_string()),
+            params: json!({"prompt": "fix the build", "tab_id": "{tab-A}"}),
+        });
+        assert_eq!(
+            app.last_delegated_prompt.as_deref(),
+            Some("fix the build")
+        );
+    }
+
+    #[test]
+    fn agent_prompt_for_other_tab_does_not_delegate() {
+        // C++ broadcasts `agent_prompt` to every helper in the window.
+        // Only the helper whose owner_tab_id matches should spawn the
+        // delegate child — else N agent panes = N duplicate sub-agents.
+        let mut app = test_app();
+        app.owner_tab_id = Some("{tab-A}".to_string());
+        app.handle_event(AppEvent::WtEvent {
+            method: "agent_prompt".to_string(),
+            pane_id: String::new(),
+            tab_id: Some("{tab-B}".to_string()),
+            params: json!({"prompt": "ignore me", "tab_id": "{tab-B}"}),
+        });
+        assert!(app.last_delegated_prompt.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Background-tab sub-agents (e.g. an autofix-spawned Copilot in a fresh tab) would on `/exit` surface a red "Pane `<UUID>`: connection failed" **inside the user's main agent pane** — even though the failed pane lived in a different tab.
- Two design errors here:
  1. `WtEvent` dispatch unconditionally pushed Critical/Actionable notifications into the active tab's chat (`current_tab_mut().messages.push(ChatMessage::Error/System(...))`). Chat is the agent-dialogue surface; conpty / process-lifecycle noise belongs in the bottom bar / `wt_notifications` queue. Both pushes removed → banner-only.
  2. Even the banner toggle was helper-wide with no per-tab scope. `wta-master` broadcasts every WT event to every helper in the window, so helper-A (tab-A) was raising banners for tab-B's events. Added a `notification.tab_id` vs `self.owner_tab_id` filter right after `classify_wt_event` — cross-tab events drop outright.
- Bonus cleanup: hoisted `agent_prompt` (command-palette `?<prompt>` delegation) out of the Actionable arm into the early-return chain (it was never a severity-classified WT event); collapsed `Critical | Actionable` into one match arm since both now share behavior (banner + `maybe_trigger_autofix` for `vt_sequence`).

## Surface rule (now codified in code comment)

> WT events (`connection_state`, `vt_sequence`) surface via the bottom bar / `wt_notifications` queue ONLY. Chat is the agent dialogue surface — only user input and agent responses go there.

## Test plan

- [x] `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml --bin wta` → 355/355 pass
- [x] Existing chat-assertion tests rewritten to assert chat-empty + banner-on contract:
  - `wt_event_critical_raises_banner_only_no_chat`
  - `wt_event_actionable_raises_banner_only_no_chat`
  - `multiple_events_different_panes`
  - `connection_state_closed_does_not_trigger_autofix_even_when_binding_cleared`
- [x] New regression tests:
  - `wt_event_critical_from_other_tab_does_not_surface_in_owner_tab` — the reported bug
  - `wt_event_critical_from_owner_tab_raises_banner_not_chat` — same-tab still raises banner, but never chat
- [x] Manual repro: trigger autofix → sub-agent opens in fresh tab → `/exit` in sub-agent → no red "connection failed" appears in main agent pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)