### PR TITLE
Gate hooks install on CLI binary on PATH

### DIFF
--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -521,6 +521,22 @@ fn ensure_installed_in(home: &Path) {
 // Per-CLI install flows
 // ---------------------------------------------------------------------------
 
+/// Whether the CLI's binary is currently resolvable on `PATH`.
+///
+/// This is the **authoritative "is the CLI installed" signal** for the
+/// per-CLI install gates below. Earlier wta builds gated install solely on
+/// the presence of `~/.<cli>` (Claude's `~/.claude`, Copilot's
+/// `~/.copilot`, etc.), but every supported CLI leaves that directory
+/// behind on uninstall (containing logs, auth tokens, plugin state, ...),
+/// so the dir-only check fires "install hooks for X" even on machines
+/// where X has been uninstalled. Probing `PATH` via `which::which` matches
+/// what [`status_for`] already does (`locate_binary` at line ~915) and
+/// what the dev probes in [`upgrade_installed_hooks`] use, so we stay
+/// consistent with the rest of the module.
+fn cli_binary_on_path(cli: CliKind) -> bool {
+    which::which(cli.name()).is_ok()
+}
+
 /// Install hooks for Claude Code by spawning `claude plugin install`.
 ///
 /// Always uses Claude Code's own plugin manager — never edits
@@ -535,6 +551,13 @@ fn ensure_installed_in(home: &Path) {
 ///   3. Spawn `claude plugin marketplace add <bundle>/claude`.
 ///   4. Spawn `claude plugin install wt-agent-hooks@wt-local`.
 fn install_for_claude(home: &Path) {
+    if !cli_binary_on_path(CliKind::Claude) {
+        tracing::debug!(
+            target: "agent_hooks",
+            "claude not on PATH; skipping hook install (CLI not installed)",
+        );
+        return;
+    }
     let claude_dir = home.join(".claude");
     if !claude_dir.is_dir() {
         tracing::debug!(target: "agent_hooks", "no ~/.claude dir; Claude not present");
@@ -635,6 +658,13 @@ fn install_for_claude(home: &Path) {
 /// to trust the plugin before any events fire. That's documented in
 /// the slice-C README; this function returns success on registration.
 fn install_for_codex(home: &Path) {
+    if !cli_binary_on_path(CliKind::Codex) {
+        tracing::debug!(
+            target: "agent_hooks",
+            "codex not on PATH; skipping hook install (CLI not installed)",
+        );
+        return;
+    }
     let codex_dir = home.join(".codex");
     if !codex_dir.is_dir() {
         tracing::debug!(target: "agent_hooks", "no ~/.codex dir; Codex not present");
@@ -719,6 +749,13 @@ fn maybe_stage_bundle_for_codex(source: &Path) -> Option<PathBuf> {
 
 /// Install hooks for Copilot CLI by spawning `copilot plugin install`.
 fn install_for_copilot(home: &Path) {
+    if !cli_binary_on_path(CliKind::Copilot) {
+        tracing::debug!(
+            target: "copilot_hooks",
+            "copilot not on PATH; skipping hook install (CLI not installed)",
+        );
+        return;
+    }
     let copilot_dir = home.join(".copilot");
     if !copilot_dir.is_dir() {
         tracing::debug!(target: "copilot_hooks", "no ~/.copilot dir; Copilot CLI not present");
@@ -814,6 +851,13 @@ fn install_for_copilot(home: &Path) {
 
 /// Install hooks for Gemini CLI by spawning `gemini extensions install`.
 fn install_for_gemini(home: &Path) {
+    if !cli_binary_on_path(CliKind::Gemini) {
+        tracing::debug!(
+            target: "gemini_hooks",
+            "gemini not on PATH; skipping hook install (CLI not installed)",
+        );
+        return;
+    }
     let gemini_dir = home.join(".gemini");
     if !gemini_dir.is_dir() {
         tracing::debug!(target: "gemini_hooks", "no ~/.gemini dir; Gemini CLI not present");


### PR DESCRIPTION
## Problem

The Settings UI **Agents → Install hooks** button (and the FRE / `wta hooks install` paths) was installing the `wt-agent-hooks` plugin into every CLI that had a `~/.<cli>` directory. But every supported CLI (Copilot, Claude, Gemini, Codex) **leaves that directory behind on uninstall** — it holds auth tokens, logs, plugin state, command history, etc. So on a machine where the user had previously installed and then uninstalled (e.g.) Codex, clicking *Install hooks* would still run `codex plugin marketplace add ...` and fail noisily, or worse, partially register a plugin against a CLI that isn't there anymore.

## Fix

Add a binary-on-PATH precheck to each `install_for_<cli>` in `agent_hooks_installer.rs`:

` `rust
fn cli_binary_on_path(cli: CliKind) -> bool {
    which::which(cli.name()).is_ok()
}
` `

This matches the authoritative `is the CLI actually installed?` signal that the rest of the module already uses:

- `status_for` → `locate_binary` (line ~915)
- `copilot_uninstall` / `claude_uninstall` (lines ~1697, ~1734)
- `upgrade_one_cli` for Claude (line ~3353)

The existing `~/.<cli>` directory check stays as a **second** gate so the existing unit tests — which pass tmp dirs as `home` — stay hermetic on a dev machine that happens to have a real CLI on PATH. (Without that, the tests would actually spawn the real CLI against the dev's real config.)

## What does **not** change

- The auto-upgrade path (`upgrade_installed_hooks`) is already opt-in — it only runs if `plugin list` reports the plugin as installed — so it does not need the same gate.
- `status()` / `uninstall()` were already using `which::which` and stay unchanged.

## Verification

- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml` → ✅ (0 errors)
- `cargo test ... agent_hooks_installer` → ✅ **123 passed, 0 failed**
