### PR TITLE
ACP model: distinguish "agent default" (unset) from the agent's "auto"/"default" model

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
@@ -245,15 +245,15 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // Reconcile a *stale* persisted id with the authoritative list.
         // Only fires when the user has actively configured a specific model
         // (non-empty) that this agent doesn't advertise — e.g. switching
-        // agents leaves a leftover id. In that case rewrite to the agent's
-        // advertised default ("default" / "auto") so the dropdown and the
-        // runtime --acp-model value stay in sync.
+        // agents leaves a leftover id. In that case reset to the empty
+        // "agent default" sentinel rather than picking the agent's
+        // "auto"/"default" entry: empty is the unambiguous "send no model
+        // override" state and renders as the ComboBox's "Default"
+        // placeholder, so we never silently mislabel a stale id as a real
+        // model the user didn't choose.
         //
-        // We *don't* reconcile when the persisted id is empty: empty is a
-        // legitimate "use whatever default the agent picks" sentinel that
-        // the user never typed in, and silently writing "default" into
-        // settings.json would be surprising. The visual fallback for that
-        // case lives in CurrentAcpModelEntry().
+        // Empty is already the legitimate "use whatever default the agent
+        // picks" sentinel, so the empty case needs no reconciliation.
         if (newSize > 0)
         {
             const auto current = _GlobalSettings.AcpModel();
@@ -270,24 +270,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 }
                 if (!matched)
                 {
-                    winrt::hstring fallbackId{};
-                    for (uint32_t i = 0; i < newSize; ++i)
-                    {
-                        const auto id = _acpModelList.GetAt(i).Id();
-                        if (id == L"default" || id == L"auto")
-                        {
-                            fallbackId = id;
-                            break;
-                        }
-                    }
-                    if (fallbackId.empty())
-                    {
-                        fallbackId = _acpModelList.GetAt(0).Id();
-                    }
-                    if (_GlobalSettings.AcpModel() != fallbackId)
-                    {
-                        _GlobalSettings.AcpModel(fallbackId);
-                    }
+                    // Stale leftover id this agent doesn't advertise → reset
+                    // to the empty "agent default" sentinel (send no model
+                    // override), which renders as the "Default" placeholder.
+                    _GlobalSettings.AcpModel(L"");
                 }
             }
         }
@@ -371,26 +357,19 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             const auto entry = _acpModelList.GetAt(i);
             if (entry.Id() == current) return entry;
         }
-        // Visual-only fallback for the unconfigured case: the user has
-        // never picked a model (empty persisted id), so we surface the
-        // agent's advertised default entry as the selected item instead
-        // of letting the ComboBox render dim PlaceholderText. We *don't*
-        // write to settings here — leaving the empty id in place keeps
-        // wta's "use the agent's own default" semantics intact.
-        // The stale-id case (non-empty + no match) is handled at the
-        // data layer by _RebuildAcpModelListFromCache.
-        if (current.empty() && _acpModelList.Size() > 0)
-        {
-            for (uint32_t i = 0; i < _acpModelList.Size(); ++i)
-            {
-                const auto entry = _acpModelList.GetAt(i);
-                const auto id = entry.Id();
-                if (id == L"default" || id == L"auto") return entry;
-            }
-            return _acpModelList.GetAt(0);
-        }
-        // Empty list (probe hasn't run yet) → ComboBox shows PlaceholderText
-        // briefly until the agent's model list arrives.
+        // Unconfigured case (empty persisted id): return null so the
+        // ComboBox renders its "Default" PlaceholderText. This is the
+        // distinct "agent default — send no model override" state and is
+        // intentionally NOT mapped onto the agent's advertised
+        // "auto"/"default" entry. That advertised entry is a real model in
+        // the agent's support list (e.g. copilot's "auto" router) which,
+        // when explicitly selected, gets forwarded via setSessionModel;
+        // conflating the two would mislabel "no override" (which resolves
+        // to the agent's own server-side default, e.g. claude-sonnet-4.6)
+        // as the "auto" model. The stale-id case (non-empty + no match) is
+        // reset to empty at the data layer by _RebuildAcpModelListFromCache,
+        // so it also lands here and shows the placeholder.
+        // Empty list (probe hasn't run yet) likewise → PlaceholderText.
         return nullptr;
     }
 

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -849,6 +849,22 @@ impl acp::Agent for HelperHandler {
             crate::session_registry::build_sessions_changed_notification(),
         )
         .await;
+        // Trace the model the agent actually selected for this session at
+        // INFO. When the WT `acpModel` setting is empty (the "agent default"
+        // case) we forward no setSessionModel, so this current_model_id from
+        // the agent's NewSessionResponse is the only INFO-level record of
+        // which model is really in effect — the acp-client current_model_id
+        // line is debug-only. The explicit case is already covered by the
+        // "forwarding set_session_model" log.
+        let agent_current_model = resp
+            .models
+            .as_ref()
+            .map(|state| state.current_model_id.0.to_string());
+        let agent_model_count = resp
+            .models
+            .as_ref()
+            .map(|state| state.available_models.len())
+            .unwrap_or(0);
         tracing::info!(
             target: "master",
             step = "helper→agent",
@@ -856,6 +872,8 @@ impl acp::Agent for HelperHandler {
             helper_id = ?self.helper_id,
             session_id = ?resp.session_id,
             registry_size = registry_size,
+            current_model_id = ?agent_current_model,
+            available_models = agent_model_count,
             "session bound to helper"
         );
         Ok(resp)


### PR DESCRIPTION
## Problem

The agent-pane model picker conflated **two different states** onto one value:

- **Unset (`acpModel=""`)** — the user never chose a model, so WT forwards **no** `setSessionModel` and the agent picks its own server-side default.
- **The agent's advertised `auto`/`default` entry** — a *real* model in the agent's support list (e.g. copilot's `auto` router, claude's `default`) which, when explicitly selected, **is** forwarded via `setSessionModel`.

When the setting was empty, the UI visually back-filled it with the agent's advertised `auto`/`default` entry and showed it as a **solid selection** — while WT actually sent nothing. So "no override" (which resolves to e.g. `claude-sonnet-4.6`) was mislabeled as the `auto` model, and there was no way to express / see the plain "agent default" state.

Verified end-to-end from logs: an unset Claude run forwards no `setSessionModel`; the agent reports `current_model_id="default"` which resolves server-side to `claude-sonnet-4-5`. The picker still rendered a solid `default`.

## Changes

**Settings editor (`AIAgentsViewModel`)**
- `CurrentAcpModelEntry`: an empty id now returns `null` so the ComboBox renders its existing `"Default"` **placeholder** (the distinct "agent default — no override" state) instead of grabbing the advertised `auto`/`default` entry.
- `_RebuildAcpModelListFromCache`: a stale non-empty id this agent doesn't advertise now resets to the **empty sentinel** rather than the advertised `auto`/`default`, so we never silently relabel it as a real model.
- The agent's advertised `auto`/`default` stays a normal, explicitly-selectable list item.

No new resource keys — the empty state reuses the existing `"Default"` placeholder, so **no localization changes** are needed.

**wta master logging**
- Log the agent-selected `current_model_id` (and advertised model count) on the INFO `"session bound to helper"` line. In the empty/"agent default" case WT forwards no `setSessionModel`, so the actually-in-effect model was previously only visible at debug level — now it's traceable at INFO:
  ```
  INFO master: session bound to helper … current_model_id=Some("default") available_models=5
  ```

## Behavior after

| State | Stored value | Dropdown shows | WT sends |
|---|---|---|---|
| Unset / cleared / stale | `""` | greyed `Default` placeholder | nothing → agent's server default |
| Explicitly picks agent `auto`/`default` | `"auto"`/`"default"` | solid selected item | `setSessionModel(...)` |
| Explicitly picks a concrete model | e.g. `claude-haiku-4.5` | that model | `setSessionModel(...)` |

## Testing
- `cargo build` (wta) — passes; new INFO field confirmed live in `wta-main_master.log`.
- C++ `Microsoft.Terminal.Settings.Editor` — incremental build compiles & links clean.
- Visual confirmation of greyed-vs-solid placeholder pending a fresh dev-app launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)