### PR TITLE
wta agent pane: hide input placeholder caret when pane is unfocused

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1152,7 +1152,7 @@ impl TabSession {
 
     /// Whether the input box is the arrow-key navigational focus target.
     /// False when the user is browsing a completed turn or a recommendation
-    /// card is showing — in both cases ↑↓ navigate elsewhere. UI affordances
+    /// card is showing — in both cases ↑↓ navigate elsewhere. UI indicators
     /// that should track "is the input cell live" (e.g. the placeholder
     /// caret cell) gate on this together with the pane's XAML focus.
     pub fn input_has_nav_focus(&self) -> bool {

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -759,6 +759,10 @@ pub enum AppEvent {
     Key(KeyEvent),
     Tick,
     Resize(u16, u16), // terminal resize (handled by ratatui)
+    /// XAML focus on our hosting TermControl changed — true when the agent
+    /// pane gained focus, false when it lost focus. Sourced from xterm
+    /// focus-in/out (CSI I / CSI O) delivered through conpty.
+    FocusChanged(bool),
     ConnectionStage(String),
     /// `session_id` lets us route the status update to the originating tab
     /// once an ACP session is bound to it. Pre-session statuses (startup
@@ -1401,6 +1405,11 @@ pub struct App {
     pub wt_connected: bool,
     pub terminal_rows: u16,
     pub terminal_cols: u16,
+    /// Whether our hosting agent pane currently has XAML focus. Driven by
+    /// xterm focus-in/out delivered through conpty. Default true: a freshly
+    /// opened pane is normally focused, and conpty only delivers an event
+    /// on the *transition*, so absent a signal we assume focused.
+    pub pane_focused: bool,
     pub should_quit: bool,
     prompt_tx: mpsc::UnboundedSender<PromptSubmission>,
     recommendation_tx: mpsc::UnboundedSender<crate::coordinator::ChoiceExecution>,
@@ -1595,6 +1604,7 @@ impl App {
             wt_connected,
             terminal_rows: 24,
             terminal_cols: 80,
+            pane_focused: true,
             should_quit: false,
             prompt_tx,
             recommendation_tx,
@@ -2900,6 +2910,7 @@ impl App {
             AppEvent::Key(_) => "key",
             AppEvent::Tick => "tick",
             AppEvent::Resize(_, _) => "resize",
+            AppEvent::FocusChanged(_) => "focus_changed",
             AppEvent::ConnectionStage(_) => "connection_stage",
             AppEvent::ProgressStatus { .. } => "progress_status",
             AppEvent::AgentConnected { .. } => "agent_connected",
@@ -2987,6 +2998,9 @@ impl App {
             AppEvent::Resize(w, h) => {
                 self.terminal_cols = w;
                 self.terminal_rows = h;
+            }
+            AppEvent::FocusChanged(focused) => {
+                self.pane_focused = focused;
             }
             AppEvent::ConnectionStage(stage) => {
                 self.state = ConnectionState::Connecting(stage);

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1150,6 +1150,15 @@ impl TabSession {
         self.chat_scroll.offset = 0;
     }
 
+    /// Whether the input box is the arrow-key navigational focus target.
+    /// False when the user is browsing a completed turn or a recommendation
+    /// card is showing — in both cases ↑↓ navigate elsewhere. UI affordances
+    /// that should track "is the input cell live" (e.g. the placeholder
+    /// caret cell) gate on this together with the pane's XAML focus.
+    pub fn input_has_nav_focus(&self) -> bool {
+        self.selected_completed_turn_idx.is_none() && self.turn.recommendations().is_none()
+    }
+
     pub fn clear_recommendations(&mut self) {
         self.selected_recommendation = 0;
         self.selected_button = 0;

--- a/tools/wta/src/event.rs
+++ b/tools/wta/src/event.rs
@@ -74,11 +74,17 @@ pub async fn read_crossterm_events(tx: mpsc::UnboundedSender<AppEvent>) {
                         AppEvent::Key(key)
                     }
                     Event::Resize(w, h) => AppEvent::Resize(w, h),
+                    // WT/conpty forwards xterm focus-in/out (CSI I / CSI O)
+                    // to the child unconditionally when the hosting TermControl
+                    // gains/loses XAML focus — one event per pane, not per
+                    // window. Used to hide the input cursor when the agent
+                    // pane is not the focused pane.
+                    Event::FocusGained => AppEvent::FocusChanged(true),
+                    Event::FocusLost => AppEvent::FocusChanged(false),
                     // We do not enable mouse capture (see main.rs run_acp_tui_mode).
                     // The terminal emulator translates wheel into Up/Down arrow
                     // keystrokes in alt-screen mode, so we never observe raw
-                    // Event::Mouse here. Drop anything else (FocusGained,
-                    // FocusLost, Paste, etc.).
+                    // Event::Mouse here. Drop anything else (Paste, etc.).
                     _ => continue,
                 };
                 if tx.send(app_event).is_err() {

--- a/tools/wta/src/ui/input.rs
+++ b/tools/wta/src/ui/input.rs
@@ -68,14 +68,18 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         // on Black = invisible) before the cursor overlay had anything to
         // reveal.
         //
-        // Only paint the white block when the pane is focused — when WT's
-        // block cursor isn't landing on the cell, the bare white square is
-        // a misleading "cursor here" indicator. Render the whole placeholder
+        // Only paint the white block when the input cell will actually have
+        // a cursor on it: the pane has XAML focus *and* the TUI is in input
+        // mode (not browsing a completed turn). When either is false WT's
+        // block cursor won't land here, so a bare white square would be a
+        // misleading "cursor here" indicator. Render the whole placeholder
         // dim instead.
+        let input_active =
+            app.pane_focused && app.current_tab().selected_completed_turn_idx.is_none();
         let mut placeholder_spans = vec![Span::styled(INPUT_PROMPT, theme::DIM)];
         let mut chars = placeholder.chars();
         if let Some(first) = chars.next() {
-            let first_style = if app.pane_focused {
+            let first_style = if input_active {
                 Style::new().fg(Color::Black).bg(Color::White)
             } else {
                 theme::DIM

--- a/tools/wta/src/ui/input.rs
+++ b/tools/wta/src/ui/input.rs
@@ -68,14 +68,15 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         // on Black = invisible) before the cursor overlay had anything to
         // reveal.
         //
-        // Only paint the white block when the input cell will actually have
-        // a cursor on it: the pane has XAML focus *and* the TUI is in input
-        // mode (not browsing a completed turn). When either is false WT's
-        // block cursor won't land here, so a bare white square would be a
-        // misleading "cursor here" indicator. Render the whole placeholder
-        // dim instead.
-        let input_active =
-            app.pane_focused && app.current_tab().selected_completed_turn_idx.is_none();
+        // Only paint the white block when the input cell is the actual
+        // navigational focus target. Otherwise the bare white square is a
+        // misleading "cursor here" indicator — most keystrokes won't land
+        // in the input. The TUI gives arrow-key focus to whichever of these
+        // is showing, in this priority: turn selection > recommendations >
+        // input. Mirror that here so the visual cue tracks the focus.
+        let input_active = app.pane_focused
+            && tab.selected_completed_turn_idx.is_none()
+            && tab.turn.recommendations().is_none();
         let mut placeholder_spans = vec![Span::styled(INPUT_PROMPT, theme::DIM)];
         let mut chars = placeholder.chars();
         if let Some(first) = chars.next() {

--- a/tools/wta/src/ui/input.rs
+++ b/tools/wta/src/ui/input.rs
@@ -68,15 +68,11 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         // on Black = invisible) before the cursor overlay had anything to
         // reveal.
         //
-        // Only paint the white block when the input cell is the actual
-        // navigational focus target. Otherwise the bare white square is a
-        // misleading "cursor here" indicator — most keystrokes won't land
-        // in the input. The TUI gives arrow-key focus to whichever of these
-        // is showing, in this priority: turn selection > recommendations >
-        // input. Mirror that here so the visual cue tracks the focus.
-        let input_active = app.pane_focused
-            && tab.selected_completed_turn_idx.is_none()
-            && tab.turn.recommendations().is_none();
+        // Only paint the white block when the input cell is actually the
+        // live caret target: the pane has XAML focus *and* the TUI's arrow
+        // keys land in the input (not in a recommendation card or a
+        // selected completed turn). See TabSession::input_has_nav_focus.
+        let input_active = app.pane_focused && tab.input_has_nav_focus();
         let mut placeholder_spans = vec![Span::styled(INPUT_PROMPT, theme::DIM)];
         let mut chars = placeholder.chars();
         if let Some(first) = chars.next() {

--- a/tools/wta/src/ui/input.rs
+++ b/tools/wta/src/ui/input.rs
@@ -67,13 +67,20 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         // the glyph would be painted onto the black cell bg first (Black
         // on Black = invisible) before the cursor overlay had anything to
         // reveal.
+        //
+        // Only paint the white block when the pane is focused — when WT's
+        // block cursor isn't landing on the cell, the bare white square is
+        // a misleading "cursor here" indicator. Render the whole placeholder
+        // dim instead.
         let mut placeholder_spans = vec![Span::styled(INPUT_PROMPT, theme::DIM)];
         let mut chars = placeholder.chars();
         if let Some(first) = chars.next() {
-            placeholder_spans.push(Span::styled(
-                first.to_string(),
-                Style::new().fg(Color::Black).bg(Color::White),
-            ));
+            let first_style = if app.pane_focused {
+                Style::new().fg(Color::Black).bg(Color::White)
+            } else {
+                theme::DIM
+            };
+            placeholder_spans.push(Span::styled(first.to_string(), first_style));
             let rest: String = chars.collect();
             if !rest.is_empty() {
                 placeholder_spans.push(Span::styled(rest, theme::DIM));


### PR DESCRIPTION
## Summary

The agent pane's input box paints a static white-bg cell at the prompt position so that WT's focused-pane block cursor lands on an already-white cell and renders as a stable square. The problem: that white cell is drawn regardless of focus, so when the pane loses focus the cell remains and reads as an active caret — even though typing has no effect.

This wires xterm focus-in/out reporting (`CSI I` / `CSI O`), which WT/conpty already forwards per-`TermControl` on every XAML focus change (one event per pane, not per window — verified via `ControlCore::GotFocus/LostFocus`), through crossterm into a new `AppEvent::FocusChanged` and `App.pane_focused` flag. `ui::input` then skips the white-bg treatment when the pane is unfocused and renders the whole placeholder dim.

Default `pane_focused: true` so a freshly opened pane (where no `FocusGained` transition fires) still gets the focused appearance until the first `FocusLost`.

No C++ / IPC / master-helper plumbing is added — the existing conpty focus-forwarding path is the signal source.

## Test plan

- [ ] Open agent pane in WT → placeholder shows the white-bg caret square.
- [ ] Click into another pane in the same tab → caret square disappears (placeholder goes dim).
- [ ] Click back into the agent pane → caret square restored.
- [ ] Same across tabs: switch tab, switch back — caret matches focus state on each transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)