### PR TITLE
Settings > Agents + About: switch links to aka.ms/intelligent-terminal*

### DIFF
--- a/src/cascadia/TerminalApp/AboutDialog.xaml
+++ b/src/cascadia/TerminalApp/AboutDialog.xaml
@@ -53,15 +53,14 @@
 
         <StackPanel Margin="-12,0,0,0"
                     Orientation="Vertical">
-            <!-- TODO(IntelligentTerminal): register these URLs on the aka.ms portal. -->
             <HyperlinkButton x:Uid="AboutDialog_SourceCodeLink"
-                             NavigateUri="https://aka.ms/intelligentterminal/source" />
+                             NavigateUri="https://aka.ms/intelligent-terminal" />
             <HyperlinkButton x:Uid="AboutDialog_DocumentationLink"
-                             NavigateUri="https://aka.ms/intelligentterminal/docs" />
+                             NavigateUri="https://aka.ms/intelligent-terminal" />
             <HyperlinkButton x:Uid="AboutDialog_ReleaseNotesLink"
-                             NavigateUri="https://aka.ms/intelligentterminal/releasenotes" />
+                             NavigateUri="https://aka.ms/intelligent-terminal-releases" />
             <HyperlinkButton x:Uid="AboutDialog_PrivacyPolicyLink"
-                             NavigateUri="https://aka.ms/intelligentterminal/privacy" />
+                             NavigateUri="https://aka.ms/intelligent-terminal-privacy" />
             <HyperlinkButton x:Uid="AboutDialog_ThirdPartyNoticesLink"
                              Click="_ThirdPartyNoticesOnClick" />
         </StackPanel>

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.cpp
@@ -2,6 +2,12 @@
 // Licensed under the MIT license.
 
 #include "pch.h"
+
+// The agent page subtitle uses inline <Run> + <Hyperlink> elements; we
+// populate their Text from code-behind because x:Uid on inline Run is not
+// reliably honored by ResourceLoader in this UWP/WinUI 2 build.
+#include <winrt/Windows.UI.Xaml.Documents.h>
+
 #include "AIAgents.h"
 #include "AIAgents.g.cpp"
 
@@ -13,6 +19,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     AIAgents::AIAgents()
     {
         InitializeComponent();
+
+        PageSubtitlePrefix().Text(RS_(L"AIAgents_PageSubtitlePrefix"));
+        PageSubtitlePrivacyLink().Text(RS_(L"AIAgents_PageSubtitlePrivacyLink"));
     }
 
     void AIAgents::OnNavigatedTo(const NavigationEventArgs& e)

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -42,11 +42,16 @@
                   Settings BreadcrumbBar from Nav_AIAgents.Content, so we only
                   add the subtitle below it here. The inline Run/Hyperlink
                   text is populated from the ResourceLoader in code-behind
-                  (x:Uid on inline Run is not honored in this codebase).  -->
-            <TextBlock Opacity="0.7"
-                       Margin="0,0,0,16"
+                  (x:Uid on inline Run is not honored in this codebase).
+                  The muted "secondary" foreground is applied only to the
+                  non-link Runs so the Hyperlink keeps its full theme
+                  accent contrast (and its hover/pressed affordance).  -->
+            <TextBlock Margin="0,0,0,16"
                        TextWrapping="Wrap">
-                <Run x:Name="PageSubtitlePrefix" Text="" /><Run Text=" " /><Hyperlink NavigateUri="https://aka.ms/intelligent-terminal-privacy">
+                <Run x:Name="PageSubtitlePrefix"
+                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                     Text="" /><Run Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Text=" " /><Hyperlink NavigateUri="https://aka.ms/intelligent-terminal-privacy">
                     <Run x:Name="PageSubtitlePrivacyLink" Text="" />
                 </Hyperlink>
             </TextBlock>

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -40,10 +40,16 @@
 
             <!--  Page subtitle. The page title itself is rendered by the
                   Settings BreadcrumbBar from Nav_AIAgents.Content, so we only
-                  add the subtitle below it here.  -->
-            <TextBlock x:Uid="AIAgents_PageSubtitle"
-                       Opacity="0.7"
-                       Margin="0,0,0,16" />
+                  add the subtitle below it here. The inline Run/Hyperlink
+                  text is populated from the ResourceLoader in code-behind
+                  (x:Uid on inline Run is not honored in this codebase).  -->
+            <TextBlock Opacity="0.7"
+                       Margin="0,0,0,16"
+                       TextWrapping="Wrap">
+                <Run x:Name="PageSubtitlePrefix" Text="" /><Run Text=" " /><Hyperlink NavigateUri="https://aka.ms/intelligent-terminal-privacy">
+                    <Run x:Name="PageSubtitlePrivacyLink" Text="" />
+                </Hyperlink>
+            </TextBlock>
 
             <!--  ═══ Agent pane group ═══
                   First sub-header on the page: override the style's 32px

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -697,13 +697,9 @@
     <value>Agents</value>
     <comment>Header for the "Agents" menu item. This navigates to a page that lets you configure AI agent integration settings.</comment>
   </data>
-  <!--  Deprecated: superseded by AIAgents_PageSubtitlePrefix +
-        AIAgents_PageSubtitlePrivacyLink. Kept solely so the orphaned
-        translations in the other locale resw files have a neutral
-        fallback and PRI263 doesn't warn. Safe to delete once those
-        translations are cleaned up.  -->
   <data name="AIAgents_PageSubtitle.Text" xml:space="preserve">
     <value>Configure how agents work across your terminal experience</value>
+    <comment>DEPRECATED — do not translate. Superseded by AIAgents_PageSubtitlePrefix + AIAgents_PageSubtitlePrivacyLink. Kept in en-US only as a neutral fallback for the not-yet-updated translations in the other locale resw files (without it, PRI263 warns about a missing neutral resource). Safe to delete once those translations are cleaned up.</comment>
   </data>
   <data name="AIAgents_PageSubtitlePrefix" xml:space="preserve">
     <value>Configure how agents work across your terminal experience.</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -697,9 +697,21 @@
     <value>Agents</value>
     <comment>Header for the "Agents" menu item. This navigates to a page that lets you configure AI agent integration settings.</comment>
   </data>
+  <!--  Deprecated: superseded by AIAgents_PageSubtitlePrefix +
+        AIAgents_PageSubtitlePrivacyLink. Kept solely so the orphaned
+        translations in the other locale resw files have a neutral
+        fallback and PRI263 doesn't warn. Safe to delete once those
+        translations are cleaned up.  -->
   <data name="AIAgents_PageSubtitle.Text" xml:space="preserve">
     <value>Configure how agents work across your terminal experience</value>
-    <comment>Subtitle shown beneath the page title on the AI Agents settings page.</comment>
+  </data>
+  <data name="AIAgents_PageSubtitlePrefix" xml:space="preserve">
+    <value>Configure how agents work across your terminal experience.</value>
+    <comment>Subtitle shown beneath the page title on the AI Agents settings page. The hyperlink in AIAgents_PageSubtitlePrivacyLink follows this sentence inline; the trailing period belongs to this prefix.</comment>
+  </data>
+  <data name="AIAgents_PageSubtitlePrivacyLink" xml:space="preserve">
+    <value>Learn about how data is used.</value>
+    <comment>Inline hyperlink text that follows the AI Agents page subtitle and navigates to the privacy policy page. Includes a trailing period.</comment>
   </data>
   <data name="AIAgents_AcpGroupHeader.Text" xml:space="preserve">
     <value>Agent pane</value>


### PR DESCRIPTION
## Summary
- Settings > Agents page subtitle now reads `Configure how agents work across your terminal experience. Learn about how data is used.` — the second sentence is an inline hyperlink to `https://aka.ms/intelligent-terminal-privacy`.
- About dialog hyperlinks switched from `aka.ms/intelligentterminal/*` (no dash) to the new `aka.ms/intelligent-terminal*` (with dash) URLs:
  - Source code → `https://aka.ms/intelligent-terminal`
  - Documentation → `https://aka.ms/intelligent-terminal`
  - Release notes → `https://aka.ms/intelligent-terminal-releases`
  - Privacy policy → `https://aka.ms/intelligent-terminal-privacy`
  - Third-Party notices: unchanged
- Stale `TODO(IntelligentTerminal): register these URLs on the aka.ms portal.` comment removed.

## Implementation notes
- The inline `<Run>` + `<Hyperlink>` text is populated from `AIAgents::AIAgents()` via `RS_(...)` — `x:Uid` on inline `<Run>` is not honored reliably in this WinUI 2 build (same pattern used by `FreOverlay.xaml`).
- Two new en-US resw keys (`AIAgents_PageSubtitlePrefix`, `AIAgents_PageSubtitlePrivacyLink`). The old `AIAgents_PageSubtitle.Text` key is kept in en-US only as a neutral fallback for the still-localized translations in the other locale resw files — silences PRI263 and can be removed once those translations are cleaned up.

## Test plan
- [ ] Open Settings → Agents and confirm the subtitle reads "Configure how agents work across your terminal experience. Learn about how data is used." with the second sentence styled as a hyperlink.
- [ ] Click the link and confirm it opens `https://aka.ms/intelligent-terminal-privacy` in the browser.
- [ ] Open the About dialog and confirm each of Source code / Documentation / Release notes / Privacy policy navigates to the correct new aka.ms URL.
- [ ] Third-Party notices link still opens the in-app notices flow (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)