### PR TITLE
fix(wta): reset refetch_in_flight on session view reopen so a lost ext_method response can't permanently lock the picker on Loading

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2980,6 +2980,26 @@ impl App {
             tab.current_view = View::Agents;
             tab.agents_view.snapshot = Some(Vec::new());
             tab.agents_view.dirty = false;
+            // Force-clear `refetch_in_flight`. If a prior request hung
+            // (ext_method response never returned — observed in the wild
+            // when something stalls the helper↔master pipe mid-flight),
+            // it would leave this flag stuck `true`. Every subsequent
+            // `schedule_agents_refetch_for_tab` then early-returns on the
+            // `refetch_in_flight` guard, so neither the 5s periodic tick
+            // nor a user-driven reopen can ever fire a new request, and
+            // the view stays on the "Loading…" shimmer forever (snapshot
+            // primed `Some(Vec::new())` here keeps `awaiting_first_snapshot`
+            // true). The bottom-bar pane toggle only emits `pane_open=false`
+            // → `pane_open=true` without an intervening `view="chat"`, so
+            // `close_agents_view_for_tab` (the only other reset path) never
+            // runs in that flow — reopening the view is the user's natural
+            // "try again" gesture, so resetting here matches intent.
+            // The stale in-flight task's eventual reply (if any) will not
+            // clobber the new state: `schedule_agents_refetch_for_tab`
+            // below bumps `next_request_id`, so the old response's
+            // `request_id` no longer matches `latest_request_id` and
+            // `handle_agents_snapshot_loaded` filters it out.
+            tab.agents_view.refetch_in_flight = false;
             if tab.agents_list_state.selected().is_none() && rows_available {
                 tab.agents_list_state.select(Some(0));
             }
@@ -10039,6 +10059,49 @@ mod tests {
         }
         assert!(app.current_tab().agents_view.snapshot.is_some());
         assert!(app.current_tab().agents_view.refetch_in_flight);
+    }
+
+    /// Regression: when a prior refetch's response was lost (helper↔master
+    /// pipe stall), `refetch_in_flight` stays `true` forever and the
+    /// `schedule_agents_refetch_for_tab` early-return short-circuits every
+    /// periodic tick. Reopening the view via the bottom-bar pane toggle
+    /// does NOT emit `view="chat"`, so `close_agents_view_for_tab` (the
+    /// only reset path) never runs. `open_agents_view_for_tab` must
+    /// therefore force-clear the flag itself, otherwise the user is stuck
+    /// on the "Loading…" shimmer permanently — observed in the wild
+    /// (tab1 helper stuck for >30 min, master log showed zero
+    /// `sessions/list` from that helper post-incident).
+    #[test]
+    fn reopen_recovers_from_stuck_refetch_in_flight() {
+        let (mut app, mut master_rx) = test_app_with_master_rx();
+
+        // First open + simulate a lost response: refetch_in_flight is left
+        // `true`, snapshot is `Some(empty)` (the open-priming state that
+        // renders as the Loading shimmer).
+        app.open_agents_view_for_tab(DEFAULT_TAB_ID.to_string());
+        let _ = master_rx
+            .try_recv()
+            .expect("first open must request sessions/list");
+        assert!(app.current_tab().agents_view.refetch_in_flight);
+
+        // Reopen WITHOUT going through close_agents_view_for_tab. This
+        // models the bottom-bar pane toggle flow: pane_open=false then
+        // pane_open=true with no `view="chat"` between them, so
+        // `refetch_in_flight` stays stuck `true` going into the reopen.
+        app.open_agents_view_for_tab(DEFAULT_TAB_ID.to_string());
+
+        // The reopen must dispatch a fresh SessionsList — pre-fix it
+        // didn't, because schedule_agents_refetch_for_tab's
+        // `refetch_in_flight` early-return swallowed the call silently.
+        match master_rx
+            .try_recv()
+            .expect("reopen must request sessions/list to recover stuck state")
+        {
+            crate::protocol::acp::client::MasterExtRequest::SessionsList { .. } => {}
+            other => panic!("expected SessionsList, got {other:?}"),
+        }
+        assert!(app.current_tab().agents_view.refetch_in_flight);
+        assert!(app.current_tab().agents_view.snapshot.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Symptom

Session view (Ctrl+Shift+/ picker) gets permanently stuck on the
`Loading…` shimmer. Observed in the wild: after running `gemini` in
two different tabs' shell panes and asking a question in one, opening
tab1's session view stayed on `Loading…` indefinitely (>30 min in the
captured logs), while tab2 rendered both sessions normally. Toggling
the session view from the bottom-bar button did not recover it.

## Root cause

`schedule_agents_refetch_for_tab` (`app.rs:3000`) has an early-return
guard:

```rust
if tab.agents_view.refetch_in_flight {
    tab.agents_view.dirty = true;
    return;
}
```

When the helper↔master ACP pipe drops a `sessions/list` response
mid-flight, the helper's `conn.ext_method` future never returns, so
`AgentsSnapshotLoaded` is never posted, so
`refetch_in_flight` stays stuck `true` forever. Every subsequent
5s periodic `SessionsChanged` tick then hits the guard, sets
`dirty = true`, and returns without sending a new request.

The only existing reset path for `refetch_in_flight` is
`close_agents_view_for_tab` (triggered by `view="chat"`). But the
bottom-bar pane toggle emits `pane_open=false` → `pane_open=true`
without an intervening `view="chat"`, so that reset never runs. The
helper has no path back to a working state — `snapshot` was primed to
`Some(Vec::new())` by `open_agents_view_for_tab`, so
`awaiting_first_snapshot` stays `true` and the shimmer persists.

Master-side logs from the captured incident: `wta-main_master.log`
shows zero `sessions/list` requests from the stuck helper after
07:56:54 onward; the helper process is still alive, its TUI keeps
rendering, but its ACP request loop is silently a no-op.

## Fix

Force-clear `refetch_in_flight` (and `dirty`) at the top of
`open_agents_view_for_tab`. Reopening the picker is the user's
natural "try again" gesture — making it the recovery path matches
intent and the existing `close_agents_view_for_tab` reset semantics.

A stale in-flight task's eventual reply cannot clobber the new
snapshot: the subsequent `schedule_agents_refetch_for_tab` bumps
`next_request_id`, so the old response's `request_id` no longer
matches `latest_request_id` and `handle_agents_snapshot_loaded`
filters it out.

## Out of scope

The deeper bug — what caused the original `sessions/list` response to
be lost in the first place — is a separate issue worth tracking. The
captured logs show `ERROR agent_client_protocol::rpc: failed to parse
incoming message: expected value at line 1 column 1. Raw: y finish
their task — not to produce the most elaborate answer...` right around
when the helper went silent, suggesting an ACP/JSON-RPC line-framing
desync between master and helper. That can also affect other
ext_method calls (`session_focus`, `session_resume_dispatched`,
`session_hook`), so it deserves its own investigation; this PR just
ensures the user can always recover their session picker via a reopen
instead of being permanently locked out.

## Test

Adds `reopen_recovers_from_stuck_refetch_in_flight` — first open
sends a `SessionsList`, the response is never delivered (so
`refetch_in_flight` stays `true`), and a reopen WITHOUT going through
`close_agents_view_for_tab` must still dispatch a fresh
`SessionsList`. Fails on `main`, passes with this change.

## Verification

- `cargo test --bin wta agents_view` — 12 passed
- `cargo test --bin wta sessions_changed` — 9 passed
- `cargo build --target x86_64-pc-windows-msvc` — clean (no new warnings)
- Live reproduction in VS-debug F5'd WT: user confirmed the picker
  now recovers (vs. staying stuck pre-fix)