### PR TITLE
feat(wta): auto-upgrade wt-agent-hooks plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,52 @@ once the session later connects.
 
 **Diag log**: `wta-ensure-host.log` in the WTA log directory — shows event flow, classification, and autofix triggers.
 
+## Hooks plugin auto-upgrade
+
+When IT is installed or upgraded, the bundled `wt-agent-hooks` plugin
+(`tools/wta/wt-agent-hooks/{copilot,claude,gemini-extension}/`) needs to
+re-land into any agent CLI the user already opted into (via Settings UI /
+FRE "Install hooks" or `wta hooks install`). This is handled silently by
+`agent_hooks_installer::upgrade_installed_hooks`, fired once per
+`wta-master` startup on a blocking-pool thread.
+
+**Trigger model — bundle version is the upgrade signal.** A tiny state
+file `<LocalCache>/IntelligentTerminal/hooks-upgrade-state.json` records
+the bundle version this wta process last saw per CLI. At startup we read
+each CLI's bundle `plugin.json` / `gemini-extension.json` (cheap, <5ms)
+and compare; if all match, we return immediately (no spawns, no IO
+beyond the cache compare). Only after the user installs / upgrades IT
+does the bundle version change → cache miss → per-CLI flow runs once,
+then the state file is rewritten and the fast path resumes.
+
+**Opt-in only.** Even on cache miss, CLIs that don't already have
+`wt-agent-hooks` installed are skipped. The auto-upgrade never installs
+into a CLI the user hasn't accepted. Disabled plugins are also skipped
+(`enabled: false` in Copilot's `config.json` / `claude plugin list`).
+
+**Per-CLI strategy.** Copilot and Claude use their `plugin update`
+subcommands; before invoking them we rewrite any stale marketplace
+`source.path` to the current bundle dir (Copilot: existing
+`cleanup_stale_copilot_marketplace`; Claude: new
+`cleanup_stale_claude_marketplace`). Gemini's `extensions update`
+silently returns `NOT_UPDATABLE` when the recorded install source no
+longer exists (typical after an MSIX version-dir bump), so we peek at
+`~/.gemini/extensions/wt-agent-hooks/.gemini-extension-install.json`
+first: if `type==local` AND `source` is still under the current bundle,
+run `extensions update` in place; otherwise fall back to
+uninstall+install while preserving the `isActive` flag.
+
+**Trigger-point caveat.** The agent CLI master spawns concurrently may
+already be past its plugin-load step by the time `plugin update` writes
+the new files — so the freshly upgraded hooks may not take effect until
+the next agent restart. Acceptable because blocking master startup on a
+Node-based `plugin update` (1-30s) would hurt every IT-upgrade boot.
+
+**Diag**: `wta-install-hooks.log` (existing) plus `target=agent_hooks`
++ `target={copilot,gemini}_hooks` trace events in
+`wta-main_master.log` show every per-CLI decision (`upgrade decision`
+log line carries `installed_version`, `bundle_version`, `action`).
+
 ## Logs & runtime data layout
 
 WTA runtime data lives under the **package-private** store, split by lifetime
@@ -147,6 +193,8 @@ same bare path when the process has no package identity):
   …\Packages\<PackageFamilyName>\LocalCache\Local\IntelligentTerminal\  <- LOCAL/cache root
       logs\                         (all wta-*.log files)          intelligent_terminal_local_root()
       hook-bundle-staging\ …        (hook-installer staging)
+      hooks-upgrade-state.json      (per-CLI bundle version cache for the
+                                     hooks auto-upgrade fast-path)
 
 # Unpackaged (dev builds run straight out of the Cargo target dir, tests):
 # BOTH roots collapse to the legacy bare %LOCALAPPDATA%\IntelligentTerminal\.

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -2234,6 +2234,812 @@ fn paths_equivalent(a: &Path, b: &Path) -> bool {
 }
 
 // ---------------------------------------------------------------------------
+// Auto-upgrade on IT install / upgrade
+// ---------------------------------------------------------------------------
+//
+// `upgrade_installed_hooks()` runs once at wta-master startup. Its job is to
+// re-deliver an updated `wt-agent-hooks` bundle to the CLIs the user has
+// already opted into (Settings UI / FRE "Install hooks" button, or
+// `wta hooks install`). It never auto-installs into a CLI the user hasn't
+// already accepted.
+//
+// Fast-path short-circuit
+// -----------------------
+//
+// The dominant cost on every master startup would be spawning
+// `claude plugin list --json` (Node.js cold start, ~1-2s). To keep the
+// common no-upgrade case effectively free, we record the bundle version
+// we last saw per-CLI in a tiny state file:
+//
+//     <intelligent_terminal_local_root>/hooks-upgrade-state.json
+//     { "copilot": "0.1.1", "claude": "0.1.1", "gemini": "0.1.1" }
+//
+// At startup we read each CLI's bundle plugin.json (cheap file IO) and
+// compare to the cached entry. If every entry matches, return immediately
+// without touching any CLI. Only when a bundle version changed (i.e. user
+// installed / upgraded IT, MSIX dropped a new bundle next to wta.exe) do
+// we run the full per-CLI flow for that CLI. After every full check we
+// rewrite the state file. Missing / unparseable state file → treat as
+// cache miss (one slow run, then back to the fast path).
+//
+// Per-CLI upgrade flow
+// --------------------
+//
+// Each CLI exposes a real `update` subcommand:
+//   * `copilot plugin update <name>` (verified in GitHub Copilot CLI docs)
+//   * `claude plugin update [name]`  (verified in Claude Code CLI docs)
+//   * `gemini extensions update <name>` (verified in google-gemini/gemini-cli
+//     `packages/cli/src/acp/commands/extensions.ts` `UpdateExtensionCommand`)
+//
+// Copilot / Claude: re-run the marketplace path cleanup (Copilot already has
+// `cleanup_stale_copilot_marketplace`; Claude needs the analogous
+// `cleanup_stale_claude_marketplace`), then invoke the CLI's `plugin update`.
+//
+// Gemini: peek at `~/.gemini/extensions/wt-agent-hooks/.gemini-extension-install.json`
+// for the recorded `{type, source}`. If `source` is under the current bundle
+// dir AND still a directory, `gemini extensions update` re-pulls from there
+// cleanly. Otherwise (post-MSIX-version-dir-bump symptom — Gemini's
+// `checkForExtensionUpdate` silently returns `NOT_UPDATABLE`), fall back to
+// uninstall + install. To preserve user intent, we capture `isActive` from
+// `gemini extensions list -o json` before uninstall and `extensions disable`
+// after reinstall if needed.
+//
+// Skip rules
+// ----------
+//
+// For each CLI: skip if not installed, if explicitly disabled (respect the
+// user's choice), or if installed_version >= bundle_version. Decisions are
+// produced by the pure `decide_upgrade` function (testable without spawning
+// any CLI).
+//
+// Trigger-point caveat
+// --------------------
+//
+// Upgrade fires AT master startup but the agent CLI master spawned
+// concurrently may have already loaded its plugins by the time `plugin
+// update` finishes writing files. The freshly upgraded hooks may not take
+// effect until the next agent restart. This is acceptable because the
+// blocking alternative (await update before agent spawn) would add 1-30s
+// to every IT-upgrade boot. See doc-comment on `upgrade_installed_hooks`.
+
+/// Strict `MAJOR.MINOR.PATCH` parse. We reject anything else (prerelease,
+/// build metadata, missing fields) so bundles MUST ship plain semver. If
+/// you need a non-`a.b.c` version in the bundle, this code skips the
+/// upgrade silently — which is conservative but correct.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Version {
+    major: u64,
+    minor: u64,
+    patch: u64,
+}
+
+impl std::str::FromStr for Version {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, ()> {
+        let mut parts = s.split('.');
+        let major = parts.next().ok_or(())?.parse::<u64>().map_err(|_| ())?;
+        let minor = parts.next().ok_or(())?.parse::<u64>().map_err(|_| ())?;
+        let patch = parts.next().ok_or(())?.parse::<u64>().map_err(|_| ())?;
+        if parts.next().is_some() {
+            return Err(());
+        }
+        Ok(Version {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+/// Read the `version` field from a JSON file. Returns `None` for any
+/// failure mode (missing file, invalid JSON, missing/non-string field,
+/// non-semver value). All failures are silent because callers treat
+/// `None` as "skip upgrade" — the conservative choice.
+fn read_version_field(path: &Path) -> Option<Version> {
+    let text = fs::read_to_string(path).ok()?;
+    let v: Value = serde_json::from_str(&text).ok()?;
+    let s = v.get("version")?.as_str()?;
+    s.parse::<Version>().ok()
+}
+
+/// Resolve the bundle manifest path for `cli` and read its declared
+/// version. Returns `None` when the bundle is unresolvable (e.g. wta is
+/// running without an MSIX bundle next to it) or the manifest is missing
+/// / malformed.
+fn read_bundled_version(cli: CliKind) -> Option<Version> {
+    let dir = bundle::resolve_cli_dir(cli)?;
+    let manifest = match cli {
+        CliKind::Copilot | CliKind::Claude => {
+            dir.join("wt-agent-hooks").join(".claude-plugin").join("plugin.json")
+        }
+        CliKind::Gemini => dir.join("gemini-extension.json"),
+    };
+    read_version_field(&manifest)
+}
+
+// ---- Installed-state readers ----------------------------------------------
+
+/// What we know about an installed plugin: its version, whether it's
+/// enabled, and (for Gemini) the path it was installed from. `version`
+/// is `Option` because some CLIs may surface a plugin entry without a
+/// parseable version; we treat that as "installed but unknown version"
+/// → conservative skip.
+#[derive(Debug, Clone)]
+struct InstalledInfo {
+    version: Option<Version>,
+    enabled: bool,
+    /// Gemini-only: the recorded install source path from
+    /// `.gemini-extension-install.json`. `None` for Copilot/Claude.
+    gemini_source: Option<PathBuf>,
+    /// Gemini-only: `type` from the metadata file. We only auto-update
+    /// `local` installs; `git`/`link` are user choices we don't
+    /// second-guess.
+    gemini_type: Option<String>,
+}
+
+/// Read Copilot's installed-plugin entry directly from
+/// `~/.copilot/config.json`. Pure file IO — no spawn.
+fn read_installed_copilot(home: &Path) -> Option<InstalledInfo> {
+    let path = home.join(".copilot").join("config.json");
+    let text = fs::read_to_string(&path).ok()?;
+    let v: Value = serde_json::from_str(&strip_jsonc_line_comments(&text)).ok()?;
+    let entry = v
+        .get("installedPlugins")?
+        .as_array()?
+        .iter()
+        .find(|e| {
+            e.get("name").and_then(|n| n.as_str()) == Some(PLUGIN_NAME)
+                && e.get("marketplace").and_then(|n| n.as_str()) == Some(MARKETPLACE_NAME)
+        })?;
+    let version = entry
+        .get("version")
+        .and_then(|x| x.as_str())
+        .and_then(|s| s.parse::<Version>().ok());
+    let enabled = entry
+        .get("enabled")
+        .and_then(|x| x.as_bool())
+        .unwrap_or(true);
+    Some(InstalledInfo {
+        version,
+        enabled,
+        gemini_source: None,
+        gemini_type: None,
+    })
+}
+
+/// Spawn `claude plugin list --json` and locate our plugin. One-shot
+/// Node spawn; the fast-path short-circuit in `upgrade_installed_hooks`
+/// ensures this only runs after a bundle version change.
+fn read_installed_claude() -> Option<InstalledInfo> {
+    let outcome = run_plugin_cli_capture("claude", &["plugin", "list", "--json"]).ok()?;
+    if !outcome.success {
+        return None;
+    }
+    let arr: Value = serde_json::from_str(outcome.stdout.trim()).ok()?;
+    let id_target = format!("{}@{}", PLUGIN_NAME, MARKETPLACE_NAME);
+    for entry in arr.as_array()? {
+        if entry.get("id").and_then(|x| x.as_str()) != Some(id_target.as_str()) {
+            continue;
+        }
+        let version = entry
+            .get("version")
+            .and_then(|x| x.as_str())
+            .and_then(|s| s.parse::<Version>().ok());
+        let enabled = entry
+            .get("enabled")
+            .and_then(|x| x.as_bool())
+            .unwrap_or(true);
+        return Some(InstalledInfo {
+            version,
+            enabled,
+            gemini_source: None,
+            gemini_type: None,
+        });
+    }
+    None
+}
+
+/// Read Gemini's installed extension from disk: version from
+/// `gemini-extension.json`, source/type from `.gemini-extension-install.json`.
+/// Pure file IO. Treats a missing metadata file as `gemini_source: None`,
+/// which forces the upgrade flow into the uninstall+install fallback.
+fn read_installed_gemini(home: &Path) -> Option<InstalledInfo> {
+    let ext_dir = gemini_extension_dir(home);
+    let manifest = ext_dir.join("gemini-extension.json");
+    let version = read_version_field(&manifest);
+    // Treat presence of the manifest file (regardless of parseable version)
+    // as "installed". A missing manifest means not installed.
+    if !manifest.is_file() {
+        return None;
+    }
+    // Read enabled/disabled from `gemini extensions list -o json` is the
+    // robust source, but it requires a spawn. Skip for the initial probe;
+    // the upgrade flow re-reads `isActive` only when it's about to do a
+    // destructive fallback (uninstall+install).
+    let install_meta = ext_dir.join(".gemini-extension-install.json");
+    let (gemini_source, gemini_type) = match fs::read_to_string(&install_meta) {
+        Ok(t) => match serde_json::from_str::<Value>(&t) {
+            Ok(v) => {
+                let src = v
+                    .get("source")
+                    .and_then(|x| x.as_str())
+                    .map(PathBuf::from);
+                let kind = v
+                    .get("type")
+                    .and_then(|x| x.as_str())
+                    .map(String::from);
+                (src, kind)
+            }
+            Err(_) => (None, None),
+        },
+        Err(_) => (None, None),
+    };
+    Some(InstalledInfo {
+        version,
+        // Disk-read can't distinguish — Gemini stores disabled state in
+        // `~/.gemini/settings.json` / scoped settings. For decision
+        // purposes, default to `enabled: true` here; the fallback path
+        // re-queries via CLI before any destructive action.
+        enabled: true,
+        gemini_source,
+        gemini_type,
+    })
+}
+
+// ---- Pure upgrade decision -----------------------------------------------
+
+/// Reason an upgrade is skipped. Surfaced via tracing so packaged-build
+/// debugging shows exactly why no action was taken.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SkipReason {
+    NotInstalled,
+    Disabled,
+    UpToDate,
+    UnknownInstalledVersion,
+    UnknownBundleVersion,
+}
+
+/// Action chosen by `decide_upgrade`. Pure data — no side effects yet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum UpgradeAction {
+    Skip(SkipReason),
+    /// Copilot / Claude: rewrite stale marketplace path, then
+    /// `plugin update <name>@<marketplace>`.
+    UpdatePlugin,
+    /// Gemini, source path still under the current bundle:
+    /// `gemini extensions update <name>` with trust env.
+    GeminiUpdateInPlace,
+    /// Gemini, source path stale or non-local: uninstall + install
+    /// (and re-disable if the extension was disabled before).
+    GeminiReinstall,
+}
+
+/// Decide what to do for one CLI given the bundle version and the
+/// installed state. Pure function — no IO. All branches covered by
+/// `upgrade_decision_*` tests.
+///
+/// `current_bundle_dir` is only consulted for Gemini (to decide whether
+/// the recorded install source still lives under the current bundle).
+fn decide_upgrade(
+    cli: CliKind,
+    bundle_version: Option<Version>,
+    installed: Option<&InstalledInfo>,
+    current_bundle_dir: Option<&Path>,
+) -> UpgradeAction {
+    let Some(bundle_version) = bundle_version else {
+        return UpgradeAction::Skip(SkipReason::UnknownBundleVersion);
+    };
+    let Some(installed) = installed else {
+        return UpgradeAction::Skip(SkipReason::NotInstalled);
+    };
+    if !installed.enabled {
+        return UpgradeAction::Skip(SkipReason::Disabled);
+    }
+    let Some(installed_version) = installed.version else {
+        return UpgradeAction::Skip(SkipReason::UnknownInstalledVersion);
+    };
+    if installed_version >= bundle_version {
+        return UpgradeAction::Skip(SkipReason::UpToDate);
+    }
+    match cli {
+        CliKind::Copilot | CliKind::Claude => UpgradeAction::UpdatePlugin,
+        CliKind::Gemini => {
+            // Auto-update only `local` installs; `git`/`link` are user
+            // configurations we don't second-guess.
+            let is_local = installed.gemini_type.as_deref() == Some("local");
+            let source_under_bundle = match (&installed.gemini_source, current_bundle_dir) {
+                (Some(src), Some(bundle_dir)) => {
+                    src.is_dir() && gemini_source_under_bundle(src, bundle_dir)
+                }
+                _ => false,
+            };
+            if is_local && source_under_bundle {
+                UpgradeAction::GeminiUpdateInPlace
+            } else {
+                UpgradeAction::GeminiReinstall
+            }
+        }
+    }
+}
+
+/// True when `source` resolves under (or equals) `bundle_dir`. Used to
+/// detect when Gemini's recorded install source still points into the
+/// currently-resolved MSIX bundle dir — only then is in-place
+/// `extensions update` safe. Uses `paths_equivalent` semantics
+/// (case-insensitive on Windows, no canonicalize).
+fn gemini_source_under_bundle(source: &Path, bundle_dir: &Path) -> bool {
+    // Walk `source`'s ancestors and check for path equivalence.
+    let mut cur = Some(source);
+    while let Some(c) = cur {
+        if paths_equivalent(c, bundle_dir) {
+            return true;
+        }
+        cur = c.parent();
+    }
+    false
+}
+
+// ---- State file (fast-path cache) -----------------------------------------
+
+/// On-disk cache that records the bundle version we last saw per CLI.
+/// Used by `upgrade_installed_hooks` to short-circuit on the common
+/// "no IT upgrade happened" case.
+#[derive(Debug, Default, Clone)]
+struct UpgradeState {
+    copilot: Option<String>,
+    claude: Option<String>,
+    gemini: Option<String>,
+}
+
+impl UpgradeState {
+    fn get(&self, cli: CliKind) -> Option<&str> {
+        match cli {
+            CliKind::Copilot => self.copilot.as_deref(),
+            CliKind::Claude => self.claude.as_deref(),
+            CliKind::Gemini => self.gemini.as_deref(),
+        }
+    }
+
+    fn set(&mut self, cli: CliKind, version: Option<String>) {
+        match cli {
+            CliKind::Copilot => self.copilot = version,
+            CliKind::Claude => self.claude = version,
+            CliKind::Gemini => self.gemini = version,
+        }
+    }
+
+    fn to_json(&self) -> Value {
+        let mut m = serde_json::Map::new();
+        if let Some(v) = &self.copilot {
+            m.insert("copilot".into(), Value::String(v.clone()));
+        }
+        if let Some(v) = &self.claude {
+            m.insert("claude".into(), Value::String(v.clone()));
+        }
+        if let Some(v) = &self.gemini {
+            m.insert("gemini".into(), Value::String(v.clone()));
+        }
+        Value::Object(m)
+    }
+
+    fn from_json(v: &Value) -> Self {
+        let obj = v.as_object();
+        let get = |key: &str| -> Option<String> {
+            obj.and_then(|o| o.get(key))
+                .and_then(|x| x.as_str())
+                .map(String::from)
+        };
+        UpgradeState {
+            copilot: get("copilot"),
+            claude: get("claude"),
+            gemini: get("gemini"),
+        }
+    }
+}
+
+/// Path to the upgrade-state file. Lives next to other transient wta
+/// diagnostics (`logs/`, `hook-bundle-staging/`) in the `LocalCache\Local`
+/// root. Returns `None` when the runtime root is unresolvable.
+fn upgrade_state_path() -> Option<PathBuf> {
+    crate::runtime_paths::intelligent_terminal_local_root()
+        .map(|root| root.join("hooks-upgrade-state.json"))
+}
+
+/// Load the cached bundle versions. Crash-safe: any IO/parse failure
+/// returns the empty state (= forces a full upgrade check next run).
+fn load_upgrade_state(path: &Path) -> UpgradeState {
+    match fs::read_to_string(path) {
+        Ok(t) => match serde_json::from_str::<Value>(&t) {
+            Ok(v) => UpgradeState::from_json(&v),
+            Err(_) => UpgradeState::default(),
+        },
+        Err(_) => UpgradeState::default(),
+    }
+}
+
+/// Persist the cached bundle versions. Best-effort: a write failure
+/// just means next startup repeats the full check.
+fn save_upgrade_state(path: &Path, state: &UpgradeState) {
+    if let Some(parent) = path.parent() {
+        if let Err(e) = fs::create_dir_all(parent) {
+            tracing::warn!(
+                target: "agent_hooks",
+                err = %e,
+                path = %parent.display(),
+                "failed to create upgrade-state parent dir",
+            );
+            return;
+        }
+    }
+    let pretty = match serde_json::to_string_pretty(&state.to_json()) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(target: "agent_hooks", err = %e, "failed to serialize upgrade state");
+            return;
+        }
+    };
+    if let Err(e) = fs::write(path, pretty) {
+        tracing::warn!(
+            target: "agent_hooks",
+            err = %e,
+            path = %path.display(),
+            "failed to write upgrade-state file",
+        );
+    }
+}
+
+// ---- Claude marketplace cleanup ------------------------------------------
+
+/// Mirror of `cleanup_stale_copilot_marketplace` for Claude. Rewrites
+/// the `wt-local` entry in `~/.claude/plugins/known_marketplaces.json`
+/// when its registered `source.path` (and the parallel `installLocation`,
+/// if present) no longer points at the current bundle. Idempotent: when
+/// the file or entry is missing, or the path already matches, no-op.
+///
+/// Returns `Ok(())` on success or no-op. Logs warnings on JSON / IO
+/// failures and continues without erroring so the caller can proceed
+/// with the `plugin update` anyway.
+fn cleanup_stale_claude_marketplace(
+    known_path: &Path,
+    expected_source: &Path,
+) -> std::io::Result<()> {
+    let text = match fs::read_to_string(known_path) {
+        Ok(t) if !t.trim().is_empty() => t,
+        Ok(_) => return Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    };
+
+    let mut settings: Value = match serde_json::from_str(&text) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                target: "agent_hooks",
+                err = %e,
+                path = %known_path.display(),
+                "known_marketplaces.json malformed; leaving untouched",
+            );
+            return Ok(());
+        }
+    };
+
+    let expected_str = expected_source.to_string_lossy().into_owned();
+    let mut changed = false;
+    let mut old_path = String::new();
+
+    {
+        let Some(root) = settings.as_object_mut() else {
+            return Ok(());
+        };
+        let Some(entry) = root.get_mut(MARKETPLACE_NAME).and_then(|v| v.as_object_mut())
+        else {
+            return Ok(());
+        };
+        if let Some(source) = entry.get_mut("source").and_then(|v| v.as_object_mut()) {
+            if source.get("source").and_then(|v| v.as_str()) == Some("directory") {
+                let current = source
+                    .get("path")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if !paths_equivalent(Path::new(&current), expected_source) {
+                    source.insert("path".to_string(), Value::String(expected_str.clone()));
+                    old_path = current;
+                    changed = true;
+                }
+            }
+        }
+        // `installLocation` is recorded as a sibling string field at the
+        // entry level (per the test fixture in this file). Keep it in
+        // lockstep with `source.path` for forward compatibility — Claude
+        // re-reads this during plugin resolution and an inconsistent pair
+        // could trip path-validation logic in future versions.
+        if let Some(install_loc) = entry.get("installLocation").and_then(|v| v.as_str()) {
+            if !paths_equivalent(Path::new(install_loc), expected_source) {
+                entry.insert(
+                    "installLocation".to_string(),
+                    Value::String(expected_str.clone()),
+                );
+                changed = true;
+            }
+        }
+    }
+
+    if !changed {
+        return Ok(());
+    }
+
+    let serialized = serde_json::to_string_pretty(&settings)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    fs::write(known_path, serialized)?;
+    tracing::info!(
+        target: "agent_hooks",
+        path = %known_path.display(),
+        old = %old_path,
+        new = %expected_str,
+        "rewrote stale wt-local marketplace path (claude)",
+    );
+    Ok(())
+}
+
+// ---- Public entry point ---------------------------------------------------
+
+/// Run the auto-upgrade check on all three supported CLIs. Idempotent
+/// and best-effort: any failure logs and continues with the next CLI.
+///
+/// Trigger point: called once per `wta-master` startup on a blocking-pool
+/// thread. The fast-path cache (see module-level comment) keeps the
+/// common no-upgrade case under ~10ms; only the first run after an IT
+/// install / upgrade pays the per-CLI spawn cost.
+///
+/// Trigger-point caveat: the agent CLI master spawns concurrently may
+/// have already loaded its plugins by the time `plugin update` finishes
+/// writing files. The freshly upgraded hooks may not take effect until
+/// the next agent restart.
+pub fn upgrade_installed_hooks() {
+    let Some(home) = home_dir() else {
+        tracing::debug!(target: "agent_hooks", "no HOME/USERPROFILE; skipping upgrade check");
+        return;
+    };
+    let state_path = upgrade_state_path();
+    let mut state = state_path
+        .as_ref()
+        .map(|p| load_upgrade_state(p))
+        .unwrap_or_default();
+
+    let mut state_dirty = false;
+    for cli in CliKind::ALL.iter().copied() {
+        let bundle_version = read_bundled_version(cli);
+        let bundle_version_str = bundle_version.map(|v| v.to_string());
+
+        // Fast path: bundle version matches the cached entry → nothing
+        // changed since last time we checked this CLI. Skip without any
+        // further IO or spawn.
+        if bundle_version_str.is_some() && bundle_version_str.as_deref() == state.get(cli) {
+            tracing::debug!(
+                target: "agent_hooks",
+                cli = cli.name(),
+                bundle = ?bundle_version_str,
+                "fast-path cache hit; no upgrade needed",
+            );
+            continue;
+        }
+
+        // Cache miss (or first ever run): do the full per-CLI check.
+        upgrade_one_cli(cli, &home, bundle_version);
+
+        // Whether or not we actually upgraded, record the bundle version
+        // we just observed so future startups can fast-path.
+        state.set(cli, bundle_version_str);
+        state_dirty = true;
+    }
+
+    if state_dirty {
+        if let Some(path) = &state_path {
+            save_upgrade_state(path, &state);
+        }
+    }
+}
+
+/// Per-CLI upgrade entry: read installed state, decide, dispatch.
+fn upgrade_one_cli(cli: CliKind, home: &Path, bundle_version: Option<Version>) {
+    let installed = match cli {
+        CliKind::Copilot => read_installed_copilot(home),
+        CliKind::Claude => {
+            // `claude plugin list --json` requires the CLI on PATH; if
+            // it isn't, treat as "not installed" rather than spawning.
+            if which::which("claude").is_err() {
+                None
+            } else {
+                read_installed_claude()
+            }
+        }
+        CliKind::Gemini => read_installed_gemini(home),
+    };
+
+    let current_bundle_dir = bundle::resolve_cli_dir(cli);
+    let action = decide_upgrade(
+        cli,
+        bundle_version,
+        installed.as_ref(),
+        current_bundle_dir.as_deref(),
+    );
+
+    tracing::info!(
+        target: "agent_hooks",
+        cli = cli.name(),
+        installed_version = ?installed.as_ref().and_then(|i| i.version),
+        bundle_version = ?bundle_version,
+        action = ?action,
+        "upgrade decision",
+    );
+
+    match action {
+        UpgradeAction::Skip(_) => {}
+        UpgradeAction::UpdatePlugin => match cli {
+            CliKind::Copilot => upgrade_copilot(home),
+            CliKind::Claude => upgrade_claude(home),
+            CliKind::Gemini => unreachable!("UpdatePlugin never returned for Gemini"),
+        },
+        UpgradeAction::GeminiUpdateInPlace => upgrade_gemini_in_place(),
+        UpgradeAction::GeminiReinstall => upgrade_gemini_reinstall(home),
+    }
+}
+
+fn upgrade_copilot(home: &Path) {
+    let Some(bundle_dir) = bundle::resolve_cli_dir(CliKind::Copilot) else {
+        tracing::warn!(target: "copilot_hooks", "bundle unresolvable; cannot upgrade");
+        return;
+    };
+    let settings_path = home.join(".copilot").join("settings.json");
+    if let Err(e) = cleanup_stale_copilot_marketplace(&settings_path, &bundle_dir) {
+        tracing::warn!(
+            target: "copilot_hooks",
+            err = %e,
+            "cleanup_stale_copilot_marketplace failed; continuing",
+        );
+    }
+    let plugin_ref = format!("{}@{}", PLUGIN_NAME, MARKETPLACE_NAME);
+    if let Err(e) = run_plugin_cli(
+        "copilot",
+        &["plugin", "update", &plugin_ref],
+        "copilot_hooks",
+        &[],
+    ) {
+        tracing::warn!(
+            target: "copilot_hooks",
+            err = %e,
+            plugin = %plugin_ref,
+            "copilot plugin update failed",
+        );
+    }
+}
+
+fn upgrade_claude(home: &Path) {
+    let Some(bundle_dir) = bundle::resolve_cli_dir(CliKind::Claude) else {
+        tracing::warn!(target: "agent_hooks", "claude bundle unresolvable; cannot upgrade");
+        return;
+    };
+    // Re-stage if bundle lives under WindowsApps; the staged path is
+    // what we'll rewrite into known_marketplaces.json below.
+    let staged = maybe_stage_bundle_for_claude(&bundle_dir);
+    let expected_source = staged.as_deref().unwrap_or(&bundle_dir);
+
+    let known_path = home
+        .join(".claude")
+        .join("plugins")
+        .join("known_marketplaces.json");
+    if let Err(e) = cleanup_stale_claude_marketplace(&known_path, expected_source) {
+        tracing::warn!(
+            target: "agent_hooks",
+            err = %e,
+            "cleanup_stale_claude_marketplace failed; continuing",
+        );
+    }
+
+    let plugin_ref = format!("{}@{}", PLUGIN_NAME, MARKETPLACE_NAME);
+    if let Err(e) = run_plugin_cli(
+        "claude",
+        &["plugin", "update", &plugin_ref],
+        "agent_hooks",
+        &[],
+    ) {
+        tracing::warn!(
+            target: "agent_hooks",
+            err = %e,
+            plugin = %plugin_ref,
+            "claude plugin update failed",
+        );
+    }
+}
+
+fn upgrade_gemini_in_place() {
+    // `extensions update` upstream yargs does NOT accept `--consent` /
+    // `--skip-settings` (those are install-only flags). Keep
+    // GEMINI_CLI_TRUST_WORKSPACE which is honored as a generic
+    // headless-mode signal.
+    if let Err(e) = run_plugin_cli_with_env(
+        "gemini",
+        &["extensions", "update", GEMINI_EXTENSION_DIR_NAME],
+        &[("GEMINI_CLI_TRUST_WORKSPACE", "true")],
+        "gemini_hooks",
+        &[],
+    ) {
+        tracing::warn!(
+            target: "gemini_hooks",
+            err = %e,
+            "gemini extensions update failed; user can re-trigger via Settings UI",
+        );
+    }
+}
+
+/// Gemini reinstall path used when the recorded install source is
+/// stale (typical after an MSIX version-dir bump). Captures the
+/// `isActive` state via `gemini extensions list -o json` before
+/// uninstall so we can restore the disabled flag after reinstall.
+fn upgrade_gemini_reinstall(home: &Path) {
+    // 1. Capture enabled/disabled state. If the list spawn fails, assume
+    //    enabled (the post-install default); we'd rather re-enable
+    //    something the user disabled than leave them with a broken
+    //    extension across an MSIX upgrade.
+    let was_enabled = match run_plugin_cli_capture("gemini", &["extensions", "list", "-o", "json"])
+    {
+        Ok(o) if o.success => {
+            let payload = if !o.stdout.trim().is_empty() {
+                &o.stdout
+            } else {
+                &o.stderr
+            };
+            parse_gemini_extensions_list_json(payload)
+                .map(|p| p.enabled)
+                .unwrap_or(true)
+        }
+        _ => true,
+    };
+
+    // 2. Uninstall — tolerate "extension not found" idempotency.
+    if let Err(e) = run_plugin_cli(
+        "gemini",
+        &["extensions", "uninstall", GEMINI_EXTENSION_DIR_NAME],
+        "gemini_hooks",
+        &["extension not found", "successfully uninstalled"],
+    ) {
+        tracing::warn!(
+            target: "gemini_hooks",
+            err = %e,
+            "gemini extensions uninstall (pre-reinstall) failed; trying install anyway",
+        );
+    }
+
+    // 3. Reinstall pointing at the current bundle dir. Reuse the
+    //    existing install flow so we pick up the same staging /
+    //    consent / libuv-crash tolerances.
+    install_for_gemini(home);
+
+    // 4. Restore disabled state if needed.
+    if !was_enabled {
+        if let Err(e) = run_plugin_cli(
+            "gemini",
+            &["extensions", "disable", GEMINI_EXTENSION_DIR_NAME],
+            "gemini_hooks",
+            &[],
+        ) {
+            tracing::warn!(
+                target: "gemini_hooks",
+                err = %e,
+                "gemini extensions disable (restore user state) failed",
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -3622,5 +4428,489 @@ Registered marketplaces:
         assert!(v2.get("marketplace_path").is_none());
         // marketplace_path_valid is always present (it's a bool, not Option).
         assert!(v2.get("marketplace_path_valid").is_some());
+    }
+
+    // ---- auto-upgrade: Version parser & ordering -----------------------
+
+    #[test]
+    fn version_parse_accepts_plain_semver() {
+        let v: Version = "0.1.1".parse().unwrap();
+        assert_eq!(v, Version { major: 0, minor: 1, patch: 1 });
+        let v: Version = "1.10.2".parse().unwrap();
+        assert_eq!(v, Version { major: 1, minor: 10, patch: 2 });
+    }
+
+    #[test]
+    fn version_parse_rejects_non_semver() {
+        assert!("0.1".parse::<Version>().is_err()); // too few segments
+        assert!("0.1.0.4".parse::<Version>().is_err()); // too many segments
+        assert!("0.1.0-rc1".parse::<Version>().is_err()); // prerelease
+        assert!("0.1.0+meta".parse::<Version>().is_err()); // build metadata
+        assert!("v0.1.0".parse::<Version>().is_err()); // leading char
+        assert!("".parse::<Version>().is_err());
+        assert!("abc".parse::<Version>().is_err());
+    }
+
+    #[test]
+    fn version_ordering_handles_double_digit_components() {
+        let a: Version = "0.1.10".parse().unwrap();
+        let b: Version = "0.1.2".parse().unwrap();
+        assert!(a > b);
+        let c: Version = "1.0.0".parse().unwrap();
+        let d: Version = "0.99.99".parse().unwrap();
+        assert!(c > d);
+        let e: Version = "0.1.1".parse().unwrap();
+        let f: Version = "0.1.1".parse().unwrap();
+        assert!(e == f);
+        assert!(!(e < f));
+    }
+
+    #[test]
+    fn version_display_round_trips() {
+        let s = "1.2.3";
+        let v: Version = s.parse().unwrap();
+        assert_eq!(v.to_string(), s);
+    }
+
+    // ---- auto-upgrade: read_version_field ------------------------------
+
+    #[test]
+    fn read_version_field_parses_plugin_json() {
+        let dir = unique_dir("read-version-ok");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("manifest.json");
+        fs::write(
+            &path,
+            r#"{"name":"wt-agent-hooks","version":"0.1.1","other":"ignored"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            read_version_field(&path),
+            Some("0.1.1".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn read_version_field_returns_none_on_garbage_or_missing() {
+        let dir = unique_dir("read-version-bad");
+        fs::create_dir_all(&dir).unwrap();
+        let missing = dir.join("missing.json");
+        assert!(read_version_field(&missing).is_none());
+
+        let bad_json = dir.join("bad.json");
+        fs::write(&bad_json, "not json").unwrap();
+        assert!(read_version_field(&bad_json).is_none());
+
+        let no_version = dir.join("no-ver.json");
+        fs::write(&no_version, r#"{"name":"foo"}"#).unwrap();
+        assert!(read_version_field(&no_version).is_none());
+
+        let bad_version = dir.join("bad-ver.json");
+        fs::write(&bad_version, r#"{"version":"0.1.0-rc1"}"#).unwrap();
+        assert!(read_version_field(&bad_version).is_none());
+    }
+
+    // ---- auto-upgrade: read_installed_copilot --------------------------
+
+    #[test]
+    fn read_installed_copilot_picks_marketplace_qualified_entry() {
+        let home = unique_dir("copilot-installed");
+        let cfg_dir = home.join(".copilot");
+        fs::create_dir_all(&cfg_dir).unwrap();
+        fs::write(
+            cfg_dir.join("config.json"),
+            r#"// User settings belong in settings.json.
+{
+  "installedPlugins": [
+    { "name": "wt-agent-hooks", "marketplace": "wt-local",
+      "version": "0.1.0", "enabled": true,
+      "cache_path": "..." },
+    { "name": "wt-agent-hooks", "marketplace": "some-other",
+      "version": "9.9.9", "enabled": true }
+  ]
+}"#,
+        )
+        .unwrap();
+
+        let info = read_installed_copilot(&home).unwrap();
+        // Must pick the wt-local entry, not the other marketplace's
+        assert_eq!(info.version, Some("0.1.0".parse().unwrap()));
+        assert!(info.enabled);
+    }
+
+    #[test]
+    fn read_installed_copilot_respects_disabled_flag() {
+        let home = unique_dir("copilot-disabled");
+        let cfg_dir = home.join(".copilot");
+        fs::create_dir_all(&cfg_dir).unwrap();
+        fs::write(
+            cfg_dir.join("config.json"),
+            r#"{
+  "installedPlugins": [
+    { "name": "wt-agent-hooks", "marketplace": "wt-local",
+      "version": "0.1.1", "enabled": false }
+  ]
+}"#,
+        )
+        .unwrap();
+        let info = read_installed_copilot(&home).unwrap();
+        assert!(!info.enabled);
+    }
+
+    #[test]
+    fn read_installed_copilot_returns_none_when_not_installed() {
+        let home = unique_dir("copilot-empty");
+        let cfg_dir = home.join(".copilot");
+        fs::create_dir_all(&cfg_dir).unwrap();
+        fs::write(cfg_dir.join("config.json"), r#"{"installedPlugins":[]}"#).unwrap();
+        assert!(read_installed_copilot(&home).is_none());
+    }
+
+    // ---- auto-upgrade: read_installed_gemini ---------------------------
+
+    #[test]
+    fn read_installed_gemini_reads_both_files() {
+        let home = unique_dir("gemini-installed");
+        let ext_dir = gemini_extension_dir(&home);
+        fs::create_dir_all(&ext_dir).unwrap();
+        fs::write(
+            ext_dir.join("gemini-extension.json"),
+            r#"{"name":"wt-agent-hooks","version":"0.1.0"}"#,
+        )
+        .unwrap();
+        let bundle_src = unique_dir("gemini-bundle-src");
+        fs::create_dir_all(&bundle_src).unwrap();
+        fs::write(
+            ext_dir.join(".gemini-extension-install.json"),
+            format!(
+                r#"{{"type":"local","source":{}}}"#,
+                serde_json::Value::String(bundle_src.display().to_string())
+            ),
+        )
+        .unwrap();
+
+        let info = read_installed_gemini(&home).unwrap();
+        assert_eq!(info.version, Some("0.1.0".parse().unwrap()));
+        assert_eq!(info.gemini_type.as_deref(), Some("local"));
+        assert_eq!(info.gemini_source.as_deref(), Some(bundle_src.as_path()));
+    }
+
+    #[test]
+    fn read_installed_gemini_returns_none_when_no_manifest() {
+        let home = unique_dir("gemini-empty");
+        assert!(read_installed_gemini(&home).is_none());
+    }
+
+    #[test]
+    fn read_installed_gemini_tolerates_missing_install_metadata() {
+        let home = unique_dir("gemini-no-install-meta");
+        let ext_dir = gemini_extension_dir(&home);
+        fs::create_dir_all(&ext_dir).unwrap();
+        fs::write(
+            ext_dir.join("gemini-extension.json"),
+            r#"{"name":"wt-agent-hooks","version":"0.1.0"}"#,
+        )
+        .unwrap();
+
+        let info = read_installed_gemini(&home).unwrap();
+        assert_eq!(info.version, Some("0.1.0".parse().unwrap()));
+        assert!(info.gemini_source.is_none());
+        assert!(info.gemini_type.is_none());
+    }
+
+    // ---- auto-upgrade: decide_upgrade ----------------------------------
+
+    fn installed(version: &str, enabled: bool) -> InstalledInfo {
+        InstalledInfo {
+            version: Some(version.parse().unwrap()),
+            enabled,
+            gemini_source: None,
+            gemini_type: None,
+        }
+    }
+
+    #[test]
+    fn decide_skip_when_not_installed() {
+        let a = decide_upgrade(
+            CliKind::Copilot,
+            Some("0.1.1".parse().unwrap()),
+            None,
+            None,
+        );
+        assert_eq!(a, UpgradeAction::Skip(SkipReason::NotInstalled));
+    }
+
+    #[test]
+    fn decide_skip_when_disabled() {
+        let info = installed("0.1.0", false);
+        let a = decide_upgrade(
+            CliKind::Copilot,
+            Some("0.1.1".parse().unwrap()),
+            Some(&info),
+            None,
+        );
+        assert_eq!(a, UpgradeAction::Skip(SkipReason::Disabled));
+    }
+
+    #[test]
+    fn decide_skip_when_up_to_date_or_newer() {
+        let info = installed("0.1.1", true);
+        let a = decide_upgrade(
+            CliKind::Copilot,
+            Some("0.1.1".parse().unwrap()),
+            Some(&info),
+            None,
+        );
+        assert_eq!(a, UpgradeAction::Skip(SkipReason::UpToDate));
+
+        // Installed newer than bundle — also skip; never downgrade.
+        let info = installed("0.2.0", true);
+        let a = decide_upgrade(
+            CliKind::Copilot,
+            Some("0.1.1".parse().unwrap()),
+            Some(&info),
+            None,
+        );
+        assert_eq!(a, UpgradeAction::Skip(SkipReason::UpToDate));
+    }
+
+    #[test]
+    fn decide_skip_when_bundle_or_installed_version_unknown() {
+        // Unknown bundle version → conservative skip.
+        let info = installed("0.1.0", true);
+        let a = decide_upgrade(CliKind::Copilot, None, Some(&info), None);
+        assert_eq!(a, UpgradeAction::Skip(SkipReason::UnknownBundleVersion));
+
+        // Installed but version unparseable → conservative skip.
+        let info = InstalledInfo {
+            version: None,
+            enabled: true,
+            gemini_source: None,
+            gemini_type: None,
+        };
+        let a = decide_upgrade(
+            CliKind::Copilot,
+            Some("0.1.1".parse().unwrap()),
+            Some(&info),
+            None,
+        );
+        assert_eq!(a, UpgradeAction::Skip(SkipReason::UnknownInstalledVersion));
+    }
+
+    #[test]
+    fn decide_copilot_and_claude_upgrade_via_update_plugin() {
+        let info = installed("0.1.0", true);
+        for cli in [CliKind::Copilot, CliKind::Claude] {
+            let a = decide_upgrade(
+                cli,
+                Some("0.1.1".parse().unwrap()),
+                Some(&info),
+                None,
+            );
+            assert_eq!(a, UpgradeAction::UpdatePlugin, "cli={cli:?}");
+        }
+    }
+
+    #[test]
+    fn decide_gemini_in_place_when_source_under_current_bundle() {
+        let bundle_dir = unique_dir("gemini-bundle-current");
+        let nested_src = bundle_dir.join("nested").join("inner");
+        fs::create_dir_all(&nested_src).unwrap();
+        let info = InstalledInfo {
+            version: Some("0.1.0".parse().unwrap()),
+            enabled: true,
+            gemini_source: Some(nested_src.clone()),
+            gemini_type: Some("local".into()),
+        };
+        let a = decide_upgrade(
+            CliKind::Gemini,
+            Some("0.1.1".parse().unwrap()),
+            Some(&info),
+            Some(&bundle_dir),
+        );
+        assert_eq!(a, UpgradeAction::GeminiUpdateInPlace);
+    }
+
+    #[test]
+    fn decide_gemini_reinstall_when_source_stale() {
+        let bundle_dir = unique_dir("gemini-bundle-new");
+        fs::create_dir_all(&bundle_dir).unwrap();
+        // Source points at a path that doesn't exist on disk.
+        let stale_src = unique_dir("gemini-stale-src");
+        let info = InstalledInfo {
+            version: Some("0.1.0".parse().unwrap()),
+            enabled: true,
+            gemini_source: Some(stale_src),
+            gemini_type: Some("local".into()),
+        };
+        let a = decide_upgrade(
+            CliKind::Gemini,
+            Some("0.1.1".parse().unwrap()),
+            Some(&info),
+            Some(&bundle_dir),
+        );
+        assert_eq!(a, UpgradeAction::GeminiReinstall);
+    }
+
+    #[test]
+    fn decide_gemini_reinstall_when_type_is_not_local() {
+        let bundle_dir = unique_dir("gemini-bundle-git");
+        let inside = bundle_dir.join("inside");
+        fs::create_dir_all(&inside).unwrap();
+        let info = InstalledInfo {
+            version: Some("0.1.0".parse().unwrap()),
+            enabled: true,
+            gemini_source: Some(inside),
+            gemini_type: Some("git".into()),
+        };
+        let a = decide_upgrade(
+            CliKind::Gemini,
+            Some("0.1.1".parse().unwrap()),
+            Some(&info),
+            Some(&bundle_dir),
+        );
+        assert_eq!(a, UpgradeAction::GeminiReinstall);
+    }
+
+    // ---- auto-upgrade: state file --------------------------------------
+
+    #[test]
+    fn upgrade_state_round_trips_through_disk() {
+        let dir = unique_dir("upgrade-state-roundtrip");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("hooks-upgrade-state.json");
+
+        let mut s = UpgradeState::default();
+        s.set(CliKind::Copilot, Some("0.1.1".into()));
+        s.set(CliKind::Claude, Some("0.1.1".into()));
+        s.set(CliKind::Gemini, Some("0.1.2".into()));
+        save_upgrade_state(&path, &s);
+
+        let loaded = load_upgrade_state(&path);
+        assert_eq!(loaded.get(CliKind::Copilot), Some("0.1.1"));
+        assert_eq!(loaded.get(CliKind::Claude), Some("0.1.1"));
+        assert_eq!(loaded.get(CliKind::Gemini), Some("0.1.2"));
+    }
+
+    #[test]
+    fn upgrade_state_load_returns_default_on_missing_or_bad_file() {
+        let dir = unique_dir("upgrade-state-bad");
+        fs::create_dir_all(&dir).unwrap();
+        let missing = dir.join("missing.json");
+        let s = load_upgrade_state(&missing);
+        assert!(s.get(CliKind::Copilot).is_none());
+
+        let garbage = dir.join("garbage.json");
+        fs::write(&garbage, "not json").unwrap();
+        let s = load_upgrade_state(&garbage);
+        assert!(s.get(CliKind::Copilot).is_none());
+    }
+
+    #[test]
+    fn upgrade_state_omits_none_entries() {
+        let mut s = UpgradeState::default();
+        s.set(CliKind::Copilot, Some("0.1.1".into()));
+        let v = s.to_json();
+        let obj = v.as_object().unwrap();
+        assert!(obj.contains_key("copilot"));
+        assert!(!obj.contains_key("claude"));
+        assert!(!obj.contains_key("gemini"));
+    }
+
+    // ---- auto-upgrade: cleanup_stale_claude_marketplace ----------------
+
+    #[test]
+    fn cleanup_stale_claude_marketplace_noop_when_file_missing() {
+        let dir = unique_dir("claude-cleanup-missing");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("known_marketplaces.json");
+        let expected = unique_dir("claude-cleanup-expected");
+        cleanup_stale_claude_marketplace(&path, &expected).unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn cleanup_stale_claude_marketplace_rewrites_source_path() {
+        let dir = unique_dir("claude-cleanup-rewrite");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("known_marketplaces.json");
+        let stale = unique_dir("claude-stale-bundle");
+        let known = serde_json::json!({
+            MARKETPLACE_NAME: {
+                "source": {
+                    "source": "directory",
+                    "path": stale.display().to_string()
+                },
+                "installLocation": stale.display().to_string()
+            }
+        });
+        fs::write(&path, serde_json::to_string_pretty(&known).unwrap()).unwrap();
+
+        let expected = unique_dir("claude-fresh-bundle");
+        cleanup_stale_claude_marketplace(&path, &expected).unwrap();
+
+        let rewritten: Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let entry = rewritten.get(MARKETPLACE_NAME).unwrap();
+        assert_eq!(
+            entry["source"]["path"].as_str().unwrap(),
+            expected.display().to_string()
+        );
+        assert_eq!(
+            entry["installLocation"].as_str().unwrap(),
+            expected.display().to_string()
+        );
+    }
+
+    #[test]
+    fn cleanup_stale_claude_marketplace_noop_when_path_already_matches() {
+        let dir = unique_dir("claude-cleanup-noop");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("known_marketplaces.json");
+        let expected = unique_dir("claude-current-bundle");
+        let known = serde_json::json!({
+            MARKETPLACE_NAME: {
+                "source": {
+                    "source": "directory",
+                    "path": expected.display().to_string()
+                }
+            }
+        });
+        let original = serde_json::to_string_pretty(&known).unwrap();
+        fs::write(&path, &original).unwrap();
+        cleanup_stale_claude_marketplace(&path, &expected).unwrap();
+        // File should be byte-identical (no rewrite).
+        assert_eq!(fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn cleanup_stale_claude_marketplace_skips_github_source() {
+        let dir = unique_dir("claude-cleanup-github");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("known_marketplaces.json");
+        let known = serde_json::json!({
+            MARKETPLACE_NAME: {
+                "source": { "source": "github", "repo": "owner/repo" }
+            }
+        });
+        let original = serde_json::to_string_pretty(&known).unwrap();
+        fs::write(&path, &original).unwrap();
+        let expected = unique_dir("claude-some-dir");
+        cleanup_stale_claude_marketplace(&path, &expected).unwrap();
+        // Should not touch github-shaped sources.
+        assert_eq!(fs::read_to_string(&path).unwrap(), original);
+    }
+
+    // ---- auto-upgrade: gemini_source_under_bundle ---------------------
+
+    #[test]
+    fn gemini_source_under_bundle_walks_ancestors() {
+        let bundle = unique_dir("gemini-under-bundle");
+        let nested = bundle.join("a").join("b").join("c");
+        fs::create_dir_all(&nested).unwrap();
+        assert!(gemini_source_under_bundle(&nested, &bundle));
+        assert!(gemini_source_under_bundle(&bundle, &bundle)); // equality
+        let outside = unique_dir("gemini-outside");
+        assert!(!gemini_source_under_bundle(&outside, &bundle));
     }
 }

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -2278,7 +2278,7 @@ fn paths_equivalent(a: &Path, b: &Path) -> bool {
 // Gemini: peek at `~/.gemini/extensions/wt-agent-hooks/.gemini-extension-install.json`
 // for the recorded `{type, source}`. If `source` is under the current bundle
 // dir AND still a directory, `gemini extensions update` re-pulls from there
-// cleanly. Otherwise (post-MSIX-version-dir-bump symptom — Gemini's
+// cleanly. Otherwise, (post-MSIX-version-dir-bump symptom — Gemini's
 // `checkForExtensionUpdate` silently returns `NOT_UPDATABLE`), fall back to
 // uninstall + install. To preserve user intent, we capture `isActive` from
 // `gemini extensions list -o json` before uninstall and `extensions disable`

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -2885,7 +2885,21 @@ fn upgrade_one_cli(cli: CliKind, home: &Path, bundle_version: Option<Version>) {
         UpgradeAction::UpdatePlugin => match cli {
             CliKind::Copilot => upgrade_copilot(home),
             CliKind::Claude => upgrade_claude(home),
-            CliKind::Gemini => unreachable!("UpdatePlugin never returned for Gemini"),
+            CliKind::Gemini => {
+                // Defensive: `decide_upgrade` is the only producer of
+                // `UpdatePlugin` and currently only returns it for
+                // Copilot/Claude — Gemini always routes to
+                // `GeminiUpdateInPlace` / `GeminiReinstall`. If a future
+                // refactor breaks that invariant we'd rather skip than
+                // panic on the blocking-pool thread (which would only be
+                // visible as a silent task failure to whoever cares to
+                // look). Log loudly so the inconsistency surfaces.
+                tracing::error!(
+                    target: "agent_hooks",
+                    cli = cli.name(),
+                    "decide_upgrade returned UpdatePlugin for Gemini; skipping (treat as bug)",
+                );
+            }
         },
         UpgradeAction::GeminiUpdateInPlace => upgrade_gemini_in_place(),
         UpgradeAction::GeminiReinstall => upgrade_gemini_reinstall(home),

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -1163,6 +1163,15 @@ pub async fn run_master_mode(cli: Cli, pipe_name: String) -> Result<()> {
         ));
     }
 
+    // Kick off the auto-upgrade check on a blocking-pool thread. Fire-and-
+    // forget — the agent CLI spawn below proceeds concurrently. Fast-path
+    // cache (see `agent_hooks_installer::upgrade_installed_hooks` doc) keeps
+    // the common no-upgrade case under ~10ms; only the first run after an
+    // IT install/upgrade does any per-CLI work. Caveat: when an upgrade is
+    // actually needed, the agent CLI process master is about to spawn may
+    // miss the new hooks until its next restart.
+    tokio::task::spawn_blocking(crate::agent_hooks_installer::upgrade_installed_hooks);
+
     let local_set = LocalSet::new();
     local_set
         .run_until(async move { run_master_loop(cli, pipe_name).await })

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -1170,7 +1170,28 @@ pub async fn run_master_mode(cli: Cli, pipe_name: String) -> Result<()> {
     // IT install/upgrade does any per-CLI work. Caveat: when an upgrade is
     // actually needed, the agent CLI process master is about to spawn may
     // miss the new hooks until its next restart.
-    tokio::task::spawn_blocking(crate::agent_hooks_installer::upgrade_installed_hooks);
+    //
+    // Wrap in `catch_unwind` so an unexpected panic inside the upgrade flow
+    // (or any of its transitive dependencies) doesn't get silently swallowed
+    // by tokio's fire-and-forget JoinHandle. Master keeps running either
+    // way; this just promotes the panic into a visible trace event.
+    tokio::task::spawn_blocking(|| {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+            crate::agent_hooks_installer::upgrade_installed_hooks,
+        ));
+        if let Err(panic) = result {
+            let msg = panic
+                .downcast_ref::<&'static str>()
+                .copied()
+                .or_else(|| panic.downcast_ref::<String>().map(|s| s.as_str()))
+                .unwrap_or("<non-string panic payload>");
+            tracing::error!(
+                target: "agent_hooks",
+                panic = %msg,
+                "upgrade_installed_hooks panicked; master continues",
+            );
+        }
+    });
 
     let local_set = LocalSet::new();
     local_set


### PR DESCRIPTION
## Summary

When IT is installed or upgraded, the bundled `wt-agent-hooks` plugin needs to re-land into any agent CLI the user already opted into (via Settings/FRE "Install hooks" or `wta hooks install`). PR #124 bumped the bundle 0.1.0 → 0.1.1 but only Copilot/Claude picked it up; **Gemini's `extensions install` short-circuited on "already installed" and existing Gemini users stayed stuck on the old `send-event.ps1`**.

This adds `agent_hooks_installer::upgrade_installed_hooks()`, fired once per `wta-master` startup on a blocking-pool thread.

## Trigger: bundle version is the upgrade signal

A tiny state file `<LocalCache>/IntelligentTerminal/hooks-upgrade-state.json` records the bundle version this wta process last saw per CLI:

```json
{ "copilot": "0.1.1", "claude": "0.1.1", "gemini": "0.1.1" }
```

At startup we read each CLI's bundle manifest (~5ms file IO) and compare. If every entry matches → return immediately, zero CLI spawns.

**Measured fast-path: 2.7ms across all three CLIs.**

Bundle versions ship inside MSIX, so they only change when the user installs/upgrades IT. The state file effectively makes the trigger _"every IT install/upgrade"_ without needing a cross-component upgrade signal from C++/MSIX. Crash-safe: missing/corrupt state file falls back to a full check.

## Opt-in only

Even on cache miss, CLIs that don't already have the plugin installed are skipped. Disabled plugins (`enabled: false`) are also skipped. The auto-upgrade never installs into a CLI the user hasn't already accepted.

## Per-CLI strategy

All three CLIs expose a real `update` subcommand (verified from upstream docs + source):

| CLI | Command | Pre-step |
|---|---|---|
| Copilot | `copilot plugin update <name>` | existing `cleanup_stale_copilot_marketplace` |
| Claude | `claude plugin update [name]` | **new** `cleanup_stale_claude_marketplace` (mirrors Copilot's — `known_marketplaces.json` stores stale source paths the same way) |
| Gemini | `gemini extensions update <name>` OR uninstall+install fallback | see below |

**Gemini source-stale fallback**: `extensions update` silently returns `NOT_UPDATABLE` when the recorded install source no longer exists (typical after an MSIX version-dir bump). We peek at `.gemini-extension-install.json` first: if `source` is still under the current bundle → `extensions update` in place; otherwise fall back to uninstall + install, preserving `isActive` via `gemini extensions disable` post-reinstall.

## Trigger-point caveat

The agent CLI master spawns concurrently may already be past its plugin-load step by the time `plugin update` writes the new files — so freshly upgraded hooks may not take effect until the next agent restart. Acceptable because blocking master startup on a Node-based `plugin update` (1-30s) would hurt every IT-upgrade boot.

## Testing

- ✅ 24 new unit tests (decision matrix, version parsing, state round-trip, claude cleanup) — all branches covered without CLI spawns
- ✅ Full wta suite: 589/589 passing
- ✅ Live verification on packaged debug build covered all 5 scenarios:

| # | Scenario | Result |
|---|---|---|
| A | Fast-path (no upgrade needed) | 2.7ms total, zero spawns ✅ |
| B | Copilot UpdatePlugin | `copilot plugin update` 0.1.0 → 0.1.1 ✅ |
| Claude UpdatePlugin | `cleanup_stale_claude_marketplace` rewrites `known_marketplaces.json`, `claude plugin update` succeeds ✅ |
| C | Gemini GeminiReinstall (highest-risk path) | captures isActive → uninstall (libuv crash tolerated) → reinstall ✅ |
| D | Opt-in protection | Uninstalled CLI gets `Skip(NotInstalled)`, never auto-reinstalled ✅ |
| E | Disabled state respected | `enabled:false` gets `Skip(Disabled)` even when bundle is newer ✅ |

Live verification logs from packaged build:
```
upgrade decision cli="copilot" installed=0.1.0 bundle=0.1.1 action=UpdatePlugin
copilot plugin update succeeded: Plugin "wt-agent-hooks@wt-local" updated successfully (v0.1.0 → v0.1.1)

upgrade decision cli="claude" installed=0.1.0 bundle=0.1.1 action=UpdatePlugin
rewrote stale wt-local marketplace path (claude)
claude plugin update succeeded: Plugin "wt-agent-hooks" updated from 0.1.0 to 0.1.1

upgrade decision cli="gemini" installed=0.1.0 bundle=0.1.1 action=GeminiReinstall
gemini extensions uninstall — "successfully uninstalled" (libuv crash handled)
gemini extensions install <bundle> succeeded
```

## Out of scope

- Auto-installing into CLIs the user hasn't opted into.
- Bumping the bundle version itself (PR #124's 0.1.1 stays; next bump uses this mechanism).
- Cleaning up Claude's `~/.claude/plugins/cache/wt-local/wt-agent-hooks/.orphaned_at` tombstones (pre-existing Claude GC behavior, separate concern).
