### PR TITLE
agent pane: blue "Agent" chip marks the pane the agent will act on

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -3280,6 +3280,9 @@ void Pane::UpdateResources(const PaneResources& resources)
 {
     _themeResources = resources;
     UpdateVisuals();
+    // Re-apply the now-current theme brush to the chip if we've already
+    // built one. No-op when the chip hasn't been lazily created yet.
+    _UpdateAgentChipBackground();
 
     if (!_IsLeaf())
     {
@@ -3340,13 +3343,24 @@ void Pane::SetAgentChipVisible(bool value)
     if (value)
     {
         _EnsureAgentChip();
-        // Re-append so the chip sits above the borders and any splitter.
+        // Avoid XAML churn: if the chip is already visible and already at
+        // the top of the children collection (so above the borders and any
+        // splitter), this call is a no-op. `_UpdateAgentChipVisibility`
+        // runs on every active-pane update and walks the whole tree, so
+        // the repeat-true case is the common one in heavily-split tabs.
         uint32_t idx = 0;
-        if (_root.Children().IndexOf(_agentChip, idx))
+        const auto& children = _root.Children();
+        const bool found = children.IndexOf(_agentChip, idx);
+        const bool alreadyOnTop = found && idx + 1 == children.Size();
+        if (alreadyOnTop && _agentChip.Visibility() == Visibility::Visible)
         {
-            _root.Children().RemoveAt(idx);
+            return;
         }
-        _root.Children().Append(_agentChip);
+        if (found)
+        {
+            children.RemoveAt(idx);
+        }
+        children.Append(_agentChip);
         _agentChip.Visibility(Visibility::Visible);
     }
     else if (_agentChip)
@@ -3385,7 +3399,7 @@ void Pane::_EnsureAgentChip()
     }
 
     Controls::TextBlock text{};
-    text.Text(L"Agent");
+    text.Text(RS_(L"Pane_AgentChipText"));
     text.FontSize(10.0);
     text.FontWeight(winrt::Windows::UI::Text::FontWeights::SemiBold());
     text.Foreground(Media::SolidColorBrush{ winrt::Windows::UI::Colors::White() });
@@ -3399,8 +3413,30 @@ void Pane::_EnsureAgentChip()
     _agentChip.CornerRadius({ 4, 4, 4, 4 });
     _agentChip.IsHitTestVisible(false);
     _agentChip.Visibility(Visibility::Collapsed);
-    _agentChip.Background(Media::SolidColorBrush{
-        winrt::Windows::UI::ColorHelper::FromArgb(0xFF, 0x2D, 0x6F, 0xE0) });
+    _UpdateAgentChipBackground();
+}
+
+// Apply the theme-tracking background brush to the chip. Reuses the
+// focused-border brush so the chip matches the accent color the rest of
+// Pane's chrome uses for "active" / "focused" state — picks up theme and
+// high-contrast changes for free via `UpdateResources`. Falls back to a
+// reasonable solid blue if `UpdateResources` hasn't pushed brushes yet
+// (e.g. very early in initialization).
+void Pane::_UpdateAgentChipBackground()
+{
+    if (!_agentChip)
+    {
+        return;
+    }
+    if (_themeResources.focusedBorderBrush)
+    {
+        _agentChip.Background(_themeResources.focusedBorderBrush);
+    }
+    else
+    {
+        _agentChip.Background(Media::SolidColorBrush{
+            winrt::Windows::UI::ColorHelper::FromArgb(0xFF, 0x2D, 0x6F, 0xE0) });
+    }
 }
 
 // Method Description:

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -3333,6 +3333,76 @@ void Pane::SetSourceOfAgentPane(bool value) noexcept
     _isSourceOfAgentPane = value;
 }
 
+// Show or hide the blue "Agent" pill in the bottom-right corner of the pane.
+// Driven from Tab / protocol-event layer — this pane just renders.
+void Pane::SetAgentChipVisible(bool value)
+{
+    if (value)
+    {
+        _EnsureAgentChip();
+        // Re-append so the chip sits above the borders and any splitter.
+        uint32_t idx = 0;
+        if (_root.Children().IndexOf(_agentChip, idx))
+        {
+            _root.Children().RemoveAt(idx);
+        }
+        _root.Children().Append(_agentChip);
+        _agentChip.Visibility(Visibility::Visible);
+    }
+    else if (_agentChip)
+    {
+        _agentChip.Visibility(Visibility::Collapsed);
+    }
+}
+
+// The connection's session GUID for terminal panes. Returns the empty
+// guid for non-terminal panes (e.g. branch nodes, agent panes, snippets).
+// Used by Tab to match a protocol-supplied pane id to a Pane.
+winrt::guid Pane::GetSessionId() const
+{
+    // Mirror `_getSessionIdFromPane` in TerminalPage.Protocol.cpp:
+    // walk content → control → connection and read the SessionId. Using
+    // GetContent() (instead of `_content` directly) keeps the non-leaf
+    // case to a clean nullptr without needing an explicit leaf check.
+    if (const auto termContent = GetContent().try_as<winrt::TerminalApp::TerminalPaneContent>())
+    {
+        if (const auto control = termContent.GetTermControl())
+        {
+            if (const auto conn = control.Connection())
+            {
+                return conn.SessionId();
+            }
+        }
+    }
+    return {};
+}
+
+void Pane::_EnsureAgentChip()
+{
+    if (_agentChip)
+    {
+        return;
+    }
+
+    Controls::TextBlock text{};
+    text.Text(L"Agent");
+    text.FontSize(10.0);
+    text.FontWeight(winrt::Windows::UI::Text::FontWeights::SemiBold());
+    text.Foreground(Media::SolidColorBrush{ winrt::Windows::UI::Colors::White() });
+
+    _agentChip = Controls::Border{};
+    _agentChip.Child(text);
+    _agentChip.HorizontalAlignment(HorizontalAlignment::Right);
+    _agentChip.VerticalAlignment(VerticalAlignment::Bottom);
+    _agentChip.Margin({ 0, 0, 8, 8 });
+    _agentChip.Padding({ 8, 1, 8, 2 });
+    _agentChip.CornerRadius({ 4, 4, 4, 4 });
+    _agentChip.IsHitTestVisible(false);
+    _agentChip.Visibility(Visibility::Collapsed);
+    _agentChip.Background(Media::SolidColorBrush{
+        winrt::Windows::UI::ColorHelper::FromArgb(0xFF, 0x2D, 0x6F, 0xE0) });
+}
+
 // Method Description:
 // - If we're a parent, place the taskbar state for all our leaves into the
 //   provided vector.

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -330,6 +330,7 @@ private:
     void _SetupEntranceAnimation();
     void _UpdateBorders();
     void _EnsureAgentChip();
+    void _UpdateAgentChipBackground();
     Borders _GetCommonBorders();
     winrt::Windows::UI::Xaml::Media::SolidColorBrush _ComputeBorderColor();
 

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -174,6 +174,8 @@ public:
     void IsAgentPane(bool value) noexcept;
     bool IsSourceOfAgentPane() const noexcept;
     void SetSourceOfAgentPane(bool value) noexcept;
+    void SetAgentChipVisible(bool value);
+    winrt::guid GetSessionId() const;
     bool IsHidden() const noexcept { return _hidden; }
 
     void EnableBroadcast(bool enabled);
@@ -265,6 +267,11 @@ private:
     // drag-to-resize. Lazily created the first time we need it.
     winrt::Windows::UI::Xaml::Controls::Border _splitter{ nullptr };
 
+    // Blue "Agent" pill shown at the bottom-right corner of the pane the
+    // agent is about to act on. Visibility is driven from the outside
+    // (Tab / protocol-event layer) — this struct just owns the chrome.
+    winrt::Windows::UI::Xaml::Controls::Border _agentChip{ nullptr };
+
     PaneResources _themeResources;
 
 #pragma region Properties that need to be transferred between child / parent panes upon splitting / closing
@@ -322,6 +329,7 @@ private:
     void _ApplySplitDefinitions();
     void _SetupEntranceAnimation();
     void _UpdateBorders();
+    void _EnsureAgentChip();
     Borders _GetCommonBorders();
     winrt::Windows::UI::Xaml::Media::SolidColorBrush _ComputeBorderColor();
 

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1191,4 +1191,8 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="Pane_AgentChipText" xml:space="preserve">
+    <value>Agent</value>
+    <comment>Short label shown in a small corner chip on the terminal pane the AI agent is about to act on. Keep very short — the chip is small. In this context, "agent" refers to an AI agent.</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -1554,7 +1554,7 @@ namespace winrt::TerminalApp::implementation
     void Tab::SetAgentChipOverride(std::optional<winrt::guid> sessionId)
     {
         // Treat the empty guid as "no override" so a malformed event can't
-        // pin the chip to a non-existent pane permanently.
+        // pin the chip to a nonexistent pane permanently.
         if (sessionId.has_value() && sessionId.value() == winrt::guid{})
         {
             sessionId = std::nullopt;

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -1460,6 +1460,12 @@ namespace winrt::TerminalApp::implementation
             previousActive->UpdateVisuals();
         }
 
+        // Recompute the "Agent" chip on every pane in this tab. Both the
+        // ClearActive() above and the SetSourceOfAgentPane(true) we may
+        // have just done can flip which pane is "the source", and the chip
+        // follows that signal whenever there is no protocol-driven override.
+        _UpdateAgentChipVisibility();
+
         // Update our own title text to match the newly-active pane.
         UpdateTitle();
         _UpdateProgressState();
@@ -1517,6 +1523,51 @@ namespace winrt::TerminalApp::implementation
         }
 
         _UpdateMenuItemStates();
+    }
+
+    // Recompute the "Agent" chip visibility on every pane in this tab.
+    // When the helper has supplied a session-id override (typically while a
+    // Send recommendation is selected in the agent pane), chip visibility
+    // is pinned to the pane whose connection SessionId matches. Otherwise
+    // it follows the source-of-agent flag.
+    void Tab::_UpdateAgentChipVisibility()
+    {
+        if (!_rootPane)
+        {
+            return;
+        }
+        if (_agentChipOverride.has_value())
+        {
+            const auto target = _agentChipOverride.value();
+            _rootPane->WalkTree([&target](const auto& pane) {
+                pane->SetAgentChipVisible(pane->GetSessionId() == target);
+            });
+        }
+        else
+        {
+            _rootPane->WalkTree([](const auto& pane) {
+                pane->SetAgentChipVisible(pane->IsSourceOfAgentPane());
+            });
+        }
+    }
+
+    void Tab::SetAgentChipOverride(std::optional<winrt::guid> sessionId)
+    {
+        // Treat the empty guid as "no override" so a malformed event can't
+        // pin the chip to a non-existent pane permanently.
+        if (sessionId.has_value() && sessionId.value() == winrt::guid{})
+        {
+            sessionId = std::nullopt;
+        }
+        _agentChipOverride = sessionId;
+        // Always recompute, even when the value didn't change. The helper
+        // re-publishes its current state on startup (and a few other sync
+        // points) so an "equal-but-redundant" event arriving here is the
+        // signal that the C++ side should re-walk the pane tree — for
+        // example to pick up a `IsSourceOfAgentPane()` transition the
+        // chip-visibility hook in `_UpdateActivePane` missed (legacy
+        // call sites that mutate the flag without going through it).
+        _UpdateAgentChipVisibility();
     }
 
     void Tab::_UpdateMenuItemStates()
@@ -2531,7 +2582,19 @@ namespace winrt::TerminalApp::implementation
         // guard, so do FocusPane (which calls _Focus) FIRST (agent's flag
         // is still false from the stash). _UpdateActivePane sets the flag.
         _rootPane->FocusPane(agentPane);
-        _UpdateActivePane(agentPane);
+        // FocusPane's synchronous `_Focus` raised GotFocus, which already
+        // called Tab::_UpdateActivePane(agentPane) via our gotFocus handler
+        // — including the SetSourceOfAgentPane(true) call that pins the
+        // chip / border onto the previously-focused terminal pane. A
+        // redundant _UpdateActivePane(agentPane) here would re-run
+        // ClearActive() and wipe that flag again (the condition that
+        // re-sets it requires `previousActive` to be the non-agent pane,
+        // but at this point previousActive is the agent pane itself).
+        // So only fall through if the GotFocus path didn't update us.
+        if (_activePane != agentPane)
+        {
+            _UpdateActivePane(agentPane);
+        }
 
         // CRITICAL: synchronous Focus(Programmatic) is unreliable on
         // freshly-re-parented or freshly-spawned TermControls. The element

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -122,6 +122,13 @@ namespace winrt::TerminalApp::implementation
         bool RestoreStashedAgentPane(winrt::Microsoft::Terminal::Settings::Model::SplitDirection direction);
         bool HasStashedAgentPane() const;
 
+        // Override which pane in this tab shows the blue "Agent" chip. Pass
+        // a session GUID to pin the chip onto that pane (e.g. while a Send
+        // recommendation is selected). Pass std::nullopt to revert to the
+        // default behavior, where the chip follows the source-of-agent
+        // flag on each pane.
+        void SetAgentChipOverride(std::optional<winrt::guid> sessionId);
+
         // Stable per-tab identifier (GUID string). Survives tab reordering
         // and is unique across the window's lifetime, unlike the index in
         // _tabs which is reused when tabs close. Used as the tab_id for
@@ -201,6 +208,12 @@ namespace winrt::TerminalApp::implementation
         std::shared_ptr<Pane> _zoomedPane{ nullptr };
         std::shared_ptr<Pane> _hiddenPane{ nullptr };
 
+        // When set, the "Agent" chip is forced onto the pane whose
+        // connection SessionId matches this guid (e.g. while the user has
+        // a Send-card selected in the agent pane). When unset, the chip
+        // falls back to following each pane's IsSourceOfAgentPane() flag.
+        std::optional<winrt::guid> _agentChipOverride{};
+
         winrt::Microsoft::Terminal::Settings::Model::IconStyle _lastIconStyle;
         winrt::hstring _lastIconPath{};
         std::optional<winrt::Windows::UI::Color> _runtimeTabColor{};
@@ -263,6 +276,7 @@ namespace winrt::TerminalApp::implementation
 
         void _UpdateActivePane(std::shared_ptr<Pane> pane);
         void _UpdateMenuItemStates();
+        void _UpdateAgentChipVisibility();
 
         winrt::hstring _GetActiveTitle() const;
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4097,6 +4097,10 @@ namespace winrt::TerminalApp::implementation
             {
                 if (targetTab->FindAgentPane())
                 {
+                    // The agent pane is being hidden — drop any chip
+                    // override so the chip doesn't stay pinned on a
+                    // background pane while the agent is out of sight.
+                    targetTab->SetAgentChipOverride(std::nullopt);
                     targetTab->StashAgentPane();
                 }
             }
@@ -4148,6 +4152,10 @@ namespace winrt::TerminalApp::implementation
         }
         // Tell wta to drop this tab's ACP session.
         _NotifyAgentTabReset(ownerTab->StableId());
+        // The agent pane (and its helper) is going away, so any chip
+        // override the helper had set is no longer authoritative. Drop it
+        // here so the chip can't get pinned by a dead helper.
+        ownerTab->SetAgentChipOverride(std::nullopt);
         _TeardownAgentPane(ownerTab);
     }
 
@@ -4208,6 +4216,68 @@ namespace winrt::TerminalApp::implementation
             winrt::to_hstring(Json::writeString(wb, evt)));
 
         // WTA will emit autofix_state:cleared — OnAutofixStateChanged handles the transition.
+    }
+
+    // Inbound event from WTA: {method:"set_agent_chip_target",
+    //                          params:{tab_id, pane_session_id?}}.
+    // Selects which pane in the tab shows the blue "Agent" chip. When
+    // pane_session_id is missing or null the tab reverts to the default
+    // chip behavior (driven by IsSourceOfAgentPane on each pane).
+    void TerminalPage::OnAgentChipTargetChanged(hstring eventJson)
+    {
+        Json::Value evt;
+        Json::CharReaderBuilder rb;
+        std::istringstream ss(winrt::to_string(eventJson));
+        std::string errs;
+        if (!Json::parseFromStream(rb, ss, &evt, &errs))
+        {
+            return;
+        }
+        const auto& params = evt["params"];
+        if (!params.isObject())
+        {
+            return;
+        }
+
+        winrt::hstring tabId;
+        if (params.isMember("tab_id") && params["tab_id"].isString())
+        {
+            tabId = winrt::to_hstring(params["tab_id"].asString());
+        }
+        if (tabId.empty())
+        {
+            return;
+        }
+        const auto targetTab = _FindTabByStableId(tabId);
+        if (!targetTab)
+        {
+            // Tab not in this window — fan-out will hit the right one.
+            return;
+        }
+
+        std::optional<winrt::guid> sessionId;
+        if (params.isMember("pane_session_id") &&
+            params["pane_session_id"].isString())
+        {
+            const auto raw = params["pane_session_id"].asString();
+            if (!raw.empty())
+            {
+                const auto wide = winrt::to_hstring(raw);
+                try
+                {
+                    // Accept both braced ({…}) and plain GUID encodings.
+                    sessionId = (raw.size() >= 2 && raw.front() == '{')
+                                    ? winrt::guid{ ::Microsoft::Console::Utils::GuidFromString(wide.c_str()) }
+                                    : winrt::guid{ ::Microsoft::Console::Utils::GuidFromPlainString(wide.c_str()) };
+                }
+                catch (...)
+                {
+                    sessionId = std::nullopt;
+                }
+            }
+        }
+
+        targetTab->SetAgentChipOverride(sessionId);
     }
 
     // Inbound event from WTA: {method:"resume_in_new_agent_tab",

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -208,6 +208,7 @@ namespace winrt::TerminalApp::implementation
         void OnCloseAgentPaneRequested(hstring eventJson);
         void OnAgentStateChanged(hstring eventJson);
         void OnResumeInNewAgentTabRequested(hstring eventJson);
+        void OnAgentChipTargetChanged(hstring eventJson);
 
         til::property_changed_event PropertyChanged;
 

--- a/src/cascadia/TerminalApp/TerminalPage.idl
+++ b/src/cascadia/TerminalApp/TerminalPage.idl
@@ -151,5 +151,12 @@ namespace TerminalApp
         // publishes a `load_session` event back to wta carrying the new
         // tab's StableId so wta calls ACP `session/load` for that tab.
         void OnResumeInNewAgentTabRequested(String eventJson);
+
+        // Inbound event from WTA carrying
+        // {method:"set_agent_chip_target",params:{tab_id, pane_session_id?}}.
+        // Helper override for which pane in the tab gets the blue "Agent"
+        // chip. A missing or null pane_session_id reverts that tab to the
+        // default chip behavior (driven by the source-of-agent flag).
+        void OnAgentChipTargetChanged(String eventJson);
     }
 }

--- a/src/cascadia/TerminalProtocol/ProtocolParsing.h
+++ b/src/cascadia/TerminalProtocol/ProtocolParsing.h
@@ -36,6 +36,7 @@ namespace Microsoft::Terminal::Protocol::Parsing
         CloseAgentPane,       // Direct to TerminalPage, no broadcast
         AgentState,           // Direct to TerminalPage, no broadcast — unified per-tab agent-pane UI snapshot (view + pane_open + ...)
         ResumeInNewAgentTab,  // Direct to TerminalPage, no broadcast
+        AgentChipTarget,      // Direct to TerminalPage, no broadcast — "draw the Agent chip on this pane (or hide override)"
         Broadcast,            // Normalize envelope + broadcast to all subscribers
         Invalid               // Failed validation
     };
@@ -84,6 +85,10 @@ namespace Microsoft::Terminal::Protocol::Parsing
             if (method == "resume_in_new_agent_tab")
             {
                 return SendEventRoute::ResumeInNewAgentTab;
+            }
+            if (method == "set_agent_chip_target")
+            {
+                return SendEventRoute::AgentChipTarget;
             }
         }
 

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
@@ -738,6 +738,11 @@ void TerminalProtocolComServer::SendEvent(winrt::hstring const& eventJson)
         // a new tab and asks wta to open an agent pane in it.
         _dispatchResumeInNewAgentTabToPage(eventJson);
         return;
+    case ProtocolParsing::SendEventRoute::AgentChipTarget:
+        // Helper override for which pane gets the "Agent" chip; null
+        // pane_session_id reverts the tab to source-flag-driven chip.
+        _dispatchAgentChipTargetToPage(eventJson);
+        return;
     case ProtocolParsing::SendEventRoute::Broadcast:
     {
         Json::StreamWriterBuilder wb;
@@ -922,6 +927,42 @@ void TerminalProtocolComServer::_dispatchResumeInNewAgentTabToPage(const winrt::
                 try
                 {
                     page.OnResumeInNewAgentTabRequested(eventJson);
+                }
+                catch (...)
+                {
+                    // Swallow: page may have been torn down during dispatch.
+                }
+            });
+    }
+}
+
+void TerminalProtocolComServer::_dispatchAgentChipTargetToPage(const winrt::hstring& eventJson)
+{
+    if (!s_emperor)
+    {
+        return;
+    }
+    // Tab StableIds are unique across windows; fan out to every window's
+    // page and let _FindTabByStableId pick the right one (pages without
+    // a matching tab no-op the call). Same shape as the other dispatchers.
+    for (const auto& host : s_emperor->GetWindows())
+    {
+        auto page = _getPage(host.get());
+        if (!page)
+        {
+            continue;
+        }
+        const auto dispatcher = page.Dispatcher();
+        if (!dispatcher)
+        {
+            continue;
+        }
+        dispatcher.RunAsync(
+            winrt::Windows::UI::Core::CoreDispatcherPriority::Normal,
+            [page, eventJson]() {
+                try
+                {
+                    page.OnAgentChipTargetChanged(eventJson);
                 }
                 catch (...)
                 {

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.h
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.h
@@ -153,5 +153,11 @@ private:
     // `load_session` event back to the wta TUI for the new tab's StableId.
     static void _dispatchResumeInNewAgentTabToPage(const winrt::hstring& eventJson);
 
+    // Same shape, for {method:"set_agent_chip_target"} — helper-side
+    // override for which pane in a tab gets the "Agent" chip. With
+    // pane_session_id=null the tab reverts to the default
+    // source-of-agent driven chip.
+    static void _dispatchAgentChipTargetToPage(const winrt::hstring& eventJson);
+
     static WindowEmperor* s_emperor;
 };

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1108,6 +1108,14 @@ pub struct TabSession {
     pub selected_button: usize,
     pub rec_scroll: Scroll,
 
+    /// Last value the helper published for this tab in a
+    /// `set_agent_chip_target` event. `Some(pane_id)` means we last asked
+    /// C++ to pin the blue "Agent" chip onto that pane; `None` means we
+    /// last asked C++ to fall back to the source-of-agent flag. Used as a
+    /// dedupe key so we only fire an event when the effective chip target
+    /// actually changes.
+    pub last_emitted_chip_override: Option<String>,
+
 
     // Input editor state — per-tab so each tab keeps its own draft text,
     // cursor, and slash-command popup across switches.
@@ -1163,6 +1171,45 @@ impl TabSession {
         self.selected_recommendation = 0;
         self.selected_button = 0;
         self.rec_scroll.reset();
+    }
+
+    /// The pane the "Agent" chip should be pinned to while this tab has a
+    /// recommendation card with a `Send` action selected, or `None` when the
+    /// tab is not in that state. Returning `None` lets the C++ side fall
+    /// back to its default behavior (chip follows the source-of-agent flag).
+    ///
+    /// Resolution order for the pane id:
+    ///   1. `Send.parent` on the selected choice when non-empty.
+    ///   2. Autofix `target_pane_id` on the current prompt (for autofix
+    ///      turns where the recommendation's `Send.parent` is left blank
+    ///      and only gets filled at execute time — see `turn_execute_card`).
+    pub fn compute_chip_card_target(&self) -> Option<String> {
+        let recs = self.turn.recommendations()?;
+        let choice = recs.choices.get(self.selected_recommendation)?;
+        let send_parent = choice.actions.iter().find_map(|a| match a {
+            crate::coordinator::RecommendedAction::Send { parent, .. } if !parent.is_empty() => {
+                Some(parent.clone())
+            }
+            _ => None,
+        });
+        if send_parent.is_some() {
+            return send_parent;
+        }
+        // Autofix fallback: the autofix prompt's `target_pane_id` is what
+        // `turn_execute_card` will fill `Send.parent` with at execute time,
+        // so the chip should already point there now.
+        if choice
+            .actions
+            .iter()
+            .any(|a| matches!(a, crate::coordinator::RecommendedAction::Send { .. }))
+        {
+            return self
+                .turn
+                .prompt()
+                .and_then(|p| p.autofix.as_ref())
+                .map(|a| a.target_pane_id.clone());
+        }
+        None
     }
 
     pub fn clear_chat_history(&mut self) {
@@ -4557,6 +4604,10 @@ impl App {
                     self.current_tab_mut().selected_recommendation -= 1;
                     self.current_tab_mut().selected_button = self.default_button_for_selected();
                     self.scroll_rec_to_selected(self.main_area_width());
+                    // Selection moved — the new card may target a different
+                    // pane (or have no Send action), so re-pin the chip.
+                    let tab_id = self.active_tab_key().to_string();
+                    self.recompute_chip_override(&tab_id);
                 }
             }
             KeyCode::Down if self.current_tab().input.is_empty() && self.current_tab().turn.recommendations().is_some() => {
@@ -4571,6 +4622,8 @@ impl App {
                     self.current_tab_mut().selected_recommendation += 1;
                     self.current_tab_mut().selected_button = default_btn;
                     self.scroll_rec_to_selected(self.main_area_width());
+                    let tab_id = self.active_tab_key().to_string();
+                    self.recompute_chip_override(&tab_id);
                 }
             }
             // Wheel-as-arrow scroll fallback: when the input is empty and no
@@ -5266,6 +5319,16 @@ impl App {
         // and the agent bar shows "Agent sessions" while the TUI below
         // actually renders chat (or vice versa).
         self.project_active_tab_state();
+
+        // Push the new active tab's chip-target (or release it) so the C++
+        // side stops drawing the previous tab's override. Helpers are
+        // per-tab and the owner-lock guard above means we only reach here
+        // for our own owner tab, so this is just a re-publish — not a
+        // cross-tab decision.
+        let to_recompute = self.tab_id.clone();
+        if let Some(t) = to_recompute {
+            self.recompute_chip_override(&t);
+        }
     }
 
     /// Drop the per-tab state for a tab that WT has just destroyed. Removes
@@ -5895,6 +5958,10 @@ impl App {
         }
         self.push_execution_info(format!("Auto-executing choice {}.", choice_label));
         self.emit_autofix_state_cleared(&active_tab);
+        // Defensive: covers the fall-back path above where we dispatched the
+        // choice directly without going through `turn_execute_card`. The
+        // matched-path case already recomputes via that callee.
+        self.recompute_chip_override(&active_tab);
     }
 
     fn emit_autofix_state_cleared(&mut self, target_tab_id: &str) {
@@ -5954,6 +6021,36 @@ impl App {
         if target_tab_id == self.active_tab_key() {
             send_bar_event(&snapshot, Some(target_tab_id));
         }
+    }
+
+    /// Recompute the chip-target override for the tab and, if it changed
+    /// since the last emit, publish a `set_agent_chip_target` event so the
+    /// C++ side pins the "Agent" chip on the right pane (or releases it,
+    /// returning to source-of-agent driven rendering). Hooked at every
+    /// state-mutation point that could affect the result: surfacing a
+    /// recommendation, navigating between cards, executing/cancelling a
+    /// card, switching the active tab.
+    fn recompute_chip_override(&mut self, tab_id: &str) {
+        let new_target = self.tab_mut(tab_id).compute_chip_card_target();
+        let tab = self.tab_mut(tab_id);
+        if tab.last_emitted_chip_override == new_target {
+            return;
+        }
+        tab.last_emitted_chip_override = new_target.clone();
+        emit_agent_chip_target(tab_id, new_target.as_deref());
+    }
+
+    /// Publish the chip-target state for this tab unconditionally, even
+    /// when it matches the last value we emitted. Used at helper startup
+    /// (right after `tab_id` is seeded from `--owner-tab-id`) so the C++
+    /// side runs `_UpdateAgentChipVisibility` against the now-current
+    /// pane tree. Without this kick, the first-launch race where the
+    /// chip-visibility hook runs *before* `IsSourceOfAgentPane` is set
+    /// leaves the chip hidden until the user induces another transition.
+    pub fn recompute_chip_override_initial(&mut self, tab_id: &str) {
+        let new_target = self.tab_mut(tab_id).compute_chip_card_target();
+        self.tab_mut(tab_id).last_emitted_chip_override = new_target.clone();
+        emit_agent_chip_target(tab_id, new_target.as_deref());
     }
 
     fn armed_fix_preview(rec: &crate::coordinator::RecommendationSet) -> String {
@@ -6084,6 +6181,16 @@ impl App {
         tab.activity_frame = 0;
         tab.timing_note = None;
         tab.turn = TurnState::Submitted(prompt);
+
+        // Submitting a new prompt dismisses any prior leftover card (the
+        // `selected_recommendation = 0` + turn reset above). If the helper
+        // had pinned the chip onto that card's pane, release it now so the
+        // chip falls back to source-of-agent while the new turn is in
+        // flight. Note: this only matters for the new-turn case; the
+        // freshly-submitted autofix path overrides chip via the eventual
+        // `turn_surface_*` callback once recommendations arrive.
+        let owned_tab = tab_id.to_string();
+        self.recompute_chip_override(&owned_tab);
     }
 
     /// Observe a streamed chunk. Thought chunks only advance the state
@@ -6483,6 +6590,11 @@ impl App {
             outcome: TurnOutcome::Empty,
             end_pending,
         };
+
+        // Exiting Surfaced{Recommendation} — release any chip override the
+        // card had pinned. The C++ side falls back to source-of-agent.
+        let target_tab = self.tab_for_session(session_id);
+        self.recompute_chip_override(&target_tab);
     }
 
     /// User pressed Esc — cancel the in-flight turn. Bumps
@@ -6562,6 +6674,11 @@ impl App {
         tab.progress_status = None;
         tab.activity_frame = 0;
         tab.turn = TurnState::Idle;
+
+        // Esc on a Send card or in-flight autofix exits the chip-override
+        // state; release whatever the helper had pinned. C++ falls back to
+        // source-of-agent driven rendering.
+        self.recompute_chip_override(&target_tab);
     }
 
     // ── Internal surface helpers (shared between eager and end-of-turn). ──
@@ -6610,6 +6727,13 @@ impl App {
             outcome: TurnOutcome::Recommendation(recommendations),
             end_pending: true,
         };
+
+        // Entering Surfaced{Recommendation} with a Send card selected is
+        // the typing→card transition; ask C++ to pin the chip onto that
+        // card's target pane (or release it when the selected card has no
+        // Send action).
+        let target_tab = self.tab_for_session(session_id);
+        self.recompute_chip_override(&target_tab);
     }
 
     /// Surface an autofix Fix recommendation as an Armed card.
@@ -6664,6 +6788,11 @@ impl App {
             outcome: TurnOutcome::Recommendation(recommendations),
             end_pending: true,
         };
+
+        // Same handoff as `turn_surface_recommendation`: a fresh Send card
+        // is now selectable, pin the chip onto its target pane.
+        let target_tab = self.tab_for_session(session_id);
+        self.recompute_chip_override(&target_tab);
     }
 
     /// Surface an autofix Explain answer as a chat turn + bottom-bar
@@ -7113,6 +7242,22 @@ fn send_bar_event(snapshot: &AutofixBarSnapshot, tab_id: Option<&str>) {
             );
         }
     }
+    send_wt_protocol_event(evt.to_string());
+}
+
+/// Tell WT which pane in `tab_id` should display the blue "Agent" chip.
+/// `pane_session_id = None` releases the override and lets the C++ side
+/// fall back to its source-of-agent driven default. Fires per-tab; multiple
+/// helpers can publish independently and C++ routes each event by tab id.
+fn emit_agent_chip_target(tab_id: &str, pane_session_id: Option<&str>) {
+    let evt = serde_json::json!({
+        "type": "event",
+        "method": "set_agent_chip_target",
+        "params": {
+            "tab_id": tab_id,
+            "pane_session_id": pane_session_id,
+        }
+    });
     send_wt_protocol_event(evt.to_string());
 }
 

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1197,7 +1197,10 @@ impl TabSession {
         }
         // Autofix fallback: the autofix prompt's `target_pane_id` is what
         // `turn_execute_card` will fill `Send.parent` with at execute time,
-        // so the chip should already point there now.
+        // so the chip should already point there now. Filter out empty
+        // strings — the C++ side treats `pane_session_id == ""` as "no
+        // override", so emitting `Some("")` would let the helper's dedupe
+        // believe it pinned the chip while WT silently ignores the event.
         if choice
             .actions
             .iter()
@@ -1207,7 +1210,8 @@ impl TabSession {
                 .turn
                 .prompt()
                 .and_then(|p| p.autofix.as_ref())
-                .map(|a| a.target_pane_id.clone());
+                .map(|a| a.target_pane_id.clone())
+                .filter(|s| !s.is_empty());
         }
         None
     }
@@ -9810,6 +9814,178 @@ mod tests {
         assert_eq!(
             app.current_tab().chat_scroll.offset, 7,
             "command popup visibility must suppress the chat-scroll fallback",
+        );
+    }
+
+    // ─── compute_chip_card_target ───────────────────────────────────────────
+
+    /// Stage a tab into `Surfaced { Recommendation(...) }` with the given
+    /// choices and selected index. Mirrors the side-effects the real
+    /// `turn_surface_recommendation` would have but skips all the
+    /// chat-history / scroll bookkeeping so the resulting state stays
+    /// minimal for the chip-target calculator.
+    fn stage_surfaced_recommendation(
+        app: &mut App,
+        choices: Vec<crate::coordinator::RecommendationChoice>,
+        selected: usize,
+        autofix_target: Option<&str>,
+    ) {
+        let prompt = SubmittedPrompt {
+            id: 1,
+            text: "p".into(),
+            submitted_at_unix_s: 0.0,
+            autofix: autofix_target.map(|t| AutofixContext {
+                target_pane_id: t.into(),
+                generation: 0,
+            }),
+        };
+        let recs = crate::coordinator::RecommendationSet {
+            recommended_choice: Some(selected),
+            choices,
+        };
+        let tab = app.tab_mut(DEFAULT_TAB_ID);
+        tab.selected_recommendation = selected;
+        tab.turn = TurnState::Surfaced {
+            prompt,
+            outcome: TurnOutcome::Recommendation(recs),
+            end_pending: false,
+        };
+    }
+
+    fn send_choice(parent: &str, input: &str) -> crate::coordinator::RecommendationChoice {
+        crate::coordinator::RecommendationChoice {
+            choice: 1,
+            title: "Run".into(),
+            rationale: String::new(),
+            actions: vec![crate::coordinator::RecommendedAction::Send {
+                parent: parent.into(),
+                input: input.into(),
+            }],
+        }
+    }
+
+    fn open_choice() -> crate::coordinator::RecommendationChoice {
+        crate::coordinator::RecommendationChoice {
+            choice: 2,
+            title: "Open".into(),
+            rationale: String::new(),
+            actions: vec![crate::coordinator::RecommendedAction::Open {
+                target: crate::coordinator::OpenTarget::Tab,
+                parent: None,
+                cwd: None,
+                title: None,
+                direction: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn chip_target_returns_none_when_idle() {
+        let app = test_app();
+        assert_eq!(app.current_tab().compute_chip_card_target(), None);
+    }
+
+    #[test]
+    fn chip_target_uses_send_parent_when_set() {
+        let mut app = test_app();
+        stage_surfaced_recommendation(
+            &mut app,
+            vec![send_choice("pane-A", "ls")],
+            0,
+            None,
+        );
+        assert_eq!(
+            app.current_tab().compute_chip_card_target(),
+            Some("pane-A".to_string()),
+        );
+    }
+
+    #[test]
+    fn chip_target_falls_back_to_autofix_target_when_send_parent_empty() {
+        let mut app = test_app();
+        // Planner-emitted Send actions in autofix turns leave `parent`
+        // blank — `turn_execute_card` fills it from `target_pane_id` at
+        // execute time. The chip should already point there now.
+        stage_surfaced_recommendation(
+            &mut app,
+            vec![send_choice("", "fix --auto")],
+            0,
+            Some("pane-failing"),
+        );
+        assert_eq!(
+            app.current_tab().compute_chip_card_target(),
+            Some("pane-failing".to_string()),
+        );
+    }
+
+    #[test]
+    fn chip_target_filters_empty_autofix_target() {
+        // C++ treats `pane_session_id == ""` as "no override", so emitting
+        // Some("") would let the helper's dedupe believe it pinned the chip
+        // while WT silently ignores the event.
+        let mut app = test_app();
+        stage_surfaced_recommendation(
+            &mut app,
+            vec![send_choice("", "fix")],
+            0,
+            Some(""),
+        );
+        assert_eq!(app.current_tab().compute_chip_card_target(), None);
+    }
+
+    #[test]
+    fn chip_target_is_none_for_non_send_card() {
+        let mut app = test_app();
+        stage_surfaced_recommendation(&mut app, vec![open_choice()], 0, None);
+        assert_eq!(app.current_tab().compute_chip_card_target(), None);
+    }
+
+    #[test]
+    fn chip_target_tracks_selected_index() {
+        let mut app = test_app();
+        stage_surfaced_recommendation(
+            &mut app,
+            vec![send_choice("pane-A", "ls"), send_choice("pane-B", "pwd")],
+            0,
+            None,
+        );
+        assert_eq!(
+            app.current_tab().compute_chip_card_target(),
+            Some("pane-A".to_string()),
+        );
+        app.current_tab_mut().selected_recommendation = 1;
+        assert_eq!(
+            app.current_tab().compute_chip_card_target(),
+            Some("pane-B".to_string()),
+        );
+    }
+
+    #[test]
+    fn chip_recompute_dedupes_and_releases_on_idle() {
+        // After surfacing a Send card, recompute should record an override.
+        // Transitioning back to Idle (here: clear the recs) should make
+        // the next recompute observe a different value and clear the
+        // last_emitted slot.
+        let mut app = test_app();
+        stage_surfaced_recommendation(
+            &mut app,
+            vec![send_choice("pane-A", "ls")],
+            0,
+            None,
+        );
+        app.recompute_chip_override(DEFAULT_TAB_ID);
+        assert_eq!(
+            app.tab_mut(DEFAULT_TAB_ID).last_emitted_chip_override,
+            Some("pane-A".to_string()),
+        );
+
+        // Drop the surfaced state — chip target now resolves to None and
+        // the dedupe slot must follow so a fresh surface re-emits cleanly.
+        app.tab_mut(DEFAULT_TAB_ID).turn = TurnState::Idle;
+        app.recompute_chip_override(DEFAULT_TAB_ID);
+        assert_eq!(
+            app.tab_mut(DEFAULT_TAB_ID).last_emitted_chip_override,
+            None,
         );
     }
 }

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2129,7 +2129,19 @@ async fn run_acp_app(
                     // (pre-warm path) where C++ has already stashed the
                     // pane — see comment on the earlier seed block.
                     tab.pane_open = !cli.start_stashed;
-                    app_state.tab_id = Some(owner_tab_id);
+                    app_state.tab_id = Some(owner_tab_id.clone());
+
+                    // Publish an initial chip-target state for this tab so
+                    // the C++ side can sync regardless of which transitions
+                    // it has seen so far. At startup no Send card is
+                    // selected, so the published target is `None` — i.e.
+                    // "release any override, fall back to the source-of-
+                    // agent flag". This is harmless when the C++ side is
+                    // already in that state and load-bearing in the race
+                    // where the agent pane was just restored from a stash
+                    // and the chip-visibility hook on the C++ side hasn't
+                    // run with the right `previousActive` yet.
+                    app_state.recompute_chip_override_initial(&owner_tab_id);
                 }
             }
 


### PR DESCRIPTION
## Summary

Shows a small blue "Agent" pill in the bottom-right of whichever terminal pane the agent pane is currently working against, so the user can see at a glance where context will be pulled from / where a Send recommendation will execute.

Two mutually-exclusive modes, both pointing at the same chip slot:

- **Typing** → chip follows `IsSourceOfAgentPane()`, the same flag `GetActivePane()` uses to resolve the context-pull target. C++ self-drives — no helper round-trip. Chip and context-pull target are always the same pane by construction.
- **Send card selected** → chip is pinned onto the action's target pane via a new `set_agent_chip_target` event from the helper. Resolution order: `Send.parent`, with `AutofixContext.target_pane_id` as the autofix-turn fallback for cards whose `parent` is filled at execute time.

## Notable fixes folded in

- `Tab::RestoreStashedAgentPane`: the explicit `_UpdateActivePane(agentPane)` after `FocusPane` was wiping the `IsSourceOfAgentPane` flag that `_Focus`→`GotFocus`→handler had *just* set synchronously. `ClearActive()` ran in the second call, and the re-set condition requires `previousActive` to be the non-agent pane — which it isn't anymore. Skip the redundant call when `_activePane == agentPane`. Without this the chip vanished on every toggle-open.
- `Tab::SetAgentChipOverride` always recomputes (no equal-value early-return), so a redundant helper event still triggers `_UpdateAgentChipVisibility` to walk the tree.
- Override is cleared on agent-pane stash and Ctrl+C×2 destroy so the chip can't stay pinned by a hidden/dead helper.

## Helper-side hooks

Every transition into/out of \`Surfaced{Recommendation}\` and every selection move within it:
\`turn_surface_recommendation\`, \`turn_surface_fix\`, \`turn_execute_card\`, \`turn_cancel\`, \`turn_submit_prompt\`, Up/Down handlers, \`switch_tab_session\`, and the \`handle_autofix_execute_request\` fallback. A diff against \`last_emitted_chip_override\` dedupes so events only fire on real changes.

An unconditional initial emit fires once on helper startup (right after \`--owner-tab-id\` is seeded) to kick C++ into recomputing against the now-current pane tree.

## Test plan

- [ ] Single tab, agent pane + 1 shell: focus shell → toggle agent open → chip on shell.
- [ ] Multi shell panes: alternate focus shell1 ↔ shell2, return to agent → chip tracks last-focused non-agent pane.
- [ ] Autofix: fail a command in shell, agent surfaces a Send card → chip pins on that shell (even if focus is elsewhere); Esc → chip falls back to source-flag mode.
- [ ] Up/Down between cards with different `Send.parent` → chip moves accordingly; navigate to a non-Send card → chip hides.
- [ ] Two windows each with an agent pane → fully isolated; events from one helper never affect the other.
- [ ] Close the agent pane (Ctrl+C×2 or tab close) → chip disappears, no orphan render.
- [ ] First launch (cold WT, toggle open agent pane via hotkey) → chip appears on shell on first focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)