### PR TITLE
Bump appxmanifest MinVersion to Windows 11 22H2 (22621.6060)

### DIFF
--- a/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
@@ -38,7 +38,7 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26100.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.22621.6060" MaxVersionTested="10.0.26100.0" />
   </Dependencies>
 
   <Resources>

--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -38,7 +38,7 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26100.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.22621.6060" MaxVersionTested="10.0.26100.0" />
   </Dependencies>
 
   <Resources>

--- a/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
@@ -39,7 +39,7 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26100.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.22621.6060" MaxVersionTested="10.0.26100.0" />
   </Dependencies>
 
   <Resources>

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -39,7 +39,7 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26100.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.22621.6060" MaxVersionTested="10.0.26100.0" />
   </Dependencies>
 
   <Resources>


### PR DESCRIPTION
## Summary of the Pull Request

Bumps the `TargetDeviceFamily` `MinVersion` from `10.0.19041.0` (Windows 10 2004) to `10.0.22621.6060` (Windows 11 22H2 servicing) across all four CascadiaPackage flavors so the appxmanifest matches the supported-OS floor declared by #177.

## References and Relevant Issues

Follow-up to #177, which updated `README.md` to state `Intelligent Terminal requires Windows 11 22H2 or later (22621.6060+)` — but the manifests still advertised Windows 10 as a valid deployment target, so the Store/MSIX layer would happily install on systems we're declaring unsupported.

## Detailed Description of the Pull Request / Additional comments

Identical one-line change in:

- `src/cascadia/CascadiaPackage/Package.appxmanifest` (Release)
- `src/cascadia/CascadiaPackage/Package-Pre.appxmanifest` (Preview)
- `src/cascadia/CascadiaPackage/Package-Dev.appxmanifest` (Dev)
- `src/cascadia/CascadiaPackage/Package-Can.appxmanifest` (Canary)

`MaxVersionTested` is unchanged (`10.0.26100.0`).

The `.wapproj` already sets `AppxOSMinVersionReplaceManifestVersion=false` / `AppxOSMaxVersionTestedReplaceManifestVersion=false` (see `CascadiaPackage.wapproj` lines 12-17), so MSBuild will not overwrite the manual value. `TargetPlatformMinVersion` in the `.wapproj` is the SDK API floor and is intentionally left alone.

## Validation Steps Performed

- Verified the four manifests are the only files in `src/cascadia` declaring `MinVersion="10.0.19041.0"`.
- Confirmed `.wapproj` does not override manifest min-version.
- `git diff` shows only the intended 4 single-line edits.