### PR TITLE
fix(wta): rebuild child PATH so mid-session-installed agent CLIs resolve

### DIFF
--- a/tools/wta/src/agent_check.rs
+++ b/tools/wta/src/agent_check.rs
@@ -492,7 +492,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn merge_paths_prefers_fresh_and_dedups_case_insensitively() {
+    fn merge_paths_prefers_fresh_and_removes_duplicates_case_insensitively() {
         let fresh = r"C:\WinGet\Links;C:\Windows\System32";
         let current = r"C:\windows\system32\;C:\Runtime\Only";
         let merged = merge_paths(fresh, current);

--- a/tools/wta/src/agent_check.rs
+++ b/tools/wta/src/agent_check.rs
@@ -195,6 +195,45 @@ pub fn refresh_path() {
     }
 }
 
+/// Build the PATH a freshly-spawned child process should inherit.
+///
+/// Windows Terminal (and therefore the `wta-master` / `wta` children it
+/// spawns) captures its environment block at process start. When an agent
+/// CLI is installed *after* WT is already running — e.g. the FRE
+/// winget-installs `copilot` mid-session — our inherited PATH stays stale,
+/// so `CreateProcess` (or `cmd /c <cli>`) can't resolve the bare CLI name
+/// and the spawn fails with "is not recognized", which surfaces as an
+/// immediate ACP-initialize failure. Rebuild PATH from the registry
+/// (system + user) so a just-installed CLI resolves without a full WT
+/// restart, merging in the current process PATH so no runtime-only entry
+/// is lost. Returns `None` when the registry read yields nothing usable.
+pub fn spawn_path() -> Option<String> {
+    let fresh = fresh_path();
+    if fresh.is_empty() {
+        return None;
+    }
+    let current = std::env::var("PATH").unwrap_or_default();
+    Some(merge_paths(&fresh, &current))
+}
+
+/// Concatenate two `;`-separated PATH strings, preferring `fresh` ordering
+/// and dropping case-insensitive duplicates (ignoring a trailing
+/// backslash). Skips empty segments.
+fn merge_paths(fresh: &str, current: &str) -> String {
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut out: Vec<&str> = Vec::new();
+    for part in fresh.split(';').chain(current.split(';')) {
+        if part.is_empty() {
+            continue;
+        }
+        let key = part.trim_end_matches('\\').to_ascii_lowercase();
+        if seen.insert(key) {
+            out.push(part);
+        }
+    }
+    out.join(";")
+}
+
 // ─── Composite functions ────────────────────────────────────────────────────
 
 /// Check a single agent: find executable + check credential.
@@ -446,4 +485,34 @@ fn expand_env_vars(s: &str) -> Option<String> {
     let len = (written as usize).saturating_sub(1);
     let os_str = std::ffi::OsString::from_wide(&out[..len]);
     Some(os_str.to_string_lossy().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_paths_prefers_fresh_and_dedups_case_insensitively() {
+        let fresh = r"C:\WinGet\Links;C:\Windows\System32";
+        let current = r"C:\windows\system32\;C:\Runtime\Only";
+        let merged = merge_paths(fresh, current);
+        assert_eq!(
+            merged,
+            r"C:\WinGet\Links;C:\Windows\System32;C:\Runtime\Only"
+        );
+    }
+
+    #[test]
+    fn merge_paths_skips_empty_segments() {
+        let merged = merge_paths(r"C:\A;;C:\B", r";C:\B;");
+        assert_eq!(merged, r"C:\A;C:\B");
+    }
+
+    #[test]
+    fn merge_paths_keeps_runtime_only_entries() {
+        // An entry present only in the live process PATH (not the registry)
+        // must survive so we never regress a runtime-injected directory.
+        let merged = merge_paths(r"C:\Reg", r"C:\Reg;C:\OnlyAtRuntime");
+        assert_eq!(merged, r"C:\Reg;C:\OnlyAtRuntime");
+    }
 }

--- a/tools/wta/src/protocol/acp/spawn.rs
+++ b/tools/wta/src/protocol/acp/spawn.rs
@@ -77,6 +77,20 @@ pub(crate) fn spawn_agent_process(agent_cmd: &str, cwd: Option<&Path>) -> Result
     // ACP host. Scrub unconditionally; other agents don't care.
     cmd.env_remove("CLAUDECODE");
 
+    // Give the agent CLI a PATH rebuilt from the Windows registry. Windows
+    // Terminal — and thus this wta-master / wta child — snapshots its
+    // environment at start, so an agent CLI installed mid-session (e.g. the
+    // FRE winget-installing `copilot` while WT is already running) is invisible
+    // to our inherited PATH. That makes `cmd /c copilot` (or a bare spawn) fail
+    // with "is not recognized", which the master reports as an immediate
+    // ACP-initialize failure. Setting the child's PATH here fixes resolution
+    // for both the `cmd /c` and direct-spawn cases without requiring a full WT
+    // restart. (Recent Rust resolves the program name against the child env's
+    // PATH when one is provided.)
+    if let Some(path) = crate::agent_check::spawn_path() {
+        cmd.env("PATH", path);
+    }
+
     // Tell the agent CLI's hook scripts (`send-event.ps1`, inherited via the
     // CLI → node → powershell process chain) where to write their diagnostic
     // trace. PowerShell can't resolve our package-private log dir on its own


### PR DESCRIPTION
Windows Terminal snapshots its environment block at process start, so the wta-master / wta children it spawns inherit a stale PATH. An agent CLI installed after WT is already running (e.g. the FRE winget-installing `copilot` mid-session) is invisible to that inherited PATH, so spawning `cmd /c copilot` (or a bare spawn) fails with "is not recognized" and surfaces as an immediate ACP-initialize failure.

Add agent_check::spawn_path(), which rebuilds PATH from the registry (system + user) and merges in the live process PATH so no runtime-only entry is lost, and apply it to the agent process env in spawn_agent_process. This lets a just-installed CLI resolve without a full WT restart.

## Summary of the Pull Request

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [X] Closes #129
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
