### PR TITLE
agent pane: Suggested-state diagnostics button opens the agent pane

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1934,9 +1934,8 @@ namespace winrt::TerminalApp::implementation
             // Suggested has no executable action — the explanation lives in
             // the chat history. The user's click means "show me what's
             // wrong", so ensure the pane is visible in chat view. The pane
-            // may be stashed, currently in sessions view, or even absent
-            // (the bar caches autofix state across stash), so handle all
-            // three before dismissing the bar indicator.
+            // may be stashed or currently in sessions view, so handle both
+            // before dismissing the bar indicator.
             const auto agentPane = activeTab->FindAgentPane();
             if (agentPane && !agentPane->IsHidden())
             {

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1931,8 +1931,27 @@ namespace winrt::TerminalApp::implementation
         }
         case AS::Suggested:
         {
-            // Ask wta to clear the suggestion — the agent pane is already
-            // open by virtue of having a non-Idle autofix state.
+            // Suggested has no executable action — the explanation lives in
+            // the chat history. The user's click means "show me what's
+            // wrong", so ensure the pane is visible in chat view. The pane
+            // may be stashed, currently in sessions view, or even absent
+            // (the bar caches autofix state across stash), so handle all
+            // three before dismissing the bar indicator.
+            const auto agentPane = activeTab->FindAgentPane();
+            if (agentPane && !agentPane->IsHidden())
+            {
+                if (agentContent.IsSessionsView())
+                {
+                    _RequestAgentStateForTab(activeTab, "chat", std::nullopt);
+                }
+            }
+            else
+            {
+                _OpenOrReuseAgentPane(/*intoSessionsView*/ false, L"AutofixSuggestion");
+            }
+
+            // Now that the user is reading the explanation in the pane,
+            // drop the bar's Suggested indicator.
             Json::Value evt;
             evt["type"] = "event";
             evt["method"] = "autofix_dismiss_suggestion";


### PR DESCRIPTION
## Summary

- In the `Suggested` autofix state the bottom-bar diagnostics button had no executable action (the explanation lives in the chat history, not as a runnable fix). The handler just sent `autofix_dismiss_suggestion`, which felt like a dead click — the user couldn't see *what* problem was found without manually opening the pane.
- Now the click ensures the agent pane is visible in **chat view** so the user lands directly on the explanation. Handles all three starting states:
  - pane stashed or absent → `_OpenOrReuseAgentPane(false, …)` restores or creates
  - pane visible in sessions view → `_RequestAgentStateForTab(activeTab, "chat", …)` switches view
  - pane already visible in chat → no-op (don't toggle it closed)
- After surfacing the pane, still emits `autofix_dismiss_suggestion` so the bar's yellow "Suggestion ready" pill clears (the user is now reading the explanation in-pane).

## Test plan

- [ ] Trigger an autofix that resolves to a Suggested (Explain) outcome, ensure the agent pane is visible in chat view, click the Suggested pill: pane stays in chat, bar pill clears.
- [ ] Same scenario but stash the agent pane first (Ctrl+Shift+.) before clicking the pill: pane un-stashes into chat view, bar pill clears.
- [ ] Same scenario but flip the pane into sessions view before clicking: pane switches back to chat view, bar pill clears.
- [ ] Verify `Detected` and `Armed` clicks still behave as before (execute / arm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)