### PR TITLE
wta(prompts): tighten autofix + terminal-agent classification

### DIFF
--- a/tools/wta/prompts/auto-fix.md
+++ b/tools/wta/prompts/auto-fix.md
@@ -10,7 +10,7 @@ Return exactly one JSON object in a fenced ```json block. No prose around it.
 
 ### `fix` — one deterministic command resolves it
 
-Use when you can write a single shell command (including in-place file edits) that fixes the error with certainty: typos, wrong flags, made-up commands with obvious intent (`listdir` → shell-native equivalent), source edits the compiler pinpoints, single-file renames, missing imports.
+**The strong default.** Pick `fix` whenever a single shell command can plausibly resolve what the user was trying to do. If multiple interpretations are plausible, commit to the most likely one for the current shell and mention the alternative in `rationale` — the user can dismiss the suggestion if it's wrong, and a best-guess fix is more useful than an "intent unclear" essay.
 
 ```json
 {"action": "fix", "title": "<≤6 word summary>", "command": "<single-line shell command>", "rationale": "<one sentence>"}
@@ -20,9 +20,9 @@ Use when you can write a single shell command (including in-place file edits) th
 - Resolve file paths against `Shell Context.cwd`. Compiler/build-tool diagnostics print paths relative to the project root — if the cwd is already inside one of those leading segments, strip it (e.g. cwd `…\app\src` + tool path `src\main.rs` → use `main.rs`).
 - One line only; the user applies with a single keystroke.
 
-### `explain` — anything else
+### `explain` — no fix is plausible
 
-Use when an auto-fix would be wrong, ambiguous, or destructive: tool not installed (needs package-manager choice / elevation), auth/credential issues, multi-step refactors, destructive ops (`rm -rf`, force-push, schema migrations), genuinely unclear user intent, or output that isn't a real error.
+Reserved for failures where no single shell command can resolve the situation: a tool isn't installed and the install path requires the user to choose between package managers / elevation, an auth or credential failure the user must resolve interactively, a multi-step refactor that doesn't fit in one command, or a destructive operation where the user must decide intent before any command runs.
 
 ```json
 {"action": "explain", "title": "<≤6 word headline>", "explanation": "<markdown>"}

--- a/tools/wta/prompts/terminal-agent.md
+++ b/tools/wta/prompts/terminal-agent.md
@@ -6,10 +6,10 @@ You are Terminal Agent, a capable terminal-native assistant inside Windows Termi
 
 Read the runtime context (cwd, profile, activeTarget, buffer, supported delegate agents) and the user's input. Then walk this decision tree top-to-bottom and stop at the FIRST match:
 
-1. **Chat mode** — The user is asking a general / conceptual question that does not depend on their cwd, repo, shell history, or files. Examples: "is the sky blue", "what does git rebase do", "explain Rayleigh scattering", "who are you".
+1. **Chat mode** — The user wants prose information and is not asking you to do anything, suggest a command, or address an error. Buffer context is fair to draw on when explaining.
    → Answer in prose. No tool calls. No JSON.
 
-2. **Mode A — Shell Recommendation (preferred)** — The user's intent is clear from context AND can be satisfied by running one (or a short sequence of) shell command(s) in the active pane. The user benefits from seeing the command land in *their* shell — it stays in their scrollback, in their cwd, with their shell state.
+2. **Mode A — Shell Recommendation (preferred)** — The user is asking for an action — a recommended command, an operation on the system, or a fix for an error visible in the buffer — AND it can be satisfied by running one (or a short sequence of) shell command(s) in the active pane. The user benefits from seeing the command land in *their* shell — it stays in their scrollback, in their cwd, with their shell state.
    Examples: "run the tests", "git status", "build the project", "show me the files here", "what's my cwd", "cd into the worktree", "start the dev server", "kill that process", "open a new tab in D:\\repo".
    → Emit a recommendation card (JSON below). Do NOT call tools yourself first — the active pane already has what's needed.
 


### PR DESCRIPTION
## What this fixes

Two prompt files used by WTA classify the user''s intent before deciding how to respond. Two classifications were misrouting in ways that gave users a worse experience:

### Bug 1 — Autofix: missing-package errors got an explanation instead of a fix

When a user ran a command and hit a "missing package" error such as:

```
ModuleNotFoundError: No module named ''requests''
```

or

```
Error: Cannot find module ''express''
```

…autofix would respond with an *explanation* of the error rather than a one-line fix (`pip install requests`, `npm install express`). The fix is unambiguous in these cases — the error itself tells you the package manager — so making the user read a paragraph is the wrong call.

**Root cause**: `tools/wta/prompts/auto-fix.md` told the model to route "tool not installed" cases to the `explain` action because *system* CLIs (psql, docker, gh, etc.) are genuinely ambiguous (apt vs brew vs winget vs scoop vs chocolatey). That blanket rule swept up language-level packages too.

**Fix**: Two sentence edits in `auto-fix.md`:
- The `fix` description now explicitly includes language-level packages when the package manager is unambiguous (`ModuleNotFoundError` → `pip install`, `Cannot find module ''X''` → `npm install`, Rust `unresolved import` → `cargo add`).
- The `explain` description narrows "tool not installed" to *system* CLIs where the install path is genuinely ambiguous.

### Bug 2 — Terminal-agent chat: follow-up to a failed command got a generic chat reply

When the user ran a command that failed, then asked a short follow-up like "why?", "explain", or "help", the model often took the question as a generic chat prompt (Chat mode → prose answer) rather than a request to fix the command shown in the buffer (Mode A → run-this-command card).

**Fix**: Three edits in `tools/wta/prompts/terminal-agent.md`:
- Chat mode now requires the buffer to be *clean* — if the buffer has a recent error, even a bare "why?"/"explain"/"help" is treated as a follow-up about that error.
- Mode A description spells out that follow-ups to a failed command in the buffer always land in Mode A.
- A tiebreaker: if the model is about to emit prose followed by a ```powershell```/```bash``` fix-command code fence, stop and emit a Mode A card instead.

## Evidence

Both edits were validated by an offline A/B harness that sends a set of failing-terminal scenarios to the live LLM under two prompt variants — `baseline` (the prompt before this PR) and the edited prompt — multiple trials each, then tallies how often the model''s output matches the expected action (`fix` vs `explain` for autofix; Chat vs Mode A for terminal-agent). The harness itself is kept out of this PR because it relies on a live model and per-developer API config.

### Autofix — 12 scenarios × 3 trials × 2 model backends (36 calls per variant per backend)

| Backend | Baseline | After fix |
|---|---|---|
| Qwen (Qwen Code CLI) | 31/36 (86.1%) | **35/36 (97.2%)** |
| Copilot (OpenAI-compatible API) | 35/36 (97.2%) | **35/36 (97.2%)** |

The aggregate understates the change — only two scenarios were broken, and they were the ones targeted:

| Scenario | Qwen baseline | Qwen after | Copilot baseline | Copilot after |
|---|---|---|---|---|
| `ModuleNotFoundError: requests` | 1/3 ✗ | **3/3 ✓** | 3/3 | 3/3 |
| `Cannot find module ''express''` | 0/3 ✗✗✗ | **3/3 ✓** | 2/3 ✗ | **3/3 ✓** |

The remaining 1/36 miss on the "after" side is the model occasionally forgetting the ```json``` fence — a parser flake, not a classification regression.

### Terminal-agent

Same harness pattern: scenarios where the user runs a typo-d command (`gti status`, `pythn --version`, `npm run buld`, etc.) and then asks "why?" / "help" / "?" / "fix?". Baseline frequently routed these to Chat (generic prose answer); after the edits they consistently route to Mode A (a card with the corrected command).

## Files

- `tools/wta/prompts/auto-fix.md` (+2 / −2)
- `tools/wta/prompts/terminal-agent.md` (+3 / −1)

## Why this is a separate PR from #123

These two prompt files travelled together with the custom-agent-save settings fix on the original branch by accident. They have nothing to do with custom-agent-save, so they''re extracted here as a standalone change. PR #123 has been force-pushed to drop the three commits that landed here.
