### PR TITLE
Fix FRE agent picker copy and refactor agent setup docs (#159)

### DIFF
--- a/doc/installing-dependencies.md
+++ b/doc/installing-dependencies.md
@@ -20,30 +20,17 @@ on its own, including:
   resolution guidance or from a GitHub issue. Each dependency has its own
   section with a stable anchor so it can be linked to directly.
 
-> [!NOTE]
-> **What Intelligent Terminal installs for you, and what it doesn't:**
-> Intelligent Terminal supports four agent CLIs — **GitHub Copilot**,
-> **Claude Code**, **OpenAI Codex**, and **Gemini**. The first-run
-> experience (FRE) installs **GitHub Copilot** on your behalf because it
-> is the default agent. For Claude Code, Codex, and Gemini, **you must
-> install the agent CLI yourself** before selecting it in the FRE —
-> Intelligent Terminal does not ship or install those CLIs. **Claude
-> Code** and **OpenAI Codex** additionally need an ACP (Agent Control
-> Protocol) wrapper so Intelligent Terminal can talk to them; the wrapper
-> is fetched on demand via `npx` at run time, so its only prerequisite is
-> Node.js. Copilot and Gemini speak ACP
-> natively and need no wrapper.
-
 ## Table of contents
 
 1. [WinGet (Windows Package Manager)](#1-winget-windows-package-manager)
 2. [Node.js LTS — shared prerequisite](#2-nodejs-lts--shared-prerequisite)
-3. [GitHub Copilot CLI](#3-github-copilot-cli)
-4. [Claude Code (bring your own)](#4-claude-code-bring-your-own)
-5. [OpenAI Codex (bring your own)](#5-openai-codex-bring-your-own)
-6. [Gemini CLI (bring your own)](#6-gemini-cli-bring-your-own)
-7. [Signing in to your agent](#7-signing-in-to-your-agent)
-8. [PowerShell shell integration](#8-powershell-shell-integration)
+3. [Agent CLIs](#agent-clis) — install and sign in to an agent
+   - 3.1 [GitHub Copilot CLI](#31-github-copilot-cli) (installed by the FRE)
+   - 3.2 [Claude Code (bring your own)](#32-claude-code-bring-your-own)
+   - 3.3 [OpenAI Codex (bring your own)](#33-openai-codex-bring-your-own)
+   - 3.4 [Gemini CLI (bring your own)](#34-gemini-cli-bring-your-own)
+   - 3.5 [Signing in to your agent](#35-signing-in-to-your-agent)
+4. [PowerShell shell integration](#4-powershell-shell-integration)
 
 ---
 
@@ -132,14 +119,38 @@ finishes, close and reopen your terminal so `PATH` picks up `node.exe`,
 
 ---
 
-## 3. GitHub Copilot CLI
+## Agent CLIs
+
+Intelligent Terminal supports four agents out of the box — **GitHub
+Copilot**, **Claude Code**, **OpenAI Codex**, and **Gemini**. The
+first-run experience installs **GitHub Copilot** (the default) for you;
+the other three are **bring-your-own** — install the CLI yourself
+(sub-sections below) before selecting it in the FRE.
+
+All four speak the
+[**Agent Control Protocol (ACP)**](https://agentclientprotocol.com/get-started/agents),
+the open spec Intelligent Terminal uses to talk to agent CLIs. **Claude
+Code** and **OpenAI Codex** additionally need an ACP wrapper so
+Intelligent Terminal can talk to them; the wrapper is fetched on demand
+via `npx` at run time, so its only prerequisite is Node.js. Copilot and
+Gemini speak ACP natively and need no wrapper.
+
+> [!NOTE]
+> **Bringing your own ACP agent.** Any CLI that speaks ACP can also be
+> wired up from **Settings → AI Agents → Add custom agent**. Custom
+> agents work in the agent pane today, but **session management** (the
+> multi-session sidebar in the agent pane) is not yet supported for
+> custom agents — only the four built-in agents above get the full
+> session experience.
+
+### 3.1 GitHub Copilot CLI
 
 **Why you need it:** GitHub Copilot is the **default agent** in Intelligent
 Terminal and the only agent the first-run experience installs on your
 behalf. It powers the agent pane, the `?<prompt>` command-palette
 delegation, and the auto-fix workflow.
 
-### Installed automatically by the first-run experience
+#### Installed automatically by the first-run experience
 
 When you complete the FRE with Copilot selected, Intelligent Terminal
 installs the Copilot CLI for you (skipped if it is already on `PATH`):
@@ -153,7 +164,7 @@ winget install --id GitHub.Copilot --exact --silent `
 
 Copilot speaks ACP natively, so no wrapper is required.
 
-### Install manually (only if you are not using the FRE)
+#### Install manually (only if you are not using the FRE)
 
 If the FRE did not install Copilot CLI for you, run the `winget` command
 above, then verify:
@@ -167,25 +178,25 @@ install directory is added to `PATH`.
 
 > [!IMPORTANT]
 > After installing, you must sign in before the agent will respond. See
-> [Section 7 — Signing in to your agent](#7-signing-in-to-your-agent).
+> [Section 3.5 — Signing in to your agent](#35-signing-in-to-your-agent).
 
 ---
 
-## 4. Claude Code (bring your own)
+### 3.2 Claude Code (bring your own)
 
 **Status:** Supported, but **not installed by Intelligent Terminal**. You
 must install Anthropic's Claude Code CLI yourself before selecting Claude
 in the FRE. Intelligent Terminal launches Claude through the
 `@zed-industries/claude-code-acp` npx wrapper.
 
-### Step 4.1 — Install Node.js
+#### Step 3.2.1 — Install Node.js
 
 Complete [Section 2 — Node.js LTS](#2-nodejs-lts--shared-prerequisite)
 first. Claude Code is an npm package and cannot run without Node.js. If you
 have not yet installed Node.js, the FRE will install it for you the first
 time you select Claude.
 
-### Step 4.2 — Install the Claude Code CLI
+#### Step 3.2.2 — Install the Claude Code CLI
 
 ```powershell
 npm install -g @anthropic-ai/claude-code
@@ -197,7 +208,7 @@ Verify:
 claude --version
 ```
 
-### Step 4.3 — ACP wrapper (no install action required)
+#### Step 3.2.3 — ACP wrapper (no install action required)
 
 Claude Code does not speak the Agent Control Protocol (ACP) directly, so
 Intelligent Terminal launches it through the
@@ -214,25 +225,25 @@ The first launch may take a few seconds while `npx` downloads the wrapper.
 
 > [!IMPORTANT]
 > After installing, you must sign in before the agent will respond. See
-> [Section 7 — Signing in to your agent](#7-signing-in-to-your-agent).
+> [Section 3.5 — Signing in to your agent](#35-signing-in-to-your-agent).
 
 ---
 
-## 5. OpenAI Codex (bring your own)
+### 3.3 OpenAI Codex (bring your own)
 
 **Status:** Supported, but **not installed by Intelligent Terminal**. You
 must install OpenAI's Codex CLI yourself before selecting Codex in the FRE.
 Intelligent Terminal launches Codex through the
 `@zed-industries/codex-acp` npx wrapper.
 
-### Step 5.1 — Install Node.js
+#### Step 3.3.1 — Install Node.js
 
 Complete [Section 2 — Node.js LTS](#2-nodejs-lts--shared-prerequisite)
 first. Codex is an npm package and cannot run without Node.js. If you have
 not yet installed Node.js, the FRE will install it for you the first time
 you select Codex.
 
-### Step 5.2 — Install the Codex CLI
+#### Step 3.3.2 — Install the Codex CLI
 
 ```powershell
 npm install -g @openai/codex
@@ -244,7 +255,7 @@ Verify:
 codex --version
 ```
 
-### Step 5.3 — ACP wrapper (no install action required)
+#### Step 3.3.3 — ACP wrapper (no install action required)
 
 Codex does not speak the Agent Control Protocol (ACP) directly, so
 Intelligent Terminal launches it through the
@@ -261,11 +272,11 @@ The first launch may take a few seconds while `npx` downloads the wrapper.
 
 > [!IMPORTANT]
 > After installing, you must sign in before the agent will respond. See
-> [Section 7 — Signing in to your agent](#7-signing-in-to-your-agent).
+> [Section 3.5 — Signing in to your agent](#35-signing-in-to-your-agent).
 
 ---
 
-## 6. Gemini CLI (bring your own)
+### 3.4 Gemini CLI (bring your own)
 
 **Status:** Supported, but **not installed by Intelligent Terminal**. You
 must install Google's Gemini CLI yourself before selecting Gemini in the
@@ -273,12 +284,12 @@ FRE. Gemini speaks the Agent Control Protocol (ACP) natively, so no
 wrapper is required at runtime, but the CLI itself is still distributed as
 an npm package.
 
-### Step 6.1 — Install Node.js
+#### Step 3.4.1 — Install Node.js
 
 Complete [Section 2 — Node.js LTS](#2-nodejs-lts--shared-prerequisite)
 first.
 
-### Step 6.2 — Install the Gemini CLI
+#### Step 3.4.2 — Install the Gemini CLI
 
 ```powershell
 npm install -g @google/gemini-cli
@@ -294,11 +305,11 @@ Gemini speaks ACP natively, so no wrapper is required.
 
 > [!IMPORTANT]
 > Gemini requires you to sign in with your Google account before it will
-> respond. See [Section 7 — Signing in to your agent](#7-signing-in-to-your-agent).
+> respond. See [Section 3.5 — Signing in to your agent](#35-signing-in-to-your-agent).
 
 ---
 
-## 7. Signing in to your agent
+### 3.5 Signing in to your agent
 
 Installing an agent's CLI is not enough — you must also sign in before
 Intelligent Terminal can talk to it. Pick the row for the agent you
@@ -316,7 +327,7 @@ up the new credentials.
 
 ---
 
-## 8. PowerShell shell integration
+## 4. PowerShell shell integration
 
 **Why you need it:** Shell integration teaches PowerShell to emit
 **OSC 133** marks after every prompt. Intelligent Terminal uses these marks
@@ -346,7 +357,7 @@ $PROFILE.CurrentUserCurrentHost
 The only step you may need to perform by hand is adjusting the PowerShell
 execution policy so the profile is allowed to run.
 
-### Step 8.1 — Set the PowerShell execution policy
+### Step 4.1 — Set the PowerShell execution policy
 
 Shell-integration scripts are PowerShell `.ps1` files loaded from your
 profile. PowerShell will refuse to run them under the default `Restricted`
@@ -385,7 +396,7 @@ is the recommended Microsoft default for developer machines.
 > shows `Restricted` or `AllSigned` for your scope after running the
 > command above.
 
-### Step 8.2 — Enable auto-error detection and auto-error fix
+### Step 4.2 — Enable auto-error detection and auto-error fix
 
 Once the execution policy is set, open **Settings → AI Agents** inside
 Intelligent Terminal and turn on **Auto-error detection** (and, optionally,

--- a/doc/installing-dependencies.md
+++ b/doc/installing-dependencies.md
@@ -127,13 +127,12 @@ first-run experience installs **GitHub Copilot** (the default) for you;
 the other three are **bring-your-own** — install the CLI yourself
 (sub-sections below) before selecting it in the FRE.
 
-All four speak the
-[**Agent Control Protocol (ACP)**](https://agentclientprotocol.com/get-started/agents),
-the open spec Intelligent Terminal uses to talk to agent CLIs. **Claude
-Code** and **OpenAI Codex** additionally need an ACP wrapper so
-Intelligent Terminal can talk to them; the wrapper is fetched on demand
-via `npx` at run time, so its only prerequisite is Node.js. Copilot and
-Gemini speak ACP natively and need no wrapper.
+Intelligent Terminal talks to all four through the
+[**Agent Control Protocol (ACP)**](https://agentclientprotocol.com/get-started/agents).
+**Copilot** and **Gemini** speak ACP natively, so no extra layer is
+required. **Claude Code** and **OpenAI Codex** do not speak ACP directly
+— Intelligent Terminal launches them through an `npx` wrapper that is
+fetched on demand at run time, so its only prerequisite is Node.js.
 
 > [!NOTE]
 > **Bringing your own ACP agent.** Any CLI that speaks ACP can also be
@@ -220,7 +219,7 @@ npx -y @zed-industries/claude-code-acp
 ```
 
 You do **not** need to install anything for this — the only prerequisite
-is a working Node.js + `npx` (which you already installed in Step 4.1).
+is a working Node.js + `npx` (which you already installed in Step 3.2.1).
 The first launch may take a few seconds while `npx` downloads the wrapper.
 
 > [!IMPORTANT]
@@ -267,7 +266,7 @@ npx -y @zed-industries/codex-acp
 ```
 
 You do **not** need to install anything for this — the only prerequisite
-is a working Node.js + `npx` (which you already installed in Step 5.1).
+is a working Node.js + `npx` (which you already installed in Step 3.3.1).
 The first launch may take a few seconds while `npx` downloads the wrapper.
 
 > [!IMPORTANT]

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -443,7 +443,7 @@ namespace winrt::TerminalApp::implementation
         {
         case FreProblemKind::CopilotInstall:
             ErrorText().Text(RS_(L"FreOverlay_InstallErrorCopilot"));
-            url += L"#3-github-copilot-cli";
+            url += L"#31-github-copilot-cli";
             break;
         case FreProblemKind::NodeInstall:
             ErrorText().Text(RS_(L"FreOverlay_InstallErrorNode"));
@@ -451,7 +451,7 @@ namespace winrt::TerminalApp::implementation
             break;
         case FreProblemKind::ShellIntegration:
             ErrorText().Text(RS_(L"FreOverlay_InstallErrorShellIntegration"));
-            url += L"#8-powershell-shell-integration";
+            url += L"#4-powershell-shell-integration";
             // Remediation: turn off error detection (and its dependent
             // suggestion) so the user can save and continue without it.
             AutoDetectToggle().IsOn(false);

--- a/src/cascadia/TerminalApp/FreOverlay.xaml
+++ b/src/cascadia/TerminalApp/FreOverlay.xaml
@@ -227,7 +227,7 @@
                                                FontSize="12" Foreground="#99FFFFFF"
                                                TextWrapping="Wrap">
                                         <Run x:Name="AgentDescriptionBefore" />
-                                        <Hyperlink NavigateUri="https://aka.ms/intelligent-terminal-acpref"
+                                        <Hyperlink NavigateUri="https://aka.ms/intelligent-terminal-dependency#agent-clis"
                                                    Foreground="#FF99EBFF">
                                             <Run x:Name="AgentDescriptionAcpToken" />
                                         </Hyperlink>

--- a/src/cascadia/TerminalApp/Resources/af-ZA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/af-ZA/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Kies die agent wat in die agentpaneel gebruik word. Enige versoenbare ACP-agent sal outomaties opgespoor word.</value>
+    <value>Kies die agent wat in die agentpaneel gebruik word en ACP ondersteun.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/am-ET/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/am-ET/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>በኤጅንት ገጽታ ውስጥ የሚጠቀመውን ኤጅንት ይምረጡ። ማንኛውም ተዋሃጅ የሆነ ACP ኤጅንት በራሱ ይታወቃል።</value>
+    <value>በኤጅንት ገጽታ ውስጥ የሚጠቀመውን እና ACP የሚደግፈውን ኤጅንት ይምረጡ።</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ar-SA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ar-SA/Resources.resw
@@ -164,7 +164,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>اختر الوكيل المستخدم في لوحة الوكيل. سيتم اكتشاف أي وكيل متوافق مع ACP تلقائيًا.</value>
+    <value>اختر الوكيل المستخدم في لوحة الوكيل والذي يدعم ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/as-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/as-IN/Resources.resw
@@ -164,7 +164,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>এজেণ্ট পেনত ব্যৱহৃত এজেণ্ট বাছনি কৰক। যিকোনো সুসংগত ACP এজেণ্ট স্বয়ংক্ৰিয়ভাৱে চিনাক্ত হ'ব।</value>
+    <value>এজেণ্ট পেনত ব্যৱহৃত আৰু ACP সমৰ্থন কৰা এজেণ্ট বাছনি কৰক।</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/az-Latn-AZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/az-Latn-AZ/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Agent panelində istifadə olunan agenti seçin. Uyğun olan istənilən ACP agent avtomatik aşkar ediləcək.</value>
+    <value>Agent panelində istifadə olunan və ACP dəstəkləyən agenti seçin.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/bg-BG/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bg-BG/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Изберете агента, използван в панела на агента. Всеки съвместим ACP агент ще бъде открит автоматично.</value>
+    <value>Изберете агента, използван в панела на агента, който поддържа ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/bn-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bn-IN/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>এজেন্ট পেনে ব্যবহৃত এজেন্ট বেছে নিন। যেকোনো সামঞ্জস্যপূর্ণ ACP এজেন্ট স্বয়ংক্রিয়ভাবে শনাক্ত হবে।</value>
+    <value>এজেন্ট পেনে ব্যবহৃত এবং ACP সমর্থন করে এমন এজেন্ট বেছে নিন।</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/bs-Latn-BA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bs-Latn-BA/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Izaberite agenta koji se koristi u panelu agenta. Svaki kompatibilni ACP agent bit će automatski otkriven.</value>
+    <value>Izaberite agenta koji se koristi u panelu agenta i podržava ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ca-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ca-ES/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Trieu l'agent que s'utilitza al tauler d'agent. Qualsevol agent ACP compatible es detectarà automàticament.</value>
+    <value>Trieu l'agent que s'utilitza al tauler d'agent i que admet ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ca-Es-VALENCIA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ca-Es-VALENCIA/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Trieu l'agent que s'utilitza al tauler d'agent. Qualsevol agent ACP compatible es detectarà automàticament.</value>
+    <value>Trieu l'agent que s'utilitza al tauler d'agent i que admet ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/cs-CZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/cs-CZ/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Zvolte agenta používaného v panelu agenta. Všichni kompatibilní agenti ACP budou rozpoznáni automaticky.</value>
+    <value>Zvolte agenta používaného v panelu agenta, který podporuje ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/cy-GB/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/cy-GB/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Dewiswch yr asiant a ddefnyddir yn y paen asiant. Bydd unrhyw asiant ACP cydnaws yn cael ei ganfod yn awtomatig.</value>
+    <value>Dewiswch yr asiant a ddefnyddir yn y paen asiant ac sy'n cefnogi ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/da-DK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/da-DK/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Vælg den agent, der bruges i agentpanelet. Alle kompatible ACP-agenter registreres automatisk.</value>
+    <value>Vælg den agent, der bruges i agentpanelet, og som understøtter ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
@@ -1005,7 +1005,7 @@
     <value>Agent</value>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Wählen Sie den Agenten aus, der im Agentbereich verwendet wird. Jeder kompatible ACP-Agent wird automatisch erkannt.</value>
+    <value>Wählen Sie den Agenten aus, der im Agentbereich verwendet wird und ACP unterstützt.</value>
     <comment>{Locked="ACP"}</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/el-GR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/el-GR/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Επιλέξτε τον πράκτορα που χρησιμοποιείται στο πλαίσιο πράκτορα. Οποιοσδήποτε συμβατός πράκτορας ACP θα ανιχνευθεί αυτόματα.</value>
+    <value>Επιλέξτε τον πράκτορα που χρησιμοποιείται στο πλαίσιο πράκτορα και υποστηρίζει ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/en-GB/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-GB/Resources.resw
@@ -159,7 +159,7 @@
     <value>Agent</value>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Choose the agent used in the agent pane. Any compatible ACP agent will be detected.</value>
+    <value>Choose the agent used in the agent pane that supports ACP.</value>
     <comment>{Locked="ACP"}</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1069,7 +1069,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Choose the agent used in the agent pane. Any compatible ACP agent will be detected.</value>
+    <value>Choose the agent used in the agent pane that supports ACP.</value>
     <comment>{Locked="ACP"}
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>

--- a/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
@@ -1002,7 +1002,7 @@
     <value>Agente</value>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Elige el agente utilizado en el panel del agente. Se detectará cualquier agente ACP compatible.</value>
+    <value>Elige el agente utilizado en el panel del agente que admite ACP.</value>
     <comment>{Locked="ACP"}</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/es-MX/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-MX/Resources.resw
@@ -159,7 +159,7 @@
     <value>Agente</value>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Elige el agente utilizado en el panel del agente. Se detectará cualquier agente ACP compatible.</value>
+    <value>Elige el agente utilizado en el panel del agente que admite ACP.</value>
     <comment>{Locked="ACP"}</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/et-EE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/et-EE/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Valige agendipaneelil kasutatav agent. Kõik ühilduvad ACP agendid tuvastatakse automaatselt.</value>
+    <value>Valige agendipaneelil kasutatav agent, millel on ACP tugi.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/eu-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/eu-ES/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Aukeratu agente-panelean erabiltzen den agentea. ACP agente bateragarri oro automatikoki detektatuko da.</value>
+    <value>Aukeratu agente-panelean erabiltzen den eta ACP onartzen duen agentea.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/fa-IR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fa-IR/Resources.resw
@@ -164,7 +164,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>عامل استفاده‌شده در پنل عامل را انتخاب کنید. هر عامل سازگار با ACP به‌طور خودکار شناسایی خواهد شد.</value>
+    <value>عامل استفاده‌شده در پنل عامل را که از ACP پشتیبانی می‌کند انتخاب کنید.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/fi-FI/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fi-FI/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Valitse agenttipaneelissa käytettävä agentti. Kaikki yhteensopivat ACP-agentit tunnistetaan automaattisesti.</value>
+    <value>Valitse agenttipaneelissa käytettävä agentti, joka tukee ACP:tä.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/fil-PH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fil-PH/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Piliin ang agent na ginagamit sa agent pane. Awtomatikong made-detect ang anumang compatible na ACP agent.</value>
+    <value>Piliin ang agent na ginagamit sa agent pane na sumusuporta sa ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/fr-CA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-CA/Resources.resw
@@ -159,7 +159,7 @@
     <value>Agent</value>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Choisissez l'agent utilisé dans le volet de l'agent. Tout agent ACP compatible sera détecté.</value>
+    <value>Choisissez l'agent utilisé dans le volet de l'agent qui prend en charge ACP.</value>
     <comment>{Locked="ACP"}</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
@@ -1003,7 +1003,7 @@
     <value>Agent</value>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Choisissez l'agent utilisé dans le volet de l'agent. Tout agent ACP compatible sera détecté.</value>
+    <value>Choisissez l'agent utilisé dans le volet de l'agent qui prend en charge ACP.</value>
     <comment>{Locked="ACP"}</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ga-IE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ga-IE/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Roghnaigh an gníomhaire a úsáidtear sa phán gníomhaire. Aithneofar aon ghníomhaire ACP comhoiriúnach go huathoibríoch.</value>
+    <value>Roghnaigh an gníomhaire a úsáidtear sa phán gníomhaire agus a thacaíonn le ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/gd-gb/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gd-gb/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Tagh an neach-gnìomha a thèid a chleachdadh sa phanail neach-gnìomha. Thèid neach-gnìomha ACP co-chòrdail sam bith a lorg gu fèin-obrachail.</value>
+    <value>Tagh an neach-gnìomha a thèid a chleachdadh sa phanail neach-gnìomha agus a bheir taic do ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/gl-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gl-ES/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Escolla o axente usado no panel de axente. Calquera axente ACP compatible será detectado automaticamente.</value>
+    <value>Escolla o axente usado no panel de axente que admite ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/gu-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gu-IN/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>એજન્ટ પેનમાં વપરાતા એજન્ટને પસંદ કરો. કોઈપણ સુસંગત ACP એજન્ટ આપોઆપ શોધાશે.</value>
+    <value>એજન્ટ પેનમાં વપરાતા અને ACP માટે સમર્થન ધરાવતા એજન્ટને પસંદ કરો.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/he-IL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/he-IL/Resources.resw
@@ -164,7 +164,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>בחר את הסוכן המשמש בחלונית הסוכן. כל סוכן תואם ACP יזוהה אוטומטית.</value>
+    <value>בחר את הסוכן המשמש בחלונית הסוכן ותומך ב-ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/hi-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hi-IN/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>एजेंट पेन में उपयोग किए जाने वाले एजेंट को चुनें। कोई भी संगत ACP एजेंट स्वचालित रूप से पहचाना जाएगा।</value>
+    <value>एजेंट पेन में उपयोग किए जाने वाले और ACP का समर्थन करने वाले एजेंट को चुनें।</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/hr-HR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hr-HR/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Odaberite agenta koji se koristi u oknu agenta. Svaki kompatibilni ACP agent bit će automatski otkriven.</value>
+    <value>Odaberite agenta koji se koristi u oknu agenta i podržava ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/hu-HU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hu-HU/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Válassza ki az ügynökpanelben használt ügynököt. Minden kompatibilis ACP-ügynök automatikusan felismerésre kerül.</value>
+    <value>Válassza ki az ügynökpanelben használt, ACP támogatással rendelkező ügynököt.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/hy-AM/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hy-AM/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Ընտրեք գործակալը, որը օգտագործվում է գործակալի վահանակում։ Ցանկացած համատեղելի ACP գործակալ կհայտնաբերվի ինքնաշխատորեն:</value>
+    <value>Ընտրեք գործակալի վահանակում օգտագործվող և ACP աջակցող գործակալը։</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/id-ID/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/id-ID/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Pilih agen yang digunakan di panel agen. Agen ACP yang kompatibel akan terdeteksi secara otomatis.</value>
+    <value>Pilih agen yang digunakan di panel agen yang mendukung ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/is-IS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/is-IS/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Veldu agentinn sem er notaður í agentspjaldinu. Allir samhæfir ACP-agentar greinast sjálfkrafa.</value>
+    <value>Veldu agentinn sem er notaður í agentspjaldinu og styður ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
@@ -1002,7 +1002,7 @@
     <value>Agente</value>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Scegli l'agente utilizzato nel riquadro agente. Verrà rilevato qualsiasi agente ACP compatibile.</value>
+    <value>Scegli l'agente utilizzato nel riquadro agente che supporta ACP.</value>
     <comment>{Locked="ACP"}</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
@@ -1008,7 +1008,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>エージェント ペインで使用するエージェントを選択します。互換性のある ACP エージェントは自動的に検出されます。</value>
+    <value>エージェント ペインで使用する、ACP をサポートするエージェントを選択します。</value>
     <comment>{Locked="ACP"}
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>

--- a/src/cascadia/TerminalApp/Resources/ka-GE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ka-GE/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>აირჩიეთ აგენტი, რომელიც გამოიყენება აგენტის პანელში. ნებისმიერი თავსებადი ACP აგენტი ავტომატურად აღმოჩნდება.</value>
+    <value>აირჩიეთ აგენტი, რომელიც გამოიყენება აგენტის პანელში და აქვს ACP მხარდაჭერა.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/kk-KZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kk-KZ/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Агент панелінде қолданылатын агентті таңдаңыз. Үйлесімді кез келген ACP агент автоматты түрде анықталады.</value>
+    <value>Агент панелінде қолданылатын және ACP қолдайтын агентті таңдаңыз.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/km-KH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/km-KH/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>ជ្រើសរើសភ្នាក់ងារដែលប្រើក្នុងផ្ទាំងភ្នាក់ងារ។ ភ្នាក់ងារ ACP ដែលត្រូវគ្នានឹងត្រូវបានកត់សម្គាល់ដោយស្វ័យប្រវត្តិ។</value>
+    <value>ជ្រើសរើសភ្នាក់ងារដែលប្រើក្នុងផ្ទាំងភ្នាក់ងារ និងគាំទ្រ ACP។</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/kn-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kn-IN/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>ಏಜೆಂಟ್ ಪೇನ್‌ನಲ್ಲಿ ಬಳಸುವ ಏಜೆಂಟ್ ಅನ್ನು ಆಯ್ಕೆಮಾಡಿ. ಯಾವುದೇ ಹೊಂದಾಣಿಕೆಯ ACP ಏಜೆಂಟ್ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಪತ್ತೆಯಾಗುತ್ತದೆ.</value>
+    <value>ಏಜೆಂಟ್ ಪೇನ್‌ನಲ್ಲಿ ಬಳಸುವ ಮತ್ತು ACP ಬೆಂಬಲಿಸುವ ಏಜೆಂಟ್ ಅನ್ನು ಆಯ್ಕೆಮಾಡಿ.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
@@ -1067,7 +1067,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>에이전트 창에서 사용할 에이전트를 선택합니다. 호환되는 ACP 에이전트가 자동으로 감지됩니다.</value>
+    <value>에이전트 창에서 사용할 ACP 지원 에이전트를 선택합니다.</value>
     <comment>{Locked="ACP"}
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>

--- a/src/cascadia/TerminalApp/Resources/kok-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kok-IN/Resources.resw
@@ -164,7 +164,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>एजेंट पेनांत वापरतात तो एजेंट वेंचात. कोणतोय सुसंगत ACP एजेंट आपशींच शोधलो वतलो.</value>
+    <value>एजेंट पेनांत वापरतात तो ACP समर्थीत एजेंट वेंचात.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/lb-LU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lb-LU/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Wielt den Agent, deen am Agent-Panell benotzt gëtt. All kompatibel ACP-Agenten ginn automatesch erkannt.</value>
+    <value>Wielt den Agent, deen am Agent-Panell benotzt gëtt an ACP ënnerstëtzt.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/lo-LA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lo-LA/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>ເລືອກ agent ທີ່ໃຊ້ໃນແຜງ agent. ACP agent ທີ່ເຂົ້າກັນໄດ້ຈະຖືກກວດພົບໂດຍອັດຕະໂນມັດ.</value>
+    <value>ເລືອກ agent ທີ່ໃຊ້ໃນແຜງ agent ແລະຮອງຮັບ ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/lt-LT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lt-LT/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Pasirinkite agentą, naudojamą agento skydelyje. Visi suderinami ACP agentai bus aptikti automatiškai.</value>
+    <value>Pasirinkite agentą, naudojamą agento skydelyje ir palaikantį ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/lv-LV/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lv-LV/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Izvēlieties aģentu, kas tiek izmantots aģenta panelī. Visi saderīgie ACP aģenti tiks noteikti automātiski.</value>
+    <value>Izvēlieties aģentu, kas tiek izmantots aģenta panelī un atbalsta ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/mi-NZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mi-NZ/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Kōwhiria te kaitiaki e whakamahia ana i te papa kaitiaki. Ka kitea aunoa ngā kaitiaki ACP hototahi.</value>
+    <value>Kōwhiria te kaitiaki e whakamahia ana i te papa kaitiaki, ā, e tautoko ana i te ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/mk-MK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mk-MK/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Изберете го агентот што се користи во панелот на агентот. Секој компатибилен ACP агент ќе биде откриен автоматски.</value>
+    <value>Изберете го агентот што се користи во панелот на агентот и поддржува ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ml-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ml-IN/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>ഏജന്റ് പെയ്നിൽ ഉപയോഗിക്കുന്ന ഏജന്റിനെ തിരഞ്ഞെടുക്കുക. അനുയോജ്യമായ ഏതൊരു ACP ഏജന്റിനെയും സ്വയമേവ കണ്ടെത്തും.</value>
+    <value>ഏജന്റ് പെയ്നിൽ ഉപയോഗിക്കുന്നതും ACP പിന്തുണയ്ക്കുന്നതുമായ ഏജന്റിനെ തിരഞ്ഞെടുക്കുക.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/mr-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mr-IN/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>एजंट पेनमध्ये वापरला जाणारा एजंट निवडा. कोणताही सुसंगत ACP एजंट आपोआप शोधला जाईल.</value>
+    <value>एजंट पेनमध्ये वापरला जाणारा आणि ACP ला समर्थन देणारा एजंट निवडा.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ms-MY/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ms-MY/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Pilih ejen yang digunakan dalam anak tetingkap ejen. Mana-mana ejen ACP yang serasi akan dikesan secara automatik.</value>
+    <value>Pilih ejen yang digunakan dalam anak tetingkap ejen yang menyokong ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/mt-MT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mt-MT/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Agħżel l-aġent li jintuża fil-pannell tal-aġent. Kwalunkwe aġent ACP kompatibbli se jiġi ddetektat awtomatikament.</value>
+    <value>Agħżel l-aġent li jintuża fil-pannell tal-aġent u li jappoġġja ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/nb-NO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nb-NO/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Velg agenten som brukes i agentpanelet. Alle kompatible ACP-agenter oppdages automatisk.</value>
+    <value>Velg agenten som brukes i agentpanelet og støtter ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ne-NP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ne-NP/Resources.resw
@@ -164,7 +164,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>एजेन्ट पेनमा प्रयोग हुने एजेन्ट छान्नुहोस्। कुनै पनि मिल्दो ACP एजेन्ट स्वचालित रूपमा पत्ता लगाइनेछ।</value>
+    <value>एजेन्ट पेनमा प्रयोग हुने र ACP समर्थन गर्ने एजेन्ट छान्नुहोस्।</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/nl-NL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nl-NL/Resources.resw
@@ -159,7 +159,7 @@
     <value>Agent</value>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Kies de agent die in het agentvenster wordt gebruikt. Elke compatibele ACP-agent wordt gedetecteerd.</value>
+    <value>Kies de agent die in het agentvenster wordt gebruikt en ACP ondersteunt.</value>
     <comment>{Locked="ACP"}</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/nn-NO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nn-NO/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Vel agenten som vert brukt i agentpanelet. Alle kompatible ACP-agentar vert oppdaga automatisk.</value>
+    <value>Vel agenten som vert brukt i agentpanelet og støttar ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/or-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/or-IN/Resources.resw
@@ -164,7 +164,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>ଏଜେଣ୍ଟ ପେନ୍‌ରେ ବ୍ୟବହୃତ ଏଜେଣ୍ଟ ବାଛନ୍ତୁ। ଯେ କୌଣସି ସୁସଙ୍ଗତ ACP ଏଜେଣ୍ଟ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଚିହ୍ନଟ ହେବ।</value>
+    <value>ଏଜେଣ୍ଟ ପେନ୍‌ରେ ବ୍ୟବହୃତ ଏବଂ ACP ସମର୍ଥନ କରୁଥିବା ଏଜେଣ୍ଟ ବାଛନ୍ତୁ।</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/pa-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pa-IN/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>ਏਜੰਟ ਪੈਨ ਵਿੱਚ ਵਰਤੇ ਜਾਣ ਵਾਲੇ ਏਜੰਟ ਨੂੰ ਚੁਣੋ। ਕੋਈ ਵੀ ਅਨੁਕੂਲ ACP ਏਜੰਟ ਆਪਣੇ ਆਪ ਖੋਜਿਆ ਜਾਵੇਗਾ।</value>
+    <value>ਏਜੰਟ ਪੈਨ ਵਿੱਚ ਵਰਤੇ ਜਾਣ ਵਾਲੇ ਅਤੇ ACP ਦਾ ਸਮਰਥਨ ਕਰਨ ਵਾਲੇ ਏਜੰਟ ਨੂੰ ਚੁਣੋ।</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/pl-PL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pl-PL/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Wybierz agenta używanego w panelu agenta. Każdy zgodny agent ACP zostanie wykryty automatycznie.</value>
+    <value>Wybierz agenta używanego w panelu agenta, który obsługuje ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
@@ -1056,7 +1056,7 @@
     <value>Agente</value>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Escolha o agente usado no painel do agente. Qualquer agente ACP compatível será detectado.</value>
+    <value>Escolha o agente usado no painel do agente compatível com ACP.</value>
     <comment>{Locked="ACP"}</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/pt-PT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-PT/Resources.resw
@@ -159,7 +159,7 @@
     <value>Agente</value>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Escolha o agente utilizado no painel do agente. Qualquer agente ACP compatível será detetado.</value>
+    <value>Escolha o agente utilizado no painel do agente que suporta ACP.</value>
     <comment>{Locked="ACP"}</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
@@ -977,7 +977,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Choose the agent used in the agent pane. Any compatible ACP agent will be detected.</value>
+    <value>Choose the agent used in the agent pane that supports ACP.</value>
     <comment>{Locked="ACP"}
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>

--- a/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
@@ -977,7 +977,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Choose the agent used in the agent pane. Any compatible ACP agent will be detected.</value>
+    <value>Choose the agent used in the agent pane that supports ACP.</value>
     <comment>{Locked="ACP"}
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>

--- a/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
@@ -977,7 +977,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Choose the agent used in the agent pane. Any compatible ACP agent will be detected.</value>
+    <value>Choose the agent used in the agent pane that supports ACP.</value>
     <comment>{Locked="ACP"}
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>

--- a/src/cascadia/TerminalApp/Resources/quz-PE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/quz-PE/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Akllay agente nisqata agente k'itipi llamk'achisqa. Ima ACP agente tupaqpas kikinmanta tarikusqa kanqa.</value>
+    <value>Akllay agente nisqata agente k'itipi llamk'achisqa, ACP nisqata yanapaq.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ro-RO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ro-RO/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Alegeți agentul utilizat în panoul agentului. Orice agent ACP compatibil va fi detectat automat.</value>
+    <value>Alegeți agentul utilizat în panoul agentului care acceptă ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
@@ -1060,7 +1060,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Выберите агента, используемого в панели агента. Любой совместимый агент ACP будет обнаружен автоматически.</value>
+    <value>Выберите агента, используемого в панели агента, который поддерживает ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/sk-SK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sk-SK/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Vyberte agenta používaného v paneli agenta. Všetci kompatibilní agenti ACP sa rozpoznajú automaticky.</value>
+    <value>Vyberte agenta používaného v paneli agenta, ktorý podporuje ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/sl-SI/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sl-SI/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Izberite agenta, ki se uporablja v podoknu agenta. Vsak združljiv agent ACP bo zaznan samodejno.</value>
+    <value>Izberite agenta, ki se uporablja v podoknu agenta in podpira ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/sq-AL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sq-AL/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Zgjidhni agjentin që përdoret në panelin e agjentit. Çdo agjent ACP i përputhshëm do të zbulohet automatikisht.</value>
+    <value>Zgjidhni agjentin që përdoret në panelin e agjentit dhe mbështet ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-BA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-BA/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Изаберите агента који се користи у панелу агента. Сваки компатибилан ACP агент биће аутоматски откривен.</value>
+    <value>Изаберите агента који се користи у панелу агента и подржава ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
@@ -1043,7 +1043,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Изаберите агента који се користи у панелу агента. Сваки компатибилан ACP агент биће аутоматски откривен.</value>
+    <value>Изаберите агента који се користи у панелу агента и подржава ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/sr-Latn-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Latn-RS/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Izaberite agenta koji se koristi u panelu agenta. Svaki kompatibilan ACP agent biće automatski otkriven.</value>
+    <value>Izaberite agenta koji se koristi u panelu agenta i podržava ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/sv-SE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sv-SE/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Välj agenten som används i agentpanelen. Alla kompatibla ACP-agenter identifieras automatiskt.</value>
+    <value>Välj agenten som används i agentpanelen och stöder ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ta-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ta-IN/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>முகவர் பலகத்தில் பயன்படுத்தப்படும் முகவரைத் தேர்ந்தெடுக்கவும். இணக்கமான எந்த ACP முகவரும் தானாகக் கண்டறியப்படும்.</value>
+    <value>முகவர் பலகத்தில் பயன்படுத்தப்படும் மற்றும் ACP ஆதரவு கொண்ட முகவரைத் தேர்ந்தெடுக்கவும்.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/te-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/te-IN/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>ఏజెంట్ పేన్‌లో ఉపయోగించే ఏజెంట్‌ను ఎంచుకోండి. ఏదైనా అనుకూల ACP ఏజెంట్ స్వయంచాలకంగా గుర్తించబడుతుంది.</value>
+    <value>ఏజెంట్ పేన్‌లో ఉపయోగించే మరియు ACPకి మద్దతు ఇచ్చే ఏజెంట్‌ను ఎంచుకోండి.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/th-TH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/th-TH/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>เลือกเอเจนต์ที่ใช้ในแผงเอเจนต์ เอเจนต์ที่เข้ากันได้กับ ACP จะถูกตรวจพบโดยอัตโนมัติ</value>
+    <value>เลือกเอเจนต์ที่ใช้ในแผงเอเจนต์และรองรับ ACP</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/tr-TR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/tr-TR/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Aracı bölmesinde kullanılan aracıyı seçin. Uyumlu herhangi bir ACP aracısı otomatik olarak algılanır.</value>
+    <value>Aracı bölmesinde kullanılan ve ACP desteği olan aracıyı seçin.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/tt-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/tt-RU/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Агент панелендә кулланылган агентны сайлагыз. Туры килгән теләсә кайсы ACP агент автоматик рәвештә ачыкланачак.</value>
+    <value>Агент панелендә кулланылган һәм ACP хуплаган агентны сайлагыз.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ug-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ug-CN/Resources.resw
@@ -50,7 +50,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>ۋەكىل تاختىسىدا ئىشلىتىلىدىغان ۋەكىلنى تاللاڭ. ھەرقانداق ماسلاشقان ACP ۋەكىل ئاپتوماتىك بايقىلىدۇ.</value>
+    <value>ۋەكىل تاختىسىدا ئىشلىتىلىدىغان ۋە ACP نى قوللايدىغان ۋەكىلنى تاللاڭ.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
@@ -1055,7 +1055,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Оберіть агента, який використовується в панелі агента. Будь-який сумісний агент ACP буде виявлено автоматично.</value>
+    <value>Оберіть агента, який використовується в панелі агента та підтримує ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ur-PK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ur-PK/Resources.resw
@@ -164,7 +164,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>ایجنٹ پین میں استعمال ہونے والا ایجنٹ منتخب کریں۔ کوئی بھی ہم آہنگ ACP ایجنٹ خود بخود شناخت ہو جائے گا۔</value>
+    <value>ایجنٹ پین میں استعمال ہونے والا اور ACP کو سپورٹ کرنے والا ایجنٹ منتخب کریں۔</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/uz-Latn-UZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uz-Latn-UZ/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Agent panelida foydalaniladigan agentni tanlang. Mos keluvchi har qanday ACP agent avtomatik aniqlanadi.</value>
+    <value>Agent panelida foydalaniladigan va ACP qo'llab-quvvatlaydigan agentni tanlang.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/vi-VN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/vi-VN/Resources.resw
@@ -163,7 +163,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>Chọn tác tử được sử dụng trong bảng tác tử. Bất kỳ tác tử ACP tương thích nào cũng sẽ được phát hiện tự động.</value>
+    <value>Chọn tác tử được sử dụng trong bảng tác tử hỗ trợ ACP.</value>
     <comment>{Locked="ACP"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentInstallHint.Text" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
@@ -1069,7 +1069,7 @@
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>选择在智能体窗格中使用的智能体。任何兼容的 ACP 智能体都会被自动检测。</value>
+    <value>选择在智能体窗格中使用的支持 ACP 的智能体。</value>
     <comment>{Locked="ACP"}
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>

--- a/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
@@ -1007,7 +1007,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_AgentDescription.Text" xml:space="preserve">
-    <value>選擇智能體窗格中使用的智能體。任何相容的 ACP 智能體都會被自動偵測。</value>
+    <value>選擇智能體窗格中使用且支援 ACP 的智能體。</value>
     <comment>{Locked="ACP"}
 In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>


### PR DESCRIPTION
Fixes #159.

## FRE wording

| Before | After |
|---|---|
| Choose the agent used in the agent pane. Any compatible **ACP** agent will be detected. | Choose the agent used in the agent pane that supports **ACP**. |

New screenshot:
<img width="1502" height="188" alt="image" src="https://github.com/user-attachments/assets/238f4fb6-d184-49d4-a0da-6adc20dcea66" />


- `ACP` stays hyperlinked.
- Link target moves from `aka.ms/intelligent-terminal-acpref` (ACP spec) to `aka.ms/intelligent-terminal-dependency#agent-clis` (the new `Agent CLIs` umbrella in our dependency doc), so users land on the four supported agents instead of the ACP spec.

## Doc refactor (`doc/installing-dependencies.md`)

Single entry point for everything agent-related:

\\\
1. WinGet
2. Node.js LTS
3. Agent CLIs                                    <-- NEW umbrella (#agent-clis)
   3.1 GitHub Copilot CLI                        <-- anchor #31-github-copilot-cli
   3.2 Claude Code (bring your own)              <-- anchor #32-claude-code-bring-your-own
   3.3 OpenAI Codex (bring your own)             <-- anchor #33-openai-codex-bring-your-own
   3.4 Gemini CLI (bring your own)               <-- anchor #34-gemini-cli-bring-your-own
   3.5 Signing in to your agent                  <-- anchor #35-signing-in-to-your-agent
4. PowerShell shell integration                  <-- was 8, anchor #4-powershell-shell-integration
\\\

- New umbrella explains what we install vs. what you bring yourself, points to the [ACP spec](https://agentclientprotocol.com/get-started/agents), and notes that custom ACP agents can be added in **Settings -> AI Agents** but **session management** is not yet supported for them.
- FRE error-message deep-links in `FreOverlay.cpp` updated to the new anchors (`#31-github-copilot-cli`, `#4-powershell-shell-integration`).
- Removed the redundant top-of-file `[!NOTE]` block that the umbrella now owns.

## Localization

`FreOverlay_AgentDescription.Text` re-translated to a single sentence in all 88 locales. `ACP` token preserved verbatim per `{Locked="ACP"}`.

## Verification

- Locale translations validated by independent verifier sub-agent: BOM preserved, XML parses, ACP token present, single-sentence structure in every locale, confidence **high**.
- Local build (`bcz no_clean`): **0 errors**.

## Out of scope (per issue)

- Settings -> AI Agents page has the same string with the same false claim. Not changed here; the issue explicitly scopes to FRE only. Happy to follow up in a separate PR.
- Custom-agent flow in Settings unchanged.