### PR TITLE
fix(wt+wta): emit connection_state:closed on UI-initiated pane/tab close

### DIFF
--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -668,6 +668,7 @@ namespace winrt::TerminalApp::implementation
         // index slot starts with a clean conversation.
         winrt::hstring closedTabStableId{};
         size_t agentPanesOnTab = 0;
+        std::shared_ptr<Pane> rootPaneForClose{};
         if (const auto tabImpl = _GetTabImpl(tab))
         {
             closedTabStableId = tabImpl->StableId();
@@ -677,6 +678,7 @@ namespace winrt::TerminalApp::implementation
             // below — see the long comment after `tab.Shutdown()`.
             if (const auto rootPane = tabImpl->GetRootPane())
             {
+                rootPaneForClose = rootPane;
                 rootPane->WalkTree([&agentPanesOnTab](const std::shared_ptr<Pane>& p) -> void {
                     if (p && p->IsAgentPane())
                     {
@@ -685,6 +687,18 @@ namespace winrt::TerminalApp::implementation
                 });
             }
         }
+
+        // Notify wta of every terminal pane in this tab BEFORE
+        // `tab.Shutdown()` destroys their controls. Tab shutdown goes
+        // through `Pane::Shutdown` -> `_setPaneContent(nullptr)` which
+        // doesn't fire `Pane::Closed` and doesn't drive the connection
+        // through its Closed state with our listener attached, so the
+        // normal ConnectionStateChanged bridge never emits
+        // `connection_state:closed`. Explicit emit here is what lets
+        // wta demote agent-session rows bound to the tab's panes to
+        // Ended on tab close (the `_HandleClosePaneRequested`
+        // counterpart covers single-pane Ctrl+Shift+W).
+        _NotifyPanesClosing(rootPaneForClose);
 
         // Removing the tab from the collection should destroy its control and disconnect its connection,
         // but it doesn't always do so. The UI tree may still be holding the control and preventing its destruction.
@@ -1046,6 +1060,12 @@ namespace winrt::TerminalApp::implementation
             state.args.emplace(state.args.begin(), std::move(splitPaneAction));
         }
         _AddPreviouslyClosedPaneOrTab(std::move(state.args));
+
+        // Notify wta of pane closure BEFORE destruction (see
+        // `_NotifyPanesClosing` for the revoker-race rationale). Must
+        // happen before `pane->Close()` since Close destroys the
+        // TermControl and the SessionId becomes unresolvable.
+        _NotifyPanesClosing(pane);
 
         // If specified, detach before closing to directly update the pane structure
         pane->Close();

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1418,6 +1418,62 @@ namespace winrt::TerminalApp::implementation
             winrt::to_hstring(Json::writeString(wb, tabEvt)));
     }
 
+    // Explicitly emit `connection_state:closed` for every terminal leaf
+    // under `rootPane`. Needed because UI-initiated pane/tab close goes
+    // through `ControlCore::_closeConnection` which revokes the
+    // `ConnectionStateChanged` listener BEFORE the connection transitions
+    // to Closed — so the normal `TermControl::ConnectionStateChanged ->
+    // ProtocolVtSequenceReceived` bridge installed in
+    // `_RegisterTerminalEvents` never fires for these paths. Without an
+    // explicit emit, wta's session-list rows bound to those pane GUIDs
+    // stay stuck at their last live status (Idle / Working /
+    // "waiting for input") forever.
+    //
+    // Process-initiated close (agent typed `/exit`, conpty closes
+    // naturally) still goes through the normal bridge because the
+    // connection's own state machine drives the transition before the
+    // revoker runs.
+    //
+    // Must be called BEFORE the destructive op (`pane->Close()`,
+    // `tab.Shutdown()`) — once content is destroyed,
+    // `GetTerminalControl()` returns null and the SessionId is
+    // unresolvable.
+    void TerminalPage::_NotifyPanesClosing(const std::shared_ptr<Pane>& rootPane)
+    {
+        if (!rootPane)
+        {
+            return;
+        }
+        rootPane->WalkTree([this](const std::shared_ptr<Pane>& p) -> void {
+            if (!p)
+            {
+                return;
+            }
+            const auto control = p->GetTerminalControl();
+            if (!control)
+            {
+                return;
+            }
+            const auto paneIdStr = _FindSessionIdForControl(control);
+            if (paneIdStr.empty())
+            {
+                return;
+            }
+            Json::Value evt;
+            evt["type"] = "event";
+            evt["method"] = "connection_state";
+            Json::Value params;
+            params["pane_id"] = paneIdStr;
+            params["state"] = "closed";
+            evt["params"] = params;
+            Json::StreamWriterBuilder wb;
+            wb["indentation"] = "";
+            ProtocolVtSequenceReceived.raise(
+                *this,
+                winrt::to_hstring(Json::writeString(wb, evt)));
+        });
+    }
+
     // Tells wta that the focused tab changed so it can re-project per-tab
     // agent-pane state (view, pane_open, autofix snapshot). wta echoes the
     // authoritative state via `agent_state_changed`, which `OnAgentStateChanged`

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -600,6 +600,7 @@ namespace winrt::TerminalApp::implementation
         TerminalApp::Tab _GetTabByTabViewItem(const IInspectable& tabViewItem) const noexcept;
 
         void _HandleClosePaneRequested(std::shared_ptr<Pane> pane);
+        void _NotifyPanesClosing(const std::shared_ptr<Pane>& rootPane);
         bool _ShouldWarnOnClose() const;
         bool _ShouldWarnOnCloseTab(const winrt::com_ptr<Tab>& tab) const;
         safe_void_coroutine _SetFocusedTab(const winrt::TerminalApp::Tab tab);

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -5029,6 +5029,13 @@ impl App {
                 // safe to apply unconditionally for non-own panes.
                 if method == "connection_state" {
                     let state = params.get("state").and_then(|v| v.as_str()).unwrap_or("");
+                    tracing::info!(
+                        target: "helper_wt_event",
+                        pane_id = %pane_id,
+                        state,
+                        self_pane = ?self.pane_id,
+                        "helper observed WT connection_state event"
+                    );
                     match state {
                         "closed" => {
                             // Capture the key BEFORE PaneClosed clears
@@ -5042,6 +5049,12 @@ impl App {
                             };
                             self.agent_sessions.apply(event.clone());
                             self.publish_session_hook(event);
+                            tracing::info!(
+                                target: "helper_wt_event",
+                                pane_id = %pane_id,
+                                key_before = ?key_before,
+                                "helper applied PaneClosed locally + published to master"
+                            );
                             if let Some(k) = key_before {
                                 crate::app::prune_phantom_session_if_ended(
                                     &mut self.agent_sessions,

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -1348,18 +1348,50 @@ async fn run_master_loop(cli: Cli, pipe_name: String) -> Result<()> {
     //    `None` and `handle_focus_session` returns a structured
     //    "focus channel unavailable" error instead of crashing the
     //    helper's ext_method call.
-    let wt: Option<Arc<dyn crate::shell::wt_channel::WtChannel>> =
+    //
+    //    We also take this opportunity to subscribe to WT events so
+    //    master can demote rows to Ended on pane-close even when no
+    //    wta-helper publishes a `PaneClosed` session_hook. Two
+    //    real-world cases this protects against:
+    //
+    //      * Gemini shell-pane sessions on Ctrl+Shift+W / close-tab:
+    //        Gemini's `SessionEnd` hook does not run reliably on hard
+    //        kill (confirmed via `hook-trace.log`), and the helper in
+    //        the closing pane (if any) dies before its connection_state
+    //        handler runs. Without master subscribing directly, the F2
+    //        row stays stuck at Idle indefinitely.
+    //      * Helper crash / kill: any path that prevents the helper
+    //        from observing-then-publishing the event.
+    //
+    //    Copilot / Claude work today because their Stop / SessionEnd
+    //    hooks fire fast enough during the CTRL_CLOSE grace window;
+    //    Gemini does not. Subscribing here makes the demotion path
+    //    agnostic to hook behavior across all three CLIs.
+    let wt_cli: Option<Arc<crate::shell::wt_channel::CliChannel>> =
         match crate::shell::wt_channel::CliChannel::connect().await {
             Ok(ch) => Some(Arc::new(ch)),
             Err(err) => {
                 tracing::warn!(
                     target: "master",
                     error = %err,
-                    "CliChannel unavailable; intellterm.wta/focus_session will error"
+                    "CliChannel unavailable; intellterm.wta/focus_session will error, \
+                     and master will not bridge WT connection_state -> PaneClosed"
                 );
                 None
             }
         };
+    // Subscribe + start_reader BEFORE wrapping as `dyn WtChannel` (the
+    // trait surface doesn't expose event subscription). Single-consumer
+    // model — focus_session uses the same channel via `run_wtcli`
+    // request/response, which doesn't touch the event sender, so there
+    // is no contention.
+    let wt_event_rx = wt_cli.as_ref().map(|c| c.subscribe_events());
+    if let Some(ref cli) = wt_cli {
+        cli.start_reader().await;
+    }
+    let wt: Option<Arc<dyn crate::shell::wt_channel::WtChannel>> = wt_cli
+        .clone()
+        .map(|c| c as Arc<dyn crate::shell::wt_channel::WtChannel>);
     let resolved_agent_id = crate::agent_registry::resolve_agent_id_from_cmd(&cli.agent);
     let cli_source = crate::agent_sessions::CliSource::from_agent_id(resolved_agent_id);
     tracing::info!(
@@ -1425,6 +1457,28 @@ async fn run_master_loop(cli: Cli, pipe_name: String) -> Result<()> {
             .await;
         }
     });
+
+    // WT event subscriber: drive PaneClosed / ConnectionFailed into the
+    // master registry directly off WT's `connection_state` events. This
+    // is the fallback for cases where no helper publishes the event —
+    // see the `wt_cli` setup above for the Gemini hard-close motivation.
+    if let Some(mut rx) = wt_event_rx {
+        let inner_for_wt = Arc::clone(&inner);
+        tokio::task::spawn_local(async move {
+            tracing::info!(
+                target: "master_wt_event",
+                "master WT event subscriber task started"
+            );
+            while let Some(event_json) = rx.recv().await {
+                handle_master_wt_event(&inner_for_wt, event_json).await;
+            }
+            tracing::warn!(
+                target: "master_wt_event",
+                "master WT event subscriber channel closed"
+            );
+        });
+    }
+
     let client = MasterClient {
         state: Arc::clone(&inner),
     };
@@ -1879,6 +1933,101 @@ async fn handle_session_hook(
     }
 
     Ok(crate::session_registry::build_session_hook_response(applied))
+}
+
+/// Master-side WT event subscriber. Bridges `connection_state`
+/// notifications from the COM channel into the master's session
+/// registry so that closing a pane (Ctrl+Shift+W, close-tab, hard kill)
+/// reliably demotes any session bound to that pane — even when no
+/// `wta-helper` publishes a `session_hook` for it. Two cases this
+/// covers in practice:
+///
+///   * Helper in the closing pane dies before its
+///     `connection_state` handler runs.
+///   * Shell-pane Gemini sessions on hard close: Gemini's `SessionEnd`
+///     hook is unreliable on `CTRL_CLOSE_EVENT` (confirmed via
+///     `hook-trace.log`), and the helper observation path may not
+///     publish for reasons we have not finished isolating.
+///
+/// Copilot / Claude's Stop / SessionEnd hooks fire fast enough that
+/// the publish-from-helper path works for them today; this subscriber
+/// makes the behavior uniform across CLIs and resilient to helper
+/// teardown order.
+async fn handle_master_wt_event(
+    state: &MasterStateInner,
+    event_json: serde_json::Value,
+) {
+    let method = event_json
+        .get("method")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if method != "connection_state" {
+        return;
+    }
+    let params = event_json
+        .get("params")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    // Match the helper-side fallback in `main.rs` (line ~2048): prefer
+    // `pane_id`; fall back to legacy `session_id` so a hypothetical
+    // older WT build still works.
+    let pane_id = params
+        .get("pane_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .or_else(|| params.get("session_id").and_then(|v| v.as_str()))
+        .unwrap_or("")
+        .to_string();
+    if pane_id.is_empty() {
+        return;
+    }
+    let pane_state = params
+        .get("state")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let event = match pane_state {
+        "closed" => crate::agent_sessions::SessionEvent::PaneClosed {
+            pane_session_id: pane_id.clone(),
+        },
+        "failed" => {
+            let reason = params
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("connection failed")
+                .to_string();
+            crate::agent_sessions::SessionEvent::ConnectionFailed {
+                pane_session_id: pane_id.clone(),
+                reason,
+            }
+        }
+        _ => return,
+    };
+    tracing::info!(
+        target: "master_wt_event",
+        pane_id = %pane_id,
+        state = %pane_state,
+        event = ?event,
+        "applying WT connection_state event to master registry"
+    );
+    let applied = state.registry.apply_event(event).await;
+    if applied {
+        tracing::info!(
+            target: "master_wt_event",
+            pane_id = %pane_id,
+            "broadcasting sessions/changed after WT-driven demotion"
+        );
+        broadcast_ext_to_helpers(
+            state,
+            crate::session_registry::build_sessions_changed_notification(),
+        )
+        .await;
+    } else {
+        tracing::debug!(
+            target: "master_wt_event",
+            pane_id = %pane_id,
+            "WT connection_state event was a no-op (pane not bound to any session)"
+        );
+    }
 }
 
 /// Extract the session key from event variants that carry one. Returns


### PR DESCRIPTION
> Stacks on top of #113 (`dev/yuazha/f2-shell-only-filter`). Base intentionally points at that branch so the diff is exactly this fix.

## Why

For Class B (shell-pane) Gemini sessions, **Ctrl+Shift+W on the pwsh pane** (or closing the tab) leaves the F2 row stuck at its last live status — typically `Idle`, or `"waiting for input"` (Attention) if the agent had just emitted an `agent.notification`. Copilot / Claude look fine in the same scenario; Gemini does not.

## Root cause

UI-initiated pane / tab close goes through `ControlCore::_closeConnection` (`TerminalControl/ControlCore.cpp:261`), which **revokes the `ConnectionStateChanged` listener on the connection BEFORE the connection transitions to Closed**. As a result, the protocol bridge in `TerminalPage::_RegisterTerminalEvents` (line ~5050) never fires for these paths — `connection_state:closed` is never broadcast to wta subscribers.

Process-initiated close (agent typed `/exit`, double Ctrl+C with a clean SessionEnd hook) still works because the connection's own state machine drives the transition before the revoker runs. That's the path Copilot / Claude rely on; Gemini's SessionEnd does not fire on hard kill (confirmed empty in `hook-trace.log`), so Gemini relied entirely on the now-broken connection_state path.

## Repro (current `dev/yuazha/f2-shell-only-filter`)

1. pwsh pane → `gemini`
2. Send a prompt that triggers `ask_user` → F2 row goes to `"waiting for input"` (Attention).
3. Ctrl+Shift+W on the pane.
4. **Bug**: F2 row stays at `"waiting for input"`.

Same shape with tab-close (X button).

## Fix — two complementary layers

### C++ (3 files) — the actual emit, plugged into the existing protocol fan-out

| Change | Where |
|---|---|
| New `TerminalPage::_NotifyPanesClosing(rootPane)` walks every terminal leaf and raises `connection_state:closed` via `ProtocolVtSequenceReceived` with the resolved `SessionId`. Must run BEFORE destruction while `Pane::GetTerminalControl()` is still live. | `TerminalPage.h` + `TerminalPage.cpp` |
| Single-pane close → call before `pane->Close()` | `TabManagement.cpp` — `_HandleClosePaneRequested` |
| Tab close → call before `tab.Shutdown()` | `TabManagement.cpp` — `_RemoveTab` (composes cleanly with the existing pre-shutdown `agentPanesOnTab` walk) |

**Idempotency**: when a process exits on its own, the natural `ConnectionStateChanged` path still fires and the master reducer's `PaneClosed` is a no-op on already-Ended rows. For UI-close paths the natural path never fires today, so the explicit emit is the only emit — no duplication.

### Rust (2 files) — defense in depth + diagnostics

| Change | Where |
|---|---|
| Master subscribes to WT events directly via `CliChannel::subscribe_events()` + `start_reader()`; new `handle_master_wt_event` bridges `connection_state` → `SessionEvent::PaneClosed` / `ConnectionFailed`. Closes the failure mode where every helper that could have observed-and-published is gone (helper in the closing pane died first; no helper in the window; etc.). Mirrors the helper-side bridge in `app.rs` exactly. | `master/mod.rs` |
| Added `target=helper_wt_event` tracing at the `connection_state` handler entry and after `PaneClosed` apply+publish. Was the load-bearing signal while bisecting this bug; catches "helper observed but didn't publish" diagnostics in one grep. | `app.rs` |

## Verification

- `cargo test --bin wta`: **557 passed, 0 failed**. This PR doesn't change Rust reducer semantics — only the entry path into them — so the existing `connection_state_closed_transitions_agent_row_to_ended` + `pane_closed_*` suites stay green.
- `cd src\cascadia\TerminalApp && bx`: **0 Error(s)**, 33 pre-existing warnings (PRI / XAML resource noise unrelated to this change).
- Manual test: pwsh pane → `gemini` → trigger state (Idle / Working / Attention) → Ctrl+Shift+W → F2 row → **Ended**. Same with tab-close (X button) and context-menu Close Pane.
- Log checks:
  - `wta-main_helper.log` shows `helper_wt_event ... state="closed" pane_id=…` once per helper.
  - `wta-main_master.log` shows `master_wt_event ... applying WT connection_state event ... event=PaneClosed { ... }`.

## Notes for review

- C++ change touches `TerminalApp` exclusively; no IDL / settings / packaging change.
- The new Rust master subscription uses the same `CliChannel` instance already created for `focus_session`. `subscribe_events` + `start_reader` use the event-channel slot; `run_wtcli` (focus_session path) is request/response and doesn't touch it — no contention.
- The `master_wt_event` task is per-process (one master); doesn't fan out per-helper subscription.

