### PR TITLE
agent pane: /restart command

### DIFF
--- a/src/cascadia/TerminalApp/SharedWta.cpp
+++ b/src/cascadia/TerminalApp/SharedWta.cpp
@@ -113,9 +113,24 @@ namespace winrt::TerminalApp::implementation
             return true;
         }
 
+        // Dedup the multi-window fan-out. `/restart` arrives via
+        // `_dispatchRestartAgentStackToPage`, which calls
+        // `OnRestartAgentStackRequested` (and thus `Restart()`) on EVERY
+        // window's UI thread. Without this guard, window B's Restart kills
+        // window A's just-spawned master, breaking the freshly-reopened
+        // helper in window A. 500 ms is comfortably larger than the typical
+        // UI-thread RunAsync hop (the 07:32 log showed a 240 ms gap between
+        // windows) and tiny compared to any human-driven legitimate "two
+        // restarts in a row".
+        if (_lastRespawn &&
+            std::chrono::steady_clock::now() - *_lastRespawn < std::chrono::milliseconds(500))
+        {
+            return true;
+        }
+
         // No cached args means we've never successfully spawned in this
         // process, which contradicts `_process.is_valid()` — defensive
-        // bail rather than _SpawnLocked'ing with empty wtaPath.
+        // bail rather than spawning with empty wtaPath.
         if (_cachedWtaPath.empty())
         {
             return false;
@@ -298,12 +313,18 @@ namespace winrt::TerminalApp::implementation
         // back to "no wta" so the next AcquirePane respawns. Set up
         // BEFORE ResumeThread so the wait is in place by the time
         // the child actually starts running.
+        //
+        // Context is the PID, not a `this` pointer. The callback
+        // dispatches via `Instance()` and uses the captured PID to
+        // detect a stale registration (see `_OnProcessExited`'s
+        // mismatch bail). Casting via `uintptr_t` is the canonical
+        // PVOID-as-integer round trip.
         HANDLE waitHandle = nullptr;
         if (!RegisterWaitForSingleObject(
                 &waitHandle,
                 process.get(),
                 &SharedWta::_OnProcessExitedThunk,
-                this,
+                reinterpret_cast<PVOID>(static_cast<uintptr_t>(pid)),
                 INFINITE,
                 WT_EXECUTEONLYONCE))
         {
@@ -329,6 +350,7 @@ namespace winrt::TerminalApp::implementation
         // leave the previous cache intact.
         _cachedWtaPath.assign(wtaPath);
         _cachedExtraArgs.assign(extraArgs.begin(), extraArgs.end());
+        _lastRespawn = std::chrono::steady_clock::now();
         return true;
     }
 
@@ -352,10 +374,15 @@ namespace winrt::TerminalApp::implementation
 
     void CALLBACK SharedWta::_OnProcessExitedThunk(PVOID context, BOOLEAN /*timedOut*/)
     {
-        static_cast<SharedWta*>(context)->_OnProcessExited();
+        // `context` is the PID at registration time, packed via
+        // `reinterpret_cast<PVOID>(static_cast<uintptr_t>(pid))`. Round
+        // trip back and let `_OnProcessExited` compare against the
+        // currently-registered PID to detect a stale callback.
+        const auto observedPid = static_cast<DWORD>(reinterpret_cast<uintptr_t>(context));
+        SharedWta::Instance()._OnProcessExited(observedPid);
     }
 
-    void SharedWta::_OnProcessExited()
+    void SharedWta::_OnProcessExited(DWORD observedPid)
     {
         // Runs on a Win32 thread-pool thread. wta has exited (crash,
         // OOM, manual kill). Clear our process record so the next
@@ -364,6 +391,19 @@ namespace winrt::TerminalApp::implementation
         // ReleasePane (which will then no-op the cleanup since
         // _process is already invalid).
         std::lock_guard lock{ _mtx };
+
+        // Stale-callback bail. `_CleanupLocked` only does a non-blocking
+        // `UnregisterWaitEx(nullptr)`, so a callback that was already
+        // queued for the OLD master can still fire after `_SpawnLocked`
+        // has installed a NEW master. The captured PID lets us tell:
+        // when it doesn't match the live `_pid`, the callback is for
+        // a previously-killed master and must not touch `_process` /
+        // `_waitHandle` (which now belong to the new master).
+        if (_pid != observedPid)
+        {
+            return;
+        }
+
         if (!_process.is_valid())
         {
             // Race: Release already cleaned up before our callback

--- a/src/cascadia/TerminalApp/SharedWta.cpp
+++ b/src/cascadia/TerminalApp/SharedWta.cpp
@@ -101,6 +101,68 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
+    bool SharedWta::Restart()
+    {
+        std::lock_guard lock{ _mtx };
+
+        // Nothing running → nothing to restart. Caller's surrounding
+        // teardown+reopen path will trigger the usual lazy `AcquirePane`
+        // spawn anyway, so this is a benign no-op (not an error).
+        if (!_process.is_valid())
+        {
+            return true;
+        }
+
+        // No cached args means we've never successfully spawned in this
+        // process, which contradicts `_process.is_valid()` — defensive
+        // bail rather than _SpawnLocked'ing with empty wtaPath.
+        if (_cachedWtaPath.empty())
+        {
+            return false;
+        }
+
+        // Drop the Job first so KILL_ON_JOB_CLOSE reaps the old master +
+        // every agent CLI descendant, then respawn under the same
+        // _masterPipeName. Any helper that's about to be torn down (the
+        // /restart caller closes every agent pane) sees its pipe go EOF
+        // and exits naturally; any helper that races a reconnect against
+        // the respawn finds the new master listening on the same name.
+        // Refcount is left untouched on purpose — the caller is still
+        // holding refs for the panes it's about to close-and-reopen, and
+        // the matching ReleasePane / AcquirePane pair will balance out.
+        _CleanupLocked();
+        return _SpawnLocked(std::wstring_view{ _cachedWtaPath }, _cachedExtraArgs);
+    }
+
+    bool SharedWta::Restart(const std::wstring_view wtaPath,
+                            std::span<const std::wstring> extraArgs)
+    {
+        if (wtaPath.empty())
+        {
+            return false;
+        }
+
+        std::lock_guard lock{ _mtx };
+
+        // Nothing live to replace (e.g. settings changed while no pane
+        // was open in any window). The next AcquirePane will _SpawnLocked
+        // with freshly-built args anyway, so we don't need to touch the
+        // cache here.
+        if (!_process.is_valid())
+        {
+            return true;
+        }
+
+        // Respawn the master with the *new* args so the running agent
+        // CLI is replaced with whatever the new settings demand. The
+        // surrounding `_RebuildAgentStack` flow has already torn down
+        // every agent pane in this window and is about to reopen one;
+        // refcount is left alone for the same reason as the cached-args
+        // overload — outgoing ReleasePane / incoming AcquirePane balance.
+        _CleanupLocked();
+        return _SpawnLocked(wtaPath, extraArgs);
+    }
+
     bool SharedWta::_SpawnLocked(const std::wstring_view wtaPath,
                                  std::span<const std::wstring> extraArgs)
     {
@@ -259,6 +321,14 @@ namespace winrt::TerminalApp::implementation
         _job = std::move(job);
         _pid = pid;
         _waitHandle = waitHandle;
+
+        // Cache the spawn inputs so `Restart()` can replay them. Overwrites
+        // any prior cache: if a respawn after crash used different
+        // settings (none today, but the path is here), the most recent
+        // wins. Done at the very end so partial-failure paths above
+        // leave the previous cache intact.
+        _cachedWtaPath.assign(wtaPath);
+        _cachedExtraArgs.assign(extraArgs.begin(), extraArgs.end());
         return true;
     }
 

--- a/src/cascadia/TerminalApp/SharedWta.h
+++ b/src/cascadia/TerminalApp/SharedWta.h
@@ -25,10 +25,13 @@
 // helpers can reconnect.
 
 #include <atomic>
+#include <chrono>
 #include <mutex>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include <wil/resource.h>
 
@@ -148,9 +151,16 @@ namespace winrt::TerminalApp::implementation
         void _CleanupLocked();
 
         // Wait-callback bridge — `RegisterWaitForSingleObject` requires
-        // a free function. The thunk dispatches to the instance method.
+        // a free function. The `context` PVOID carries the PID this
+        // wait was registered for (not a `this` pointer — the singleton
+        // is reached via `Instance()`), so the callback can detect a
+        // stale registration after `_CleanupLocked` + `_SpawnLocked`
+        // replaced the master out from under it. Without that check,
+        // a delayed callback for the OLD master would null out the
+        // *new* master's `_process` / `_waitHandle` and silently break
+        // crash detection.
         static void CALLBACK _OnProcessExitedThunk(PVOID context, BOOLEAN timedOut);
-        void _OnProcessExited();
+        void _OnProcessExited(DWORD observedPid);
 
         mutable std::mutex _mtx;
         wil::unique_handle _process;
@@ -170,5 +180,14 @@ namespace winrt::TerminalApp::implementation
         // agent pane. Empty when no successful spawn has happened.
         std::wstring _cachedWtaPath;
         std::vector<std::wstring> _cachedExtraArgs;
+        // Wall-clock-ish stamp of the most recent successful spawn.
+        // Used by the no-arg `Restart()` to dedup the fan-out from
+        // `_dispatchRestartAgentStackToPage`: every open window's
+        // `OnRestartAgentStackRequested` calls `Restart()` on its own
+        // UI thread, and without dedup they sequentially kill each
+        // other's freshly-spawned masters. A short time window is
+        // enough because the fan-out runs in tight succession on
+        // adjacent UI-thread ticks.
+        std::optional<std::chrono::steady_clock::time_point> _lastRespawn;
     };
 }

--- a/src/cascadia/TerminalApp/SharedWta.h
+++ b/src/cascadia/TerminalApp/SharedWta.h
@@ -79,6 +79,38 @@ namespace winrt::TerminalApp::implementation
         /// teardown paths that aren't sure whether they acquired).
         void ReleasePane();
 
+        /// Force-restart the wta-master process, bypassing the
+        /// `AcquirePane`/`ReleasePane` reference count. Used by the
+        /// `/restart` slash command path: the caller (TerminalPage)
+        /// tears down every agent pane around this call, so the
+        /// refcount-based teardown isn't enough — there may be other
+        /// panes' Closed handlers that have yet to fire. After this
+        /// returns, the next `AcquirePane` finds a fresh master
+        /// listening on the same `_masterPipeName` (intentionally
+        /// stable across respawns so any helpers spawned with the old
+        /// cmdline can still find it).
+        ///
+        /// Replays the `wtaPath` + `extraArgs` cached from the first
+        /// successful spawn so the new master inherits the same
+        /// per-process settings as the one being replaced. This makes
+        /// `/restart` semantically "give me the same agent CLI but
+        /// fresh".
+        ///
+        /// Settings changes (acpAgent / acpModel / etc.) need to spawn
+        /// the master with a *different* cmdline. For that case, call
+        /// the overload that takes a fresh `wtaPath` + `extraArgs` —
+        /// it replaces the cached spawn args before respawning, so
+        /// the new master inherits the new per-process settings and
+        /// any subsequent crash-recovery respawn uses the same.
+        ///
+        /// No-op if the master isn't running, or if there were no
+        /// cached spawn args (no AcquirePane has succeeded this
+        /// process) and no fresh args were supplied. Returns true on
+        /// successful respawn or no-op.
+        bool Restart();
+        bool Restart(const std::wstring_view wtaPath,
+                     std::span<const std::wstring> extraArgs);
+
         /// Whether wta is currently spawned. Becomes false after a
         /// crash is observed by the wait callback, or after the last
         /// pane releases.
@@ -131,5 +163,12 @@ namespace winrt::TerminalApp::implementation
         // helpers spawned with stale cmdline can still find the
         // currently-live master.
         std::wstring _masterPipeName;
+        // Cached cmdline inputs from the most recent successful
+        // `_SpawnLocked`. Replayed verbatim by `Restart()` so the
+        // refreshed master inherits the per-process settings that
+        // were in effect when this Terminal process first booted an
+        // agent pane. Empty when no successful spawn has happened.
+        std::wstring _cachedWtaPath;
+        std::vector<std::wstring> _cachedExtraArgs;
     };
 }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1466,6 +1466,47 @@ namespace winrt::TerminalApp::implementation
             winrt::to_hstring(Json::writeString(wb, evt)));
     }
 
+    // Builds the per-process flag/value pairs that wta-master inherits
+    // at spawn time. Single source of truth so the first-acquire path
+    // (`_AutoCreateHiddenAgentPaneShared`) and the settings-change-
+    // driven respawn path (`_RebuildAgentStack` → `SharedWta::Restart`)
+    // stay in sync. Each pair is pushed as two separate vector elements
+    // so SharedWta can apply its own Windows command-line quoting.
+    std::vector<std::wstring> TerminalPage::_BuildSharedWtaExtraArgs()
+    {
+        const auto& globals = _settings.GlobalSettings();
+        // Resolved here (not on the caller side) so the Restart path
+        // doesn't have to duplicate the lookup. `agentCliPath` may be
+        // empty when no agent CLI is detected but policy doesn't actively
+        // block — pass through anyway; wta will surface the failure to
+        // spawn the child as an ACP error.
+        const auto agentCliPath = _ResolveEffectiveAgentCliPath(globals, [this]() { return _DetectAgentCli(); });
+
+        std::vector<std::wstring> extraArgs;
+        const auto pushFlagValue = [&extraArgs](const std::wstring_view flag, const std::wstring_view value) {
+            if (value.empty())
+            {
+                return;
+            }
+            extraArgs.emplace_back(flag);
+            extraArgs.emplace_back(value);
+        };
+        pushFlagValue(L"--agent", agentCliPath);
+        pushFlagValue(L"--agent-id", globals.EffectiveAcpAgent());
+        if (!globals.EffectiveAutoFixEnabled())
+        {
+            extraArgs.emplace_back(L"--no-autofix");
+        }
+        if (const auto lang = _ResolveEffectiveLanguage(globals); !lang.empty())
+        {
+            pushFlagValue(L"--language", lang);
+        }
+        pushFlagValue(L"--acp-model", globals.AcpModel());
+        pushFlagValue(L"--delegate-agent", _ResolveEffectiveDelegateAgent(globals));
+        pushFlagValue(L"--delegate-model", globals.DelegateModel());
+        return extraArgs;
+    }
+
     // Helper+master agent-pane creation. The C++ side spawns one wta-helper as
     // a regular conpty child per agent pane; SharedWta owns the singleton
     // wta-master process that the helpers connect to over a named pipe (helper
@@ -1510,38 +1551,12 @@ namespace winrt::TerminalApp::implementation
 
         // Build the per-process settings the master will inherit.
         // These are baked at first-spawn time only; subsequent acquires
-        // reuse the same master. Runtime changes flow over event channels
-        // (`autofix_enabled_changed` is the existing one).
-        //
-        // Push as tokenized flag/value pairs; SharedWta handles all
-        // Windows command-line quoting via QuoteAndEscapeCommandlineArg.
-        std::vector<std::wstring> extraArgs;
-        const auto pushFlagValue = [&extraArgs](const std::wstring_view flag, const std::wstring_view value) {
-            if (value.empty())
-            {
-                return;
-            }
-            extraArgs.emplace_back(flag);
-            extraArgs.emplace_back(value);
-        };
-        // `agentCliPath` was resolved above for the GPO policy check.
-        // It may be empty when no agent CLI is detected but policy
-        // doesn't actively block (e.g. fresh install with no agents
-        // installed) — pass through anyway; wta will surface the
-        // failure to spawn the child as an ACP error.
-        pushFlagValue(L"--agent", agentCliPath);
-        pushFlagValue(L"--agent-id", globals.EffectiveAcpAgent());
-        if (!globals.EffectiveAutoFixEnabled())
-        {
-            extraArgs.emplace_back(L"--no-autofix");
-        }
-        if (const auto lang = _ResolveEffectiveLanguage(globals); !lang.empty())
-        {
-            pushFlagValue(L"--language", lang);
-        }
-        pushFlagValue(L"--acp-model", globals.AcpModel());
-        pushFlagValue(L"--delegate-agent", _ResolveEffectiveDelegateAgent(globals));
-        pushFlagValue(L"--delegate-model", globals.DelegateModel());
+        // reuse the same master (settings changes route through
+        // `_RebuildAgentStack` → `SharedWta::Restart` instead). Runtime
+        // changes flow over event channels (`autofix_enabled_changed`
+        // is the existing one). See `_BuildSharedWtaExtraArgs` for the
+        // shared arg layout.
+        auto extraArgs = _BuildSharedWtaExtraArgs();
 
         auto& shared = winrt::TerminalApp::implementation::SharedWta::Instance();
         if (!shared.AcquirePane(std::wstring_view{ wtaPath }, extraArgs))
@@ -2396,6 +2411,46 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
+        // Tear down every tab's agent pane first. The user must reopen
+        // each (per-tab toggle) — there's no longer a "shared pane" to
+        // reposition. Tear down is async: the pane's `Closed` handlers
+        // (which call `SharedWta::ReleasePane`) typically haven't fired
+        // yet when control returns to us.
+        for (const auto& tabImpl : tabsThatHadAgentPane)
+        {
+            _TeardownAgentPane(tabImpl);
+        }
+
+        // Force-respawn the master with the NEW per-process settings
+        // before reopening. Without this, the pending teardowns above
+        // leave the refcount > 0 when `_OpenOrReuseAgentPane` calls
+        // `AcquirePane`, so AcquirePane sees a live master and reuses
+        // it — silently ignoring the freshly-built --agent / --agent-id /
+        // --acp-model args, leaving the OLD agent CLI behind the pipe.
+        //
+        // `SharedWta::Restart(wtaPath, extraArgs)` does
+        // `_CleanupLocked` + `_SpawnLocked(newArgs)` while leaving the
+        // refcount alone (outgoing ReleasePane / incoming AcquirePane
+        // balance out). When the master isn't running (e.g. settings
+        // changed while no pane was open in *any* window), it no-ops
+        // — the next AcquirePane will spawn fresh with the caller's
+        // new args.
+        //
+        // This call is also why we don't gate it behind `hadAny`: even
+        // when no pane is open in *this* window, the master may still
+        // be alive serving another window. Respawning here keeps every
+        // window in sync with the new settings.
+        if (const auto wtaPath = _DetectWtaPath(); !wtaPath.empty())
+        {
+            const auto restartArgs = _BuildSharedWtaExtraArgs();
+            auto& shared = winrt::TerminalApp::implementation::SharedWta::Instance();
+            if (!shared.Restart(std::wstring_view{ wtaPath }, restartArgs))
+            {
+                _agentPaneLog("_RebuildAgentStack: SharedWta::Restart returned false");
+                // Fall through — the reopen path will retry via AcquirePane.
+            }
+        }
+
         if (!hadAny)
         {
             _lastAgentSettings = current;
@@ -2403,16 +2458,15 @@ namespace winrt::TerminalApp::implementation
             return;
         }
 
-        for (const auto& tabImpl : tabsThatHadAgentPane)
-        {
-            _TeardownAgentPane(tabImpl);
-        }
-        _lastAgentSettings = current;
-
         // Recreate on the active terminal tab so the user sees something
         // immediately. Other tabs that had an agent pane will need to be
         // re-toggled by the user.
         _OpenOrReuseAgentPane(false, L"SettingsReload");
+
+        // Snapshot update at the very end of the change-handling block
+        // so any early-failure path above leaves the snapshot stale and
+        // the next entry re-triggers a rebuild attempt.
+        _lastAgentSettings = current;
     }
 
     void TerminalPage::_FlushPendingAgentRebuild()
@@ -4216,6 +4270,83 @@ namespace winrt::TerminalApp::implementation
         // here so the chip can't get pinned by a dead helper.
         ownerTab->SetAgentChipOverride(std::nullopt);
         _TeardownAgentPane(ownerTab);
+    }
+
+    // `/restart` from any agent pane's TUI lands here via the
+    // `restart_agent_stack` SendEvent route. The single window receiving
+    // the dispatch owns the user-visible side of the restart for itself;
+    // other windows' panes (if any) are torn down implicitly when the
+    // shared master they were attached to dies under `SharedWta::Restart()`
+    // (helper pipes go EOF → helpers exit → ConPty death → those tabs
+    // show "process exited" panes until the user retoggles).
+    //
+    // Designed as a near-clone of the `_RebuildAgentStack` settings-change
+    // path: tear down every agent pane in this window, then re-toggle the
+    // active tab's pane. The new wta-helper that gets spawned by the
+    // re-toggle calls `SharedWta::AcquirePane`, which (because Restart
+    // already respawned the master) sees a valid `_process` and just
+    // bumps the refcount — connecting the new helper to the freshly-spawned
+    // master under the same stable pipe name.
+    void TerminalPage::OnRestartAgentStackRequested(hstring /*eventJson*/)
+    {
+        _agentPaneLog("OnRestartAgentStackRequested: /restart received from wta");
+
+        // Reentrancy guard — share the flag with the settings-driven
+        // `_RebuildAgentStack` path. If a settings reload is racing this
+        // request, skip; the reload will pick up where we'd leave off.
+        if (_agentRebuilding)
+        {
+            _agentPaneLog("OnRestartAgentStackRequested: already rebuilding, skipping");
+            return;
+        }
+        _agentRebuilding = true;
+        auto guard = wil::scope_exit([this]() noexcept { _agentRebuilding = false; });
+
+        // Mirror _RebuildAgentStack's "find every tab that has an agent
+        // pane right now" scan; teardown is per-tab so we have to enumerate
+        // before mutating.
+        std::vector<winrt::com_ptr<Tab>> tabsThatHadAgentPane;
+        for (const auto& t : _tabs)
+        {
+            if (auto tabImpl = _GetTabImpl(t))
+            {
+                if (tabImpl->FindAgentPane())
+                {
+                    tabsThatHadAgentPane.push_back(tabImpl);
+                }
+            }
+        }
+
+        if (tabsThatHadAgentPane.empty())
+        {
+            _agentPaneLog("OnRestartAgentStackRequested: no agent pane in this window, nothing to tear down");
+            // Still kick the master restart — another window may have
+            // panes that need master reset. SharedWta::Restart no-ops if
+            // master isn't running, so this is safe either way.
+            winrt::TerminalApp::implementation::SharedWta::Instance().Restart();
+            return;
+        }
+
+        for (const auto& tabImpl : tabsThatHadAgentPane)
+        {
+            _TeardownAgentPane(tabImpl);
+        }
+
+        // Force-respawn master with the cached spawn args (same agent CLI,
+        // same per-process settings). Bypasses AcquirePane's refcount so
+        // we don't have to wait for the just-issued teardowns' async
+        // Closed handlers to fire and drive refcount to zero.
+        if (!winrt::TerminalApp::implementation::SharedWta::Instance().Restart())
+        {
+            _agentPaneLog("OnRestartAgentStackRequested: SharedWta::Restart returned false");
+            // Fall through anyway — the reopen below will retry via
+            // AcquirePane, which lazily spawns when _process is invalid.
+        }
+
+        // Reopen the active tab's pane immediately so the user sees
+        // continuity. Tabs that had a pane but aren't active need to be
+        // retoggled by the user — same UX as _RebuildAgentStack.
+        _OpenOrReuseAgentPane(false, L"RestartAgent");
     }
 
     // Send {method:"autofix_execute",params:{pane_id}} over the outbound

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4278,7 +4278,7 @@ namespace winrt::TerminalApp::implementation
     // other windows' panes (if any) are torn down implicitly when the
     // shared master they were attached to dies under `SharedWta::Restart()`
     // (helper pipes go EOF → helpers exit → ConPty death → those tabs
-    // show "process exited" panes until the user retoggles).
+    // show "process exited" panes until the user toggles them open again).
     //
     // Designed as a near-clone of the `_RebuildAgentStack` settings-change
     // path: tear down every agent pane in this window, then re-toggle the
@@ -4345,7 +4345,7 @@ namespace winrt::TerminalApp::implementation
 
         // Reopen the active tab's pane immediately so the user sees
         // continuity. Tabs that had a pane but aren't active need to be
-        // retoggled by the user — same UX as _RebuildAgentStack.
+        // toggled open again by the user — same UX as _RebuildAgentStack.
         _OpenOrReuseAgentPane(false, L"RestartAgent");
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -209,6 +209,7 @@ namespace winrt::TerminalApp::implementation
         void OnAgentStateChanged(hstring eventJson);
         void OnResumeInNewAgentTabRequested(hstring eventJson);
         void OnAgentChipTargetChanged(hstring eventJson);
+        void OnRestartAgentStackRequested(hstring eventJson);
 
         til::property_changed_event PropertyChanged;
 
@@ -404,6 +405,13 @@ namespace winrt::TerminalApp::implementation
         void _TeardownAgentPane(const winrt::com_ptr<Tab>& tab);
         void _RebuildAgentStack();
         void _FlushPendingAgentRebuild();
+        // Build the per-process flag/value pairs that the wta-master
+        // inherits at spawn time (--agent, --agent-id, --no-autofix,
+        // --language, --acp-model, --delegate-agent, --delegate-model).
+        // Single source of truth shared by `_AutoCreateHiddenAgentPaneShared`
+        // (first acquire) and `_RebuildAgentStack` (settings-change-driven
+        // SharedWta::Restart). Reads from `_settings.GlobalSettings()`.
+        std::vector<std::wstring> _BuildSharedWtaExtraArgs();
         // Helper+master agent-pane creation (Z-M3, default since Z-M6):
         // spawns a wta-helper as a normal conpty child for this pane and
         // connects it to the SharedWta-managed wta-master process over a

--- a/src/cascadia/TerminalApp/TerminalPage.idl
+++ b/src/cascadia/TerminalApp/TerminalPage.idl
@@ -158,5 +158,13 @@ namespace TerminalApp
         // chip. A missing or null pane_session_id reverts that tab to the
         // default chip behavior (driven by the source-of-agent flag).
         void OnAgentChipTargetChanged(String eventJson);
+
+        // Inbound event from WTA carrying {method:"restart_agent_stack"}.
+        // Emitted by the `/restart` slash command. The page tears down
+        // every agent pane, force-restarts the wta-master process via
+        // `SharedWta::Restart()` (bypassing the AcquirePane refcount),
+        // and re-toggles the active tab's pane so the user lands on a
+        // fresh agent CLI session under the same stable master pipe.
+        void OnRestartAgentStackRequested(String eventJson);
     }
 }

--- a/src/cascadia/TerminalProtocol/ProtocolParsing.h
+++ b/src/cascadia/TerminalProtocol/ProtocolParsing.h
@@ -37,6 +37,7 @@ namespace Microsoft::Terminal::Protocol::Parsing
         AgentState,           // Direct to TerminalPage, no broadcast — unified per-tab agent-pane UI snapshot (view + pane_open + ...)
         ResumeInNewAgentTab,  // Direct to TerminalPage, no broadcast
         AgentChipTarget,      // Direct to TerminalPage, no broadcast — "draw the Agent chip on this pane (or hide override)"
+        RestartAgentStack,    // Direct to TerminalPage, no broadcast — `/restart` from any agent pane TUI
         Broadcast,            // Normalize envelope + broadcast to all subscribers
         Invalid               // Failed validation
     };
@@ -89,6 +90,10 @@ namespace Microsoft::Terminal::Protocol::Parsing
             if (method == "set_agent_chip_target")
             {
                 return SendEventRoute::AgentChipTarget;
+            }
+            if (method == "restart_agent_stack")
+            {
+                return SendEventRoute::RestartAgentStack;
             }
         }
 

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
@@ -743,6 +743,12 @@ void TerminalProtocolComServer::SendEvent(winrt::hstring const& eventJson)
         // pane_session_id reverts the tab to source-flag-driven chip.
         _dispatchAgentChipTargetToPage(eventJson);
         return;
+    case ProtocolParsing::SendEventRoute::RestartAgentStack:
+        // `/restart` from any agent pane TUI. Page-side handler tears
+        // down every agent pane in its window and force-restarts the
+        // wta-master process via SharedWta.
+        _dispatchRestartAgentStackToPage(eventJson);
+        return;
     case ProtocolParsing::SendEventRoute::Broadcast:
     {
         Json::StreamWriterBuilder wb;
@@ -855,6 +861,44 @@ void TerminalProtocolComServer::_dispatchCloseAgentPaneToPage(const winrt::hstri
                 try
                 {
                     page.OnCloseAgentPaneRequested(eventJson);
+                }
+                catch (...)
+                {
+                    // Swallow: page may have been torn down during dispatch.
+                }
+            });
+    }
+}
+
+void TerminalProtocolComServer::_dispatchRestartAgentStackToPage(const winrt::hstring& eventJson)
+{
+    if (!s_emperor)
+    {
+        return;
+    }
+    // Fan out to every window so each page tears down its own agent panes.
+    // The actual `SharedWta::Restart()` call inside each page-side handler
+    // takes the shared lock and is safe to invoke multiple times — only the
+    // first one in flight does work; the others observe `_process` invalid
+    // (or already-respawned by the winning thread) and no-op.
+    for (const auto& host : s_emperor->GetWindows())
+    {
+        auto page = _getPage(host.get());
+        if (!page)
+        {
+            continue;
+        }
+        const auto dispatcher = page.Dispatcher();
+        if (!dispatcher)
+        {
+            continue;
+        }
+        dispatcher.RunAsync(
+            winrt::Windows::UI::Core::CoreDispatcherPriority::Normal,
+            [page, eventJson]() {
+                try
+                {
+                    page.OnRestartAgentStackRequested(eventJson);
                 }
                 catch (...)
                 {

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.h
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.h
@@ -159,5 +159,12 @@ private:
     // source-of-agent driven chip.
     static void _dispatchAgentChipTargetToPage(const winrt::hstring& eventJson);
 
+    // Same shape, for {method:"restart_agent_stack"} — emitted by the
+    // `/restart` slash command in any agent pane TUI. Fans out to every
+    // window so each page can tear down its agent panes; the
+    // `SharedWta::Restart()` call inside is process-wide and idempotent
+    // across windows.
+    static void _dispatchRestartAgentStackToPage(const winrt::hstring& eventJson);
+
     static WindowEmperor* s_emperor;
 };

--- a/tools/wta/locales/en-US.yml
+++ b/tools/wta/locales/en-US.yml
@@ -87,7 +87,7 @@ commands.help_close_hint: "  Esc        Close this help"  # {Locked="Esc"}
 commands.help.summary: "Show this command list"
 commands.clear.summary: "Clear the chat scrollback (keeps session)"
 commands.new.summary: "Start a fresh ACP session (drops history)"  # {Locked="ACP"}
-commands.restart.summary: "Restart agent: reset CLI and reopen the pane"
+commands.restart.summary: "Restart agent: reset CLI and reconnect"
 commands.stop.summary: "Cancel the in-flight prompt"
 commands.sessions.summary: "Open the historical sessions picker (Ctrl+Shift+/)"  # {Locked="Ctrl+Shift+/"}
 

--- a/tools/wta/locales/en-US.yml
+++ b/tools/wta/locales/en-US.yml
@@ -87,7 +87,7 @@ commands.help_close_hint: "  Esc        Close this help"  # {Locked="Esc"}
 commands.help.summary: "Show this command list"
 commands.clear.summary: "Clear the chat scrollback (keeps session)"
 commands.new.summary: "Start a fresh ACP session (drops history)"  # {Locked="ACP"}
-commands.restart.summary: "Reconnect: kill agent process and respawn"
+commands.restart.summary: "Restart agent: reset CLI and reopen the pane"
 commands.stop.summary: "Cancel the in-flight prompt"
 commands.sessions.summary: "Open the historical sessions picker (Ctrl+Shift+/)"  # {Locked="Ctrl+Shift+/"}
 

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -6020,11 +6020,25 @@ impl App {
                 self.project_active_tab_state();
             }
             CommandKind::Restart => {
-                // Full reconnect. Reset every tab: drop session_id (the
-                // old SessionIds are about to become invalid), clear
-                // streaming state, wipe scrollback. The ACP client side
-                // will kill the agent child and respawn it; subsequent
-                // prompts on each tab will lazily get a fresh session.
+                // Behavior depends on which transport this App is running on:
+                //
+                // * Standalone mode: the ACP client owns the agent CLI child.
+                //   `restart_tx` triggers an in-process tear-down + respawn;
+                //   subsequent prompts get a fresh session on each tab. The
+                //   `Connecting("Restarting agent...")` state lasts until the
+                //   new `initialize` round-trip lands.
+                //
+                // * Helper mode: master owns the agent CLI lifetime, so a
+                //   single helper cannot restart it in-process. The helper's
+                //   `restart_rx` arm asks the C++ side to force-restart the
+                //   whole agent stack (`restart_agent_stack` SendEvent →
+                //   TerminalPage tears down every agent pane,
+                //   `SharedWta::Restart` respawns master on the same stable
+                //   pipe name, then the active tab's pane is re-opened). The
+                //   user briefly sees the agent pane flash closed and reopen
+                //   with a clean session. The `Connecting("Restarting...")`
+                //   state set below is short-lived — this helper process is
+                //   on its way out as part of the pane teardown.
                 self.state = ConnectionState::Connecting("Restarting agent...".to_string());
                 self.session_to_tab.clear();
                 self.session_id.clear();

--- a/tools/wta/src/commands.rs
+++ b/tools/wta/src/commands.rs
@@ -14,6 +14,19 @@ pub enum CommandKind {
     Clear,
     Stop,
     New,
+    /// Reset the agent CLI subprocess.
+    ///
+    /// * Standalone wta: tears down + respawns the agent CLI in-process;
+    ///   tabs lazily get fresh sessions on the next prompt.
+    /// * Helper mode: fires a `restart_agent_stack` `SendEvent` to the C++
+    ///   side, which mirrors the path settings reload already takes when
+    ///   `acpAgent` changes: tear down every agent pane (master + helper
+    ///   processes die with them), force `SharedWta::Restart()` to bypass
+    ///   refcount and respawn master on the *same stable pipe name*, and
+    ///   re-toggle the active tab's agent pane. The new helper auto-
+    ///   connects to the new master. Visible UX: agent panes flash closed
+    ///   and reopen with a clean session; nothing requires the user to
+    ///   restart Windows Terminal.
     Restart,
     Sessions,
 }

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1789,7 +1789,10 @@ impl acp::Client for WtaClient {
 ///
 /// Wires the same App-facing select-loop as `run_inner`, minus the
 /// restart-loop wrapper: helper mode doesn't own the agent CLI lifetime
-/// (master does), so `restart_rx` is drained but logged as unsupported.
+/// (master does). `/restart` is delegated to the C++ side via a
+/// `restart_agent_stack` `SendEvent`; that path tears down every agent
+/// pane, force-restarts master under the same stable pipe name, and
+/// re-toggles the active pane so the user lands on a fresh session.
 ///
 /// See doc/specs/Multi-window-agent-pane.md for the helper+master
 /// architecture, and `tools/wta/src/master/mod.rs` for the peer.
@@ -2173,10 +2176,11 @@ pub async fn run_acp_client_over_pipe(
     periodic_refetch.tick().await;
 
     // Main event loop. Mirrors `run_inner`'s select arms, minus the
-    // restart-loop wrapper (helper mode can't restart — master owns
-    // the agent CLI). A `/restart` signal is logged and reported back
-    // to the user as a no-op; deeper restart support is a Phase 3+
-    // concern (the master itself would need a "respawn" path).
+    // restart-loop wrapper (helper mode can't restart in-process — master
+    // owns the agent CLI). `/restart` fires a `restart_agent_stack`
+    // `SendEvent` to the C++ side; that path force-restarts the whole
+    // agent stack (tear down panes → `SharedWta::Restart()` → respawn on
+    // the same stable pipe name → re-toggle active pane).
     loop {
         tokio::select! {
             biased;
@@ -2207,19 +2211,30 @@ pub async fn run_acp_client_over_pipe(
                 dispatch_master_ext_request(req, &conn, &event_tx);
             }
             Some(req) = restart_rx.recv() => {
-                tracing::warn!(
+                // Helper can't restart the agent CLI in-process — master owns
+                // its lifetime, and master itself is a singleton owned by
+                // `SharedWta` on the C++ side. Ask the C++ side to do a full
+                // force-restart of the agent stack: tear down every agent
+                // pane, kill master via `SharedWta::Restart()` (bypassing
+                // refcount), respawn master under the same stable pipe name,
+                // and re-toggle the active tab's pane. The new wta-helper
+                // that gets spawned will reconnect to the new master and
+                // the user sees a fresh session.
+                //
+                // Signal travels: helper → `wtcli send_event` →
+                // `IProtocolServer::SendEvent` (route `RestartAgentStack`) →
+                // `TerminalPage::OnRestartAgentStackRequested`.
+                tracing::info!(
                     target: "helper",
                     new_agent = ?req.agent_cmd,
-                    "restart requested in helper mode — not supported \
-                     (master owns the agent CLI lifetime); reporting to user"
+                    "restart requested — asking WT to force-restart the agent stack"
                 );
-                let _ = event_tx.send(AppEvent::AgentError {
-                    session_id: None,
-                    message: "/restart is not available in this agent pane \
-                              — restart is owned by the shared wta-master \
-                              process. Close and reopen the pane to recover."
-                        .to_string(),
+                let evt = serde_json::json!({
+                    "type": "event",
+                    "method": "restart_agent_stack",
+                    "params": {},
                 });
+                crate::app::send_wt_protocol_event(evt.to_string());
             }
             Some(req) = cancel_rx.recv() => {
                 let session_id_str = req.session_id.clone();

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -2221,8 +2221,9 @@ pub async fn run_acp_client_over_pipe(
                 // that gets spawned will reconnect to the new master and
                 // the user sees a fresh session.
                 //
-                // Signal travels: helper → `wtcli send_event` →
-                // `IProtocolServer::SendEvent` (route `RestartAgentStack`) →
+                // Signal travels: helper → `wtcli publish` (see
+                // `app::send_wt_protocol_event`) → `IProtocolServer::SendEvent`
+                // (route `RestartAgentStack`) →
                 // `TerminalPage::OnRestartAgentStackRequested`.
                 tracing::info!(
                     target: "helper",


### PR DESCRIPTION
## Summary

- **`/restart` slash command now works.** Pressing `/restart` in the agent pane TUI tears down every agent pane, force-respawns `wta-master` (and the agent CLI it owns) under the same stable named-pipe name, and re-toggles the active tab's pane. Previously the helper showed `/restart is not available in this agent pane — restart is owned by the shared wta-master process.`
- **Long-standing `acpAgent` settings-reload bug fixed.** Changing `acpAgent` (e.g. copilot → claude) used to tear down all agent panes but leave `wta-master` running with the *old* agent CLI behind it — the new helper just reconnected to the same master, silently ignoring the setting change. `_RebuildAgentStack` now calls `SharedWta::Restart(wtaPath, freshExtraArgs)` so a setting change actually swaps the CLI.

## What changed

### C++ side
- **`SharedWta::Restart()`** — new method (two overloads). Bypasses the `AcquirePane`/`ReleasePane` refcount, drops the Job (KILL_ON_JOB_CLOSE reaps master + agent CLI), and respawns under the same `_masterPipeName`. The no-arg overload replays cached spawn args (semantic: "same CLI, fresh process"); the `(wtaPath, extraArgs)` overload replaces the cache before respawning (semantic: "new settings, take effect now"). `_SpawnLocked` now caches the latest spawn inputs.
- **`TerminalPage::OnRestartAgentStackRequested`** — handler for the new SendEvent route. Mirrors `_RebuildAgentStack`'s scan→teardown→reopen sequence under the same `_agentRebuilding` reentrancy guard.
- **`TerminalPage::_BuildSharedWtaExtraArgs`** — extracted the master cmdline builder (`--agent`, `--agent-id`, `--no-autofix`, `--language`, `--acp-model`, `--delegate-agent`, `--delegate-model`) so first-acquire and restart paths use one source of truth.
- **`SendEventRoute::RestartAgentStack`** — new route in `ProtocolParsing.h` + dispatch in `TerminalProtocolComServer` (fans out to every window, mirroring `close_agent_pane`). No IDL change; piggybacks on the existing `IProtocolServer::SendEvent`.
- **`_RebuildAgentStack`** — now also calls `SharedWta::Restart(wtaPath, freshExtraArgs)` after teardown so settings changes actually take effect on master.

### Rust side
- **Helper `restart_rx` arm** — sends `{method: "restart_agent_stack"}` via `send_wt_protocol_event` (same path as `close_agent_pane`). The helper does nothing else; its pane will be closed by the C++ side momentarily.
- **`commands.rs` / `en-US.yml`** — `/restart` summary updated to "Restart agent: reset CLI and reopen the pane".
- Comments in `client.rs`, `app.rs`, `commands.rs` documenting the standalone-vs-helper restart paths.

## Test plan

- [ ] `/restart` in an agent pane: pane closes briefly and reopens with a clean session; no "Connecting…" stuck state; agent name/version still match.
- [ ] `/restart` with multiple agent panes across tabs: master is killed and respawned; active tab's pane reopens, other tabs' panes show "process exited" (same UX as `_RebuildAgentStack` for non-active tabs).
- [ ] `/restart` across multiple windows: every window's panes are torn down via the fan-out dispatch; master respawns once.
- [ ] Change `acpModel` in settings.json: model swap still works (was working before, must not regress).
- [ ] Change `acpAgent` in settings.json (copilot → claude): the new pane connects to the new agent CLI (previously regressed — verify the fix).
- [ ] No agent pane open + `/restart` is impossible to reach by definition; instead change `acpAgent` while no pane is open: cached args refresh, next pane open uses the new settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)