### PR TITLE
Add Alt+Shift+B to open the delegate agent in a new tab

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1707,6 +1707,14 @@ namespace winrt::TerminalApp::implementation
         args.Handled(true);
     }
 
+    void TerminalPage::_HandleOpenBackgroundAgent(const IInspectable& /*sender*/,
+                                                  const ActionEventArgs& args)
+    {
+        OutputDebugStringW(L"[AgentPane] _HandleOpenBackgroundAgent called\n");
+        _OpenBackgroundAgentTab();
+        args.Handled(true);
+    }
+
     void TerminalPage::_HandleOpenAgentSessions(const IInspectable& /*sender*/,
                                                 const ActionEventArgs& args)
     {

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1153,7 +1153,29 @@ namespace winrt::TerminalApp::implementation
 
     void TerminalPage::_DelegatePromptToAgent(const winrt::hstring& prompt)
     {
-        _agentPaneLog("_DelegatePromptToAgent called, prompt='" + winrt::to_string(prompt) + "'");
+        _LaunchDelegate(prompt);
+    }
+
+    // Open the delegate agent interactively in a brand-new tab with no
+    // startup prompt — the "background agent" hotkey (Alt+Shift+B). This is
+    // the no-prompt sibling of the `?<prompt>` delegation: `wta delegate`
+    // (invoked with no PROMPT positional) connects to WT over COM and spawns
+    // a new tab whose commandline is the delegate agent's own interactive CLI.
+    void TerminalPage::_OpenBackgroundAgentTab()
+    {
+        _LaunchDelegate(std::nullopt);
+    }
+
+    // Launch a hidden `wta delegate` process. With a prompt this is the
+    // `?<prompt>` foreground delegation (one-shot; the prompt is baked into
+    // the new tab's agent CLI). Without a prompt the agent opens interactively
+    // in a new tab. Either way wta itself creates the tab via the WT COM
+    // protocol; this launched process exits once the tab is spawned.
+    void TerminalPage::_LaunchDelegate(const std::optional<winrt::hstring>& prompt)
+    {
+        _agentPaneLog(prompt.has_value() ?
+                          "_LaunchDelegate called, prompt='" + winrt::to_string(*prompt) + "'" :
+                          "_LaunchDelegate called (interactive, no prompt)");
 
         // Find the WTA executable.
         const auto wtaPath = _DetectWtaPath();
@@ -1245,13 +1267,18 @@ namespace winrt::TerminalApp::implementation
             cmdline += L" --cwd " + quoteArg(std::wstring_view{ activeCwd });
         }
 
-        // Append the prompt as a positional argument.
-        std::wstring escapedPrompt{ prompt };
-        for (size_t pos = 0; (pos = escapedPrompt.find(L'"', pos)) != std::wstring::npos; pos += 2)
+        // Append the prompt as a positional argument — only for the
+        // foreground `?<prompt>` path. With no prompt, `wta delegate` opens
+        // the agent interactively (no PROMPT positional).
+        if (prompt.has_value() && !prompt->empty())
         {
-            escapedPrompt.replace(pos, 1, L"\"\"");
+            std::wstring escapedPrompt{ *prompt };
+            for (size_t pos = 0; (pos = escapedPrompt.find(L'"', pos)) != std::wstring::npos; pos += 2)
+            {
+                escapedPrompt.replace(pos, 1, L"\"\"");
+            }
+            cmdline += fmt::format(FMT_COMPILE(L" \"{}\""), escapedPrompt);
         }
-        cmdline += fmt::format(FMT_COMPILE(L" \"{}\""), escapedPrompt);
 
         _agentPaneLog("launching: " + winrt::to_string(winrt::hstring{ cmdline }));
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -677,6 +677,8 @@ namespace winrt::TerminalApp::implementation
         winrt::hstring _DetectWtaPath() const;
         std::optional<uint32_t> _FindSourceOfAgentPaneId(const std::shared_ptr<Pane>& root);
         void _DelegatePromptToAgent(const winrt::hstring& prompt);
+        void _OpenBackgroundAgentTab();
+        void _LaunchDelegate(const std::optional<winrt::hstring>& prompt);
 
         // Note (Phase 5): the per-pane wta-process watch + Job Object members
         // and their setup/teardown methods were removed when the legacy

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -106,6 +106,7 @@ static constexpr std::string_view OpenAgentPaneKey{ "openAgentPane" };
 static constexpr std::string_view FocusAgentPaneKey{ "focusAgentPane" };
 static constexpr std::string_view OpenAgentSessionsKey{ "openAgentSessions" };
 static constexpr std::string_view TriggerAutofixKey{ "triggerAutofix" };
+static constexpr std::string_view OpenBackgroundAgentKey{ "openBackgroundAgent" };
 static constexpr std::string_view ShowProtocolInfoKey{ "showProtocolInfo" };
 static constexpr std::string_view BugReportKey{ "bugReport" };
 

--- a/src/cascadia/TerminalSettingsModel/ActionMap.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.cpp
@@ -113,6 +113,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 { ShortcutAction::FocusAgentPane, USES_RESOURCE(L"FocusAgentPaneCommandKey") },
                 { ShortcutAction::OpenAgentSessions, USES_RESOURCE(L"OpenAgentSessionsCommandKey") },
                 { ShortcutAction::TriggerAutofix, USES_RESOURCE(L"TriggerAutofixCommandKey") },
+                { ShortcutAction::OpenBackgroundAgent, USES_RESOURCE(L"OpenBackgroundAgentCommandKey") },
                 { ShortcutAction::OpenCWD, USES_RESOURCE(L"OpenCWDCommandKey") },
                 { ShortcutAction::OpenNewTabDropdown, USES_RESOURCE(L"OpenNewTabDropdownCommandKey") },
                 { ShortcutAction::OpenScratchpad, USES_RESOURCE(L"OpenScratchpadKey") },

--- a/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
+++ b/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
@@ -119,6 +119,7 @@
     ON_ALL_ACTIONS(FocusAgentPane)          \
     ON_ALL_ACTIONS(OpenAgentSessions)       \
     ON_ALL_ACTIONS(TriggerAutofix)          \
+    ON_ALL_ACTIONS(OpenBackgroundAgent)     \
     ON_ALL_ACTIONS(ShowProtocolInfo)        \
     ON_ALL_ACTIONS(BugReport)
 

--- a/src/cascadia/TerminalSettingsModel/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/de-DE/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -984,4 +984,7 @@
   <data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Autofix auslösen</value></data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data>
   <data name="BugReportCommandKey" xml:space="preserve"><value>Fehler melden (Protokolle sammeln)</value></data>
+  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>Hintergrund-Agent in neuer Registerkarte öffnen</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -1005,4 +1005,7 @@
   <data name="PromptActionArgumentLocalized" xml:space="preserve">
     <value>Prompt</value>
   </data>
+  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>Open background agent in a new tab</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/es-ES/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -984,4 +984,7 @@
   <data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Ejecutar corrección automática</value></data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Consulta</value></data>
   <data name="BugReportCommandKey" xml:space="preserve"><value>Informar de un error (recopilar registros)</value></data>
+  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>Abrir agente en segundo plano en una pestaña nueva</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/fr-FR/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -985,4 +985,7 @@
   <data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Déclencher la correction automatique</value></data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data>
   <data name="BugReportCommandKey" xml:space="preserve"><value>Signaler un bug (collecter les journaux)</value></data>
+  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>Ouvrir l'agent en arrière-plan dans un nouvel onglet</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/it-IT/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -984,4 +984,7 @@
   <data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Esegui correzione automatica</value></data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data>
   <data name="BugReportCommandKey" xml:space="preserve"><value>Segnala un bug (raccogli i log)</value></data>
+  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>Apri agente in background in una nuova scheda</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/ja-JP/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -984,4 +984,7 @@
   <data name="TriggerAutofixCommandKey" xml:space="preserve"><value>自動修正を実行する</value></data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve"><value>プロンプト</value></data>
   <data name="BugReportCommandKey" xml:space="preserve"><value>バグを報告 (ログを収集)</value></data>
+  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>バックグラウンド エージェントを新しいタブで開く</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/ko-KR/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1001,4 +1001,7 @@
   <data name="BugReportCommandKey" xml:space="preserve">
     <value>버그 보고(로그 수집)</value>
   </data>
+  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>새 탭에서 백그라운드 에이전트 열기</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/pt-BR/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1001,4 +1001,7 @@
   <data name="BugReportCommandKey" xml:space="preserve">
     <value>Relatar um bug (coletar logs)</value>
   </data>
+  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>Abrir agente em segundo plano em uma nova guia</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-ploc/Resources.resw
@@ -980,6 +980,6 @@
     <value>Šрļϊŧ ѕìžє !!!</value>
   </data>
 <data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data>  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
-    <value>Ǿрέń ъαčкĝŕǿųпď ªĝеηţ ìπ å ⁿ℮ŵ ťãв !!! !!! !!! !</value>
+    <value>Open background agent in a new tab</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-ploc/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -979,4 +979,7 @@
   <data name="SplitSizeActionArgumentLocalized" xml:space="preserve">
     <value>Šрļϊŧ ѕìžє !!!</value>
   </data>
-<data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data></root>
+<data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data>  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>Open background agent in a new tab</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
+</root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-ploc/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -980,6 +980,6 @@
     <value>Šрļϊŧ ѕìžє !!!</value>
   </data>
 <data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data>  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
-    <value>Open background agent in a new tab</value>
+    <value>Ǿрέń ъαčкĝŕǿųпď ªĝеηţ ìπ å ⁿ℮ŵ ťãв !!! !!! !!! !</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-ploca/Resources.resw
@@ -980,6 +980,6 @@
     <value>Šрļϊŧ ѕìžє !!!</value>
   </data>
 <data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data>  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
-    <value>Ǿрέń ъαčкĝŕǿųпď ªĝеηţ ìπ å ⁿ℮ŵ ťãв !!! !!! !!! !</value>
+    <value>Open background agent in a new tab</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-ploca/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -979,4 +979,7 @@
   <data name="SplitSizeActionArgumentLocalized" xml:space="preserve">
     <value>Šрļϊŧ ѕìžє !!!</value>
   </data>
-<data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data></root>
+<data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data>  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>Open background agent in a new tab</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
+</root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-ploca/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -980,6 +980,6 @@
     <value>Šрļϊŧ ѕìžє !!!</value>
   </data>
 <data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data>  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
-    <value>Open background agent in a new tab</value>
+    <value>Ǿрέń ъαčкĝŕǿųпď ªĝеηţ ìπ å ⁿ℮ŵ ťãв !!! !!! !!! !</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-plocm/Resources.resw
@@ -980,6 +980,6 @@
     <value>Šрļϊŧ ѕìžє !!!</value>
   </data>
 <data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data>  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
-    <value>Ǿрέń ъαčкĝŕǿųпď ªĝеηţ ìπ å ⁿ℮ŵ ťãв !!! !!! !!! !</value>
+    <value>Open background agent in a new tab</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-plocm/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -979,4 +979,7 @@
   <data name="SplitSizeActionArgumentLocalized" xml:space="preserve">
     <value>Šрļϊŧ ѕìžє !!!</value>
   </data>
-<data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data></root>
+<data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data>  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>Open background agent in a new tab</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
+</root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-plocm/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -980,6 +980,6 @@
     <value>Šрļϊŧ ѕìžє !!!</value>
   </data>
 <data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data>  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
-    <value>Open background agent in a new tab</value>
+    <value>Ǿрέń ъαčкĝŕǿųпď ªĝеηţ ìπ å ⁿ℮ŵ ťãв !!! !!! !!! !</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/ru-RU/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1001,4 +1001,7 @@
   <data name="BugReportCommandKey" xml:space="preserve">
     <value>Сообщить об ошибке (собрать журналы)</value>
   </data>
+  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>Открыть фонового агента в новой вкладке</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/sr-Cyrl-RS/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1001,4 +1001,7 @@
   <data name="BugReportCommandKey" xml:space="preserve">
     <value>Пријави грешку (прикупи евиденције)</value>
   </data>
+  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>Отвори позадинског агента у новој картици</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/uk-UA/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -984,4 +984,7 @@
   <data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Запустити автовиправлення</value></data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Запит</value></data>
   <data name="BugReportCommandKey" xml:space="preserve"><value>Повідомити про помилку (зібрати журнали)</value></data>
+  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>Відкрити фоновий агент у новій вкладці</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/zh-CN/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1001,4 +1001,7 @@
   <data name="BugReportCommandKey" xml:space="preserve">
     <value>报告问题（收集日志）</value>
   </data>
+  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>在新标签页中打开后台智能体</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/zh-TW/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -984,4 +984,7 @@
   <data name="TriggerAutofixCommandKey" xml:space="preserve"><value>觸發自動修正</value></data>
   <data name="PromptActionArgumentLocalized" xml:space="preserve"><value>提示</value></data>
   <data name="BugReportCommandKey" xml:space="preserve"><value>回報問題（收集記錄）</value></data>
+  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
+    <value>在新索引標籤中開啟背景代理</value>
+  <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -561,6 +561,7 @@
         { "command": "focusAgentPane", "id": "Terminal.FocusAgentPane" },
         { "command": "openAgentSessions", "id": "Terminal.OpenAgentSessions" },
         { "command": "triggerAutofix", "id": "Terminal.TriggerAutofix" },
+        { "command": "openBackgroundAgent", "id": "Terminal.OpenBackgroundAgent" },
         { "command": "bugReport", "id": "Terminal.BugReport" },
         // Tab Management
         // "command": "closeTab" is unbound by default.
@@ -750,6 +751,7 @@
         { "keys": "ctrl+shift+f", "id": "Terminal.FindText" },
         { "keys": "ctrl+shift+p", "id": "Terminal.ToggleCommandPalette" },
         { "keys": "alt+shift+/", "id": "Terminal.OpenAgentDelegation" },
+        { "keys": "alt+shift+b", "id": "Terminal.OpenBackgroundAgent" },
         { "keys": "win+sc(41)", "id": "Terminal.QuakeMode" },
         { "keys": "alt+space", "id": "Terminal.OpenSystemMenu" },
         { "keys": "ctrl+shift+period", "id": "Terminal.OpenAgentPane" },

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -1066,7 +1066,8 @@ fn extract_balanced_json_object(text: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_delegate_launch_commandline, default_delegate_agent_runtimes, parse_autofix_response,
+        build_delegate_interactive_commandline, build_delegate_launch_commandline,
+        default_delegate_agent_runtimes, parse_autofix_response,
         parse_recommendation_set, resolve_created_pane_id,
         validate_recommendation_set_for_coordinator_target, AutofixDecision,
         DelegatePromptDelivery, OpenTarget, RecommendedAction,
@@ -1167,6 +1168,27 @@ mod tests {
         assert!(commandline.contains("copilot"));
         assert!(commandline.contains("--model claude-haiku-4.5"));
         assert!(commandline.contains("-i \"Fix the Rust build error and run cargo build\""));
+    }
+
+    #[test]
+    fn delegate_interactive_commandline_omits_startup_prompt() {
+        let runtime = default_delegate_agent_runtimes(
+            Some("copilot --model claude-haiku-4.5"),
+            Some("copilot --acp --stdio --model gpt-5.2"),
+            None,
+        )
+        .into_iter()
+        .find(|runtime| runtime.id == "copilot")
+        .expect("copilot runtime should exist");
+
+        let commandline = build_delegate_interactive_commandline(&runtime).unwrap();
+
+        // May be wrapped as "cmd /c copilot ..." if copilot.exe isn't on PATH.
+        assert!(commandline.contains("copilot"));
+        // Model is still applied for the interactive launch.
+        assert!(commandline.contains("--model claude-haiku-4.5"));
+        // No startup-prompt flag is appended when there's no prompt.
+        assert!(!commandline.contains("-i "));
     }
 
     #[test]

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -431,7 +431,7 @@ async fn execute_choice(
                     None => format!("Opening {}.", target_label),
                 }));
                 let commandline = runtime
-                    .map(|runtime| build_delegate_launch_commandline(runtime, input))
+                    .map(|runtime| build_delegate_launch_commandline(runtime, Some(input)))
                     .transpose()?;
                 let pane_id = match target {
                     OpenTarget::Tab => {
@@ -660,12 +660,22 @@ pub fn build_delegate_commandline(
     runtime: &DelegateAgentRuntime,
     input: &str,
 ) -> Result<String> {
-    build_delegate_launch_commandline(runtime, input)
+    build_delegate_launch_commandline(runtime, Some(input))
+}
+
+/// Build the commandline for launching a delegate agent interactively, with
+/// no startup prompt. The agent's own CLI/TUI fills the new tab and waits for
+/// user input. Used by the "open background agent" hotkey (Alt+Shift+B), the
+/// no-prompt sibling of `?<prompt>` delegation.
+pub fn build_delegate_interactive_commandline(
+    runtime: &DelegateAgentRuntime,
+) -> Result<String> {
+    build_delegate_launch_commandline(runtime, None)
 }
 
 fn build_delegate_launch_commandline(
     runtime: &DelegateAgentRuntime,
-    input: &str,
+    input: Option<&str>,
 ) -> Result<String> {
     let commandline = runtime.commandline.trim();
     if commandline.is_empty() {
@@ -689,12 +699,17 @@ fn build_delegate_launch_commandline(
     };
     let resolved_ref = with_model.as_str();
 
-    let raw = match runtime.prompt_delivery {
-        DelegatePromptDelivery::LaunchThenSend => resolved_ref.to_string(),
-        DelegatePromptDelivery::LaunchWithStartupPrompt => {
-            ensure_non_empty("input", input)?;
-            build_delegate_startup_prompt_commandline(resolved_ref, input)?
-        }
+    let raw = match input {
+        // Interactive (no prompt): launch the bare agent CLI regardless of
+        // the configured prompt-delivery mode.
+        None => resolved_ref.to_string(),
+        Some(input) => match runtime.prompt_delivery {
+            DelegatePromptDelivery::LaunchThenSend => resolved_ref.to_string(),
+            DelegatePromptDelivery::LaunchWithStartupPrompt => {
+                ensure_non_empty("input", input)?;
+                build_delegate_startup_prompt_commandline(resolved_ref, input)?
+            }
+        },
     };
     // .cmd/.bat shims (e.g. npm-installed CLIs) can't be launched directly
     // via CreateProcess — wrap with cmd /c so the command interpreter finds them.
@@ -1080,7 +1095,7 @@ mod tests {
             .expect("copilot runtime should exist");
 
         let commandline =
-            build_delegate_launch_commandline(&runtime, "Fix the build and report back").unwrap();
+            build_delegate_launch_commandline(&runtime, Some("Fix the build and report back")).unwrap();
 
         assert!(!commandline.contains("--model"));
         // May be wrapped as "cmd /c copilot ..." if copilot.exe isn't on PATH.
@@ -1144,7 +1159,7 @@ mod tests {
 
         let commandline = build_delegate_launch_commandline(
             &runtime,
-            "Fix the Rust build error and run cargo build",
+            Some("Fix the Rust build error and run cargo build"),
         )
         .unwrap();
 
@@ -1168,7 +1183,7 @@ mod tests {
         .expect("copilot runtime should exist");
 
         let commandline =
-            build_delegate_launch_commandline(&runtime, "Inspect the repo and summarize").unwrap();
+            build_delegate_launch_commandline(&runtime, Some("Inspect the repo and summarize")).unwrap();
 
         assert_eq!(
             commandline,

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -407,7 +407,9 @@ enum Command {
         target: Option<String>,
     },
 
-    /// Delegate a prompt to a new tab with a configured agent (fire-and-forget)
+    /// Open a configured delegate agent in a new tab (fire-and-forget). With a
+    /// PROMPT, the prompt is baked into the agent's launch; omit PROMPT to open
+    /// the agent interactively with no startup prompt.
     Delegate {
         /// The prompt to send to the delegate agent. Omit to open the agent
         /// interactively in a new tab with no startup prompt.

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -409,9 +409,10 @@ enum Command {
 
     /// Delegate a prompt to a new tab with a configured agent (fire-and-forget)
     Delegate {
-        /// The prompt to send to the delegate agent
+        /// The prompt to send to the delegate agent. Omit to open the agent
+        /// interactively in a new tab with no startup prompt.
         #[arg(value_name = "PROMPT")]
-        prompt: String,
+        prompt: Option<String>,
 
         /// Agent CLI command (used to derive delegate agent commandline)
         #[arg(long, default_value = agent_registry::DEFAULT_ACP_COMMAND)]
@@ -770,7 +771,7 @@ async fn main() -> Result<()> {
             cwd,
         }) => {
             run_delegate(
-                &prompt,
+                prompt.as_deref(),
                 &agent,
                 delegate_agent.as_deref(),
                 delegate_model.as_deref(),
@@ -1451,14 +1452,14 @@ async fn run_listen(pane_filter: Option<&str>) -> Result<()> {
 // ─── Delegate prompt to new tab agent ────────────────────────────────────────
 
 async fn run_delegate(
-    prompt: &str,
+    prompt: Option<&str>,
     agent_cmd: &str,
     delegate_agent_cmd: Option<&str>,
     delegate_model: Option<&str>,
     cwd: Option<&str>,
 ) -> Result<()> {
     let _guard = logging::init("delegate");
-    tracing::info!(prompt, agent = agent_cmd, cwd, "run_delegate started");
+    tracing::info!(prompt = ?prompt, agent = agent_cmd, cwd, "run_delegate started");
 
     let (debug_tx, _) = tokio::sync::mpsc::unbounded_channel::<app::DebugMessage>();
     let channel = match connect_to_wt_protocol(debug_tx).await {
@@ -1501,42 +1502,12 @@ async fn run_delegate(
 /// the user's working pane, so a single query is enough.
 async fn delegate_with_context(
     shell_mgr: &ShellManager,
-    prompt: &str,
+    prompt: Option<&str>,
     agent_cmd: &str,
     delegate_agent_cmd: Option<&str>,
     delegate_model: Option<&str>,
     cwd: Option<&str>,
 ) -> Result<()> {
-    let active = shell_mgr.wt_get_active_pane().await.ok();
-    let active_pane_id = active
-        .as_ref()
-        .and_then(|v| v.get("session_id"))
-        .and_then(|v| match v {
-            serde_json::Value::String(s) => Some(s.clone()),
-            serde_json::Value::Number(n) => Some(n.to_string()),
-            _ => None,
-        });
-
-    let pane_context = if let Some(ref pane_id) = active_pane_id {
-        match shell_mgr.wt_read_pane_output(pane_id, Some(30)).await {
-            Ok(value) => value
-                .get("content")
-                .and_then(|c| c.as_str())
-                .map(|s| s.to_string()),
-            Err(_) => None,
-        }
-    } else {
-        None
-    };
-
-    let full_prompt = match (pane_context, active_pane_id) {
-        (Some(context), Some(pane_id)) => format!(
-            "{}\n\n## Terminal Context (pane {})\n```\n{}\n```",
-            prompt, pane_id, context
-        ),
-        _ => prompt.to_string(),
-    };
-
     let delegate_agents = crate::coordinator::default_delegate_agent_runtimes(
         delegate_agent_cmd,
         Some(agent_cmd),
@@ -1546,7 +1517,45 @@ async fn delegate_with_context(
         .first()
         .ok_or_else(|| anyhow::anyhow!("no delegate agent configured"))?;
 
-    let commandline = crate::coordinator::build_delegate_commandline(runtime, &full_prompt)?;
+    let commandline = match prompt {
+        // Prompt present → enrich it with the active pane's recent output and
+        // bake it into the new tab's agent CLI (the `?<prompt>` path).
+        Some(prompt) if !prompt.trim().is_empty() => {
+            let active = shell_mgr.wt_get_active_pane().await.ok();
+            let active_pane_id = active
+                .as_ref()
+                .and_then(|v| v.get("session_id"))
+                .and_then(|v| match v {
+                    serde_json::Value::String(s) => Some(s.clone()),
+                    serde_json::Value::Number(n) => Some(n.to_string()),
+                    _ => None,
+                });
+
+            let pane_context = if let Some(ref pane_id) = active_pane_id {
+                match shell_mgr.wt_read_pane_output(pane_id, Some(30)).await {
+                    Ok(value) => value
+                        .get("content")
+                        .and_then(|c| c.as_str())
+                        .map(|s| s.to_string()),
+                    Err(_) => None,
+                }
+            } else {
+                None
+            };
+
+            let full_prompt = match (pane_context, active_pane_id) {
+                (Some(context), Some(pane_id)) => format!(
+                    "{}\n\n## Terminal Context (pane {})\n```\n{}\n```",
+                    prompt, pane_id, context
+                ),
+                _ => prompt.to_string(),
+            };
+
+            crate::coordinator::build_delegate_commandline(runtime, &full_prompt)?
+        }
+        // No prompt → open the delegate agent interactively in the new tab.
+        _ => crate::coordinator::build_delegate_interactive_commandline(runtime)?,
+    };
 
     tracing::debug!(commandline, cwd, "delegate_with_context: launching");
 


### PR DESCRIPTION
## What

Adds a new `openBackgroundAgent` action, bound by default to **Alt+Shift+B**, that opens the configured **delegate agent** interactively in a brand-new tab with **no startup prompt**.

This is the no-prompt sibling of the existing `?<prompt>` delegation (Alt+Shift+? / `alt+shift+/`):

| Trigger | Behavior |
|---|---|
| `?<prompt>` / `Alt+Shift+?` | Delegate **with** a prompt → new tab runs the delegate agent CLI with the prompt baked in (one-shot) |
| **`Alt+Shift+B`** (new) | Delegate **with no prompt** → new tab runs the delegate agent CLI interactively |

The whole tab is the agent (the delegate agent's own CLI/TUI), using the `delegateAgent` / `delegateModel` / `delegateCustomCommand` settings.

## How

**wta (Rust)**
- `wta delegate`'s `PROMPT` positional is now optional. With no prompt, `delegate_with_context` skips pane-context enrichment and builds a bare interactive commandline via the new `build_delegate_interactive_commandline`. `build_delegate_launch_commandline` now takes `Option<&str>`.

**Terminal (C++)**
- New `ShortcutAction::OpenBackgroundAgent` added to `AllShortcutActions.h`; the handler declaration and dispatch wiring are auto-generated by the existing X-macros.
- `_DelegatePromptToAgent` refactored into a shared `_LaunchDelegate(std::optional<hstring>)`; `_OpenBackgroundAgentTab()` calls it with `std::nullopt`. Either way `wta delegate` itself creates the tab over the WT COM protocol.
- `defaults.json`: command entry + `alt+shift+b` keybinding.
- `OpenBackgroundAgentCommandKey` added to all locales (real locales translated; `qps-*` pseudo-locales kept English to match the fork's existing agent strings).

## Testing
- `cargo build` + 7 delegate unit tests pass.
- Full C++ incremental build: 0 errors.
- All 16 `.resw` files validated as well-formed XML with the key present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)