### PR TITLE
FRE: refresh PATH so wta finds CLIs installed during the same WT session

### DIFF
--- a/src/cascadia/TerminalApp/SharedWta.cpp
+++ b/src/cascadia/TerminalApp/SharedWta.cpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "../WinRTUtils/inc/WtExeUtils.h"
+#include "../inc/WtaProcess.h"
 
 namespace winrt::TerminalApp::implementation
 {
@@ -183,6 +184,17 @@ namespace winrt::TerminalApp::implementation
         // (no job → no KILL_ON_JOB_CLOSE containment).
         DWORD creationFlags = CREATE_NO_WINDOW | CREATE_UNICODE_ENVIRONMENT | CREATE_SUSPENDED;
 
+        // FRE may install Copilot CLI via winget *after* WT's own process
+        // env block was captured at launch. WT does not handle WM_SETTINGCHANGE
+        // to refresh its PATH (see WindowEmperor.cpp WM_SETTINGCHANGE handler;
+        // env-var reload is explicitly deferred per GH#15102). If we passed
+        // lpEnvironment=nullptr, wta would inherit that stale block and fail
+        // to find newly-installed CLIs in the same session. Extend PATH with
+        // %LOCALAPPDATA%\Microsoft\WinGet\Links and %APPDATA%\npm so a freshly
+        // installed Copilot is discoverable on first agent-pane open.
+        auto envBlock = Microsoft::Terminal::WtaProcess::BuildExtendedPathEnvBlock();
+        wchar_t* lpEnvironment = envBlock.empty() ? nullptr : envBlock.data();
+
         std::wstring mutableCmdLine{ commandline };
         if (!CreateProcessW(
                 /* lpApplicationName    */ nullptr,
@@ -191,7 +203,7 @@ namespace winrt::TerminalApp::implementation
                 /* lpThreadAttributes   */ nullptr,
                 /* bInheritHandles      */ FALSE,
                 /* dwCreationFlags      */ creationFlags,
-                /* lpEnvironment        */ nullptr,
+                /* lpEnvironment        */ lpEnvironment,
                 /* lpCurrentDirectory   */ nullptr,
                 /* lpStartupInfo        */ &si,
                 /* lpProcessInformation */ &pi))

--- a/tools/wta/src/agent_check.rs
+++ b/tools/wta/src/agent_check.rs
@@ -186,12 +186,81 @@ pub async fn install(agent_id: &str, on_line: impl FnMut(String) + Send + 'stati
     }
 }
 
-/// Refresh the current process's PATH from the Windows registry.
-/// Call after installing software so `find_exe` picks up the new binary.
+/// Refresh the current process's PATH so newly-installed binaries become
+/// discoverable. Merges the inherited PATH (preserving its entries and order)
+/// with the registry-fresh PATH from HKLM+HKCU\Environment, appending any
+/// entries from the registry that weren't already present.
+///
+/// Merging (rather than overwriting) preserves PATH entries that the parent
+/// deliberately injected — e.g. a dev session launching WT with a portable
+/// or custom agent CLI on a temporary PATH — while still picking up shims
+/// that were registered to the user/system environment after this process
+/// inherited its env block.
 pub fn refresh_path() {
-    let path = fresh_path();
-    if !path.is_empty() {
-        std::env::set_var("PATH", &path);
+    let fresh = fresh_path();
+    if fresh.is_empty() {
+        return;
+    }
+    let inherited = std::env::var("PATH").unwrap_or_default();
+    let merged = merge_path(&inherited, &fresh);
+    if !merged.is_empty() {
+        std::env::set_var("PATH", merged);
+    }
+}
+
+/// Merge two `;`-separated PATH strings: keep `base` entries in their original
+/// order, then append entries from `extra` that aren't already present. Entry
+/// comparison is case-insensitive and ignores trailing `\` (Windows path
+/// conventions).
+fn merge_path(base: &str, extra: &str) -> String {
+    use std::collections::HashSet;
+    let normalize = |s: &str| s.trim_end_matches('\\').to_ascii_lowercase();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out: Vec<&str> = Vec::new();
+    for entry in base.split(';').filter(|s| !s.is_empty()) {
+        if seen.insert(normalize(entry)) {
+            out.push(entry);
+        }
+    }
+    for entry in extra.split(';').filter(|s| !s.is_empty()) {
+        if seen.insert(normalize(entry)) {
+            out.push(entry);
+        }
+    }
+    out.join(";")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_path;
+
+    #[test]
+    fn merge_preserves_inherited_order_and_appends_new_entries() {
+        let base = r"C:\custom\bin;C:\Windows\System32";
+        let extra = r"C:\Windows\System32;C:\Users\me\AppData\Local\Microsoft\WinGet\Links";
+        let merged = merge_path(base, extra);
+        assert_eq!(
+            merged,
+            r"C:\custom\bin;C:\Windows\System32;C:\Users\me\AppData\Local\Microsoft\WinGet\Links"
+        );
+    }
+
+    #[test]
+    fn merge_dedupes_case_insensitively_and_ignores_trailing_backslash() {
+        let base = r"C:\Foo\;C:\bar";
+        let extra = r"c:\foo;C:\BAR\;C:\baz";
+        let merged = merge_path(base, extra);
+        assert_eq!(merged, r"C:\Foo\;C:\bar;C:\baz");
+    }
+
+    #[test]
+    fn merge_with_empty_base_returns_extra_deduped() {
+        assert_eq!(merge_path("", r"C:\a;C:\a\;c:\A"), r"C:\a");
+    }
+
+    #[test]
+    fn merge_with_empty_extra_returns_base_deduped() {
+        assert_eq!(merge_path(r"C:\a;;C:\b", ""), r"C:\a;C:\b");
     }
 }
 

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -530,18 +530,18 @@ enum InitialView {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Refresh PATH from the Windows registry before any spawn / find_exe
-    // call. wta is normally launched by Windows Terminal, whose process
-    // environment block is captured at WT startup and never refreshed
-    // (WT explicitly defers WM_SETTINGCHANGE env reload — see
-    // WindowEmperor.cpp WM_SETTINGCHANGE handler, GH#15102). If the user
-    // just installed (or upgraded) a CLI like Copilot via winget through
-    // the FRE, our inherited PATH is stale and `tokio::Command::new(
+    // Refresh PATH before any spawn / find_exe call. wta is normally launched
+    // by Windows Terminal, whose process environment block is captured at WT
+    // startup and never refreshed (WT explicitly defers WM_SETTINGCHANGE env
+    // reload — see WindowEmperor.cpp WM_SETTINGCHANGE handler, GH#15102). If
+    // the user just installed (or upgraded) a CLI like Copilot via winget
+    // through the FRE, our inherited PATH is stale and `tokio::Command::new(
     // "copilot")` would miss the new shim. agent_check::refresh_path()
-    // re-reads HKLM+HKCU\Environment PATH and updates this process's
-    // env so subsequent spawns find the binary. Cheap, idempotent, and
-    // belt-and-suspenders against any future caller that forgets to
-    // pass an extended env block.
+    // merges HKLM+HKCU\Environment PATH on top of the inherited PATH (it
+    // preserves inherited entries — e.g. a dev-session portable CLI — and
+    // appends any registry entries not already present), so subsequent
+    // spawns find the binary. Cheap, idempotent, and belt-and-suspenders
+    // against any future caller that forgets to pass an extended env block.
     agent_check::refresh_path();
 
     // Detect and set the system locale for i18n.

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -530,6 +530,20 @@ enum InitialView {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Refresh PATH from the Windows registry before any spawn / find_exe
+    // call. wta is normally launched by Windows Terminal, whose process
+    // environment block is captured at WT startup and never refreshed
+    // (WT explicitly defers WM_SETTINGCHANGE env reload — see
+    // WindowEmperor.cpp WM_SETTINGCHANGE handler, GH#15102). If the user
+    // just installed (or upgraded) a CLI like Copilot via winget through
+    // the FRE, our inherited PATH is stale and `tokio::Command::new(
+    // "copilot")` would miss the new shim. agent_check::refresh_path()
+    // re-reads HKLM+HKCU\Environment PATH and updates this process's
+    // env so subsequent spawns find the binary. Cheap, idempotent, and
+    // belt-and-suspenders against any future caller that forgets to
+    // pass an extended env block.
+    agent_check::refresh_path();
+
     // Detect and set the system locale for i18n.
     // normalize_locale() maps unmatched regions to the canonical variant (e.g., de-AT → de-DE).
     //


### PR DESCRIPTION
## Problem

When the FRE installs a CLI (e.g. `winget install GitHub.Copilot`) during the same WT session, two layers of stale-PATH caching prevent the freshly-installed binary from being picked up:

1. **WT's own environment is frozen at process launch.** `WindowEmperor` explicitly *does not* refresh env on `WM_SETTINGCHANGE` (GH#15102 deferred the rebroadcast handler). `SharedWta::_SpawnLocked` was calling `CreateProcessW` with `lpEnvironment = nullptr`, so `wta.exe` inherited WT's frozen PATH and missed `%LOCALAPPDATA%\Microsoft\WinGet\Links` / `%APPDATA%\npm` added since launch.
2. **wta's own PATH lookups are equally stale.** `agent_registry::resolve_bare_agent_name` calls `std::env::var("PATH")`, and `tokio::Command::new("copilot")` falls through to the CreateProcessW PATH search — both off the same frozen environment.

Net effect: the FRE happily installs Copilot, then the very next agent-pane spawn fails to find it. The user has to relaunch WT.

## Fix

**`SharedWta::_SpawnLocked`** — build an extended PATH env block via the existing `BuildExtendedPathEnvBlock` helper (same one `_InstallHooksAsync` uses) and pass it to `CreateProcessW`. This appends the winget Links + npm dirs to *current* PATH, so wta inherits a working environment even when WT's own copy is stale.

**`wta::main()`** — call `agent_check::refresh_path()` as the first line. This reads HKLM+HKCU `Environment\Path` from the registry and writes the fresh value back via `std::env::set_var`, which propagates to all subsequent `std::env::var` reads *and* the env inherited by `tokio::Command` children.

Together these mean: install during the FRE → agent-pane spawn picks up the new binary immediately, no relaunch required.

## Verification

- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml` — clean, 1m55s, only pre-existing warnings.
- C++ side mirrors the existing `_InstallHooksAsync` pattern verbatim (same helper, same `CREATE_UNICODE_ENVIRONMENT` flag), so no behavioral surprise expected.

## Out of scope

- Version probe / auto-upgrade for outdated Copilot CLI — that's the follow-up branch `dev/yeelam/fre-cli-version-probe`.
- FRE login-assist — universal need but tracked separately.
