### PR TITLE
fix(wta): session resume — single row, preserved title, collapsed replayed history

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -288,6 +288,42 @@ pub struct CompletedTurn {
     pub trailing_marker: Option<String>,
 }
 
+/// Maximum displayed characters for a collapsed turn header preview.
+/// Picked so the `▶ > <preview>…` row stays well under a typical 120-col
+/// wrap width even after the chevron + prompt prefix; longer prompts get
+/// truncated with a trailing ellipsis. The full original text is always
+/// preserved in the turn's first `details` entry.
+const COLLAPSED_PROMPT_PREVIEW_CHARS: usize = 80;
+
+/// Build the single-line preview shown in a collapsed `CompletedTurn`
+/// header. Takes the first non-blank line of the prompt and clips it to
+/// `COLLAPSED_PROMPT_PREVIEW_CHARS`. Multi-line prompts (system prompts,
+/// pasted blocks, etc.) collapse to one row instead of wrapping over
+/// dozens of lines in the chat scrollback.
+pub fn collapsed_prompt_preview(text: &str) -> String {
+    let first_line = text
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("");
+    let mut iter = first_line.chars();
+    let mut out: String = (&mut iter).take(COLLAPSED_PROMPT_PREVIEW_CHARS).collect();
+    // Append ellipsis if the prompt has more content than the preview
+    // covered — either the first line itself was longer, or there are
+    // additional non-empty lines below.
+    let truncated = iter.next().is_some()
+        || text
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .nth(1)
+            .is_some();
+    if truncated {
+        out.push('…');
+    }
+    out
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PlanEntry {
     pub content: String,
@@ -1462,6 +1498,67 @@ impl TabSession {
             let text = std::mem::take(&mut self.pending_agent_response);
             self.messages.push(ChatMessage::Agent(text));
         }
+    }
+
+    /// Compact replayed history into collapsed `CompletedTurn` rows so a
+    /// long resumed session doesn't dump the entire transcript inline.
+    /// Called at session/load completion (after `flush_load_replay_pending`)
+    /// from the `SessionAttached` handler.
+    ///
+    /// Algorithm: walk `self.messages` left-to-right; each `User` opens a
+    /// new turn. The turn's `prompt` is a SHORT single-line preview of
+    /// the user text (so the collapsed `▶ > <preview>` row stays at one
+    /// visual line even for huge system-prompt-as-user dumps); the full
+    /// original `User(text)` is stored as the first entry of `details`,
+    /// followed by subsequent non-User messages. Messages that come
+    /// BEFORE the first User (e.g. the `System("Resuming session …")`
+    /// marker, or a stray Agent dump) stay in `messages` as-is — only
+    /// User-anchored turns get packed. Each packed turn has `expanded:
+    /// false` so history is collapsed by default. Tab + Enter toggles
+    /// individual rows.
+    pub fn pack_replayed_messages_into_turns(&mut self) {
+        if self.messages.is_empty() {
+            return;
+        }
+        let drained: Vec<ChatMessage> = std::mem::take(&mut self.messages);
+        let mut kept: Vec<ChatMessage> = Vec::new();
+        // `details` always opens with the full original ChatMessage::User
+        // so expanding the turn shows the entire prompt text. `prompt`
+        // is the short preview used in the collapsed header row.
+        let mut current: Option<(String, Vec<ChatMessage>)> = None;
+        for msg in drained {
+            match msg {
+                ChatMessage::User(text) => {
+                    if let Some((prompt, details)) = current.take() {
+                        self.completed_turns.push(CompletedTurn {
+                            prompt,
+                            details,
+                            expanded: false,
+                            trailing_marker: None,
+                        });
+                    }
+                    let preview = collapsed_prompt_preview(&text);
+                    let details = vec![ChatMessage::User(text)];
+                    current = Some((preview, details));
+                }
+                other => {
+                    if let Some((_, details)) = current.as_mut() {
+                        details.push(other);
+                    } else {
+                        kept.push(other);
+                    }
+                }
+            }
+        }
+        if let Some((prompt, details)) = current.take() {
+            self.completed_turns.push(CompletedTurn {
+                prompt,
+                details,
+                expanded: false,
+                trailing_marker: None,
+            });
+        }
+        self.messages = kept;
     }
 
     /// Cycle the past-turn selection toward older entries.
@@ -3825,6 +3922,7 @@ impl App {
                     .unwrap_or(false);
                 if tab.loading_session && is_load_target {
                     tab.flush_load_replay_pending();
+                    tab.pack_replayed_messages_into_turns();
                     tab.loading_session = false;
                     tab.loading_target_session_id = None;
                     tab.scroll_to_bottom();
@@ -9658,6 +9756,159 @@ mod tests {
         assert!(app.tab_sessions["OWNER-TAB"]
             .loading_target_session_id
             .is_none());
+    }
+
+    /// Replayed history must be packed into collapsed CompletedTurn rows
+    /// after session/load completes. Each User message opens a new turn;
+    /// the prompt header is a short preview (the full original User text
+    /// is kept as the first details entry so expanding shows everything).
+    /// Subsequent non-User messages become later details. Default
+    /// `expanded: false` so the resumed transcript doesn't dump as one
+    /// long wall.
+    #[test]
+    fn pack_replayed_messages_groups_into_collapsed_turns() {
+        let mut tab = TabSession::default();
+        tab.messages = vec![
+            ChatMessage::System("Resuming session abc...".to_string()),
+            ChatMessage::User("# Terminal Agent\nYou are...".to_string()),
+            ChatMessage::Agent("Hello, I am ready.".to_string()),
+            ChatMessage::User("list files".to_string()),
+            ChatMessage::ToolCall {
+                id: "t1".to_string(),
+                title: "ls".to_string(),
+                status: "done".to_string(),
+            },
+            ChatMessage::Agent("Here are the files...".to_string()),
+        ];
+
+        tab.pack_replayed_messages_into_turns();
+
+        // System marker stays — it's not anchored to a User.
+        assert_eq!(tab.messages.len(), 1);
+        assert!(matches!(&tab.messages[0], ChatMessage::System(s) if s.starts_with("Resuming")));
+
+        // Two turns: one per User prompt.
+        assert_eq!(tab.completed_turns.len(), 2);
+
+        let t0 = &tab.completed_turns[0];
+        // Preview shows first non-empty line + ellipsis (extra lines below).
+        assert_eq!(t0.prompt, "# Terminal Agent…");
+        // details = [original full User, Agent reply].
+        assert_eq!(t0.details.len(), 2);
+        assert!(matches!(&t0.details[0], ChatMessage::User(s) if s.starts_with("# Terminal Agent\nYou are")));
+        assert!(matches!(&t0.details[1], ChatMessage::Agent(_)));
+        assert!(!t0.expanded, "replayed turn must default to collapsed");
+        assert!(t0.trailing_marker.is_none());
+
+        let t1 = &tab.completed_turns[1];
+        // Short single-line prompt — no ellipsis.
+        assert_eq!(t1.prompt, "list files");
+        // details = [original User, ToolCall, Agent].
+        assert_eq!(t1.details.len(), 3);
+        assert!(matches!(&t1.details[0], ChatMessage::User(s) if s == "list files"));
+        assert!(matches!(&t1.details[1], ChatMessage::ToolCall { .. }));
+        assert!(matches!(&t1.details[2], ChatMessage::Agent(_)));
+        assert!(!t1.expanded);
+    }
+
+    /// Preview logic: huge single-line prompt must clip to the cap with
+    /// a trailing ellipsis; short single-line prompts stay verbatim.
+    #[test]
+    fn collapsed_prompt_preview_clips_long_single_line() {
+        let long = "a".repeat(500);
+        let preview = collapsed_prompt_preview(&long);
+        // 80 chars + ellipsis.
+        assert_eq!(preview.chars().count(), 81);
+        assert!(preview.ends_with('…'));
+
+        let short = "hello world";
+        assert_eq!(collapsed_prompt_preview(short), "hello world");
+        assert!(!collapsed_prompt_preview(short).ends_with('…'));
+    }
+
+    /// Edge: messages that come BEFORE the first User must NOT be lost —
+    /// they stay in `tab.messages`. Pre-User stray Agent dumps (rare but
+    /// possible) should remain visible rather than being silently dropped.
+    #[test]
+    fn pack_replayed_messages_preserves_pre_user_orphans() {
+        let mut tab = TabSession::default();
+        tab.messages = vec![
+            ChatMessage::System("Resuming...".to_string()),
+            ChatMessage::Agent("stray context dump".to_string()),
+            ChatMessage::User("hi".to_string()),
+            ChatMessage::Agent("hello".to_string()),
+        ];
+
+        tab.pack_replayed_messages_into_turns();
+
+        assert_eq!(tab.messages.len(), 2);
+        assert!(matches!(&tab.messages[0], ChatMessage::System(_)));
+        assert!(matches!(&tab.messages[1], ChatMessage::Agent(s) if s == "stray context dump"));
+        assert_eq!(tab.completed_turns.len(), 1);
+        assert_eq!(tab.completed_turns[0].prompt, "hi");
+        assert!(!tab.completed_turns[0].expanded);
+    }
+
+    /// Empty messages must no-op (no panic, no spurious turn).
+    #[test]
+    fn pack_replayed_messages_empty_is_noop() {
+        let mut tab = TabSession::default();
+        tab.pack_replayed_messages_into_turns();
+        assert!(tab.messages.is_empty());
+        assert!(tab.completed_turns.is_empty());
+    }
+
+    /// Integration: SessionAttached for the load target must trigger
+    /// packing — replayed User/Agent rows must end up as collapsed
+    /// CompletedTurn entries, not loose ChatMessage rows.
+    #[test]
+    fn session_attached_for_load_target_packs_replayed_history() {
+        let (mut app, _load_session_rx) = make_app_with_load_session_channel();
+        app.owner_tab_id = Some("OWNER-TAB".to_string());
+        app.tab_sessions
+            .insert("OWNER-TAB".to_string(), TabSession::default());
+
+        app.handle_event(AppEvent::WtEvent {
+            method: "load_session".to_string(),
+            pane_id: String::new(),
+            tab_id: None,
+            params: json!({
+                "tab_id": "OWNER-TAB",
+                "session_id": "sess-target",
+                "cwd": "",
+            }),
+        });
+        // Simulate replay chunks landing in messages.
+        let tab = app.tab_sessions.get_mut("OWNER-TAB").unwrap();
+        tab.messages.push(ChatMessage::User("first prompt".to_string()));
+        tab.messages.push(ChatMessage::Agent("first reply".to_string()));
+        tab.messages.push(ChatMessage::User("second prompt".to_string()));
+        tab.messages.push(ChatMessage::Agent("second reply".to_string()));
+
+        app.handle_event(AppEvent::SessionAttached {
+            tab_id: "OWNER-TAB".to_string(),
+            session_id: "sess-target".to_string(),
+            available_models: vec![],
+            current_model_id: None,
+        });
+
+        let tab = &app.tab_sessions["OWNER-TAB"];
+        assert!(!tab.loading_session);
+        assert_eq!(
+            tab.completed_turns.len(),
+            2,
+            "both replayed user prompts must become collapsed CompletedTurn rows"
+        );
+        for turn in &tab.completed_turns {
+            assert!(!turn.expanded, "replayed turns default collapsed");
+        }
+        // The leading System("Resuming session ...") marker stays in
+        // messages — it's not anchored to a User so packing leaves it
+        // alone.
+        assert!(tab
+            .messages
+            .iter()
+            .all(|m| matches!(m, ChatMessage::System(_))));
     }
 
     // ─── WtNotification auto-dismiss ────────────────────────────────────────

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2069,11 +2069,13 @@ async fn run_acp_app(
                 let shell_mgr_for_pipe = Arc::clone(&shell_mgr);
                 let acp_model = cli.acp_model.clone();
                 let owner_tab = cli.owner_tab_id.clone();
+                let initial_load_sid = cli.initial_load_session_id.clone();
                 tokio::task::spawn_local(async move {
                     if let Err(e) = protocol::acp::client::run_acp_client_over_pipe(
                         pipe_name,
                         acp_model,
                         owner_tab,
+                        initial_load_sid,
                         event_tx_for_pipe.clone(),
                         prompt_rx,
                         cancel_rx,

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -878,6 +878,25 @@ impl acp::Agent for HelperHandler {
                     .duration_since(std::time::UNIX_EPOCH)
                     .ok()
                     .map(|d| d.as_millis() as u64);
+                // Carry the title (and updated_at) forward from the row
+                // that already exists for this sid. Master seeds the
+                // registry at startup with rows from `history_loader`
+                // which include the disk-derived chat title (e.g.
+                // "# Terminal AgentYou"). A naked `SessionInfo::new`
+                // upsert would clobber that title with `None`, leaving
+                // the resumed Live row showing "—" in F2. By copying
+                // the prior title we keep the resumed row identifiable
+                // to the user.
+                if let Some(existing) =
+                    self.state.registry.lookup(&session_id).await
+                {
+                    if info.title.is_none() {
+                        info.title = existing.title;
+                    }
+                    if info.updated_at.is_none() {
+                        info.updated_at = existing.updated_at;
+                    }
+                }
                 self.state.registry.upsert(info.clone()).await;
                 crate::master::broadcast_ext_to_helpers(
                     &self.state,

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1936,7 +1936,7 @@ async fn handle_load_failure(
                 target: "acp_load_session",
                 tab = %tab_id,
                 fallback_session_id = %new_sid,
-                "boot-time load fallback to new_session succeeded"
+                "boot-time load fell back to new_session successfully"
             );
             {
                 let mut g = tab_to_session.lock().await;
@@ -2359,7 +2359,7 @@ pub async fn run_acp_client_over_pipe(
     });
 
     // Per-tab session cache. Same semantics as in `run_inner`. Only
-    // pre-populate the owner-tab binding when we actually have a
+    // prepopulate the owner-tab binding when we actually have a
     // bootstrap session — otherwise the `load_session_rx` arm would
     // see the placeholder sid as a prior session, try to `cancel` it,
     // and the agent CLI would reject the cancel for an unknown sid.

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1867,18 +1867,137 @@ fn inject_wta_pane_meta(meta: &mut Option<acp::Meta>) {
     if wt_session.is_empty() {
         return;
     }
-    let pane_session_id = wt_session
+    let normalized = wt_session
         .trim_matches(|c| c == '{' || c == '}')
         .to_ascii_lowercase();
-    if pane_session_id.is_empty() {
+    if normalized.is_empty() {
         return;
     }
     crate::session_registry::inject_wta_meta(
         meta,
         &crate::session_registry::WtaMeta {
-            pane_session_id: Some(pane_session_id),
+            pane_session_id: Some(normalized),
         },
     );
+}
+
+/// Handle a `session/load` failure (Err or timeout) in the
+/// `load_session_rx` arm of `run_acp_client_over_pipe`.
+///
+/// Two cases:
+///   * `old_sid = Some` (mid-life F2 load failure): restore the prior
+///     binding so the pane keeps a usable session. The user sees a
+///     `TabError` and their existing session is still alive.
+///   * `old_sid = None` (boot-time load failure with no bootstrap):
+///     fall back to creating a fresh `new_session` so the pane is
+///     still usable. The user sees a `TabError` AND a working blank
+///     session, matching the pre-Plan-B UX where a bootstrap session
+///     was always created.
+async fn handle_load_failure(
+    old_sid: Option<&acp::SessionId>,
+    tab_id: String,
+    cwd: std::path::PathBuf,
+    conn: Arc<acp::ClientSideConnection>,
+    tab_to_session: Arc<tokio::sync::Mutex<HashMap<String, acp::SessionId>>>,
+    event_tx: mpsc::UnboundedSender<AppEvent>,
+    error_message: String,
+) {
+    if let Some(old) = old_sid {
+        // Mid-life F2 load failure path: restore prior binding.
+        let mut g = tab_to_session.lock().await;
+        g.insert(tab_id.clone(), old.clone());
+        drop(g);
+        let _ = event_tx.send(AppEvent::TabError {
+            tab_id,
+            message: error_message,
+        });
+        return;
+    }
+
+    // Boot-time load failure: helper has no prior session for this
+    // tab (we skipped the bootstrap when `--initial-load-session-id`
+    // was set). Create a fresh `new_session` so prompts have
+    // somewhere to land.
+    let _ = event_tx.send(AppEvent::TabError {
+        tab_id: tab_id.clone(),
+        message: format!("{} Starting a fresh session instead.", error_message),
+    });
+    let mut new_req = acp::NewSessionRequest::new(cwd);
+    inject_wta_pane_meta(&mut new_req.meta);
+    let fallback = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        conn.new_session(new_req),
+    )
+    .await;
+    match fallback {
+        Ok(Ok(resp)) => {
+            let new_sid = resp.session_id.clone();
+            tracing::info!(
+                target: "acp_load_session",
+                tab = %tab_id,
+                fallback_session_id = %new_sid,
+                "boot-time load fallback to new_session succeeded"
+            );
+            {
+                let mut g = tab_to_session.lock().await;
+                g.insert(tab_id.clone(), new_sid.clone());
+            }
+            // Index the fallback session as an agent-pane origin so
+            // F2 can show it as a Historical row on next cold start
+            // (it is now a real, persistent session).
+            let pane_session_id = std::env::var("WT_SESSION").unwrap_or_default();
+            let pane_for_index = if pane_session_id.is_empty() {
+                None
+            } else {
+                Some(pane_session_id.as_str())
+            };
+            crate::agent_pane_origin::append_default(new_sid.0.as_ref(), pane_for_index);
+            let (available_models, current_model_id) = match &resp.models {
+                Some(state) => {
+                    let models: Vec<crate::app::AcpModelInfo> = state
+                        .available_models
+                        .iter()
+                        .map(|m| crate::app::AcpModelInfo {
+                            id: m.model_id.0.to_string(),
+                            name: m.name.clone(),
+                            description: m.description.clone(),
+                        })
+                        .collect();
+                    (models, Some(state.current_model_id.0.to_string()))
+                }
+                None => (Vec::new(), None),
+            };
+            let _ = event_tx.send(AppEvent::SessionAttached {
+                tab_id,
+                session_id: new_sid.to_string(),
+                available_models,
+                current_model_id,
+            });
+        }
+        Ok(Err(e)) => {
+            tracing::error!(
+                target: "acp_load_session",
+                tab = %tab_id,
+                error = ?e,
+                "boot-time load fallback new_session failed"
+            );
+            let _ = event_tx.send(AppEvent::TabError {
+                tab_id,
+                message: format!("Fallback new_session also failed: {}", e),
+            });
+        }
+        Err(_) => {
+            tracing::error!(
+                target: "acp_load_session",
+                tab = %tab_id,
+                "boot-time load fallback new_session timed out after 30s"
+            );
+            let _ = event_tx.send(AppEvent::TabError {
+                tab_id,
+                message: "Fallback new_session timed out after 30s.".to_string(),
+            });
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1886,6 +2005,7 @@ pub async fn run_acp_client_over_pipe(
     pipe_name: String,
     acp_model_override: Option<String>,
     owner_tab_id: Option<String>,
+    initial_load_session_id: Option<String>,
     event_tx: mpsc::UnboundedSender<AppEvent>,
     mut prompt_rx: mpsc::UnboundedReceiver<PromptSubmission>,
     mut cancel_rx: mpsc::UnboundedReceiver<CancelRequest>,
@@ -2091,83 +2211,123 @@ pub async fn run_acp_client_over_pipe(
         }
     }
 
-    // Create the initial session bound to the owner tab.
-    let _ = event_tx.send(AppEvent::ConnectionStage("Creating session...".to_string()));
-    startup_probe.log("Creating session (over pipe)");
+    // Create the initial session bound to the owner tab — unless this
+    // helper was spawned with `--initial-load-session-id`, in which case
+    // we skip the bootstrap entirely and let the boot-time `load_session`
+    // (queued by main.rs as an `AppEvent::WtEvent`) be the helper's
+    // first session. Skipping the bootstrap avoids the F2 duplicate-row
+    // bug: master used to register both the bootstrap and the loaded
+    // sid (both bound to the same WT pane) and the F2 view showed two
+    // Live rows for the same agent pane.
     let cwd = std::env::current_dir().unwrap_or_default();
-    let mut new_session_req = acp::NewSessionRequest::new(cwd);
-    inject_wta_pane_meta(&mut new_session_req.meta);
-    let session_future = conn.new_session(new_session_req);
-    let session = tokio::time::timeout(std::time::Duration::from_secs(30), session_future)
-        .await
-        .map_err(|_| anyhow::anyhow!("new_session over master pipe timed out after 30s"))?
-        .map_err(|e| anyhow::anyhow!("new_session over master pipe failed: {}", e))?;
-
-    let session_id = session.session_id.clone();
-    startup_probe.log(&format!("Session created (over pipe): {}", session_id));
-    if is_agent_pane {
-        // Carry the WT pane-session GUID alongside the ACP session id so
-        // agent-pane origin tracking can recover the owning pane later
-        // (matches origin/main's `append_default` signature after #66).
-        let pane_session_id = std::env::var("WT_SESSION").unwrap_or_default();
-        let pane_for_index = if pane_session_id.is_empty() {
-            None
-        } else {
-            Some(pane_session_id.as_str())
-        };
-        tracing::info!(
-            target: "agent_pane_origin",
-            session_id = %session_id,
-            pane_session_id = %pane_session_id,
-            "recording agent-pane session origin (startup over pipe)",
-        );
-        crate::agent_pane_origin::append_default(session_id.0.as_ref(), pane_for_index);
-    }
-
-    let (available_models, current_model_id) = match &session.models {
-        Some(state) => {
-            let models: Vec<crate::app::AcpModelInfo> = state
-                .available_models
-                .iter()
-                .map(|m| crate::app::AcpModelInfo {
-                    id: m.model_id.0.to_string(),
-                    name: m.name.clone(),
-                    description: m.description.clone(),
-                })
-                .collect();
-            (models, Some(state.current_model_id.0.to_string()))
-        }
-        None => (Vec::new(), None),
-    };
-
-    // Apply --acp-model if requested. No `--agent` cmdline to parse in
-    // helper mode (master owns the agent CLI), so this is the only
-    // model-selection input.
-    if let Some(requested_model) = acp_model_override.filter(|s| !s.trim().is_empty()) {
-        let _ = event_tx.send(AppEvent::ConnectionStage(format!(
-            "Selecting model {}...",
-            requested_model
-        )));
-        startup_probe.log(&format!(
-            "Setting ACP session model to {} (over pipe)",
-            requested_model
-        ));
-        conn.set_session_model(acp::SetSessionModelRequest::new(
-            session_id.clone(),
-            requested_model.clone(),
-        ))
-        .await
-        .map_err(|e| {
-            anyhow::anyhow!(
-                "set_session_model failed for requested model {}: {}",
-                requested_model,
-                e
+    let (session_id, available_models, current_model_id, has_bootstrap) =
+        if let Some(load_sid) = initial_load_session_id.as_deref() {
+            // No bootstrap. AgentConnected fires with the to-be-loaded
+            // sid as a placeholder so the App flips to Connected (and
+            // binds session_id → owner_tab in `session_to_tab` early,
+            // so any session/update chunks arriving before the
+            // load_session response route to the right tab). The
+            // actual `load_session` is driven by the App after it
+            // processes the queued WtEvent — see `load_session_rx`
+            // arm below for success/failure handling, including the
+            // fallback-to-new-session on boot-time load failure.
+            startup_probe.log(&format!(
+                "skipping bootstrap session/new (initial_load_session_id={} set)",
+                load_sid,
+            ));
+            let _ = event_tx.send(AppEvent::ConnectionStage(format!(
+                "Resuming session {}...",
+                load_sid
+            )));
+            (
+                acp::SessionId::new(load_sid.to_string()),
+                Vec::<crate::app::AcpModelInfo>::new(),
+                None,
+                false,
             )
-        })?;
-        startup_probe.log(&format!(
-            "ACP session model set to {} (over pipe)",
-            requested_model
-        ));
+        } else {
+            let _ = event_tx.send(AppEvent::ConnectionStage("Creating session...".to_string()));
+            startup_probe.log("Creating session (over pipe)");
+            let mut new_session_req = acp::NewSessionRequest::new(cwd.clone());
+            inject_wta_pane_meta(&mut new_session_req.meta);
+            let session_future = conn.new_session(new_session_req);
+            let session =
+                tokio::time::timeout(std::time::Duration::from_secs(30), session_future)
+                    .await
+                    .map_err(|_| {
+                        anyhow::anyhow!("new_session over master pipe timed out after 30s")
+                    })?
+                    .map_err(|e| {
+                        anyhow::anyhow!("new_session over master pipe failed: {}", e)
+                    })?;
+
+            let session_id = session.session_id.clone();
+            startup_probe.log(&format!("Session created (over pipe): {}", session_id));
+            if is_agent_pane {
+                let pane_session_id = std::env::var("WT_SESSION").unwrap_or_default();
+                let pane_for_index = if pane_session_id.is_empty() {
+                    None
+                } else {
+                    Some(pane_session_id.as_str())
+                };
+                tracing::info!(
+                    target: "agent_pane_origin",
+                    session_id = %session_id,
+                    pane_session_id = %pane_session_id,
+                    "recording agent-pane session origin (startup over pipe)",
+                );
+                crate::agent_pane_origin::append_default(session_id.0.as_ref(), pane_for_index);
+            }
+
+            let (available_models, current_model_id) = match &session.models {
+                Some(state) => {
+                    let models: Vec<crate::app::AcpModelInfo> = state
+                        .available_models
+                        .iter()
+                        .map(|m| crate::app::AcpModelInfo {
+                            id: m.model_id.0.to_string(),
+                            name: m.name.clone(),
+                            description: m.description.clone(),
+                        })
+                        .collect();
+                    (models, Some(state.current_model_id.0.to_string()))
+                }
+                None => (Vec::new(), None),
+            };
+            (session_id, available_models, current_model_id, true)
+        };
+
+    // Apply --acp-model if requested. Only valid when we actually have
+    // a bootstrap session to mutate; for the initial-load path the
+    // loaded session's model is whatever the agent stored — overriding
+    // it before the load completes would race the load itself.
+    if has_bootstrap {
+        if let Some(requested_model) = acp_model_override.filter(|s| !s.trim().is_empty()) {
+            let _ = event_tx.send(AppEvent::ConnectionStage(format!(
+                "Selecting model {}...",
+                requested_model
+            )));
+            startup_probe.log(&format!(
+                "Setting ACP session model to {} (over pipe)",
+                requested_model
+            ));
+            conn.set_session_model(acp::SetSessionModelRequest::new(
+                session_id.clone(),
+                requested_model.clone(),
+            ))
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "set_session_model failed for requested model {}: {}",
+                    requested_model,
+                    e
+                )
+            })?;
+            startup_probe.log(&format!(
+                "ACP session model set to {} (over pipe)",
+                requested_model
+            ));
+        }
     }
 
     // Notify app of connection. No raw `program/args` to summarise in
@@ -2198,10 +2358,16 @@ pub async fn run_acp_client_over_pipe(
         load_session_supported,
     });
 
-    // Per-tab session cache. Same semantics as in `run_inner`.
+    // Per-tab session cache. Same semantics as in `run_inner`. Only
+    // pre-populate the owner-tab binding when we actually have a
+    // bootstrap session — otherwise the `load_session_rx` arm would
+    // see the placeholder sid as a prior session, try to `cancel` it,
+    // and the agent CLI would reject the cancel for an unknown sid.
+    // With no entry, the load arm sees `old_sid = None` and loads
+    // cleanly.
     let tab_to_session: Arc<tokio::sync::Mutex<HashMap<String, acp::SessionId>>> =
         Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    {
+    if has_bootstrap {
         let mut g = tab_to_session.lock().await;
         let initial_tab_key = owner_tab_id.clone().unwrap_or_else(|| "0".to_string());
         g.insert(initial_tab_key, session_id.clone());
@@ -2447,7 +2613,7 @@ pub async fn run_acp_client_over_pipe(
                     }
 
                     let session_id = acp::SessionId::new(req.session_id.clone());
-                    let mut load_req = acp::LoadSessionRequest::new(session_id.clone(), cwd);
+                    let mut load_req = acp::LoadSessionRequest::new(session_id.clone(), cwd.clone());
                     // Tell master which WT pane owns the session we're
                     // about to rehydrate, so the registry row for the
                     // resumed sid carries `pane_session_id = <this
@@ -2499,16 +2665,22 @@ pub async fn run_acp_client_over_pipe(
                                 error = ?e,
                                 "load_session failed (helper)"
                             );
-                            let _ = event_tx_for_load.send(AppEvent::TabError {
-                                tab_id: req.tab_id.clone(),
-                                message: format!(
+                            handle_load_failure(
+                                old_sid.as_ref(),
+                                req.tab_id.clone(),
+                                cwd.clone(),
+                                Arc::clone(&conn_for_load),
+                                Arc::clone(&tab_to_session_for_load),
+                                event_tx_for_load.clone(),
+                                format!(
                                     "Failed to resume session in agent pane: {}. \
                                      The connected agent may not recognize this \
                                      session id (CLI mismatch), or `session/load` \
                                      is unsupported.",
                                     e
                                 ),
-                            });
+                            )
+                            .await;
                         }
                         Err(_) => {
                             tracing::warn!(
@@ -2517,13 +2689,18 @@ pub async fn run_acp_client_over_pipe(
                                 session_id = %req.session_id,
                                 "load_session timed out after 60s (helper)"
                             );
-                            let _ = event_tx_for_load.send(AppEvent::TabError {
-                                tab_id: req.tab_id.clone(),
-                                message:
-                                    "Resume timed out after 60s — the agent \
-                                     did not respond to `session/load`."
-                                        .to_string(),
-                            });
+                            handle_load_failure(
+                                old_sid.as_ref(),
+                                req.tab_id.clone(),
+                                cwd.clone(),
+                                Arc::clone(&conn_for_load),
+                                Arc::clone(&tab_to_session_for_load),
+                                event_tx_for_load.clone(),
+                                "Resume timed out after 60s — the agent \
+                                 did not respond to `session/load`."
+                                    .to_string(),
+                            )
+                            .await;
                         }
                     }
                 });


### PR DESCRIPTION
Three independent fixes for the F2 `Resume Session` flow on agent panes.

## 1. `9096d72` — Skip bootstrap `session/new` when `--initial-load-session-id` is set

**Bug**: After resuming a session, the session list showed **two** rows for the same agent pane — the bootstrap session WTA always opens up front, plus the resumed one. Both `Enter`ed into the same physical pane, which was very confusing.

**Fix**: When the helper is launched with `--initial-load-session-id`, skip the unconditional bootstrap `session/new` and go straight to `session/load`. The pane ends up with **one** ACP session, not two.

## 2. `be71382` — Preserve title in `MasterClient::load_session`

**Bug**: Right after fix #1, the resumed pane's session-list row lost its title (showed just `Agent pane session abcd1234: —` instead of the original chat title).

**Fix**: `MasterClient::load_session` was upserting the registry row with an empty title. Pull the existing title from the registry before the upsert so it survives the swap.

## 3. `a9e879b` — Pack replayed history into collapsed CompletedTurn rows

**Bug**: A resumed agent pane dumped the **entire** replayed transcript inline — including the multi-thousand-character system prompt rendered as a single User message. The pane became one continuous wall of wrapped text that was effectively unreadable.

**Fix**: At `SessionAttached` time (load complete), walk `self.messages` and bundle each User → following non-User block into a `CompletedTurn` with `expanded: false`. The collapsed header row shows a single-line preview (first non-empty line, clipped to 80 chars with `…`); the full original User text is preserved as `details[0]` so `Tab + Enter` expands the row back to the complete original content. Messages before the first User (System `Resuming session …` marker, stray Agent dumps) stay inline.

Reuses the existing fold UI — no new chrome.

## Tests
- 4 new unit tests covering pack grouping, pre-User orphan retention, no-op-on-empty, long-prompt preview clipping
- 1 new integration test covering `SessionAttached` → pack ordering
- All 534 `wta` unit tests pass