### PR TITLE
feat(wta): store runtime data in package LocalState instead of bare LOCALAPPDATA

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -962,6 +962,7 @@ maxval
 maxversiontested
 MAXWORD
 maybenull
+mbr
 MBUTTON
 MBUTTONDBLCLK
 MBUTTONDOWN

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,33 +129,49 @@ once the session later connects.
 
 **Diag log**: `wta-ensure-host.log` in the WTA log directory — shows event flow, classification, and autofix triggers.
 
-## Logs
+## Logs & runtime data layout
 
-WTA writes structured logs (and all other runtime data) under a single root
-resolved by `runtime_paths::intelligent_terminal_root()`. The layout depends
-on whether the process has package identity:
+WTA runtime data lives under the **package-private** store, split by lifetime
+into two roots (both resolved in `runtime_paths.rs`, both falling back to the
+same bare path when the process has no package identity):
 
 ```
 # Packaged (every production wta process — helper is a conpty child of the
 # packaged WindowsTerminal.exe, master is spawned in-package by SharedWta):
-%LOCALAPPDATA%\Packages\<PackageFamilyName>\LocalState\IntelligentTerminal\logs\
+
+  …\Packages\<PackageFamilyName>\LocalState\IntelligentTerminal\   <- STATE root
+      prompts\                      (prompt overrides)             intelligent_terminal_root()
+      agent-pane-sessions.jsonl     (session origin index)
+      master-pipe.txt               (helper↔master rendezvous)
+
+  …\Packages\<PackageFamilyName>\LocalCache\Local\IntelligentTerminal\  <- LOCAL/cache root
+      logs\                         (all wta-*.log files)          intelligent_terminal_local_root()
+      hook-bundle-staging\ …        (hook-installer staging)
 
 # Unpackaged (dev builds run straight out of the Cargo target dir, tests):
-%LOCALAPPDATA%\IntelligentTerminal\logs\
+# BOTH roots collapse to the legacy bare %LOCALAPPDATA%\IntelligentTerminal\.
 ```
 
-The packaged path keeps WTA's data inside the package's private store, so it
-is removed on uninstall and isolated between the dev-sideload family
-(`IntelligentTerminal_rd9vj3e6a2mbr`) and the store family
-(`Microsoft.IntelligentTerminal_8wekyb3d8bbwe`) instead of sharing one bare
-`%LOCALAPPDATA%\IntelligentTerminal` directory. It sits alongside the WT
-app's own `settings.json` / `state.json` in `LocalState`.
+Rationale for the split: **State** = persistent, must-survive, package-private
+data → `LocalState` (alongside the WT app's own `settings.json` / `state.json`).
+**Local/cache** = transient, regenerable diagnostics → `LocalCache\Local`, the
+cache store that doesn't roam / back up.
 
-The family name comes from `GetCurrentPackageFamilyName` (windows-sys);
-`%LOCALAPPDATA%\Packages\<pfn>\LocalState` is exactly what WinRT
-`ApplicationData.Current.LocalFolder` resolves to, so we construct it
-directly rather than pulling in the WinRT projection. When the call reports
-no package identity, the root falls back to the legacy bare path above.
+Both roots are package-private — removed on uninstall and isolated between the
+dev-sideload family (`IntelligentTerminal_rd9vj3e6a2mbr`) and the store family
+(`Microsoft.IntelligentTerminal_8wekyb3d8bbwe`) — instead of sharing one bare
+`%LOCALAPPDATA%\IntelligentTerminal` directory. The family name comes from
+`GetCurrentPackageFamilyName` (windows-sys); the `Packages\<pfn>\LocalState` and
+`…\LocalCache\Local` paths are what WinRT `ApplicationData.Current.LocalFolder`
+/ `LocalCacheFolder` resolve to, so we construct them directly rather than
+pulling in the WinRT projection.
+
+**Other writers of the same dirs** (kept in lock-step with the Rust roots):
+- C++ `AgentPaneLog.h` (`_intelligentTerminalLogDir()`) — `wta-agent-pane.log`
+  and the bug-report-zip action, both → the LocalCache\Local `logs\`.
+- PowerShell hooks (`send-event.ps1`) — `hook-trace.log` → the dir handed down
+  by wta-master via the `WTA_HOOK_LOG_DIR` env var (PowerShell can't resolve the
+  package-private path itself).
 
 > Earlier builds wrote everything to the bare `%LOCALAPPDATA%\IntelligentTerminal`
 > regardless of identity (the `LOCALAPPDATA` env var is **not** redirected into

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,22 +131,36 @@ once the session later connects.
 
 ## Logs
 
-WTA writes structured logs to:
+WTA writes structured logs (and all other runtime data) under a single root
+resolved by `runtime_paths::intelligent_terminal_root()`. The layout depends
+on whether the process has package identity:
 
 ```
-C:\Users\<user>\AppData\Local\IntelligentTerminal\logs\
+# Packaged (every production wta process — helper is a conpty child of the
+# packaged WindowsTerminal.exe, master is spawned in-package by SharedWta):
+%LOCALAPPDATA%\Packages\<PackageFamilyName>\LocalState\IntelligentTerminal\logs\
+
+# Unpackaged (dev builds run straight out of the Cargo target dir, tests):
+%LOCALAPPDATA%\IntelligentTerminal\logs\
 ```
 
-The path is built off the `LOCALAPPDATA` env var, which is **not** redirected
-into the package sandbox on Win10/11 (the env-var virtualization that
-hides the regular LOCALAPPDATA was a UWP-era behavior; current Windows
-keeps the env var pointing at the real `\AppData\Local\`). Packaged and
-unpackaged wta processes therefore share the same log directory.
+The packaged path keeps WTA's data inside the package's private store, so it
+is removed on uninstall and isolated between the dev-sideload family
+(`IntelligentTerminal_rd9vj3e6a2mbr`) and the store family
+(`Microsoft.IntelligentTerminal_8wekyb3d8bbwe`) instead of sharing one bare
+`%LOCALAPPDATA%\IntelligentTerminal` directory. It sits alongside the WT
+app's own `settings.json` / `state.json` in `LocalState`.
 
-The sandbox path
-`%LOCALAPPDATA%\Packages\IntelligentTerminal_<id>\LocalCache\Local\IntelligentTerminal\logs`
-exists as a transparent virtualization of the same directory (NTFS reparse
-points) — both paths return the same files.
+The family name comes from `GetCurrentPackageFamilyName` (windows-sys);
+`%LOCALAPPDATA%\Packages\<pfn>\LocalState` is exactly what WinRT
+`ApplicationData.Current.LocalFolder` resolves to, so we construct it
+directly rather than pulling in the WinRT projection. When the call reports
+no package identity, the root falls back to the legacy bare path above.
+
+> Earlier builds wrote everything to the bare `%LOCALAPPDATA%\IntelligentTerminal`
+> regardless of identity (the `LOCALAPPDATA` env var is **not** redirected into
+> the sandbox on Win10/11). There is no migration — old data is left in place
+> and simply ignored.
 
 Log level is controlled by `WTA_LOG` env var (default: `info`; set `debug`
 for the noisy traces).

--- a/src/cascadia/TerminalApp/AgentPaneLog.h
+++ b/src/cascadia/TerminalApp/AgentPaneLog.h
@@ -8,9 +8,11 @@
 // timestamp format, log path, and error-handling semantics stay in lock-
 // step.
 //
-// Output: `%LOCALAPPDATA%\IntelligentTerminal\logs\wta-agent-pane.log`,
-// one ISO8601 UTC line per call with millisecond precision so timestamps
-// correlate with `wta-main_*.log` down to the millisecond.
+// Output: the WTA log directory + `wta-agent-pane.log`, one ISO8601 UTC line
+// per call with millisecond precision so timestamps correlate with
+// `wta-main_*.log` down to the millisecond. The log directory is resolved by
+// `_intelligentTerminalLogDir()` below to match wta's Rust
+// `runtime_paths::intelligent_terminal_local_root()`.
 //
 // Header-only `inline` so each translation unit that includes this picks
 // up its own copy of the symbol without ODR conflicts.
@@ -18,6 +20,7 @@
 #pragma once
 
 #include <windows.h>
+#include <appmodel.h>
 
 #include <chrono>
 #include <ctime>
@@ -29,20 +32,52 @@
 
 namespace winrt::TerminalApp::implementation
 {
-    inline void _agentPaneLog(const std::string& msg)
+    // Resolve the WTA log directory. Mirrors wta's
+    // `runtime_paths::intelligent_terminal_local_root()` exactly so the C++
+    // and Rust sides write into the same folder:
+    //
+    //   * Packaged:   %LOCALAPPDATA%\Packages\<PackageFamilyName>\LocalCache\Local\IntelligentTerminal\logs
+    //   * Unpackaged: %LOCALAPPDATA%\IntelligentTerminal\logs
+    //
+    // Logs are transient cache, hence `LocalCache\Local` (not `LocalState`,
+    // which holds persistent state like the agent-pane session index).
+    // Returns an empty path when `%LOCALAPPDATA%` is unavailable.
+    inline std::filesystem::path _intelligentTerminalLogDir()
     {
         wchar_t localAppData[MAX_PATH];
         if (GetEnvironmentVariableW(L"LOCALAPPDATA", localAppData, MAX_PATH) == 0)
         {
-            return;
+            return {};
         }
         // Build a `filesystem::path` from the raw wstring. `std::ofstream`'s
         // wstring overload is a MSVC extension; the standard ctor only
         // accepts `const char*`, `std::string`, and `std::filesystem::path`.
         // Going via `path` keeps the code portable.
-        std::filesystem::path logDir{ std::wstring(localAppData) };
-        logDir /= L"IntelligentTerminal";
-        logDir /= L"logs";
+        std::filesystem::path base{ std::wstring(localAppData) };
+
+        // Two-call pattern: query the family-name length first. A packaged
+        // process returns ERROR_INSUFFICIENT_BUFFER and fills `length`; an
+        // unpackaged one returns APPMODEL_ERROR_NO_PACKAGE.
+        UINT32 length = 0;
+        if (GetCurrentPackageFamilyName(&length, nullptr) == ERROR_INSUFFICIENT_BUFFER && length != 0)
+        {
+            std::wstring family(length, L'\0');
+            if (GetCurrentPackageFamilyName(&length, family.data()) == ERROR_SUCCESS)
+            {
+                family.resize(::wcslen(family.c_str())); // drop trailing NUL(s)
+                return base / L"Packages" / family / L"LocalCache" / L"Local" / L"IntelligentTerminal" / L"logs";
+            }
+        }
+        return base / L"IntelligentTerminal" / L"logs";
+    }
+
+    inline void _agentPaneLog(const std::string& msg)
+    {
+        std::filesystem::path logDir = _intelligentTerminalLogDir();
+        if (logDir.empty())
+        {
+            return;
+        }
 
         // No-throw overload — this is a diagnostic logger; we never want
         // a filesystem hiccup (race with a concurrent rmdir, permission

--- a/src/cascadia/TerminalApp/AgentPaneLog.h
+++ b/src/cascadia/TerminalApp/AgentPaneLog.h
@@ -20,7 +20,6 @@
 #pragma once
 
 #include <windows.h>
-#include <appmodel.h>
 
 #include <chrono>
 #include <ctime>
@@ -30,45 +29,16 @@
 #include <string>
 #include <system_error>
 
+#include "../inc/IntelligentTerminalPaths.h"
+
 namespace winrt::TerminalApp::implementation
 {
-    // Resolve the WTA log directory. Mirrors wta's
-    // `runtime_paths::intelligent_terminal_local_root()` exactly so the C++
-    // and Rust sides write into the same folder:
-    //
-    //   * Packaged:   %LOCALAPPDATA%\Packages\<PackageFamilyName>\LocalCache\Local\IntelligentTerminal\logs
-    //   * Unpackaged: %LOCALAPPDATA%\IntelligentTerminal\logs
-    //
-    // Logs are transient cache, hence `LocalCache\Local` (not `LocalState`,
-    // which holds persistent state like the agent-pane session index).
-    // Returns an empty path when `%LOCALAPPDATA%` is unavailable.
+    // The WTA log directory, resolved by the shared
+    // `IntelligentTerminal::LogDir()` (package LocalCache\Local when packaged)
+    // so this logger, the bug-report-zip action, and the Rust side all agree.
     inline std::filesystem::path _intelligentTerminalLogDir()
     {
-        wchar_t localAppData[MAX_PATH];
-        if (GetEnvironmentVariableW(L"LOCALAPPDATA", localAppData, MAX_PATH) == 0)
-        {
-            return {};
-        }
-        // Build a `filesystem::path` from the raw wstring. `std::ofstream`'s
-        // wstring overload is a MSVC extension; the standard ctor only
-        // accepts `const char*`, `std::string`, and `std::filesystem::path`.
-        // Going via `path` keeps the code portable.
-        std::filesystem::path base{ std::wstring(localAppData) };
-
-        // Two-call pattern: query the family-name length first. A packaged
-        // process returns ERROR_INSUFFICIENT_BUFFER and fills `length`; an
-        // unpackaged one returns APPMODEL_ERROR_NO_PACKAGE.
-        UINT32 length = 0;
-        if (GetCurrentPackageFamilyName(&length, nullptr) == ERROR_INSUFFICIENT_BUFFER && length != 0)
-        {
-            std::wstring family(length, L'\0');
-            if (GetCurrentPackageFamilyName(&length, family.data()) == ERROR_SUCCESS)
-            {
-                family.resize(::wcslen(family.c_str())); // drop trailing NUL(s)
-                return base / L"Packages" / family / L"LocalCache" / L"Local" / L"IntelligentTerminal" / L"logs";
-            }
-        }
-        return base / L"IntelligentTerminal" / L"logs";
+        return ::IntelligentTerminal::LogDir();
     }
 
     inline void _agentPaneLog(const std::string& msg)

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1830,14 +1830,15 @@ namespace winrt::TerminalApp::implementation
         {
             co_return;
         }
-        wil::unique_cotaskmem_string localAppDataRaw;
-        if (FAILED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localAppDataRaw)) || !localAppDataRaw)
+        const std::filesystem::path desktop{ desktopRaw.get() };
+        // Resolve the WTA log dir the same way the Rust side and the agent-pane
+        // logger do (package LocalCache\Local when packaged) so the bug report
+        // captures the logs that are actually being written.
+        const std::filesystem::path logsDir = _intelligentTerminalLogDir();
+        if (logsDir.empty())
         {
             co_return;
         }
-
-        const std::filesystem::path desktop{ desktopRaw.get() };
-        const std::filesystem::path logsDir = std::filesystem::path(localAppDataRaw.get()) / L"IntelligentTerminal" / L"logs";
 
         // create_directories is a no-op if the path already exists. We do this so
         // tar always has *something* to archive, even on a brand-new install where

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -9,6 +9,7 @@
 
 #include "CTerminalHandoff.h"
 #include "../../types/inc/utils.hpp"
+#include "../inc/IntelligentTerminalPaths.h"
 
 #include "ConptyConnection.g.cpp"
 
@@ -71,6 +72,22 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
                 wchar_t buf[512];
                 if (GetEnvironmentVariableW(L"WT_COM_CLSID", buf, ARRAYSIZE(buf)))
                     environment.as_map().insert_or_assign(L"WT_COM_CLSID", buf);
+            }
+
+            // Hand the WTA log directory to the agent CLIs' PowerShell hooks
+            // (send-event.ps1) that run inside this shell. They can't resolve
+            // the package-private path themselves — a hook process is
+            // unpackaged and only sees the un-redirected %LOCALAPPDATA%, with
+            // no way to learn the package family name — so we inject the
+            // already-resolved path here, the same way WT_COM_CLSID is. (The
+            // Rust side sets the same var in spawn.rs for agent-pane CLIs,
+            // which don't come through ConptyConnection.) Must be injected
+            // here for the same reason as WT_COM_CLSID: regenerate() builds
+            // _initialEnv from the registry, not the process environment block.
+            {
+                const auto wtaLogDir = ::IntelligentTerminal::LogDir();
+                if (!wtaLogDir.empty())
+                    environment.as_map().insert_or_assign(L"WTA_HOOK_LOG_DIR", wtaLogDir.wstring());
             }
 
             // WSLENV is a colon-delimited list of environment variables (+flags) that should appear inside WSL

--- a/src/cascadia/inc/IntelligentTerminalPaths.h
+++ b/src/cascadia/inc/IntelligentTerminalPaths.h
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// IntelligentTerminalPaths.h — shared resolver for the Intelligent Terminal /
+// WTA runtime log directory.
+//
+// Mirrors wta's Rust `runtime_paths::intelligent_terminal_local_root()` exactly
+// so every writer of the WTA logs — the Rust wta processes, the C++ agent-pane
+// logger / bug-report-zip action, and the conpty environment injection that
+// lets agent-CLI PowerShell hooks find the dir — all target the same folder.
+//
+// Header-only `inline` so each translation unit picks up its own copy without
+// ODR conflicts. Lives in `src/cascadia/inc/` so both TerminalApp and
+// TerminalConnection can include it via `../inc/IntelligentTerminalPaths.h`
+// without creating a cross-project dependency.
+
+#pragma once
+
+#include <windows.h>
+#include <appmodel.h>
+
+#include <filesystem>
+#include <string>
+
+namespace IntelligentTerminal
+{
+    // Resolve the WTA log directory:
+    //
+    //   * Packaged:   %LOCALAPPDATA%\Packages\<PackageFamilyName>\LocalCache\Local\IntelligentTerminal\logs
+    //   * Unpackaged: %LOCALAPPDATA%\IntelligentTerminal\logs
+    //
+    // Logs are transient cache, hence `LocalCache\Local` (not `LocalState`,
+    // which holds persistent state like the agent-pane session index). Returns
+    // an empty path when `%LOCALAPPDATA%` is unavailable.
+    inline std::filesystem::path LogDir()
+    {
+        wchar_t localAppData[MAX_PATH];
+        if (GetEnvironmentVariableW(L"LOCALAPPDATA", localAppData, MAX_PATH) == 0)
+        {
+            return {};
+        }
+        std::filesystem::path base{ std::wstring(localAppData) };
+
+        // Two-call pattern: query the family-name length first. A packaged
+        // process returns ERROR_INSUFFICIENT_BUFFER and fills `length`; an
+        // unpackaged one returns APPMODEL_ERROR_NO_PACKAGE.
+        UINT32 length = 0;
+        if (GetCurrentPackageFamilyName(&length, nullptr) == ERROR_INSUFFICIENT_BUFFER && length != 0)
+        {
+            std::wstring family(length, L'\0');
+            if (GetCurrentPackageFamilyName(&length, family.data()) == ERROR_SUCCESS)
+            {
+                family.resize(::wcslen(family.c_str())); // drop trailing NUL(s)
+                return base / L"Packages" / family / L"LocalCache" / L"Local" / L"IntelligentTerminal" / L"logs";
+            }
+        }
+        return base / L"IntelligentTerminal" / L"logs";
+    }
+}

--- a/tools/wta/Cargo.toml
+++ b/tools/wta/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1", features = ["derive"] }
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Globalization",
+    "Win32_Storage_Packaging_Appx",
     "Win32_System_Environment",
     "Win32_System_Registry",
     "Win32_System_Threading",

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -1658,7 +1658,8 @@ fn gemini_extension_dir(home: &Path) -> PathBuf {
 /// sweeps it so a clean uninstall doesn't leave the materialized copy
 /// behind.
 fn legacy_staging_dirs(cli: CliKind) -> Vec<PathBuf> {
-    let Some(root) = crate::runtime_paths::intelligent_terminal_root() else {
+    // Staging copies are transient cache → the `LocalCache\Local` root.
+    let Some(root) = crate::runtime_paths::intelligent_terminal_local_root() else {
         return Vec::new();
     };
     let mut dirs = Vec::new();
@@ -1926,7 +1927,8 @@ fn maybe_stage_bundle_for_claude(source: &Path) -> Option<PathBuf> {
     if !is_under_windows_apps(source) {
         return None;
     }
-    let root = crate::runtime_paths::intelligent_terminal_root()?;
+    // Staging copy is transient cache → the `LocalCache\Local` root.
+    let root = crate::runtime_paths::intelligent_terminal_local_root()?;
     let staged = root.join(STAGING_SUBDIR).join(CliKind::Claude.dir_name());
     match restage_bundle_dir(source, &staged) {
         Ok(()) => {
@@ -2390,7 +2392,7 @@ mod tests {
     /// uninstall doesn't leave the MSIX workaround copy behind.
     #[test]
     fn legacy_staging_dirs_includes_active_claude_staging() {
-        let Some(root) = crate::runtime_paths::intelligent_terminal_root() else {
+        let Some(root) = crate::runtime_paths::intelligent_terminal_local_root() else {
             // No LOCALAPPDATA on this host (extremely unusual) — nothing to
             // assert. The function would return an empty Vec in that case
             // and the sweep would log a warning, which is the documented

--- a/tools/wta/src/logging.rs
+++ b/tools/wta/src/logging.rs
@@ -19,7 +19,9 @@ pub(crate) fn default_filter_directive(debug_assertions: bool) -> &'static str {
 }
 
 pub fn init(process: &str) -> WorkerGuard {
-    let log_dir = crate::runtime_paths::intelligent_terminal_root()
+    // Logs are transient diagnostics → the cache (`LocalCache\Local`) root,
+    // not the persistent `LocalState` state root.
+    let log_dir = crate::runtime_paths::intelligent_terminal_local_root()
         .map(|r| r.join("logs"))
         .unwrap_or_else(|| std::env::temp_dir().join("IntelligentTerminal").join("logs"));
     let _ = std::fs::create_dir_all(&log_dir);

--- a/tools/wta/src/protocol/acp/spawn.rs
+++ b/tools/wta/src/protocol/acp/spawn.rs
@@ -77,6 +77,17 @@ pub(crate) fn spawn_agent_process(agent_cmd: &str, cwd: Option<&Path>) -> Result
     // ACP host. Scrub unconditionally; other agents don't care.
     cmd.env_remove("CLAUDECODE");
 
+    // Tell the agent CLI's hook scripts (`send-event.ps1`, inherited via the
+    // CLI → node → powershell process chain) where to write their diagnostic
+    // trace. PowerShell can't resolve our package-private log dir on its own
+    // (it only sees the un-redirected `%LOCALAPPDATA%`, and doesn't know the
+    // package family name), so we hand it the already-resolved path. The hook
+    // falls back to bare `%LOCALAPPDATA%\IntelligentTerminal\logs` when this
+    // is unset (unpackaged dev runs, or an older wta that didn't set it).
+    if let Some(local_root) = crate::runtime_paths::intelligent_terminal_local_root() {
+        cmd.env("WTA_HOOK_LOG_DIR", local_root.join("logs"));
+    }
+
     // Forward the user's locale to the agent process via standard POSIX
     // environment variables. Many agent CLIs (and the large language models
     // they speak to) honor `LANG` / `LC_ALL` to choose their response

--- a/tools/wta/src/runtime_paths.rs
+++ b/tools/wta/src/runtime_paths.rs
@@ -1,10 +1,85 @@
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
+/// Canonical on-disk root for all WTA runtime data (logs, the prompt
+/// override directory, the agent-pane session index, the master-pipe
+/// rendezvous file, hook-installer staging, …).
+///
+/// Layout depends on whether the current process has package identity:
+///
+///   * **Packaged** (the normal case — every production wta process runs
+///     either as a conpty child of the packaged WindowsTerminal.exe or as
+///     a master spawned in-package by SharedWta, so it inherits package
+///     identity):
+///         %LOCALAPPDATA%\Packages\<PackageFamilyName>\LocalState\IntelligentTerminal\
+///     This keeps WTA's data inside the package's private store — it is
+///     cleaned up on uninstall, isolated between the dev-sideload family
+///     (`IntelligentTerminal_rd9vj3e6a2mbr`) and the store family
+///     (`Microsoft.IntelligentTerminal_8wekyb3d8bbwe`), and sits alongside
+///     the WT app's own `settings.json` / `state.json` in `LocalState`.
+///
+///   * **Unpackaged** (dev builds run directly out of the Cargo target dir,
+///     tests): falls back to the bare
+///         %LOCALAPPDATA%\IntelligentTerminal\
+///     This is the legacy location. Note such processes already fail COM
+///     activation (0x80073D54), so they are not a supported production
+///     configuration — the fallback exists only so logging / tests keep
+///     working when run outside the package.
+///
+/// Resolution is cached: `intelligent_terminal_root` is called on every log
+/// write, and querying package identity is a syscall, so we resolve once.
 pub fn intelligent_terminal_root() -> Option<PathBuf> {
-    std::env::var_os("LOCALAPPDATA")
+    static ROOT: OnceLock<Option<PathBuf>> = OnceLock::new();
+    ROOT.get_or_init(resolve_root).clone()
+}
+
+fn resolve_root() -> Option<PathBuf> {
+    let local = std::env::var_os("LOCALAPPDATA")
         .or_else(|| std::env::var_os("APPDATA"))
-        .map(PathBuf::from)
-        .map(|path| path.join("IntelligentTerminal"))
+        .map(PathBuf::from)?;
+
+    match current_package_family_name() {
+        Some(family) => Some(
+            local
+                .join("Packages")
+                .join(family)
+                .join("LocalState")
+                .join("IntelligentTerminal"),
+        ),
+        None => Some(local.join("IntelligentTerminal")),
+    }
+}
+
+/// Returns the current process's package family name (e.g.
+/// `IntelligentTerminal_rd9vj3e6a2mbr`), or `None` when the process has no
+/// package identity (unpackaged) or the OS call fails for any other reason.
+fn current_package_family_name() -> Option<std::ffi::OsString> {
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER;
+    use windows_sys::Win32::Storage::Packaging::Appx::GetCurrentPackageFamilyName;
+
+    // First call with a null buffer queries the required length. A packaged
+    // process returns ERROR_INSUFFICIENT_BUFFER and fills `len`; an
+    // unpackaged process returns APPMODEL_ERROR_NO_PACKAGE (any non-122 rc
+    // means "no usable identity" for our purposes).
+    let mut len: u32 = 0;
+    let rc = unsafe { GetCurrentPackageFamilyName(&mut len, std::ptr::null_mut()) };
+    if rc != ERROR_INSUFFICIENT_BUFFER || len == 0 {
+        return None;
+    }
+
+    // `len` includes the trailing NUL; allocate exactly that and call again.
+    let mut buf = vec![0u16; len as usize];
+    let rc = unsafe { GetCurrentPackageFamilyName(&mut len, buf.as_mut_ptr()) };
+    if rc != 0 {
+        return None;
+    }
+
+    let end = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+    if end == 0 {
+        return None;
+    }
+    Some(std::ffi::OsString::from_wide(&buf[..end]))
 }
 
 pub fn runtime_prompt_root() -> Option<PathBuf> {
@@ -23,4 +98,36 @@ pub fn runtime_log_path(file_name: &str) -> PathBuf {
 
 pub fn master_pipe_file_path() -> Option<PathBuf> {
     intelligent_terminal_root().map(|root| root.join("master-pipe.txt"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unpackaged_process_has_no_package_family_name() {
+        // `cargo test` runs the test binary without package identity, so the
+        // OS call must report "no package" and we must fall back gracefully
+        // rather than panicking or returning a bogus name.
+        assert_eq!(current_package_family_name(), None);
+    }
+
+    #[test]
+    fn unpackaged_root_falls_back_to_bare_intelligent_terminal() {
+        // With no package identity (test context), the root is the legacy
+        // bare `…\IntelligentTerminal`, NOT a `Packages\<pfn>\LocalState`
+        // path. Guard the suffix so a future regression that always emits
+        // the packaged layout is caught.
+        let root = resolve_root().expect("LOCALAPPDATA/APPDATA set in CI/dev");
+        assert!(
+            root.ends_with("IntelligentTerminal"),
+            "unexpected root: {}",
+            root.display(),
+        );
+        assert!(
+            !root.to_string_lossy().contains("LocalState"),
+            "unpackaged root must not point into a package store: {}",
+            root.display(),
+        );
+    }
 }

--- a/tools/wta/src/runtime_paths.rs
+++ b/tools/wta/src/runtime_paths.rs
@@ -1,51 +1,67 @@
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
-/// Canonical on-disk root for all WTA runtime data (logs, the prompt
-/// override directory, the agent-pane session index, the master-pipe
-/// rendezvous file, hook-installer staging, …).
+// WTA runtime data lives under two package-private roots, split by lifetime:
+//
+//   * **State** (`intelligent_terminal_root`) — persistent data that must
+//     survive and stay private to the package: the prompt-override directory,
+//     the agent-pane session index (`agent-pane-sessions.jsonl`), and the
+//     master-pipe rendezvous file. Stored in the package's `LocalState`,
+//     alongside the WT app's own `settings.json` / `state.json`.
+//
+//   * **Local / cache** (`intelligent_terminal_local_root`) — transient,
+//     regenerable diagnostics: log files and hook-bundle staging copies.
+//     Stored in the package's `LocalCache\Local`, the cache store that
+//     doesn't roam / back up.
+//
+// Both roots are package-private (cleaned up on uninstall, isolated between
+// the dev-sideload family `IntelligentTerminal_rd9vj3e6a2mbr` and the store
+// family `Microsoft.IntelligentTerminal_8wekyb3d8bbwe`). Both fall back to
+// the same legacy bare `%LOCALAPPDATA%\IntelligentTerminal\` when the process
+// has no package identity (dev builds run straight out of the Cargo target
+// dir, tests) — such processes already fail COM activation (0x80073D54), so
+// the fallback exists only so logging / tests keep working out of package.
+
+/// Persistent, package-private **state** root: `…\LocalState\IntelligentTerminal\`
+/// (or bare `%LOCALAPPDATA%\IntelligentTerminal\` when unpackaged). Backs
+/// prompts, the agent-pane session index, and the master-pipe file.
 ///
-/// Layout depends on whether the current process has package identity:
-///
-///   * **Packaged** (the normal case — every production wta process runs
-///     either as a conpty child of the packaged WindowsTerminal.exe or as
-///     a master spawned in-package by SharedWta, so it inherits package
-///     identity):
-///         %LOCALAPPDATA%\Packages\<PackageFamilyName>\LocalState\IntelligentTerminal\
-///     This keeps WTA's data inside the package's private store — it is
-///     cleaned up on uninstall, isolated between the dev-sideload family
-///     (`IntelligentTerminal_rd9vj3e6a2mbr`) and the store family
-///     (`Microsoft.IntelligentTerminal_8wekyb3d8bbwe`), and sits alongside
-///     the WT app's own `settings.json` / `state.json` in `LocalState`.
-///
-///   * **Unpackaged** (dev builds run directly out of the Cargo target dir,
-///     tests): falls back to the bare
-///         %LOCALAPPDATA%\IntelligentTerminal\
-///     This is the legacy location. Note such processes already fail COM
-///     activation (0x80073D54), so they are not a supported production
-///     configuration — the fallback exists only so logging / tests keep
-///     working when run outside the package.
-///
-/// Resolution is cached: `intelligent_terminal_root` is called on every log
-/// write, and querying package identity is a syscall, so we resolve once.
+/// Cached: queried on the hot path and package-identity lookup is a syscall.
 pub fn intelligent_terminal_root() -> Option<PathBuf> {
     static ROOT: OnceLock<Option<PathBuf>> = OnceLock::new();
-    ROOT.get_or_init(resolve_root).clone()
+    ROOT.get_or_init(|| resolve_root(&["LocalState"])).clone()
 }
 
-fn resolve_root() -> Option<PathBuf> {
+/// Transient, package-private **cache** root:
+/// `…\LocalCache\Local\IntelligentTerminal\` (or bare
+/// `%LOCALAPPDATA%\IntelligentTerminal\` when unpackaged). Backs log files
+/// and hook-bundle staging.
+///
+/// Cached for the same reason as [`intelligent_terminal_root`].
+pub fn intelligent_terminal_local_root() -> Option<PathBuf> {
+    static ROOT: OnceLock<Option<PathBuf>> = OnceLock::new();
+    ROOT.get_or_init(|| resolve_root(&["LocalCache", "Local"]))
+        .clone()
+}
+
+/// Resolve a root under `%LOCALAPPDATA%`. When the process is packaged the
+/// data lands under `Packages\<PackageFamilyName>\<package_subdir…>\IntelligentTerminal`;
+/// otherwise it falls back to the bare `%LOCALAPPDATA%\IntelligentTerminal`
+/// (the `package_subdir` is ignored, since there is no package store to
+/// nest under).
+fn resolve_root(package_subdir: &[&str]) -> Option<PathBuf> {
     let local = std::env::var_os("LOCALAPPDATA")
         .or_else(|| std::env::var_os("APPDATA"))
         .map(PathBuf::from)?;
 
     match current_package_family_name() {
-        Some(family) => Some(
-            local
-                .join("Packages")
-                .join(family)
-                .join("LocalState")
-                .join("IntelligentTerminal"),
-        ),
+        Some(family) => {
+            let mut path = local.join("Packages").join(family);
+            for segment in package_subdir {
+                path.push(segment);
+            }
+            Some(path.join("IntelligentTerminal"))
+        }
         None => Some(local.join("IntelligentTerminal")),
     }
 }
@@ -87,7 +103,7 @@ pub fn runtime_prompt_root() -> Option<PathBuf> {
 }
 
 pub fn runtime_log_path(file_name: &str) -> PathBuf {
-    if let Some(root) = intelligent_terminal_root() {
+    if let Some(root) = intelligent_terminal_local_root() {
         let log_dir = root.join("logs");
         let _ = std::fs::create_dir_all(&log_dir);
         return log_dir.join(file_name);
@@ -113,21 +129,39 @@ mod tests {
     }
 
     #[test]
-    fn unpackaged_root_falls_back_to_bare_intelligent_terminal() {
-        // With no package identity (test context), the root is the legacy
-        // bare `…\IntelligentTerminal`, NOT a `Packages\<pfn>\LocalState`
-        // path. Guard the suffix so a future regression that always emits
+    fn unpackaged_roots_fall_back_to_bare_intelligent_terminal() {
+        // With no package identity (test context), BOTH roots collapse to the
+        // legacy bare `…\IntelligentTerminal` — there is no package store to
+        // nest the LocalState / LocalCache split under. Guard that neither
+        // leaks a package-relative segment, so a regression that always emits
         // the packaged layout is caught.
-        let root = resolve_root().expect("LOCALAPPDATA/APPDATA set in CI/dev");
-        assert!(
-            root.ends_with("IntelligentTerminal"),
-            "unexpected root: {}",
-            root.display(),
-        );
-        assert!(
-            !root.to_string_lossy().contains("LocalState"),
-            "unpackaged root must not point into a package store: {}",
-            root.display(),
+        for root in [
+            resolve_root(&["LocalState"]),
+            resolve_root(&["LocalCache", "Local"]),
+        ] {
+            let root = root.expect("LOCALAPPDATA/APPDATA set in CI/dev");
+            assert!(
+                root.ends_with("IntelligentTerminal"),
+                "unexpected root: {}",
+                root.display(),
+            );
+            let s = root.to_string_lossy();
+            assert!(
+                !s.contains("LocalState") && !s.contains("LocalCache"),
+                "unpackaged root must not point into a package store: {}",
+                root.display(),
+            );
+        }
+    }
+
+    #[test]
+    fn state_and_local_roots_agree_when_unpackaged() {
+        // The state (LocalState) and local (LocalCache\Local) roots only
+        // diverge under package identity; unpackaged they must resolve to the
+        // same bare directory so dev runs keep a single on-disk root.
+        assert_eq!(
+            intelligent_terminal_root(),
+            intelligent_terminal_local_root(),
         );
     }
 }

--- a/tools/wta/wt-agent-hooks/claude/.claude-plugin/marketplace.json
+++ b/tools/wta/wt-agent-hooks/claude/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "wt-agent-hooks",
       "description": "Forward CLI agent hook events to Windows Terminal for WTA display",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "source": "./wt-agent-hooks"
     }
   ]

--- a/tools/wta/wt-agent-hooks/claude/wt-agent-hooks/.claude-plugin/plugin.json
+++ b/tools/wta/wt-agent-hooks/claude/wt-agent-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wt-agent-hooks",
   "description": "Forward CLI agent hook events to Windows Terminal for WTA display",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Agentic Terminal"
   },

--- a/tools/wta/wt-agent-hooks/claude/wt-agent-hooks/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/claude/wt-agent-hooks/hooks/send-event.ps1
@@ -63,7 +63,16 @@ try {
     # try/catch and would otherwise leak into the parent CLI transcript.
     # A persistent failure (read-only / no disk) surfaces via unbounded
     # log growth, which is a visible signal.
-    $traceDir = Join-Path $env:LOCALAPPDATA 'IntelligentTerminal\logs'
+    # Prefer the package-private log dir handed down by wta-master via
+    # WTA_HOOK_LOG_DIR — it points at the LocalCache\Local store this script
+    # can't resolve on its own (it only sees the un-redirected %LOCALAPPDATA%
+    # and doesn't know the package family name). Fall back to the bare path
+    # when the var is absent (unpackaged dev runs / older wta).
+    $traceDir = if ($env:WTA_HOOK_LOG_DIR) {
+        $env:WTA_HOOK_LOG_DIR
+    } else {
+        Join-Path $env:LOCALAPPDATA 'IntelligentTerminal\logs'
+    }
     if (-not (Test-Path -LiteralPath $traceDir)) {
         New-Item -ItemType Directory -Path $traceDir -Force -ErrorAction SilentlyContinue | Out-Null
     }

--- a/tools/wta/wt-agent-hooks/copilot/.claude-plugin/marketplace.json
+++ b/tools/wta/wt-agent-hooks/copilot/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "wt-agent-hooks",
       "description": "Forward CLI agent hook events to Windows Terminal for WTA display",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "source": "./wt-agent-hooks"
     }
   ]

--- a/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/.claude-plugin/plugin.json
+++ b/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wt-agent-hooks",
   "description": "Forward CLI agent hook events to Windows Terminal for WTA display",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Agentic Terminal"
   },

--- a/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.ps1
@@ -63,7 +63,16 @@ try {
     # try/catch and would otherwise leak into the parent CLI transcript.
     # A persistent failure (read-only / no disk) surfaces via unbounded
     # log growth, which is a visible signal.
-    $traceDir = Join-Path $env:LOCALAPPDATA 'IntelligentTerminal\logs'
+    # Prefer the package-private log dir handed down by wta-master via
+    # WTA_HOOK_LOG_DIR — it points at the LocalCache\Local store this script
+    # can't resolve on its own (it only sees the un-redirected %LOCALAPPDATA%
+    # and doesn't know the package family name). Fall back to the bare path
+    # when the var is absent (unpackaged dev runs / older wta).
+    $traceDir = if ($env:WTA_HOOK_LOG_DIR) {
+        $env:WTA_HOOK_LOG_DIR
+    } else {
+        Join-Path $env:LOCALAPPDATA 'IntelligentTerminal\logs'
+    }
     if (-not (Test-Path -LiteralPath $traceDir)) {
         New-Item -ItemType Directory -Path $traceDir -Force -ErrorAction SilentlyContinue | Out-Null
     }

--- a/tools/wta/wt-agent-hooks/gemini-extension/gemini-extension.json
+++ b/tools/wta/wt-agent-hooks/gemini-extension/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "wt-agent-hooks",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Forward Gemini CLI hook events to Windows Terminal for WTA display"
 }

--- a/tools/wta/wt-agent-hooks/gemini-extension/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/gemini-extension/hooks/send-event.ps1
@@ -63,7 +63,16 @@ try {
     # try/catch and would otherwise leak into the parent CLI transcript.
     # A persistent failure (read-only / no disk) surfaces via unbounded
     # log growth, which is a visible signal.
-    $traceDir = Join-Path $env:LOCALAPPDATA 'IntelligentTerminal\logs'
+    # Prefer the package-private log dir handed down by wta-master via
+    # WTA_HOOK_LOG_DIR — it points at the LocalCache\Local store this script
+    # can't resolve on its own (it only sees the un-redirected %LOCALAPPDATA%
+    # and doesn't know the package family name). Fall back to the bare path
+    # when the var is absent (unpackaged dev runs / older wta).
+    $traceDir = if ($env:WTA_HOOK_LOG_DIR) {
+        $env:WTA_HOOK_LOG_DIR
+    } else {
+        Join-Path $env:LOCALAPPDATA 'IntelligentTerminal\logs'
+    }
     if (-not (Test-Path -LiteralPath $traceDir)) {
         New-Item -ItemType Directory -Path $traceDir -Force -ErrorAction SilentlyContinue | Out-Null
     }


### PR DESCRIPTION
## What

Move all WTA runtime data out of the bare `%LOCALAPPDATA%\IntelligentTerminal` and into the **package-private** store, split by lifetime into two roots:

| Root | Location (packaged) | Holds |
|---|---|---|
| **State** — `intelligent_terminal_root()` | `…\Packages\<pfn>\LocalState\IntelligentTerminal\` | `prompts\`, `agent-pane-sessions.jsonl`, `master-pipe.txt` |
| **Local / cache** — `intelligent_terminal_local_root()` | `…\Packages\<pfn>\LocalCache\Local\IntelligentTerminal\` | `logs\`, hook-bundle staging |

Both fall back to the legacy bare `%LOCALAPPDATA%\IntelligentTerminal\` when the process has no package identity (dev builds run straight out of the Cargo target dir, tests).

## Why

- The bare path is **shared** by the dev-sideload family (`IntelligentTerminal_rd9vj3e6a2mbr`) and the store family (`Microsoft.IntelligentTerminal_8wekyb3d8bbwe`), and is **never cleaned up on uninstall**. Package-private roots fix both.
- **State vs cache split**: persistent must-survive data (prompt overrides, session-origin index, pipe rendezvous) → `LocalState`, alongside the WT app's own `settings.json`/`state.json`. Transient regenerable diagnostics (logs, staging) → `LocalCache\Local`.

## How

`GetCurrentPackageFamilyName` (already-present `windows-sys` dep + the `Win32_Storage_Packaging_Appx` feature) → construct the path. That's what WinRT `ApplicationData.Current.LocalFolder` / `LocalCacheFolder` resolve to, so no WinRT projection / apartment init is needed. Roots cached in `OnceLock`.

### Every writer kept in lock-step (so the bare path stays empty)

| Writer | Mechanism |
|---|---|
| Rust wta (master/helper/delegate/wtcli, logs, jsonl, prompts, pipe, staging) | `runtime_paths.rs` two roots |
| C++ `wta-agent-pane.log` + bug-report-zip action | shared `inc/IntelligentTerminalPaths.h` (`IntelligentTerminal::LogDir()`), mirrors the Rust local root |
| PowerShell hooks `hook-trace.log` (copilot/claude/gemini `send-event.ps1`) | read `WTA_HOOK_LOG_DIR`, injected by **(a)** `spawn.rs` for agent-pane CLIs and **(b)** `ConptyConnection.cpp` for interactive shell-pane CLIs |

`ConptyConnection`, not `WindowEmperor`, is the right injection point for shell panes: their `_initialEnv` is rebuilt from the registry, not inherited from the WT process env — so a process-wide `SetEnvironmentVariable` would never reach them (same reason `WT_COM_CLSID` is re-injected there).

The `wt-agent-hooks` plugin version is bumped `0.1.0 → 0.1.1` so the CLIs reinstall the `send-event.ps1` that reads `WTA_HOOK_LOG_DIR` (the CLIs only re-copy on a version change).

## Notes / scope

- **No migration** — pre-existing bare-path data is left in place and ignored.
- Audited the other raw `LOCALAPPDATA` readers (`app.rs` WinGet / `find_state_json`, `history_loader` test) — they point at third-party CLI dirs / WT's own state.json, **not** our root, so they're correctly left untouched.
- Known acceptable gaps: a CLI sandboxed in its own AppContainer can't write via the user ACE (current CLIs aren't); a CLI run entirely outside WT writes no `hook-trace.log` at all (the `WT_COM_CLSID` gate exits first).

## Testing

- ✅ `cargo build` + `cargo test` (runtime_paths + staging tests; new tests assert both roots collapse to the bare path when unpackaged and never leak a package segment).
- ✅ C++ `bcz no_clean` — 0 errors.
- ✅ All three `send-event.ps1` parse clean (`Parser::ParseFile`).
<img width="1421" height="638" alt="image" src="https://github.com/user-attachments/assets/69b8b204-f0c4-47b4-a8e9-2552098547f2" />

### Live verification (F5 deploy, 2026-05-30)

Confirmed on a packaged run that every writer lands in the expected place and the bare path gets no new writes:

- **`LocalCache\Local\IntelligentTerminal\logs\`** — `wta-main_master.log`, `wta-main_helper.log`, C++ `wta-agent-pane.log`, **and** PowerShell `hook-trace.log` ✅
- **`LocalState\IntelligentTerminal\`** — `master-pipe.txt`, `agent-pane-sessions.jsonl`, `prompts\` ✅
- **bare `%LOCALAPPDATA%\IntelligentTerminal\`** — no new writes from normal operation (only stale pre-fix files) ✅

Also verified the supporting mechanisms end-to-end: the version bump triggers the CLI plugin upgrade (copilot/claude → 0.1.1, new `send-event.ps1` deployed), `cleanup_stale_copilot_marketplace` rewrites the marketplace `source.path` to the running bundle, and `WTA_HOOK_LOG_DIR` reaches the hook so `hook-trace.log` is written into the package dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)