### PR TITLE
Inherit settings.json from Microsoft Terminal on first launch (#130)

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -1212,13 +1212,14 @@ try
     auto settingsString = til::io::read_file_as_utf8_string_if_exists(_settingsPath(), false, &lastWriteTime);
     auto firstTimeSetup = settingsString.empty();
 
-    // If it's the firstTimeSetup and a preview build, then try to
-    // read settings.json from the Release stable file path if it exists.
+    // If it's the firstTimeSetup and a shipped build, then try to
+    // read settings.json from the stable Microsoft Windows Terminal file
+    // path if it exists (GH#130: shipped Intelligent Terminal also migrates).
     // Otherwise use default settings file provided from original settings file
     bool releaseSettingExists = false;
     if (firstTimeSetup && !IsPortableMode())
     {
-#if defined(WT_BRANDING_PREVIEW) || defined(WT_BRANDING_CANARY)
+#if defined(WT_BRANDING_RELEASE) || defined(WT_BRANDING_PREVIEW) || defined(WT_BRANDING_CANARY)
         {
             try
             {

--- a/tools/wta/CUSTOMIZATION.md
+++ b/tools/wta/CUSTOMIZATION.md
@@ -4,8 +4,8 @@
 
 Edit `agentCliPath` in the Terminal settings file you are using.
 
-Packaged Windows Terminal:
-- `%LOCALAPPDATA%\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json`
+Packaged IntelligentTerminal:
+- `%LOCALAPPDATA%\Packages\Microsoft.IntelligentTerminal_8wekyb3d8bbwe\LocalState\settings.json`
 
 Portable/local IntelligentTerminal:
 - `%LOCALAPPDATA%\Programs\IntelligentTerminal\settings\settings.json`


### PR DESCRIPTION
## Summary

On first launch, **Intelligent Terminal** inherits the user's existing
**Microsoft Windows Terminal** `settings.json` — themes, fonts, key
bindings, profiles, and color schemes carry over automatically — so the
user lands in a familiar environment instead of a blank default.

Closes #130.

## Motivation

Users installing Intelligent Terminal alongside the stable Microsoft
Windows Terminal hit an empty, default-looking app on first run and have
to re-do every piece of personalization they already invested in WT.
Issue #130 asks for this to "just work."

## How it works

Upstream WT already had this logic for the Preview and Canary channels:
when `CascadiaSettings::LoadAll()` detects a first-run state (no
`settings.json` in the package's `LocalState`), it reads the stable
Microsoft Terminal's `settings.json` from
`%LOCALAPPDATA%\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\`
(cross-package via `KF_FLAG_NO_PACKAGE_REDIRECTION`) and re-serializes
it through IT's own settings model on the existing
`mustWriteToDisk = firstTimeSetup` path.

The previous gate was:

```cpp
#if defined(WT_BRANDING_PREVIEW) || defined(WT_BRANDING_CANARY)
```

Official Intelligent Terminal releases build with
`WindowsTerminalBranding=Release` (see `build/pipelines/ob-release.yml`
default), which maps to `WT_BRANDING_RELEASE` — so the shipped IT
product was excluded.

This PR adds `WT_BRANDING_RELEASE` to the gate:

```cpp
#if defined(WT_BRANDING_RELEASE) || defined(WT_BRANDING_PREVIEW) || defined(WT_BRANDING_CANARY)
```

`WT_BRANDING_DEV` remains intentionally excluded so engineering clean
installs don't silently pull in a developer's personal settings — same
behavior as before for Dev builds.

## Scope of change

- **One file**, `src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp`.
- Added `WT_BRANDING_RELEASE` to the existing `#if` predicate.
- Rewrote the surrounding comment to reference GH#130 and explain the
  Release/Preview/Canary scope and the Dev exclusion.
- No new UX, no toggle, no new setting, no schema change. Inheritance is
  a silent part of the existing first-run experience (FRE), gated by the
  existing `firstTimeSetup` flag (empty `settings.json`).

## Behavior

| Scenario | Result |
|---|---|
| Fresh install of shipped IT (Release branding), stable WT settings exist | IT inherits WT's `settings.json` on first launch |
| Fresh install of shipped IT, no stable WT installed | IT starts with the default `settings.json` (unchanged) |
| User deletes IT's `settings.json` to reset | IT re-inherits from WT (matches the prior Preview/Canary semantics) |
| Existing IT install with a populated `settings.json` | No-op — gated by `firstTimeSetup` |
| Portable mode | Skipped (existing `!IsPortableMode()` guard) |
| Local **Dev** build (`WT_BRANDING_DEV`) | Skipped — engineering clean installs do not auto-inherit |
| Stable WT `settings.json` malformed | Schema-tolerant parser ignores unknown fields; bad fields fall back to defaults |

## Validation

- Built `Microsoft.Terminal.Settings.ModelLib` locally — 0 errors.
- No new tests: this change widens an existing, upstream-tested
  predicate; behavior for Preview/Canary is unchanged, behavior for Dev
  is unchanged, behavior for Release becomes the same path Preview and
  Canary already exercise.

## PR Checklist

- [x] Closes #130
- [x] Tests added/passed — existing behavior; no test surface change
- [x] Documentation updated — n/a (no user-visible UX or setting added)
- [x] Schema updated — n/a (no schema change)
