### PR TITLE
MVP session origin filter (shell-pane only) + wta sessions list --origin debug

### DIFF
--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -326,3 +326,52 @@ all the side effects:
   a new tab + reconcile the agent pane),
 * on-failure `PaneClosed` rebroadcast (so a stuck Live row
   transitions to Ended after `wtcli focus-pane` returns NotFound).
+
+### MVP origin filter (F2 picker shows shell-pane sessions only)
+
+The F2 picker currently ships in MVP mode: it only surfaces
+**Class B** (shell-pane) sessions — the user manually ran `copilot`
+/ `claude` / `gemini` in a regular shell. **Class A** (agent-pane)
+sessions stay in the registry so Enter routing, alive-mirror
+reconciliation, `intellterm.wta/session_added|removed`, and
+`wta sessions list` all keep seeing every row; they just don't
+render in the picker and aren't reachable by the cursor.
+
+The gate is a single constant — `app.rs::MVP_F2_ORIGIN_FILTER` —
+threaded through `App::f2_origin_filter` so that the three places
+that have to stay in sync read the same value:
+
+1. `App::agents_rows_for_tab` (cursor / Enter dispatch source of
+   truth) — applies the filter to both the snapshot path and the
+   registry-fallback path.
+2. The post-history-scan auto-select and the Delete clamp (same
+   file) — `iter_sorted_with_filters(cli, self.f2_origin_filter)`.
+3. `ui/agents_view::render` — applies the same retain to keep the
+   rendered rows lined up with the cursor model.
+
+`agent_sessions::OriginFilter` (`ShellOnly | AgentPaneOnly | All`)
+is the public surface; `iter_sorted_with_filters` is the registry
+API. `iter_sorted_filtered` is preserved as a thin wrapper
+(`origin = All`) so existing call sites keep their behavior.
+
+**Debug overrides** (no rebuild required):
+
+| Surface | How to see everything |
+|---|---|
+| F2 picker, single helper | `WTA_F2_SHOW_AGENT_PANE=1` in that helper's env |
+| Out-of-band debug list | `wta sessions list` (defaults to `--origin all`) |
+| Slice to shell only | `wta sessions list --origin shell` |
+| Slice to agent-pane only | `wta sessions list --origin agent-pane` |
+
+`wta sessions list` always asks master for the full registry and
+filters client-side, so it can act as the eye-of-god view even
+while every helper's F2 picker stays in `ShellOnly`. The table
+output gains an `ORIGIN` column (`Shell` / `AgentPane` / `-` for
+untagged legacy rows); JSON output is unchanged because the field
+was already serialized.
+
+**Removing MVP gate.** When agent-pane session management is
+ready, flip `MVP_F2_ORIGIN_FILTER` to `OriginFilter::All` and
+delete `WTA_F2_SHOW_AGENT_PANE` handling in
+`resolve_f2_origin_filter`. No other call site needs to change.
+

--- a/tools/wta/src/agent_sessions.rs
+++ b/tools/wta/src/agent_sessions.rs
@@ -141,6 +141,61 @@ pub enum SessionOrigin {
     AgentPane,
 }
 
+/// View-layer filter for `SessionOrigin`. Used by the F2 / `/sessions`
+/// picker so an MVP build can restrict the list to shell-pane sessions
+/// (user typed `copilot` in a normal shell) and hide WTA-spawned
+/// agent-pane sessions, without removing the data from the registry.
+///
+/// Set the MVP default in `app.rs::MVP_F2_ORIGIN_FILTER`. Set
+/// `WTA_F2_SHOW_AGENT_PANE=1` to flip a single helper process to
+/// `All` for debugging. The `wta sessions list` CLI also accepts
+/// `--origin <shell|agent-pane|all>` for the same purpose.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum OriginFilter {
+    /// Keep rows whose origin is `Unknown` (the user ran the CLI
+    /// directly in a shell pane) and rows with no origin recorded.
+    /// Hide `AgentPane` rows.
+    ShellOnly,
+    /// Keep only `AgentPane` rows (sessions WTA spawned for an
+    /// Intelligent Terminal agent pane). Hide `Unknown` and untagged
+    /// rows. Provided for symmetry / future un-MVP toggle; not used
+    /// by the default UX today.
+    AgentPaneOnly,
+    /// Keep every row regardless of origin. The historical default
+    /// and the right setting for debug tooling that wants to see
+    /// the full registry contents.
+    #[default]
+    All,
+}
+
+impl OriginFilter {
+    /// Predicate for `AgentSession.origin` (always populated).
+    pub fn matches(self, origin: &SessionOrigin) -> bool {
+        match self {
+            OriginFilter::All           => true,
+            OriginFilter::ShellOnly     => matches!(origin, SessionOrigin::Unknown),
+            OriginFilter::AgentPaneOnly => matches!(origin, SessionOrigin::AgentPane),
+        }
+    }
+
+    /// Predicate for `SessionInfo.origin: Option<SessionOrigin>`.
+    ///
+    /// `None` means the row was serialized before the field existed
+    /// (or arrived via a notification path that doesn't carry origin
+    /// — see `agent_sessions.rs::parse_ext_notification`). We treat a
+    /// missing origin as `Unknown` for filtering purposes; this is a
+    /// compatibility fallback, not a positive identification of
+    /// shell origin. The master tags every `session/new` and
+    /// `session/load` with `Some(AgentPane)` for Class A, so in
+    /// practice `None` rows here are legacy / unclassified.
+    pub fn matches_opt(self, origin: Option<&SessionOrigin>) -> bool {
+        match origin {
+            Some(o) => self.matches(o),
+            None    => matches!(self, OriginFilter::All | OriginFilter::ShellOnly),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct AgentSession {
     pub key:               AgentKey,
@@ -628,14 +683,29 @@ impl AgentSessionRegistry {
     /// so that, when the agent pane is running a known CLI (copilot /
     /// claude / gemini), the list only shows sessions for that CLI.
     pub fn iter_sorted_filtered(&self, filter: Option<&CliSource>) -> Vec<&AgentSession> {
-        let sorted = self.iter_sorted();
-        match filter {
-            None => sorted,
-            Some(want) => sorted
-                .into_iter()
-                .filter(|s| &s.cli_source == want)
-                .collect(),
-        }
+        self.iter_sorted_with_filters(filter, OriginFilter::All)
+    }
+
+    /// Two-axis variant of [`iter_sorted_filtered`]: filter on both
+    /// `cli_source` (CLI the row belongs to) and `origin` (whether the
+    /// session was started in a shell pane or by WTA's own agent pane).
+    /// Used by the F2 / `/sessions` picker and by `wta sessions list
+    /// --origin`; the registry itself stays complete so other consumers
+    /// (Enter routing, alive-mirror reconciliation, `wta sessions list`
+    /// without `--origin`) see every row.
+    pub fn iter_sorted_with_filters(
+        &self,
+        cli: Option<&CliSource>,
+        origin: OriginFilter,
+    ) -> Vec<&AgentSession> {
+        self.iter_sorted()
+            .into_iter()
+            .filter(|s| match cli {
+                None       => true,
+                Some(want) => &s.cli_source == want,
+            })
+            .filter(|s| origin.matches(&s.origin))
+            .collect()
     }
 
     pub fn take_dirty(&mut self) -> bool {
@@ -2104,6 +2174,108 @@ mod tests {
 
         let all_len = reg.iter_sorted_filtered(None).len();
         assert_eq!(all_len, 2);
+    }
+
+    #[test]
+    fn iter_sorted_with_filters_partitions_by_origin() {
+        // Two rows, identical CLI, different SessionOrigin. ShellOnly
+        // must hide the AgentPane row; AgentPaneOnly is the inverse;
+        // All keeps both. Confirms the MVP F2 filter contract.
+        let mut reg = AgentSessionRegistry::new();
+        reg.apply(SessionEvent::SessionStarted {
+            key: k("shell-row"),
+            cli_source: CliSource::Copilot,
+            pane_session_id: pane("p-shell"),
+            cwd: PathBuf::from("/x"),
+            title: "shell".into(),
+        });
+        reg.apply(SessionEvent::SessionStarted {
+            key: k("pane-row"),
+            cli_source: CliSource::Copilot,
+            pane_session_id: pane("p-pane"),
+            cwd: PathBuf::from("/x"),
+            title: "pane".into(),
+        });
+        // Tag one row as AgentPane; the other stays at the default
+        // (Unknown) which represents a shell-pane session.
+        reg.set_origin("pane-row", SessionOrigin::AgentPane);
+
+        let shell_only: Vec<&str> = reg
+            .iter_sorted_with_filters(None, OriginFilter::ShellOnly)
+            .iter()
+            .map(|s| s.key.as_str())
+            .collect();
+        assert_eq!(shell_only, vec!["shell-row"]);
+
+        let pane_only: Vec<&str> = reg
+            .iter_sorted_with_filters(None, OriginFilter::AgentPaneOnly)
+            .iter()
+            .map(|s| s.key.as_str())
+            .collect();
+        assert_eq!(pane_only, vec!["pane-row"]);
+
+        let all = reg.iter_sorted_with_filters(None, OriginFilter::All);
+        assert_eq!(all.len(), 2);
+
+        // The legacy single-arg helper must keep returning every row
+        // (origin = All) so existing callers don't silently start
+        // hiding agent-pane rows.
+        assert_eq!(reg.iter_sorted_filtered(None).len(), 2);
+    }
+
+    #[test]
+    fn iter_sorted_with_filters_composes_cli_and_origin() {
+        // Mix of (cli, origin) combos — the two axes must be ANDed.
+        let mut reg = AgentSessionRegistry::new();
+        for (key, cli) in [
+            ("cop-shell", CliSource::Copilot),
+            ("cop-pane",  CliSource::Copilot),
+            ("cla-shell", CliSource::Claude),
+            ("cla-pane",  CliSource::Claude),
+        ] {
+            reg.apply(SessionEvent::SessionStarted {
+                key: k(key),
+                cli_source: cli,
+                pane_session_id: pane(&format!("p-{key}")),
+                cwd: PathBuf::from("/x"),
+                title: key.into(),
+            });
+        }
+        reg.set_origin("cop-pane", SessionOrigin::AgentPane);
+        reg.set_origin("cla-pane", SessionOrigin::AgentPane);
+
+        let copilot_shell: Vec<&str> = reg
+            .iter_sorted_with_filters(Some(&CliSource::Copilot), OriginFilter::ShellOnly)
+            .iter()
+            .map(|s| s.key.as_str())
+            .collect();
+        assert_eq!(copilot_shell, vec!["cop-shell"]);
+
+        let claude_pane: Vec<&str> = reg
+            .iter_sorted_with_filters(Some(&CliSource::Claude), OriginFilter::AgentPaneOnly)
+            .iter()
+            .map(|s| s.key.as_str())
+            .collect();
+        assert_eq!(claude_pane, vec!["cla-pane"]);
+    }
+
+    #[test]
+    fn origin_filter_matches_opt_treats_none_as_shell() {
+        // SessionInfo.origin is Option<SessionOrigin>; None can mean
+        // "serialized before the field existed" or "arrived via a
+        // notification path that doesn't carry origin". The MVP
+        // contract: treat None as shell so legacy rows stay visible.
+        assert!(OriginFilter::ShellOnly.matches_opt(None));
+        assert!(OriginFilter::ShellOnly.matches_opt(Some(&SessionOrigin::Unknown)));
+        assert!(!OriginFilter::ShellOnly.matches_opt(Some(&SessionOrigin::AgentPane)));
+
+        assert!(!OriginFilter::AgentPaneOnly.matches_opt(None));
+        assert!(!OriginFilter::AgentPaneOnly.matches_opt(Some(&SessionOrigin::Unknown)));
+        assert!(OriginFilter::AgentPaneOnly.matches_opt(Some(&SessionOrigin::AgentPane)));
+
+        assert!(OriginFilter::All.matches_opt(None));
+        assert!(OriginFilter::All.matches_opt(Some(&SessionOrigin::Unknown)));
+        assert!(OriginFilter::All.matches_opt(Some(&SessionOrigin::AgentPane)));
     }
 
     // -------- B-8: liveness/activity 2D + alive-pane snapshot --------

--- a/tools/wta/src/agent_sessions.rs
+++ b/tools/wta/src/agent_sessions.rs
@@ -2225,7 +2225,8 @@ mod tests {
 
     #[test]
     fn iter_sorted_with_filters_composes_cli_and_origin() {
-        // Mix of (cli, origin) combos — the two axes must be ANDed.
+        // Mix of (cli, origin) combos — the two axes must be combined
+        // with a logical AND.
         let mut reg = AgentSessionRegistry::new();
         for (key, cli) in [
             ("cop-shell", CliSource::Copilot),

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -33,6 +33,46 @@ mod turn_state;
 
 pub use turn_state::{AutofixContext, ChunkKind, SubmittedPrompt, TurnOutcome, TurnState};
 
+// ─── MVP F2 origin filter ────────────────────────────────────────────────────
+//
+// The session-management view (F2 / `/sessions`) currently ships in MVP
+// mode: it only surfaces shell-pane sessions (the user manually ran
+// `copilot` / `claude` / `gemini` in a regular shell). Agent-pane
+// sessions (Class A — created by WTA on behalf of an Intelligent
+// Terminal agent pane) stay in the registry so Enter routing,
+// alive-mirror reconciliation, and `wta sessions list` continue to
+// work; they just don't render in the picker.
+//
+// To bring agent-pane sessions back into the picker once the manage UX
+// is ready, flip this constant to `OriginFilter::All` and delete the
+// `WTA_F2_SHOW_AGENT_PANE` env override below. No other call sites
+// need to change — all consumers go through
+// `App::f2_origin_filter`.
+const MVP_F2_ORIGIN_FILTER: crate::agent_sessions::OriginFilter =
+    crate::agent_sessions::OriginFilter::ShellOnly;
+
+/// Resolve the F2 / `/sessions` origin filter for this process.
+///
+/// Defaults to [`MVP_F2_ORIGIN_FILTER`]. The `WTA_F2_SHOW_AGENT_PANE`
+/// env var (set to `1` / `true`) flips a single helper to
+/// `OriginFilter::All` for debugging — matches the existing
+/// `WTA_LOG_AGENT_EVENT` / `WTA_SOURCE_*` convention. Each helper is
+/// a separate process so the override only affects the pane that
+/// launched with the env var set; the rest of the Terminal keeps the
+/// MVP default.
+pub fn resolve_f2_origin_filter() -> crate::agent_sessions::OriginFilter {
+    match std::env::var("WTA_F2_SHOW_AGENT_PANE")
+        .ok()
+        .as_deref()
+        .map(str::trim)
+    {
+        Some("1") | Some("true") | Some("TRUE") | Some("True") | Some("yes") => {
+            crate::agent_sessions::OriginFilter::All
+        }
+        _ => MVP_F2_ORIGIN_FILTER,
+    }
+}
+
 use crate::commands::{self, CommandKind, CommandSpec, ParsedCommand};
 use crate::coordinator::{
     parse_autofix_response, parse_recommendation_set, recommended_choice_index,
@@ -1862,6 +1902,14 @@ pub struct App {
     /// with a clear error before opening a new tab when the agent
     /// can't rehydrate ACP sessions. Set on `AgentConnected`.
     pub agent_supports_load_session: bool,
+    /// Origin filter for the F2 / `/sessions` picker. Captured once at
+    /// `App::new` time via [`resolve_f2_origin_filter`] so the value is
+    /// stable for the lifetime of this helper process. Read by
+    /// [`Self::agents_rows_for_tab`] (the cursor / Enter source of
+    /// truth), the post-history-scan auto-select, the Delete clamp,
+    /// and the `agents_view::render` call in `ui/layout.rs`. See
+    /// [`MVP_F2_ORIGIN_FILTER`] for the gate to flip when un-MVP.
+    pub f2_origin_filter: crate::agent_sessions::OriginFilter,
     // Onboarding: signals main.rs to install agent hook plugins on demand.
     install_request_tx: Option<mpsc::UnboundedSender<()>>,
     /// Posts `AppEvent::AgentSessionEvent` from background callbacks
@@ -2072,6 +2120,7 @@ impl App {
             agent_sessions: crate::agent_sessions::AgentSessionRegistry::new(),
             history_load_state: HistoryLoadState::NotStarted,
             agent_supports_load_session: false,
+            f2_origin_filter: resolve_f2_origin_filter(),
             install_request_tx: None,
             agent_event_tx: None,
             session_hook_tx: None,
@@ -3018,6 +3067,7 @@ impl App {
 
     fn agents_rows_for_tab(&self, tab_id: &str) -> Vec<crate::agent_sessions::AgentSession> {
         let filter = self.current_cli_filter();
+        let origin = self.f2_origin_filter;
         if let Some(snapshot) = self
             .tab_sessions
             .get(tab_id)
@@ -3028,10 +3078,17 @@ impl App {
             if let Some(want) = filter.as_ref() {
                 rows.retain(|s| &s.cli_source == want || matches!(&s.cli_source, crate::agent_sessions::CliSource::Unknown(v) if v.is_empty()));
             }
+            // Apply the MVP origin filter on top of the cli filter.
+            // Snapshot rows come from master via SessionInfo where origin
+            // is Option<SessionOrigin>; session_info_to_agent_session
+            // collapses None -> SessionOrigin::Unknown so a registry-style
+            // `matches(&s.origin)` is sufficient and stays consistent
+            // with the registry branch below.
+            rows.retain(|s| origin.matches(&s.origin));
             rows
         } else {
             self.agent_sessions
-                .iter_sorted_filtered(filter.as_ref())
+                .iter_sorted_with_filters(filter.as_ref(), origin)
                 .into_iter()
                 .cloned()
                 .collect()
@@ -4391,7 +4448,10 @@ impl App {
                     && self.current_tab().agents_list_state.selected().is_none()
                     && !self
                         .agent_sessions
-                        .iter_sorted_filtered(self.current_cli_filter().as_ref())
+                        .iter_sorted_with_filters(
+                            self.current_cli_filter().as_ref(),
+                            self.f2_origin_filter,
+                        )
                         .is_empty()
                 {
                     self.current_tab_mut().agents_list_state.select(Some(0));
@@ -5658,11 +5718,15 @@ impl App {
                             if matches!(status, Ended | Historical) {
                                 self.agent_sessions.remove(&key);
                                 // Keep the cursor in-bounds after eviction.
-                                // Re-query through the same filter so the
-                                // selection clamp matches the rendered list.
+                                // Re-query through the same filters so the
+                                // selection clamp matches the rendered list
+                                // (both cli + MVP origin filter).
                                 let new_count = self
                                     .agent_sessions
-                                    .iter_sorted_filtered(self.current_cli_filter().as_ref())
+                                    .iter_sorted_with_filters(
+                                        self.current_cli_filter().as_ref(),
+                                        self.f2_origin_filter,
+                                    )
                                     .len();
                                 let tab = self.current_tab_mut();
                                 if new_count == 0 {
@@ -10338,6 +10402,108 @@ mod tests {
         assert!(master_rx.try_recv().is_err(), "closed UI must not refetch");
     }
 
+    /// MVP F2 origin filter: with `ShellOnly`, agent-pane rows must
+    /// be hidden from `agents_rows_for_tab` (the cursor / Enter
+    /// dispatch source of truth) — *not just* from `agents_view::render`.
+    /// A bug where render filtered but `agents_rows_for_tab` didn't
+    /// would let Enter on visible row N activate hidden row M.
+    #[test]
+    fn shell_only_filter_hides_agent_pane_rows_from_cursor_model() {
+        use crate::agent_sessions::{OriginFilter, SessionOrigin};
+        let mut app = test_app();
+        app.f2_origin_filter = OriginFilter::ShellOnly;
+        // Snapshot path: master pushed two rows — one tagged
+        // AgentPane (Class A, hidden under ShellOnly), one tagged
+        // Unknown (Class B, visible).
+        let mut pane = session_info_for_test("class-a");
+        pane.origin = Some(SessionOrigin::AgentPane);
+        pane.last_activity_at_ms = Some(200);
+        let mut shell = session_info_for_test("class-b");
+        shell.origin = Some(SessionOrigin::Unknown);
+        shell.last_activity_at_ms = Some(100);
+        app.current_tab_mut().agents_view.snapshot = Some(vec![pane, shell]);
+
+        let rows = app.agents_rows_for_tab(DEFAULT_TAB_ID);
+        assert_eq!(rows.len(), 1, "only the Class B row is visible: {rows:?}");
+        assert_eq!(rows[0].key, "class-b");
+
+        // Flip to All — both rows must reappear so the un-MVP toggle
+        // brings agent-pane rows back without any other code change.
+        app.f2_origin_filter = OriginFilter::All;
+        let rows = app.agents_rows_for_tab(DEFAULT_TAB_ID);
+        assert_eq!(rows.len(), 2);
+
+        // AgentPaneOnly is the inverse — only Class A surfaces.
+        app.f2_origin_filter = OriginFilter::AgentPaneOnly;
+        let rows = app.agents_rows_for_tab(DEFAULT_TAB_ID);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].key, "class-a");
+    }
+
+    /// Registry path (no snapshot): the same filter must apply when
+    /// `agents_rows_for_tab` falls back to `agent_sessions` directly.
+    /// Without this, helpers that haven't received a master snapshot
+    /// yet would show every row regardless of the MVP filter.
+    #[test]
+    fn shell_only_filter_applies_to_registry_fallback_path() {
+        use crate::agent_sessions::{CliSource, OriginFilter, SessionEvent, SessionOrigin};
+        use std::path::PathBuf;
+        let mut app = test_app();
+        app.f2_origin_filter = OriginFilter::ShellOnly;
+        // No snapshot primed — `agents_rows_for_tab` goes through
+        // `iter_sorted_with_filters` on the registry.
+        app.agent_sessions.apply(SessionEvent::SessionStarted {
+            key: "shell-key".into(),
+            cli_source: CliSource::Claude,
+            pane_session_id: "00000000-0000-0000-0000-00000000aaaa".into(),
+            cwd: PathBuf::from("/x"),
+            title: "shell".into(),
+        });
+        app.agent_sessions.apply(SessionEvent::SessionStarted {
+            key: "pane-key".into(),
+            cli_source: CliSource::Claude,
+            pane_session_id: "00000000-0000-0000-0000-00000000bbbb".into(),
+            cwd: PathBuf::from("/x"),
+            title: "pane".into(),
+        });
+        app.agent_sessions.set_origin("pane-key", SessionOrigin::AgentPane);
+
+        let rows = app.agents_rows_for_tab(DEFAULT_TAB_ID);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].key, "shell-key");
+    }
+
+    /// `resolve_f2_origin_filter` reads the `WTA_F2_SHOW_AGENT_PANE`
+    /// env var. With it unset (or 0/false) the MVP default
+    /// (`ShellOnly`) wins; with it set to a truthy value we flip to
+    /// `All` so a single debug helper can see everything without a
+    /// rebuild.
+    ///
+    /// Env vars are process-global, so this test serializes via the
+    /// `WTA_F2_SHOW_AGENT_PANE_TEST_LOCK` mutex shared with any other
+    /// future test that touches the same var.
+    #[test]
+    fn resolve_f2_origin_filter_respects_env_override() {
+        use crate::agent_sessions::OriginFilter;
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        std::env::remove_var("WTA_F2_SHOW_AGENT_PANE");
+        assert_eq!(crate::app::resolve_f2_origin_filter(), MVP_F2_ORIGIN_FILTER);
+        assert_eq!(MVP_F2_ORIGIN_FILTER, OriginFilter::ShellOnly);
+
+        std::env::set_var("WTA_F2_SHOW_AGENT_PANE", "1");
+        assert_eq!(crate::app::resolve_f2_origin_filter(), OriginFilter::All);
+
+        std::env::set_var("WTA_F2_SHOW_AGENT_PANE", "true");
+        assert_eq!(crate::app::resolve_f2_origin_filter(), OriginFilter::All);
+
+        std::env::set_var("WTA_F2_SHOW_AGENT_PANE", "0");
+        assert_eq!(crate::app::resolve_f2_origin_filter(), MVP_F2_ORIGIN_FILTER);
+
+        std::env::remove_var("WTA_F2_SHOW_AGENT_PANE");
+    }
+
     #[test]
     fn snapshot_refetch_preserves_focused_sid() {
         let (mut app, mut master_rx) = test_app_with_master_rx();
@@ -10656,10 +10822,15 @@ mod tests {
     /// Class A dead + Enter ran the CLI --resume flag path.
     #[test]
     fn enter_on_class_a_dead_row_dispatches_resume_in_agent_pane() {
-        use crate::agent_sessions::{CliSource, SessionEvent, SessionOrigin};
+        use crate::agent_sessions::{CliSource, OriginFilter, SessionEvent, SessionOrigin};
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         use std::path::PathBuf;
         let mut app = test_app();
+        // This test exercises the Class A (AgentPane) Enter routing,
+        // which the MVP F2 filter hides. Opt out so the row is
+        // visible to the cursor; the dispatch logic under test is
+        // unchanged by the filter.
+        app.f2_origin_filter = OriginFilter::All;
         app.agent_supports_load_session = true;
         app.agent_sessions.apply(SessionEvent::SessionStarted {
             key: "abc-class-a".into(),
@@ -10692,10 +10863,15 @@ mod tests {
     /// Shift flips the default → ResumeCliFlag (new tab CLI --resume).
     #[test]
     fn shift_enter_on_class_a_dead_row_dispatches_cli_resume() {
-        use crate::agent_sessions::{CliSource, SessionEvent, SessionOrigin};
+        use crate::agent_sessions::{CliSource, OriginFilter, SessionEvent, SessionOrigin};
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         use std::path::PathBuf;
         let mut app = test_app();
+        // See enter_on_class_a_dead_row_dispatches_resume_in_agent_pane
+        // for the OriginFilter::All rationale — the MVP filter hides
+        // Class A rows from the cursor model; this test exercises the
+        // routing logic that fires when they ARE visible.
+        app.f2_origin_filter = OriginFilter::All;
         app.agent_supports_load_session = true;
         app.agent_sessions.apply(SessionEvent::SessionStarted {
             key: "abc-class-a-shift".into(),
@@ -10734,10 +10910,14 @@ mod tests {
     /// A origin to confirm origin doesn't matter for Live rows.
     #[test]
     fn shift_enter_on_class_a_live_row_focuses() {
-        use crate::agent_sessions::{CliSource, SessionEvent, SessionOrigin};
+        use crate::agent_sessions::{CliSource, OriginFilter, SessionEvent, SessionOrigin};
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         use std::path::PathBuf;
         let mut app = test_app();
+        // Same rationale as the Class A dead-row tests above:
+        // MVP F2 filter hides AgentPane rows, this test verifies the
+        // dispatch logic for when they are visible.
+        app.f2_origin_filter = OriginFilter::All;
         app.agent_sessions.apply(SessionEvent::SessionStarted {
             key: "live-class-a".into(),
             cli_source: CliSource::Claude,

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -470,7 +470,40 @@ enum SessionsAction {
         /// Override the wta-master named pipe path.
         #[arg(long, value_name = "PIPE_NAME")]
         master: Option<String>,
+
+        /// Restrict the list to a session origin. `all` (default) shows
+        /// every row — that matches the historical debug behavior.
+        /// `shell` shows only user-started shell-pane sessions (the
+        /// MVP F2 default). `agent-pane` shows only sessions that
+        /// WTA spawned for an Intelligent Terminal agent pane.
+        #[arg(long, value_enum, default_value_t = SessionsOriginArg::All)]
+        origin: SessionsOriginArg,
     },
+}
+
+/// CLI value for `wta sessions list --origin`. Mirrors
+/// [`agent_sessions::OriginFilter`] but lives in `main.rs` so the
+/// clap derive can attach `ValueEnum` without polluting the library
+/// crate with clap as a dependency.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+enum SessionsOriginArg {
+    /// Shell-pane sessions only (Class B). Matches the MVP F2 picker.
+    Shell,
+    /// Agent-pane sessions only (Class A). Hidden from the MVP F2
+    /// picker; surfaced here for debugging.
+    AgentPane,
+    /// Every row in the registry — historical debug default.
+    All,
+}
+
+impl SessionsOriginArg {
+    fn to_filter(self) -> agent_sessions::OriginFilter {
+        match self {
+            SessionsOriginArg::Shell     => agent_sessions::OriginFilter::ShellOnly,
+            SessionsOriginArg::AgentPane => agent_sessions::OriginFilter::AgentPaneOnly,
+            SessionsOriginArg::All       => agent_sessions::OriginFilter::All,
+        }
+    }
 }
 
 /// Subcommands for `wta hooks`.
@@ -784,7 +817,9 @@ async fn main() -> Result<()> {
 
         // ── Master session registry CLI ──
         Some(Command::Sessions { action }) => match action {
-            SessionsAction::List { master } => run_sessions_list(master, json_mode).await,
+            SessionsAction::List { master, origin } => {
+                run_sessions_list(master, origin.to_filter(), json_mode).await
+            }
         },
 
         // ── Manage agent hooks (install/status/uninstall) ──
@@ -1064,15 +1099,28 @@ impl acp::Client for SessionsCliClient {
     }
 }
 
-async fn run_sessions_list(master_override: Option<String>, json_mode: bool) -> Result<()> {
+async fn run_sessions_list(
+    master_override: Option<String>,
+    origin_filter: agent_sessions::OriginFilter,
+    json_mode: bool,
+) -> Result<()> {
     let local = tokio::task::LocalSet::new();
     let sessions = local
         .run_until(fetch_sessions_from_master(master_override))
         .await?;
+    // Origin filter is applied client-side: master always returns the
+    // full registry so this command can act as the debug eye-of-god
+    // view (default `--origin all`). `--origin shell` matches what
+    // the MVP F2 picker shows; `--origin agent-pane` surfaces the
+    // rows MVP F2 hides.
+    let filtered: Vec<session_registry::SessionInfo> = sessions
+        .into_iter()
+        .filter(|s| origin_filter.matches_opt(s.origin.as_ref()))
+        .collect();
     if json_mode {
-        print!("{}", format_sessions_json_lines(&sessions)?);
+        print!("{}", format_sessions_json_lines(&filtered)?);
     } else {
-        print!("{}", format_sessions_table(&sessions));
+        print!("{}", format_sessions_table(&filtered));
     }
     Ok(())
 }
@@ -1165,17 +1213,18 @@ fn format_sessions_table(sessions: &[session_registry::SessionInfo]) -> String {
         return out;
     }
     out.push_str(&format!(
-        "{:<24} {:<10} {:<10} {:<20} {:<20} {}\n",
-        "SESSION", "STATUS", "CLI", "PANE", "UPDATED", "TITLE"
+        "{:<24} {:<10} {:<10} {:<10} {:<20} {:<20} {}\n",
+        "SESSION", "STATUS", "CLI", "ORIGIN", "PANE", "UPDATED", "TITLE"
     ));
     for session in sessions {
         let sid = session.session_id.to_string();
         let short_sid = if sid.len() > 24 { &sid[..24] } else { sid.as_str() };
         out.push_str(&format!(
-            "{:<24} {:<10} {:<10} {:<20} {:<20} {}\n",
+            "{:<24} {:<10} {:<10} {:<10} {:<20} {:<20} {}\n",
             short_sid,
             status_label(session.status.as_ref()),
             cli_source_label(session.cli_source.as_ref()),
+            origin_label(session.origin.as_ref()),
             session.pane_session_id.as_deref().unwrap_or("-"),
             session.updated_at.as_deref().unwrap_or("-"),
             session.title.as_deref().unwrap_or("-"),
@@ -1195,6 +1244,19 @@ fn cli_source_label(source: Option<&agent_sessions::CliSource>) -> String {
         Some(agent_sessions::CliSource::Gemini) => "Gemini".to_string(),
         Some(agent_sessions::CliSource::Unknown(s)) if !s.is_empty() => s.clone(),
         _ => "-".to_string(),
+    }
+}
+
+/// Render a `SessionOrigin` for the `wta sessions list` table. `None`
+/// is the on-the-wire representation for "field absent" (legacy rows
+/// or notification paths that don't carry origin) — we print `-`
+/// rather than fabricating an origin so the operator can tell
+/// "untagged" from "shell".
+fn origin_label(origin: Option<&agent_sessions::SessionOrigin>) -> &'static str {
+    match origin {
+        Some(agent_sessions::SessionOrigin::AgentPane) => "AgentPane",
+        Some(agent_sessions::SessionOrigin::Unknown)   => "Shell",
+        None                                           => "-",
     }
 }
 
@@ -2613,8 +2675,46 @@ mod cli_tests {
 
         assert!(cli.json);
         match cli.command {
-            Some(Command::Sessions { action: SessionsAction::List { master } }) => {
+            Some(Command::Sessions { action: SessionsAction::List { master, origin } }) => {
                 assert_eq!(master.as_deref(), Some(r"\\.\pipe\wta-master-test"));
+                // Default keeps the historical debug behavior — show
+                // every origin. MVP F2 picker has its own default in
+                // `app::resolve_f2_origin_filter`; this CLI default is
+                // intentionally divergent so `wta sessions list` is
+                // the "see everything" debug tool.
+                assert_eq!(origin, SessionsOriginArg::All);
+            }
+            other => panic!("expected sessions list command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sessions_list_cli_parses_origin_shell() {
+        let cli = Cli::try_parse_from(["wta", "sessions", "list", "--origin", "shell"])
+            .expect("sessions list --origin shell parses");
+        match cli.command {
+            Some(Command::Sessions { action: SessionsAction::List { origin, .. } }) => {
+                assert_eq!(origin, SessionsOriginArg::Shell);
+                assert_eq!(
+                    origin.to_filter(),
+                    agent_sessions::OriginFilter::ShellOnly,
+                );
+            }
+            other => panic!("expected sessions list command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sessions_list_cli_parses_origin_agent_pane() {
+        let cli = Cli::try_parse_from(["wta", "sessions", "list", "--origin", "agent-pane"])
+            .expect("sessions list --origin agent-pane parses");
+        match cli.command {
+            Some(Command::Sessions { action: SessionsAction::List { origin, .. } }) => {
+                assert_eq!(origin, SessionsOriginArg::AgentPane);
+                assert_eq!(
+                    origin.to_filter(),
+                    agent_sessions::OriginFilter::AgentPaneOnly,
+                );
             }
             other => panic!("expected sessions list command, got {other:?}"),
         }
@@ -2657,5 +2757,28 @@ mod cli_tests {
         assert!(out.contains("Idle"));
         assert!(out.contains("Claude"));
         assert!(out.contains("pane-table"));
+        // ORIGIN column exists and untagged rows render as "-" so the
+        // operator can tell "legacy / unclassified" from "shell".
+        assert!(out.contains("ORIGIN"));
+        let body = out.lines().nth(1).expect("body row present");
+        assert!(body.contains(" - "), "untagged origin renders as '-' got: {body}");
+    }
+
+    #[test]
+    fn sessions_table_renders_origin_labels() {
+        let mut shell = session_registry::SessionInfo::new(
+            agent_client_protocol::SessionId::new("sid-shell"),
+            std::path::PathBuf::from("C:\\repo"),
+        );
+        shell.origin = Some(agent_sessions::SessionOrigin::Unknown);
+        let mut pane = session_registry::SessionInfo::new(
+            agent_client_protocol::SessionId::new("sid-pane"),
+            std::path::PathBuf::from("C:\\repo"),
+        );
+        pane.origin = Some(agent_sessions::SessionOrigin::AgentPane);
+
+        let out = format_sessions_table(&[shell, pane]);
+        assert!(out.contains("Shell"), "shell origin label present: {out}");
+        assert!(out.contains("AgentPane"), "agent-pane origin label present: {out}");
     }
 }

--- a/tools/wta/src/ui/agents_view.rs
+++ b/tools/wta/src/ui/agents_view.rs
@@ -9,7 +9,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use unicode_width::UnicodeWidthStr;
 
 use crate::agent_sessions::{
-    AgentSession, AgentSessionRegistry, AgentStatus, CliSource, SessionOrigin,
+    AgentSession, AgentSessionRegistry, AgentStatus, CliSource, OriginFilter, SessionOrigin,
 };
 use crate::app::HistoryLoadState;
 use crate::session_registry::SessionInfo;
@@ -33,6 +33,12 @@ pub fn render(
     history_load_state: HistoryLoadState,
     activity_frame: usize,
     cli_filter: Option<&CliSource>,
+    // MVP origin filter — `ShellOnly` by default, see
+    // `app.rs::MVP_F2_ORIGIN_FILTER`. Must match whatever filter
+    // `App::agents_rows_for_tab` applies so the rendered rows line
+    // up with the cursor / Enter dispatch model. Caller threads the
+    // stored `app.f2_origin_filter`.
+    origin_filter: OriginFilter,
     // True iff the F2 view is waiting on its first `session/list`
     // snapshot from master (snapshot is currently empty AND a refetch
     // request is in flight). Without this signal we have no way to
@@ -99,36 +105,61 @@ pub fn render(
     };
 
     let using_snapshot = snapshot.is_some();
-    let sorted: Vec<AgentSession> = if let Some(snapshot) = snapshot {
+    let filter_start = std::time::Instant::now();
+    let (sorted, pre_filter_total): (Vec<AgentSession>, usize) = if let Some(snapshot) = snapshot {
         let mut rows: Vec<_> = snapshot
             .iter()
             .map(crate::app::session_info_to_agent_session)
             .collect();
         rows.sort_by(|a, b| b.last_activity_at.cmp(&a.last_activity_at));
+        let total = rows.len();
         if let Some(want) = cli_filter {
             rows.retain(|s| {
                 &s.cli_source == want
                     || matches!(&s.cli_source, CliSource::Unknown(v) if v.is_empty())
             });
         }
-        rows
+        // MVP origin filter. Stays in sync with the same retain inside
+        // `App::agents_rows_for_tab` (which feeds the cursor / Enter
+        // dispatch); both call sites read `app.f2_origin_filter`.
+        // `session_info_to_agent_session` collapses None origin to
+        // SessionOrigin::Unknown so `matches(&s.origin)` is correct
+        // for the snapshot path too.
+        rows.retain(|s| origin_filter.matches(&s.origin));
+        (rows, total)
     } else {
-        reg.iter_sorted_filtered(cli_filter)
+        let total = reg.iter_sorted().len();
+        let rows: Vec<AgentSession> = reg
+            .iter_sorted_with_filters(cli_filter, origin_filter)
             .into_iter()
             .cloned()
-            .collect()
+            .collect();
+        (rows, total)
     };
+    let filter_elapsed_us = filter_start.elapsed().as_micros() as u64;
+    tracing::debug!(
+        target: "f2_filter_perf",
+        total      = pre_filter_total,
+        kept       = sorted.len(),
+        cli_filter = ?cli_filter,
+        origin     = ?origin_filter,
+        elapsed_us = filter_elapsed_us,
+        source     = if using_snapshot { "snapshot" } else { "registry" },
+        "f2 origin/cli filter applied"
+    );
     tracing::info!(
         target: "agents_view_filter",
         filter = ?cli_filter,
+        origin = ?origin_filter,
         visible = sorted.len(),
-        total = if using_snapshot { sorted.len() } else { reg.iter_sorted().len() },
+        total = pre_filter_total,
         "rendering agent sessions list"
     );
     tracing::debug!(
         target: "agents_render",
         total = sorted.len(),
         filter = ?cli_filter,
+        origin = ?origin_filter,
         first_three = ?sorted.iter().take(3).map(|s| (
             s.key.clone(),
             format!("{:?}", s.status),

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -49,6 +49,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         let load_state = app.history_load_state;
         let activity_frame = app.activity_frame as usize;
         let cli_filter = app.current_cli_filter();
+        let origin_filter = app.f2_origin_filter;
         let tab = app.tab_sessions.entry(tab_id).or_default();
         // Show the loading shimmer while we're waiting on the very first
         // `session/list` response from master. `open_agents_view_for_tab`
@@ -73,6 +74,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             load_state,
             activity_frame,
             cli_filter.as_ref(),
+            origin_filter,
             awaiting_first_snapshot,
         );
         return;


### PR DESCRIPTION
## What

MVP gate for the F2 / `/sessions` picker: surface **shell-pane sessions only** (Class B — user manually ran `copilot` / `claude` / `gemini` in a normal shell). **Agent-pane sessions** (Class A — spawned by WTA's own agent pane) stay in the registry so Enter routing, alive-mirror reconciliation, `intellterm.wta/session_added|removed`, and `wta sessions list` keep behaving as before — they just don't render in the picker and aren't reachable by the cursor.

This is explicitly **MVP scope**: agent-pane session management is deferred to a later release. None of the Class A support code is deleted; one constant flip un-MVPs the whole feature.

## Why view-layer filter (not data-layer)

Both Class A and Class B sessions share the same on-disk CLI history dirs (`~/.copilot/`, `~/.claude/`, `~/.gemini/`). The agent-pane index (`agent-pane-sessions.jsonl`) is a small sidecar that *tags* reconstructed rows as `AgentPane` — it isn't the heavy I/O. Skipping it at load time would save almost nothing AND lose the origin tag (every row would become `Unknown`), so the agent-pane sessions would actually appear *more* in the picker, not less.

View-layer `retain` on the registry costs sub-millisecond even at 10k rows. `f2_filter_perf` tracing records pre/post counts so we can verify in production.

## How — three-place consistency

A blind spot caught early by rubber-duck review: filtering only at render would let cursor on visible row N activate hidden row M, because Enter dispatch reads `App::agents_rows_for_tab`, not the render slice. The filter therefore lives in three places, all reading the same `app.f2_origin_filter`:

1. **`App::agents_rows_for_tab`** — cursor / Enter dispatch source of truth. Both snapshot and registry-fallback branches apply `OriginFilter::matches`.
2. **Post-history-scan auto-select** + **Delete clamp** — both call `iter_sorted_with_filters(cli, self.f2_origin_filter)` so selection clamping matches the rendered list.
3. **`ui::agents_view::render`** — identical `retain` keeps the displayed rows lined up with the cursor model. Adds `tracing::debug!(target: "f2_filter_perf", ...)` so a degenerate registry can be diagnosed without guessing.

## Debug overrides — no rebuild required

| Surface | Action |
|---|---|
| F2 picker (single helper) | `WTA_F2_SHOW_AGENT_PANE=1` in that helper's env → `OriginFilter::All` |
| Out-of-band debug list | `wta sessions list` (defaults to `--origin all`) |
| Slice to shell only | `wta sessions list --origin shell` |
| Slice to agent-pane only | `wta sessions list --origin agent-pane` |

The CLI default intentionally diverges from the F2 default: `wta sessions list` is the eye-of-god debug view, so it shows everything by default. Table output gains an `ORIGIN` column (`Shell` / `AgentPane` / `-` for legacy untagged rows). JSON output is unchanged — origin was already serialized.

## Removing the MVP gate

Flip `app::MVP_F2_ORIGIN_FILTER` to `OriginFilter::All` and delete the env override in `resolve_f2_origin_filter`. **Zero other call sites change.**

## Files

| File | Change |
|---|---|
| `agent_sessions.rs` | `OriginFilter { ShellOnly, AgentPaneOnly, All }` + `iter_sorted_with_filters(cli, origin)`; `iter_sorted_filtered` now delegates with `origin = All` |
| `app.rs` | `MVP_F2_ORIGIN_FILTER` const + `resolve_f2_origin_filter()`; new `App::f2_origin_filter` field; `agents_rows_for_tab` + post-scan seed + Delete clamp wired through the two-axis filter |
| `ui/agents_view.rs` | `render(..., origin_filter, ...)` + `f2_filter_perf` tracing |
| `ui/layout.rs` | threads `app.f2_origin_filter` |
| `main.rs` | `wta sessions list --origin <shell\|agent-pane\|all>` + `ORIGIN` column |
| `AGENTS.md` | New "MVP origin filter" section under "Session liveness + Enter routing" |

## Tests

* `agent_sessions`: `iter_sorted_with_filters_partitions_by_origin`, `iter_sorted_with_filters_composes_cli_and_origin`, `origin_filter_matches_opt_treats_none_as_shell`.
* `app`: `shell_only_filter_hides_agent_pane_rows_from_cursor_model` (snapshot path), `shell_only_filter_applies_to_registry_fallback_path`, `resolve_f2_origin_filter_respects_env_override` (env-var matrix + cleanup).
* `main`: `sessions_list_cli_parses_origin_shell` / `_agent_pane`, `sessions_table_renders_origin_labels` + existing tests updated for the new variant field.
* Pre-existing Class A dispatch tests (`enter_on_class_a_dead_row*`, `shift_enter_on_class_a_live_row_focuses`) explicitly set `app.f2_origin_filter = All` — they test routing logic, not MVP UX policy.

`cargo test --bin wta`: **557 passed, 0 failed**.

## Smoke check

```
wta sessions list --help
```
shows `--origin <shell|agent-pane|all>` with the per-value docstrings and `[default: all]`.
