### PR TITLE
agent pane: reuse FreOverlay_AgentLabel.Text for the chip

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -3399,7 +3399,7 @@ void Pane::_EnsureAgentChip()
     }
 
     Controls::TextBlock text{};
-    text.Text(RS_(L"Pane_AgentChipText"));
+    text.Text(RS_(L"FreOverlay_AgentLabel.Text"));
     text.FontSize(10.0);
     text.FontWeight(winrt::Windows::UI::Text::FontWeights::SemiBold());
     text.Foreground(Media::SolidColorBrush{ winrt::Windows::UI::Colors::White() });

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -3399,7 +3399,7 @@ void Pane::_EnsureAgentChip()
     }
 
     Controls::TextBlock text{};
-    text.Text(RS_(L"FreOverlay_AgentLabel.Text"));
+    text.Text(RS_(L"FreOverlay_AgentLabel/Text"));
     text.FontSize(10.0);
     text.FontWeight(winrt::Windows::UI::Text::FontWeights::SemiBold());
     text.Foreground(Media::SolidColorBrush{ winrt::Windows::UI::Colors::White() });

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1191,8 +1191,4 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
-  <data name="Pane_AgentChipText" xml:space="preserve">
-    <value>Agent</value>
-    <comment>Short label shown in a small corner chip on the terminal pane the AI agent is about to act on. Keep very short — the chip is small. In this context, "agent" refers to an AI agent.</comment>
-  </data>
 </root>


### PR DESCRIPTION
## Summary
- The "Agent" chip resource (`Pane_AgentChipText`) added in #87 only existed in `en-US/Resources.resw`, so non-English users would see the English fallback.
- `FreOverlay_AgentLabel.Text` already ships across every locale with the same word ("Agent") and the same disambiguation comment (AI agent, not human).
- Point `Pane.cpp` at the existing localized key and remove the duplicate string. Follow-up to PR feedback on #87.

## Test plan
- [ ] Build Terminal, open an agent pane, confirm the chip still renders "Agent" in en-US.
- [ ] Switch the OS display language to one of the localized locales (e.g. ja-JP, de-DE) and confirm the chip picks up the localized string instead of falling back to English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)