### PR TITLE
fix(wta): drop stale cwds before launching new tabs/panes

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2616,7 +2616,24 @@ impl App {
         // the user file a useful report). The trailing `\x1b[0m`
         // reset guarantees any post-failure output isn't tinted /
         // blinking.
-        let cwd_string = s.cwd.to_string_lossy().to_string();
+        let raw_cwd_string = s.cwd.to_string_lossy().to_string();
+        // Validate the historical cwd before handing it to wtcli. If the
+        // project directory has been moved/deleted since the session was
+        // recorded, passing `-d <stale>` makes `wtcli new-tab` succeed
+        // up until `CreateProcessW`, which then fails with
+        // `ERROR_DIRECTORY` and leaves the user with a broken pane.
+        // Dropping `-d` lets WT fall back to the profile's
+        // `startingDirectory` (ultimately `%USERPROFILE%`), matching a
+        // plain "open new tab" action.
+        let valid_cwd = crate::cwd_util::validate_starting_directory(&s.cwd);
+        if valid_cwd.is_none() && !raw_cwd_string.is_empty() {
+            tracing::warn!(
+                target: "agents_view",
+                key = %key,
+                cwd = %raw_cwd_string,
+                "dispatch_resume: stored cwd is no longer a valid directory; falling back to profile default",
+            );
+        }
         let short_key: String = key.chars().take(8).collect();
         let launch_commandline = format!(
             "cmd /c echo \x1b[1;36;5mResuming {} session {}...\x1b[0m && {}",
@@ -2627,10 +2644,12 @@ impl App {
             "-c".to_string(),
             launch_commandline.clone(),
         ];
-        if !cwd_string.is_empty() {
+        if let Some(ref cwd) = valid_cwd {
             argv.push("-d".to_string());
-            argv.push(cwd_string.clone());
+            argv.push(cwd.clone());
         }
+        // For logs/tests: report the cwd we actually used (empty when fallback).
+        let cwd_string = valid_cwd.clone().unwrap_or_default();
 
         // Optimistic state flip: bump Historical/Ended -> Idle so a rapid
         // second Enter on the same row sees a non-terminal status and
@@ -2806,7 +2825,22 @@ impl App {
         }
 
         let key = s.key.clone();
-        let cwd_string = s.cwd.to_string_lossy().to_string();
+        let raw_cwd_string = s.cwd.to_string_lossy().to_string();
+        // Same rationale as dispatch_resume: a stale cwd hands C++ a
+        // bad `startingDirectory` for `_OpenNewTab`, which propagates to
+        // `ConptyConnection::CreateProcessW` and produces a broken pane.
+        // Omit the field entirely on failure so WT uses the profile's
+        // default starting directory.
+        let valid_cwd = crate::cwd_util::validate_starting_directory(&s.cwd);
+        if valid_cwd.is_none() && !raw_cwd_string.is_empty() {
+            tracing::warn!(
+                target: "agents_view",
+                key = %key,
+                cwd = %raw_cwd_string,
+                "dispatch_resume_in_agent_pane: stored cwd is no longer a valid directory; omitting from resume_in_new_agent_tab event",
+            );
+        }
+        let cwd_string = valid_cwd.unwrap_or_default();
 
         // Mirror dispatch_resume's optimistic state flip so a rapid
         // double press doesn't double-dispatch.
@@ -2815,13 +2849,15 @@ impl App {
         self.publish_session_hook(resume_event);
         self.dispatch_session_resume_dispatched_rpc(&key);
 
+        let mut params = serde_json::Map::new();
+        params.insert("session_id".to_string(), serde_json::Value::String(key.clone()));
+        if !cwd_string.is_empty() {
+            params.insert("cwd".to_string(), serde_json::Value::String(cwd_string.clone()));
+        }
         let evt = serde_json::json!({
             "type": "event",
             "method": "resume_in_new_agent_tab",
-            "params": {
-                "session_id": key,
-                "cwd": cwd_string,
-            }
+            "params": params,
         });
         send_wt_protocol_event(evt.to_string());
 
@@ -10100,13 +10136,18 @@ mod tests {
     fn enter_on_history_row_dispatches_new_tab_with_resume() {
         use crate::agent_sessions::{CliSource, SessionEvent};
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-        use std::path::PathBuf;
+        // Use a real existing directory so cwd_util::validate_starting_directory
+        // accepts it. A non-existent path would (correctly) be dropped from
+        // the argv — that behaviour is covered by
+        // `enter_on_history_row_with_missing_cwd_omits_d_flag` below.
+        let real_cwd = std::env::temp_dir();
+        let real_cwd_str = real_cwd.to_string_lossy().to_string();
         let mut app = test_app();
         app.agent_sessions.apply(SessionEvent::SessionStarted {
             key: "abc-123".into(),
             cli_source: CliSource::Claude,
             pane_session_id: "p".into(),
-            cwd: PathBuf::from("/work/proj"),
+            cwd: real_cwd.clone(),
             title: "t".into(),
         });
         app.agent_sessions.apply(SessionEvent::SessionStopped {
@@ -10159,9 +10200,69 @@ mod tests {
         // Resume is keyed off the session's project cwd — the new tab's
         // primary pane must start in that directory so the CLI's session
         // store lookup (`~/.claude/projects/<encoded-cwd>/...`) succeeds.
+        let expected = format!("-d {}", real_cwd_str);
         assert!(
-            argv.contains("-d /work/proj"),
-            "expected -d <cwd>; argv: {}",
+            argv.contains(&expected),
+            "expected `{}` in argv: {}",
+            expected,
+            argv
+        );
+    }
+
+    /// When the stored cwd no longer exists on disk (e.g. user deleted
+    /// the project), `dispatch_resume` must omit `-d <cwd>` entirely so
+    /// wtcli falls back to the profile's startingDirectory. Without
+    /// this guard, `CreateProcessW` would fail with `ERROR_DIRECTORY`
+    /// and produce a visibly-broken pane.
+    #[test]
+    fn enter_on_history_row_with_missing_cwd_omits_d_flag() {
+        use crate::agent_sessions::{CliSource, SessionEvent};
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use std::path::PathBuf;
+        let missing = {
+            let mut p = std::env::temp_dir();
+            p.push(format!(
+                "wta-missing-cwd-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or(0)
+            ));
+            p
+        };
+        assert!(!missing.exists());
+        let mut app = test_app();
+        app.agent_sessions.apply(SessionEvent::SessionStarted {
+            key: "abc-stale".into(),
+            cli_source: CliSource::Claude,
+            pane_session_id: "p".into(),
+            cwd: PathBuf::from(&missing),
+            title: "t".into(),
+        });
+        app.agent_sessions.apply(SessionEvent::SessionStopped {
+            key: "abc-stale".into(),
+            reason: "user_exit".into(),
+        });
+        app.current_tab_mut().current_view = View::Agents;
+        app.current_tab_mut().agents_list_state.select(Some(0));
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        let cmd = app
+            .last_dispatched_command_for_test()
+            .expect("a command was dispatched");
+        assert_eq!(cmd.kind, DispatchedCommandKind::NewTabResume);
+        let argv = cmd.argv.join(" ");
+        assert!(argv.contains("new-tab"), "argv: {}", argv);
+        // The stale cwd must NOT have leaked through as `-d`.
+        assert!(
+            !argv.contains("-d "),
+            "argv must omit -d when cwd is missing: {}",
+            argv
+        );
+        assert!(
+            !argv.contains(&missing.to_string_lossy().to_string()),
+            "argv must not embed the stale cwd: {}",
             argv
         );
     }
@@ -10176,7 +10277,11 @@ mod tests {
         // regression-checked.
         use crate::agent_sessions::{CliSource, SessionEvent};
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-        use std::path::PathBuf;
+        // Use a real existing directory so cwd_util::validate_starting_directory
+        // accepts it. A missing cwd would (correctly) be omitted —
+        // covered by `shift_enter_on_history_row_with_missing_cwd_omits_cwd`.
+        let real_cwd = std::env::temp_dir();
+        let real_cwd_str = real_cwd.to_string_lossy().to_string();
         let mut app = test_app();
         // Capability gate: dispatch is only attempted when the agent
         // advertised loadSession. Without this, the handler
@@ -10186,7 +10291,7 @@ mod tests {
             key: "abc-123".into(),
             cli_source: CliSource::Claude,
             pane_session_id: "p".into(),
-            cwd: PathBuf::from("/work/proj"),
+            cwd: real_cwd.clone(),
             title: "t".into(),
         });
         app.agent_sessions.apply(SessionEvent::SessionStopped {
@@ -10206,7 +10311,70 @@ mod tests {
         let argv = cmd.argv.join(" ");
         assert!(argv.contains("resume_in_new_agent_tab"), "argv: {}", argv);
         assert!(argv.contains("--session-id abc-123"), "argv: {}", argv);
-        assert!(argv.contains("--cwd /work/proj"), "argv: {}", argv);
+        let expected = format!("--cwd {}", real_cwd_str);
+        assert!(
+            argv.contains(&expected),
+            "expected `{}` in argv: {}",
+            expected,
+            argv
+        );
+    }
+
+    /// Shift+Enter mirror of `enter_on_history_row_with_missing_cwd_omits_d_flag`:
+    /// when the stored cwd no longer exists, the resume-in-agent-pane
+    /// path must omit the `cwd` field from the emitted
+    /// `resume_in_new_agent_tab` event so WT's `_OpenNewTab` falls back
+    /// to the profile's startingDirectory (otherwise the new tab opens
+    /// with a broken connection).
+    #[test]
+    fn shift_enter_on_history_row_with_missing_cwd_omits_cwd() {
+        use crate::agent_sessions::{CliSource, SessionEvent};
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use std::path::PathBuf;
+        let missing = {
+            let mut p = std::env::temp_dir();
+            p.push(format!(
+                "wta-missing-shift-cwd-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or(0)
+            ));
+            p
+        };
+        assert!(!missing.exists());
+        let mut app = test_app();
+        app.agent_supports_load_session = true;
+        app.agent_sessions.apply(SessionEvent::SessionStarted {
+            key: "abc-stale".into(),
+            cli_source: CliSource::Claude,
+            pane_session_id: "p".into(),
+            cwd: PathBuf::from(&missing),
+            title: "t".into(),
+        });
+        app.agent_sessions.apply(SessionEvent::SessionStopped {
+            key: "abc-stale".into(),
+            reason: "user_exit".into(),
+        });
+        app.current_tab_mut().current_view = View::Agents;
+        app.current_tab_mut().agents_list_state.select(Some(0));
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT));
+
+        let cmd = app
+            .last_dispatched_command_for_test()
+            .expect("a command was dispatched");
+        assert_eq!(cmd.kind, DispatchedCommandKind::ResumeInAgentPane);
+        let argv = cmd.argv.join(" ");
+        assert!(argv.contains("resume_in_new_agent_tab"), "argv: {}", argv);
+        // The cwd is recorded in the dispatched-command tape as
+        // `--cwd <s>` where `<s>` is empty after fallback. We assert
+        // the stale path doesn't leak through.
+        assert!(
+            !argv.contains(&missing.to_string_lossy().to_string()),
+            "argv must not embed the stale cwd: {}",
+            argv
+        );
     }
 
     #[test]

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2858,16 +2858,19 @@ impl App {
 
         #[cfg(test)]
         {
+            let mut argv = vec![
+                "resume_in_new_agent_tab".to_string(),
+                "--session-id".to_string(),
+                s.key.clone(),
+            ];
+            if !cwd_string.is_empty() {
+                argv.push("--cwd".to_string());
+                argv.push(cwd_string);
+            }
             self.last_dispatched_command = Some(DispatchedCommand {
                 kind: DispatchedCommandKind::ResumeInAgentPane,
                 session_id: Some(s.key.clone()),
-                argv: vec![
-                    "resume_in_new_agent_tab".to_string(),
-                    "--session-id".to_string(),
-                    s.key.clone(),
-                    "--cwd".to_string(),
-                    cwd_string,
-                ],
+                argv,
             });
         }
     }
@@ -10125,7 +10128,7 @@ mod tests {
         use crate::agent_sessions::{CliSource, SessionEvent};
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         // Use a real existing directory so cwd_util::validate_starting_directory
-        // accepts it. A non-existent path would (correctly) be dropped from
+        // accepts it. A missing path would (correctly) be dropped from
         // the argv — that behaviour is covered by
         // `enter_on_history_row_with_missing_cwd_omits_d_flag` below.
         let real_cwd = std::env::temp_dir();
@@ -10355,9 +10358,15 @@ mod tests {
         assert_eq!(cmd.kind, DispatchedCommandKind::ResumeInAgentPane);
         let argv = cmd.argv.join(" ");
         assert!(argv.contains("resume_in_new_agent_tab"), "argv: {}", argv);
-        // The cwd is recorded in the dispatched-command tape as
-        // `--cwd <s>` where `<s>` is empty after fallback. We assert
-        // the stale path doesn't leak through.
+        // Fallback contract: the --cwd flag (and any value) must be
+        // omitted entirely so the consumer uses its default. A
+        // regression that sent `--cwd ""` would slip past a
+        // string-contains check, hence the explicit flag assertion.
+        assert!(
+            !cmd.argv.iter().any(|a| a == "--cwd"),
+            "argv must omit --cwd when cwd is missing: {:?}",
+            cmd.argv
+        );
         assert!(
             !argv.contains(&missing.to_string_lossy().to_string()),
             "argv must not embed the stale cwd: {}",

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2617,14 +2617,8 @@ impl App {
         // reset guarantees any post-failure output isn't tinted /
         // blinking.
         let raw_cwd_string = s.cwd.to_string_lossy().to_string();
-        // Validate the historical cwd before handing it to wtcli. If the
-        // project directory has been moved/deleted since the session was
-        // recorded, passing `-d <stale>` makes `wtcli new-tab` succeed
-        // up until `CreateProcessW`, which then fails with
-        // `ERROR_DIRECTORY` and leaves the user with a broken pane.
-        // Dropping `-d` lets WT fall back to the profile's
-        // `startingDirectory` (ultimately `%USERPROFILE%`), matching a
-        // plain "open new tab" action.
+        // Drop stale cwd so wtcli falls back to the profile default
+        // rather than failing CreateProcessW with ERROR_DIRECTORY.
         let valid_cwd = crate::cwd_util::validate_starting_directory(&s.cwd);
         if valid_cwd.is_none() && !raw_cwd_string.is_empty() {
             tracing::warn!(
@@ -2648,7 +2642,6 @@ impl App {
             argv.push("-d".to_string());
             argv.push(cwd.clone());
         }
-        // For logs/tests: report the cwd we actually used (empty when fallback).
         let cwd_string = valid_cwd.clone().unwrap_or_default();
 
         // Optimistic state flip: bump Historical/Ended -> Idle so a rapid
@@ -2826,11 +2819,6 @@ impl App {
 
         let key = s.key.clone();
         let raw_cwd_string = s.cwd.to_string_lossy().to_string();
-        // Same rationale as dispatch_resume: a stale cwd hands C++ a
-        // bad `startingDirectory` for `_OpenNewTab`, which propagates to
-        // `ConptyConnection::CreateProcessW` and produces a broken pane.
-        // Omit the field entirely on failure so WT uses the profile's
-        // default starting directory.
         let valid_cwd = crate::cwd_util::validate_starting_directory(&s.cwd);
         if valid_cwd.is_none() && !raw_cwd_string.is_empty() {
             tracing::warn!(

--- a/tools/wta/src/cwd_util.rs
+++ b/tools/wta/src/cwd_util.rs
@@ -41,7 +41,7 @@
 //! launch failure inline via `ConptyConnection` if the path really is
 //! bad, but we don't *create* false failures by guessing.
 
-use std::path::Path;
+use std::path::{Component, Path, Prefix};
 
 /// Returns `Some(string)` if the candidate cwd is safe to forward to a
 /// launcher. The result is:
@@ -66,7 +66,7 @@ pub fn validate_starting_directory<P: AsRef<Path>>(path: P) -> Option<String> {
         return None;
     }
 
-    if !is_local_windows_path(&s) {
+    if !is_local_windows_path(p) {
         // Unix-style, WSL UNC, generic UNC, relative — pass through.
         // See the module-level doc comment for the rationale.
         return Some(s.into_owned());
@@ -78,37 +78,32 @@ pub fn validate_starting_directory<P: AsRef<Path>>(path: P) -> Option<String> {
     }
 }
 
-/// `true` only when `s` looks like a *local* Windows path we can safely
-/// hit with `fs::metadata` without risking a slow / hanging syscall:
+/// `true` only when `path` parses to a *local* Windows drive-letter
+/// path that we can safely hit with `fs::metadata` without risking a
+/// slow / hanging syscall.
 ///
-/// * `C:`, `C:\…`, `C:/…` (drive-letter, absolute or drive-relative)
-/// * `\\?\C:\…` / `//?/C:\…` (extended-length, drive-letter form)
+/// Uses [`std::path::Prefix`] for classification, which is the stdlib's
+/// canonical Windows-path parser. The two prefix kinds we treat as
+/// local are:
 ///
-/// Explicitly NOT local-Windows:
+/// * [`Prefix::Disk`] — `C:\…`, `C:/…`, `C:` (drive-letter, absolute
+///   or drive-relative)
+/// * [`Prefix::VerbatimDisk`] — `\\?\C:\…` (extended-length, drive-letter)
 ///
-/// * `/foo`, `~/foo`, `~` (Unix-style / WSL home expansion)
-/// * `\\wsl$\<distro>\…`, `\\wsl.localhost\<distro>\…` (WSL UNC)
-/// * `\\?\UNC\server\share\…` (extended-length UNC, including WSL)
-/// * `\\server\share\…` (generic network UNC)
-/// * `foo\bar`, `./foo` (relative)
-fn is_local_windows_path(s: &str) -> bool {
-    // Drive-letter form: "C:" or "C:\..." or "C:/..."
-    if has_drive_letter_prefix(s) {
-        return true;
-    }
-    // Extended-length, drive-letter only. "\\?\UNC\..." routes to a UNC
-    // path so it's intentionally NOT counted as local.
-    for prefix in [r"\\?\", "//?/"] {
-        if let Some(rest) = s.strip_prefix(prefix) {
-            return has_drive_letter_prefix(rest);
-        }
-    }
-    false
-}
-
-fn has_drive_letter_prefix(s: &str) -> bool {
-    let bytes = s.as_bytes();
-    bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic()
+/// All other prefix kinds ([`Prefix::UNC`], [`Prefix::VerbatimUNC`],
+/// [`Prefix::DeviceNS`], [`Prefix::Verbatim`]) and prefix-less paths
+/// (Unix-style `/foo`, `~/foo`; relative `foo\bar`) fall through as
+/// non-local and skip validation.
+///
+/// Note: `Path::components` only recognises Windows prefixes on
+/// `cfg(windows)` targets, which is fine — wta is built for
+/// `x86_64-pc-windows-msvc` exclusively (see `.cargo/config.toml`).
+fn is_local_windows_path(path: &Path) -> bool {
+    matches!(
+        path.components().next(),
+        Some(Component::Prefix(p))
+            if matches!(p.kind(), Prefix::Disk(_) | Prefix::VerbatimDisk(_))
+    )
 }
 
 #[cfg(test)]
@@ -252,9 +247,12 @@ mod tests {
             r"d:\users\me",
             r"\\?\C:\foo",
             r"\\?\D:\bar",
-            "//?/C:/foo",
         ] {
-            assert!(is_local_windows_path(s), "should be local: {}", s);
+            assert!(
+                is_local_windows_path(Path::new(s)),
+                "should be local: {}",
+                s
+            );
         }
         // NOT local: unix, UNC (including WSL & extended-length UNC), relative.
         for s in [
@@ -272,7 +270,11 @@ mod tests {
             r"foo\bar",
             "./foo",
         ] {
-            assert!(!is_local_windows_path(s), "should NOT be local: {}", s);
+            assert!(
+                !is_local_windows_path(Path::new(s)),
+                "should NOT be local: {}",
+                s
+            );
         }
     }
 }

--- a/tools/wta/src/cwd_util.rs
+++ b/tools/wta/src/cwd_util.rs
@@ -19,34 +19,96 @@
 //! deliberately do NOT pick a substitute directory ourselves — letting
 //! the consumer's normal default kick in keeps behaviour consistent with
 //! a vanilla "open new tab" action.
+//!
+//! ## WSL / UNC / Unix-path safety
+//!
+//! `fs::metadata` operates against the **Windows** filesystem, so a path
+//! that's perfectly valid in WSL (`/home/user/proj`, `~/proj`) would be
+//! reported as missing — and we'd wrongly strip it, leaving a WSL
+//! profile booting in `%USERPROFILE%` instead of the project root.
+//! Worse, `\\wsl$\<distro>\...` and `\\wsl.localhost\<distro>\...` UNC
+//! paths can stall `fs::metadata` for seconds when the distro isn't
+//! running, which is exactly the hazard that
+//! [GH microsoft/terminal#9541] caused WT itself to drop its own
+//! pre-launch existence check (see `Profile::EvaluateStartingDirectory`
+//! in `src/cascadia/TerminalSettingsModel/Profile.cpp`).
+//!
+//! We therefore only run the existence check on paths we can cheaply
+//! prove are **local Windows** (drive-letter form, optionally with the
+//! `\\?\` extended-length prefix). Everything else — Unix-style,
+//! WSL UNC, network UNC, relative — is passed through unchanged. In
+//! those cases the original behaviour applies: WT will still surface a
+//! launch failure inline via `ConptyConnection` if the path really is
+//! bad, but we don't *create* false failures by guessing.
 
 use std::path::Path;
 
-/// Returns `Some(string)` if `path` is non-empty and refers to an
-/// existing directory. Otherwise returns `None`, signalling the caller
-/// should drop the cwd argument entirely so the launcher falls back to
-/// its own default.
+/// Returns `Some(string)` if the candidate cwd is safe to forward to a
+/// launcher. The result is:
 ///
-/// The check is a single `fs::metadata` syscall. On local NTFS this is
-/// effectively free; on slow / unreachable network or WSL paths it can
-/// block briefly. We accept that trade-off because:
-/// * the cost is paid on a low-frequency dispatch path (Enter on a
-///   historical agent session row, boot-time resume), not anywhere
-///   latency-sensitive;
-/// * the failure mode without the check (silently-broken pane) is worse
-///   than a one-off stall;
-/// * if `metadata` errors out (timeout, ACCESS_DENIED, anything), we
-///   treat the path as invalid and fall back — which is the safe
-///   direction.
+/// * `None` when `path` is empty, **or** when it's a local Windows path
+///   that doesn't exist / isn't a directory. The caller should drop the
+///   cwd argument entirely so the launcher falls back to its own
+///   default.
+/// * `Some(s)` in every other case — including paths we deliberately
+///   *don't* validate (Unix-style, WSL UNC, network UNC, relative).
+///   For those, we return the string unchanged so downstream behaviour
+///   matches what it would have done before this helper existed.
+///
+/// The existence check is a single `fs::metadata` syscall scoped to
+/// local Windows paths only. On local NTFS this is effectively free;
+/// we don't run it on WSL/network paths precisely to avoid the
+/// multi-second stalls those filesystems can introduce.
 pub fn validate_starting_directory<P: AsRef<Path>>(path: P) -> Option<String> {
     let p = path.as_ref();
-    if p.as_os_str().is_empty() {
+    let s = p.to_string_lossy();
+    if s.is_empty() {
         return None;
     }
+
+    if !is_local_windows_path(&s) {
+        // Unix-style, WSL UNC, generic UNC, relative — pass through.
+        // See the module-level doc comment for the rationale.
+        return Some(s.into_owned());
+    }
+
     match std::fs::metadata(p) {
-        Ok(meta) if meta.is_dir() => Some(p.to_string_lossy().into_owned()),
+        Ok(meta) if meta.is_dir() => Some(s.into_owned()),
         _ => None,
     }
+}
+
+/// `true` only when `s` looks like a *local* Windows path we can safely
+/// hit with `fs::metadata` without risking a slow / hanging syscall:
+///
+/// * `C:`, `C:\…`, `C:/…` (drive-letter, absolute or drive-relative)
+/// * `\\?\C:\…` / `//?/C:\…` (extended-length, drive-letter form)
+///
+/// Explicitly NOT local-Windows:
+///
+/// * `/foo`, `~/foo`, `~` (Unix-style / WSL home expansion)
+/// * `\\wsl$\<distro>\…`, `\\wsl.localhost\<distro>\…` (WSL UNC)
+/// * `\\?\UNC\server\share\…` (extended-length UNC, including WSL)
+/// * `\\server\share\…` (generic network UNC)
+/// * `foo\bar`, `./foo` (relative)
+fn is_local_windows_path(s: &str) -> bool {
+    // Drive-letter form: "C:" or "C:\..." or "C:/..."
+    if has_drive_letter_prefix(s) {
+        return true;
+    }
+    // Extended-length, drive-letter only. "\\?\UNC\..." routes to a UNC
+    // path so it's intentionally NOT counted as local.
+    for prefix in [r"\\?\", "//?/"] {
+        if let Some(rest) = s.strip_prefix(prefix) {
+            return has_drive_letter_prefix(rest);
+        }
+    }
+    false
+}
+
+fn has_drive_letter_prefix(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic()
 }
 
 #[cfg(test)]
@@ -73,9 +135,8 @@ mod tests {
     }
 
     #[test]
-    fn nonexistent_path_returns_none() {
+    fn nonexistent_local_path_returns_none() {
         let p = unique_temp_dir("nope");
-        // Make sure it really doesn't exist.
         let _ = fs::remove_dir_all(&p);
         assert!(!p.exists());
         assert_eq!(validate_starting_directory(&p), None);
@@ -92,11 +153,127 @@ mod tests {
     }
 
     #[test]
-    fn existing_directory_returns_canonicalish_string() {
+    fn existing_directory_returns_path_string() {
         let dir = unique_temp_dir("ok");
         fs::create_dir_all(&dir).unwrap();
         let got = validate_starting_directory(&dir);
         assert_eq!(got, Some(dir.to_string_lossy().into_owned()));
         let _ = fs::remove_dir_all(&dir);
     }
+
+    /// Unix-style cwds (typical for WSL profiles) must pass through
+    /// unchanged. They can't be validated against the Windows filesystem
+    /// without false-rejecting every WSL session — that bug would show
+    /// up as "all my WSL agent panes boot in %USERPROFILE% instead of
+    /// the project root".
+    #[test]
+    fn unix_style_paths_pass_through_unchanged() {
+        for s in ["/home/user/proj", "/", "/tmp", "~/work", "~"] {
+            assert_eq!(
+                validate_starting_directory(s),
+                Some(s.to_string()),
+                "unix-style path `{}` was filtered",
+                s
+            );
+        }
+    }
+
+    /// WSL UNC paths can stall `fs::metadata` for seconds when the
+    /// distro is stopped — the exact failure GH#9541 fixed in WT. We
+    /// avoid the syscall entirely and trust WT/wtcli to surface a real
+    /// failure inline if the path is unreachable.
+    #[test]
+    fn wsl_unc_paths_pass_through_unchanged() {
+        for s in [
+            r"\\wsl$\Ubuntu\home\user\proj",
+            r"\\wsl.localhost\Ubuntu\home\user\proj",
+            r"\\?\UNC\wsl$\Ubuntu\home\user\proj",
+        ] {
+            assert_eq!(
+                validate_starting_directory(s),
+                Some(s.to_string()),
+                "WSL UNC path `{}` was filtered",
+                s
+            );
+        }
+    }
+
+    /// Generic SMB / network UNC paths are also pass-through: the
+    /// remote host may be unreachable and we don't want to gate a
+    /// launch on a network round-trip.
+    #[test]
+    fn network_unc_paths_pass_through_unchanged() {
+        for s in [r"\\server\share\proj", r"\\10.0.0.1\share\dir"] {
+            assert_eq!(
+                validate_starting_directory(s),
+                Some(s.to_string()),
+                "UNC path `{}` was filtered",
+                s
+            );
+        }
+    }
+
+    /// Relative paths have no anchor we can resolve from here. Pass
+    /// through and let the launcher interpret them in its own context.
+    #[test]
+    fn relative_paths_pass_through_unchanged() {
+        for s in ["foo", r"foo\bar", "./foo", r".\foo"] {
+            assert_eq!(
+                validate_starting_directory(s),
+                Some(s.to_string()),
+                "relative path `{}` was filtered",
+                s
+            );
+        }
+    }
+
+    /// Extended-length drive-letter form (`\\?\C:\...`) is a local
+    /// Windows path and SHOULD be validated like a regular `C:\...`.
+    #[test]
+    fn extended_length_drive_letter_is_validated() {
+        let dir = unique_temp_dir("extlen");
+        fs::create_dir_all(&dir).unwrap();
+        let ext = format!(r"\\?\{}", dir.to_string_lossy());
+        let got = validate_starting_directory(&ext);
+        assert_eq!(got, Some(ext.clone()));
+        // Non-existent extended-length path → None.
+        let _ = fs::remove_dir_all(&dir);
+        assert_eq!(validate_starting_directory(&ext), None);
+    }
+
+    #[test]
+    fn is_local_windows_path_classification() {
+        // Local Windows: drive-letter forms.
+        for s in [
+            r"C:\",
+            r"C:\foo",
+            "C:/foo",
+            "C:",
+            r"d:\users\me",
+            r"\\?\C:\foo",
+            r"\\?\D:\bar",
+            "//?/C:/foo",
+        ] {
+            assert!(is_local_windows_path(s), "should be local: {}", s);
+        }
+        // NOT local: unix, UNC (including WSL & extended-length UNC), relative.
+        for s in [
+            "",
+            "/",
+            "/home/user",
+            "~/proj",
+            "~",
+            r"\\server\share",
+            r"\\wsl$\Ubuntu\home",
+            r"\\wsl.localhost\Ubuntu\home",
+            r"\\?\UNC\server\share",
+            r"\\?\UNC\wsl$\Ubuntu",
+            "foo",
+            r"foo\bar",
+            "./foo",
+        ] {
+            assert!(!is_local_windows_path(s), "should NOT be local: {}", s);
+        }
+    }
 }
+

--- a/tools/wta/src/cwd_util.rs
+++ b/tools/wta/src/cwd_util.rs
@@ -1,0 +1,102 @@
+//! Validation helper for "starting directory" values that wta hands to
+//! external launchers (`wtcli new-tab -d <cwd>`, the `resume_in_new_agent_tab`
+//! protocol event consumed by WT to spawn a new tab, the boot-time
+//! `--initial-load-cwd` flag, etc.).
+//!
+//! Agent session metadata (cwd recorded by Claude/Copilot/Gemini in their
+//! per-session JSONL files) can easily go stale: the user moves or deletes
+//! the project directory, mounts a different drive, etc. Passing a stale
+//! cwd downstream causes `CreateProcessW` to fail with
+//! `ERROR_DIRECTORY` (0x10b), which surfaces as a new tab/pane that opens
+//! but is immediately broken — the connection prints
+//! `Could not find ... working directory` and the user can't type
+//! anything useful.
+//!
+//! Validating BEFORE we hand the value off lets us fall back cleanly: by
+//! omitting the directory argument entirely, the consumer uses its own
+//! default chain (profile `startingDirectory` → `%USERPROFILE%`), which
+//! mirrors what plain `wtcli new-tab` (no `-d`) already does. We
+//! deliberately do NOT pick a substitute directory ourselves — letting
+//! the consumer's normal default kick in keeps behaviour consistent with
+//! a vanilla "open new tab" action.
+
+use std::path::Path;
+
+/// Returns `Some(string)` if `path` is non-empty and refers to an
+/// existing directory. Otherwise returns `None`, signalling the caller
+/// should drop the cwd argument entirely so the launcher falls back to
+/// its own default.
+///
+/// The check is a single `fs::metadata` syscall. On local NTFS this is
+/// effectively free; on slow / unreachable network or WSL paths it can
+/// block briefly. We accept that trade-off because:
+/// * the cost is paid on a low-frequency dispatch path (Enter on a
+///   historical agent session row, boot-time resume), not anywhere
+///   latency-sensitive;
+/// * the failure mode without the check (silently-broken pane) is worse
+///   than a one-off stall;
+/// * if `metadata` errors out (timeout, ACCESS_DENIED, anything), we
+///   treat the path as invalid and fall back — which is the safe
+///   direction.
+pub fn validate_starting_directory<P: AsRef<Path>>(path: P) -> Option<String> {
+    let p = path.as_ref();
+    if p.as_os_str().is_empty() {
+        return None;
+    }
+    match std::fs::metadata(p) {
+        Ok(meta) if meta.is_dir() => Some(p.to_string_lossy().into_owned()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn unique_temp_dir(tag: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        p.push(format!("wta-cwd-util-{tag}-{pid}-{nanos}"));
+        p
+    }
+
+    #[test]
+    fn empty_path_returns_none() {
+        assert_eq!(validate_starting_directory(""), None);
+        assert_eq!(validate_starting_directory(PathBuf::new()), None);
+    }
+
+    #[test]
+    fn nonexistent_path_returns_none() {
+        let p = unique_temp_dir("nope");
+        // Make sure it really doesn't exist.
+        let _ = fs::remove_dir_all(&p);
+        assert!(!p.exists());
+        assert_eq!(validate_starting_directory(&p), None);
+    }
+
+    #[test]
+    fn file_path_returns_none() {
+        let dir = unique_temp_dir("file");
+        fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("a.txt");
+        fs::write(&file, b"x").unwrap();
+        assert_eq!(validate_starting_directory(&file), None);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn existing_directory_returns_canonicalish_string() {
+        let dir = unique_temp_dir("ok");
+        fs::create_dir_all(&dir).unwrap();
+        let got = validate_starting_directory(&dir);
+        assert_eq!(got, Some(dir.to_string_lossy().into_owned()));
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/tools/wta/src/cwd_util.rs
+++ b/tools/wta/src/cwd_util.rs
@@ -1,103 +1,37 @@
-//! Validation helper for "starting directory" values that wta hands to
-//! external launchers (`wtcli new-tab -d <cwd>`, the `resume_in_new_agent_tab`
-//! protocol event consumed by WT to spawn a new tab, the boot-time
-//! `--initial-load-cwd` flag, etc.).
+//! Drops stale cwds before wta hands them to a launcher (`wtcli new-tab -d`,
+//! `resume_in_new_agent_tab`, `--initial-load-cwd`). A missing cwd would
+//! otherwise turn into a broken pane via `CreateProcessW` failing with
+//! `ERROR_DIRECTORY`. On failure we omit the arg so the launcher uses its
+//! own default chain (profile `startingDirectory` → `%USERPROFILE%`).
 //!
-//! Agent session metadata (cwd recorded by Claude/Copilot/Gemini in their
-//! per-session JSONL files) can easily go stale: the user moves or deletes
-//! the project directory, mounts a different drive, etc. Passing a stale
-//! cwd downstream causes `CreateProcessW` to fail with
-//! `ERROR_DIRECTORY` (0x10b), which surfaces as a new tab/pane that opens
-//! but is immediately broken — the connection prints
-//! `Could not find ... working directory` and the user can't type
-//! anything useful.
-//!
-//! Validating BEFORE we hand the value off lets us fall back cleanly: by
-//! omitting the directory argument entirely, the consumer uses its own
-//! default chain (profile `startingDirectory` → `%USERPROFILE%`), which
-//! mirrors what plain `wtcli new-tab` (no `-d`) already does. We
-//! deliberately do NOT pick a substitute directory ourselves — letting
-//! the consumer's normal default kick in keeps behaviour consistent with
-//! a vanilla "open new tab" action.
-//!
-//! ## WSL / UNC / Unix-path safety
-//!
-//! `fs::metadata` operates against the **Windows** filesystem, so a path
-//! that's perfectly valid in WSL (`/home/user/proj`, `~/proj`) would be
-//! reported as missing — and we'd wrongly strip it, leaving a WSL
-//! profile booting in `%USERPROFILE%` instead of the project root.
-//! Worse, `\\wsl$\<distro>\...` and `\\wsl.localhost\<distro>\...` UNC
-//! paths can stall `fs::metadata` for seconds when the distro isn't
-//! running, which is exactly the hazard that
-//! [GH microsoft/terminal#9541] caused WT itself to drop its own
-//! pre-launch existence check (see `Profile::EvaluateStartingDirectory`
-//! in `src/cascadia/TerminalSettingsModel/Profile.cpp`).
-//!
-//! We therefore only run the existence check on paths we can cheaply
-//! prove are **local Windows** (drive-letter form, optionally with the
-//! `\\?\` extended-length prefix). Everything else — Unix-style,
-//! WSL UNC, network UNC, relative — is passed through unchanged. In
-//! those cases the original behaviour applies: WT will still surface a
-//! launch failure inline via `ConptyConnection` if the path really is
-//! bad, but we don't *create* false failures by guessing.
+//! Only *local* Windows paths are existence-checked. Unix-style, WSL UNC
+//! and network UNC paths pass through unchanged: they can't be checked
+//! against the Windows fs without false-rejecting valid WSL cwds, and
+//! WSL/network UNC can stall `fs::metadata` for seconds (see GH#9541).
 
 use std::path::{Component, Path, Prefix};
 
-/// Returns `Some(string)` if the candidate cwd is safe to forward to a
-/// launcher. The result is:
-///
-/// * `None` when `path` is empty, **or** when it's a local Windows path
-///   that doesn't exist / isn't a directory. The caller should drop the
-///   cwd argument entirely so the launcher falls back to its own
-///   default.
-/// * `Some(s)` in every other case — including paths we deliberately
-///   *don't* validate (Unix-style, WSL UNC, network UNC, relative).
-///   For those, we return the string unchanged so downstream behaviour
-///   matches what it would have done before this helper existed.
-///
-/// The existence check is a single `fs::metadata` syscall scoped to
-/// local Windows paths only. On local NTFS this is effectively free;
-/// we don't run it on WSL/network paths precisely to avoid the
-/// multi-second stalls those filesystems can introduce.
+/// `None` if `path` is empty, or if it's a local Windows path that
+/// doesn't exist / isn't a directory. `Some(s)` otherwise — including
+/// non-local paths, which are passed through unvalidated.
 pub fn validate_starting_directory<P: AsRef<Path>>(path: P) -> Option<String> {
     let p = path.as_ref();
     let s = p.to_string_lossy();
     if s.is_empty() {
         return None;
     }
-
     if !is_local_windows_path(p) {
-        // Unix-style, WSL UNC, generic UNC, relative — pass through.
-        // See the module-level doc comment for the rationale.
         return Some(s.into_owned());
     }
-
     match std::fs::metadata(p) {
         Ok(meta) if meta.is_dir() => Some(s.into_owned()),
         _ => None,
     }
 }
 
-/// `true` only when `path` parses to a *local* Windows drive-letter
-/// path that we can safely hit with `fs::metadata` without risking a
-/// slow / hanging syscall.
-///
-/// Uses [`std::path::Prefix`] for classification, which is the stdlib's
-/// canonical Windows-path parser. The two prefix kinds we treat as
-/// local are:
-///
-/// * [`Prefix::Disk`] — `C:\…`, `C:/…`, `C:` (drive-letter, absolute
-///   or drive-relative)
-/// * [`Prefix::VerbatimDisk`] — `\\?\C:\…` (extended-length, drive-letter)
-///
-/// All other prefix kinds ([`Prefix::UNC`], [`Prefix::VerbatimUNC`],
-/// [`Prefix::DeviceNS`], [`Prefix::Verbatim`]) and prefix-less paths
-/// (Unix-style `/foo`, `~/foo`; relative `foo\bar`) fall through as
-/// non-local and skip validation.
-///
-/// Note: `Path::components` only recognises Windows prefixes on
-/// `cfg(windows)` targets, which is fine — wta is built for
-/// `x86_64-pc-windows-msvc` exclusively (see `.cargo/config.toml`).
+/// `true` for drive-letter (`C:\…`) and verbatim-drive (`\\?\C:\…`)
+/// paths only. UNC, device-namespace, Unix-style, and relative paths
+/// return `false` and skip the existence check.
 fn is_local_windows_path(path: &Path) -> bool {
     matches!(
         path.components().next(),

--- a/tools/wta/src/cwd_util.rs
+++ b/tools/wta/src/cwd_util.rs
@@ -1,4 +1,4 @@
-//! Drops stale cwds before wta hands them to a launcher (`wtcli new-tab -d`,
+//! Drops stale cwd values before wta hands them to a launcher (`wtcli new-tab -d`,
 //! `resume_in_new_agent_tab`, `--initial-load-cwd`). A missing cwd would
 //! otherwise turn into a broken pane via `CreateProcessW` failing with
 //! `ERROR_DIRECTORY`. On failure we omit the arg so the launcher uses its
@@ -6,7 +6,7 @@
 //!
 //! Only *local* Windows paths are existence-checked. Unix-style, WSL UNC
 //! and network UNC paths pass through unchanged: they can't be checked
-//! against the Windows fs without false-rejecting valid WSL cwds, and
+//! against the Windows fs without false-rejecting valid WSL paths, and
 //! WSL/network UNC can stall `fs::metadata` for seconds (see GH#9541).
 
 use std::path::{Component, Path, Prefix};
@@ -90,7 +90,7 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
-    /// Unix-style cwds (typical for WSL profiles) must pass through
+    /// Unix-style paths (typical for WSL profiles) must pass through
     /// unchanged. They can't be validated against the Windows filesystem
     /// without false-rejecting every WSL session — that bug would show
     /// up as "all my WSL agent panes boot in %USERPROFILE% instead of
@@ -160,12 +160,12 @@ mod tests {
     /// Windows path and SHOULD be validated like a regular `C:\...`.
     #[test]
     fn extended_length_drive_letter_is_validated() {
-        let dir = unique_temp_dir("extlen");
+        let dir = unique_temp_dir("extended_len");
         fs::create_dir_all(&dir).unwrap();
         let ext = format!(r"\\?\{}", dir.to_string_lossy());
         let got = validate_starting_directory(&ext);
         assert_eq!(got, Some(ext.clone()));
-        // Non-existent extended-length path → None.
+        // Missing extended-length path → None.
         let _ = fs::remove_dir_all(&dir);
         assert_eq!(validate_starting_directory(&ext), None);
     }

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -9,6 +9,7 @@ mod agent_sessions;
 mod app;
 mod commands;
 mod coordinator;
+mod cwd_util;
 mod event;
 mod helper;
 mod history_loader;
@@ -2464,7 +2465,24 @@ async fn run_acp_app(
                                 .initial_load_cwd
                                 .as_deref()
                                 .map(str::to_string)
-                                .filter(|s| !s.is_empty());
+                                .filter(|s| !s.is_empty())
+                                .and_then(|s| {
+                                    // See cwd_util::validate_starting_directory:
+                                    // a stale --initial-load-cwd ultimately
+                                    // becomes a broken pane via WT's
+                                    // ConptyConnection. Drop it on failure
+                                    // and let the consumer fall back to the
+                                    // profile default.
+                                    let v = crate::cwd_util::validate_starting_directory(&s);
+                                    if v.is_none() {
+                                        tracing::warn!(
+                                            target: "acp_load_session",
+                                            cwd = %s,
+                                            "--initial-load-cwd refers to a missing directory; dropping from load_session params",
+                                        );
+                                    }
+                                    v
+                                });
                             tracing::info!(
                                 target: "acp_load_session",
                                 session_id = sid,

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2467,12 +2467,6 @@ async fn run_acp_app(
                                 .map(str::to_string)
                                 .filter(|s| !s.is_empty())
                                 .and_then(|s| {
-                                    // See cwd_util::validate_starting_directory:
-                                    // a stale --initial-load-cwd ultimately
-                                    // becomes a broken pane via WT's
-                                    // ConptyConnection. Drop it on failure
-                                    // and let the consumer fall back to the
-                                    // profile default.
                                     let v = crate::cwd_util::validate_starting_directory(&s);
                                     if v.is_none() {
                                         tracing::warn!(


### PR DESCRIPTION
## Problem

Resuming an agent session, opening an agent pane, or booting wta with `--initial-load-cwd` would silently produce a broken tab/pane when the recorded project directory had been moved or deleted: the launch reached `CreateProcessW`, which then failed with `ERROR_DIRECTORY`, and the user was left with an unusable connection that printed `Could not find ... working directory`.

## Fix

Validate the cwd on the **wta launcher** side before forwarding it to wtcli / the `resume_in_new_agent_tab` protocol event / `load_session`. On failure, **omit** the cwd arg so the consumer falls back to its own default chain (profile `startingDirectory` → `%USERPROFILE%`), matching a plain "new tab" action.

Validation is scoped to **local Windows paths only** (drive-letter or `\\?\C:\...`) using `std::path::Prefix`. Unix-style, WSL UNC (`\\wsl$\...`), generic UNC, and relative paths pass through unvalidated — `fs::metadata` on those is either incorrect (false-rejects valid WSL paths) or hazardous (multi-second stalls on dormant distros, the same reason `Profile::EvaluateStartingDirectory` removed its existence check in microsoft/terminal#9541).

A `tracing::warn!` is logged at each call site when validation drops a cwd, so the fallback is diagnosable.

## Changes

- New `tools/wta/src/cwd_util.rs` (`validate_starting_directory` + `is_local_windows_path`, 10 unit tests).
- Wired into 3 launch sites: `dispatch_resume`, `dispatch_resume_in_agent_pane`, `--initial-load-cwd`.
- 4 updated/new tests in `app.rs` covering both the happy path and the missing-cwd fallback.

## Test

- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml --bin wta` → **570 / 570 pass**.
- No new dependencies (tests use `std::env::temp_dir()`).

## Risk

Surgical, launcher-side only. Does not touch wtcli, the COM server, or any C++ code. The fallback path is the same one wta already takes when no cwd was recorded.
