### PR TITLE
Refresh synthetic session title from disk in handle_session_hook

### DIFF
--- a/tools/wta/src/history_loader.rs
+++ b/tools/wta/src/history_loader.rs
@@ -95,10 +95,23 @@ pub fn load_all() -> Vec<AgentSession> {
 /// on disk (caller keeps whatever synthetic title it had).
 pub fn lookup_title_for_session(cli: CliSource, key: &str) -> Option<String> {
     let home = home_dir()?;
+    lookup_title_for_session_in(&home, cli, key)
+}
+
+/// Testable variant of [`lookup_title_for_session`] that accepts a
+/// caller-supplied `home` directory. Production code uses the
+/// `USERPROFILE` / `HOME` env var via `home_dir()`; tests pin a tmp
+/// dir without racing on env mutation. Returns `None` for CLIs whose
+/// titles aren't sourced from on-disk artefacts (`Unknown`).
+pub fn lookup_title_for_session_in(
+    home: &Path,
+    cli: CliSource,
+    key: &str,
+) -> Option<String> {
     match cli {
-        CliSource::Copilot => copilot_title_for_key(&home, key),
-        CliSource::Claude  => claude_title_for_key(&home, key),
-        CliSource::Gemini  => gemini_title_for_key(&home, key),
+        CliSource::Copilot => copilot_title_for_key(home, key),
+        CliSource::Claude  => claude_title_for_key(home, key),
+        CliSource::Gemini  => gemini_title_for_key(home, key),
         _ => None,
     }
 }

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -1824,6 +1824,17 @@ async fn handle_sessions_list(
 /// (added in Task A), and broadcasts `sessions/changed` to every connected
 /// helper when the reducer actually mutated state. Idempotent / no-op events
 /// (reducer returned `false`) skip the broadcast to avoid push storms.
+///
+/// Title-from-disk refresh: after the reducer applies, we re-check master's
+/// row for a "synthetic" title (cwd basename / empty) and try to upgrade it
+/// by reading the CLI's on-disk session artefacts (Copilot's `workspace.yaml
+/// summary:`/`name:`, Claude/Gemini's first user prompt). The helper already
+/// runs the equivalent refresh against its *local* registry, but F2 renders
+/// from master's snapshot — without this refresh master never sees the
+/// upgraded title and the row keeps showing the cwd basename forever for
+/// shell-pane CLI sessions whose first hook arrives before the CLI has
+/// written the chat title to disk (e.g. Copilot's UserPromptSubmit fires
+/// before its LLM-generated `name:` is written).
 async fn handle_session_hook(
     state: &MasterStateInner,
     params: &serde_json::value::RawValue,
@@ -1843,8 +1854,23 @@ async fn handle_session_hook(
         "received helper session hook"
     );
 
+    // Capture the session key BEFORE moving `event` into the reducer so
+    // we can dispatch the post-apply title refresh against the right
+    // row. Pane-keyed variants (PaneClosed, ConnectionFailed) don't
+    // carry a session key — they only transition the row to Ended /
+    // Error, where the title is whatever it already was, so skipping
+    // the refresh is fine.
+    let refresh_key = session_event_key(&event).map(str::to_owned);
+
     let applied = state.registry.apply_event(event).await;
-    if applied {
+
+    let title_upgraded = if let Some(key) = refresh_key {
+        try_refresh_title_from_disk(&state.registry, &acp::SessionId::new(key)).await
+    } else {
+        false
+    };
+
+    if applied || title_upgraded {
         broadcast_ext_to_helpers(
             state,
             crate::session_registry::build_sessions_changed_notification(),
@@ -1853,6 +1879,102 @@ async fn handle_session_hook(
     }
 
     Ok(crate::session_registry::build_session_hook_response(applied))
+}
+
+/// Extract the session key from event variants that carry one. Returns
+/// `None` for pane-only variants (PaneClosed, ConnectionFailed) — those
+/// don't have a stable session id without a reverse lookup, and they
+/// transition the row to a terminal state where the title doesn't need
+/// refreshing anyway.
+fn session_event_key(event: &crate::agent_sessions::SessionEvent) -> Option<&str> {
+    use crate::agent_sessions::SessionEvent;
+    match event {
+        SessionEvent::SessionStarted { key, .. }
+        | SessionEvent::ToolStarting { key, .. }
+        | SessionEvent::ToolCompleted { key }
+        | SessionEvent::Notification { key, .. }
+        | SessionEvent::SessionStopped { key, .. }
+        | SessionEvent::ResumeDispatched { key }
+        | SessionEvent::ResumePaneAssigned { key, .. } => Some(key.as_str()),
+        SessionEvent::PaneClosed { .. } | SessionEvent::ConnectionFailed { .. } => None,
+    }
+}
+
+/// If the row for `sid` has a synthetic title (None / empty / cwd
+/// basename) and we can resolve a richer title from the CLI's on-disk
+/// session artefacts, atomically upgrade the row's title. Returns
+/// `true` iff the title actually changed.
+///
+/// Reads workspace.yaml / JSONL outside the registry lock; commits via
+/// the atomic `upgrade_title_if_synthetic` registry method so a
+/// concurrent `apply_event` can't lose status / pane_session_id from a
+/// full-row upsert with a stale clone (which is what naïve
+/// lookup→clone→mutate→upsert would do here).
+async fn try_refresh_title_from_disk(
+    registry: &std::sync::Arc<dyn crate::session_registry::SessionRegistry>,
+    sid: &acp::SessionId,
+) -> bool {
+    try_refresh_title_from_disk_with(registry, sid, |cli, key| {
+        crate::history_loader::lookup_title_for_session(cli, key)
+    })
+    .await
+}
+
+/// Testable inner of [`try_refresh_title_from_disk`]: the disk lookup
+/// is injected as a closure so tests can avoid mutating `USERPROFILE`
+/// or staging files. Production code uses the wrapper above which
+/// pins the closure to `history_loader::lookup_title_for_session`.
+async fn try_refresh_title_from_disk_with<F>(
+    registry: &std::sync::Arc<dyn crate::session_registry::SessionRegistry>,
+    sid: &acp::SessionId,
+    lookup: F,
+) -> bool
+where
+    F: FnOnce(crate::agent_sessions::CliSource, &str) -> Option<String>,
+{
+    let Some(info) = registry.lookup(sid).await else {
+        return false;
+    };
+    // Skip the disk read when the title is already a real one (not
+    // empty / None / equal to the cwd basename). Avoids hammering
+    // workspace.yaml / JSONL on every hook event for sessions that are
+    // already labelled.
+    let cwd_leaf = info
+        .cwd
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    let is_synthetic = match info.title.as_deref() {
+        None | Some("") => true,
+        Some(t) => t == cwd_leaf,
+    };
+    if !is_synthetic {
+        return false;
+    }
+    // cli_source is needed to dispatch the right per-CLI on-disk
+    // scanner; rows that landed in master without one (legacy /
+    // partially-populated history seeds) can't be refreshed.
+    let Some(cli) = info.cli_source.clone() else {
+        return false;
+    };
+    let Some(disk_title) = lookup(cli, &info.session_id.0) else {
+        return false;
+    };
+    if disk_title.is_empty() {
+        return false;
+    }
+    let upgraded = registry
+        .upgrade_title_if_synthetic(sid, &disk_title)
+        .await;
+    if upgraded {
+        tracing::info!(
+            target: "session_hook",
+            session_id = %sid.0,
+            new_title = %disk_title,
+            "upgraded synthetic title from on-disk session artefacts",
+        );
+    }
+    upgraded
 }
 
 /// Pure async handler for the `intellterm.wta/focus_session` ExtRequest.
@@ -3082,5 +3204,200 @@ mod tests {
             crate::session_registry::INTELLTERM_METHOD_SESSIONS_CHANGED
         );
         assert_eq!(notification.params.get(), "{}");
+    }
+
+    // ── try_refresh_title_from_disk_with ────────────────────────────
+
+    #[tokio::test]
+    async fn try_refresh_title_upgrades_synthetic_cwd_basename_title() {
+        // Repro of the production bug: shell-pane Copilot first hook arrives
+        // with title = cwd basename ("alice" for cwd C:\Users\alice). Later,
+        // the on-disk workspace.yaml has the real `name:` field, but the
+        // helper-local upgrade never reaches master. This is the master-side
+        // upgrade path.
+        let state = make_state();
+        let event = crate::agent_sessions::SessionEvent::SessionStarted {
+            key: "sid-y".to_string(),
+            cli_source: crate::agent_sessions::CliSource::Copilot,
+            pane_session_id: "pane-y".to_string(),
+            cwd: std::path::PathBuf::from("C:\\Users\\alice"),
+            title: "alice".to_string(),
+        };
+        state.registry.apply_event(event).await;
+
+        let sid = acp::SessionId::new("sid-y".to_string());
+        let upgraded = try_refresh_title_from_disk_with(&state.registry, &sid, |cli, key| {
+            assert_eq!(cli, crate::agent_sessions::CliSource::Copilot);
+            assert_eq!(key, "sid-y");
+            Some("No Coding Task Identified".to_string())
+        })
+        .await;
+        assert!(upgraded, "title should be upgraded from synthetic basename");
+        assert_eq!(
+            state.registry.lookup(&sid).await.unwrap().title.as_deref(),
+            Some("No Coding Task Identified")
+        );
+    }
+
+    #[tokio::test]
+    async fn try_refresh_title_skips_when_title_is_real() {
+        let state = make_state();
+        let event = crate::agent_sessions::SessionEvent::SessionStarted {
+            key: "sid-real".to_string(),
+            cli_source: crate::agent_sessions::CliSource::Copilot,
+            pane_session_id: "pane-real".to_string(),
+            cwd: std::path::PathBuf::from("/repo/proj"),
+            // "Some Real Title" ≠ "proj" → not synthetic. Lookup must not run.
+            title: "Some Real Title".to_string(),
+        };
+        state.registry.apply_event(event).await;
+
+        let sid = acp::SessionId::new("sid-real".to_string());
+        let lookup_called = std::cell::Cell::new(false);
+        let upgraded = try_refresh_title_from_disk_with(&state.registry, &sid, |_, _| {
+            lookup_called.set(true);
+            Some("would-be-overwrite".to_string())
+        })
+        .await;
+        assert!(!upgraded);
+        assert!(
+            !lookup_called.get(),
+            "disk lookup must be skipped when title is already real"
+        );
+        assert_eq!(
+            state.registry.lookup(&sid).await.unwrap().title.as_deref(),
+            Some("Some Real Title")
+        );
+    }
+
+    #[tokio::test]
+    async fn try_refresh_title_skips_when_cli_source_missing() {
+        // Rows without a cli_source (legacy / partial seeds) can't be
+        // dispatched to a per-CLI on-disk scanner; refresh must be a
+        // no-op rather than trying to guess.
+        let state = make_state();
+        let mut info = crate::session_registry::SessionInfo::new(
+            acp::SessionId::new("sid-bare".to_string()),
+            std::path::PathBuf::from("/x/proj"),
+        );
+        info.title = Some("proj".to_string()); // synthetic
+        // info.cli_source intentionally left as None
+        state.registry.upsert(info).await;
+
+        let sid = acp::SessionId::new("sid-bare".to_string());
+        let upgraded = try_refresh_title_from_disk_with(&state.registry, &sid, |_, _| {
+            panic!("lookup must not be invoked without cli_source");
+        })
+        .await;
+        assert!(!upgraded);
+    }
+
+    #[tokio::test]
+    async fn try_refresh_title_skips_when_lookup_returns_none_or_empty() {
+        let state = make_state();
+        let event = crate::agent_sessions::SessionEvent::SessionStarted {
+            key: "sid-none".to_string(),
+            cli_source: crate::agent_sessions::CliSource::Copilot,
+            pane_session_id: "pane-none".to_string(),
+            cwd: std::path::PathBuf::from("/x/proj"),
+            title: "proj".to_string(),
+        };
+        state.registry.apply_event(event).await;
+        let sid = acp::SessionId::new("sid-none".to_string());
+
+        // Disk lookup returns None (e.g. workspace.yaml `name:` not yet
+        // written by Copilot at the moment this hook arrives).
+        let upgraded = try_refresh_title_from_disk_with(&state.registry, &sid, |_, _| None).await;
+        assert!(!upgraded);
+        assert_eq!(
+            state.registry.lookup(&sid).await.unwrap().title.as_deref(),
+            Some("proj"),
+            "title must stay synthetic when no disk title is available"
+        );
+
+        // Disk lookup returns empty string — treat as None.
+        let upgraded = try_refresh_title_from_disk_with(&state.registry, &sid, |_, _| {
+            Some(String::new())
+        })
+        .await;
+        assert!(!upgraded);
+    }
+
+    #[tokio::test]
+    async fn try_refresh_title_returns_false_for_missing_session() {
+        let state = make_state();
+        let sid = acp::SessionId::new("nope".to_string());
+        let upgraded = try_refresh_title_from_disk_with(&state.registry, &sid, |_, _| {
+            panic!("lookup must not run for missing session");
+        })
+        .await;
+        assert!(!upgraded);
+    }
+
+    #[test]
+    fn session_event_key_returns_key_for_keyed_variants() {
+        use crate::agent_sessions::{CliSource, SessionEvent};
+        let cases: Vec<(SessionEvent, Option<&str>)> = vec![
+            (
+                SessionEvent::SessionStarted {
+                    key: "k1".into(),
+                    cli_source: CliSource::Copilot,
+                    pane_session_id: "p".into(),
+                    cwd: std::path::PathBuf::new(),
+                    title: String::new(),
+                },
+                Some("k1"),
+            ),
+            (
+                SessionEvent::ToolStarting {
+                    key: "k2".into(),
+                    tool_name: "t".into(),
+                },
+                Some("k2"),
+            ),
+            (SessionEvent::ToolCompleted { key: "k3".into() }, Some("k3")),
+            (
+                SessionEvent::Notification {
+                    key: "k4".into(),
+                    message: "m".into(),
+                },
+                Some("k4"),
+            ),
+            (
+                SessionEvent::SessionStopped {
+                    key: "k5".into(),
+                    reason: "r".into(),
+                },
+                Some("k5"),
+            ),
+            (
+                SessionEvent::ResumeDispatched { key: "k6".into() },
+                Some("k6"),
+            ),
+            (
+                SessionEvent::ResumePaneAssigned {
+                    key: "k7".into(),
+                    pane_session_id: "p".into(),
+                },
+                Some("k7"),
+            ),
+            // Pane-only variants: no session key → refresh skipped.
+            (
+                SessionEvent::PaneClosed {
+                    pane_session_id: "p".into(),
+                },
+                None,
+            ),
+            (
+                SessionEvent::ConnectionFailed {
+                    pane_session_id: "p".into(),
+                    reason: "r".into(),
+                },
+                None,
+            ),
+        ];
+        for (event, expected) in cases {
+            assert_eq!(session_event_key(&event), expected, "event={event:?}");
+        }
     }
 }

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -769,6 +769,27 @@ pub trait SessionRegistry: Send + Sync {
     /// Returns Some((flipped, current_status_label)) where `flipped` is true
     /// only when the row was Historical and was transitioned this call.
     async fn mark_resume_dispatched(&self, sid: &acp::SessionId) -> Option<(bool, String)>;
+
+    /// Atomically replace `title` for `sid` only if the current title is
+    /// "synthetic" (`None`, empty, or equal to the cwd basename). Returns
+    /// `true` iff the title was actually changed. The candidate must be
+    /// non-empty.
+    ///
+    /// Mirrors the helper-side `AgentSessionRegistry::upgrade_title_if_synthetic`
+    /// (see `agent_sessions.rs`). Master needs the same surface so it can
+    /// upgrade titles from disk after a `session_hook` ExtRequest applies an
+    /// event — without it, F2 (which renders master's snapshot) keeps showing
+    /// the synthetic cwd-basename title even after the CLI writes the real
+    /// chat title to disk.
+    ///
+    /// The check + mutate happen under one lock so a concurrent `apply_event`
+    /// or `upsert` can't race the disk-read-and-write that an alternative
+    /// `lookup → mutate clone → upsert` flow would produce.
+    async fn upgrade_title_if_synthetic(
+        &self,
+        sid: &acp::SessionId,
+        candidate: &str,
+    ) -> bool;
 }
 
 /// Production implementation. Uses `tokio::sync::Mutex` for parity with the
@@ -848,6 +869,37 @@ impl SessionRegistry for InMemoryRegistry {
         } else {
             Some((false, current_label))
         }
+    }
+
+    async fn upgrade_title_if_synthetic(
+        &self,
+        sid: &acp::SessionId,
+        candidate: &str,
+    ) -> bool {
+        if candidate.is_empty() {
+            return false;
+        }
+        let mut guard = self.inner.lock().await;
+        let Some(entry) = guard.sessions.get_mut(sid) else {
+            return false;
+        };
+        let cwd_leaf = entry
+            .cwd
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("");
+        let is_synthetic = match entry.title.as_deref() {
+            None | Some("") => true,
+            Some(t) => t == cwd_leaf,
+        };
+        if !is_synthetic {
+            return false;
+        }
+        if entry.title.as_deref() == Some(candidate) {
+            return false;
+        }
+        entry.title = Some(candidate.to_string());
+        true
     }
 }
 
@@ -1385,6 +1437,135 @@ mod tests {
         apply_snapshot(&reg, &loaded, items.clone()).await;
         apply_snapshot(&reg, &loaded, items).await;
         assert_eq!(reg.snapshot().await.len(), 2, "second apply matches first");
+    }
+
+    // ── upgrade_title_if_synthetic ──────────────────────────────────
+
+    fn info_with(id: &str, cwd: &str, title: Option<&str>) -> SessionInfo {
+        let mut s = SessionInfo::new(acp::SessionId::new(id.to_string()), PathBuf::from(cwd));
+        s.title = title.map(str::to_owned);
+        s
+    }
+
+    #[tokio::test]
+    async fn upgrade_title_replaces_none_title() {
+        let reg = InMemoryRegistry::new();
+        reg.upsert(info_with("s1", "/repo/proj", None)).await;
+        let sid = acp::SessionId::new("s1".to_string());
+        assert!(reg.upgrade_title_if_synthetic(&sid, "Real Title").await);
+        assert_eq!(
+            reg.lookup(&sid).await.unwrap().title.as_deref(),
+            Some("Real Title")
+        );
+    }
+
+    #[tokio::test]
+    async fn upgrade_title_replaces_empty_title() {
+        let reg = InMemoryRegistry::new();
+        reg.upsert(info_with("s1", "/repo/proj", Some(""))).await;
+        let sid = acp::SessionId::new("s1".to_string());
+        assert!(reg.upgrade_title_if_synthetic(&sid, "Real Title").await);
+        assert_eq!(
+            reg.lookup(&sid).await.unwrap().title.as_deref(),
+            Some("Real Title")
+        );
+    }
+
+    #[tokio::test]
+    async fn upgrade_title_replaces_cwd_basename_title() {
+        // The exact bug from the helper logs: cwd=C:\Users\<user>,
+        // title="<user>" (cwd basename). Helper-local upgrade ran but
+        // never reached master; master keeps "<user>" forever. This
+        // method is the atomic primitive that lets handle_session_hook
+        // upgrade master's row when it observes the same condition.
+        let reg = InMemoryRegistry::new();
+        reg.upsert(info_with("s1", "C:\\Users\\alice", Some("alice")))
+            .await;
+        let sid = acp::SessionId::new("s1".to_string());
+        assert!(
+            reg.upgrade_title_if_synthetic(&sid, "No Coding Task Identified")
+                .await
+        );
+        assert_eq!(
+            reg.lookup(&sid).await.unwrap().title.as_deref(),
+            Some("No Coding Task Identified")
+        );
+    }
+
+    #[tokio::test]
+    async fn upgrade_title_leaves_real_title_untouched() {
+        let reg = InMemoryRegistry::new();
+        reg.upsert(info_with("s1", "/repo/proj", Some("Real Existing Title")))
+            .await;
+        let sid = acp::SessionId::new("s1".to_string());
+        // "proj" (cwd basename) ≠ "Real Existing Title", so the row is
+        // NOT synthetic — even an attempted upgrade must not clobber it.
+        assert!(
+            !reg.upgrade_title_if_synthetic(&sid, "Different Title").await
+        );
+        assert_eq!(
+            reg.lookup(&sid).await.unwrap().title.as_deref(),
+            Some("Real Existing Title")
+        );
+    }
+
+    #[tokio::test]
+    async fn upgrade_title_rejects_empty_candidate() {
+        let reg = InMemoryRegistry::new();
+        reg.upsert(info_with("s1", "/repo/proj", None)).await;
+        let sid = acp::SessionId::new("s1".to_string());
+        assert!(!reg.upgrade_title_if_synthetic(&sid, "").await);
+        assert!(reg.lookup(&sid).await.unwrap().title.is_none());
+    }
+
+    #[tokio::test]
+    async fn upgrade_title_idempotent_when_candidate_matches_existing() {
+        let reg = InMemoryRegistry::new();
+        reg.upsert(info_with("s1", "/repo/proj", Some("Same"))).await;
+        let sid = acp::SessionId::new("s1".to_string());
+        // Same != "proj" basename, so the row isn't synthetic — and
+        // even if it were, returning false on no-op keeps the
+        // broadcast budget low.
+        assert!(!reg.upgrade_title_if_synthetic(&sid, "Same").await);
+    }
+
+    #[tokio::test]
+    async fn upgrade_title_returns_false_for_missing_session() {
+        let reg = InMemoryRegistry::new();
+        let sid = acp::SessionId::new("nope".to_string());
+        assert!(!reg.upgrade_title_if_synthetic(&sid, "Real Title").await);
+    }
+
+    #[tokio::test]
+    async fn upgrade_title_preserves_other_fields() {
+        // Regression guard for the rubber-duck concern: a naïve
+        // lookup → clone → mutate title → upsert flow would clobber
+        // status / pane_session_id / current_tool / last_activity_at
+        // if another writer raced between lookup and upsert. The
+        // atomic method must touch *only* `title`.
+        let reg = InMemoryRegistry::new();
+        let mut row = info_with("s1", "C:\\Users\\alice", Some("alice"));
+        row.pane_session_id = Some("pane-abc".to_string());
+        row.status = Some(AgentStatus::Working);
+        row.cli_source = Some(CliSource::Copilot);
+        row.current_tool = Some("write".to_string());
+        row.last_activity_at_ms = Some(123_456_789);
+        row.origin = Some(SessionOrigin::Unknown);
+        reg.upsert(row.clone()).await;
+
+        let sid = acp::SessionId::new("s1".to_string());
+        assert!(reg.upgrade_title_if_synthetic(&sid, "Real Title").await);
+
+        let found = reg.lookup(&sid).await.unwrap();
+        assert_eq!(found.title.as_deref(), Some("Real Title"));
+        // Everything else is preserved.
+        assert_eq!(found.pane_session_id.as_deref(), Some("pane-abc"));
+        assert_eq!(found.status, Some(AgentStatus::Working));
+        assert_eq!(found.cli_source, Some(CliSource::Copilot));
+        assert_eq!(found.current_tool.as_deref(), Some("write"));
+        assert_eq!(found.last_activity_at_ms, Some(123_456_789));
+        assert_eq!(found.origin, Some(SessionOrigin::Unknown));
+        assert_eq!(found.cwd, PathBuf::from("C:\\Users\\alice"));
     }
 
     // ── _meta.wta extract / inject ──────────────────────────────────


### PR DESCRIPTION
## Summary

F2 session list keeps showing the **cwd basename** (e.g. `<user>` when cwd is `C:\Users\<user>`) instead of the real Copilot-generated chat title (`workspace.yaml` `name:` / `summary:` field), for Copilot CLI sessions started in a normal shell pane.

## Root cause

F2 renders from master's `SessionInfo` snapshot (since PR #73). Helper's `apply_hook_event_to_registry` already runs a `lookup_title_for_session` -> `upgrade_title_if_synthetic` pass against its **local** `AgentSessionRegistry`, but:

1. Helper publishes the SessionStarted to master via `intellterm.wta/session_hook` **before** the local title refresh runs (`app.rs` line 634-636 vs 671-680).
2. The helper-local upgrade never reaches master - no `title_updated` event exists.
3. Master keeps the synthetic `cwd basename` title forever.

Confirmed in production `wta-main_helper.log` (timestamps relative):

`
T+0    session_hook sent to master event=SessionStarted{ title: "<user>" }
T+7s   applied event=agent.stop  (workspace.yaml name: written at T+1s)
T+19s  agents_render ... ("<sid>...", "Idle", "<user>")   <- stale
`

## Fix

Mirror the helper's refresh loop on master. After `handle_session_hook` applies an event, look up the row, detect a synthetic title (`None` / empty / equal to cwd basename), and if so call the per-CLI on-disk lookup. Commit via a new **atomic** `SessionRegistry::upgrade_title_if_synthetic(sid, candidate)` method so a concurrent `apply_event` can't lose `status` / `pane_session_id` / `current_tool` / `last_activity_at_ms` from a stale full-row upsert (rubber-duck caught this).

- Pane-only variants (`PaneClosed`, `ConnectionFailed`) don't carry a session key and only transition rows to a terminal state - refresh is skipped.
- Disk lookup runs outside the registry lock.
- `try_refresh_title_from_disk` is factored into an `_with(...)` closure-injected inner so tests can avoid mutating `USERPROFILE`.
- New `history_loader::lookup_title_for_session_in(home, cli, key)` exposes a testable variant of the production `home_dir()`-based wrapper.

## Why PR #101 is unrelated

PR #101 only changed `MasterClient::load_session` to **preserve** existing titles when upserting a resumed row - that's the inverse of this bug, and only touches the `load_session` resume path. `new_session` / `handle_session_hook` are untouched. This bug exists since PR #73 made master's snapshot the authoritative source for F2.

## Tests

- 8 new `InMemoryRegistry` tests for `upgrade_title_if_synthetic` (`None` / empty / cwd-basename -> upgraded; real title preserved; empty candidate rejected; missing session; all-fields-preserved regression guard).
- 5 new `try_refresh_title_from_disk_with` tests including the canonical `C:\Users\<user>` repro shape.
- 1 new test for `session_event_key` covering all 9 `SessionEvent` variants.
- All 548 existing wta tests pass.

## Verification

After rebuild, opening `copilot` in cwd `C:\Users\<user>`, sending a prompt, and waiting for Copilot to finish (`agent.stop` hook fires after Copilot writes the `name:` field): F2 row should now show the real title (e.g. `"No Coding Task Identified"`) instead of the username.