### PR TITLE
wta agent pane: drop pane GUID from autofix turn label

### DIFF
--- a/tools/wta/locales/af-ZA.yml
+++ b/tools/wta/locales/af-ZA.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Onlangse opdragmislukking outomaties gediagnoseer"
 chat.turn_canceled: "(gekanselleer)"
 chat.turn_executed: "→ uitgevoer: %{title}"
 

--- a/tools/wta/locales/am-ET.yml
+++ b/tools/wta/locales/am-ET.yml
@@ -49,6 +49,7 @@ chat.plan_header: "እቅድ፡"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "የቅርብ ጊዜ ትዕዛዝ ብልሽት በራስ-ሰር ተመርምሯል"
 chat.turn_canceled: "(ተሰርዟል)"
 chat.turn_executed: "→ ተፈጽሟል: %{title}"
 

--- a/tools/wta/locales/ar-SA.yml
+++ b/tools/wta/locales/ar-SA.yml
@@ -49,6 +49,7 @@ chat.plan_header: "الخطة:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "تم التشخيص التلقائي لفشل أمر حديث"
 chat.turn_canceled: "(تم الإلغاء)"
 chat.turn_executed: "→ تم التنفيذ: %{title}"
 

--- a/tools/wta/locales/as-IN.yml
+++ b/tools/wta/locales/as-IN.yml
@@ -49,6 +49,7 @@ chat.plan_header: "পৰিকল্পনা:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "শেহতীয়া আদেশ বিফলতা স্বয়ংক্ৰিয়ভাৱে নিৰ্ণয় কৰা হৈছে"
 chat.turn_canceled: "(বাতিল কৰা হৈছে)"
 chat.turn_executed: "→ সম্পাদন কৰা হ’ল: %{title}"
 

--- a/tools/wta/locales/az-Latn-AZ.yml
+++ b/tools/wta/locales/az-Latn-AZ.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Son əmr xətası avtomatik diaqnoz edildi"
 chat.turn_canceled: "(ləğv edildi)"
 chat.turn_executed: "→ icra edildi: %{title}"
 

--- a/tools/wta/locales/bg-BG.yml
+++ b/tools/wta/locales/bg-BG.yml
@@ -49,6 +49,7 @@ chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Автоматично диагностициран скорошен неуспех на команда"
 chat.turn_canceled: "(отменено)"
 chat.turn_executed: "→ изпълнено: %{title}"
 

--- a/tools/wta/locales/bn-IN.yml
+++ b/tools/wta/locales/bn-IN.yml
@@ -49,6 +49,7 @@ chat.plan_header: "পরিকল্পনা:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "সাম্প্রতিক কমান্ড ব্যর্থতা স্বয়ংক্রিয়ভাবে নির্ণয় করা হয়েছে"
 chat.turn_canceled: "(বাতিল করা হয়েছে)"
 chat.turn_executed: "→ সম্পন্ন: %{title}"
 

--- a/tools/wta/locales/bs-Latn-BA.yml
+++ b/tools/wta/locales/bs-Latn-BA.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Automatski dijagnostikovan nedavni neuspjeh komande"
 chat.turn_canceled: "(otkazano)"
 chat.turn_executed: "→ izvršeno: %{title}"
 

--- a/tools/wta/locales/ca-ES.yml
+++ b/tools/wta/locales/ca-ES.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Pla:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Diagnosticada automàticament una fallada recent d'una ordre"
 chat.turn_canceled: "(cancel·lat)"
 chat.turn_executed: "→ executat: %{title}"
 

--- a/tools/wta/locales/ca-Es-VALENCIA.yml
+++ b/tools/wta/locales/ca-Es-VALENCIA.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Pla:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Diagnosticada automàticament una fallada recent d'una ordre"
 chat.turn_canceled: "(cancel·lat)"
 chat.turn_executed: "→ executat: %{title}"
 

--- a/tools/wta/locales/cs-CZ.yml
+++ b/tools/wta/locales/cs-CZ.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plán:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Automaticky diagnostikováno nedávné selhání příkazu"
 chat.turn_canceled: "(zrušeno)"
 chat.turn_executed: "→ provedeno: %{title}"
 

--- a/tools/wta/locales/cy-GB.yml
+++ b/tools/wta/locales/cy-GB.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Cynllun:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Methiant gorchymyn diweddar wedi'i ddiagnosio'n awtomatig"
 chat.turn_canceled: "(canslwyd)"
 chat.turn_executed: "→ wedi'i weithredu: %{title}"
 

--- a/tools/wta/locales/da-DK.yml
+++ b/tools/wta/locales/da-DK.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Automatisk diagnosticeret en nylig kommandofejl"
 chat.turn_canceled: "(annulleret)"
 chat.turn_executed: "→ udført: %{title}"
 

--- a/tools/wta/locales/de-DE.yml
+++ b/tools/wta/locales/de-DE.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Kürzlicher Befehlsfehler automatisch diagnostiziert"
 chat.turn_canceled: "(abgebrochen)"
 chat.turn_executed: "→ ausgeführt: %{title}"
 

--- a/tools/wta/locales/el-GR.yml
+++ b/tools/wta/locales/el-GR.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Σχέδιο:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Αυτόματη διάγνωση πρόσφατης αποτυχίας εντολής"
 chat.turn_canceled: "(ακυρώθηκε)"
 chat.turn_executed: "→ εκτελέστηκε: %{title}"
 

--- a/tools/wta/locales/en-GB.yml
+++ b/tools/wta/locales/en-GB.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Auto-diagnosed a recent command failure"
 chat.turn_canceled: "(cancelled)"
 chat.turn_executed: "→ executed: %{title}"
 

--- a/tools/wta/locales/en-US.yml
+++ b/tools/wta/locales/en-US.yml
@@ -56,6 +56,9 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+# Prompt-line label shown on a completed turn that was auto-triggered by
+# autofix (a command failure in another pane), rather than typed by the user.
+chat.autofix_prompt_label: "Auto-diagnosed a recent command failure"
 # Trailing marker on a chat turn that the user canceled (pressed Esc).
 chat.turn_canceled: "(canceled)"
 # Trailing marker after the user executed a suggested action. %{title} is the

--- a/tools/wta/locales/es-ES.yml
+++ b/tools/wta/locales/es-ES.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Diagnosticado automáticamente un fallo reciente de un comando"
 chat.turn_canceled: "(cancelado)"
 chat.turn_executed: "→ ejecutado: %{title}"
 

--- a/tools/wta/locales/es-MX.yml
+++ b/tools/wta/locales/es-MX.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Diagnosticado automáticamente una falla reciente de un comando"
 chat.turn_canceled: "(cancelado)"
 chat.turn_executed: "→ ejecutado: %{title}"
 

--- a/tools/wta/locales/et-EE.yml
+++ b/tools/wta/locales/et-EE.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plaan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Hiljutine käsutõrge automaatselt diagnoositud"
 chat.turn_canceled: "(tühistatud)"
 chat.turn_executed: "→ käivitatud: %{title}"
 

--- a/tools/wta/locales/eu-ES.yml
+++ b/tools/wta/locales/eu-ES.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plana:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Azken komando-hutsegite bat automatikoki diagnostikatua"
 chat.turn_canceled: "(bertan behera utzita)"
 chat.turn_executed: "→ exekutatuta: %{title}"
 

--- a/tools/wta/locales/fa-IR.yml
+++ b/tools/wta/locales/fa-IR.yml
@@ -49,6 +49,7 @@ chat.plan_header: "طرح:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "خرابی فرمان اخیر به‌طور خودکار تشخیص داده شد"
 chat.turn_canceled: "(لغو شد)"
 chat.turn_executed: "→ اجرا شد: %{title}"
 

--- a/tools/wta/locales/fi-FI.yml
+++ b/tools/wta/locales/fi-FI.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Suunnitelma:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Äskettäinen komentovirhe diagnosoitu automaattisesti"
 chat.turn_canceled: "(peruutettu)"
 chat.turn_executed: "→ suoritettu: %{title}"
 

--- a/tools/wta/locales/fil-PH.yml
+++ b/tools/wta/locales/fil-PH.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plano:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Awtomatikong na-diagnose ang kamakailang pagkabigo ng command"
 chat.turn_canceled: "(kinansela)"
 chat.turn_executed: "→ naisagawa: %{title}"
 

--- a/tools/wta/locales/fr-CA.yml
+++ b/tools/wta/locales/fr-CA.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan :"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Échec récent d'une commande diagnostiqué automatiquement"
 chat.turn_canceled: "(annulé)"
 chat.turn_executed: "→ exécuté : %{title}"
 

--- a/tools/wta/locales/fr-FR.yml
+++ b/tools/wta/locales/fr-FR.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan :"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Échec récent d'une commande diagnostiqué automatiquement"
 chat.turn_canceled: "(annulé)"
 chat.turn_executed: "→ exécuté : %{title}"
 

--- a/tools/wta/locales/ga-IE.yml
+++ b/tools/wta/locales/ga-IE.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plean:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Diagnóisíodh teip ar ordú le déanaí go huathoibríoch"
 chat.turn_canceled: "(cealaithe)"
 chat.turn_executed: "→ rinneadh: %{title}"
 

--- a/tools/wta/locales/gd-gb.yml
+++ b/tools/wta/locales/gd-gb.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plana:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Air breithneachadh gu fèin-obrachail air fàilligeadh àithne o chionn ghoirid"
 chat.turn_canceled: "(air a sgur)"
 chat.turn_executed: "→ air a chur an gnìomh: %{title}"
 

--- a/tools/wta/locales/gl-ES.yml
+++ b/tools/wta/locales/gl-ES.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Diagnosticouse automaticamente un fallo recente dun comando"
 chat.turn_canceled: "(cancelado)"
 chat.turn_executed: "→ executado: %{title}"
 

--- a/tools/wta/locales/gu-IN.yml
+++ b/tools/wta/locales/gu-IN.yml
@@ -49,6 +49,7 @@ chat.plan_header: "યોજના:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "તાજેતરની આદેશ નિષ્ફળતાનું આપમેળે નિદાન કરવામાં આવ્યું"
 chat.turn_canceled: "(રદ કરેલ)"
 chat.turn_executed: "→ ચલાવાયું: %{title}"
 

--- a/tools/wta/locales/he-IL.yml
+++ b/tools/wta/locales/he-IL.yml
@@ -49,6 +49,7 @@ chat.plan_header: "תוכנית:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "כשל פקודה אחרון אובחן אוטומטית"
 chat.turn_canceled: "(בוטל)"
 chat.turn_executed: "→ בוצע: %{title}"
 

--- a/tools/wta/locales/hi-IN.yml
+++ b/tools/wta/locales/hi-IN.yml
@@ -49,6 +49,7 @@ chat.plan_header: "योजना:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "हाल की कमांड विफलता का स्वतः निदान किया गया"
 chat.turn_canceled: "(रद्द कर दिया गया)"
 chat.turn_executed: "→ निष्पादित: %{title}"
 

--- a/tools/wta/locales/hr-HR.yml
+++ b/tools/wta/locales/hr-HR.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Automatski dijagnosticiran nedavni neuspjeh naredbe"
 chat.turn_canceled: "(otkazano)"
 chat.turn_executed: "→ izvršeno: %{title}"
 

--- a/tools/wta/locales/hu-HU.yml
+++ b/tools/wta/locales/hu-HU.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Terv:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Egy közelmúltbeli parancshiba automatikus diagnosztizálása"
 chat.turn_canceled: "(megszakítva)"
 chat.turn_executed: "→ végrehajtva: %{title}"
 

--- a/tools/wta/locales/hy-AM.yml
+++ b/tools/wta/locales/hy-AM.yml
@@ -53,6 +53,7 @@ chat.plan_header: "Պլան՝"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Վերջին հրամանի ձախողումը ինքնաշխատ ախտորոշվել է"
 chat.turn_canceled: "(չեղարկվել է)"
 chat.turn_executed: "→ կատարվել է: %{title}"
 

--- a/tools/wta/locales/id-ID.yml
+++ b/tools/wta/locales/id-ID.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Rencana:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Kegagalan perintah terbaru terdiagnosis otomatis"
 chat.turn_canceled: "(dibatalkan)"
 chat.turn_executed: "→ dijalankan: %{title}"
 

--- a/tools/wta/locales/is-IS.yml
+++ b/tools/wta/locales/is-IS.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Áætlun:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Nýleg skipanavilla sjálfgreind"
 chat.turn_canceled: "(hætt við)"
 chat.turn_executed: "→ keyrt: %{title}"
 

--- a/tools/wta/locales/it-IT.yml
+++ b/tools/wta/locales/it-IT.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Piano:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Diagnosticato automaticamente un errore recente di un comando"
 chat.turn_canceled: "(annullato)"
 chat.turn_executed: "→ eseguito: %{title}"
 

--- a/tools/wta/locales/ja-JP.yml
+++ b/tools/wta/locales/ja-JP.yml
@@ -45,6 +45,7 @@ chat.plan_header: "プラン:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "直近のコマンド失敗を自動診断しました"
 chat.turn_canceled: "(キャンセル済み)"
 chat.turn_executed: "→ 実行済み: %{title}"
 

--- a/tools/wta/locales/ka-GE.yml
+++ b/tools/wta/locales/ka-GE.yml
@@ -49,6 +49,7 @@ chat.plan_header: "გეგმა:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "ბრძანების ბოლო შეცდომა ავტომატურად დიაგნოსტირებულია"
 chat.turn_canceled: "(გაუქმდა)"
 chat.turn_executed: "→ შესრულდა: %{title}"
 

--- a/tools/wta/locales/kk-KZ.yml
+++ b/tools/wta/locales/kk-KZ.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Жоспар:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Соңғы пәрмен қателігі автоматты түрде диагноз қойылды"
 chat.turn_canceled: "(бас тартылды)"
 chat.turn_executed: "→ орындалды: %{title}"
 

--- a/tools/wta/locales/km-KH.yml
+++ b/tools/wta/locales/km-KH.yml
@@ -53,6 +53,7 @@ chat.plan_header: "ផែនការ:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "បរាជ័យពាក្យបញ្ជាថ្មីៗត្រូវបានធ្វើរោគវិនិច្ឆ័យដោយស្វ័យប្រវត្តិ"
 chat.turn_canceled: "(បានបោះបង់)"
 chat.turn_executed: "→ បានដំណើរការ: %{title}"
 

--- a/tools/wta/locales/kn-IN.yml
+++ b/tools/wta/locales/kn-IN.yml
@@ -49,6 +49,7 @@ chat.plan_header: "ಯೋಜನೆ:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "ಇತ್ತೀಚಿನ ಆದೇಶ ವೈಫಲ್ಯವನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ರೋಗನಿರ್ಣಯ ಮಾಡಲಾಗಿದೆ"
 chat.turn_canceled: "(ರದ್ದುಗೊಳಿಸಲಾಗಿದೆ)"
 chat.turn_executed: "→ ಕಾರ್ಯಗತಗೊಂಡಿದೆ: %{title}"
 

--- a/tools/wta/locales/ko-KR.yml
+++ b/tools/wta/locales/ko-KR.yml
@@ -45,6 +45,7 @@ chat.plan_header: "계획:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "최근 명령 실패를 자동으로 진단했습니다"
 chat.turn_canceled: "(취소됨)"
 chat.turn_executed: "→ 실행됨: %{title}"
 

--- a/tools/wta/locales/kok-IN.yml
+++ b/tools/wta/locales/kok-IN.yml
@@ -49,6 +49,7 @@ chat.plan_header: "योजना:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "अद्ल्या आदेश अपयशाचें स्वयं-निदान केलें"
 chat.turn_canceled: "(रद्द केल्लें)"
 chat.turn_executed: "→ निश्पादीत: %{title}"
 

--- a/tools/wta/locales/lb-LU.yml
+++ b/tools/wta/locales/lb-LU.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plang:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Rezent Kommandoversoen automatesch diagnostizéiert"
 chat.turn_canceled: "(ofgebrach)"
 chat.turn_executed: "→ ausgeféiert: %{title}"
 

--- a/tools/wta/locales/lo-LA.yml
+++ b/tools/wta/locales/lo-LA.yml
@@ -49,6 +49,7 @@ chat.plan_header: "ແຜນການ:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "ການລົ້ມເຫລວຄຳສັ່ງຫຼ້າສຸດໄດ້ຮັບການວິນິດໄສໂດຍອັດຕະໂນມັດ"
 chat.turn_canceled: "(ຍົກເລີກແລ້ວ)"
 chat.turn_executed: "→ ດໍາເນີນການແລ້ວ: %{title}"
 

--- a/tools/wta/locales/lt-LT.yml
+++ b/tools/wta/locales/lt-LT.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Planas:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Automatiškai diagnozuotas neseniai įvykęs komandos sutrikimas"
 chat.turn_canceled: "(atšaukta)"
 chat.turn_executed: "→ įvykdyta: %{title}"
 

--- a/tools/wta/locales/lv-LV.yml
+++ b/tools/wta/locales/lv-LV.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plāns:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Automātiski diagnosticēta nesena komandas kļūme"
 chat.turn_canceled: "(atcelts)"
 chat.turn_executed: "→ izpildīts: %{title}"
 

--- a/tools/wta/locales/mi-NZ.yml
+++ b/tools/wta/locales/mi-NZ.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Mahere:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Kua tātaringia aunoatia te rahunga whakahau tata"
 chat.turn_canceled: "(whakakorea)"
 chat.turn_executed: "→ kua mahia: %{title}"
 

--- a/tools/wta/locales/mk-MK.yml
+++ b/tools/wta/locales/mk-MK.yml
@@ -49,6 +49,7 @@ chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Автоматски дијагностициран неодамнешен неуспех на наредба"
 chat.turn_canceled: "(откажано)"
 chat.turn_executed: "→ извршено: %{title}"
 

--- a/tools/wta/locales/ml-IN.yml
+++ b/tools/wta/locales/ml-IN.yml
@@ -49,6 +49,7 @@ chat.plan_header: "പദ്ധതി:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "സമീപകാല കമാൻഡ് പരാജയം സ്വയം നിർണ്ണയിച്ചു"
 chat.turn_canceled: "(റദ്ദാക്കി)"
 chat.turn_executed: "→ നടപ്പിലാക്കി: %{title}"
 

--- a/tools/wta/locales/mr-IN.yml
+++ b/tools/wta/locales/mr-IN.yml
@@ -49,6 +49,7 @@ chat.plan_header: "योजना:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "अलीकडील कमांड अपयशाचे स्वयंचलितपणे निदान केले"
 chat.turn_canceled: "(रद्द केले)"
 chat.turn_executed: "→ अंमलात आणले: %{title}"
 

--- a/tools/wta/locales/ms-MY.yml
+++ b/tools/wta/locales/ms-MY.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Pelan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Kegagalan arahan baru-baru ini didiagnosis secara automatik"
 chat.turn_canceled: "(dibatalkan)"
 chat.turn_executed: "→ dilaksanakan: %{title}"
 

--- a/tools/wta/locales/mt-MT.yml
+++ b/tools/wta/locales/mt-MT.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Pjan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Falliment riċenti ta' kmand iddijanjostikat awtomatikament"
 chat.turn_canceled: "(ikkanċellat)"
 chat.turn_executed: "→ ġie eżegwit: %{title}"
 

--- a/tools/wta/locales/nb-NO.yml
+++ b/tools/wta/locales/nb-NO.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Nylig kommandofeil diagnostisert automatisk"
 chat.turn_canceled: "(avbrutt)"
 chat.turn_executed: "→ utført: %{title}"
 

--- a/tools/wta/locales/ne-NP.yml
+++ b/tools/wta/locales/ne-NP.yml
@@ -49,6 +49,7 @@ chat.plan_header: "योजना:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "हालैको आदेश असफलता स्वचालित रूपमा निदान गरियो"
 chat.turn_canceled: "(रद्द गरियो)"
 chat.turn_executed: "→ कार्यान्वयन गरियो: %{title}"
 

--- a/tools/wta/locales/nl-NL.yml
+++ b/tools/wta/locales/nl-NL.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Recente opdrachtfout automatisch gediagnosticeerd"
 chat.turn_canceled: "(geannuleerd)"
 chat.turn_executed: "→ uitgevoerd: %{title}"
 

--- a/tools/wta/locales/nn-NO.yml
+++ b/tools/wta/locales/nn-NO.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Nyleg kommandofeil diagnostisert automatisk"
 chat.turn_canceled: "(avbroten)"
 chat.turn_executed: "→ utført: %{title}"
 

--- a/tools/wta/locales/or-IN.yml
+++ b/tools/wta/locales/or-IN.yml
@@ -49,6 +49,7 @@ chat.plan_header: "ଯୋଜନା:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "ସମ୍ପ୍ରତି କମାଣ୍ଡ ବିଫଳତା ସ୍ୱୟଂଚାଳିତ ଭାବେ ନିଦାନ କରାଯାଇଛି"
 chat.turn_canceled: "(ବାତିଲ କରାଗଲା)"
 chat.turn_executed: "→ କାର୍ଯ୍ୟକାରୀ ହୋଇଛି: %{title}"
 

--- a/tools/wta/locales/pa-IN.yml
+++ b/tools/wta/locales/pa-IN.yml
@@ -49,6 +49,7 @@ chat.plan_header: "ਯੋਜਨਾ:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "ਹਾਲੀਆ ਕਮਾਂਡ ਅਸਫਲਤਾ ਆਪਣੇ ਆਪ ਨਿਦਾਨ ਕੀਤੀ ਗਈ"
 chat.turn_canceled: "(ਰੱਦ ਕੀਤਾ ਗਿਆ)"
 chat.turn_executed: "→ ਚਲਾਇਆ ਗਿਆ: %{title}"
 

--- a/tools/wta/locales/pl-PL.yml
+++ b/tools/wta/locales/pl-PL.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Automatyczne zdiagnozowanie ostatniego błędu polecenia"
 chat.turn_canceled: "(anulowano)"
 chat.turn_executed: "→ wykonano: %{title}"
 

--- a/tools/wta/locales/pt-BR.yml
+++ b/tools/wta/locales/pt-BR.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plano:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Falha recente de comando diagnosticada automaticamente"
 chat.turn_canceled: "(cancelado)"
 chat.turn_executed: "→ executado: %{title}"
 

--- a/tools/wta/locales/pt-PT.yml
+++ b/tools/wta/locales/pt-PT.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plano:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Falha recente de comando diagnosticada automaticamente"
 chat.turn_canceled: "(cancelado)"
 chat.turn_executed: "→ executado: %{title}"
 

--- a/tools/wta/locales/qps-ploc.yml
+++ b/tools/wta/locales/qps-ploc.yml
@@ -50,6 +50,7 @@ chat.plan_header: "[Ṗĺåñ:!!]"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "[(Åûţö-ðïåĝñöšéð å réçéñţ çöɱɱåñð ƒåïĺûré!!)]"
 chat.turn_canceled: "[(çåñçéĺéð!!)]"
 chat.turn_executed: "[→ éẋéçûţéð: %{title}!!]"
 

--- a/tools/wta/locales/qps-ploca.yml
+++ b/tools/wta/locales/qps-ploca.yml
@@ -49,6 +49,7 @@ chat.plan_header: "[!!_Plan:_!!]"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "[!!_(Auto-diagnosed a recent command failure)_!!]"
 chat.turn_canceled: "[!!_(canceled)_!!]"
 chat.turn_executed: "[!!_→ executed: %{title}_!!]"
 

--- a/tools/wta/locales/qps-plocm.yml
+++ b/tools/wta/locales/qps-plocm.yml
@@ -49,6 +49,7 @@ chat.plan_header: "[!! Pla_n: !!]"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "[!! Auto-diagnosed_a_recent_command_failure !!]"
 chat.turn_canceled: "[!! (cancel_ed) !!]"
 chat.turn_executed: "[!! → execu_ted: %{title} !!]"
 

--- a/tools/wta/locales/quz-PE.yml
+++ b/tools/wta/locales/quz-PE.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Ruwana:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Sapan kamachiykuq pantarisqa ñakaq qhawasqa"
 chat.turn_canceled: "(saqisqa)"
 chat.turn_executed: "→ ruwasqa: %{title}"
 

--- a/tools/wta/locales/ro-RO.yml
+++ b/tools/wta/locales/ro-RO.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Eșec recent al comenzii diagnosticat automat"
 chat.turn_canceled: "(anulat)"
 chat.turn_executed: "→ executat: %{title}"
 

--- a/tools/wta/locales/ru-RU.yml
+++ b/tools/wta/locales/ru-RU.yml
@@ -49,6 +49,7 @@ chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Автоматически диагностирован недавний сбой команды"
 chat.turn_canceled: "(отменено)"
 chat.turn_executed: "→ выполнено: %{title}"
 

--- a/tools/wta/locales/sk-SK.yml
+++ b/tools/wta/locales/sk-SK.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plán:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Automaticky diagnostikované nedávne zlyhanie príkazu"
 chat.turn_canceled: "(zrušené)"
 chat.turn_executed: "→ vykonané: %{title}"
 

--- a/tools/wta/locales/sl-SI.yml
+++ b/tools/wta/locales/sl-SI.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Načrt:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Samodejno diagnosticirana nedavna napaka ukaza"
 chat.turn_canceled: "(preklicano)"
 chat.turn_executed: "→ izvedeno: %{title}"
 

--- a/tools/wta/locales/sq-AL.yml
+++ b/tools/wta/locales/sq-AL.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plani:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Dështim i fundit i komandës është diagnostikuar automatikisht"
 chat.turn_canceled: "(anuluar)"
 chat.turn_executed: "→ ekzekutuar: %{title}"
 

--- a/tools/wta/locales/sr-Cyrl-BA.yml
+++ b/tools/wta/locales/sr-Cyrl-BA.yml
@@ -49,6 +49,7 @@ chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Аутоматски дијагностикован недавни неуспех команде"
 chat.turn_canceled: "(отказано)"
 chat.turn_executed: "→ извршено: %{title}"
 

--- a/tools/wta/locales/sr-Cyrl-RS.yml
+++ b/tools/wta/locales/sr-Cyrl-RS.yml
@@ -49,6 +49,7 @@ chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Аутоматски дијагностикован недавни неуспех команде"
 chat.turn_canceled: "(отказано)"
 chat.turn_executed: "→ извршено: %{title}"
 

--- a/tools/wta/locales/sr-Latn-RS.yml
+++ b/tools/wta/locales/sr-Latn-RS.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Automatski dijagnostikovan nedavni neuspeh komande"
 chat.turn_canceled: "(otkazano)"
 chat.turn_executed: "→ izvršeno: %{title}"
 

--- a/tools/wta/locales/sv-SE.yml
+++ b/tools/wta/locales/sv-SE.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Automatiskt diagnostiserat ett nyligen inträffat kommandofel"
 chat.turn_canceled: "(avbruten)"
 chat.turn_executed: "→ utförd: %{title}"
 

--- a/tools/wta/locales/ta-IN.yml
+++ b/tools/wta/locales/ta-IN.yml
@@ -49,6 +49,7 @@ chat.plan_header: "திட்டம்:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "சமீபத்திய கட்டளை தோல்வி தானாகவே கண்டறியப்பட்டது"
 chat.turn_canceled: "(ரத்து செய்யப்பட்டது)"
 chat.turn_executed: "→ செயல்படுத்தப்பட்டது: %{title}"
 

--- a/tools/wta/locales/te-IN.yml
+++ b/tools/wta/locales/te-IN.yml
@@ -49,6 +49,7 @@ chat.plan_header: "ప్లాన్:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "ఇటీవలి కమాండ్ వైఫల్యం స్వయంచాలకంగా నిర్ధారించబడింది"
 chat.turn_canceled: "(రద్దు చేయబడింది)"
 chat.turn_executed: "→ అమలు చేయబడింది: %{title}"
 

--- a/tools/wta/locales/th-TH.yml
+++ b/tools/wta/locales/th-TH.yml
@@ -49,6 +49,7 @@ chat.plan_header: "แผน:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "วินิจฉัยความล้มเหลวของคำสั่งล่าสุดโดยอัตโนมัติ"
 chat.turn_canceled: "(ยกเลิกแล้ว)"
 chat.turn_executed: "→ ดำเนินการแล้ว: %{title}"
 

--- a/tools/wta/locales/tr-TR.yml
+++ b/tools/wta/locales/tr-TR.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Son komut hatası otomatik olarak teşhis edildi"
 chat.turn_canceled: "(iptal edildi)"
 chat.turn_executed: "→ yürütüldü: %{title}"
 

--- a/tools/wta/locales/tt-RU.yml
+++ b/tools/wta/locales/tt-RU.yml
@@ -49,6 +49,7 @@ chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Соңгы команда хатасы автоматик рәвештә диагнозланды"
 chat.turn_canceled: "(гамәлдән чыгарылды)"
 chat.turn_executed: "→ үтәлде: %{title}"
 

--- a/tools/wta/locales/ug-CN.yml
+++ b/tools/wta/locales/ug-CN.yml
@@ -49,6 +49,7 @@ chat.plan_header: "پىلان:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "يېقىنقى بۇيرۇق مەغلۇبىيىتى ئاپتوماتىك دىئاگنوز قىلىندى"
 chat.turn_canceled: "(ئەمەلدىن قالدۇرۇلدى)"
 chat.turn_executed: "→ ئىجرا قىلىندى: %{title}"
 

--- a/tools/wta/locales/uk-UA.yml
+++ b/tools/wta/locales/uk-UA.yml
@@ -49,6 +49,7 @@ chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Автоматично діагностовано нещодавню помилку команди"
 chat.turn_canceled: "(скасовано)"
 chat.turn_executed: "→ виконано: %{title}"
 

--- a/tools/wta/locales/ur-PK.yml
+++ b/tools/wta/locales/ur-PK.yml
@@ -49,6 +49,7 @@ chat.plan_header: "منصوبہ:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "حالیہ کمانڈ کی ناکامی کا خودکار طور پر تشخیص کیا گیا"
 chat.turn_canceled: "(منسوخ)"
 chat.turn_executed: "→ پر عمل کر دیا گیا: %{title}"
 

--- a/tools/wta/locales/uz-Latn-UZ.yml
+++ b/tools/wta/locales/uz-Latn-UZ.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Reja:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Yaqindagi buyruq xatosi avtomatik tarzda tashxis qilindi"
 chat.turn_canceled: "(bekor qilindi)"
 chat.turn_executed: "→ bajarildi: %{title}"
 

--- a/tools/wta/locales/vi-VN.yml
+++ b/tools/wta/locales/vi-VN.yml
@@ -49,6 +49,7 @@ chat.plan_header: "Kế hoạch:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "Đã tự động chẩn đoán một lỗi lệnh gần đây"
 chat.turn_canceled: "(đã hủy)"
 chat.turn_executed: "→ đã thực thi: %{title}"
 

--- a/tools/wta/locales/zh-CN.yml
+++ b/tools/wta/locales/zh-CN.yml
@@ -45,6 +45,7 @@ chat.plan_header: "计划："
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "已自动诊断最近的一次命令失败"
 chat.turn_canceled: "(已取消)"
 chat.turn_executed: "→ 已执行: %{title}"
 

--- a/tools/wta/locales/zh-TW.yml
+++ b/tools/wta/locales/zh-TW.yml
@@ -45,6 +45,7 @@ chat.plan_header: "計畫："
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}
 chat.plan_marker_pending: "[ ]"  # {Locked}
+chat.autofix_prompt_label: "已自動診斷最近的一次命令失敗"
 chat.turn_canceled: "(已取消)"
 chat.turn_executed: "→ 已執行: %{title}"
 

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -6310,13 +6310,8 @@ impl App {
                     details.push(ChatMessage::Agent(visible));
                 }
                 if !details.is_empty() {
-                    let pane_label = prompt
-                        .autofix
-                        .as_ref()
-                        .map(|a| a.target_pane_id.clone())
-                        .expect("autofix finalize requires autofix prompt");
                     tab.completed_turns.push(CompletedTurn {
-                        prompt: format!("Auto-diagnosed error in pane {pane_label}"),
+                        prompt: t!("chat.autofix_prompt_label").into_owned(),
                         details,
                         expanded: true,
                         trailing_marker: None,
@@ -6514,14 +6509,14 @@ impl App {
         let new_turn_data: Option<(String, Option<String>)> = match &tab.turn {
             TurnState::Submitted(prompt) => {
                 let label = match prompt.autofix.as_ref() {
-                    Some(a) => format!("Auto-diagnosed error in pane {}", a.target_pane_id),
+                    Some(_) => t!("chat.autofix_prompt_label").into_owned(),
                     None => prompt.text.clone(),
                 };
                 Some((label, None))
             }
             TurnState::Streaming { prompt, buf } => {
                 let label = match prompt.autofix.as_ref() {
-                    Some(a) => format!("Auto-diagnosed error in pane {}", a.target_pane_id),
+                    Some(_) => t!("chat.autofix_prompt_label").into_owned(),
                     None => prompt.text.clone(),
                 };
                 let visible = ui::chat::user_visible_stream_text(buf).map(|c| c.into_owned());
@@ -6641,7 +6636,7 @@ impl App {
         self.emit_autofix_state_armed(&target_tab, &pane_id, &preview);
         let rec_idx = recommended_choice_index(&recommendations);
         let summary = format_recommendations_for_chat(&recommendations);
-        let turn_prompt_label = format!("Auto-diagnosed error in pane {pane_id}");
+        let turn_prompt_label = t!("chat.autofix_prompt_label").into_owned();
         let tab = self.session_tab_mut(session_id);
         let prompt = tab.turn.prompt().cloned().expect("prompt set");
         let mut details = tab.current_turn_details();
@@ -6693,7 +6688,7 @@ impl App {
             ),
         );
 
-        let turn_prompt_label = format!("Auto-diagnosed error in pane {pane_id}");
+        let turn_prompt_label = t!("chat.autofix_prompt_label").into_owned();
         {
             let tab = self.session_tab_mut(session_id);
             let mut details = tab.current_turn_details();


### PR DESCRIPTION
## Summary
- Autofix-triggered chat turns showed `Auto-diagnosed error in pane <GUID>` as the prompt-line header — the GUID is meaningless to users and the rest of the sentence isn't much better.
- Replaced all 5 call sites with a new localized `chat.autofix_prompt_label` key: `"Auto-diagnosed a recent command failure"`. Pane GUID is dropped entirely; non-en-US locales fall back to en-US automatically (`fallback = "en-US"` in `main.rs`).
- Touched paths: `turn_surface_fix`, `turn_surface_explain`, the Ignore finalize path, and both Submitted/Streaming arms of cancel.

## Test plan
- [ ] Trigger a failing command in another pane (with PowerShell OSC 133 marks + agent pane open + `autoFixEnabled: true`) and confirm the autofix Fix card's prompt-line reads `Auto-diagnosed a recent command failure` (no GUID).
- [ ] Press Esc mid-stream during an autofix turn → cancelled completed-turn shows the same label.
- [ ] Click Ignore on an autofix turn that streamed some prose → completed-turn shows the same label.
- [ ] Click the bottom-bar Suggested pill (Explain path) → expanded turn shows the same label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)