### PR TITLE
FRE fix: refresh PATH from registry

### DIFF
--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -11,6 +11,7 @@
 #include "../inc/ShellIntegration.h"
 #include "../inc/RtlHelper.h"
 
+#include <til/env.h>
 #include <winrt/Windows.UI.Xaml.Documents.h>
 
 using namespace winrt::Windows::Foundation;
@@ -24,6 +25,28 @@ namespace winrt::TerminalApp::implementation
     FreOverlay::FreOverlay()
     {
         InitializeComponent();
+    }
+
+    // ── PATH refresh helper ───────────────────────────────────────────
+
+    // Re-read PATH from the Windows registry (system + user) and update
+    // the current process's PATH environment variable. This makes
+    // SearchPathW pick up directories added after Terminal launched
+    // (e.g. WinGet\Links after installing Copilot via winget).
+    static void _RefreshProcessPath()
+    {
+        til::env freshEnv;
+        freshEnv.regenerate();
+        const auto block = freshEnv.to_string();
+        // Extract PATH from the regenerated block
+        for (const wchar_t* p = block.c_str(); *p; p += wcslen(p) + 1)
+        {
+            if (_wcsnicmp(p, L"Path=", 5) == 0 || _wcsnicmp(p, L"PATH=", 5) == 0)
+            {
+                SetEnvironmentVariableW(L"PATH", p + 5);
+                break;
+            }
+        }
     }
 
     // ── Detection helpers ───────────────────────────────────────────────
@@ -546,6 +569,15 @@ namespace winrt::TerminalApp::implementation
                 _ShowProblem(FreProblemKind::NodeInstall);
                 co_return;
             }
+        }
+
+        // After installing prerequisites, refresh the current process's
+        // PATH from the Windows registry so SearchPathW (used by
+        // _DetectAgentCli, Settings UI, etc.) can find freshly-installed
+        // CLIs without restarting Terminal.
+        if (needsCopilot || needsNode)
+        {
+            _RefreshProcessPath();
         }
 
         // 4+5. Install hooks and shell integration. Run both, collect any

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -11,7 +11,6 @@
 #include "../inc/ShellIntegration.h"
 #include "../inc/RtlHelper.h"
 
-#include <til/env.h>
 #include <winrt/Windows.UI.Xaml.Documents.h>
 
 using namespace winrt::Windows::Foundation;
@@ -25,28 +24,6 @@ namespace winrt::TerminalApp::implementation
     FreOverlay::FreOverlay()
     {
         InitializeComponent();
-    }
-
-    // ── PATH refresh helper ───────────────────────────────────────────
-
-    // Re-read PATH from the Windows registry (system + user) and update
-    // the current process's PATH environment variable. This makes
-    // SearchPathW pick up directories added after Terminal launched
-    // (e.g. WinGet\Links after installing Copilot via winget).
-    static void _RefreshProcessPath()
-    {
-        til::env freshEnv;
-        freshEnv.regenerate();
-        const auto block = freshEnv.to_string();
-        // Extract PATH from the regenerated block
-        for (const wchar_t* p = block.c_str(); *p; p += wcslen(p) + 1)
-        {
-            if (_wcsnicmp(p, L"Path=", 5) == 0 || _wcsnicmp(p, L"PATH=", 5) == 0)
-            {
-                SetEnvironmentVariableW(L"PATH", p + 5);
-                break;
-            }
-        }
     }
 
     // ── Detection helpers ───────────────────────────────────────────────
@@ -577,7 +554,7 @@ namespace winrt::TerminalApp::implementation
         // CLIs without restarting Terminal.
         if (needsCopilot || needsNode)
         {
-            _RefreshProcessPath();
+            ::Microsoft::Terminal::WtaProcess::RefreshProcessPath();
         }
 
         // 4+5. Install hooks and shell integration. Run both, collect any

--- a/src/cascadia/TerminalApp/SharedWta.cpp
+++ b/src/cascadia/TerminalApp/SharedWta.cpp
@@ -8,7 +8,7 @@
 #include <string>
 
 #include "../WinRTUtils/inc/WtExeUtils.h"
-#include <til/env.h>
+#include "../inc/WtaProcess.h"
 
 namespace winrt::TerminalApp::implementation
 {
@@ -261,14 +261,13 @@ namespace winrt::TerminalApp::implementation
         // (no job → no KILL_ON_JOB_CLOSE containment).
         DWORD creationFlags = CREATE_NO_WINDOW | CREATE_UNICODE_ENVIRONMENT | CREATE_SUSPENDED;
 
-        // Build a fresh environment from the Windows registry so the
-        // master sees PATH entries added after Terminal launched (e.g.
-        // WinGet\Links after FRE installs copilot). Without this the
-        // master inherits Terminal's startup-time PATH which may not
-        // include freshly-installed CLIs.
-        til::env masterEnv;
-        masterEnv.regenerate();
-        auto envBlock = masterEnv.to_string();
+        // Refresh the current process's PATH from the Windows registry
+        // so the master (which inherits our env) sees PATH entries added
+        // after Terminal launched (e.g. WinGet\Links after FRE installs
+        // copilot). Using RefreshProcessPath + lpEnvironment=nullptr
+        // preserves all process-only variables (WT_COM_CLSID, etc.)
+        // that regenerate() would drop.
+        ::Microsoft::Terminal::WtaProcess::RefreshProcessPath();
 
         std::wstring mutableCmdLine{ commandline };
         if (!CreateProcessW(
@@ -278,7 +277,7 @@ namespace winrt::TerminalApp::implementation
                 /* lpThreadAttributes   */ nullptr,
                 /* bInheritHandles      */ FALSE,
                 /* dwCreationFlags      */ creationFlags,
-                /* lpEnvironment        */ envBlock.empty() ? nullptr : envBlock.data(),
+                /* lpEnvironment        */ nullptr,
                 /* lpCurrentDirectory   */ nullptr,
                 /* lpStartupInfo        */ &si,
                 /* lpProcessInformation */ &pi))

--- a/src/cascadia/TerminalApp/SharedWta.cpp
+++ b/src/cascadia/TerminalApp/SharedWta.cpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "../WinRTUtils/inc/WtExeUtils.h"
+#include <til/env.h>
 
 namespace winrt::TerminalApp::implementation
 {
@@ -260,6 +261,15 @@ namespace winrt::TerminalApp::implementation
         // (no job → no KILL_ON_JOB_CLOSE containment).
         DWORD creationFlags = CREATE_NO_WINDOW | CREATE_UNICODE_ENVIRONMENT | CREATE_SUSPENDED;
 
+        // Build a fresh environment from the Windows registry so the
+        // master sees PATH entries added after Terminal launched (e.g.
+        // WinGet\Links after FRE installs copilot). Without this the
+        // master inherits Terminal's startup-time PATH which may not
+        // include freshly-installed CLIs.
+        til::env masterEnv;
+        masterEnv.regenerate();
+        auto envBlock = masterEnv.to_string();
+
         std::wstring mutableCmdLine{ commandline };
         if (!CreateProcessW(
                 /* lpApplicationName    */ nullptr,
@@ -268,7 +278,7 @@ namespace winrt::TerminalApp::implementation
                 /* lpThreadAttributes   */ nullptr,
                 /* bInheritHandles      */ FALSE,
                 /* dwCreationFlags      */ creationFlags,
-                /* lpEnvironment        */ nullptr,
+                /* lpEnvironment        */ envBlock.empty() ? nullptr : envBlock.data(),
                 /* lpCurrentDirectory   */ nullptr,
                 /* lpStartupInfo        */ &si,
                 /* lpProcessInformation */ &pi))

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
@@ -12,6 +12,7 @@
 #include "../inc/CustomAgentId.h"
 #include "../inc/WtaProcess.h"
 
+#include <til/env.h>
 #include <json/json.h>
 
 using namespace winrt::Windows::Foundation;
@@ -37,6 +38,23 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────
+
+    // Re-read PATH from the Windows registry and update the current
+    // process so SearchPathW finds CLIs installed after Terminal launched.
+    static void _RefreshProcessPath()
+    {
+        til::env freshEnv;
+        freshEnv.regenerate();
+        const auto block = freshEnv.to_string();
+        for (const wchar_t* p = block.c_str(); *p; p += wcslen(p) + 1)
+        {
+            if (_wcsnicmp(p, L"Path=", 5) == 0 || _wcsnicmp(p, L"PATH=", 5) == 0)
+            {
+                SetEnvironmentVariableW(L"PATH", p + 5);
+                break;
+            }
+        }
+    }
 
     bool AIAgentsViewModel::_IsAgentInstalled(const wchar_t* name)
     {
@@ -109,6 +127,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _GlobalSettings{ globalSettings }
     {
         namespace Reg = ::Microsoft::Terminal::Settings::Model::AgentRegistry;
+
+        // Refresh PATH from the Windows registry so SearchPathW can find
+        // CLIs installed after Terminal launched (e.g. WinGet\Links).
+        _RefreshProcessPath();
 
         // ACP-capable agents — use GPO-filtered list so only policy-allowed
         // agents appear in the dropdown. Also skip agents whose CLI isn't

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
@@ -12,7 +12,6 @@
 #include "../inc/CustomAgentId.h"
 #include "../inc/WtaProcess.h"
 
-#include <til/env.h>
 #include <json/json.h>
 
 using namespace winrt::Windows::Foundation;
@@ -38,23 +37,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────
-
-    // Re-read PATH from the Windows registry and update the current
-    // process so SearchPathW finds CLIs installed after Terminal launched.
-    static void _RefreshProcessPath()
-    {
-        til::env freshEnv;
-        freshEnv.regenerate();
-        const auto block = freshEnv.to_string();
-        for (const wchar_t* p = block.c_str(); *p; p += wcslen(p) + 1)
-        {
-            if (_wcsnicmp(p, L"Path=", 5) == 0 || _wcsnicmp(p, L"PATH=", 5) == 0)
-            {
-                SetEnvironmentVariableW(L"PATH", p + 5);
-                break;
-            }
-        }
-    }
 
     bool AIAgentsViewModel::_IsAgentInstalled(const wchar_t* name)
     {
@@ -130,7 +112,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         // Refresh PATH from the Windows registry so SearchPathW can find
         // CLIs installed after Terminal launched (e.g. WinGet\Links).
-        _RefreshProcessPath();
+        ::Microsoft::Terminal::WtaProcess::RefreshProcessPath();
 
         // ACP-capable agents — use GPO-filtered list so only policy-allowed
         // agents appear in the dropdown. Also skip agents whose CLI isn't

--- a/src/cascadia/inc/WtaProcess.h
+++ b/src/cascadia/inc/WtaProcess.h
@@ -14,7 +14,6 @@
 
 #include <filesystem>
 #include <string>
-#include <til/env.h>
 
 namespace Microsoft::Terminal::WtaProcess
 {
@@ -236,15 +235,61 @@ namespace Microsoft::Terminal::WtaProcess
     // the current process's PATH environment variable. This makes
     // SearchPathW pick up directories added after Terminal launched
     // (e.g. WinGet\Links after installing Copilot via winget).
+    // Pure Win32 — no til/env or WinRT dependency.
     inline void RefreshProcessPath()
     {
-        til::env freshEnv;
-        freshEnv.regenerate();
-        auto& map = freshEnv.as_map();
-        auto it = map.find(L"Path");
-        if (it != map.end())
+        auto readRegPath = [](HKEY root, const wchar_t* subkey) -> std::wstring {
+            HKEY hk{};
+            if (RegOpenKeyExW(root, subkey, 0, KEY_READ, &hk) != ERROR_SUCCESS)
+                return {};
+            DWORD size = 0, kind = 0;
+            if (RegQueryValueExW(hk, L"Path", nullptr, &kind, nullptr, &size) != ERROR_SUCCESS || size == 0)
+            {
+                RegCloseKey(hk);
+                return {};
+            }
+            std::wstring buf(size / sizeof(wchar_t), L'\0');
+            if (RegQueryValueExW(hk, L"Path", nullptr, &kind,
+                                 reinterpret_cast<BYTE*>(buf.data()), &size) != ERROR_SUCCESS)
+            {
+                RegCloseKey(hk);
+                return {};
+            }
+            RegCloseKey(hk);
+            // Trim trailing null(s)
+            while (!buf.empty() && buf.back() == L'\0')
+                buf.pop_back();
+            // Expand %VAR% references if REG_EXPAND_SZ
+            if (kind == REG_EXPAND_SZ)
+            {
+                DWORD needed = ExpandEnvironmentStringsW(buf.c_str(), nullptr, 0);
+                if (needed > 0)
+                {
+                    std::wstring expanded(needed, L'\0');
+                    ExpandEnvironmentStringsW(buf.c_str(), expanded.data(), needed);
+                    while (!expanded.empty() && expanded.back() == L'\0')
+                        expanded.pop_back();
+                    return expanded;
+                }
+            }
+            return buf;
+        };
+
+        auto sysPath = readRegPath(HKEY_LOCAL_MACHINE,
+                                   LR"(SYSTEM\CurrentControlSet\Control\Session Manager\Environment)");
+        auto usrPath = readRegPath(HKEY_CURRENT_USER, L"Environment");
+
+        std::wstring combined;
+        if (!sysPath.empty() && !usrPath.empty())
+            combined = sysPath + L";" + usrPath;
+        else if (!sysPath.empty())
+            combined = sysPath;
+        else if (!usrPath.empty())
+            combined = usrPath;
+
+        if (!combined.empty())
         {
-            SetEnvironmentVariableW(L"PATH", it->second.c_str());
+            SetEnvironmentVariableW(L"PATH", combined.c_str());
         }
     }
 

--- a/src/cascadia/inc/WtaProcess.h
+++ b/src/cascadia/inc/WtaProcess.h
@@ -14,6 +14,7 @@
 
 #include <filesystem>
 #include <string>
+#include <til/env.h>
 
 namespace Microsoft::Terminal::WtaProcess
 {
@@ -229,6 +230,22 @@ namespace Microsoft::Terminal::WtaProcess
         envBlock += L'\0'; // double-null terminator
         FreeEnvironmentStringsW(currentEnv);
         return envBlock;
+    }
+
+    // Re-read PATH from the Windows registry (system + user) and update
+    // the current process's PATH environment variable. This makes
+    // SearchPathW pick up directories added after Terminal launched
+    // (e.g. WinGet\Links after installing Copilot via winget).
+    inline void RefreshProcessPath()
+    {
+        til::env freshEnv;
+        freshEnv.regenerate();
+        auto& map = freshEnv.as_map();
+        auto it = map.find(L"Path");
+        if (it != map.end())
+        {
+            SetEnvironmentVariableW(L"PATH", it->second.c_str());
+        }
     }
 
     // Spawn `wta.exe <argsAfterExe>` and wait for completion (no stdout capture).

--- a/src/cascadia/inc/WtaProcess.h
+++ b/src/cascadia/inc/WtaProcess.h
@@ -235,7 +235,7 @@ namespace Microsoft::Terminal::WtaProcess
     // Reads system + user PATH from the registry, then appends any
     // directories not already present. Preserves session-specific
     // entries inherited from the parent process.
-    // Pure Win32 + std::wstring only — no til/env, no STL containers.
+    // Pure Win32 + std::wstring — no til/env or WinRT dependency.
     inline void RefreshProcessPath()
     {
         auto readRegPath = [](HKEY root, const wchar_t* subkey) -> std::wstring {
@@ -274,10 +274,14 @@ namespace Microsoft::Terminal::WtaProcess
                 if (needed > 0)
                 {
                     std::wstring expanded(needed, L'\0');
-                    ExpandEnvironmentStringsW(buf.c_str(), expanded.data(), needed);
-                    while (!expanded.empty() && expanded.back() == L'\0')
-                        expanded.pop_back();
-                    return expanded;
+                    DWORD written = ExpandEnvironmentStringsW(buf.c_str(), expanded.data(), needed);
+                    if (written > 0 && written <= needed)
+                    {
+                        while (!expanded.empty() && expanded.back() == L'\0')
+                            expanded.pop_back();
+                        return expanded;
+                    }
+                    // Expansion failed — fall through to return unexpanded buf
                 }
             }
             return buf;

--- a/src/cascadia/inc/WtaProcess.h
+++ b/src/cascadia/inc/WtaProcess.h
@@ -231,11 +231,11 @@ namespace Microsoft::Terminal::WtaProcess
         return envBlock;
     }
 
-    // Re-read PATH from the Windows registry (system + user) and update
-    // the current process's PATH environment variable. This makes
-    // SearchPathW pick up directories added after Terminal launched
-    // (e.g. WinGet\Links after installing Copilot via winget).
-    // Pure Win32 — no til/env or WinRT dependency.
+    // Merge registry PATH entries into the current process's PATH.
+    // Reads system + user PATH from the registry, then appends any
+    // directories not already present. Preserves session-specific
+    // entries inherited from the parent process.
+    // Pure Win32 + std::wstring only — no til/env, no STL containers.
     inline void RefreshProcessPath()
     {
         auto readRegPath = [](HKEY root, const wchar_t* subkey) -> std::wstring {
@@ -248,7 +248,15 @@ namespace Microsoft::Terminal::WtaProcess
                 RegCloseKey(hk);
                 return {};
             }
-            std::wstring buf(size / sizeof(wchar_t), L'\0');
+            // Only process string types
+            if (kind != REG_SZ && kind != REG_EXPAND_SZ)
+            {
+                RegCloseKey(hk);
+                return {};
+            }
+            // Round up to whole wchar_t count to guard against odd byte sizes
+            const DWORD wcharCount = (size + sizeof(wchar_t) - 1) / sizeof(wchar_t);
+            std::wstring buf(wcharCount, L'\0');
             if (RegQueryValueExW(hk, L"Path", nullptr, &kind,
                                  reinterpret_cast<BYTE*>(buf.data()), &size) != ERROR_SUCCESS)
             {
@@ -275,21 +283,64 @@ namespace Microsoft::Terminal::WtaProcess
             return buf;
         };
 
+        // Case-insensitive check: is `entry` already somewhere in
+        // the semicolon-delimited `path`?
+        auto pathContains = [](const std::wstring& path, const std::wstring& entry) -> bool {
+            if (entry.empty())
+                return true;
+            // Walk the semicolon-delimited string without allocating
+            size_t start = 0;
+            while (start <= path.size())
+            {
+                auto pos = path.find(L';', start);
+                if (pos == std::wstring::npos)
+                    pos = path.size();
+                if (pos - start == entry.size() &&
+                    _wcsnicmp(path.c_str() + start, entry.c_str(), entry.size()) == 0)
+                {
+                    return true;
+                }
+                start = pos + 1;
+            }
+            return false;
+        };
+
         auto sysPath = readRegPath(HKEY_LOCAL_MACHINE,
                                    LR"(SYSTEM\CurrentControlSet\Control\Session Manager\Environment)");
         auto usrPath = readRegPath(HKEY_CURRENT_USER, L"Environment");
 
-        std::wstring combined;
-        if (!sysPath.empty() && !usrPath.empty())
-            combined = sysPath + L";" + usrPath;
-        else if (!sysPath.empty())
-            combined = sysPath;
-        else if (!usrPath.empty())
-            combined = usrPath;
+        // Get current process PATH
+        wchar_t currentBuf[32767]{};
+        GetEnvironmentVariableW(L"PATH", currentBuf, 32767);
+        std::wstring currentPath{ currentBuf };
 
-        if (!combined.empty())
+        // Append registry entries not already in the process PATH
+        bool changed = false;
+        auto mergeFrom = [&](const std::wstring& regPath) {
+            size_t start = 0;
+            while (start < regPath.size())
+            {
+                auto pos = regPath.find(L';', start);
+                if (pos == std::wstring::npos)
+                    pos = regPath.size();
+                auto entry = regPath.substr(start, pos - start);
+                if (!entry.empty() && !pathContains(currentPath, entry))
+                {
+                    if (!currentPath.empty() && currentPath.back() != L';')
+                        currentPath += L';';
+                    currentPath += entry;
+                    changed = true;
+                }
+                start = pos + 1;
+            }
+        };
+
+        mergeFrom(sysPath);
+        mergeFrom(usrPath);
+
+        if (changed)
         {
-            SetEnvironmentVariableW(L"PATH", combined.c_str());
+            SetEnvironmentVariableW(L"PATH", currentPath.c_str());
         }
     }
 


### PR DESCRIPTION
…rable

After winget installs an agent CLI (e.g. Copilot), the new executable lands in %LOCALAPPDATA%\Microsoft\WinGet\Links which may not be in Terminal's startup-time PATH. Three fixes:

- FreOverlay: _RefreshProcessPath() after winget install so SearchPathW/_DetectAgentCli find the new binary immediately
- SharedWta: master process uses til::env::regenerate() instead of inheriting Terminal's stale PATH
- AIAgentsViewModel: Settings UI refreshes PATH from registry before agent detection so agents installed outside Terminal are visible

## Summary of the Pull Request

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
