### PR TITLE
feat(wta): smooth streaming TUI output with typewriter reveal

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -988,6 +988,13 @@ pub struct DispatchedCommand {
 pub enum AppEvent {
     Key(KeyEvent),
     Tick,
+    /// High-frequency (~30Hz) reveal animation tick. Drives the typewriter
+    /// smoothing of the streaming agent response (advances `reveal_chars`).
+    /// Separate from `Tick` so we can run the reveal at 30fps without
+    /// quadrupling the spinner's full-frame flush rate: a `RevealTick` only
+    /// forces a redraw when there is unrevealed pending text on the current
+    /// tab (`has_reveal_backlog`).
+    RevealTick,
     Resize(u16, u16), // terminal resize (handled by ratatui)
     /// XAML focus on our hosting TermControl changed — true when the agent
     /// pane gained focus, false when it lost focus. Sourced from xterm
@@ -1315,6 +1322,13 @@ pub struct TabSession {
     // back to the spinner label derived from `turn` when None.
     pub progress_status: Option<String>,
     pub activity_frame: usize,
+    /// Typewriter reveal cursor: how many characters of the *user-visible*
+    /// streaming text are currently shown. The full text lives in
+    /// `turn.buffer()`; the renderer only emits the first `reveal_chars`
+    /// chars of it. Advanced toward the full length by `RevealTick`
+    /// (`advance_reveal`), reset to 0 when a new turn starts streaming, and
+    /// made irrelevant on finalize (the committed message renders in full).
+    pub reveal_chars: usize,
     pub timing_note: Option<String>,
     pub selection_visible_pending: bool,
 
@@ -3879,6 +3893,7 @@ impl App {
             AppEvent::SessionsChanged => "sessions_changed",
             AppEvent::AgentsSnapshotLoaded { .. } => "agents_snapshot_loaded",
             AppEvent::MasterMutationCompleted { .. } => "master_mutation_completed",
+            AppEvent::RevealTick => "reveal_tick",
         }
     }
 
@@ -3942,6 +3957,9 @@ impl App {
             AppEvent::Resize(w, h) => {
                 self.terminal_cols = w;
                 self.terminal_rows = h;
+            }
+            AppEvent::RevealTick => {
+                self.advance_reveal();
             }
             AppEvent::FocusChanged(focused) => {
                 self.pane_focused = focused;
@@ -5551,6 +5569,11 @@ impl App {
     fn event_requires_redraw(&self, event: &AppEvent) -> bool {
         match event {
             AppEvent::Tick => self.has_activity_indicator() || self.show_notification_banner,
+            // The reveal animation only needs a frame while there is still
+            // unrevealed pending text on the *visible* tab. When the reveal
+            // has caught up (or nothing is streaming) this is a cheap no-op
+            // tick that doesn't redraw — so idle/no-backlog costs nothing.
+            AppEvent::RevealTick => self.has_reveal_backlog(),
             AppEvent::AgentMessageChunk { .. } => true,
             AppEvent::DebugPipeMessage(_) => self.show_debug_panel,
             // History only affects the agent session view; chat doesn't read it.
@@ -5558,6 +5581,51 @@ impl App {
             // view is showing — pay the one frame.
             AppEvent::HistoricalSessionsLoaded(_) => true,
             _ => true,
+        }
+    }
+
+    /// Number of *user-visible* characters in a tab's streaming buffer, i.e.
+    /// the length of what the renderer would show in full. `None` when the
+    /// tab is not streaming visible prose.
+    fn tab_visible_stream_len(tab: &TabSession) -> Option<usize> {
+        let buf = tab.turn.buffer()?;
+        crate::ui::chat::user_visible_stream_text(buf).map(|t| t.chars().count())
+    }
+
+    /// True iff the current (visible) tab has streaming text that the reveal
+    /// cursor hasn't caught up to yet. Used to gate `RevealTick` redraws.
+    fn has_reveal_backlog(&self) -> bool {
+        let tab = self.current_tab();
+        matches!(Self::tab_visible_stream_len(tab), Some(len) if tab.reveal_chars < len)
+    }
+
+    /// Advance the typewriter reveal cursor on every streaming tab. The step
+    /// is *adaptive*: it grows with the backlog so the reveal can never fall
+    /// permanently behind a fast model — any backlog is drained within
+    /// `REVEAL_CATCHUP_FRAMES` ticks. Combined with the fact that finalize
+    /// commits the message in full (un-gated), this guarantees the smoothing
+    /// never increases the total time for the response to appear: it only
+    /// redistributes *when* characters show up within the streaming window.
+    fn advance_reveal(&mut self) {
+        // ~30fps tick. `REVEAL_MIN_STEP` is the floor so a slow trickle still
+        // animates; the `backlog / REVEAL_CATCHUP_FRAMES` term speeds up to
+        // match (and overtake) arrival, capping the visible lag at roughly
+        // `REVEAL_CATCHUP_FRAMES` ticks (~130ms).
+        const REVEAL_MIN_STEP: usize = 3;
+        const REVEAL_CATCHUP_FRAMES: usize = 4;
+        for tab in self.tab_sessions.values_mut() {
+            let Some(len) = Self::tab_visible_stream_len(tab) else {
+                continue;
+            };
+            if tab.reveal_chars >= len {
+                // Clamp down if the visible text shrank (e.g. a fenced JSON
+                // block replaced the streamed prose).
+                tab.reveal_chars = len;
+                continue;
+            }
+            let backlog = len - tab.reveal_chars;
+            let step = REVEAL_MIN_STEP.max(backlog / REVEAL_CATCHUP_FRAMES);
+            tab.reveal_chars = (tab.reveal_chars + step).min(len);
         }
     }
 
@@ -7164,6 +7232,8 @@ impl App {
                     prompt,
                     buf: text.to_string(),
                 };
+                // New turn: restart the typewriter reveal from the top.
+                tab.reveal_chars = 0;
                 true
             }
             // Thought chunk while Submitted: enter Streaming with empty buf.
@@ -7177,6 +7247,7 @@ impl App {
                     prompt,
                     buf: String::new(),
                 };
+                tab.reveal_chars = 0;
                 false
             }
             // Streaming → Streaming, append message chunks only.

--- a/tools/wta/src/event.rs
+++ b/tools/wta/src/event.rs
@@ -10,6 +10,15 @@ pub async fn read_crossterm_events(tx: mpsc::UnboundedSender<AppEvent>) {
     let mut ticker = time::interval(Duration::from_millis(120));
     ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
+    // Separate, higher-frequency ticker (~30fps) that drives only the
+    // typewriter reveal animation (`AppEvent::RevealTick`). Kept distinct from
+    // the 120ms spinner `Tick` so the reveal can run smoothly without
+    // quadrupling spinner full-frame flushes — a `RevealTick` only forces a
+    // redraw when there is unrevealed pending text (see
+    // `App::event_requires_redraw` / `has_reveal_backlog`).
+    let mut reveal_ticker = time::interval(Duration::from_millis(33));
+    reveal_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
     tracing::info!(target: "input", "crossterm reader task starting");
     let mut consecutive_errors = 0usize;
 
@@ -17,6 +26,12 @@ pub async fn read_crossterm_events(tx: mpsc::UnboundedSender<AppEvent>) {
         tokio::select! {
             _ = ticker.tick() => {
                 if tx.send(AppEvent::Tick).is_err() {
+                    tracing::info!(target: "input", "crossterm reader exiting: AppEvent channel closed");
+                    break;
+                }
+            }
+            _ = reveal_ticker.tick() => {
+                if tx.send(AppEvent::RevealTick).is_err() {
                     tracing::info!(target: "input", "crossterm reader exiting: AppEvent channel closed");
                     break;
                 }

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -387,13 +387,29 @@ fn pending_render_text(tab: &crate::app::TabSession) -> Option<Cow<'_, str>> {
 }
 
 fn build_pending_stream_lines<'a>(app: &App, wrap_width: usize) -> Vec<Line<'a>> {
-    let Some(text) = pending_render_text(app.current_tab()) else {
+    let tab = app.current_tab();
+    let Some(text) = pending_render_text(tab) else {
         return Vec::new();
+    };
+    // Typewriter smoothing: only reveal the first `reveal_chars` characters of
+    // the streaming text. The reveal cursor is advanced toward the full length
+    // by the `RevealTick` animation (`App::advance_reveal`), turning the
+    // upstream ~90-char-every-~100ms bursts into a smooth character flow. The
+    // full text is always in `turn.buffer()`, and finalize commits it in full,
+    // so this never drops or delays the final content.
+    let revealed: Cow<'_, str> = {
+        let total = text.chars().count();
+        let shown = tab.reveal_chars.min(total);
+        if shown >= total {
+            text
+        } else {
+            Cow::Owned(text.chars().take(shown).collect())
+        }
     };
     let mut lines = Vec::new();
     push_dot_prefixed_lines(
         &mut lines,
-        &text,
+        &revealed,
         wrap_width,
         theme::DOT_AGENT,
         theme::AGENT_TEXT,


### PR DESCRIPTION
## Problem

The agent CLI streams responses in ~90-character chunks roughly every ~100ms (helper → master → agent CLI). The TUI rendered each chunk verbatim, so long responses appeared in visible bursts — "a few chars, pause, a few chars" — rather than flowing smoothly. (Investigated via log-driven tracing; the chunk granularity is upstream and not easily changed, so the fix is display-side.)

## Fix

Add a display-side **typewriter reveal**:

- `TabSession.reveal_chars` — how many characters of the *user-visible* streaming text are currently shown. The full text always lives in `turn.buffer()`; the renderer (`build_pending_stream_lines`) only emits the first `reveal_chars` chars.
- New **`AppEvent::RevealTick`** driven by a dedicated ~33ms (30fps) ticker in `event.rs`, kept separate from the 120ms spinner `Tick` so the spinner's full-frame flushes are **not** quadrupled.
- `App::advance_reveal` advances the cursor with an **adaptive** step `max(3, backlog/4)`: the larger the backlog the faster it reveals, so it always keeps up with a fast model and any backlog drains within ~4 frames (~130ms).
- `event_requires_redraw(RevealTick) = has_reveal_backlog()` — a RevealTick only forces a redraw while there's still unrevealed text on the visible tab, so idle / caught-up ticks are a near-zero-cost no-op.

## Does this make responses take longer to appear? No.

Finalize commits the message in full (un-gated by `reveal_chars`), and the adaptive step guarantees the reveal catches up before/at end-of-turn. So the **total** time for a response to appear is unchanged — only the *within-stream* distribution of when characters show up is redistributed into a smooth flow. A naive fixed-slow rate (which *would* add lag) is explicitly avoided.

## Tuning knobs

- `event.rs` reveal ticker interval: `33ms`
- `advance_reveal`: `REVEAL_MIN_STEP=3` (trickle floor), `REVEAL_CATCHUP_FRAMES=4` (backlog drain frames)

## Testing

- `cargo build` (bare + `x86_64-pc-windows-msvc` targets) — both green
- `cargo test --bin wta` — 605 passed, 0 failed
- Manual: streamed long responses now flow character-by-character instead of in bursts