### PR TITLE
wtcli: actionable diagnostics for common COM activation failures

### DIFF
--- a/src/tools/wtcli/main.cpp
+++ b/src/tools/wtcli/main.cpp
@@ -37,6 +37,67 @@ private:
 
 // ── Helpers ──
 
+// Print a context-appropriate diagnostic for a COM activation failure.
+// We special-case a few HRESULTs that have known, actionable causes; for
+// anything else we fall back to the raw HRESULT + system message so bug
+// reports retain the original signal.
+static void PrintConnectionError(HRESULT hr, const wchar_t* sysMessage)
+{
+    switch (hr)
+    {
+    case RPC_E_SERVERFAULT: // 0x80010105
+        // Combase's MetadataBasedMarshaler (used for cross-process WinRT
+        // activation when no proxy/stub DLL is registered) crashes on
+        // older Windows builds — observed on stock Win10 21H2 (combase
+        // 19041.1288) and Win11 22H2 (combase 22621.x). Fixed in newer
+        // cumulative updates and in Win11 24H2+. We deliberately do NOT
+        // cite a specific build number here because the fix shipped via
+        // ordinary monthly cumulative updates rather than a named release.
+        fprintf(stderr,
+                "[wtcli] Could not connect to Intelligent Terminal.\n"
+                "        This Windows build contains a known issue with cross-process\n"
+                "        WinRT activation. To fix:\n"
+                "          1. Open Settings > Windows Update\n"
+                "          2. Install all available updates and restart\n"
+                "          3. Try the command again\n"
+                "        If you are already on the latest Windows 11 24H2 (or newer)\n"
+                "        and still see this, please file an issue.\n"
+                "        (HRESULT 0x%08X: %ls)\n",
+                static_cast<uint32_t>(hr), sysMessage);
+        break;
+
+    case REGDB_E_CLASSNOTREG: // 0x80040154
+        // The TerminalProtocolComServer COM class is not registered. This
+        // typically means Intelligent Terminal's MSIX package failed to
+        // finish (re)registering — e.g. after a stuck upgrade. Reinstall
+        // or repair usually fixes it.
+        fprintf(stderr,
+                "[wtcli] Could not connect to Intelligent Terminal.\n"
+                "        Intelligent Terminal's COM server is not registered with\n"
+                "        Windows. This usually means the app's install or upgrade did\n"
+                "        not complete successfully. To fix, try one of the following:\n"
+                "          - Reinstall Intelligent Terminal from the Store / installer\n"
+                "          - Run the repair script bundled with the install\n"
+                "        (HRESULT 0x%08X: %ls)\n",
+                static_cast<uint32_t>(hr), sysMessage);
+        break;
+
+    case CO_E_SERVER_EXEC_FAILURE: // 0x80080005
+        fprintf(stderr,
+                "[wtcli] Could not launch the Intelligent Terminal protocol server.\n"
+                "        The server process failed to start. Make sure Intelligent\n"
+                "        Terminal is installed and try restarting it.\n"
+                "        (HRESULT 0x%08X: %ls)\n",
+                static_cast<uint32_t>(hr), sysMessage);
+        break;
+
+    default:
+        fprintf(stderr, "[wtcli] Connection failed: 0x%08X %ls\n",
+                static_cast<uint32_t>(hr), sysMessage);
+        break;
+    }
+}
+
 static Protocol::IProtocolServer ConnectToTerminal(Protocol::AuthResult* outAuth = nullptr)
 {
     wchar_t clsid[128]{};
@@ -68,8 +129,7 @@ static Protocol::IProtocolServer ConnectToTerminal(Protocol::AuthResult* outAuth
     }
     catch (const winrt::hresult_error& e)
     {
-        fprintf(stderr, "[wtcli] Connection failed: 0x%08X %ls\n",
-                static_cast<uint32_t>(e.code()), e.message().c_str());
+        PrintConnectionError(e.code(), e.message().c_str());
         return nullptr;
     }
 }


### PR DESCRIPTION
## Summary

When `wtcli` fails to connect to the Intelligent Terminal protocol
server, the user previously saw an opaque HRESULT with no guidance:

```
[wtcli] Connection failed: 0x80010105 The server threw an exception.
```

This change makes three common, actionable failure modes self-explanatory:

| HRESULT | Cause | New message guides the user to |
|---|---|---|
| `0x80010105` `RPC_E_SERVERFAULT` | Combase MetadataBasedMarshaler crash during cross-process WinRT activation (older Windows builds) | Install all pending Windows Updates |
| `0x80040154` `REGDB_E_CLASSNOTREG` | IT's COM class not registered (stuck/failed MSIX upgrade) | Reinstall / repair |
| `0x80080005` `CO_E_SERVER_EXEC_FAILURE` | Server process failed to start | Make sure IT is running, try restarting |

Any other HRESULT falls back to the original `Connection failed: 0x...`
format so bug reports retain the raw signal.

## Context

This is a **ship-tomorrow stop-gap** while the real fix is in flight on
dev/yeelam/reliability/com-proxy-stub. The root cause for the most
visible failure (`0x80010105`) is that IT's `IProtocolServer` is a
WinRT interface activated cross-process **without a registered
proxy/stub DLL**, which forces combase down its MetadataBasedMarshaler
path. That path crashes inside `combase.dll` on stale Win10 21H2
(combase 19041.1288) and Win11 22H2 (combase 22621.x) — observed
faulting offsets `0xbdc9b` / `0xc548b`. The crash does not reproduce
on Win11 24H2+ (combase 26100.x).

The real fix is to give `IProtocolServer` a hand-generated proxy/stub
DLL — exactly the same pattern upstream Microsoft Terminal has used for
`IConsoleHandoff` (the Default Terminal Handler feature) for years on
millions of Win10 19041+ devices. Until that lands, this PR at least
tells the affected user **what to do** instead of showing them a hex code.

### Why we don't cite a specific Windows build number

The fix on the OS side shipped via ordinary monthly cumulative updates
rather than a named release, so citing `>= build X.Y.Z` would be
wrong for some users (and there's no documented build number we can
trust). `Install all pending Windows Updates` is a phrasing that is
correct regardless of which exact CU was the actual fix point.

## Verification

- ✅ **Build**: full `bx` of `src/tools/wtcli/wtcli.vcxproj` succeeds (0 errors, 1 unrelated `/DEBUG:FASTLINK` warning from VS toolchain).
- ✅ **Scope**: `git diff main --stat` shows only `src/tools/wtcli/main.cpp` changed (62 insertions, 2 deletions).
- ✅ **Backward compatibility**: any HRESULT not in the switch falls through to the existing one-line format — no regression for unknown failures.