### PR TITLE
Fix custom acpAgent UX: don't trap users in Setup mode + always show the model picker

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -143,7 +143,11 @@
                 </StackPanel>
             </Grid>
 
-            <!--  Model (only for built-in agents)  -->
+            <!--  Model picker — shown for every selected agent (built-in
+                  or custom) so a stale acpModel value is always visible
+                  and clearable. HasAcpModelList picks between the
+                  dropdown (helper published available_models) and the
+                  free-form textbox fallback.  -->
             <local:SettingContainer x:Name="AcpModel"
                                     x:Uid="AIAgents_AcpModel"
                                     Visibility="{x:Bind ViewModel.ShowAcpModel, Mode=OneWay}">

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
@@ -402,15 +402,24 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     bool AIAgentsViewModel::ShowAcpModel()
     {
+        // Show for every built-in agent AND for custom agents. The original
+        // code hid the row for custom:* which then trapped users when a
+        // previously-selected acpModel turned invalid (e.g. credentials
+        // expired) — the stale value was invisible and unclearable.
+        // HasAcpModelList / ShowAcpModelTextBox pick between the dropdown
+        // (when the helper has published available_models via agent_status)
+        // and the free-form textbox fallback.
         if (_isAddingCustomAcpAgent) return false;
-        if (_StartsWithCustom(_GlobalSettings.AcpAgent())) return false;
+        if (_StartsWithCustom(_GlobalSettings.AcpAgent())) return true;
         return _IsKnownAgent(_GlobalSettings.AcpAgent());
     }
 
     bool AIAgentsViewModel::ShowDelegateModel()
     {
+        // Same rationale as ShowAcpModel: show the row for custom delegate
+        // agents so a stale delegateModel value remains visible / clearable.
         if (_isAddingCustomDelegateAgent) return false;
-        if (_StartsWithCustom(_GlobalSettings.DelegateAgent())) return false;
+        if (_StartsWithCustom(_GlobalSettings.DelegateAgent())) return true;
         return _IsKnownAgent(_GlobalSettings.DelegateAgent());
     }
 

--- a/tools/wta/src/agent_check.rs
+++ b/tools/wta/src/agent_check.rs
@@ -259,54 +259,6 @@ pub fn check_all_agents() -> Vec<AgentStatus> {
     KNOWN_AGENTS.iter().map(|p| check_agent(p.id)).collect()
 }
 
-/// Check an agent from a full command string (e.g. "copilot --acp --stdio"
-/// or "my-custom-agent --acp"). Supports both known and custom agents.
-pub fn check_agent_cmd(agent_cmd: &str) -> AgentStatus {
-    let exe_name = agent_cmd.split_whitespace().next().unwrap_or(agent_cmd);
-
-    // Try to match a known agent first
-    let profile = agent_registry::lookup_profile(exe_name);
-    if profile.id != "unknown" {
-        return check_agent(profile.id);
-    }
-
-    // Custom agent: check if the executable exists on fresh PATH
-    let path_var = fresh_path();
-    let mut cli_path = None;
-
-    // Check as-is (might be a full path)
-    if std::path::Path::new(exe_name).is_file() {
-        cli_path = Some(exe_name.to_string());
-    }
-
-    // Check on PATH with common extensions
-    if cli_path.is_none() {
-        for ext in &["", ".exe", ".cmd"] {
-            let name = format!("{}{}", exe_name, ext);
-            for dir in std::env::split_paths(&path_var) {
-                let candidate = dir.join(&name);
-                if candidate.is_file() {
-                    cli_path = Some(candidate.to_string_lossy().to_string());
-                    break;
-                }
-            }
-            if cli_path.is_some() { break; }
-        }
-    }
-
-    let cli_found = cli_path.is_some();
-
-    AgentStatus {
-        id: exe_name.to_string(),
-        display_name: exe_name.to_string(),
-        cli_found,
-        cli_path,
-        has_credential: false, // unknown for custom agents
-        install_hint: String::new(),
-        auth_hint: t!("agent.custom.auth_hint", name = exe_name).into_owned(),
-    }
-}
-
 /// Ensure an agent is installed: find → install if missing → refresh PATH → find again.
 pub async fn ensure_installed(
     agent_id: &str,
@@ -515,4 +467,5 @@ mod tests {
         let merged = merge_paths(r"C:\Reg", r"C:\Reg;C:\OnlyAtRuntime");
         assert_eq!(merged, r"C:\Reg;C:\OnlyAtRuntime");
     }
+
 }

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -228,6 +228,36 @@ impl PreflightResult {
         self.cli_status == CheckStatus::Passed
             && matches!(self.auth_status, CheckStatus::Passed | CheckStatus::Skipped)
     }
+
+    /// Synthesize a `Passed` preflight result for a custom or unknown agent
+    /// id. We deliberately do **not** run an out-of-band PATH check for these
+    /// — the user-supplied command can be anything (`.cmd`, `.ps1`,
+    /// `node script.js`, an alias) and any guess we make disagrees with what
+    /// the spawner actually does. Real spawn failures surface via the
+    /// `ConnectionFailed` → `ConnectionState::Failed` lifecycle, which is the
+    /// authoritative error path.
+    ///
+    /// Returning `cli_status=Passed` keeps the TUI out of Setup mode so the
+    /// chat input stays responsive. The display name is derived from the
+    /// canonical id (`custom:<name>` → `<name>`) so the UI never collapses
+    /// to the generic `DEFAULT_PROFILE` "Agent" label.
+    pub fn passed_for_custom_agent(canonical_id: &str) -> Self {
+        let display_name = canonical_id
+            .strip_prefix("custom:")
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| canonical_id.to_string());
+        Self {
+            agent_id: canonical_id.to_string(),
+            display_name,
+            cli_status: CheckStatus::Passed,
+            cli_path: None,
+            auth_status: CheckStatus::Skipped,
+            install_hint: String::new(),
+            install_url: String::new(),
+            auth_hint: String::new(),
+        }
+    }
 }
 
 /// Build the unified setup options list based on the setup reason.
@@ -8560,6 +8590,42 @@ fn prev_word_boundary(input: &str, cursor_pos: usize) -> usize {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// Custom-agent preflight regression: when the user's `acpAgent` is a
+    /// `custom:*` id, the preflight must NOT gate the TUI into Setup mode.
+    /// Previously `check_agent("custom:foo")` walked PATH for a literal
+    /// `custom:foo.exe`, always failed, and dropped the TUI into Setup with
+    /// the misleading `DEFAULT_PROFILE` "Agent" display name — blocking
+    /// `/restart` and other chat input until a re-save lifecycle-raced the
+    /// preflight failure.
+    #[test]
+    fn passed_for_custom_agent_never_triggers_setup_mode() {
+        let r = PreflightResult::passed_for_custom_agent("custom:foo");
+        // Identity preserved on the canonical id (downstream retry/auth
+        // paths still see `custom:foo`, not the bare exe name).
+        assert_eq!(r.agent_id, "custom:foo");
+        // Display name comes from the canonical id stripped of the
+        // `custom:` prefix — never the generic `DEFAULT_PROFILE` "Agent".
+        assert_eq!(r.display_name, "foo");
+        // `all_passed()` must return true so the PreflightComplete handler
+        // does NOT enter `AppMode::Setup` ("Agent not installed" banner).
+        assert!(r.all_passed());
+        assert_eq!(r.cli_status, CheckStatus::Passed);
+        assert!(matches!(r.auth_status, CheckStatus::Skipped));
+    }
+
+    /// Defensive: a bare `custom:` (empty name) or a non-`custom:` unknown id
+    /// must not produce an empty display name. Falls back to the canonical id.
+    #[test]
+    fn passed_for_custom_agent_falls_back_when_no_custom_suffix() {
+        let r = PreflightResult::passed_for_custom_agent("custom:");
+        assert_eq!(r.display_name, "custom:");
+        assert!(r.all_passed());
+
+        let r2 = PreflightResult::passed_for_custom_agent("some-unknown-id");
+        assert_eq!(r2.display_name, "some-unknown-id");
+        assert!(r2.all_passed());
+    }
 
     // Helper to create an App for testing (avoids needing real channels for simple state tests).
     fn test_app() -> App {

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2379,26 +2379,35 @@ async fn run_acp_app(
                     "current_agent_id assigned",
                 );
                 let agent_id = canonical_id.as_str();
-                let status = agent_check::check_agent(agent_id);
-                let preflight_result = app::PreflightResult {
-                    agent_id: status.id.clone(),
-                    display_name: status.display_name.clone(),
-                    cli_status: if status.cli_found {
-                        app::CheckStatus::Passed
-                    } else {
-                        app::CheckStatus::Failed("Not found on PATH".to_string())
-                    },
-                    cli_path: status.cli_path.clone(),
-                    auth_status: if !status.cli_found {
-                        app::CheckStatus::Skipped
-                    } else if status.has_credential {
-                        app::CheckStatus::Passed
-                    } else {
-                        app::CheckStatus::Skipped
-                    },
-                    install_hint: status.install_hint.clone(),
-                    install_url: String::new(),
-                    auth_hint: status.auth_hint.clone(),
+                let preflight_result = if agent_id.starts_with("custom:")
+                    || agent_registry::lookup_profile_by_id(agent_id).id == "unknown"
+                {
+                    // Custom/unknown agents: command is opaque (`.cmd`, `node script.js`,
+                    // shell function, …); a PATH probe would lie. The real spawn produces
+                    // the authoritative error via `ConnectionFailed`, so skip preflight.
+                    app::PreflightResult::passed_for_custom_agent(&canonical_id)
+                } else {
+                    let status = agent_check::check_agent(agent_id);
+                    app::PreflightResult {
+                        agent_id: canonical_id.clone(),
+                        display_name: status.display_name.clone(),
+                        cli_status: if status.cli_found {
+                            app::CheckStatus::Passed
+                        } else {
+                            app::CheckStatus::Failed("Not found on PATH".to_string())
+                        },
+                        cli_path: status.cli_path.clone(),
+                        auth_status: if !status.cli_found {
+                            app::CheckStatus::Skipped
+                        } else if status.has_credential {
+                            app::CheckStatus::Passed
+                        } else {
+                            app::CheckStatus::Skipped
+                        },
+                        install_hint: status.install_hint.clone(),
+                        install_url: String::new(),
+                        auth_hint: status.auth_hint.clone(),
+                    }
                 };
                 tracing::info!(
                     target: "preflight",


### PR DESCRIPTION
# Fix `acpAgent` custom-agent UX: don't trap users in Setup mode + always show the model picker

## Symptoms

When `acpAgent` is a custom command (e.g. `qwen.cmd --acp`), the agent pane on a cold start shows a disconnected/Setup banner saying **"Agent not installed"**:

1. The TUI is in Setup mode, so `/restart` and other chat input is swallowed.
2. Restarting Intelligent Terminal doesn't help — same banner.
3. Re-saving the **exact same** `acpAgent` value sometimes flips to connected (a lifecycle race, not a real recovery).
4. The error names the agent generically as **"Agent"** instead of the user's command.
5. Once connected, the **Model row is missing from Settings → AI agents** for custom agents — so if the persisted `acpModel` value becomes invalid (e.g. `coder-model(qwen-oauth)` after qwen-oauth credentials expire), there's no way to see or clear it. Every cold start then re-sends the stale model to the agent, the agent rejects it, and the helper crashes the handshake → back to Setup mode again.

## Root cause

Two coupled bugs feeding each other:

**Bug A — Bogus preflight failure.** C++ passes `--agent-id custom:qwen --agent "qwen.cmd --acp"` to `wta`. The preflight does `check_agent("custom:qwen")`, which:

- routes through `find_exe("custom:qwen")` → `lookup_profile_by_id("custom:qwen")` returns `DEFAULT_PROFILE` (id `"unknown"`, display `"Agent"`);
- then searches PATH for literal files named `custom:qwen.exe` / `custom:qwen.cmd` — which never match.

Result: `cli_found = false` → `PreflightResult.cli_status = Failed` → `app.rs` enters `AppMode::Setup` and blocks chat input. Display name falls back to `"Agent"`. Symptoms 1, 2, 3, 4 all share this single deterministic failure.

The re-save "fix" works because in some runs `agent_status=connected` beats the preflight gate via a lifecycle race — not a real recovery, just timing.

**Bug B — Invisible stale `acpModel`.** `AIAgentsViewModel::ShowAcpModel` / `ShowDelegateModel` returned `false` for any `custom:*` agent — so the model picker row was hidden entirely. A previously-selected `acpModel` value (e.g. `coder-model(qwen-oauth)`) stayed persisted in `settings.json`, invisible and unclearable. On each cold start the helper then sent the stale value via ACP `session/setModel`; if the agent rejected it (e.g. credentials expired) the helper classified it as `handshake_failed` → `state=failed` → Setup mode (back to symptom 1).

## Fix

**Preflight: skip the PATH gate for any user-supplied agent.**

For `custom:*` ids and any id not in the registry, `tools/wta/src/main.rs` now synthesizes a `Passed` `PreflightResult` via `PreflightResult::passed_for_custom_agent(canonical_id)` instead of running `check_agent` against the synthetic profile id. Rationale: a user-supplied command can be anything (`.cmd` launcher, `node script.js`, `cmd /c …`, a PowerShell function, an alias). Any PATH walk we do disagrees with what the real spawner does, and a false `Failed` result here is exactly what trapped users in Setup mode. The actual spawn already produces an authoritative error via the `ConnectionFailed` → `ConnectionState::Failed` lifecycle, so the right answer is to delete the speculative gate — not try to make it smarter.

Display name is derived from the canonical id (`custom:<name>` → `<name>`) so the UI never collapses to the generic `DEFAULT_PROFILE` `"Agent"` label.

`check_agent_cmd` and the four related helpers (`check_agent_cmd_test_only`, `is_executable_extension`, `executable_extensions_to_check`, plus their tests) are removed — they were only ever called by the preflight path this PR replaces.

**Settings UI: show the model picker for custom agents too.**

`AIAgentsViewModel::ShowAcpModel` / `ShowDelegateModel` no longer short-circuit to `false` when the agent id starts with `custom:`:

```cpp
// Before:                                            // After:
if (_isAddingCustomAcpAgent) return false;            if (_isAddingCustomAcpAgent) return false;
if (_StartsWithCustom(...AcpAgent())) return false;   if (_StartsWithCustom(...AcpAgent())) return true;
return _IsKnownAgent(...AcpAgent());                  return _IsKnownAgent(...AcpAgent());
```

`HasAcpModelList` / `ShowAcpModelTextBox` already pick between the ComboBox (when the helper has published `available_models` via `agent_status`) and the free-form TextBox fallback — both work for custom agents. The data flow into `AcpRuntimeState::SetAvailableModels` is also agent-agnostic (`TerminalPage::OnAgentStatusChanged` + `wta probe-models`); only the visibility gate was hiding it.

This means users can now see the persisted `acpModel` for any custom agent and clear it if it's stale. The helper filters empty values (`.filter(|s| !s.trim().is_empty())` at `client.rs:2432, 3303`) before sending `session/setModel`, so an empty TextBox value cleanly falls back to whatever default the agent picks.

## How this fixes each symptom

| # | Symptom | Fixed by |
|---|---------|----------|
| 1 | TUI in Setup mode, `/restart` swallowed | Bug A — preflight no longer returns `Failed` for custom ids, so `AppMode::Setup` is never entered |
| 2 | Restart doesn't help | Same |
| 3 | Re-save sometimes works (race) | Same — the gate is gone, no race to win |
| 4 | Display name is "Agent" | `passed_for_custom_agent` derives display from canonical id (`custom:foo` → `foo`) |
| 5 | Model picker hidden, stale `acpModel` invisible | Bug B — model row now shows for custom agents; user can clear stale value |

## Out of scope (separate follow-ups)

- **`/restart` is a no-op in helper mode** — helper logs `restart_tx` being signaled but no `OnRestartAgentStackRequested` ever fires in C++. Needs a separate trace through `client.rs:2577` → `restart_agent_stack` SendEvent → `TerminalPage::OnRestartAgentStackRequested`. Filing as separate issue.
- **`set_session_model` rejection should not crash the handshake** — the helper currently classifies an agent's `session/setModel` rejection as `handshake_failed` → `state=failed`, which forces Setup mode. A softer behavior (warning + proceed with agent default) would prevent symptom 5 even when the user *hasn't* discovered the model textbox yet.
- `app.rs:3627` Retry button calls `check_agent(agent_id)` and so will always be a no-op for `custom:*` agents. Pre-existing.
- `app.rs:4199-4200` auth-error fallback also goes through `lookup_profile(agent_id)` and collapses to `"unknown"` / `"Agent"` for custom ids. Pre-existing.

## Testing

**Rust unit tests** (`cargo test --manifest-path tools/wta/Cargo.toml`):

- 2 new tests pinning the never-trigger-Setup-mode contract:
  - `passed_for_custom_agent_never_triggers_setup_mode` — asserts `agent_id` preserved, `display_name` derived from canonical id, and `all_passed()` is true.
  - `passed_for_custom_agent_falls_back_when_no_custom_suffix` — verifies the helper handles bare `unknown`-class ids.
- Removed test scaffolding for the deleted `check_agent_cmd` path.

**C++ side:** `AIAgentsViewModel` has no existing `ut_` test project (only the source files reference these getters). Adding one would require building a new harness with a fake `GlobalAppSettings` + WinRT stubs — disproportionate to a 1-line getter change. Behavior is verifiable via manual UI inspection: set `acpAgent: "qwen.cmd --acp"`, open Settings → AI agents → confirm Model row is visible (TextBox or ComboBox depending on whether the helper has connected and published `available_models`).

**Manual repro reproduced and verified fixed:** the original "save twice to connect" symptom no longer occurs; first save with a custom agent connects on the first try.

