### PR TITLE
FRE/Settings: grey out shell integration when PS execution policy blocks unsigned scripts

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -26,6 +26,7 @@ AImpl
 AInplace
 ALIGNRIGHT
 allocing
+allsigned
 alpc
 ALTERNATENAME
 ALTF

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1990,6 +1990,7 @@ namespace winrt::TerminalApp::implementation
         bool wpAlready = false;
         bool pwshOk = false;
         bool wpOk = false;
+        bool epBlocked = false;
         {
             std::lock_guard<std::mutex> guard{ _shellIntegrationReconcileMutex };
             // Re-check after acquiring the lock. If a settings reload (toggle
@@ -2006,6 +2007,7 @@ namespace winrt::TerminalApp::implementation
                 wpAlready = wpResult.alreadyInstalled;
                 pwshOk = pwshResult.success;
                 wpOk = wpResult.success;
+                epBlocked = pwshResult.executionPolicyBlocked || wpResult.executionPolicyBlocked;
             }
         }
 
@@ -2023,6 +2025,42 @@ namespace winrt::TerminalApp::implementation
             else if (allAlreadyInstalled)
             {
                 // Already configured — no dialog needed
+            }
+            else if (epBlocked)
+            {
+                // Specific message: execution policy is refusing scripts.
+                // Different remediation than a generic write failure (the user
+                // needs to change execution policy, not retry). Build the body
+                // as a TextBlock with the sentence on one line and a clickable
+                // "Learn how to fix this manually" Hyperlink on a separate
+                // line below — matches the FreOverlay error-banner pattern
+                // and avoids any concat/RTL issues with inline links.
+                if (auto presenter{ strong->_dialogPresenter.get() })
+                {
+                    Controls::ContentDialog dialog;
+                    dialog.Title(winrt::box_value(RS_(L"InitShellIntegrationErrorTitle")));
+
+                    Controls::TextBlock body;
+                    body.TextWrapping(TextWrapping::Wrap);
+
+                    Documents::Run sentence;
+                    sentence.Text(RS_(L"InitShellIntegrationExecutionPolicyErrorMessage"));
+                    body.Inlines().Append(sentence);
+
+                    body.Inlines().Append(Documents::LineBreak{});
+
+                    Documents::Hyperlink link;
+                    link.NavigateUri(winrt::Windows::Foundation::Uri{ L"https://aka.ms/intelligent-terminal-dependency#4-powershell-shell-integration" });
+                    Documents::Run linkRun;
+                    linkRun.Text(RS_(L"FreOverlay_ErrorHelpLink"));
+                    link.Inlines().Append(linkRun);
+                    body.Inlines().Append(link);
+
+                    dialog.Content(body);
+                    dialog.CloseButtonText(RS_(L"Ok"));
+                    dialog.DefaultButton(Controls::ContentDialogButton::Close);
+                    presenter.ShowDialog(dialog);
+                }
             }
             else if (anyFailure)
             {

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -554,6 +554,20 @@ namespace winrt::TerminalApp::implementation
             ErrorText().Text(RS_(L"FreOverlay_InstallErrorNode"));
             url += L"#2-nodejs-lts--shared-prerequisite";
             break;
+        case FreProblemKind::ShellIntegrationExecutionPolicy:
+            ErrorText().Text(RS_(L"FreOverlay_InstallErrorShellIntegrationExecutionPolicy"));
+            url += L"#4-powershell-shell-integration";
+            // Same remediation as generic shell-integration failure: turn
+            // off error detection so the user can save and continue. Once
+            // they fix execution policy they can re-enable it from Settings.
+            AutoDetectToggle().IsOn(false);
+            _UpdateSuggestionEnabledState();
+            if (_settings)
+            {
+                _settings.GlobalSettings().AutoErrorDetectionEnabled(false);
+                _settings.GlobalSettings().AutoFixEnabled(false);
+            }
+            break;
         case FreProblemKind::ShellIntegration:
             ErrorText().Text(RS_(L"FreOverlay_InstallErrorShellIntegration"));
             url += L"#4-powershell-shell-integration";
@@ -716,6 +730,7 @@ namespace winrt::TerminalApp::implementation
         // Save retries them.
         bool hooksFailed = false;
         bool shellIntegFailed = false;
+        bool shellIntegEpBlocked = false;
 
         // 4. Hooks — skip if GPO blocks it or settings unavailable.
         if (SessionManagementToggle().IsOn() &&
@@ -747,7 +762,7 @@ namespace winrt::TerminalApp::implementation
             co_await winrt::resume_background();
             namespace SI = ::Microsoft::Terminal::ShellIntegration;
             const auto pwsh7Result = SI::InstallForTarget(SI::Target::Pwsh);
-            const auto winPsResult = SI::InstallForTarget(SI::Target::WindowsPowerShell);
+            const auto windowsPsResult = SI::InstallForTarget(SI::Target::WindowsPowerShell);
 
             {
                 std::string detail = "[FRE] Shell integration: pwsh7=";
@@ -755,15 +770,24 @@ namespace winrt::TerminalApp::implementation
                 if (!pwsh7Result.success && !pwsh7Result.errorMessage.empty())
                     detail += " (" + winrt::to_string(winrt::hstring{ pwsh7Result.errorMessage }) + ")";
                 detail += " winPs=";
-                detail += winPsResult.success ? "ok" : "FAILED";
-                if (!winPsResult.success && !winPsResult.errorMessage.empty())
-                    detail += " (" + winrt::to_string(winrt::hstring{ winPsResult.errorMessage }) + ")";
+                detail += windowsPsResult.success ? "ok" : "FAILED";
+                if (!windowsPsResult.success && !windowsPsResult.errorMessage.empty())
+                    detail += " (" + winrt::to_string(winrt::hstring{ windowsPsResult.errorMessage }) + ")";
                 _agentPaneLog(detail);
             }
 
-            if (!pwsh7Result.success || !winPsResult.success)
+            if (!pwsh7Result.success || !windowsPsResult.success)
             {
                 shellIntegFailed = true;
+                // If either host's failure was specifically the execution
+                // policy, surface the policy-specific message instead of the
+                // generic write-failed one. The user needs different
+                // remediation (Set-ExecutionPolicy / GPO) vs. a transient
+                // file write failure.
+                if (pwsh7Result.executionPolicyBlocked || windowsPsResult.executionPolicyBlocked)
+                {
+                    shellIntegEpBlocked = true;
+                }
             }
         }
 
@@ -777,8 +801,9 @@ namespace winrt::TerminalApp::implementation
             auto self = weak.get();
             if (!self) co_return;
 
-            _ShowProblem(shellIntegFailed ? FreProblemKind::ShellIntegration
-                                          : FreProblemKind::Hooks);
+            _ShowProblem(shellIntegEpBlocked ? FreProblemKind::ShellIntegrationExecutionPolicy
+                                             : shellIntegFailed ? FreProblemKind::ShellIntegration
+                                                                : FreProblemKind::Hooks);
             co_return;
         }
 

--- a/src/cascadia/TerminalApp/FreOverlay.h
+++ b/src/cascadia/TerminalApp/FreOverlay.h
@@ -60,8 +60,9 @@ namespace winrt::TerminalApp::implementation
             WingetMissing = 0, // hard prerequisite — winget itself unavailable
             CopilotInstall = 1, // hard prerequisite — winget GitHub.Copilot
             NodeInstall = 2, // hard prerequisite — winget OpenJS.NodeJS.LTS
-            ShellIntegration = 3, // optional feature — error detection
-            Hooks = 4, // optional feature — session management
+            ShellIntegrationExecutionPolicy = 3, // optional feature — error detection blocked by PowerShell execution policy
+            ShellIntegration = 4, // optional feature — error detection (generic install failure)
+            Hooks = 5, // optional feature — session management
         };
 
         // Show a single problem: set the error message + manual-fix link, then

--- a/src/cascadia/TerminalApp/Resources/af-ZA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/af-ZA/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Kom meer te wete</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell-uitvoeringsbeleid blokkeer skripte.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell-uitvoeringsbeleid blokkeer skripte. Foutopsporing afgeskakel.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/am-ET/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/am-ET/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>ተጨማሪ ይወቁ</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>የPowerShell ማስፈጸሚያ ፖሊሲ ስክሪፕቶችን እያገደ ነው።</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ የPowerShell ማስፈጸሚያ ፖሊሲ ስክሪፕቶችን እያገደ ነው። የስህተት ማወቂያ ጠፍቷል።</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ar-SA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ar-SA/Resources.resw
@@ -323,4 +323,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>تعرّف على المزيد</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>نهج تنفيذ PowerShell يحظر البرامج النصية.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ نهج تنفيذ PowerShell يحظر البرامج النصية. تم إيقاف اكتشاف الأخطاء.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/as-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/as-IN/Resources.resw
@@ -323,4 +323,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>অধিক জানক</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell এক্সিকিউচন নীতিয়ে স্ক্ৰিপ্ট অৱৰোধ কৰি আছে।</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell এক্সিকিউচন নীতিয়ে স্ক্ৰিপ্ট অৱৰোধ কৰি আছে। ত্ৰুটি চিনাক্তকৰণ বন্ধ কৰা হ’ল।</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/az-Latn-AZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/az-Latn-AZ/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Daha çox öyrənin</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell icra siyasəti skriptləri bloklayır.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell icra siyasəti skriptləri bloklayır. Xəta aşkarlanması söndürüldü.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/bg-BG/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bg-BG/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Научете повече</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Правилата за изпълнение на PowerShell блокират скриптовете.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Правилата за изпълнение на PowerShell блокират скриптовете. Откриването на грешки е изключено.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/bn-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bn-IN/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>আরও জানুন</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell এক্সিকিউশন পলিসি স্ক্রিপ্ট ব্লক করছে।</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell এক্সিকিউশন পলিসি স্ক্রিপ্ট ব্লক করছে। ত্রুটি শনাক্তকরণ বন্ধ করা হয়েছে।</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/bs-Latn-BA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bs-Latn-BA/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Saznajte više</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell pravila izvršavanja blokiraju skripte.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell pravila izvršavanja blokiraju skripte. Otkrivanje grešaka je isključeno.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ca-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ca-ES/Resources.resw
@@ -145,4 +145,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Més informació</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>La directiva d'execució de PowerShell està bloquejant els scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ La directiva d'execució de PowerShell està bloquejant els scripts. Detecció d'errors desactivada.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ca-Es-VALENCIA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ca-Es-VALENCIA/Resources.resw
@@ -145,4 +145,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Més informació</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>La directiva d'execució de PowerShell està bloquejant els scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ La directiva d'execució de PowerShell està bloquejant els scripts. Detecció d'errors desactivada.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/cs-CZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/cs-CZ/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Další informace</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Zásady spouštění PowerShellu blokují skripty.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Zásady spouštění PowerShellu blokují skripty. Detekce chyb byla vypnuta.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/cy-GB/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/cy-GB/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Dysgu mwy</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Mae polisi gweithredu PowerShell yn rhwystro sgriptiau.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Mae polisi gweithredu PowerShell yn rhwystro sgriptiau. Canfod gwallau wedi'i ddiffodd.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/da-DK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/da-DK/Resources.resw
@@ -323,4 +323,12 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Få mere at vide</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell-udførelsespolitikken blokerer scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell-udførelsespolitikken blokerer scripts. Fejlregistrering deaktiveret.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
@@ -1174,4 +1174,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Weitere Informationen</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Die PowerShell-Ausführungsrichtlinie blockiert Skripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Die PowerShell-Ausführungsrichtlinie blockiert Skripts. Fehlererkennung deaktiviert.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/el-GR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/el-GR/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Μάθετε περισσότερα</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Η πολιτική εκτέλεσης του PowerShell αποκλείει τα σενάρια.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Η πολιτική εκτέλεσης του PowerShell αποκλείει τα σενάρια. Ο εντοπισμός σφαλμάτων απενεργοποιήθηκε.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-GB/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-GB/Resources.resw
@@ -317,4 +317,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Learn more</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell execution policy is blocking scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell execution policy is blocking scripts. Error detection turned off.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1003,6 +1003,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Failed to initialize shell integration. Could not determine your PowerShell profile path. Make sure the target shell is installed.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell execution policy is blocking scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
   <data name="AgentNotConfiguredTitle" xml:space="preserve">
     <value>AI Assistant is not available</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
@@ -1163,6 +1167,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
     <value>⚠ Failed to install shell integration. Error detection has been turned off. You can re-enable it and try again, or save to continue without it.</value>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell execution policy is blocking scripts. Error detection turned off.</value>
+    <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Learn how to fix this manually</value>

--- a/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
@@ -1171,4 +1171,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Más información</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>La directiva de ejecución de PowerShell está bloqueando los scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ La directiva de ejecución de PowerShell está bloqueando los scripts. Detección de errores desactivada.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/es-MX/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-MX/Resources.resw
@@ -317,4 +317,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Más información</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>La directiva de ejecución de PowerShell está bloqueando los scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ La directiva de ejecución de PowerShell está bloqueando los scripts. Detección de errores desactivada.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/et-EE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/et-EE/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Lisateave</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShelli käivituspoliitika blokeerib skripte.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShelli käivituspoliitika blokeerib skripte. Vigade tuvastamine välja lülitatud.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/eu-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/eu-ES/Resources.resw
@@ -145,4 +145,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Gehiago jakin</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell exekuzio-politikak script-ak blokeatzen ditu.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell exekuzio-politikak script-ak blokeatzen ditu. Erroreen detekzioa desaktibatuta.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fa-IR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fa-IR/Resources.resw
@@ -323,4 +323,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>بیشتر بدانید</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>خط‌مشی اجرای PowerShell اسکریپت‌ها را مسدود می‌کند.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ خط‌مشی اجرای PowerShell اسکریپت‌ها را مسدود می‌کند. تشخیص خطا غیرفعال شد.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fi-FI/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fi-FI/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Lue lisää</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShellin suorituskäytäntö estää komentosarjat.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShellin suorituskäytäntö estää komentosarjat. Virheiden tunnistus poistettu käytöstä.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fil-PH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fil-PH/Resources.resw
@@ -258,4 +258,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Matuto pa</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Hinaharangan ng execution policy ng PowerShell ang mga script.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Hinaharangan ng execution policy ng PowerShell ang mga script. Na-off ang error detection.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fr-CA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-CA/Resources.resw
@@ -317,4 +317,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>En savoir plus</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>La stratégie d'exécution de PowerShell bloque les scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ La stratégie d'exécution de PowerShell bloque les scripts. Détection des erreurs désactivée.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
@@ -1172,4 +1172,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>En savoir plus</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>La stratégie d'exécution de PowerShell bloque les scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ La stratégie d'exécution de PowerShell bloque les scripts. Détection des erreurs désactivée.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ga-IE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ga-IE/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Foghlaim tuilleadh</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Tá beartas feidhmithe PowerShell ag cosc scripteanna.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Tá beartas feidhmithe PowerShell ag cosc scripteanna. Brath earráidí múchta.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/gd-gb/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gd-gb/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Faigh a-mach barrachd</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Tha poileasaidh ruith PowerShell a' bacadh sgriobtaichean.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Tha poileasaidh ruith PowerShell a' bacadh sgriobtaichean. Tha lorg mhearachdan dheth.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/gl-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gl-ES/Resources.resw
@@ -145,4 +145,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Saiba máis</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>A directiva de execución de PowerShell está a bloquear os scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ A directiva de execución de PowerShell está a bloquear os scripts. Detección de erros desactivada.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/gu-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gu-IN/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>વધુ જાણો</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell એક્ઝિક્યુશન પોલિસી સ્ક્રિપ્ટ્સને અવરોધી રહી છે.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell એક્ઝિક્યુશન પોલિસી સ્ક્રિપ્ટ્સને અવરોધી રહી છે. ભૂલ શોધ બંધ કરી દીધી.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/he-IL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/he-IL/Resources.resw
@@ -323,4 +323,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>למד עוד</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>מדיניות הביצוע של PowerShell חוסמת סקריפטים.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ מדיניות הביצוע של PowerShell חוסמת סקריפטים. זיהוי שגיאות כובה.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hi-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hi-IN/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>और जानें</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell निष्पादन नीति स्क्रिप्ट्स को अवरुद्ध कर रही है।</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell निष्पादन नीति स्क्रिप्ट्स को अवरुद्ध कर रही है। त्रुटि पहचान बंद कर दी गई।</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hr-HR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hr-HR/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Saznajte više</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell pravila izvođenja blokiraju skripte.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell pravila izvođenja blokiraju skripte. Otkrivanje pogrešaka isključeno.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hu-HU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hu-HU/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>További információ</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>A PowerShell végrehajtási házirendje blokkolja a parancsfájlokat.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ A PowerShell végrehajtási házirendje blokkolja a parancsfájlokat. A hibaészlelés kikapcsolva.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hy-AM/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hy-AM/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Իմացեք ավելին</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell-ի կատարման քաղաքականությունն արգելափակում է սկրիպտները։</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell-ի կատարման քաղաքականությունն արգելափակում է սկրիպտները։ Սխալների հայտնաբերումն անջատված է։</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/id-ID/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/id-ID/Resources.resw
@@ -258,4 +258,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Pelajari selengkapnya</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Kebijakan eksekusi PowerShell memblokir skrip.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Kebijakan eksekusi PowerShell memblokir skrip. Deteksi kesalahan dinonaktifkan.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/is-IS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/is-IS/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Frekari upplýsingar</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Keyrslustefna PowerShell hindrar forskriftir.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Keyrslustefna PowerShell hindrar forskriftir. Villuleit slökkt.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
@@ -1171,4 +1171,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Altre informazioni</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Il criterio di esecuzione di PowerShell sta bloccando gli script.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Il criterio di esecuzione di PowerShell sta bloccando gli script. Rilevamento errori disattivato.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
@@ -1180,4 +1180,12 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>詳細情報</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell の実行ポリシーがスクリプトをブロックしています。</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell の実行ポリシーがスクリプトをブロックしています。エラー検出はオフになりました。</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ka-GE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ka-GE/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>შეიტყვეთ მეტი</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell-ის შესრულების პოლიტიკა ბლოკავს სკრიპტებს.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell-ის შესრულების პოლიტიკა ბლოკავს სკრიპტებს. შეცდომების აღმოჩენა გამორთულია.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/kk-KZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kk-KZ/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Толығырақ біліңіз</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell орындау саясаты сценарийлерді бұғаттайды.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell орындау саясаты сценарийлерді бұғаттайды. Қателерді анықтау өшірілді.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/km-KH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/km-KH/Resources.resw
@@ -145,4 +145,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>ស្វែងយល់បន្ថែម</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>គោលនយោបាយប្រតិបត្តិរបស់ PowerShell កំពុងទប់ស្កាត់ស្គ្រីប។</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ គោលនយោបាយប្រតិបត្តិរបស់ PowerShell កំពុងទប់ស្កាត់ស្គ្រីប។ ការរកឃើញកំហុសត្រូវបានបិទ។</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/kn-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kn-IN/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>ಇನ್ನಷ್ಟು ತಿಳಿಯಿರಿ</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell ಎಕ್ಸಿಕ್ಯೂಷನ್ ನೀತಿಯು ಸ್ಕ್ರಿಪ್ಟ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸುತ್ತಿದೆ.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell ಎಕ್ಸಿಕ್ಯೂಷನ್ ನೀತಿಯು ಸ್ಕ್ರಿಪ್ಟ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸುತ್ತಿದೆ. ದೋಷ ಪತ್ತೆ ಆಫ್ ಮಾಡಲಾಗಿದೆ.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
@@ -1243,4 +1243,12 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>자세한 정보</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell 실행 정책이 스크립트를 차단하고 있습니다.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell 실행 정책이 스크립트를 차단하고 있습니다. 오류 감지가 꺼졌습니다.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/kok-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kok-IN/Resources.resw
@@ -323,4 +323,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>अदीक जाणून घ्यात</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell एक्झिक्यूशन धोरणान स्क्रिप्ट्स आडावपी आसा.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell एक्झिक्यूशन धोरणान स्क्रिप्ट्स आडावपी आसा. चूक सोद बंद केल्या.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lb-LU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lb-LU/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Méi erfahren</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>D'PowerShell-Ausféierungspolitik blockéiert Scripten.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ D'PowerShell-Ausféierungspolitik blockéiert Scripten. D'Feelerkennung ass ausgeschalt.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lo-LA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lo-LA/Resources.resw
@@ -145,4 +145,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>ຮຽນຮູ້ເພີ່ມເຕີມ</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>ນະໂຍບາຍການດຳເນີນການຂອງ PowerShell ກໍາລັງບລັອກສະຄຣິບ.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ ນະໂຍບາຍການດຳເນີນການຂອງ PowerShell ກໍາລັງບລັອກສະຄຣິບ. ການກວດຫາຂໍ້ຜິດພາດຖືກປິດແລ້ວ.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lt-LT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lt-LT/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Sužinokite daugiau</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>„PowerShell“ vykdymo strategija blokuoja scenarijus.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ „PowerShell“ vykdymo strategija blokuoja scenarijus. Klaidų aptikimas išjungtas.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lv-LV/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lv-LV/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Uzziniet vairāk</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell izpildes politika bloķē skriptus.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell izpildes politika bloķē skriptus. Kļūdu noteikšana ir izslēgta.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mi-NZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mi-NZ/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>He atu kōrero</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Kei te ārai te kaupapahere whakatinana o PowerShell i ngā tuhinga.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Kei te ārai te kaupapahere whakatinana o PowerShell i ngā tuhinga. Kua whakawetohia te kitenga hapa.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mk-MK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mk-MK/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Дознајте повеќе</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Политиката за извршување на PowerShell ги блокира скриптите.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Политиката за извршување на PowerShell ги блокира скриптите. Детекцијата на грешки е исклучена.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ml-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ml-IN/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>കൂടുതലറിയുക</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell എക്സിക്യൂഷൻ പോളിസി സ്ക്രിപ്റ്റുകളെ തടയുന്നു.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell എക്സിക്യൂഷൻ പോളിസി സ്ക്രിപ്റ്റുകളെ തടയുന്നു. പിശക് കണ്ടെത്തൽ ഓഫ് ചെയ്തു.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mr-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mr-IN/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>अधिक जाणून घ्या</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell कार्यान्वयन धोरण स्क्रिप्ट्स अवरोधित करत आहे.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell कार्यान्वयन धोरण स्क्रिप्ट्स अवरोधित करत आहे. त्रुटी शोध बंद केले.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ms-MY/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ms-MY/Resources.resw
@@ -258,4 +258,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Ketahui lebih lanjut</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Dasar pelaksanaan PowerShell menyekat skrip.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Dasar pelaksanaan PowerShell menyekat skrip. Pengesanan ralat dimatikan.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mt-MT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mt-MT/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Sir iktar</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Il-politika tal-eżekuzzjoni ta' PowerShell qed timblokka l-iskripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Il-politika tal-eżekuzzjoni ta' PowerShell qed timblokka l-iskripts. Id-detezzjoni tal-iżbalji mitfija.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/nb-NO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nb-NO/Resources.resw
@@ -323,4 +323,12 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Finn ut mer</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell-utførelsespolicyen blokkerer skript.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell-utførelsespolicyen blokkerer skript. Feiloppdaging slått av.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ne-NP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ne-NP/Resources.resw
@@ -323,4 +323,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>थप जान्नुहोस्</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell कार्यान्वयन नीतिले स्क्रिप्टहरू रोक्दैछ।</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell कार्यान्वयन नीतिले स्क्रिप्टहरू रोक्दैछ। त्रुटि पत्ता लगाउने बन्द गरियो।</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/nl-NL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nl-NL/Resources.resw
@@ -317,4 +317,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Meer informatie</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Het uitvoeringsbeleid van PowerShell blokkeert scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Het uitvoeringsbeleid van PowerShell blokkeert scripts. Foutdetectie uitgeschakeld.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/nn-NO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nn-NO/Resources.resw
@@ -323,4 +323,12 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Finn ut meir</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell-utføringspolicyen blokkerer skript.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell-utføringspolicyen blokkerer skript. Feiloppdaging slått av.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/or-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/or-IN/Resources.resw
@@ -323,4 +323,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>ଅଧିକ ଜାଣନ୍ତୁ</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell କାର୍ଯ୍ୟକାରୀ ନୀତି ସ୍କ୍ରିପ୍ଟ୍‌କୁ ଅବରୋଧ କରୁଛି।</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell କାର୍ଯ୍ୟକାରୀ ନୀତି ସ୍କ୍ରିପ୍ଟ୍‌କୁ ଅବରୋଧ କରୁଛି। ତ୍ରୁଟି ଚିହ୍ନଟ ବନ୍ଦ କରାଗଲା।</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pa-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pa-IN/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>ਹੋਰ ਜਾਣੋ</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell ਐਗਜ਼ੀਕਿਊਸ਼ਨ ਨੀਤੀ ਸਕ੍ਰਿਪਟਾਂ ਨੂੰ ਬਲੌਕ ਕਰ ਰਹੀ ਹੈ।</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell ਐਗਜ਼ੀਕਿਊਸ਼ਨ ਨੀਤੀ ਸਕ੍ਰਿਪਟਾਂ ਨੂੰ ਬਲੌਕ ਕਰ ਰਹੀ ਹੈ। ਗਲਤੀ ਖੋਜ ਬੰਦ ਕਰ ਦਿੱਤੀ।</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pl-PL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pl-PL/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Dowiedz się więcej</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Zasady wykonywania programu PowerShell blokują skrypty.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Zasady wykonywania programu PowerShell blokują skrypty. Wykrywanie błędów wyłączone.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
@@ -1229,4 +1229,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Saiba mais</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>A política de execução do PowerShell está bloqueando scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ A política de execução do PowerShell está bloqueando scripts. Detecção de erros desativada.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pt-PT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-PT/Resources.resw
@@ -317,4 +317,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Saiba mais</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>A política de execução do PowerShell está a bloquear scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ A política de execução do PowerShell está a bloquear scripts. Deteção de erros desativada.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
@@ -1153,4 +1153,12 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Learn more</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell execution policy is blocking scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell execution policy is blocking scripts. Error detection turned off.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
@@ -1153,4 +1153,12 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Learn more</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell execution policy is blocking scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell execution policy is blocking scripts. Error detection turned off.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
@@ -1153,4 +1153,12 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Learn more</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell execution policy is blocking scripts.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell execution policy is blocking scripts. Error detection turned off.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/quz-PE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/quz-PE/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Aswan yachay</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell ruwana kamachiy script-kunata hark'achkan.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell ruwana kamachiy script-kunata hark'achkan. Pantay taripay wichqasqa.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ro-RO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ro-RO/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Aflați mai multe</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Politica de execuție PowerShell blochează scripturile.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Politica de execuție PowerShell blochează scripturile. Detectarea erorilor dezactivată.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
@@ -1235,4 +1235,12 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Подробнее</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Политика выполнения PowerShell блокирует скрипты.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Политика выполнения PowerShell блокирует скрипты. Обнаружение ошибок отключено.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sk-SK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sk-SK/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Ďalšie informácie</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Politika spúšťania PowerShellu blokuje skripty.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Politika spúšťania PowerShellu blokuje skripty. Detekcia chýb vypnutá.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sl-SI/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sl-SI/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Več informacij</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Pravilnik o izvajanju PowerShell blokira skripte.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Pravilnik o izvajanju PowerShell blokira skripte. Zaznavanje napak izklopljeno.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sq-AL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sq-AL/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Mësoni më shumë</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Politika e ekzekutimit të PowerShell po bllokon skriptet.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Politika e ekzekutimit të PowerShell po bllokon skriptet. Zbulimi i gabimeve u çaktivizua.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-BA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-BA/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Сазнајте више</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell политика извршавања блокира скрипте.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell политика извршавања блокира скрипте. Откривање грешака је искључено.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
@@ -1241,4 +1241,12 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Сазнајте више</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell политика извршавања блокира скрипте.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell политика извршавања блокира скрипте. Откривање грешака је искључено.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sr-Latn-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Latn-RS/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Saznajte više</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell politika izvršavanja blokira skripte.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell politika izvršavanja blokira skripte. Otkrivanje grešaka je isključeno.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sv-SE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sv-SE/Resources.resw
@@ -323,4 +323,12 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Läs mer</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShells körningsprincip blockerar skript.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShells körningsprincip blockerar skript. Feldetektering inaktiverad.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ta-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ta-IN/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>மேலும் அறிக</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell செயல்படுத்தல் கொள்கை ஸ்கிரிப்ட்களைத் தடுக்கிறது.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell செயல்படுத்தல் கொள்கை ஸ்கிரிப்ட்களைத் தடுக்கிறது. பிழை கண்டறிதல் முடக்கப்பட்டது.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/te-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/te-IN/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>మరింత తెలుసుకోండి</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell ఎగ్జిక్యూషన్ విధానం స్క్రిప్ట్‌లను నిరోధిస్తోంది.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell ఎగ్జిక్యూషన్ విధానం స్క్రిప్ట్‌లను నిరోధిస్తోంది. లోపం గుర్తింపు ఆపివేయబడింది.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/th-TH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/th-TH/Resources.resw
@@ -258,4 +258,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>เรียนรู้เพิ่มเติม</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>นโยบายการดำเนินการของ PowerShell กำลังบล็อกสคริปต์</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ นโยบายการดำเนินการของ PowerShell กำลังบล็อกสคริปต์ การตรวจจับข้อผิดพลาดถูกปิดใช้งาน</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/tr-TR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/tr-TR/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Daha fazla bilgi edinin</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell yürütme ilkesi betikleri engelliyor.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell yürütme ilkesi betikleri engelliyor. Hata algılama kapatıldı.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/tt-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/tt-RU/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Күбрәк белегез</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell үтәү сәясәте скриптларны блоклый.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell үтәү сәясәте скриптларны блоклый. Хата ачыклау сүндерелде.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ug-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ug-CN/Resources.resw
@@ -209,4 +209,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>تېخىمۇ بىلىڭ</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell ئىجرا سىياسىتى قوليازمىلارنى چەكلەۋاتىدۇ.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell ئىجرا سىياسىتى قوليازمىلارنى چەكلەۋاتىدۇ. خاتالىق بايقاش تاقالدى.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
@@ -1226,4 +1226,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Дізнатися більше</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Політика виконання PowerShell блокує сценарії.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Політика виконання PowerShell блокує сценарії. Виявлення помилок вимкнено.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ur-PK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ur-PK/Resources.resw
@@ -323,4 +323,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>مزید جانیں</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell ایگزیکیوشن پالیسی اسکرپٹس کو بلاک کر رہی ہے۔</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell ایگزیکیوشن پالیسی اسکرپٹس کو بلاک کر رہی ہے۔ خرابی کی نشاندہی بند کر دی گئی۔</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/uz-Latn-UZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uz-Latn-UZ/Resources.resw
@@ -322,4 +322,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Batafsil bilib oling</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell bajarish siyosati skriptlarni bloklamoqda.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell bajarish siyosati skriptlarni bloklamoqda. Xatolarni aniqlash oʻchirildi.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/vi-VN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/vi-VN/Resources.resw
@@ -258,4 +258,12 @@
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>Tìm hiểu thêm</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>Chính sách thực thi PowerShell đang chặn các tập lệnh.</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ Chính sách thực thi PowerShell đang chặn các tập lệnh. Phát hiện lỗi đã bị tắt.</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
@@ -1245,4 +1245,12 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>了解详细信息</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell 执行策略正在阻止脚本。</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell 执行策略正在阻止脚本。错误检测已关闭。</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
@@ -1179,4 +1179,12 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FreOverlay_AutoDetectShellIntegrationHintLink" xml:space="preserve">
     <value>深入了解</value>
   </data>
+  <data name="InitShellIntegrationExecutionPolicyErrorMessage" xml:space="preserve">
+    <value>PowerShell 執行原則正在封鎖指令碼。</value>
+    <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
+  </data>
+  <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
+    <value>⚠ PowerShell 執行原則正在封鎖指令碼。錯誤偵測已關閉。</value>
+    <comment>{Locked="PowerShell"}</comment>
+  </data>
 </root>

--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -81,6 +81,14 @@ class TerminalCoreUnitTests::ShellIntegrationTests final
     // Install -> Uninstall -> Install round-trip
     TEST_METHOD(InstallUninstallInstall_RoundTrip);
 
+    // ExecutionPolicy detection.
+    TEST_METHOD(PolicyName_RestrictedAndAllSigned_AreBlocking);
+    TEST_METHOD(PolicyName_RemoteSignedAndPermissive_AreNotBlocking);
+    TEST_METHOD(PolicyName_EmptyOrUnknown_NotBlocking);
+    TEST_METHOD(QueryExecutionPolicy_NonexistentExe_ReturnsEmpty);
+    TEST_METHOD(QueryExecutionPolicy_ParsesStdoutAndLowercases);
+    TEST_METHOD(QueryExecutionPolicy_TrimsWhitespaceAndStopsAtFirstLine);
+
     TEST_CLASS_SETUP(ClassSetup)
     {
         return true;
@@ -711,4 +719,81 @@ void ShellIntegrationTests::InstallUninstallInstall_RoundTrip()
     VERIFY_IS_TRUE(Install(profile.wstring()).success);
     VERIFY_ARE_EQUAL(afterFirstInstall, _ReadFile(profile),
                      L"Round-trip: second Install must produce byte-identical output to first");
+}
+
+// ─── ExecutionPolicy detection ────────────────────────────────────────────────
+
+void ShellIntegrationTests::PolicyName_RestrictedAndAllSigned_AreBlocking()
+{
+    // The two policy names that refuse to run unsigned local scripts —
+    // the exact case our $PROFILE block hits because we don't Authenticode-sign
+    // it. Comparison must be lowercase (QueryExecutionPolicy normalizes its
+    // output) — verifying mixed case here would test the wrong contract.
+    VERIFY_IS_TRUE(details::PolicyNameBlocksUnsignedScripts(L"restricted"));
+    VERIFY_IS_TRUE(details::PolicyNameBlocksUnsignedScripts(L"allsigned"));
+}
+
+void ShellIntegrationTests::PolicyName_RemoteSignedAndPermissive_AreNotBlocking()
+{
+    // RemoteSigned lets *local* unsigned scripts run (it only blocks
+    // downloaded ones) — that's the default for pwsh on Windows, so it
+    // must not trigger the EP-blocked path or we'd false-positive on
+    // the most common pwsh install.
+    VERIFY_IS_FALSE(details::PolicyNameBlocksUnsignedScripts(L"remote" L"signed"));
+    VERIFY_IS_FALSE(details::PolicyNameBlocksUnsignedScripts(L"unrestricted"));
+    VERIFY_IS_FALSE(details::PolicyNameBlocksUnsignedScripts(L"bypass"));
+    VERIFY_IS_FALSE(details::PolicyNameBlocksUnsignedScripts(L"undefined"));
+}
+
+void ShellIntegrationTests::PolicyName_EmptyOrUnknown_NotBlocking()
+{
+    // Empty string is what QueryExecutionPolicy returns when CreateProcess
+    // fails (e.g. pwsh.exe not installed). Treating that as "not blocking"
+    // is the deliberate fail-open behavior: we don't want a missing
+    // optional host to lock the user out of error detection.
+    VERIFY_IS_FALSE(details::PolicyNameBlocksUnsignedScripts(L""));
+    VERIFY_IS_FALSE(details::PolicyNameBlocksUnsignedScripts(L"something" L"else"));
+}
+
+void ShellIntegrationTests::QueryExecutionPolicy_NonexistentExe_ReturnsEmpty()
+{
+    // CreateProcess fails synchronously when the exe doesn't resolve —
+    // QueryExecutionPolicy must return empty (not hang, not throw) so the
+    // pwsh-not-installed case fails open.
+    const auto out = details::QueryExecutionPolicy(L"definitely-not-a-real-binary-zzzzz.exe");
+    VERIFY_IS_TRUE(out.empty());
+}
+
+void ShellIntegrationTests::QueryExecutionPolicy_ParsesStdoutAndLowercases()
+{
+    // Smoke test against real powershell.exe (always present on Windows).
+    // We don't care WHICH policy the runner returns — we care that the
+    // QueryExecutionPolicy contract holds:
+    //   * the call completes within the 5s timeout (no hang on the pipe),
+    //   * stdout is captured (non-empty), and
+    //   * the result is lowercase ASCII letters only — the parser strips
+    //     newlines / spaces / tabs, lowercases A-Z, but a stray BOM byte or
+    //     control char would slip through and silently break the comparison
+    //     against the known policy names in PolicyNameBlocksUnsignedScripts.
+    const auto out = details::QueryExecutionPolicy(L"powershell.exe");
+    VERIFY_IS_FALSE(out.empty(), L"powershell.exe must be on PATH on Windows runners");
+    for (const auto c : out)
+    {
+        VERIFY_IS_TRUE(c >= L'a' && c <= L'z',
+                       L"QueryExecutionPolicy output must be lowercase ASCII letters only "
+                       L"(no whitespace, control chars, or BOM bytes leaking through)");
+    }
+}
+
+void ShellIntegrationTests::QueryExecutionPolicy_TrimsWhitespaceAndStopsAtFirstLine()
+{
+    // Same invariant tested two ways for redundancy with the smoke test:
+    // even if PowerShell ever adds blank-line padding, the parser must
+    // skip leading blanks and stop at the first non-empty line. The smoke
+    // test above already exercises the "single token" path; verify here that
+    // calling QueryExecutionPolicy back-to-back stays cheap and consistent,
+    // and that nothing depends on first-call side effects in the function.
+    const auto first = details::QueryExecutionPolicy(L"powershell.exe");
+    const auto second = details::QueryExecutionPolicy(L"powershell.exe");
+    VERIFY_ARE_EQUAL(first, second, L"QueryExecutionPolicy must be deterministic for the same host");
 }

--- a/src/cascadia/inc/ShellIntegration.h
+++ b/src/cascadia/inc/ShellIntegration.h
@@ -24,6 +24,7 @@
 #include <string_view>
 #include <utility>
 #include <ShlObj.h>
+#include <wil/resource.h>
 
 namespace Microsoft::Terminal::ShellIntegration
 {
@@ -39,7 +40,181 @@ namespace Microsoft::Terminal::ShellIntegration
         bool success{ false };
         bool alreadyInstalled{ false }; // true when skipped because already configured
         std::wstring errorMessage;
+        bool executionPolicyBlocked{ false }; // true when the host's effective PowerShell execution policy refuses unsigned local scripts
     };
+
+    namespace details
+    {
+        // Runs `<exe> -NoProfile -NonInteractive -Command Get-ExecutionPolicy`
+        // synchronously and returns the lowercased policy name from stdout
+        // (e.g. "restricted"). Returns an empty string if the executable can't
+        // be launched (typical for pwsh.exe when PowerShell 7 isn't installed)
+        // or if the call doesn't finish within the timeout.
+        //
+        // `-Command <expr>` runs an inline expression that is NOT subject to
+        // the .ps1 execution policy, so this works even when the answer is
+        // Restricted / AllSigned. We deliberately do NOT pass
+        // `-ExecutionPolicy` because that would set the Process scope and
+        // override the value we're trying to read.
+        inline std::wstring QueryExecutionPolicy(LPCWSTR exe) noexcept
+        {
+            // This is a best-effort helper: any failure (CreateProcess, pipe,
+            // read hang, OOM, …) must fail-open by returning an empty string
+            // so the caller treats the policy as "not blocking" rather than
+            // crashing the Terminal over a diagnostic probe. The whole body
+            // is wrapped in a swallow-all try/catch and every Win32 step
+            // either returns {} on failure or is bounded by a timeout.
+            try
+            {
+                SECURITY_ATTRIBUTES sa{};
+                sa.nLength = sizeof(sa);
+                sa.bInheritHandle = TRUE;
+
+                HANDLE rawRead = nullptr;
+                HANDLE rawWrite = nullptr;
+                if (!CreatePipe(&rawRead, &rawWrite, &sa, 0))
+                {
+                    return {};
+                }
+                wil::unique_handle readEnd{ rawRead };
+                wil::unique_handle writeEnd{ rawWrite };
+                SetHandleInformation(readEnd.get(), HANDLE_FLAG_INHERIT, 0);
+
+                STARTUPINFOW si{};
+                si.cb = sizeof(si);
+                si.dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
+                si.wShowWindow = SW_HIDE;
+                si.hStdOutput = writeEnd.get();
+                si.hStdError = writeEnd.get();
+                si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+
+                std::wstring cmdLine{ L"\"" };
+                cmdLine += exe;
+                cmdLine += L"\" -NoProfile -NonInteractive -Command Get-ExecutionPolicy";
+
+                PROCESS_INFORMATION pi{};
+                if (!CreateProcessW(nullptr,
+                                    cmdLine.data(),
+                                    nullptr,
+                                    nullptr,
+                                    TRUE,
+                                    CREATE_NO_WINDOW,
+                                    nullptr,
+                                    nullptr,
+                                    &si,
+                                    &pi))
+                {
+                    return {};
+                }
+                wil::unique_handle process{ pi.hProcess };
+                wil::unique_handle thread{ pi.hThread };
+
+                // Drop our copy of the write end so the read side sees EOF
+                // when the child exits — otherwise ReadFile would block
+                // indefinitely.
+                writeEnd.reset();
+
+                // Bound the child to 5 seconds total wall-clock. If it
+                // hasn't exited by then (hung profile, misbehaving anti-virus
+                // shim, inherited write handle held by a grandchild, …),
+                // terminate it so the subsequent ReadFile is guaranteed to
+                // hit EOF and return promptly. We deliberately wait BEFORE
+                // reading: doing it the other way around (the natural
+                // streaming-read pattern) means a hung ReadFile would
+                // prevent the timeout from ever firing.
+                if (WaitForSingleObject(process.get(), 5000) != WAIT_OBJECT_0)
+                {
+                    TerminateProcess(process.get(), 1);
+                    // Give the OS a brief grace period to close the handle
+                    // table so the write end is released.
+                    WaitForSingleObject(process.get(), 1000);
+                }
+
+                std::string raw;
+                char buf[256];
+                DWORD bytesRead = 0;
+                // Cap the total bytes we'll accept so a runaway child can't
+                // make us spin forever even after the timeout fired.
+                while (raw.size() < 4096 &&
+                       ReadFile(readEnd.get(), buf, sizeof(buf), &bytesRead, nullptr) &&
+                       bytesRead > 0)
+                {
+                    raw.append(buf, bytesRead);
+                }
+
+                std::wstring result;
+                for (const char c : raw)
+                {
+                    if (c == '\r' || c == '\n')
+                    {
+                        if (!result.empty())
+                        {
+                            break;
+                        }
+                        continue;
+                    }
+                    // Only collect ASCII letters. Drops whitespace, control chars,
+                    // and any stray non-ASCII bytes (e.g. a UTF-16 BOM emitted by
+                    // PowerShell when stdout is redirected) that would otherwise
+                    // silently break the comparison against the known policy
+                    // names in PolicyNameBlocksUnsignedScripts.
+                    if (c >= 'A' && c <= 'Z')
+                    {
+                        result.push_back(static_cast<wchar_t>(c + 0x20));
+                    }
+                    else if (c >= 'a' && c <= 'z')
+                    {
+                        result.push_back(static_cast<wchar_t>(c));
+                    }
+                }
+                return result;
+            }
+            catch (...)
+            {
+                // Fail-open: any unexpected error means "we couldn't tell",
+                // which the caller treats as "not blocking". The user will
+                // still see the normal shell-integration error path if the
+                // install actually fails later.
+                return {};
+            }
+        }
+
+        // True when the policy name refuses to run unsigned local scripts —
+        // i.e. our shell-integration block, which is appended to $PROFILE and
+        // not Authenticode-signed.
+        inline bool PolicyNameBlocksUnsignedScripts(std::wstring_view name) noexcept
+        {
+            return name == L"restricted" || name == L"allsigned";
+        }
+    }
+
+    // True when the effective PowerShell execution policy for `target` refuses
+    // to run unsigned local scripts. Asks PowerShell itself rather than walking
+    // the registry / Group Policy hives — `Get-ExecutionPolicy` returns the
+    // effective policy after considering every scope plus the built-in default,
+    // exactly the value the shell will obey when trying to load $PROFILE.
+    //
+    // Cached per-host for the lifetime of the Terminal process: changing
+    // execution policy requires the user to restart their shells anyway, so
+    // re-querying within a single Terminal lifetime would not catch the
+    // change in time to matter.
+    inline bool ExecutionPolicyBlocksShellIntegration(Target target) noexcept
+    {
+        if (target == Target::Pwsh)
+        {
+            // pwsh.exe is optional. If it isn't installed QueryExecutionPolicy
+            // returns "" which doesn't match any blocking policy → not blocked,
+            // and the install attempt for that profile dir will succeed
+            // (creating a $PROFILE for a host the user hasn't installed is
+            // harmless — it sits inert until they install PowerShell 7).
+            static const bool blocked = details::PolicyNameBlocksUnsignedScripts(
+                details::QueryExecutionPolicy(L"pwsh.exe"));
+            return blocked;
+        }
+        static const bool blocked = details::PolicyNameBlocksUnsignedScripts(
+            details::QueryExecutionPolicy(L"powershell.exe"));
+        return blocked;
+    }
 
     namespace details
     {
@@ -530,6 +705,16 @@ if (-not $Global:__ShellInteg_Installed) {
     // Synchronous — call from a background thread.
     inline InstallResult InstallForTarget(Target target)
     {
+        // Probe the effective execution policy first. If the host refuses
+        // unsigned local scripts our $PROFILE block would either silently
+        // no-op or throw a PSSecurityException on every shell start. Fail
+        // up front with executionPolicyBlocked set so the caller can show a
+        // policy-specific error instead of a generic write-failed message.
+        if (ExecutionPolicyBlocksShellIntegration(target))
+        {
+            return { false, false, L"PowerShell execution policy blocks scripts", true };
+        }
+
         auto profilePath = DiscoverProfilePath(target);
         if (profilePath.empty())
         {

--- a/src/cascadia/inc/ShellIntegration.h
+++ b/src/cascadia/inc/ShellIntegration.h
@@ -194,26 +194,21 @@ namespace Microsoft::Terminal::ShellIntegration
     // effective policy after considering every scope plus the built-in default,
     // exactly the value the shell will obey when trying to load $PROFILE.
     //
-    // Cached per-host for the lifetime of the Terminal process: changing
-    // execution policy requires the user to restart their shells anyway, so
-    // re-querying within a single Terminal lifetime would not catch the
-    // change in time to matter.
+    // Re-queried on every call so that after the user fixes the policy outside
+    // (e.g. `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`) and clicks
+    // Save again, the Terminal picks up the new policy instead of returning a
+    // stale cached "blocked" verdict. The cost is one extra PowerShell spawn
+    // per Save / Install attempt, which is negligible next to the profile file
+    // I/O that follows.
     inline bool ExecutionPolicyBlocksShellIntegration(Target target) noexcept
     {
-        if (target == Target::Pwsh)
-        {
-            // pwsh.exe is optional. If it isn't installed QueryExecutionPolicy
-            // returns "" which doesn't match any blocking policy → not blocked,
-            // and the install attempt for that profile dir will succeed
-            // (creating a $PROFILE for a host the user hasn't installed is
-            // harmless — it sits inert until they install PowerShell 7).
-            static const bool blocked = details::PolicyNameBlocksUnsignedScripts(
-                details::QueryExecutionPolicy(L"pwsh.exe"));
-            return blocked;
-        }
-        static const bool blocked = details::PolicyNameBlocksUnsignedScripts(
-            details::QueryExecutionPolicy(L"powershell.exe"));
-        return blocked;
+        // pwsh.exe is optional. If it isn't installed QueryExecutionPolicy
+        // returns "" which doesn't match any blocking policy → not blocked,
+        // and the install attempt for that profile dir will succeed
+        // (creating a $PROFILE for a host the user hasn't installed is
+        // harmless — it sits inert until they install PowerShell 7).
+        const auto exe = target == Target::Pwsh ? L"pwsh.exe" : L"powershell.exe";
+        return details::PolicyNameBlocksUnsignedScripts(details::QueryExecutionPolicy(exe));
     }
 
     namespace details


### PR DESCRIPTION
## Summary

When the PowerShell execution policy is set to **Restricted** or **AllSigned** on the target host, our shell-integration block in `$PROFILE` won't run — PowerShell refuses to load the unsigned script. Before this PR the install would appear to succeed and the user would only discover the problem later (broken OSC 133 detection, no auto-fix, etc.). Now we detect the policy ahead of time and surface a dedicated error in both entry points.

## Detection

`details::QueryExecutionPolicy(exe)` shells out to PowerShell once per host (cached for the Terminal's lifetime) and runs:

```
<powershell|pwsh>.exe -NoProfile -NonInteractive -Command Get-ExecutionPolicy
```

Asking PowerShell itself returns the **effective** policy after the OS resolves every scope (MachinePolicy → UserPolicy → Process → CurrentUser → LocalMachine → built-in default) — no registry / GPO walking, no need to model precedence ourselves.

The result is compared to a tiny allow/deny list in `PolicyNameBlocksUnsignedScripts`:

| Policy name | Blocks unsigned `$PROFILE` block? |
|---|---|
| `restricted` | yes |
| `allsigned` | yes |
| `remotesigned` / `unrestricted` / `bypass` / `undefined` | no |

<img width="2292" height="1047" alt="image" src="https://github.com/user-attachments/assets/db80dc22-76ea-4a93-8a77-5bb60f07ef3b" />

### Crash & hang hardening (review feedback)

`QueryExecutionPolicy` is a best-effort diagnostic — it must never crash or hang the Terminal:

- `noexcept` + the entire body wrapped in `try { ... } catch (...) { return {}; }`. Any unexpected failure fails open.
- `WaitForSingleObject(process, 5000)` runs **before** the `ReadFile` drain (the previous ordering had them swapped, so a hung child would leave `ReadFile` blocked forever and the timeout would never fire). On timeout we `TerminateProcess` and grant a 1 s grace for the OS to close the inherited write handle so the subsequent read hits EOF promptly.
- The read loop is bounded to 4 KB so a runaway child cannot make us spin even after termination.
- Any failure path returns `""` → `PolicyNameBlocksUnsignedScripts("")` is `false` → caller proceeds as "not blocking". User still sees the normal shell-integration error path if install actually fails later; no crash possible.

## UX

### FRE

Adds a new `FreProblemKind::ShellIntegrationExecutionPolicy` variant. The banner reads:

> ⚠ Shell integration was not installed because the PowerShell execution policy is blocking scripts.

…with the existing "Learn how to fix this" hyperlink pointing at the dependency docs.

### Settings → Save

When the user toggles shell integration **on** in Settings, the same detection runs on Save. If blocked we abort the save and show a `ContentDialog`:

- **Title:** *PowerShell execution policy is blocking shell integration*
- **Body:** *PowerShell execution policy is blocking scripts.* followed by a clickable hyperlink "Learn how to change it" → https://aka.ms/intelligent-terminal-dependency#4-powershell-shell-integration
- The dialog body is a real `TextBlock` with an inline `Hyperlink` element (not a raw URL string), matching the rich-dialog pattern used elsewhere in `TerminalWindow.cpp`.

## Localization

All four new resource keys (`FreOverlay_ErrorMessage_ShellIntegrationExecutionPolicy`, `Settings_ShellIntegrationExecutionPolicy_DialogTitle`, `…_MessagePrefix`, `…_MessageLink`) are translated into all 88 supported locales. `PowerShell` is tagged `{Locked}` and kept verbatim. The ⚠ glyph and trailing space are preserved. BOM and CRLF preserved per `.github/instructions/localization.instructions.md`.

## Tests

6 new unit tests in `ShellIntegrationTests.cpp` covering:

- `PolicyNameBlocksUnsignedScripts` for `restricted` / `allsigned` / `remotesigned` / `unrestricted` / `bypass` / `undefined` / empty / unknown
- `QueryExecutionPolicy` for non-existent exe (returns empty — exercises the fail-open path)
- `QueryExecutionPolicy` parses real `powershell.exe` stdout (lowercase ASCII letters only)
- `QueryExecutionPolicy` is deterministic (caching contract)

Suite: **42 / 42 pass** locally.

## Spell-check

`.github/actions/spelling/expect/expect.txt` adds only `allsigned` (the external policy-name token used in tests). No other words touched.
