### PR TITLE
fix(spelling): allow _wcsnicmp CRT function name

### DIFF
--- a/.github/actions/spelling/allow/apis.txt
+++ b/.github/actions/spelling/allow/apis.txt
@@ -188,6 +188,7 @@ USEROBJECTFLAGS
 Vcpp
 Viewbox
 virtualalloc
+wcsnicmp
 wcsnlen
 WDJ
 winhttp

--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -1330,7 +1330,6 @@ PSINGLE
 psl
 psldl
 PSNRET
-PSobject
 psp
 PSPCB
 psr
@@ -1541,7 +1540,6 @@ SHOWWINDOW
 sidebyside
 SIF
 SIGDN
-Signtool
 SINGLETHREADED
 siup
 sixel
@@ -1820,7 +1818,6 @@ VSTS
 VSTT
 vswhere
 vtapp
-VTE
 VTID
 vtmode
 vtpipeterm
@@ -1936,7 +1933,6 @@ wstr
 wstrings
 wsz
 wta
-WTCLI
 wtai
 wtd
 WTEXT


### PR DESCRIPTION
Two small check-spelling config cleanups, both pre-existing (not from #182):

**1. Allow the `_wcsnicmp` CRT function name**
The workflow strips the leading underscore from `_wcsnicmp` (used in `src/cascadia/inc/WtaProcess.h`) and flagged `wcsnicmp` as unrecognized. Added it to `allow/apis.txt` next to its sibling `wcsnlen`.

**2. Remove 4 unused case-variant duplicates from `expect/expect.txt`**
check-spelling is case-sensitive, so allow/ entries only cover the exact casing listed. These 4 expect.txt entries have differently-cased counterparts in allow/ AND aren't used in the codebase, so they're dead weight:

| expect.txt (removed) | covered by | kept because used |
|---|---|---|
| `PSobject` | `allow/allow.txt` psobject | — |
| `Signtool` | `allow/allow.txt` signtool | — |
| `VTE` | `allow/allow.txt` vte | — |
| `WTCLI` | `allow/apis.txt` wtcli | — |

NOT removed (lowercase forms appear in code, so allow/ uppercase doesn't cover):
- `ftcs` → `doc/specs/#11000 - Marks/Shell-Integration-Marks.md` (image filename)
- `msaa` → `src/host/AccessibilityNotifier.cpp` (C++ local variable)
- `stdcpp` → `src/common.build.pre.props` (MSBuild `stdcpp20`/`stdcpp17`)