### PR TITLE
wta agent pane: remove dead agent_prompt event broadcast pipeline

### DIFF
--- a/doc/security-model.md
+++ b/doc/security-model.md
@@ -133,7 +133,7 @@ flowchart TB
     InPane -- "ConPTY stdout<br/>VT / OSC 133 / AgentEvent" --> WT
     DelegateAgent -- "ConPTY stdout<br/>VT / OSC / optional hooks" --> WT
     WT -- "render/capture output" --> Scroll
-    WT -- "VT/OSC, agent_prompt,<br/>autofix events" --> EventBus
+    WT -- "VT/OSC,<br/>autofix events" --> EventBus
 
     WTAAgent -- "spawn wtcli<br/>for WT operations<br/>(including send-keys)" --> WTCLI
     WTADelegate -- "GetActivePane / ReadPaneOutput /<br/>CreateTab(commandline)<br/>via wtcli / COM" --> WTCLI

--- a/doc/specs/Multi-window-agent-pane.md
+++ b/doc/specs/Multi-window-agent-pane.md
@@ -504,7 +504,6 @@ mutates per-tab or per-window state includes the relevant ids in its
 | `tab_changed` | yes | yes | skip if `our_window != target_window`; then owner-lock in `switch_tab_session` |
 | `tab_closed` | yes | yes | skip if `our_window != target_window` |
 | `tab_renamed` | old + new | dest | owner-match self-filters; non-owners ignore |
-| `agent_prompt` | yes | n/a | route by `tab_id` |
 | `autofix_execute` | yes (+ pane_id) | n/a | route by `tab_id` / `pane_id` |
 
 **Outbound events from helpers carry `tab_id`** (= owner_tab_id). C++

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1695,7 +1695,7 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        _OpenOrReuseAgentPane(L"", false, L"Action");
+        _OpenOrReuseAgentPane(false, L"Action");
         args.Handled(true);
     }
 
@@ -1741,7 +1741,7 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        _OpenOrReuseAgentPane(L"", /*intoSessionsView*/ true, L"SessionsAction");
+        _OpenOrReuseAgentPane(/*intoSessionsView*/ true, L"SessionsAction");
         args.Handled(true);
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -965,7 +965,7 @@ namespace winrt::TerminalApp::implementation
         // welcome hint immediately.
         if (const auto tab = _GetFocusedTabImpl())
         {
-            _OpenOrReuseAgentPane(L"", false, L"FirstRunExperience");
+            _OpenOrReuseAgentPane(false, L"FirstRunExperience");
             // Focus is set in the Initialized callback once the pane is ready.
         }
     }
@@ -1840,7 +1840,7 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        _OpenOrReuseAgentPane(L"", /*intoSessionsView*/ false, L"BottomBarToggle");
+        _OpenOrReuseAgentPane(/*intoSessionsView*/ false, L"BottomBarToggle");
         _UpdateBottomBarState();
     }
 
@@ -1880,7 +1880,7 @@ namespace winrt::TerminalApp::implementation
             return;
         }
         // No agent pane on this tab — spawn one in sessions view.
-        _OpenOrReuseAgentPane(L"", /*intoSessionsView*/ true, L"BottomBarSessions");
+        _OpenOrReuseAgentPane(/*intoSessionsView*/ true, L"BottomBarSessions");
         _UpdateBottomBarState();
     }
 
@@ -2372,7 +2372,7 @@ namespace winrt::TerminalApp::implementation
         // Recreate on the active terminal tab so the user sees something
         // immediately. Other tabs that had an agent pane will need to be
         // re-toggled by the user.
-        _OpenOrReuseAgentPane(L"", false, L"SettingsReload");
+        _OpenOrReuseAgentPane(false, L"SettingsReload");
     }
 
     void TerminalPage::_FlushPendingAgentRebuild()
@@ -2390,9 +2390,9 @@ namespace winrt::TerminalApp::implementation
         _RebuildAgentStack();
     }
 
-    void TerminalPage::_OpenOrReuseAgentPane(const winrt::hstring& prompt, bool intoSessionsView, const wchar_t* triggerSource)
+    void TerminalPage::_OpenOrReuseAgentPane(bool intoSessionsView, const wchar_t* triggerSource)
     {
-        _agentPaneLog("_OpenOrReuseAgentPane called, prompt='" + winrt::to_string(prompt) + "', intoSessionsView=" + (intoSessionsView ? "true" : "false"));
+        _agentPaneLog(std::string{ "_OpenOrReuseAgentPane called, intoSessionsView=" } + (intoSessionsView ? "true" : "false"));
 
         const auto emitAgentPaneOpened = [&]() {
 #if defined(WT_BRANDING_RELEASE)
@@ -2489,25 +2489,6 @@ namespace winrt::TerminalApp::implementation
 
             _agentPaneLog("found agent pane on focused tab");
 
-            if (!prompt.empty())
-            {
-                // Broadcast prompt to wta via the WT protocol.
-                _agentPaneLog("prompt non-empty, broadcasting agent_prompt event");
-                Json::Value evt;
-                evt["type"] = "event";
-                evt["method"] = "agent_prompt";
-                Json::Value params;
-                params["prompt"] = winrt::to_string(prompt);
-                params["tab_id"] = winrt::to_string(focusedTab->StableId());
-                evt["params"] = params;
-                Json::StreamWriterBuilder wb;
-                wb["indentation"] = "";
-                ProtocolVtSequenceReceived.raise(
-                    *this,
-                    winrt::to_hstring(Json::writeString(wb, evt)));
-                return;
-            }
-
             if (intoSessionsView)
             {
                 // Open-into-sessions: never close, just flip the view +
@@ -2522,10 +2503,10 @@ namespace winrt::TerminalApp::implementation
                 return;
             }
 
-            // Empty prompt: toggle close. Apply locally FIRST (see comment
-            // on the unstash branch above for why we don't wait for wta's
-            // echo). wta echo lands in OnAgentStateChanged and is
-            // idempotent against the already-stashed pane.
+            // Toggle close. Apply locally FIRST (see comment on the unstash
+            // branch above for why we don't wait for wta's echo). wta echo
+            // lands in OnAgentStateChanged and is idempotent against the
+            // already-stashed pane.
             _agentPaneLog("toggle: stashing existing agent pane locally + notifying wta");
             focusedTab->StashAgentPane();
             _RequestAgentStateForTab(focusedTab, std::nullopt, /*pane_open*/ false);
@@ -2535,10 +2516,6 @@ namespace winrt::TerminalApp::implementation
 
         _agentPaneLog("no agent pane on focused tab, creating new one");
 
-        if (!prompt.empty())
-        {
-            _agentPaneLog("_OpenOrReuseAgentPane: dropping prompt (not yet wired through helper+master)");
-        }
         if (!_AutoCreateHiddenAgentPaneShared(focusedTab, intoSessionsView))
         {
             _agentPaneLog("_OpenOrReuseAgentPane: _AutoCreateHiddenAgentPaneShared failed");
@@ -2565,7 +2542,7 @@ namespace winrt::TerminalApp::implementation
         if (!existingPane)
         {
             // No agent pane on this tab — open one.
-            _OpenOrReuseAgentPane(L"", false, L"FocusAction");
+            _OpenOrReuseAgentPane(false, L"FocusAction");
             return;
         }
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -634,7 +634,7 @@ namespace winrt::TerminalApp::implementation
         // per-pane-wta architecture was deleted. Helper processes are now
         // ordinary conpty children of TermControl — TermControl /
         // ConptyConnection owns their lifetime.
-        void _OpenOrReuseAgentPane(const winrt::hstring& prompt, bool intoSessionsView, const wchar_t* triggerSource);
+        void _OpenOrReuseAgentPane(bool intoSessionsView, const wchar_t* triggerSource);
         void _FocusAgentPane();
         void _RepositionAgentPanes();
         static winrt::Microsoft::Terminal::Settings::Model::SplitDirection _AgentPanePositionToSplitDirection(const winrt::hstring& position);

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -686,20 +686,6 @@ pub fn classify_wt_event(
                 age_ticks: 100,
             }
         }
-        "agent_prompt" => {
-            let prompt = params
-                .get("prompt")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            WtNotification {
-                severity: WtEventSeverity::Actionable,
-                pane_id: pane_id.to_string(),
-                tab_id: tab,
-                summary: format!("agent_prompt:{}", prompt),
-                acknowledged: false,
-                age_ticks: 0,
-            }
-        }
         "set_agent_state" => {
             // handle_event consumes set_agent_state at the top of WtEvent
             // before classification runs, so classify normally never sees


### PR DESCRIPTION
## Summary

Follow-up cleanup promised in [#79's review reply](https://github.com/microsoft/intelligent-terminal/pull/79#discussion_r3308319925). The `agent_prompt` event broadcast pipeline is scaffolding that never got wired up after the shared-wta migration — removing it on both sides.

**Behaviorally a no-op**: no UX entry point reached the deleted code.

## Why it's dead

- `_OpenOrReuseAgentPane(prompt, ...)` is the only C++ emitter, gated on `if (!prompt.empty())`. All 7 callers pass `L""`:
  | Caller | File |
  |---|---|
  | FirstRunExperience | `TerminalPage.cpp` |
  | `_HandleOpenAgentPane` (`>Toggle AI assistant` action) | `AppActionHandlers.cpp` |
  | `_HandleOpenAgentSessions` | `AppActionHandlers.cpp` |
  | BottomBarToggle | `TerminalPage.cpp` |
  | BottomBarSessions | `TerminalPage.cpp` |
  | SettingsReload | `TerminalPage.cpp` |
  | FocusAction | `TerminalPage.cpp` |
- The function's no-pane fallback already logs `"_OpenOrReuseAgentPane: dropping prompt (not yet wired through helper+master)"` — the shared-wta migration author left this as TODO and never came back to it.
- `openAgentPane` action is registered via `ON_ALL_ACTIONS` (not `ON_ALL_ACTIONS_WITH_ARGS`), so action JSON can't supply a prompt either.
- The `?<prompt>` UX path that users actually hit goes through `_DelegatePromptToAgent` (TerminalPage.cpp:1132), which spawns `wta delegate` as a direct C++ subprocess. Unrelated to this event.

## What was removed

**C++:**
- `if (!prompt.empty()) { ... ProtocolVtSequenceReceived.raise(...) ... }` block in `_OpenOrReuseAgentPane`
- `prompt` parameter on `_OpenOrReuseAgentPane` signature; updated all 7 callers
- The "dropping prompt (not yet wired through helper+master)" fallback log

**WTA:**
- `classify_wt_event` arm for `"agent_prompt"`
- (The `Actionable` early-return for `agent_prompt` in the `WtEvent` handler was already removed by #79.)

**Docs:**
- `agent_prompt` references in `doc/security-model.md` (event-bus diagram) and `doc/specs/Multi-window-agent-pane.md` (event routing table)

## What was kept

- `delegate_to_tab_agent` in WTA. Still called from `tools/wta/src/main.rs:2151` (the `cli.prompt` positional path used when wta is launched with a bare prompt arg, e.g., via `wta delegate <prompt>`'s sibling code path).

## Stats

6 files, 15 insertions / 53 deletions.

## Test plan

- [x] `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml --bin wta` — 355/355 pass
- [x] Local VS build of `OpenConsole.slnx`; manual smoke check of agent pane toggle / sessions view / bottom bar — all action paths still work (no behavioral change expected since deleted code was unreachable)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)