### PR TITLE
Session management: loading banner for shell-pane session resume (#135)

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2602,8 +2602,26 @@ impl App {
         // npm-installed CLIs (`copilot.cmd`, `claude.cmd`, `gemini.cmd`)
         // need cmd.exe's PATHEXT resolution to launch from a bare name
         // (`CreateProcess` returns 0x80070002 for `.cmd` shims).
+        //
+        // Loading banner (issue #135): the agent CLIs take 1–3s of
+        // Node.js cold-start + JSONL history parse before they paint
+        // anything, so the new tab was blank with no feedback. Prepend
+        // a blinking ANSI banner (`SGR 1;36;5` = bold cyan slow-blink)
+        // so the user sees immediate animated feedback in the new
+        // pane while the CLI cold-starts. The CLI's alt-screen TUI
+        // takes over once it boots and overwrites this line cleanly,
+        // so the banner leaves no residue on success. On CLI launch
+        // failure the banner stays put together with cmd.exe's error
+        // message — that's a feature, not a bug (the short id helps
+        // the user file a useful report). The trailing `\x1b[0m`
+        // reset guarantees any post-failure output isn't tinted /
+        // blinking.
         let cwd_string = s.cwd.to_string_lossy().to_string();
-        let launch_commandline = format!("cmd /c {}", commandline);
+        let short_key: String = key.chars().take(8).collect();
+        let launch_commandline = format!(
+            "cmd /c echo \x1b[1;36;5mResuming {} session {}...\x1b[0m && {}",
+            cli_id, short_key, commandline
+        );
         let mut argv = vec![
             "new-tab".to_string(),
             "-c".to_string(),
@@ -10110,10 +10128,21 @@ mod tests {
         );
         // The CLI invocation is still wrapped in `cmd /c` so .cmd shims
         // resolve via PATHEXT, but the legacy `cd /d` prefix is gone —
-        // cwd is threaded through wtcli's `-d` flag now.
+        // cwd is threaded through wtcli's `-d` flag now. Issue #135:
+        // a blinking ANSI loading banner (`SGR 1;36;5` = bold cyan
+        // slow-blink) is prepended so the user sees immediate animated
+        // feedback while the CLI cold-starts; the CLI's alt-screen TUI
+        // overwrites it on success.
         assert!(
-            argv.contains("cmd /c claude --resume abc-123"),
-            "argv: {}",
+            argv.contains(
+                "cmd /c echo \x1b[1;36;5mResuming claude session abc-123...\x1b[0m"
+            ),
+            "expected blinking loading banner echo; argv: {:?}",
+            argv
+        );
+        assert!(
+            argv.contains("&& claude --resume abc-123"),
+            "expected resume command chained after banner; argv: {}",
             argv
         );
         assert!(


### PR DESCRIPTION
Fixes #135.

## Problem

When a user opens a historical shell-pane agent session from the Session management view (Enter on a Ended/Historical row), `dispatch_resume` opens a new WT tab running `cmd /c <cli> --resume <id>`. The agent CLIs (claude / copilot / gemini — all Node.js `.cmd` shims) take 1–3s of cold-start + JSONL history parse before painting their TUI. During that window the new pane was completely blank with **zero feedback**, so users could not tell whether anything was happening (see screenshot in #135).

## Fix

Prepend a **blinking ANSI banner** via `cmd /c echo` so the new pane immediately shows:

> ![banner preview](https://placehold.co/600x40/0a0a0a/00d4d4?text=Resuming+claude+session+abc12345...)

Styled bold + cyan + slow-blink (SGR `1;36;5`). The CLI's alt-screen TUI overwrites the line cleanly on success; on launch failure the banner stays put together with cmd.exe's error output, where the 8-char id helps the user file a useful report. Trailing SGR `0` reset ensures any post-failure stderr is not tinted / blinking.

Concretely the launch commandline changes from:

`
cmd /c claude --resume <id>
`

to:

`
cmd /c echo \x1b[1;36;5mResuming claude session abc12345...\x1b[0m && claude --resume <id>
`

## Scope / non-effects

- **Process tree unchanged.** `cmd /c` was already in the pipeline for PATHEXT resolution of `.cmd` shims; `echo` is a cmd.exe builtin so no extra PID is introduced. Pane root process is still cmd.exe → CLI, same as before.
- **Pane GUID binding & session registry bookkeeping unchanged.** The `ResumePaneAssigned` callback fires from `wtcli new-tab --json`, independent of the commandline contents.

## Test

Updated the existing `enter_on_history_row_dispatches_new_tab_with_resume` test to assert both the banner echo and the chained resume command. 23 resume/dispatch tests pass:

`
cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml --bin wta -- resume dispatch
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured
`

Manual verification (after F5 / deploy of CascadiaPackage so the package-side wta.exe is refreshed):

1. `>Session management`
2. Pick a Ended/Historical row (any prior `claude` / `copilot` / `gemini` shell session)
3. Press **Enter**
4. New tab immediately shows blinking cyan `Resuming <cli> session <id>...`
5. CLI TUI takes over after 1–3s and clears the line