### PR TITLE
Split error detection from auto-suggest into two dependent settings

### DIFF
--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -93,6 +93,8 @@ namespace winrt::TerminalApp::implementation
         SettingsSubtitleLink().Text(RS_(L"FreOverlay_SettingsSubtitleLink"));
 
         // Set toggle On/Off labels
+        AutoDetectToggle().OnContent(winrt::box_value(RS_(L"FreOverlay_ToggleOn")));
+        AutoDetectToggle().OffContent(winrt::box_value(RS_(L"FreOverlay_ToggleOff")));
         AutoErrorToggle().OnContent(winrt::box_value(RS_(L"FreOverlay_ToggleOn")));
         AutoErrorToggle().OffContent(winrt::box_value(RS_(L"FreOverlay_ToggleOff")));
         SessionManagementToggle().OnContent(winrt::box_value(RS_(L"FreOverlay_ToggleOn")));
@@ -165,17 +167,29 @@ namespace winrt::TerminalApp::implementation
         else if (currentPos == L"top") PanePositionComboBox().SelectedIndex(3);
         else PanePositionComboBox().SelectedIndex(0); // default: bottom
 
-        // Set toggles from current settings, respecting GPO policy
+        // Set toggles from current settings, respecting GPO policy.
+        // Detection drives the suggestion toggle's enabled state (see
+        // _UpdateSuggestionEnabledState), so configure it first.
+        AutoDetectToggle().IsOn(globals.EffectiveAutoErrorDetectionEnabled());
+
+        // Master-detail: EffectiveAutoFixEnabled already returns false when
+        // detection is off, so the suggestion toggle starts consistent with the
+        // master toggle (and reflects the stored preference when detection is
+        // on).
         AutoErrorToggle().IsOn(globals.EffectiveAutoFixEnabled());
         if (globals.IsAutoFixPolicyLocked())
         {
-            AutoErrorToggle().IsEnabled(false);
             const auto policyText = RS_(L"FreOverlay_PolicyLocked");
             AutoErrorPolicyNotice().Text(policyText);
             AutoErrorPolicyNotice().Visibility(Visibility::Visible);
             // Accessibility: explain why the toggle is disabled
             Automation::AutomationProperties::SetHelpText(AutoErrorToggle(), policyText);
         }
+
+        // Apply the detection→suggestion dependency once both toggles are
+        // configured (also covers the GPO-locked case via the policy check
+        // inside the helper).
+        _UpdateSuggestionEnabledState();
 
         // Session management toggle — honour AllowAgentSessionHooks GPO
         if (globals.IsAgentSessionHooksPolicyLocked())
@@ -196,6 +210,8 @@ namespace winrt::TerminalApp::implementation
             WelcomePage(), RS_(L"FreOverlay_WelcomeTitle/Text"));
         Automation::AutomationProperties::SetName(
             SettingsPage(), RS_(L"FreOverlay_SettingsTitle/Text"));
+        Automation::AutomationProperties::SetName(
+            AutoDetectToggle(), RS_(L"FreOverlay_AutoDetectLabel/Text"));
         Automation::AutomationProperties::SetName(
             AutoErrorToggle(), RS_(L"FreOverlay_AutoErrorLabel/Text"));
         Automation::AutomationProperties::SetName(
@@ -233,6 +249,40 @@ namespace winrt::TerminalApp::implementation
         {
             hint.Visibility(toggle.IsOn() ? Visibility::Visible : Visibility::Collapsed);
         }
+    }
+
+    // ── Detection → suggestion dependency ───────────────────────────────
+
+    void FreOverlay::_OnAutoDetectToggled(const IInspectable& /*sender*/,
+                                          const RoutedEventArgs& /*args*/)
+    {
+        _UpdateSuggestionEnabledState();
+    }
+
+    void FreOverlay::_UpdateSuggestionEnabledState()
+    {
+        // Guard: Toggled can fire during InitializeComponent before the
+        // sibling control exists.
+        auto detect = AutoDetectToggle();
+        auto suggest = AutoErrorToggle();
+        if (!detect || !suggest)
+        {
+            return;
+        }
+
+        const bool detectionOn = detect.IsOn();
+        const bool autoFixLocked = _settings && _settings.GlobalSettings().IsAutoFixPolicyLocked();
+
+        // Master-detail: detection off ⇒ turn the suggestion off and make it
+        // non-interactable (can't configure a suggestion you can't detect).
+        // Detection on ⇒ re-enable it; its On/Off is the stored preference
+        // (set on init), so re-enabling doesn't force it on. The auto-fix GPO
+        // can still lock it off.
+        if (!detectionOn)
+        {
+            suggest.IsOn(false);
+        }
+        suggest.IsEnabled(detectionOn && !autoFixLocked);
     }
 
     // ── Page navigation ─────────────────────────────────────────────────
@@ -334,6 +384,7 @@ namespace winrt::TerminalApp::implementation
         {
             const auto& globals = _settings.GlobalSettings();
             globals.AcpAgent(agentId);
+            globals.AutoErrorDetectionEnabled(AutoDetectToggle().IsOn());
             globals.AutoFixEnabled(AutoErrorToggle().IsOn());
 
             const auto posIdx = PanePositionComboBox().SelectedIndex();
@@ -398,11 +449,12 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        // 5. Install shell integration unconditionally. The Detected pill
-        // (suggest-mode default — toggle off) also needs OSC 133 emitted
-        // by the shell to drive the bottom-bar state machine. The toggle
-        // only controls whether WTA *automatically* invokes the LLM on
-        // failure, not whether errors are detected at all.
+        // 5. Install shell integration only when error detection is enabled.
+        // Detection is driven by the OSC 133 marks emitted by shell
+        // integration; with detection off we honour "don't access my shell"
+        // and skip the install entirely. (The suggestion toggle is a
+        // strict subset — it can't be on unless detection is on.)
+        if (AutoDetectToggle().IsOn())
         {
             auto self = weak.get();
             if (!self) co_return;

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -273,8 +273,8 @@ namespace winrt::TerminalApp::implementation
         const bool detectionOn = detect.IsOn();
         const bool autoFixLocked = _settings && _settings.GlobalSettings().IsAutoFixPolicyLocked();
 
-        // Master-detail: detection off ⇒ turn the suggestion off and make it
-        // non-interactable (can't configure a suggestion you can't detect).
+        // Master-detail: detection off ⇒ turn the suggestion off and disable it
+        // (can't configure a suggestion you can't detect).
         // Detection on ⇒ re-enable it; its On/Off is the stored preference
         // (set on init), so re-enabling doesn't force it on. The auto-fix GPO
         // can still lock it off.

--- a/src/cascadia/TerminalApp/FreOverlay.h
+++ b/src/cascadia/TerminalApp/FreOverlay.h
@@ -43,12 +43,19 @@ namespace winrt::TerminalApp::implementation
                                       const winrt::Windows::UI::Xaml::Controls::SelectionChangedEventArgs& args);
         void _OnSessionManagementToggled(const winrt::Windows::Foundation::IInspectable& sender,
                                          const winrt::Windows::UI::Xaml::RoutedEventArgs& args);
+        void _OnAutoDetectToggled(const winrt::Windows::Foundation::IInspectable& sender,
+                                  const winrt::Windows::UI::Xaml::RoutedEventArgs& args);
 
         // No-op kept for IDL compatibility.
         void ResetDragOffset();
 
     private:
         winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings _settings{ nullptr };
+
+        // Apply the detection→suggestion master-detail dependency: detection
+        // off turns the suggestion toggle off and disables it; detection on
+        // re-enables it (preserving the stored value).
+        void _UpdateSuggestionEnabledState();
 
         // Detect whether an executable is on PATH.
         static bool _IsAgentInstalled(const wchar_t* name);

--- a/src/cascadia/TerminalApp/FreOverlay.xaml
+++ b/src/cascadia/TerminalApp/FreOverlay.xaml
@@ -15,6 +15,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="using:TerminalApp"
+             xmlns:mux="using:Microsoft.UI.Xaml.Controls"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
              TabFocusNavigation="Cycle">
@@ -28,6 +29,7 @@
 
     <!--  Full-screen dark background  -->
     <Grid x:Name="RootGrid" Background="#FF1E1E1E"
+          RequestedTheme="Dark"
           HighContrastAdjustment="Auto">
         <Grid.RowDefinitions>
             <!--  Title bar space  -->
@@ -198,7 +200,11 @@
                                 MaxWidth="{StaticResource StandardControlMaxWidth}"
                                 HorizontalAlignment="Center">
                         <!--  Agent  -->
-                        <Border Background="#19FFFFFF" CornerRadius="4" Padding="16,12">
+                        <Border Background="{ThemeResource ExpanderHeaderBackground}"
+                                BorderBrush="{ThemeResource ExpanderHeaderBorderBrush}"
+                                BorderThickness="{ThemeResource ExpanderHeaderBorderThickness}"
+                                CornerRadius="{ThemeResource ControlCornerRadius}"
+                                Padding="16,12">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
@@ -235,17 +241,25 @@
                             </Grid>
                         </Border>
 
-                        <!--  Automatic error detection — gates suggestion below.
-                              When off, the suggestion toggle is forced off and
-                              disabled (see _OnAutoDetectToggled).  -->
-                        <Border Background="#19FFFFFF" CornerRadius="4" Padding="16,12">
-                            <StackPanel Spacing="4">
+                        <!--  Automatic error detection (master) + suggestion
+                              (nested), modeled as an Expander to match the
+                              settings editor: detection's toggle lives in the
+                              always-visible header; the suggestion toggle is
+                              nested in the body and is forced off + disabled
+                              when detection is off (see _OnAutoDetectToggled).
+                              RequestedTheme=Dark so the Expander chrome matches
+                              the dark full-screen FRE.  -->
+                        <mux:Expander RequestedTheme="Dark"
+                                      HorizontalAlignment="Stretch"
+                                      HorizontalContentAlignment="Stretch"
+                                      IsExpanded="True">
+                            <mux:Expander.Header>
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
-                                    <StackPanel Grid.Column="0" Spacing="2">
+                                    <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="2">
                                         <TextBlock x:Uid="FreOverlay_AutoDetectLabel"
                                                    FontSize="14" FontWeight="SemiBold"
                                                    Foreground="White" />
@@ -258,20 +272,17 @@
                                                   HorizontalAlignment="Right" MinWidth="0"
                                                   Toggled="_OnAutoDetectToggled" />
                                 </Grid>
-                            </StackPanel>
-                        </Border>
-
-                        <!--  Automatic error suggestion — depends on detection
-                              above (auto-suggest needs errors to be detected
-                              first).  -->
-                        <Border Background="#19FFFFFF" CornerRadius="4" Padding="16,12">
+                            </mux:Expander.Header>
+                            <!--  Body: suggestion (nested dependent). Plain rows,
+                                  no separate card — forced off + disabled when
+                                  detection is off.  -->
                             <StackPanel Spacing="4">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
-                                    <StackPanel Grid.Column="0" Spacing="2">
+                                    <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="2">
                                         <TextBlock x:Uid="FreOverlay_AutoErrorLabel"
                                                    FontSize="14" FontWeight="SemiBold"
                                                    Foreground="White" />
@@ -289,10 +300,14 @@
                                            Visibility="Collapsed"
                                            AutomationProperties.LiveSetting="Polite" />
                             </StackPanel>
-                        </Border>
+                        </mux:Expander>
 
                         <!--  Session management  -->
-                        <Border Background="#19FFFFFF" CornerRadius="4" Padding="16,12">
+                        <Border Background="{ThemeResource ExpanderHeaderBackground}"
+                                BorderBrush="{ThemeResource ExpanderHeaderBorderBrush}"
+                                BorderThickness="{ThemeResource ExpanderHeaderBorderThickness}"
+                                CornerRadius="{ThemeResource ControlCornerRadius}"
+                                Padding="16,12">
                             <StackPanel Spacing="4">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
@@ -326,7 +341,11 @@
                         </Border>
 
                         <!--  Pane position  -->
-                        <Border Background="#19FFFFFF" CornerRadius="4" Padding="16,12">
+                        <Border Background="{ThemeResource ExpanderHeaderBackground}"
+                                BorderBrush="{ThemeResource ExpanderHeaderBorderBrush}"
+                                BorderThickness="{ThemeResource ExpanderHeaderBorderThickness}"
+                                CornerRadius="{ThemeResource ControlCornerRadius}"
+                                Padding="16,12">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />

--- a/src/cascadia/TerminalApp/FreOverlay.xaml
+++ b/src/cascadia/TerminalApp/FreOverlay.xaml
@@ -258,11 +258,6 @@
                                                   HorizontalAlignment="Right" MinWidth="0"
                                                   Toggled="_OnAutoDetectToggled" />
                                 </Grid>
-                                <TextBlock x:Name="AutoDetectPolicyNotice"
-                                           FontSize="12" FontStyle="Italic"
-                                           Foreground="#CCFFA500" TextWrapping="Wrap"
-                                           Visibility="Collapsed"
-                                           AutomationProperties.LiveSetting="Polite" />
                             </StackPanel>
                         </Border>
 

--- a/src/cascadia/TerminalApp/FreOverlay.xaml
+++ b/src/cascadia/TerminalApp/FreOverlay.xaml
@@ -235,7 +235,40 @@
                             </Grid>
                         </Border>
 
-                        <!--  Auto-error detection  -->
+                        <!--  Automatic error detection — gates suggestion below.
+                              When off, the suggestion toggle is forced off and
+                              disabled (see _OnAutoDetectToggled).  -->
+                        <Border Background="#19FFFFFF" CornerRadius="4" Padding="16,12">
+                            <StackPanel Spacing="4">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <StackPanel Grid.Column="0" Spacing="2">
+                                        <TextBlock x:Uid="FreOverlay_AutoDetectLabel"
+                                                   FontSize="14" FontWeight="SemiBold"
+                                                   Foreground="White" />
+                                        <TextBlock x:Uid="FreOverlay_AutoDetectDescription"
+                                                   FontSize="12" Foreground="#99FFFFFF"
+                                                   TextWrapping="Wrap" />
+                                    </StackPanel>
+                                    <ToggleSwitch x:Name="AutoDetectToggle" Grid.Column="1"
+                                                  IsOn="True" VerticalAlignment="Center"
+                                                  HorizontalAlignment="Right" MinWidth="0"
+                                                  Toggled="_OnAutoDetectToggled" />
+                                </Grid>
+                                <TextBlock x:Name="AutoDetectPolicyNotice"
+                                           FontSize="12" FontStyle="Italic"
+                                           Foreground="#CCFFA500" TextWrapping="Wrap"
+                                           Visibility="Collapsed"
+                                           AutomationProperties.LiveSetting="Polite" />
+                            </StackPanel>
+                        </Border>
+
+                        <!--  Automatic error suggestion — depends on detection
+                              above (auto-suggest needs errors to be detected
+                              first).  -->
                         <Border Background="#19FFFFFF" CornerRadius="4" Padding="16,12">
                             <StackPanel Spacing="4">
                                 <Grid>

--- a/src/cascadia/TerminalApp/Resources/af-ZA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/af-ZA/Resources.resw
@@ -177,4 +177,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/af-ZA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/af-ZA/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Stel outomaties oplossings vir mislukte opdragte voor</value>
+    <value>Outomatiese foutvoorstel</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Wanneer dit geaktiveer is, ontleed die KI-agent outomaties mislukte opdragte en stel 'n oplossing voor. Wanneer dit gedeaktiveer is, wys mislukte opdragte 'n klikbare wenk in die statusbalk — druk Ctrl+Alt+. of klik die wenk om 'n oplossing te versoek.</value>
+    <value>Gee Intelligent Terminal toestemming om foute na jou agent te stuur om outomaties oplossings voor te stel.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -178,9 +178,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Outomatiese foutopsporing</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Gee Intelligent Terminal toestemming om toegang tot jou dop te verkry en foute outomaties op te spoor.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/am-ET/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/am-ET/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>ለተሳኩ ትዕዛዞች ጥገናዎችን በራስ-ሰር ይጠቁሙ</value>
+    <value>ራስ-ሰር የስህተት ጥቆማ</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>ሲነቃ፣ AI ወኪሉ የተሳኩ ትዕዛዞችን በራስ-ሰር ይተነትናል እና ጥገና ያቀርባል። ሲጠፋ፣ የተሳኩ ትዕዛዞች በሁኔታ አሞሌ ላይ ሊጫን የሚችል ፍንጭ ያሳያሉ — ጥገና ለመጠየቅ Ctrl+Alt+. ይጫኑ ወይም ፍንጩን ጠቅ ያድርጉ።</value>
+    <value>Intelligent Terminal እርማቶችን ራስ-ሰር ለመጠቆም ስህተቶችን ወደ ወኪልዎ እንዲልክ ይፍቀዱ።</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -178,9 +178,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>ራስ-ሰር የስህተት ማወቅ</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal ወደ ሼልዎ መድረስ እና ስህተቶችን ራስ-ሰር እንዲያውቅ ይፍቀዱ።</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/am-ET/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/am-ET/Resources.resw
@@ -177,4 +177,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ar-SA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ar-SA/Resources.resw
@@ -172,10 +172,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>اقتراح الإصلاحات تلقائيًا للأوامر الفاشلة</value>
+    <value>اقتراح الأخطاء التلقائي</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>عند التمكين، يحلل وكيل الذكاء الاصطناعي الأوامر الفاشلة تلقائيًا ويقترح إصلاحًا. عند التعطيل، تعرض الأوامر الفاشلة تلميحًا قابلاً للنقر في شريط الحالة — اضغط على Ctrl+Alt+. أو انقر على التلميح لطلب إصلاح.</value>
+    <value>امنح Intelligent Terminal إذنًا بإرسال الأخطاء إلى الوكيل لاقتراح الإصلاحات تلقائيًا.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>الكشف التلقائي عن الأخطاء</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>امنح Intelligent Terminal إذنًا بالوصول إلى الصدفة واكتشاف الأخطاء تلقائيًا.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ar-SA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ar-SA/Resources.resw
@@ -291,4 +291,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/as-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/as-IN/Resources.resw
@@ -292,4 +292,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/as-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/as-IN/Resources.resw
@@ -172,10 +172,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>বিফল কমাণ্ডসমূহৰ বাবে স্বয়ংক্ৰিয়ভাৱে সমাধান পৰামৰ্শ দিয়ক</value>
+    <value>স্বয়ংক্ৰিয় ত্ৰুটি পৰামৰ্শ</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>সক্ষম কৰিলে, AI এজেণ্টে স্বয়ংক্ৰিয়ভাৱে বিফল কমাণ্ডসমূহ বিশ্লেষণ কৰে আৰু সমাধান প্ৰস্তাৱ কৰে। অক্ষম কৰিলে, বিফল কমাণ্ডসমূহে স্থিতি বাৰত ক্লিক কৰিব পৰা ইংগিত দেখুৱায় — সমাধান বিচাৰিবলৈ Ctrl+Alt+. টিপক বা ইংগিতত ক্লিক কৰক।</value>
+    <value>Intelligent Terminal ক স্বয়ংক্ৰিয়ভাৱে সমাধান পৰামৰ্শ দিবলৈ আপোনাৰ এজেণ্টলৈ ত্ৰুটি পঠিয়াবলৈ অনুমতি দিয়ক।</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -293,9 +293,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>স্বয়ংক্ৰিয় ত্ৰুটি চিনাক্তকৰণ</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal ক আপোনাৰ শ্বেল ব্যৱহাৰ কৰিবলৈ আৰু ত্ৰুটিসমূহ স্বয়ংক্ৰিয়ভাৱে চিনাক্ত কৰিবলৈ অনুমতি দিয়ক।</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/az-Latn-AZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/az-Latn-AZ/Resources.resw
@@ -290,4 +290,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/az-Latn-AZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/az-Latn-AZ/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Uğursuz əmrlər üçün düzəlişləri avtomatik təklif et</value>
+    <value>Avtomatik səhv təklifi</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Aktiv edildikdə, AI agenti uğursuz əmrləri avtomatik təhlil edir və düzəliş təklif edir. Deaktiv edildikdə, uğursuz əmrlər status panelində klikləmək mümkün olan ipucu göstərir — düzəliş tələb etmək üçün Ctrl+Alt+. düyməsini basın və ya ipucunu klikləyin.</value>
+    <value>Intelligent Terminal-ə düzəlişləri avtomatik təklif etmək üçün səhvləri agentinizə göndərmək icazəsi verin.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -291,9 +291,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Avtomatik səhv aşkarlanması</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal-ə qabığınıza daxil olmaq və səhvləri avtomatik aşkarlamaq icazəsi verin.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/bg-BG/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bg-BG/Resources.resw
@@ -290,4 +290,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/bg-BG/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bg-BG/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Автоматично предлагане на корекции за неуспешни команди</value>
+    <value>Автоматично предлагане на грешки</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Когато е активирано, AI агентът автоматично анализира неуспешните команди и предлага корекция. Когато е деактивирано, неуспешните команди показват подсказка с възможност за щракване в лентата на състоянието — натиснете Ctrl+Alt+. или щракнете върху подсказката, за да поискате корекция.</value>
+    <value>Разрешете на Intelligent Terminal да изпраща грешки до вашия агент за автоматично предлагане на корекции.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -291,9 +291,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Автоматично откриване на грешки</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Разрешете на Intelligent Terminal достъп до вашата обвивка и автоматично откриване на грешки.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/bn-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bn-IN/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/bn-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bn-IN/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>ব্যর্থ কমান্ডের জন্য স্বয়ংক্রিয়ভাবে সমাধানের পরামর্শ দিন</value>
+    <value>স্বয়ংক্রিয় ত্রুটি পরামর্শ</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>সক্ষম করা হলে, AI এজেন্ট স্বয়ংক্রিয়ভাবে ব্যর্থ কমান্ড বিশ্লেষণ করে এবং একটি সমাধান প্রস্তাব করে। অক্ষম করা হলে, ব্যর্থ কমান্ডগুলি স্ট্যাটাস বারে একটি ক্লিকযোগ্য ইঙ্গিত প্রদর্শন করে — সমাধান অনুরোধ করতে Ctrl+Alt+. চাপুন বা ইঙ্গিতটিতে ক্লিক করুন।</value>
+    <value>Intelligent Terminal-কে স্বয়ংক্রিয়ভাবে সমাধানের পরামর্শ দেওয়ার জন্য আপনার এজেন্টে ত্রুটি পাঠাতে অনুমতি দিন।</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>স্বয়ংক্রিয় ত্রুটি সনাক্তকরণ</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal-কে আপনার শেল অ্যাক্সেস করতে এবং স্বয়ংক্রিয়ভাবে ত্রুটি সনাক্ত করতে অনুমতি দিন।</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/bs-Latn-BA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bs-Latn-BA/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Automatski predloži popravke za neuspjele komande</value>
+    <value>Automatski prijedlog grešaka</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Kada je omogućeno, AI agent automatski analizira neuspjele komande i predlaže popravku. Kada je onemogućeno, neuspjele komande prikazuju savjet na koji se može kliknuti u traci stanja — pritisnite Ctrl+Alt+. ili kliknite na savjet da zatražite popravku.</value>
+    <value>Dozvolite aplikaciji Intelligent Terminal da šalje greške vašem agentu radi automatskog predlaganja popravki.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -178,9 +178,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatsko otkrivanje grešaka</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Dozvolite aplikaciji Intelligent Terminal pristup vašoj ljusci i automatsko otkrivanje grešaka.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/bs-Latn-BA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bs-Latn-BA/Resources.resw
@@ -177,4 +177,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ca-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ca-ES/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Suggereix solucions automàticament per a ordres fallides</value>
+    <value>Suggeriment automàtic d'errors</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Quan està habilitat, l'agent d'IA analitza automàticament les ordres fallides i proposa una solució. Quan està deshabilitat, les ordres fallides mostren un suggeriment clicable a la barra d'estat — premeu Ctrl+Alt+. o feu clic al suggeriment per sol·licitar una solució.</value>
+    <value>Permet que l'Intelligent Terminal enviï errors al teu agent per suggerir solucions automàticament.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -123,9 +123,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Inactiu</value>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Detecció automàtica d'errors</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Permet que l'Intelligent Terminal accedeixi a l'intèrpret d'ordres i detecti errors automàticament.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ca-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ca-ES/Resources.resw
@@ -122,4 +122,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_ToggleOff" xml:space="preserve">
     <value>Inactiu</value>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ca-Es-VALENCIA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ca-Es-VALENCIA/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Suggereix solucions automàticament per a ordres fallides</value>
+    <value>Suggeriment automàtic d'errors</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Quan està habilitat, l'agent d'IA analitza automàticament les ordres fallides i proposa una solució. Quan està deshabilitat, les ordres fallides mostren un suggeriment clicable a la barra d'estat — premeu Ctrl+Alt+. o feu clic al suggeriment per a sol·licitar una solució.</value>
+    <value>Permet que l'Intelligent Terminal envie errors al teu agent per suggerir solucions automàticament.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -123,9 +123,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Inactiu</value>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Detecció automàtica d'errors</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Permet que l'Intelligent Terminal accedisca a l'intèrpret d'ordres i detecte errors automàticament.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ca-Es-VALENCIA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ca-Es-VALENCIA/Resources.resw
@@ -122,4 +122,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_ToggleOff" xml:space="preserve">
     <value>Inactiu</value>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/cs-CZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/cs-CZ/Resources.resw
@@ -290,4 +290,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/cs-CZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/cs-CZ/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Automaticky navrhovat opravy pro neúspěšné příkazy</value>
+    <value>Automatický návrh oprav chyb</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Pokud je tato možnost povolena, agent AI automaticky analyzuje neúspěšné příkazy a navrhuje opravu. Pokud je zakázána, neúspěšné příkazy zobrazí klikatelný tip ve stavovém řádku — stiskněte Ctrl+Alt+. nebo klikněte na tip pro vyžádání opravy.</value>
+    <value>Povolte aplikaci Intelligent Terminal odesílat chyby agentovi pro automatické navrhování oprav.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -291,9 +291,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatická detekce chyb</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Povolte aplikaci Intelligent Terminal přístup k prostředí shell a automatickou detekci chyb.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/cy-GB/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/cy-GB/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Awgrymu trwsiadau yn awtomatig ar gyfer gorchmynion wedi methu</value>
+    <value>Awgrymu gwallau yn awtomatig</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Pan fydd wedi ei alluogi, mae'r asiant AI yn dadansoddi gorchmynion sydd wedi methu yn awtomatig ac yn cynnig trwsiad. Pan fydd wedi'i analluogi, mae gorchmynion sydd wedi methu yn dangos awgrym y gellir clicio arno yn y bar statws — pwyswch Ctrl+Alt+. neu cliciwch ar yr awgrym i ofyn am drwsiad.</value>
+    <value>Rhowch ganiatâd i Intelligent Terminal anfon gwallau at eich asiant i awgrymu atebion yn awtomatig.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -178,9 +178,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Canfod gwallau yn awtomatig</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Rhowch ganiatâd i Intelligent Terminal gael mynediad i'ch cragen a chanfod gwallau yn awtomatig.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/cy-GB/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/cy-GB/Resources.resw
@@ -177,4 +177,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/da-DK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/da-DK/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/da-DK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/da-DK/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Foreslå automatisk rettelser til mislykkede kommandoer</value>
+    <value>Automatisk fejlforslag</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Når dette er aktiveret, analyserer AI-agenten automatisk mislykkede kommandoer og foreslår en rettelse. Når det er deaktiveret, viser mislykkede kommandoer et tip, der kan klikkes på, i statuslinjen — tryk på Ctrl+Alt+. eller klik på tippet for at anmode om en rettelse.</value>
+    <value>Giv Intelligent Terminal tilladelse til at sende fejl til din agent for automatisk at foreslå rettelser.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatisk fejlregistrering</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Giv Intelligent Terminal tilladelse til at få adgang til din shell og automatisk registrere fejl.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
@@ -1013,10 +1013,10 @@
     <comment>{Locked="Node.js","NPX"}</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Korrekturen für fehlgeschlagene Befehle automatisch vorschlagen</value>
+    <value>Automatischer Fehlervorschlag</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Wenn aktiviert, analysiert der KI-Agent fehlgeschlagene Befehle automatisch und schlägt eine Korrektur vor. Wenn deaktiviert, wird für fehlgeschlagene Befehle ein anklickbarer Hinweis in der Statusleiste angezeigt — drücken Sie Ctrl+Alt+. oder klicken Sie auf den Hinweis, um eine Korrektur anzufordern.</value>
+    <value>Erlauben Sie Intelligent Terminal, Fehler an Ihren Agent zu senden, um automatisch Korrekturen vorzuschlagen.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -1140,9 +1140,9 @@
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatische Fehlererkennung</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Erlauben Sie Intelligent Terminal, auf Ihre Shell zuzugreifen und Fehler automatisch zu erkennen.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
@@ -1139,4 +1139,10 @@
     <value>Terminal Protocol</value>
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/el-GR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/el-GR/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Αυτόματη πρόταση διορθώσεων για αποτυχημένες εντολές</value>
+    <value>Αυτόματη πρόταση σφαλμάτων</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Όταν είναι ενεργοποιημένο, ο πράκτορας τεχνητής νοημοσύνης αναλύει αυτόματα τις αποτυχημένες εντολές και προτείνει μια διόρθωση. Όταν είναι απενεργοποιημένο, οι αποτυχημένες εντολές εμφανίζουν μια υπόδειξη με δυνατότητα κλικ στη γραμμή κατάστασης — πατήστε Ctrl+Alt+. ή κάντε κλικ στην υπόδειξη για να ζητήσετε μια διόρθωση.</value>
+    <value>Επιτρέψτε στο Intelligent Terminal να στέλνει σφάλματα στον agent για αυτόματη πρόταση διορθώσεων.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -178,9 +178,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Αυτόματος εντοπισμός σφαλμάτων</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Επιτρέψτε στο Intelligent Terminal να αποκτήσει πρόσβαση στο κέλυφος και να εντοπίζει αυτόματα σφάλματα.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/el-GR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/el-GR/Resources.resw
@@ -177,4 +177,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-GB/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-GB/Resources.resw
@@ -285,4 +285,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-GB/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-GB/Resources.resw
@@ -167,10 +167,10 @@
     <comment>{Locked="Node.js","NPX"}</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Auto-suggest fixes for failed commands</value>
+    <value>Automatic error suggestion</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>When enabled, the AI agent automatically analyses failed commands and proposes a fix. When disabled, failed commands surface a clickable hint in the status bar — press Ctrl+Alt+. or click the hint to request a fix.</value>
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1078,12 +1078,21 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>{Locked="Node.js","NPX"}
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+    <comment>Header for the toggle that lets the terminal observe the shell and detect failed commands.</comment>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name. Description for the automatic-error-detection toggle in the first-run wizard.</comment>
+  </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Auto-suggest fixes for failed commands</value>
+    <value>Automatic error suggestion</value>
+    <comment>Header for the toggle that lets the agent automatically suggest fixes for detected errors. Depends on automatic error detection being on.</comment>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>When enabled, the AI agent automatically analyzes failed commands and proposes a fix. When disabled, failed commands surface a clickable hint in the status bar — press Ctrl+Alt+. or click the hint to request a fix.</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} Description for the auto-suggest-fixes toggle in the first-run wizard. "AI agent" is a generic role name (Copilot, Claude, Gemini), not a human.</comment>
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name. Description for the automatic-error-suggestion toggle in the first-run wizard. In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
     <value>Session management</value>

--- a/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
@@ -1010,10 +1010,10 @@
     <comment>{Locked="Node.js","NPX"}</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Sugerir correcciones automáticamente para comandos fallidos</value>
+    <value>Sugerencia automática de errores</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Cuando está habilitado, el agente de IA analiza automáticamente los comandos fallidos y propone una corrección. Cuando está deshabilitado, los comandos fallidos muestran una sugerencia en la barra de estado en la que se puede hacer clic — presione Ctrl+Alt+. o haga clic en la sugerencia para solicitar una corrección.</value>
+    <value>Permita que Intelligent Terminal envíe errores a su agente para sugerir correcciones automáticamente.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -1137,9 +1137,9 @@
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Detección automática de errores</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Permita que Intelligent Terminal acceda a su shell y detecte errores automáticamente.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
@@ -1136,4 +1136,10 @@
     <value>Terminal Protocol</value>
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/es-MX/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-MX/Resources.resw
@@ -285,4 +285,10 @@
     <value>Terminal Protocol</value>
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/es-MX/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-MX/Resources.resw
@@ -167,10 +167,10 @@
     <comment>{Locked="Node.js","NPX"}</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Sugerir correcciones automáticamente para comandos fallidos</value>
+    <value>Sugerencia automática de errores</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Cuando está habilitado, el agente de IA analiza automáticamente los comandos fallidos y propone una corrección. Cuando está deshabilitado, los comandos fallidos muestran una sugerencia en la barra de estado en la que se puede hacer clic — presione Ctrl+Alt+. o haga clic en la sugerencia para solicitar una corrección.</value>
+    <value>Permita que Intelligent Terminal envíe errores a su agente para sugerir correcciones automáticamente.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -286,9 +286,9 @@
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Detección automática de errores</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Permita que Intelligent Terminal acceda a su shell y detecte errores automáticamente.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/et-EE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/et-EE/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/et-EE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/et-EE/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Soovita automaatselt parandusi nurjunud käskudele</value>
+    <value>Automaatne vigade soovitamine</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Kui see on lubatud, analüüsib AI-agent automaatselt nurjunud käske ja pakub välja paranduse. Kui see on keelatud, kuvavad nurjunud käsud olekuribal klõpsatava vihje — paranduse taotlemiseks vajutage Ctrl+Alt+. või klõpsake vihjel.</value>
+    <value>Lubage rakendusel Intelligent Terminal saata vead teie agendile, et automaatselt parandusi soovitada.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automaatne vigade tuvastamine</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Lubage rakendusel Intelligent Terminal pääseda juurde teie kestale ja tuvastada vead automaatselt.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/eu-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/eu-ES/Resources.resw
@@ -122,4 +122,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_ToggleOff" xml:space="preserve">
     <value>Desaktibatuta</value>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/eu-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/eu-ES/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Iradoki konponketak automatikoki huts egindako komandoetarako</value>
+    <value>Erroreen iradokizun automatikoa</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Gaituta dagoenean, IA agenteak automatikoki aztertzen ditu huts egindako komandoak eta konponketa bat proposatzen du. Desgaituta dagoenean, huts egindako komandoek egoera-barran klikatu daitekeen aholku bat erakusten dute — sakatu Ctrl+Alt+. edo egin klik aholkuan konponketa eskatzeko.</value>
+    <value>Eman baimena Intelligent Terminal-i erroreak zure agenteari bidaltzeko konponketak automatikoki iradokitzeko.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -123,9 +123,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Desaktibatuta</value>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Erroreen detekzio automatikoa</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Eman baimena Intelligent Terminal-i zure shell-era sartzeko eta erroreak automatikoki detektatzeko.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fa-IR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fa-IR/Resources.resw
@@ -172,10 +172,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>پیشنهاد خودکار رفع‌ها برای فرمان‌های ناموفق</value>
+    <value>پیشنهاد خودکار خطا</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>هنگام فعال بودن، عامل هوش مصنوعی به طور خودکار فرمان‌های ناموفق را تحلیل می‌کند و یک رفع پیشنهاد می‌دهد. هنگام غیرفعال بودن، فرمان‌های ناموفق یک راهنمای قابل کلیک در نوار وضعیت نمایش می‌دهند — برای درخواست رفع، Ctrl+Alt+. را فشار دهید یا روی راهنما کلیک کنید.</value>
+    <value>به Intelligent Terminal اجازه دهید خطاها را برای پیشنهاد خودکار راه‌حل به عامل شما ارسال کند.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>تشخیص خودکار خطا</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>به Intelligent Terminal اجازه دهید به پوسته شما دسترسی پیدا کند و خطاها را به طور خودکار تشخیص دهد.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fa-IR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fa-IR/Resources.resw
@@ -291,4 +291,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fi-FI/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fi-FI/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fi-FI/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fi-FI/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Ehdota automaattisesti korjauksia epäonnistuneille komennoille</value>
+    <value>Automaattinen virheiden ehdotus</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Kun käytössä, tekoälyagentti analysoi automaattisesti epäonnistuneet komennot ja ehdottaa korjausta. Kun ei käytössä, epäonnistuneet komennot näyttävät napsautettavan vihjeen tilarivillä — paina Ctrl+Alt+. tai napsauta vihjettä pyytääksesi korjausta.</value>
+    <value>Salli Intelligent Terminalin lähettää virheet agentille korjausten ehdottamiseksi automaattisesti.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automaattinen virheiden tunnistus</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Salli Intelligent Terminalin käyttää komentotulkkia ja tunnistaa virheet automaattisesti.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fil-PH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fil-PH/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Awtomatikong magmungkahi ng mga ayos para sa mga nabigong utos</value>
+    <value>Awtomatikong mungkahi ng error</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Kapag pinagana, awtomatikong sinusuri ng AI agent ang mga nabigong utos at nagmumungkahi ng ayos. Kapag hindi pinagana, ang mga nabigong utos ay nagpapakita ng mai-click na pahiwatig sa status bar — pindutin ang Ctrl+Alt+. o i-click ang pahiwatig upang humiling ng ayos.</value>
+    <value>Bigyan ang Intelligent Terminal ng pahintulot na magpadala ng mga error sa iyong agent upang awtomatikong magmungkahi ng mga ayos.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -236,9 +236,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Sarado</value>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Awtomatikong pagtukoy ng error</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Bigyan ang Intelligent Terminal ng pahintulot na i-access ang iyong shell at awtomatikong tukuyin ang mga error.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fil-PH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fil-PH/Resources.resw
@@ -235,4 +235,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_ToggleOff" xml:space="preserve">
     <value>Sarado</value>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fr-CA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-CA/Resources.resw
@@ -285,4 +285,10 @@
     <value>Terminal Protocol</value>
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fr-CA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-CA/Resources.resw
@@ -167,10 +167,10 @@
     <comment>{Locked="Node.js","NPX"}</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Suggérer automatiquement des correctifs pour les commandes en échec</value>
+    <value>Suggestion automatique des erreurs</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Lorsque cette option est activée, l'agent IA analyse automatiquement les commandes en échec et propose un correctif. Lorsqu'elle est désactivée, les commandes en échec affichent une indication cliquable dans la barre d'état — appuyez sur Ctrl+Alt+. ou cliquez sur l'indication pour demander un correctif.</value>
+    <value>Autorisez Intelligent Terminal à envoyer les erreurs à votre agent pour suggérer automatiquement des correctifs.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -286,9 +286,9 @@
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Détection automatique des erreurs</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Autorisez Intelligent Terminal à accéder à votre shell et à détecter automatiquement les erreurs.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
@@ -1011,10 +1011,10 @@
     <comment>{Locked="Node.js","NPX"}</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Suggérer automatiquement des correctifs pour les commandes en échec</value>
+    <value>Suggestion automatique des erreurs</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Lorsque cette option est activée, l'agent IA analyse automatiquement les commandes en échec et propose un correctif. Lorsqu'elle est désactivée, les commandes en échec affichent une indication cliquable dans la barre d'état — appuyez sur Ctrl+Alt+. ou cliquez sur l'indication pour demander un correctif.</value>
+    <value>Autorisez Intelligent Terminal à envoyer les erreurs à votre agent pour suggérer automatiquement des correctifs.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -1138,9 +1138,9 @@
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Détection automatique des erreurs</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Autorisez Intelligent Terminal à accéder à votre shell et à détecter automatiquement les erreurs.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
@@ -1137,4 +1137,10 @@
     <value>Terminal Protocol</value>
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ga-IE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ga-IE/Resources.resw
@@ -177,4 +177,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ga-IE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ga-IE/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Mol deisithe go huathoibríoch d'orduithe a theip orthu</value>
+    <value>Moladh earráidí uathoibríoch</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Nuair atá sé cumasaithe, déanann an ghníomhaire IS anailís uathoibríoch ar orduithe a theip orthu agus molann sé deisiú. Nuair atá sé díchumasaithe, taispeánann orduithe a theip orthu nod inchliceáilte sa bharra stádais — brúigh Ctrl+Alt+. nó cliceáil ar an nod chun deisiú a iarraidh.</value>
+    <value>Tabhair cead do Intelligent Terminal earráidí a sheoladh chuig do ghníomhaire chun réitigh a mholadh go huathoibríoch.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -178,9 +178,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Brath earráidí uathoibríoch</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Tabhair cead do Intelligent Terminal rochtain a fháil ar do bhlaosc agus earráidí a bhrath go huathoibríoch.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/gd-gb/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gd-gb/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Mol càraidhean gu fèin-obrachail airson àitheantan a dh'fhàillig</value>
+    <value>Moladh mhearachdan fèin-obrachail</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Nuair a tha e an comas, bidh an riochdaire IF a' mion-sgrùdadh àitheantan a dh'fhàillig gu fèin-obrachail agus a' moladh càradh. Nuair a tha e à comas, seallaidh àitheantan a dh'fhàillig sanas as urrainn briogadh air sa bhàr-staid — brùth Ctrl+Alt+. no briog air an t-sanas gus càradh iarraidh.</value>
+    <value>Thoir cead do Intelligent Terminal mearachdan a chur gun àidseant agad gus fuasglaidhean a mholadh gu fèin-obrachail.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -178,9 +178,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Lorg mhearachdan fèin-obrachail</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Thoir cead do Intelligent Terminal cothrom fhaighinn air an t-slige agad agus mearachdan a lorg gu fèin-obrachail.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/gd-gb/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gd-gb/Resources.resw
@@ -177,4 +177,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/gl-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gl-ES/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Suxerir automaticamente correccións para comandos fallidos</value>
+    <value>Suxestión automática de erros</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Cando está activado, o axente de IA analiza automaticamente os comandos fallidos e propón unha corrección. Cando está desactivado, os comandos fallidos mostran unha suxestión na que se pode facer clic na barra de estado — preme Ctrl+Alt+. ou fai clic na suxestión para solicitar unha corrección.</value>
+    <value>Permite que Intelligent Terminal envíe erros ao teu axente para suxerir solucións automaticamente.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -123,9 +123,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Desactivado</value>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Detección automática de erros</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Permite que Intelligent Terminal acceda ao teu intérprete de ordes e detecte erros automaticamente.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/gl-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gl-ES/Resources.resw
@@ -122,4 +122,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_ToggleOff" xml:space="preserve">
     <value>Desactivado</value>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/gu-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gu-IN/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>નિષ્ફળ આદેશો માટે સ્વચાલિત રીતે સુધારાઓ સૂચવો</value>
+    <value>સ્વચાલિત ભૂલ સૂચન</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>જ્યારે સક્ષમ હોય, ત્યારે AI એજન્ટ નિષ્ફળ આદેશોનું સ્વચાલિત રીતે વિશ્લેષણ કરે છે અને સુધારો સૂચવે છે. જ્યારે અક્ષમ હોય, ત્યારે નિષ્ફળ આદેશો સ્થિતિ બારમાં ક્લિક કરી શકાય તેવી સંકેત બતાવે છે — સુધારાની વિનંતી કરવા માટે Ctrl+Alt+. દબાવો અથવા સંકેત પર ક્લિક કરો.</value>
+    <value>Intelligent Terminal ને આપમેળે સુધારા સૂચવવા માટે તમારા એજન્ટને ભૂલો મોકલવાની પરવાનગી આપો.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>સ્વચાલિત ભૂલ શોધ</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal ને તમારા શેલને ઍક્સેસ કરવાની અને ભૂલોને આપમેળે શોધવાની પરવાનગી આપો.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/gu-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gu-IN/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/he-IL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/he-IL/Resources.resw
@@ -172,10 +172,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>הצע אוטומטית תיקונים לפקודות שנכשלו</value>
+    <value>הצעת שגיאות אוטומטית</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>כאשר מופעל, סוכן הבינה המלאכותית מנתח אוטומטית פקודות שנכשלו ומציע תיקון. כאשר מושבת, פקודות שנכשלו מציגות רמז שניתן ללחוץ עליו בשורת המצב — הקש Ctrl+Alt+. או לחץ על הרמז כדי לבקש תיקון.</value>
+    <value>העניק ל-Intelligent Terminal הרשאה לשלוח שגיאות לסוכן שלך כדי להציע תיקונים באופן אוטומטי.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>זיהוי שגיאות אוטומטי</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>העניק ל-Intelligent Terminal הרשאה לגשת למעטפת שלך ולזהות שגיאות באופן אוטומטי.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/he-IL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/he-IL/Resources.resw
@@ -291,4 +291,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hi-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hi-IN/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hi-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hi-IN/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>विफल कमांड के लिए स्वचालित रूप से सुधार सुझाएं</value>
+    <value>स्वचालित त्रुटि सुझाव</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>सक्षम होने पर, AI एजेंट विफल कमांड का स्वचालित रूप से विश्लेषण करता है और एक सुधार का प्रस्ताव करता है। अक्षम होने पर, विफल कमांड स्थिति पट्टी में एक क्लिक करने योग्य संकेत दिखाते हैं — सुधार का अनुरोध करने के लिए Ctrl+Alt+. दबाएं या संकेत पर क्लिक करें।</value>
+    <value>Intelligent Terminal को स्वचालित रूप से समाधान सुझाने के लिए अपने एजेंट को त्रुटियां भेजने की अनुमति दें।</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>स्वचालित त्रुटि पहचान</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal को अपने शेल तक पहुंचने और स्वचालित रूप से त्रुटियों का पता लगाने की अनुमति दें।</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hr-HR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hr-HR/Resources.resw
@@ -290,4 +290,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hr-HR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hr-HR/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Automatski predloži popravke za neuspjele naredbe</value>
+    <value>Automatski prijedlog pogrešaka</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Kada je omogućeno, AI agent automatski analizira neuspjele naredbe i predlaže popravak. Kada je onemogućeno, neuspjele naredbe prikazuju savjet na koji se može kliknuti u traci stanja — pritisnite Ctrl+Alt+. ili kliknite na savjet kako biste zatražili popravak.</value>
+    <value>Dopustite aplikaciji Intelligent Terminal slanje pogrešaka vašem agentu radi automatskog predlaganja popravaka.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -291,9 +291,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatsko otkrivanje pogrešaka</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Dopustite aplikaciji Intelligent Terminal pristup ljusci i automatsko otkrivanje pogrešaka.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hu-HU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hu-HU/Resources.resw
@@ -290,4 +290,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hu-HU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hu-HU/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Javítások automatikus javaslata sikertelen parancsokhoz</value>
+    <value>Automatikus hibajavaslat</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Ha engedélyezve van, az AI ügynök automatikusan elemzi a sikertelen parancsokat, és javaslatot tesz egy javításra. Ha le van tiltva, a sikertelen parancsok kattintható tippet jelenítenek meg az állapotsorban — nyomja meg a Ctrl+Alt+. billentyűkombinációt, vagy kattintson a tippre a javítás kéréséhez.</value>
+    <value>Engedélyezze az Intelligent Terminal számára, hogy hibákat küldjön az ügynöknek a javítások automatikus javaslásához.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -291,9 +291,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatikus hibafelismerés</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Engedélyezze az Intelligent Terminal számára, hogy hozzáférjen a parancshéjhoz, és automatikusan felismerje a hibákat.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hy-AM/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hy-AM/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Ինքնաբերաբար առաջարկել շտկումներ ձախողված հրամանների համար</value>
+    <value>Սխալների ավտոմատ առաջարկ</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Միացված լինելու դեպքում AI գործակալը ինքնաբերաբար վերլուծում է ձախողված հրամանները և առաջարկում շտկում: Անջատված լինելու դեպքում ձախողված հրամանները կարգավիճակի տողում ցույց են տալիս սեղմելի ակնարկ — սեղմեք Ctrl+Alt+. կամ սեղմեք ակնարկի վրա շտկում խնդրելու համար:</value>
+    <value>Թույլ տվեք Intelligent Terminal-ին սխալներ ուղարկել ձեր գործակալին՝ ավտոմատ կերպով ուղղումներ առաջարկելու համար։</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -178,9 +178,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Սխալների ավտոմատ հայտնաբերում</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Թույլ տվեք Intelligent Terminal-ին մուտք գործել ձեր թաղանթ և ավտոմատ կերպով հայտնաբերել սխալները։</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hy-AM/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hy-AM/Resources.resw
@@ -177,4 +177,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/id-ID/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/id-ID/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Sarankan perbaikan secara otomatis untuk perintah yang gagal</value>
+    <value>Saran kesalahan otomatis</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Ketika diaktifkan, agen AI secara otomatis menganalisis perintah yang gagal dan mengusulkan perbaikan. Ketika dinonaktifkan, perintah yang gagal menampilkan petunjuk yang dapat diklik di bilah status — tekan Ctrl+Alt+. atau klik petunjuk untuk meminta perbaikan.</value>
+    <value>Izinkan Intelligent Terminal mengirim kesalahan ke agen Anda untuk menyarankan perbaikan secara otomatis.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -236,9 +236,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Nonaktif</value>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Deteksi kesalahan otomatis</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Izinkan Intelligent Terminal mengakses shell Anda dan mendeteksi kesalahan secara otomatis.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/id-ID/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/id-ID/Resources.resw
@@ -235,4 +235,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_ToggleOff" xml:space="preserve">
     <value>Nonaktif</value>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/is-IS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/is-IS/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/is-IS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/is-IS/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Stinga sjálfkrafa upp á lagfæringum fyrir misheppnaðar skipanir</value>
+    <value>Sjálfvirk villutillaga</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Þegar þetta er virkjað greinir gervigreindarumboðsmaðurinn sjálfkrafa misheppnaðar skipanir og leggur til lagfæringu. Þegar þetta er óvirkt sýna misheppnaðar skipanir smelltanlega vísbendingu á stöðustikunni — ýttu á Ctrl+Alt+. eða smelltu á vísbendinguna til að biðja um lagfæringu.</value>
+    <value>Veittu Intelligent Terminal heimild til að senda villur til umboðsmannsins þíns til að stinga sjálfkrafa upp á lagfæringum.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Sjálfvirk villugreining</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Veittu Intelligent Terminal heimild til að fá aðgang að skelinni þinni og greina villur sjálfkrafa.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
@@ -1010,10 +1010,10 @@
     <comment>{Locked="Node.js","NPX"}</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Suggerisci automaticamente correzioni per i comandi non riusciti</value>
+    <value>Suggerimento automatico degli errori</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Se abilitato, l'agente IA analizza automaticamente i comandi non riusciti e propone una correzione. Se disabilitato, i comandi non riusciti mostrano un suggerimento selezionabile nella barra di stato — premi Ctrl+Alt+. o fai clic sul suggerimento per richiedere una correzione.</value>
+    <value>Consenti a Intelligent Terminal di inviare gli errori all'agente per suggerire automaticamente le correzioni.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -1137,9 +1137,9 @@
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Rilevamento automatico degli errori</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Consenti a Intelligent Terminal di accedere alla shell e rilevare automaticamente gli errori.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
@@ -1136,4 +1136,10 @@
     <value>Terminal Protocol</value>
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
@@ -1146,4 +1146,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
@@ -1018,10 +1018,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>失敗したコマンドの修正候補を自動的に提案する</value>
+    <value>エラーの自動提案</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>有効にすると、AI エージェントが失敗したコマンドを自動的に分析し、修正案を提案します。無効にすると、失敗したコマンドはステータス バーにクリック可能なヒントを表示します — Ctrl+Alt+. を押すか、ヒントをクリックすると修正をリクエストできます。</value>
+    <value>Intelligent Terminal がエラーをエージェントに送信して、修正を自動的に提案することを許可します。</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -1147,9 +1147,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>エラーの自動検出</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal にシェルへのアクセスを許可し、エラーを自動的に検出します。</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ka-GE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ka-GE/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>ავტომატურად შესთავაზე გასწორებები წარუმატებელი ბრძანებებისთვის</value>
+    <value>შეცდომების ავტომატური შემოთავაზება</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>ჩართვისას, AI აგენტი ავტომატურად აანალიზებს წარუმატებელ ბრძანებებს და სთავაზობს გასწორებას. გამორთვისას, წარუმატებელი ბრძანებები სტატუსის ზოლზე აჩვენებენ დაჭერად მინიშნებას — დააჭირეთ Ctrl+Alt+. ან დააწკაპუნეთ მინიშნებაზე გასწორების მოთხოვნისთვის.</value>
+    <value>მიეცით Intelligent Terminal-ს უფლება, გაუგზავნოს შეცდომები თქვენს აგენტს გასწორებების ავტომატურად შემოთავაზებისთვის.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -178,9 +178,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>შეცდომების ავტომატური აღმოჩენა</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>მიეცით Intelligent Terminal-ს უფლება, წვდომა ჰქონდეს თქვენს გარსზე და ავტომატურად აღმოაჩინოს შეცდომები.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ka-GE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ka-GE/Resources.resw
@@ -177,4 +177,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/kk-KZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kk-KZ/Resources.resw
@@ -290,4 +290,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/kk-KZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kk-KZ/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Сәтсіз пәрмендер үшін түзетулерді автоматты түрде ұсыну</value>
+    <value>Қателерді автоматты түрде ұсыну</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Қосылған кезде, ЖИ агенті сәтсіз пәрмендерді автоматты түрде талдайды және түзету ұсынады. Өшірілген кезде, сәтсіз пәрмендер күй жолағында басуға болатын кеңесті көрсетеді — түзетуді сұрау үшін Ctrl+Alt+. пернесін басыңыз немесе кеңесті басыңыз.</value>
+    <value>Intelligent Terminal қолданбасына түзетулерді автоматты түрде ұсыну үшін қателерді агентіңізге жіберуге рұқсат беріңіз.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -291,9 +291,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Қателерді автоматты түрде анықтау</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal қолданбасына қабықшаңызға кіруге және қателерді автоматты түрде анықтауға рұқсат беріңіз.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/km-KH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/km-KH/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>ស្នើការជួសជុលដោយស្វ័យប្រវត្តិសម្រាប់ពាក្យបញ្ជាដែលបរាជ័យ</value>
+    <value>ការណែនាំកំហុសដោយស្វ័យប្រវត្តិ</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>នៅពេលបើក ភ្នាក់ងារ AI វិភាគពាក្យបញ្ជាដែលបរាជ័យដោយស្វ័យប្រវត្តិ និងស្នើការជួសជុល។ នៅពេលបិទ ពាក្យបញ្ជាដែលបរាជ័យបង្ហាញការណែនាំដែលអាចចុចបាននៅរបារស្ថានភាព — ចុច Ctrl+Alt+. ឬចុចលើការណែនាំដើម្បីស្នើសុំការជួសជុល។</value>
+    <value>ផ្តល់សិទ្ធិឱ្យ Intelligent Terminal ផ្ញើកំហុសទៅភ្នាក់ងាររបស់អ្នក ដើម្បីណែនាំការកែតម្រូវដោយស្វ័យប្រវត្តិ។</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -123,9 +123,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>បិទ</value>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>ការរកឃើញកំហុសដោយស្វ័យប្រវត្តិ</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>ផ្តល់សិទ្ធិឱ្យ Intelligent Terminal ចូលប្រើសែលរបស់អ្នក និងរកឃើញកំហុសដោយស្វ័យប្រវត្តិ។</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/km-KH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/km-KH/Resources.resw
@@ -122,4 +122,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_ToggleOff" xml:space="preserve">
     <value>បិទ</value>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/kn-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kn-IN/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/kn-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kn-IN/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>ವಿಫಲವಾದ ಆಜ್ಞೆಗಳಿಗೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಪರಿಹಾರಗಳನ್ನು ಸೂಚಿಸಿ</value>
+    <value>ಸ್ವಯಂಚಾಲಿತ ದೋಷ ಸಲಹೆ</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>ಸಕ್ರಿಯಗೊಳಿಸಿದಾಗ, AI ಏಜೆಂಟ್ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ವಿಫಲವಾದ ಆಜ್ಞೆಗಳನ್ನು ವಿಶ್ಲೇಷಿಸುತ್ತದೆ ಮತ್ತು ಪರಿಹಾರವನ್ನು ಪ್ರಸ್ತಾಪಿಸುತ್ತದೆ. ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿದಾಗ, ವಿಫಲವಾದ ಆಜ್ಞೆಗಳು ಸ್ಥಿತಿ ಪಟ್ಟಿಯಲ್ಲಿ ಕ್ಲಿಕ್ ಮಾಡಬಹುದಾದ ಸುಳಿವನ್ನು ತೋರಿಸುತ್ತವೆ — ಪರಿಹಾರವನ್ನು ವಿನಂತಿಸಲು Ctrl+Alt+. ಒತ್ತಿರಿ ಅಥವಾ ಸುಳಿವಿನ ಮೇಲೆ ಕ್ಲಿಕ್ ಮಾಡಿ.</value>
+    <value>ಪರಿಹಾರಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸೂಚಿಸಲು ನಿಮ್ಮ ಏಜೆಂಟ್‌ಗೆ ದೋಷಗಳನ್ನು ಕಳುಹಿಸಲು Intelligent Terminal ಗೆ ಅನುಮತಿ ನೀಡಿ.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>ಸ್ವಯಂಚಾಲಿತ ದೋಷ ಪತ್ತೆ</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>ನಿಮ್ಮ ಶೆಲ್ ಅನ್ನು ಪ್ರವೇಶಿಸಲು ಮತ್ತು ದೋಷಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಪತ್ತೆಹಚ್ಚಲು Intelligent Terminal ಗೆ ಅನುಮತಿ ನೀಡಿ.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
@@ -1077,10 +1077,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>실패한 명령에 대한 수정 사항 자동 제안</value>
+    <value>자동 오류 제안</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>사용하도록 설정하면 AI 에이전트가 실패한 명령을 자동으로 분석하고 수정 사항을 제안합니다. 사용하지 않도록 설정하면 실패한 명령에 대해 상태 표시줄에 클릭 가능한 힌트가 표시됩니다 — Ctrl+Alt+. 를 누르거나 힌트를 클릭하여 수정을 요청합니다.</value>
+    <value>Intelligent Terminal이 오류를 에이전트로 보내 수정 사항을 자동으로 제안하도록 허용합니다.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -1210,9 +1210,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>자동 오류 검색</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal이 셸에 액세스하여 오류를 자동으로 검색하도록 허용합니다.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
@@ -1209,4 +1209,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/kok-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kok-IN/Resources.resw
@@ -172,10 +172,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>अयशस्वी आदेशांखातीर आपशींच निवारण सुचोवचें</value>
+    <value>स्वयंचलित त्रुटी सुचोवणी</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>सक्षम केल्यार, AI एजंट अयशस्वी आदेशांचें आपशींच विश्लेषण करता आनी एक निवारण सुचयता. अकार्यान्वीत केल्यार, अयशस्वी आदेश स्थिती पट्ट्येंत क्लीक करपाक मेळपी सुचोवणी दाखयतात — निवारणाक मागणी करपाक Ctrl+Alt+. दामचो वा सुचोवणेर क्लीक करचो.</value>
+    <value>Intelligent Terminal क आपशीच उपाय सुचोवपाक तुमच्या एजंटाक त्रुटी धाडपाक परवानगी दियात.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -293,9 +293,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>स्वयंचलित त्रुटी सोद</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal क तुमच्या शेलांत प्रवेश करपाक आनी त्रुटी आपशीच सोदपाक परवानगी दियात.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/kok-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kok-IN/Resources.resw
@@ -292,4 +292,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lb-LU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lb-LU/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Automatesch Fixe fir feelgeschloen Befehler proposéieren</value>
+    <value>Automatesche Feelervirschlag</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Wann aktivéiert, analyséiert den AI-Agent automatesch feelgeschloen Befehler an proposéiert e Fix. Wann deaktivéiert, weisen feelgeschloen Befehler en klickbaren Hiweis an der Statusbar — dréckt Ctrl+Alt+. oder klickt den Hiweis fir e Fix unzefroen.</value>
+    <value>Erlaabt Intelligent Terminal Feeler un Ären Agent ze schécken fir automatesch Korrekturen virzeschloen.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -179,9 +179,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatesch Feelererkennung</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Erlaabt Intelligent Terminal Zougrëff op Är Shell an d'Feeler automatesch z'erkennen.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lb-LU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lb-LU/Resources.resw
@@ -178,4 +178,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lo-LA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lo-LA/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>ແນະນຳການແກ້ໄຂໂດຍອັດຕະໂນມັດສຳລັບຄຳສັ່ງທີ່ລົ້ມເຫລວ</value>
+    <value>ການແນະນຳຂໍ້ຜິດພາດອັດຕະໂນມັດ</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>ເມື່ອເປີດໃຊ້ງານ, ຕົວແທນ AI ຈະວິເຄາະຄຳສັ່ງທີ່ລົ້ມເຫລວໂດຍອັດຕະໂນມັດ ແລະ ສະເໜີການແກ້ໄຂ. ເມື່ອປິດການໃຊ້ງານ, ຄຳສັ່ງທີ່ລົ້ມເຫລວຈະສະແດງຄຳແນະນຳທີ່ສາມາດຄລິກໄດ້ໃນແຖບສະຖານະ — ກົດ Ctrl+Alt+. ຫລື ຄລິກທີ່ຄຳແນະນຳເພື່ອຮ້ອງຂໍການແກ້ໄຂ.</value>
+    <value>ອະນຸຍາດໃຫ້ Intelligent Terminal ສົ່ງຂໍ້ຜິດພາດໄປຫາຕົວແທນຂອງທ່ານເພື່ອແນະນຳການແກ້ໄຂໂດຍອັດຕະໂນມັດ.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -123,9 +123,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>ປິດ</value>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>ການກວດຫາຂໍ້ຜິດພາດອັດຕະໂນມັດ</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>ອະນຸຍາດໃຫ້ Intelligent Terminal ເຂົ້າເຖິງເຊລຂອງທ່ານ ແລະກວດຫາຂໍ້ຜິດພາດໂດຍອັດຕະໂນມັດ.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lo-LA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lo-LA/Resources.resw
@@ -122,4 +122,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_ToggleOff" xml:space="preserve">
     <value>ປິດ</value>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lt-LT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lt-LT/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Automatiškai siūlyti pataisymus nepavykusioms komandoms</value>
+    <value>Automatinis klaidų siūlymas</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Kai įjungta, DI agentas automatiškai analizuoja nepavykusias komandas ir siūlo pataisymą. Kai išjungta, nepavykusios komandos rodo spustelimą užuominą būsenos juostoje — paspauskite Ctrl+Alt+. arba spustelėkite užuominą, kad paprašytumėte pataisymo.</value>
+    <value>Leiskite „Intelligent Terminal“ siųsti klaidas jūsų agentui, kad automatiškai pasiūlytų pataisymus.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatinis klaidų aptikimas</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Leiskite „Intelligent Terminal“ pasiekti jūsų apvalkalą ir automatiškai aptikti klaidas.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lt-LT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lt-LT/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lv-LV/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lv-LV/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lv-LV/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lv-LV/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Automātiski ieteikt labojumus neveiksmīgām komandām</value>
+    <value>Automātisks kļūdu ieteikums</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Kad iespējots, MI aģents automātiski analizē neveiksmīgas komandas un piedāvā labojumu. Kad atspējots, neveiksmīgas komandas statusa joslā rāda noklikšķināmu mājienu — nospiediet Ctrl+Alt+. vai noklikšķiniet uz mājiena, lai pieprasītu labojumu.</value>
+    <value>Atļaujiet Intelligent Terminal sūtīt kļūdas jūsu aģentam, lai automātiski ieteiktu labojumus.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automātiska kļūdu noteikšana</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Atļaujiet Intelligent Terminal piekļūt jūsu čaulai un automātiski noteikt kļūdas.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mi-NZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mi-NZ/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Whakaaroaroa whakatika aunoa mō ngā whakahau kīhai i angitu</value>
+    <value>Te tono hapa aunoa</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Ina whakaahei, ka tātari aunoa te kaihoko AI i ngā whakahau kīhai i angitu, ka tūtohu whakatika. Ina whakakorea, ka whakaaturia e ngā whakahau kīhai i angitu he tohu pāwhiri ki te paewhiri tūnga — pēhi Ctrl+Alt+. mā te pāwhiri rānei i te tohu kia tono whakatika.</value>
+    <value>Tukua a Intelligent Terminal kia tuku hapa ki tō kaihoko hei tono whakatika aunoa.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -178,9 +178,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Te kimi hapa aunoa</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Tukua a Intelligent Terminal kia uru ki tō anga me te kimi hapa aunoa.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mi-NZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mi-NZ/Resources.resw
@@ -177,4 +177,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mk-MK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mk-MK/Resources.resw
@@ -290,4 +290,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mk-MK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mk-MK/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Автоматски предложи поправки за неуспешни команди</value>
+    <value>Автоматски предлог за грешки</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Кога е овозможено, агентот за вештачка интелигенција автоматски ги анализира неуспешните команди и предлага поправка. Кога е оневозможено, неуспешните команди прикажуваат совет на кој може да се кликне во статусната лента — притиснете Ctrl+Alt+. или кликнете на советот за да побарате поправка.</value>
+    <value>Дозволете му на Intelligent Terminal да испраќа грешки до вашиот агент за автоматско предлагање поправки.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -291,9 +291,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Автоматско откривање грешки</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Дозволете му на Intelligent Terminal да пристапи до вашата обвивка и автоматски да открива грешки.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ml-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ml-IN/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>പരാജയപ്പെട്ട കമാൻഡുകൾക്ക് സ്വയമേവ പരിഹാരങ്ങൾ നിർദ്ദേശിക്കുക</value>
+    <value>സ്വയമേവയുള്ള പിശക് നിർദ്ദേശം</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>പ്രവർത്തനക്ഷമമാക്കിയാൽ, AI ഏജന്റ് പരാജയപ്പെട്ട കമാൻഡുകൾ സ്വയമേവ വിശകലനം ചെയ്യുകയും ഒരു പരിഹാരം നിർദ്ദേശിക്കുകയും ചെയ്യുന്നു. പ്രവർത്തനരഹിതമാക്കിയാൽ, പരാജയപ്പെട്ട കമാൻഡുകൾ സ്റ്റാറ്റസ് ബാറിൽ ക്ലിക്ക് ചെയ്യാവുന്ന ഒരു സൂചന കാണിക്കും — പരിഹാരം അഭ്യർത്ഥിക്കാൻ Ctrl+Alt+. അമർത്തുക അല്ലെങ്കിൽ സൂചനയിൽ ക്ലിക്ക് ചെയ്യുക.</value>
+    <value>പരിഹാരങ്ങൾ സ്വയമേവ നിർദ്ദേശിക്കാൻ നിങ്ങളുടെ ഏജന്റിലേക്ക് പിശകുകൾ അയയ്ക്കാൻ Intelligent Terminal-നെ അനുവദിക്കുക.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>സ്വയമേവയുള്ള പിശക് കണ്ടെത്തൽ</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>നിങ്ങളുടെ ഷെല്ലിലേക്ക് പ്രവേശിക്കാനും പിശകുകൾ സ്വയമേവ കണ്ടെത്താനും Intelligent Terminal-നെ അനുവദിക്കുക.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ml-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ml-IN/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mr-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mr-IN/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mr-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mr-IN/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>अयशस्वी आदेशांसाठी सुधारणा स्वयंचलितपणे सुचवा</value>
+    <value>स्वयंचलित त्रुटी सूचना</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>सक्षम केल्यावर, AI एजंट अयशस्वी आदेशांचे स्वयंचलितपणे विश्लेषण करतो आणि एक सुधारणा प्रस्तावित करतो. अक्षम केल्यावर, अयशस्वी आदेश स्थिती पट्टीमध्ये क्लिक करण्यायोग्य सूचना दर्शवितात — सुधारणेची विनंती करण्यासाठी Ctrl+Alt+. दाबा किंवा सूचनेवर क्लिक करा.</value>
+    <value>Intelligent Terminal ला निराकरणे स्वयंचलितपणे सुचवण्यासाठी तुमच्या एजंटला त्रुटी पाठवण्याची परवानगी द्या.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>स्वयंचलित त्रुटी शोध</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal ला तुमच्या शेलमध्ये प्रवेश करण्याची आणि त्रुटी स्वयंचलितपणे शोधण्याची परवानगी द्या.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ms-MY/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ms-MY/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Cadangkan pembetulan secara automatik untuk arahan yang gagal</value>
+    <value>Cadangan ralat automatik</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Apabila diaktifkan, agen AI secara automatik menganalisis arahan yang gagal dan mencadangkan pembetulan. Apabila dinyahaktifkan, arahan yang gagal akan memaparkan petunjuk yang boleh diklik dalam bar status — tekan Ctrl+Alt+. atau klik petunjuk untuk meminta pembetulan.</value>
+    <value>Benarkan Intelligent Terminal menghantar ralat kepada ejen anda untuk mencadangkan pembetulan secara automatik.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -236,9 +236,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Mati</value>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Pengesanan ralat automatik</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Benarkan Intelligent Terminal mengakses shell anda dan mengesan ralat secara automatik.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ms-MY/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ms-MY/Resources.resw
@@ -235,4 +235,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_ToggleOff" xml:space="preserve">
     <value>Mati</value>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mt-MT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mt-MT/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Issuġġerixxi awtomatikament tiswijiet għal kmandi li jfallu</value>
+    <value>Suġġeriment awtomatiku tal-iżbalji</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Meta tkun attivata, l-aġent tal-IA janalizza awtomatikament il-kmandi li jfallu u jipproponi tiswija. Meta tkun diżattivata, il-kmandi li jfallu juru ħjiel li tista' tikklikkja fil-bar tal-istat — agħfas Ctrl+Alt+. jew ikklikkja l-ħjiel biex titlob tiswija.</value>
+    <value>Agħti permess lil Intelligent Terminal biex jibgħat l-iżbalji lill-aġent tiegħek biex jissuġġerixxi soluzzjonijiet awtomatikament.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -178,9 +178,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Identifikazzjoni awtomatika tal-iżbalji</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Agħti permess lil Intelligent Terminal biex jaċċessa l-qoxra tiegħek u jidentifika l-iżbalji awtomatikament.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mt-MT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mt-MT/Resources.resw
@@ -177,4 +177,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/nb-NO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nb-NO/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Foreslå automatisk reparasjoner for mislykkede kommandoer</value>
+    <value>Automatisk feilforslag</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Når aktivert, analyserer AI-agenten automatisk mislykkede kommandoer og foreslår en reparasjon. Når deaktivert, viser mislykkede kommandoer et klikkbart tips i statuslinjen — trykk Ctrl+Alt+. eller klikk på tipset for å be om en reparasjon.</value>
+    <value>Gi Intelligent Terminal tillatelse til å sende feil til agenten for automatisk å foreslå rettelser.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatisk feilregistrering</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Gi Intelligent Terminal tillatelse til å få tilgang til skallet og automatisk oppdage feil.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/nb-NO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nb-NO/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ne-NP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ne-NP/Resources.resw
@@ -172,10 +172,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>असफल आदेशहरूका लागि स्वतः सुधारहरू सुझाव दिनुहोस्</value>
+    <value>स्वचालित त्रुटि सुझाव</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>सक्षम पारिएको बेला, AI एजेन्टले असफल आदेशहरूको स्वतः विश्लेषण गर्छ र सुधारको प्रस्ताव गर्छ। अक्षम पारिएको बेला, असफल आदेशहरूले स्थिति पट्टीमा क्लिक गर्न मिल्ने संकेत देखाउँछ — सुधारको अनुरोध गर्न Ctrl+Alt+. थिच्नुहोस् वा संकेतमा क्लिक गर्नुहोस्।</value>
+    <value>Intelligent Terminal लाई स्वचालित रूपमा समाधान सुझाव दिन तपाईंको एजेन्टमा त्रुटिहरू पठाउन अनुमति दिनुहोस्।</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -293,9 +293,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>स्वचालित त्रुटि पत्ता लगाउने</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal लाई तपाईंको सेलमा पहुँच गर्न र त्रुटिहरू स्वचालित रूपमा पत्ता लगाउन अनुमति दिनुहोस्।</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ne-NP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ne-NP/Resources.resw
@@ -292,4 +292,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/nl-NL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nl-NL/Resources.resw
@@ -167,10 +167,10 @@
     <comment>{Locked="Node.js","NPX"}</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Automatisch oplossingen voorstellen voor mislukte opdrachten</value>
+    <value>Automatische foutsuggestie</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Wanneer ingeschakeld, analyseert de AI-agent automatisch mislukte opdrachten en stelt een oplossing voor. Wanneer uitgeschakeld, tonen mislukte opdrachten een klikbare hint in de statusbalk — druk op Ctrl+Alt+. of klik op de hint om een oplossing aan te vragen.</value>
+    <value>Geef Intelligent Terminal toestemming om fouten naar uw agent te sturen om automatisch oplossingen voor te stellen.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -286,9 +286,9 @@
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatische foutdetectie</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Geef Intelligent Terminal toestemming om toegang te krijgen tot uw shell en automatisch fouten te detecteren.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/nl-NL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nl-NL/Resources.resw
@@ -285,4 +285,10 @@
     <value>Terminal Protocol</value>
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/nn-NO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nn-NO/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/nn-NO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nn-NO/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Foreslå automatisk reparasjonar for mislukka kommandoar</value>
+    <value>Automatisk feilforslag</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Når aktivert, analyserer KI-agenten automatisk mislukka kommandoar og føreslår ein reparasjon. Når deaktivert, viser mislukka kommandoar eit klikkbart tips i statuslinja — trykk Ctrl+Alt+. eller klikk på tipset for å be om ein reparasjon.</value>
+    <value>Gi Intelligent Terminal løyve til å sende feil til agenten for automatisk å føreslå rettingar.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatisk feilregistrering</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Gi Intelligent Terminal løyve til å få tilgang til skalet og automatisk oppdage feil.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/or-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/or-IN/Resources.resw
@@ -172,10 +172,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>ବିଫଳ କମାଣ୍ଡଗୁଡ଼ିକ ପାଇଁ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ସମାଧାନ ପ୍ରସ୍ତାବ ଦିଅନ୍ତୁ</value>
+    <value>ସ୍ୱୟଂଚାଳିତ ତ୍ରୁଟି ପରାମର୍ଶ</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>ସକ୍ଷମ ହେଲେ, AI ଏଜେଣ୍ଟ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ବିଫଳ କମାଣ୍ଡଗୁଡ଼ିକୁ ବିଶ୍ଳେଷଣ କରେ ଏବଂ ଏକ ସମାଧାନ ପ୍ରସ୍ତାବ ଦିଏ। ଅକ୍ଷମ ହେଲେ, ବିଫଳ କମାଣ୍ଡଗୁଡ଼ିକ ସ୍ଥିତି ବାରରେ ଏକ କ୍ଲିକଯୋଗ୍ୟ ସୂଚନା ଦେଖାଏ — ସମାଧାନ ଅନୁରୋଧ କରିବାକୁ Ctrl+Alt+. ଦବାନ୍ତୁ କିମ୍ବା ସୂଚନା ଉପରେ କ୍ଲିକ କରନ୍ତୁ।</value>
+    <value>Intelligent Terminal କୁ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ସମାଧାନ ପରାମର୍ଶ ଦେବାକୁ ଆପଣଙ୍କ ଏଜେଣ୍ଟକୁ ତ୍ରୁଟି ପଠାଇବାକୁ ଅନୁମତି ଦିଅନ୍ତୁ।</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -293,9 +293,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>ସ୍ୱୟଂଚାଳିତ ତ୍ରୁଟି ଚିହ୍ନଟ</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal କୁ ଆପଣଙ୍କ ଶେଲ୍ ଆକ୍ସେସ୍ କରିବାକୁ ଏବଂ ତ୍ରୁଟିଗୁଡ଼ିକୁ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଚିହ୍ନଟ କରିବାକୁ ଅନୁମତି ଦିଅନ୍ତୁ।</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/or-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/or-IN/Resources.resw
@@ -292,4 +292,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pa-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pa-IN/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pa-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pa-IN/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>ਅਸਫਲ ਕਮਾਂਡਾਂ ਲਈ ਆਪਣੇ-ਆਪ ਠੀਕ ਸੁਝਾਓ</value>
+    <value>ਆਟੋਮੈਟਿਕ ਗਲਤੀ ਸੁਝਾਅ</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>ਜਦੋਂ ਯੋਗ ਕੀਤਾ ਜਾਂਦਾ ਹੈ, AI ਏਜੰਟ ਅਸਫਲ ਕਮਾਂਡਾਂ ਦਾ ਆਪਣੇ-ਆਪ ਵਿਸ਼ਲੇਸ਼ਣ ਕਰਦਾ ਹੈ ਅਤੇ ਇੱਕ ਠੀਕ ਦਾ ਪ੍ਰਸਤਾਵ ਦਿੰਦਾ ਹੈ। ਜਦੋਂ ਅਯੋਗ ਕੀਤਾ ਜਾਂਦਾ ਹੈ, ਅਸਫਲ ਕਮਾਂਡਾਂ ਸਥਿਤੀ ਪੱਟੀ ਵਿੱਚ ਕਲਿੱਕ ਕਰਨ ਯੋਗ ਸੰਕੇਤ ਦਿਖਾਉਂਦੀਆਂ ਹਨ — ਠੀਕ ਦੀ ਬੇਨਤੀ ਕਰਨ ਲਈ Ctrl+Alt+. ਦਬਾਓ ਜਾਂ ਸੰਕੇਤ 'ਤੇ ਕਲਿੱਕ ਕਰੋ।</value>
+    <value>Intelligent Terminal ਨੂੰ ਆਪਣੇ ਆਪ ਹੱਲ ਸੁਝਾਉਣ ਲਈ ਤੁਹਾਡੇ ਏਜੰਟ ਨੂੰ ਗਲਤੀਆਂ ਭੇਜਣ ਦੀ ਇਜਾਜ਼ਤ ਦਿਓ।</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>ਆਟੋਮੈਟਿਕ ਗਲਤੀ ਖੋਜ</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal ਨੂੰ ਤੁਹਾਡੇ ਸ਼ੈੱਲ ਤੱਕ ਪਹੁੰਚ ਕਰਨ ਅਤੇ ਗਲਤੀਆਂ ਨੂੰ ਆਪਣੇ ਆਪ ਖੋਜਣ ਦੀ ਇਜਾਜ਼ਤ ਦਿਓ।</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pl-PL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pl-PL/Resources.resw
@@ -290,4 +290,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pl-PL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pl-PL/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Automatycznie sugeruj poprawki dla nieudanych poleceń</value>
+    <value>Automatyczne sugerowanie błędów</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Po włączeniu agent SI automatycznie analizuje nieudane polecenia i proponuje poprawkę. Po wyłączeniu nieudane polecenia pokazują klikalną wskazówkę na pasku stanu — naciśnij Ctrl+Alt+. lub kliknij wskazówkę, aby zażądać poprawki.</value>
+    <value>Zezwól aplikacji Intelligent Terminal na wysyłanie błędów do agenta w celu automatycznego sugerowania poprawek.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -291,9 +291,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatyczne wykrywanie błędów</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Zezwól aplikacji Intelligent Terminal na dostęp do powłoki i automatyczne wykrywanie błędów.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
@@ -1194,4 +1194,10 @@
     <value>Terminal Protocol</value>
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
@@ -1064,10 +1064,10 @@
     <comment>{Locked="Node.js","NPX"}</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Sugerir correções automaticamente para comandos com falha</value>
+    <value>Sugestão automática de erros</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Quando habilitado, o agente de IA analisa automaticamente os comandos com falha e propõe uma correção. Quando desabilitado, os comandos com falha exibem uma dica clicável na barra de status — pressione Ctrl+Alt+. ou clique na dica para solicitar uma correção.</value>
+    <value>Permita que o Intelligent Terminal envie erros ao agente para sugerir correções automaticamente.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -1195,9 +1195,9 @@
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Detecção automática de erros</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Permita que o Intelligent Terminal acesse o shell e detecte erros automaticamente.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pt-PT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-PT/Resources.resw
@@ -285,4 +285,10 @@
     <value>Terminal Protocol</value>
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pt-PT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-PT/Resources.resw
@@ -167,10 +167,10 @@
     <comment>{Locked="Node.js","NPX"}</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Sugerir correções automaticamente para comandos com falha</value>
+    <value>Sugestão automática de erros</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Quando ativado, o agente de IA analisa automaticamente os comandos com falha e propõe uma correção. Quando desativado, os comandos com falha mostram uma sugestão clicável na barra de estado — prima Ctrl+Alt+. ou clique na sugestão para pedir uma correção.</value>
+    <value>Permita que o Intelligent Terminal envie erros ao agente para sugerir correções automaticamente.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -286,9 +286,9 @@
     <comment>{Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Deteção automática de erros</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Permita que o Intelligent Terminal aceda à shell e detete erros automaticamente.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
@@ -1119,4 +1119,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
@@ -1119,4 +1119,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
@@ -1119,4 +1119,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/quz-PE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/quz-PE/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Mana atisqa kamachiykunapaq allichaykunata kikinmanta yuyaychay</value>
+    <value>Pantasqakunata unaylla yuyaychay</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Kachasqa kaspa, AI yanapaqqa mana atisqa kamachiykunata kikinmanta yachay, hinaspa allichayta yuyaychan. Mana kachasqa kaspa, mana atisqa kamachiykunaqa qhawana siq'ipi ñit'inalla willakuyta rikuchinku — allichayta mañakunapaq Ctrl+Alt+. ñit'iy utaq willakuy patapi ñit'iy.</value>
+    <value>Intelligent Terminal-man saqiy pantasqakunata agente-ykiman apachinanpaq allichaykunata unaylla yuyaychananpaq.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -178,9 +178,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Pantasqakunata unaylla tariy</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal-man saqiy shell-niykiman yaykunanpaq hinaspa pantasqakunata unaylla tarinanpaq.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/quz-PE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/quz-PE/Resources.resw
@@ -177,4 +177,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ro-RO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ro-RO/Resources.resw
@@ -290,4 +290,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ro-RO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ro-RO/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Sugerează automat remedieri pentru comenzile eșuate</value>
+    <value>Sugerarea automată a erorilor</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Când este activat, agentul IA analizează automat comenzile eșuate și propune o remediere. Când este dezactivat, comenzile eșuate afișează un indiciu pe care se poate face clic în bara de stare — apăsați Ctrl+Alt+. sau faceți clic pe indiciu pentru a solicita o remediere.</value>
+    <value>Permiteți Intelligent Terminal să trimită erorile către agent pentru a sugera automat remedieri.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -291,9 +291,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Detectarea automată a erorilor</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Permiteți Intelligent Terminal să acceseze shell-ul și să detecteze automat erorile.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
@@ -1200,4 +1200,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
@@ -1069,10 +1069,10 @@
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Автоматически предлагать исправления для команд с ошибками</value>
+    <value>Автоматическое предложение исправлений</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Если включено, ИИ-агент автоматически анализирует команды с ошибками и предлагает исправление. Если отключено, для команд с ошибками в строке состояния отображается подсказка, по которой можно щелкнуть — нажмите Ctrl+Alt+. или щелкните подсказку, чтобы запросить исправление.</value>
+    <value>Разрешите Intelligent Terminal отправлять ошибки агенту для автоматического предложения исправлений.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -1201,9 +1201,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Автоматическое обнаружение ошибок</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Разрешите Intelligent Terminal доступ к оболочке и автоматическое обнаружение ошибок.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sk-SK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sk-SK/Resources.resw
@@ -290,4 +290,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sk-SK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sk-SK/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Automaticky navrhovať opravy pre neúspešné príkazy</value>
+    <value>Automatický návrh opráv chýb</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Keď je povolené, agent UI automaticky analyzuje neúspešné príkazy a navrhuje opravu. Keď je zakázané, neúspešné príkazy zobrazujú kliknutelnú radu v stavovom riadku — stlačením Ctrl+Alt+. alebo kliknutím na radu si vyžiadate opravu.</value>
+    <value>Povoľte aplikácii Intelligent Terminal odosielať chyby agentovi na automatické navrhovanie opráv.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -291,9 +291,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatická detekcia chýb</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Povoľte aplikácii Intelligent Terminal prístup k prostrediu shell a automatickú detekciu chýb.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sl-SI/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sl-SI/Resources.resw
@@ -290,4 +290,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sl-SI/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sl-SI/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Samodejno predlagaj popravke za neuspele ukaze</value>
+    <value>Samodejno predlaganje napak</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Ko je omogočeno, agent UI samodejno analizira neuspele ukaze in predlaga popravek. Ko je onemogočeno, neuspeli ukazi prikažejo namig, ki ga je mogoče klikniti, v vrstici stanja — pritisnite Ctrl+Alt+. ali kliknite namig, da zahtevate popravek.</value>
+    <value>Dovolite aplikaciji Intelligent Terminal pošiljanje napak vašemu agentu za samodejno predlaganje popravkov.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -291,9 +291,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Samodejno zaznavanje napak</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Dovolite aplikaciji Intelligent Terminal dostop do lupine in samodejno zaznavanje napak.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sq-AL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sq-AL/Resources.resw
@@ -290,4 +290,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sq-AL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sq-AL/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Sugjero automatikisht rregullime për komandat e dështuara</value>
+    <value>Sugjerimi automatik i gabimeve</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Kur është aktivizuar, agjenti i IA analizon automatikisht komandat e dështuara dhe propozon një rregullim. Kur është çaktivizuar, komandat e dështuara shfaqin një këshillë të klikueshme në shiritin e statusit — shtypni Ctrl+Alt+. ose klikoni mbi këshillën për të kërkuar një rregullim.</value>
+    <value>Lejoni Intelligent Terminal të dërgojë gabimet te agjenti juaj për të sugjeruar rregullime automatikisht.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -291,9 +291,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Zbulimi automatik i gabimeve</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Lejoni Intelligent Terminal të hyjë në guaskën tuaj dhe të zbulojë gabimet automatikisht.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-BA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-BA/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Аутоматски предложи исправке за неуспеле команде</value>
+    <value>Аутоматски предлог исправки</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Када је омогућено, ВИ агент аутоматски анализира неуспеле команде и предлаже исправку. Када је онемогућено, неуспеле команде приказују наговештај на који је могуће кликнути у статусној траци — притисните Ctrl+Alt+. или кликните на наговештај да бисте затражили исправку.</value>
+    <value>Дозволите да Intelligent Terminal шаље грешке вашем агенту ради аутоматског предлагања исправки.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -178,9 +178,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Аутоматско откривање грешака</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Дозволите да Intelligent Terminal приступи вашој командној линији и аутоматски открива грешке.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-BA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-BA/Resources.resw
@@ -177,4 +177,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
@@ -1052,10 +1052,10 @@
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Аутоматски предложи исправке за неуспеле команде</value>
+    <value>Аутоматски предлог исправки</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Када је омогућено, ВИ агент аутоматски анализира неуспеле команде и предлаже исправку. Када је онемогућено, неуспеле команде приказују наговештај на који је могуће кликнути у статусној траци — притисните Ctrl+Alt+. или кликните на наговештај да бисте затражили исправку.</value>
+    <value>Дозволите да Intelligent Terminal шаље грешке вашем агенту ради аутоматског предлагања исправки.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -1207,9 +1207,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Аутоматско откривање грешака</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Дозволите да Intelligent Terminal приступи вашој командној линији и аутоматски открива грешке.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
@@ -1206,4 +1206,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sr-Latn-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Latn-RS/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Automatski predloži ispravke za neuspele komande</value>
+    <value>Automatski predlog ispravki</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Kada je omogućeno, VI agent automatski analizira neuspele komande i predlaže ispravku. Kada je onemogućeno, neuspele komande prikazuju nagoveštaj na koji je moguće kliknuti u statusnoj traci — pritisnite Ctrl+Alt+. ili kliknite na nagoveštaj da biste zatražili ispravku.</value>
+    <value>Dozvolite da Intelligent Terminal šalje greške vašem agentu radi automatskog predlaganja ispravki.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -178,9 +178,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatsko otkrivanje grešaka</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Dozvolite da Intelligent Terminal pristupi vašoj komandnoj liniji i automatski otkriva greške.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sr-Latn-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Latn-RS/Resources.resw
@@ -177,4 +177,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sv-SE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sv-SE/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sv-SE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sv-SE/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Föreslå automatiskt korrigeringar för misslyckade kommandon</value>
+    <value>Automatiskt felförslag</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>När det är aktiverat analyserar AI-agenten automatiskt misslyckade kommandon och föreslår en korrigering. När det är inaktiverat visar misslyckade kommandon ett klickbart tips i statusfältet — tryck på Ctrl+Alt+. eller klicka på tipset för att begära en korrigering.</value>
+    <value>Ge Intelligent Terminal behörighet att skicka fel till din agent för att automatiskt föreslå korrigeringar.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatisk feldetektering</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Ge Intelligent Terminal behörighet att komma åt skalet och automatiskt identifiera fel.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ta-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ta-IN/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ta-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ta-IN/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>தோல்வியடைந்த கட்டளைகளுக்கு தானாகவே சரிசெய்தலை பரிந்துரைக்கவும்</value>
+    <value>தானியங்கி பிழை பரிந்துரை</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>இயக்கப்பட்டால், AI முகவர் தோல்வியடைந்த கட்டளைகளை தானாகவே பகுப்பாய்வு செய்து சரிசெய்தலை முன்மொழிகிறது. முடக்கப்பட்டால், தோல்வியடைந்த கட்டளைகள் நிலைப்பட்டியில் கிளிக் செய்யக்கூடிய குறிப்பைக் காண்பிக்கின்றன — சரிசெய்தலை கோர Ctrl+Alt+. ஐ அழுத்தவும் அல்லது குறிப்பை கிளிக் செய்யவும்.</value>
+    <value>தீர்வுகளைத் தானாகவே பரிந்துரைக்க உங்கள் முகவருக்குப் பிழைகளை அனுப்ப Intelligent Terminal-ஐ அனுமதிக்கவும்.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>தானியங்கி பிழை கண்டறிதல்</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>உங்கள் ஷெல்லை அணுகவும் பிழைகளைத் தானாகவே கண்டறியவும் Intelligent Terminal-ஐ அனுமதிக்கவும்.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/te-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/te-IN/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>విఫలమైన ఆదేశాల కోసం స్వయంచాలకంగా పరిష్కారాలను సూచించండి</value>
+    <value>స్వయంచాలక లోపం సూచన</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>ప్రారంభించబడినప్పుడు, AI ఏజెంట్ స్వయంచాలకంగా విఫలమైన ఆదేశాలను విశ్లేషిస్తుంది మరియు ఒక పరిష్కారాన్ని ప్రతిపాదిస్తుంది. నిలిపివేయబడినప్పుడు, విఫలమైన ఆదేశాలు స్థితి పట్టీలో క్లిక్ చేయగల సూచనను చూపుతాయి — పరిష్కారాన్ని అభ్యర్థించడానికి Ctrl+Alt+. నొక్కండి లేదా సూచనపై క్లిక్ చేయండి.</value>
+    <value>పరిష్కారాలను స్వయంచాలకంగా సూచించడానికి మీ ఏజెంట్‌కు లోపాలను పంపడానికి Intelligent Terminal‌ను అనుమతించండి.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -292,9 +292,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>స్వయంచాలక లోపం గుర్తింపు</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>మీ షెల్‌ను యాక్సెస్ చేయడానికి మరియు లోపాలను స్వయంచాలకంగా గుర్తించడానికి Intelligent Terminal‌ను అనుమతించండి.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/te-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/te-IN/Resources.resw
@@ -291,4 +291,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/th-TH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/th-TH/Resources.resw
@@ -235,4 +235,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_ToggleOff" xml:space="preserve">
     <value>ปิด</value>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/th-TH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/th-TH/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>แนะนำการแก้ไขโดยอัตโนมัติสำหรับคำสั่งที่ล้มเหลว</value>
+    <value>การแนะนำข้อผิดพลาดอัตโนมัติ</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>เมื่อเปิดใช้งาน เอเจนต์ AI จะวิเคราะห์คำสั่งที่ล้มเหลวโดยอัตโนมัติและเสนอการแก้ไข เมื่อปิดใช้งาน คำสั่งที่ล้มเหลวจะแสดงคำใบ้ที่คลิกได้ในแถบสถานะ — กด Ctrl+Alt+. หรือคลิกที่คำใบ้เพื่อขอการแก้ไข</value>
+    <value>อนุญาตให้ Intelligent Terminal ส่งข้อผิดพลาดไปยังตัวแทนของคุณเพื่อแนะนำการแก้ไขโดยอัตโนมัติ</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -236,9 +236,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>ปิด</value>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>การตรวจหาข้อผิดพลาดอัตโนมัติ</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>อนุญาตให้ Intelligent Terminal เข้าถึงเชลล์ของคุณและตรวจหาข้อผิดพลาดโดยอัตโนมัติ</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/tr-TR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/tr-TR/Resources.resw
@@ -290,4 +290,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/tr-TR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/tr-TR/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Başarısız komutlar için otomatik olarak düzeltmeler öner</value>
+    <value>Otomatik hata önerisi</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Etkinleştirildiğinde, AI aracısı başarısız komutları otomatik olarak analiz eder ve bir düzeltme önerir. Devre dışı bırakıldığında, başarısız komutlar durum çubuğunda tıklanabilir bir ipucu gösterir — bir düzeltme istemek için Ctrl+Alt+. tuşlarına basın veya ipucuna tıklayın.</value>
+    <value>Intelligent Terminal uygulamasının düzeltmeleri otomatik olarak önermek için hataları aracınıza göndermesine izin verin.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -291,9 +291,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Otomatik hata algılama</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal uygulamasının kabuğunuza erişmesine ve hataları otomatik olarak algılamasına izin verin.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/tt-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/tt-RU/Resources.resw
@@ -290,4 +290,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/tt-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/tt-RU/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Уңышсыз боерыклар өчен төзәтмәләрне автоматик тәкъдим итү</value>
+    <value>Хаталарны автоматик тәкъдим итү</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Кушылган булса, ЯИ-агент уңышсыз боерыкларны автоматик рәвештә тикшерә һәм төзәтмә тәкъдим итә. Сүндерелгән булса, уңышсыз боерыклар хәл сызыгында басып була торган киңәш күрсәтә — төзәтмә сорау өчен Ctrl+Alt+. басыгыз яки киңәшкә басыгыз.</value>
+    <value>Intelligent Terminal'га төзәтмәләрне автоматик тәкъдим итү өчен хаталарны агентыгызга җибәрергә рөхсәт итегез.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -291,9 +291,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Хаталарны автоматик ачыклау</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal'га кабыгыгызга керергә һәм хаталарны автоматик рәвештә ачыкларга рөхсәт итегез.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ug-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ug-CN/Resources.resw
@@ -58,10 +58,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>مەغلۇپ بولغان بۇيرۇقلار ئۈچۈن تۈزىتىشلەرنى ئاپتوماتىك تەۋسىيە قىلىش</value>
+    <value>ئاپتوماتىك خاتالىق تەكلىپى</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>قوزغىتىلغاندا، AI ۋاكالەتچىسى مەغلۇپ بولغان بۇيرۇقلارنى ئاپتوماتىك تەھلىل قىلىپ، بىر تۈزىتىش تەكلىپ قىلىدۇ. چەكلەنگەندە، مەغلۇپ بولغان بۇيرۇقلار ھالەت بالداقتا چېكىشكە بولىدىغان كۆرسەتمە كۆرسىتىدۇ — تۈزىتىش تەلەپ قىلىش ئۈچۈن Ctrl+Alt+. نى بېسىڭ ياكى كۆرسەتمىنى چېكىڭ.</value>
+    <value>Intelligent Terminal غا خاتالىقلارنى ۋاكالەتچىڭىزگە ئەۋەتىپ، تۈزىتىشلەرنى ئاپتوماتىك تەكلىپ قىلىشقا رۇخسەت بېرىڭ.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -178,9 +178,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>ئاپتوماتىك خاتالىق بايقاش</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal غا شېلىڭىزنى زىيارەت قىلىش ۋە خاتالىقلارنى ئاپتوماتىك بايقاشقا رۇخسەت بېرىڭ.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ug-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ug-CN/Resources.resw
@@ -177,4 +177,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
@@ -1063,10 +1063,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Автоматично пропонувати виправлення для невдалих команд</value>
+    <value>Автоматична пропозиція виправлень</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Якщо ввімкнено, ШІ-агент автоматично аналізує невдалі команди та пропонує виправлення. Якщо вимкнено, невдалі команди показують підказку в рядку стану, на яку можна клацнути — натисніть Ctrl+Alt+. або клацніть підказку, щоб запитати виправлення.</value>
+    <value>Дозвольте Intelligent Terminal надсилати помилки вашому агенту для автоматичної пропозиції виправлень.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -1195,9 +1195,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Автоматичне виявлення помилок</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Дозвольте Intelligent Terminal отримати доступ до оболонки та автоматично виявляти помилки.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
@@ -1194,4 +1194,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ur-PK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ur-PK/Resources.resw
@@ -172,10 +172,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>ناکام کمانڈز کے لیے خودکار طور پر اصلاحات تجویز کریں</value>
+    <value>خودکار خرابی کی تجویز</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>فعال ہونے پر، AI ایجنٹ خودکار طور پر ناکام کمانڈز کا تجزیہ کرتا ہے اور ایک اصلاح تجویز کرتا ہے۔ غیر فعال ہونے پر، ناکام کمانڈز اسٹیٹس بار میں ایک قابل کلک اشارہ ظاہر کرتی ہیں — اصلاح کی درخواست کرنے کے لیے Ctrl+Alt+. دبائیں یا اشارے پر کلک کریں۔</value>
+    <value>Intelligent Terminal کو خودکار طور پر اصلاحات تجویز کرنے کے لیے اپنے ایجنٹ کو خرابیاں بھیجنے کی اجازت دیں۔</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -293,9 +293,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>خودکار خرابی کا پتہ لگانا</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal کو اپنے شیل تک رسائی اور خودکار طور پر خرابیوں کا پتہ لگانے کی اجازت دیں۔</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ur-PK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ur-PK/Resources.resw
@@ -292,4 +292,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/uz-Latn-UZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uz-Latn-UZ/Resources.resw
@@ -290,4 +290,10 @@
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/uz-Latn-UZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uz-Latn-UZ/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Bajarilmagan buyruqlar uchun tuzatishlarni avtomatik taklif qilish</value>
+    <value>Xatolarni avtomatik taklif qilish</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Yoqilganda, AI agenti bajarilmagan buyruqlarni avtomatik tahlil qilib, tuzatish taklif qiladi. O'chirilganda, bajarilmagan buyruqlar holat panelida bosish mumkin bo'lgan maslahatni ko'rsatadi — tuzatish so'rash uchun Ctrl+Alt+. tugmasini bosing yoki maslahatga bosing.</value>
+    <value>Intelligent Terminal'ga tuzatishlarni avtomatik taklif qilish uchun xatolarni agentingizga yuborishga ruxsat bering.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -291,9 +291,9 @@
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Xatolarni avtomatik aniqlash</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Intelligent Terminal'ga qobig'ingizga kirish va xatolarni avtomatik aniqlashga ruxsat bering.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/vi-VN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/vi-VN/Resources.resw
@@ -171,10 +171,10 @@
     <comment>{Locked="Node.js","NPX"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>Tự động đề xuất các bản sửa lỗi cho các lệnh không thành công</value>
+    <value>Tự động đề xuất lỗi</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>Khi được bật, tác nhân AI tự động phân tích các lệnh không thành công và đề xuất một bản sửa lỗi. Khi bị tắt, các lệnh không thành công sẽ hiển thị một gợi ý có thể nhấp vào trên thanh trạng thái — nhấn Ctrl+Alt+. hoặc nhấp vào gợi ý để yêu cầu một bản sửa lỗi.</value>
+    <value>Cho phép Intelligent Terminal gửi lỗi đến tác nhân của bạn để tự động đề xuất bản sửa lỗi.</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -236,9 +236,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Tắt</value>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Tự động phát hiện lỗi</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>Cho phép Intelligent Terminal truy cập shell của bạn và tự động phát hiện lỗi.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/vi-VN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/vi-VN/Resources.resw
@@ -235,4 +235,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_ToggleOff" xml:space="preserve">
     <value>Tắt</value>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
@@ -1211,4 +1211,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
@@ -1079,10 +1079,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>自动为失败的命令建议修复方案</value>
+    <value>自动错误建议</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>启用后,AI 智能体将自动分析失败的命令并提出修复建议。禁用后,失败的命令会在状态栏中显示一个可点击的提示 — 按 Ctrl+Alt+. 或单击该提示以请求修复。</value>
+    <value>允许 Intelligent Terminal 将错误发送给你的代理以自动建议修复。</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -1212,9 +1212,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>自动错误检测</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>允许 Intelligent Terminal 访问你的 shell 并自动检测错误。</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
@@ -1145,4 +1145,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Terminal Protocol</value>
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
+  <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
@@ -1017,10 +1017,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AutoErrorLabel.Text" xml:space="preserve">
-    <value>自動為失敗的命令建議修正</value>
+    <value>自動錯誤建議</value>
   </data>
   <data name="FreOverlay_AutoErrorDescription.Text" xml:space="preserve">
-    <value>啟用時,AI 代理會自動分析失敗的命令並提出修正建議。停用時,失敗的命令會在狀態列中顯示可點擊的提示 — 按 Ctrl+Alt+. 或點擊提示以要求修正。</value>
+    <value>允許 Intelligent Terminal 將錯誤傳送給您的代理程式以自動建議修正。</value>
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
   </data>
   <data name="FreOverlay_SessionLabel.Text" xml:space="preserve">
@@ -1146,9 +1146,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Title for the teaching tip that displays Terminal Protocol connection information. {Locked="Terminal Protocol"}</comment>
   </data>
   <data name="FreOverlay_AutoDetectLabel.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>自動錯誤偵測</value>
   </data>
   <data name="FreOverlay_AutoDetectDescription.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
+    <value>允許 Intelligent Terminal 存取您的 shell 並自動偵測錯誤。</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4990,6 +4990,18 @@ namespace winrt::TerminalApp::implementation
                             }
 
                             // isOsc133 path — forward as vt_sequence.
+                            // Detection gate: when the user turned error
+                            // detection off ("don't access my shell"), drop
+                            // the OSC 133 command marks here — no Detected
+                            // pill, no forwarding to WTA, no background
+                            // analysis. (Scoped to OSC 133 so AgentEvents,
+                            // a separate channel, keep flowing.) Unlike the
+                            // auto-suggest pref — which still wants the
+                            // Detected pill — detection off means we observe
+                            // nothing.
+                            if (!page->_settings.GlobalSettings().EffectiveAutoErrorDetectionEnabled())
+                                return;
+
                             Json::Value evt;
                             evt["type"] = "event";
                             evt["method"] = "vt_sequence";

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -142,19 +142,79 @@
                           Style="{StaticResource ComboBoxSettingStyle}" />
             </local:SettingContainer>
 
-            <!--  Auto-error detection  -->
-            <local:SettingContainer x:Name="AutoFixEnabled"
-                                    x:Uid="AIAgents_AutoFix">
-                <StackPanel>
-                    <ToggleSwitch IsOn="{x:Bind ViewModel.AutoFixEnabled, Mode=TwoWay}"
-                                  IsEnabled="{x:Bind local:AIAgents.NotBool(ViewModel.IsAutoFixPolicyLocked), Mode=OneWay}"
-                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            <!--  Automatic error detection (parent) + Automatic error
+                  suggestion (dependent child). Modeled as an Expander so the
+                  hierarchy is explicit: detection's master toggle lives in the
+                  always-visible header; suggestion is nested in the expand body
+                  and stays disabled until detection is on (ViewModel.
+                  CanSuggestErrors). Hand-built header (vs. ExpanderSetting
+                  ContainerStyle) because that style's header-right slot is a
+                  read-only text preview and can't host the master toggle.  -->
+            <muxc:Expander x:Name="AutoErrorDetectionExpander"
+                           Margin="0,4,0,0"
+                           HorizontalAlignment="Stretch"
+                           HorizontalContentAlignment="Stretch"
+                           IsExpanded="True">
+                <muxc:Expander.Header>
+                    <Grid MinHeight="64">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0"
+                                    VerticalAlignment="Center"
+                                    Spacing="2">
+                            <TextBlock x:Uid="AIAgents_AutoErrorDetectionTitle"
+                                       FontWeight="SemiBold"
+                                       TextWrapping="Wrap" />
+                            <TextBlock x:Uid="AIAgents_AutoErrorDetectionCaption"
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       TextWrapping="Wrap" />
+                        </StackPanel>
+                        <ToggleSwitch Grid.Column="1"
+                                      MinWidth="0"
+                                      VerticalAlignment="Center"
+                                      AutomationProperties.AccessibilityView="Content"
+                                      IsOn="{x:Bind ViewModel.AutoErrorDetectionEnabled, Mode=TwoWay}" />
+                    </Grid>
+                </muxc:Expander.Header>
+                <!--  Nested dependent setting: suggestion. Plain rows (no nested
+                      SettingContainer) so it sits inside the detection Expander
+                      body with no "card-in-card" background. Greyed out
+                      whenever detection is off or auto-fix is GPO-locked
+                      (ViewModel.CanSuggestErrors). Its On/Off reflects the
+                      user's own value and is independent of the detection
+                      toggle.  -->
+                <StackPanel Margin="0,4,0,0">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0"
+                                    VerticalAlignment="Center"
+                                    Spacing="2">
+                            <TextBlock x:Uid="AIAgents_AutoErrorSuggestionTitle"
+                                       TextWrapping="Wrap" />
+                            <TextBlock x:Uid="AIAgents_AutoErrorSuggestionCaption"
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       TextWrapping="Wrap" />
+                        </StackPanel>
+                        <ToggleSwitch Grid.Column="1"
+                                      MinWidth="0"
+                                      VerticalAlignment="Center"
+                                      AutomationProperties.AccessibilityView="Content"
+                                      IsOn="{x:Bind ViewModel.AutoFixEnabled, Mode=TwoWay}"
+                                      IsEnabled="{x:Bind ViewModel.CanSuggestErrors, Mode=OneWay}" />
+                    </Grid>
                     <TextBlock x:Uid="AIAgents_PolicyLocked"
                                Visibility="{x:Bind ViewModel.IsAutoFixPolicyLocked, Mode=OneWay}"
                                Opacity="0.6"
                                Margin="0,4,0,0" />
                 </StackPanel>
-            </local:SettingContainer>
+            </muxc:Expander>
 
             <!--  Agent session tracking (hooks) — last entry in the Agent pane group.
                   Collapsible SettingContainer (Expander style). When expanded:

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
@@ -682,17 +682,50 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
     }
 
-    // ── AutoFix ──────────────────────────────────────────────────────────
+    // ── Auto error detection ───────────────────────────────────────────────
+
+    bool AIAgentsViewModel::AutoErrorDetectionEnabled() const
+    {
+        return _GlobalSettings.EffectiveAutoErrorDetectionEnabled();
+    }
+
+    void AIAgentsViewModel::AutoErrorDetectionEnabled(bool value)
+    {
+        if (_GlobalSettings.AutoErrorDetectionEnabled() == value) return;
+        _GlobalSettings.AutoErrorDetectionEnabled(value);
+        // Master-detail: detection drives both the suggestion toggle's enabled
+        // state (CanSuggestErrors) and its effective value (EffectiveAutoFix
+        // Enabled flips to false when detection is off), so refresh both. The
+        // stored autoFixEnabled preference is preserved, so re-enabling
+        // detection restores the previous suggestion value rather than forcing
+        // it on.
+        _NotifyChanges(L"HasAutoErrorDetectionEnabled", L"AutoErrorDetectionEnabled",
+                       L"CanSuggestErrors", L"AutoFixEnabled");
+        // Shell integration installation is triggered on Save, not on toggle.
+    }
+
+    bool AIAgentsViewModel::HasAutoErrorDetectionEnabled() const
+    {
+        return _GlobalSettings.HasAutoErrorDetectionEnabled();
+    }
+
+    // ── AutoFix (auto-suggest) ─────────────────────────────────────────────
 
     bool AIAgentsViewModel::AutoFixEnabled() const
     {
+        // Master-detail: suggestion follows detection. EffectiveAutoFixEnabled
+        // returns false whenever detection is off (or GPO blocks autofix), so
+        // the toggle reads Off when the master is off; when detection is on it
+        // reflects the user's stored autoFixEnabled preference.
         return _GlobalSettings.EffectiveAutoFixEnabled();
     }
 
     void AIAgentsViewModel::AutoFixEnabled(bool value)
     {
-        // Reject writes when policy blocks autofix.
-        if (_GlobalSettings.IsAutoFixPolicyLocked())
+        // Reject writes when policy blocks autofix or detection is off (the
+        // toggle is disabled in those cases, but guard against races).
+        if (_GlobalSettings.IsAutoFixPolicyLocked() ||
+            !_GlobalSettings.EffectiveAutoErrorDetectionEnabled())
         {
             return;
         }
@@ -705,6 +738,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     bool AIAgentsViewModel::HasAutoFixEnabled() const
     {
         return _GlobalSettings.HasAutoFixEnabled();
+    }
+
+    bool AIAgentsViewModel::CanSuggestErrors() const
+    {
+        return !_GlobalSettings.IsAutoFixPolicyLocked() &&
+               _GlobalSettings.EffectiveAutoErrorDetectionEnabled();
     }
 
     // ── Pane position ────────────────────────────────────────────────────

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.h
@@ -102,9 +102,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AcpModel);
         bool ShowDelegateModel();
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, DelegateModel);
+        bool AutoErrorDetectionEnabled() const;
+        void AutoErrorDetectionEnabled(bool value);
+        bool HasAutoErrorDetectionEnabled() const;
         bool AutoFixEnabled() const;
         void AutoFixEnabled(bool value);
         bool HasAutoFixEnabled() const;
+        bool CanSuggestErrors() const;
 
         // GPO policy lock indicators
         bool IsAgentPolicyLocked() const { return _GlobalSettings.IsAgentPolicyLocked(); }

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.idl
@@ -75,8 +75,8 @@ namespace Microsoft.Terminal.Settings.Editor
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(String, DelegateModel);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AutoErrorDetectionEnabled);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AutoFixEnabled);
-        // Whether the auto-suggest toggle is interactable: detection must be on
-        // and the auto-fix GPO must not be locking it off.
+        // Whether the auto-suggest toggle should be enabled: detection must be
+        // on and the auto-fix GPO must not be locking it off.
         Boolean CanSuggestErrors { get; };
 
         // GPO policy lock indicators.

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.idl
@@ -73,7 +73,11 @@ namespace Microsoft.Terminal.Settings.Editor
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(String, AcpModel);
         Boolean ShowDelegateModel { get; };
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(String, DelegateModel);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AutoErrorDetectionEnabled);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AutoFixEnabled);
+        // Whether the auto-suggest toggle is interactable: detection must be on
+        // and the auto-fix GPO must not be locking it off.
+        Boolean CanSuggestErrors { get; };
 
         // GPO policy lock indicators.
         // IsAgentPolicyLocked: AllowedAgents policy is active — agent

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -880,10 +880,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             ShowLoadWarningsDialog.raise(*this, _settingsClone.Warnings());
         }
 
-        // Install shell integration if autofix was enabled.
-        // Only raise once — _InitShellIntegration handles both targets
-        // and shows a single dialog when done.
-        if (_settingsClone.GlobalSettings().AutoFixEnabled())
+        // Install shell integration if error detection was enabled. Detection
+        // is what needs the OSC 133 marks; auto-suggest is a strict subset and
+        // can't be on without it. Only raise once — _InitShellIntegration
+        // handles both targets and shows a single dialog when done.
+        if (_settingsClone.GlobalSettings().AutoErrorDetectionEnabled())
         {
             InitShellIntegrationRequested.raise(*this, ShellIntegrationTarget::Pwsh);
         }

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -2842,4 +2842,16 @@
     <value>Hooks-Installation fehlgeschlagen. Überprüfen Sie %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log auf Details.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -2843,15 +2843,15 @@
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Automatische Fehlererkennung</value>
   </data>
   <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+    <value>Erlauben Sie Intelligent Terminal, auf Ihre Shell zuzugreifen und Fehler automatisch zu erkennen. Verfügbar in PowerShell und Windows PowerShell.</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
-    <value>Automatic error suggestion</value>
+    <value>Automatischer Fehlervorschlag</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+    <value>Erlauben Sie Intelligent Terminal, Fehler an Ihren Agent zu senden, um automatisch Korrekturen vorzuschlagen.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -746,14 +746,22 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Supplementary description for the command palette agent setting. 
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
-  <data name="AIAgents_AutoFix.Header" xml:space="preserve">
-    <value>Auto-suggest fixes for failed commands</value>
-    <comment>Header for the toggle that controls whether the AI agent automatically diagnoses failed commands. When off, errors still show a clickable hint in the status bar but the agent is only invoked on demand.
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+    <comment>Title for the master toggle (Expander header) that lets the terminal observe the shell and detect failed commands. The Automatic error suggestion setting is nested under this one.</comment>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+    <comment>{Locked="PowerShell","Windows PowerShell"} "Intelligent Terminal" is the product name. Caption under the automatic-error-detection title.</comment>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+    <comment>Title for the nested toggle that lets the agent automatically suggest fixes for detected errors. Depends on (and is nested under) automatic error detection.
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
-  <data name="AIAgents_AutoFix.HelpText" xml:space="preserve">
-    <value>When enabled, the AI agent automatically analyzes failed commands and proposes a fix. When disabled, failed commands surface a clickable hint in the status bar — press Ctrl+Alt+. or click the hint to request a fix.</value>
-    <comment>Supplementary description for the auto-suggest-fixes setting.
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name. Caption under the automatic-error-suggestion title.
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="AIAgents_PanePosition.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -2843,15 +2843,15 @@
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Detección automática de errores</value>
   </data>
   <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+    <value>Permita que Intelligent Terminal acceda a su shell y detecte errores automáticamente. Disponible en PowerShell y Windows PowerShell.</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
-    <value>Automatic error suggestion</value>
+    <value>Sugerencia automática de errores</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+    <value>Permita que Intelligent Terminal envíe errores a su agente para sugerir correcciones automáticamente.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -2842,4 +2842,16 @@
     <value>Error de instalación de Hooks. Consulte %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log para obtener detalles.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -2843,4 +2843,16 @@
     <value>Échec de l’installation Hooks. Consultez %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log pour plus de détails.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -2844,15 +2844,15 @@
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Détection automatique des erreurs</value>
   </data>
   <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+    <value>Autorisez Intelligent Terminal à accéder à votre shell et à détecter automatiquement les erreurs. Disponible dans PowerShell et Windows PowerShell.</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
-    <value>Automatic error suggestion</value>
+    <value>Suggestion automatique des erreurs</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+    <value>Autorisez Intelligent Terminal à envoyer les erreurs à votre agent pour suggérer automatiquement des correctifs.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -2842,4 +2842,16 @@
     <value>Installazione di Hooks non riuscita. Controllare %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log per i dettagli.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -2843,15 +2843,15 @@
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Rilevamento automatico degli errori</value>
   </data>
   <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+    <value>Consenti a Intelligent Terminal di accedere alla shell e rilevare automaticamente gli errori. Disponibile in PowerShell e Windows PowerShell.</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
-    <value>Automatic error suggestion</value>
+    <value>Suggerimento automatico degli errori</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+    <value>Consenti a Intelligent Terminal di inviare gli errori all'agente per suggerire automaticamente le correzioni.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -2842,4 +2842,16 @@
     <value>Hooks のインストールに失敗しました。詳細については %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log を確認してください。</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -2843,15 +2843,15 @@
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>エラーの自動検出</value>
   </data>
   <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+    <value>Intelligent Terminal にシェルへのアクセスを許可し、エラーを自動的に検出します。PowerShell および Windows PowerShell で利用できます。</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
-    <value>Automatic error suggestion</value>
+    <value>エラーの自動提案</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+    <value>Intelligent Terminal がエラーをエージェントに送信して、修正を自動的に提案することを許可します。</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -2921,15 +2921,15 @@
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>자동 오류 검색</value>
   </data>
   <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+    <value>Intelligent Terminal이 셸에 액세스하여 오류를 자동으로 검색하도록 허용합니다. PowerShell 및 Windows PowerShell에서 사용할 수 있습니다.</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
-    <value>Automatic error suggestion</value>
+    <value>자동 오류 제안</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+    <value>Intelligent Terminal이 오류를 에이전트로 보내 수정 사항을 자동으로 제안하도록 허용합니다.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -2920,4 +2920,16 @@
     <value>Hooks 설치에 실패했습니다. 자세한 내용은 %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log를 확인하세요.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -2897,4 +2897,16 @@
     <value>Falha na instalação de Hooks. Confira %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log para obter detalhes.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -2898,15 +2898,15 @@
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Detecção automática de erros</value>
   </data>
   <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+    <value>Permita que o Intelligent Terminal acesse o shell e detecte erros automaticamente. Disponível no PowerShell e no Windows PowerShell.</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
-    <value>Automatic error suggestion</value>
+    <value>Sugestão automática de erros</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+    <value>Permita que o Intelligent Terminal envie erros ao agente para sugerir correções automaticamente.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -2827,4 +2827,16 @@
     <value>Hooks installation failed. Check %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log for details.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -2827,4 +2827,16 @@
     <value>Hooks installation failed. Check %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log for details.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -2827,4 +2827,16 @@
     <value>Hooks installation failed. Check %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log for details.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -2898,15 +2898,15 @@
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Автоматическое обнаружение ошибок</value>
   </data>
   <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+    <value>Разрешите Intelligent Terminal доступ к оболочке и автоматическое обнаружение ошибок. Доступно в PowerShell и Windows PowerShell.</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
-    <value>Automatic error suggestion</value>
+    <value>Автоматическое предложение исправлений</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+    <value>Разрешите Intelligent Terminal отправлять ошибки агенту для автоматического предложения исправлений.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -2897,4 +2897,16 @@
     <value>Не удалось установить Hooks. Подробности см. в %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -2918,4 +2918,16 @@
     <value>Инсталација Hooks није успела. Детаље потражите у %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -2919,15 +2919,15 @@
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Аутоматско откривање грешака</value>
   </data>
   <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+    <value>Дозволите да Intelligent Terminal приступи вашој командној линији и аутоматски открива грешке. Доступно у PowerShell и Windows PowerShell.</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
-    <value>Automatic error suggestion</value>
+    <value>Аутоматски предлог исправки</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+    <value>Дозволите да Intelligent Terminal шаље грешке вашем агенту ради аутоматског предлагања исправки.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -2565,15 +2565,15 @@
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>Автоматичне виявлення помилок</value>
   </data>
   <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+    <value>Дозвольте Intelligent Terminal отримати доступ до оболонки та автоматично виявляти помилки. Доступно в PowerShell і Windows PowerShell.</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
-    <value>Automatic error suggestion</value>
+    <value>Автоматична пропозиція виправлень</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+    <value>Дозвольте Intelligent Terminal надсилати помилки вашому агенту для автоматичної пропозиції виправлень.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -2564,4 +2564,16 @@
     <value>Не вдалося встановити Hooks. Докладні відомості див. у %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -2920,15 +2920,15 @@
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>自动错误检测</value>
   </data>
   <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+    <value>允许 Intelligent Terminal 访问你的 shell 并自动检测错误。适用于 PowerShell 和 Windows PowerShell。</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
-    <value>Automatic error suggestion</value>
+    <value>自动错误建议</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+    <value>允许 Intelligent Terminal 将错误发送给你的代理以自动建议修复。</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -2919,4 +2919,16 @@
     <value>Hooks 安装失败。请查看 %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log 获取详细信息。</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -2843,15 +2843,15 @@
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
-    <value>Automatic error detection</value>
+    <value>自動錯誤偵測</value>
   </data>
   <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+    <value>允許 Intelligent Terminal 存取您的 shell 並自動偵測錯誤。適用於 PowerShell 和 Windows PowerShell。</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
-    <value>Automatic error suggestion</value>
+    <value>自動錯誤建議</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+    <value>允許 Intelligent Terminal 將錯誤傳送給您的代理程式以自動建議修正。</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -2842,4 +2842,16 @@
     <value>Hooks 安裝失敗。請查看 %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log 以取得詳細資料。</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
+  <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
+    <value>Automatic error detection</value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
+    <value>Automatic error suggestion</value>
+  </data>
+  <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -2013,6 +2013,7 @@ void CascadiaSettings::LogSettingChanges(bool isJsonLoad) const
         };
         if (isJsonLoad)
         {
+            emitIntelligentFeatureConfigured("AutoErrorDetection", _globals->AutoErrorDetectionEnabled() ? L"true" : L"false");
             emitIntelligentFeatureConfigured("AutoFix", _globals->AutoFixEnabled() ? L"true" : L"false");
             if (const auto agentPanePosition = _globals->AgentPanePosition(); !agentPanePosition.empty())
             {

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -602,9 +602,23 @@ winrt::hstring GlobalAppSettings::EffectiveDelegateAgent() const
     return agent;
 }
 
+bool GlobalAppSettings::EffectiveAutoErrorDetectionEnabled() const
+{
+    return AutoErrorDetectionEnabled();
+}
+
 bool GlobalAppSettings::EffectiveAutoFixEnabled() const
 {
     if (!AgentPolicy::IsAutoFixAllowed())
+    {
+        return false;
+    }
+    // Auto-suggest depends on detection: if errors aren't being detected,
+    // there is nothing to send to the agent, so suggestion is implicitly
+    // off too. This makes the dependency hold everywhere consumers read the
+    // effective value (WTA, bottom bar) regardless of the raw settings.json
+    // value or the FRE / settings-editor UI state.
+    if (!EffectiveAutoErrorDetectionEnabled())
     {
         return false;
     }

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
@@ -86,6 +86,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         // empty. If a feature is blocked by policy, returns false.
         hstring EffectiveAcpAgent() const;
         hstring EffectiveDelegateAgent() const;
+        bool EffectiveAutoErrorDetectionEnabled() const;
         bool EffectiveAutoFixEnabled() const;
 
         // Whether GPO policy is actively restricting these settings.

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -118,6 +118,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_SETTING(String, AcpModel);
         INHERITABLE_SETTING(String, DelegateAgent);
         INHERITABLE_SETTING(String, DelegateModel);
+        INHERITABLE_SETTING(Boolean, AutoErrorDetectionEnabled);
         INHERITABLE_SETTING(Boolean, AutoFixEnabled);
         INHERITABLE_SETTING(String, AcpCustomCommand);
         INHERITABLE_SETTING(String, DelegateCustomCommand);
@@ -136,6 +137,7 @@ namespace Microsoft.Terminal.Settings.Model
         // raw INHERITABLE_SETTING properties for runtime decisions.
         String EffectiveAcpAgent { get; };
         String EffectiveDelegateAgent { get; };
+        Boolean EffectiveAutoErrorDetectionEnabled { get; };
         Boolean EffectiveAutoFixEnabled { get; };
 
         // Whether GPO policy is actively restricting these settings.

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -76,6 +76,7 @@ Author(s):
     X(hstring, AcpModel, "acpModel", L"")                                                                                                                                                               \
     X(hstring, DelegateAgent, "delegateAgent", L"copilot")                                                                                                                                              \
     X(hstring, DelegateModel, "delegateModel", L"")                                                                                                                                                    \
+    X(bool, AutoErrorDetectionEnabled, "autoErrorDetectionEnabled", true)                                                                                                                               \
     X(bool, AutoFixEnabled, "autoFixEnabled", false)                                                                                                                                                    \
     X(hstring, AcpCustomCommand, "acpCustomCommand", L"")                                                                                                                                              \
     X(hstring, DelegateCustomCommand, "delegateCustomCommand", L"")                                                                                                                                    \


### PR DESCRIPTION
## Summary

Splits the single auto-fix setting into two dependent settings to match the FRE / settings-editor design:

- **Automatic error detection** (master, default **on**) — permission to observe the shell and detect failed commands.
- **Automatic error suggestion** (detail, default off) — send detected errors to the agent for an automatic fix.

**Master-detail dependency:** turning detection off forces suggestion off + disables it (and at runtime skips installing shell integration / suppresses the bottom-bar detection UI). Turning it back on re-enables suggestion, preserving the stored value.

## Changes

- **Settings model**: new `autoErrorDetectionEnabled` (default `true`) + policy-aware `EffectiveAutoErrorDetectionEnabled`. `EffectiveAutoFixEnabled` now cascades to `false` when detection is off, so WTA and the bottom bar honour the dependency everywhere.
- **FRE (`FreOverlay`)**: detection toggle above suggestion; shell integration installed only when detection is on.
- **Settings editor (`AIAgents`)**: detection rendered as an `Expander` parent with the suggestion nested inside as plain rows (no "card-in-card" background); suggestion disabled until detection is on (`CanSuggestErrors`).
- **`TerminalPage`**: gate OSC 133 forwarding on detection (scoped to the OSC 133 branch so `AgentEvent`s keep flowing).
- **Localization**: the new resource keys are added to **all** locale `.resw` files — an en-US-only key crashes the packaged app at runtime with `0x80073B0C` under a non-en-US UI language.

## Testing

- `bcz no_clean` full build: **0 errors**.
- Manual F5: detection on + suggestion off by default; toggling detection off greys out + turns off suggestion; back on re-enables it.
<img width="1208" height="667" alt="image" src="https://github.com/user-attachments/assets/30303b37-36a5-45c2-b762-26fc0b1c1564" />

<img width="1242" height="269" alt="image" src="https://github.com/user-attachments/assets/4b969b20-a175-4b8d-a2b3-ce2161e5af88" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
