### PR TITLE
fre: modal busy overlay during save/install (locks form, shows progress)

### DIFF
--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -26,10 +26,10 @@ namespace winrt::TerminalApp::implementation
     {
         InitializeComponent();
 
-        // The Save button hosts a ProgressRing + TextBlock instead of a
-        // plain text Content, so x:Uid can't carry the label. Seed the
-        // idle state (label = "Save", ring hidden, form interactive).
-        _SetSavingState(false);
+        // Seed the overlay's status text from the existing localized
+        // resource (reused here rather than adding a new .Text key
+        // across every locale).
+        SavingStatusText().Text(RS_(L"FreOverlay_SettingUp"));
     }
 
     // ── Detection helpers ───────────────────────────────────────────────
@@ -641,9 +641,9 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        // 2. Enter the "saving" state: dim + block the form, disable the
-        // button, spin the ring, switch the label to "Setting up...".
-        // Hide any previous error.
+        // 2. Enter the "saving" state: disable the form, raise the
+        // SavingOverlay (with spinner + "Setting up..."), disable the
+        // Save button. Hide any previous error.
         _SetSavingState(true);
         ErrorPanel().Visibility(Visibility::Collapsed);
 
@@ -862,23 +862,21 @@ namespace winrt::TerminalApp::implementation
     //   state to descendants (it ANDs with each child's own IsEnabled)
     //   without clobbering the per-control IsEnabled values, so
     //   policy-driven disables (locked toggles, etc.) survive when we
-    //   restore. Crucially, IsEnabled blocks keyboard input too — unlike
-    //   IsHitTestVisible, which is pointer-only and would leave Tab /
-    //   Space / arrows working on the form mid-install. Opacity gives
-    //   the user visual confirmation that the area is inert.
+    //   restore. Crucially, IsEnabled blocks keyboard input too —
+    //   unlike IsHitTestVisible, which is pointer-only and would leave
+    //   Tab / Space / arrows working on the form mid-install.
+    // - The SavingOverlay (a semi-opaque Border sitting in the same
+    //   Grid cell as the form, z-stacked on top) gives the visual: a
+    //   centered ProgressRing + "Setting up..." status text. Its
+    //   Background also catches any stray pointer input the disabled
+    //   form might still surface.
     // - The Save button is gated separately so an Enter keypress can't
     //   re-fire the click while we're already saving.
     void FreOverlay::_SetSavingState(bool saving)
     {
         SettingsFormScroller().IsEnabled(!saving);
-        SettingsFormScroller().Opacity(saving ? 0.5 : 1.0);
-
+        SavingOverlay().Visibility(saving ? Visibility::Visible : Visibility::Collapsed);
+        SavingProgressRing().IsActive(saving);
         SaveButton().IsEnabled(!saving);
-        SaveProgressRing().IsActive(saving);
-        SaveProgressRing().Visibility(saving ? Visibility::Visible : Visibility::Collapsed);
-        // RS_ requires a string literal (the key is extracted at build
-        // time), so branch rather than select the key at runtime.
-        SaveButtonText().Text(saving ? RS_(L"FreOverlay_SettingUp")
-                                     : RS_(L"FreOverlay_SaveButton/Content"));
     }
 }

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -302,6 +302,18 @@ namespace winrt::TerminalApp::implementation
             AgentComboBox(), RS_(L"FreOverlay_AgentLabel/Text"));
         Automation::AutomationProperties::SetName(
             PanePositionComboBox(), RS_(L"FreOverlay_PanePositionLabel/Text"));
+
+        // Give the SavingProgressRing a localized accessible Name so
+        // Narrator announces "Setting up Intelligent Terminal" when
+        // focus moves to it during a save/install (and "Setting up
+        // Intelligent Terminal, busy" if the user later presses Caps+0
+        // mid-install). Without this, focus reads just "ProgressRing".
+        // Paired with the Focus-before-IsActive(true) ordering in
+        // _SetSavingState so the initial focus announcement does NOT
+        // include the "busy" state prefix — that comes later only on
+        // explicit re-query.
+        Automation::AutomationProperties::SetName(
+            SavingProgressRing(), RS_(L"FreOverlay_SettingUp"));
     }
 
     // ── Agent selection changed ─────────────────────────────────────────
@@ -937,26 +949,44 @@ namespace winrt::TerminalApp::implementation
         if (saving)
         {
             overlay.Visibility(Visibility::Visible);
-            // Move focus BEFORE activating the spinner. Narrator
-            // announces the focused control's state on focus change; if
-            // IsActive is already true, the announcement is prefixed
-            // with "busy" which buries the "Setting up..." notification
-            // we fire below. Toggling IsActive after focus tends to
-            // not re-announce.
-            ring.Focus(FocusState::Programmatic);
             ring.IsActive(true);
             scroller.IsEnabled(false);
             save.IsEnabled(false);
 
-            // Narrator: focus moving to the ProgressRing alone reads
-            // "ProgressRing" — a blind user has no idea what's busy.
-            // Announce the operation name explicitly with
-            // ImportantMostRecent so this wins over the focus
-            // announcement. Same RaiseNotificationEvent pattern as
-            // TerminalPage::_ShowFreOverlay (welcome) — uses SaveButton
-            // as the peer source because announcements fired through a
-            // UserControl's automation peer don't propagate to Narrator
-            // reliably; a concrete focusable Control does.
+            // Move focus to the ProgressRing AFTER the synchronous
+            // layout work completes. Calling ring.Focus() right after
+            // overlay.Visibility(Visible) silently fails — the ring
+            // isn't in the live visual tree yet, Focus() returns false
+            // (we don't see it because the return value is discarded),
+            // and focus stays on the SaveButton the user just clicked.
+            // Mirror the deferred-focus pattern used in
+            // TerminalPage::_ShowFreOverlay (line ~955) for the FRE
+            // NextButton: dispatch at Low priority so the focus call
+            // runs after the visibility change has been laid out.
+            Dispatcher().RunAsync(
+                winrt::Windows::UI::Core::CoreDispatcherPriority::Low,
+                [weak = get_weak()]() {
+                    if (auto self = weak.get())
+                    {
+                        if (auto r = self->SavingProgressRing())
+                        {
+                            r.Focus(FocusState::Programmatic);
+                        }
+                    }
+                });
+
+            // Narrator: the deferred focus above will eventually fire a
+            // focus event with the ProgressRing's Name ("Setting up
+            // Intelligent Terminal", set in Initialize via SetName) +
+            // its "busy" state. RaiseNotificationEvent ensures the
+            // user hears something immediately, before that deferred
+            // focus lands. Together: an early notification on entry,
+            // and a meaningful Caps+Tab readout (or focus-changed
+            // announcement on re-entry) once focus is parked on the
+            // ring. Uses SaveButton as the peer source (matches the
+            // FRE welcome pattern in TerminalPage::_ShowFreOverlay)
+            // because UserControl peers don't propagate notifications
+            // to Narrator reliably; a concrete focusable Control does.
             if (auto peer = Automation::Peers::FrameworkElementAutomationPeer::FromElement(SaveButton()))
             {
                 peer.RaiseNotificationEvent(

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -605,26 +605,12 @@ namespace winrt::TerminalApp::implementation
         // so flip "(will install)" → "(installed)" for anything now on PATH.
         _PopulateAgentComboBox();
 
-        // Re-enable editing so the user can adjust selections and retry.
-        // _SetSavingState(false) parks focus on SaveButton as its safe
-        // default — fine for the success path (where the overlay
-        // immediately collapses) but suboptimal here: a Narrator user
-        // would be told the error and then find their focus on the
-        // generic Save button, with no clear cue that they're "on the
-        // error" or what they can do about it. Override the focus to
-        // the help-link inside the ErrorPanel — it's the only
-        // actionable element in the error area, and pressing Enter
-        // there opens the manual-fix docs (the natural next action
-        // after hearing the error). The user can Shift+Tab back to
-        // SaveButton if they want to retry instead.
-        _SetSavingState(false);
-
-        // Narrator: order matters. Fire the error notification BEFORE
-        // moving focus to the hyperlink, so the user hears the error
-        // message first and the focus-location ("Learn how to fix,
-        // link") second. Doing it the other way around means the
-        // focus announcement plays first and the error sounds like an
-        // afterthought.
+        // Narrator: order matters. Fire the error notification FIRST,
+        // BEFORE any focus transitions, so the assertive announcement
+        // is queued before the Save-button focus event that
+        // _SetSavingState(false) emits below. Without this ordering,
+        // some Narrator versions announce "Save button" first and the
+        // actual error message sounds like an afterthought.
         //
         // The ErrorText carries LiveSetting="Assertive" in XAML, but
         // live regions don't fire reliably for Text changes that
@@ -642,6 +628,19 @@ namespace winrt::TerminalApp::implementation
                 L"FreInstallErrorAnnouncement");
         }
 
+        // Re-enable editing so the user can adjust selections and retry.
+        // _SetSavingState(false) parks focus on SaveButton as its safe
+        // default — fine for the success path (where the overlay
+        // immediately collapses) but suboptimal here: a Narrator user
+        // would be told the error and then find their focus on the
+        // generic Save button, with no clear cue that they're "on the
+        // error" or what they can do about it. Override the focus to
+        // the help-link inside the ErrorPanel — it's the only
+        // actionable element in the error area, and pressing Enter
+        // there opens the manual-fix docs (the natural next action
+        // after hearing the error). The user can Shift+Tab back to
+        // SaveButton if they want to retry instead.
+        _SetSavingState(false);
         ErrorHelpLink().Focus(FocusState::Programmatic);
     }
 

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -956,17 +956,29 @@ namespace winrt::TerminalApp::implementation
             return;
         }
 
-        // Order matters: we want focus to move exactly once across the
-        // transition. If we disable the form first, XAML forcibly evicts
-        // focus from the disabled subtree to an unpredictable place
-        // (possibly lost entirely), which breaks keyboard navigation and
-        // Narrator for the duration of the save. Raise the overlay
-        // first so the ProgressRing can receive focus (it needs
-        // IsTabStop=true, set in XAML — Border itself isn't a Control
-        // and can't host focus), snatch focus to it, then disable the
-        // form — at which point the form has no focus to evict. On the
-        // way back, re-enable first so Focus(SaveButton) lands on an
-        // enabled target, then hide the overlay.
+        // Saving-state transition note. Order intentionally accepts
+        // two focus changes in close succession on entry:
+        //   (1) save.IsEnabled(false) below evicts focus from the
+        //       SaveButton (the user just clicked Save, so focus was
+        //       on it). XAML auto-moves focus to the next available
+        //       tab stop; with the form also disabled, that's
+        //       effectively "nowhere".
+        //   (2) The deferred Dispatcher().RunAsync(Low) further down
+        //       moves focus to the ProgressRing once layout settles
+        //       (~one frame later — calling Focus() inline right
+        //       after overlay.Visibility(Visible) silently fails
+        //       because the ring isn't in the live visual tree yet).
+        // The RaiseNotificationEvent ("Setting up...") fires
+        // synchronously with ImportantMostRecent priority and
+        // preempts the brief between-state focus eviction in
+        // Narrator, so the user hears the operation name rather
+        // than noise. We deliberately do NOT defer save.IsEnabled
+        // alongside the focus call: that would create a window
+        // where the user could re-click Save mid-install.
+        //
+        // On the way back (saving=false), we re-enable scroller and
+        // save before calling save.Focus, so the focus target is
+        // already enabled when XAML lands it.
         if (saving)
         {
             overlay.Visibility(Visibility::Visible);

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -25,6 +25,11 @@ namespace winrt::TerminalApp::implementation
     FreOverlay::FreOverlay()
     {
         InitializeComponent();
+
+        // The Save button hosts a ProgressRing + TextBlock instead of a
+        // plain text Content, so x:Uid can't carry the label. Seed the
+        // idle state (label = "Save", ring hidden, form interactive).
+        _SetSavingState(false);
     }
 
     // ── Detection helpers ───────────────────────────────────────────────
@@ -600,8 +605,8 @@ namespace winrt::TerminalApp::implementation
         // so flip "(will install)" → "(installed)" for anything now on PATH.
         _PopulateAgentComboBox();
 
-        SaveButton().Content(winrt::box_value(RS_(L"FreOverlay_SaveButton/Content")));
-        SaveButton().IsEnabled(true);
+        // Re-enable editing so the user can adjust selections and retry.
+        _SetSavingState(false);
     }
 
     IAsyncAction FreOverlay::_SaveAndInstallAsync()
@@ -636,9 +641,10 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        // 2. Disable button, hide previous error
-        SaveButton().Content(winrt::box_value(RS_(L"FreOverlay_SettingUp")));
-        SaveButton().IsEnabled(false);
+        // 2. Enter the "saving" state: dim + block the form, disable the
+        // button, spin the ring, switch the label to "Setting up...".
+        // Hide any previous error.
+        _SetSavingState(true);
         ErrorPanel().Visibility(Visibility::Collapsed);
 
         // 3. Install prerequisites if needed (blocking — cannot proceed without these)
@@ -819,8 +825,10 @@ namespace winrt::TerminalApp::implementation
             _PopulateAgentComboBox();
 
             _agentPaneLog("[FRE] Completed — raising Completed event");
-            SaveButton().Content(winrt::box_value(RS_(L"FreOverlay_SaveButton/Content")));
-            SaveButton().IsEnabled(true);
+            // Restore the editable state before raising Completed so that
+            // if anything keeps the overlay alive a moment longer, it
+            // doesn't appear stuck in the "saving" visual.
+            _SetSavingState(false);
             Completed.raise(*this, nullptr);
         }
     }
@@ -843,5 +851,34 @@ namespace winrt::TerminalApp::implementation
 
     void FreOverlay::ResetDragOffset()
     {
+    }
+
+    // ── Saving state ────────────────────────────────────────────────────
+
+    // Toggle the overlay between "saving / installing" and "idle / editable".
+    //
+    // - The settings ScrollViewer is disabled as a group while saving.
+    //   IsEnabled on an ancestor propagates an "effectively disabled"
+    //   state to descendants (it ANDs with each child's own IsEnabled)
+    //   without clobbering the per-control IsEnabled values, so
+    //   policy-driven disables (locked toggles, etc.) survive when we
+    //   restore. Crucially, IsEnabled blocks keyboard input too — unlike
+    //   IsHitTestVisible, which is pointer-only and would leave Tab /
+    //   Space / arrows working on the form mid-install. Opacity gives
+    //   the user visual confirmation that the area is inert.
+    // - The Save button is gated separately so an Enter keypress can't
+    //   re-fire the click while we're already saving.
+    void FreOverlay::_SetSavingState(bool saving)
+    {
+        SettingsFormScroller().IsEnabled(!saving);
+        SettingsFormScroller().Opacity(saving ? 0.5 : 1.0);
+
+        SaveButton().IsEnabled(!saving);
+        SaveProgressRing().IsActive(saving);
+        SaveProgressRing().Visibility(saving ? Visibility::Visible : Visibility::Collapsed);
+        // RS_ requires a string literal (the key is extracted at build
+        // time), so branch rather than select the key at runtime.
+        SaveButtonText().Text(saving ? RS_(L"FreOverlay_SettingUp")
+                                     : RS_(L"FreOverlay_SaveButton/Content"));
     }
 }

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -888,9 +888,35 @@ namespace winrt::TerminalApp::implementation
             return;
         }
 
-        scroller.IsEnabled(!saving);
-        overlay.Visibility(saving ? Visibility::Visible : Visibility::Collapsed);
-        ring.IsActive(saving);
-        save.IsEnabled(!saving);
+        // Order matters: we want focus to move exactly once across the
+        // transition. If we disable the form first, XAML forcibly evicts
+        // focus from the disabled subtree to an unpredictable place
+        // (possibly lost entirely), which breaks keyboard navigation and
+        // Narrator for the duration of the save. Raise the overlay
+        // first so the ProgressRing can receive focus (it needs
+        // IsTabStop=true, set in XAML — Border itself isn't a Control
+        // and can't host focus), snatch focus to it, then disable the
+        // form — at which point the form has no focus to evict. On the
+        // way back, re-enable first so Focus(SaveButton) lands on an
+        // enabled target, then hide the overlay.
+        if (saving)
+        {
+            overlay.Visibility(Visibility::Visible);
+            ring.IsActive(true);
+            ring.Focus(FocusState::Programmatic);
+            scroller.IsEnabled(false);
+            save.IsEnabled(false);
+        }
+        else
+        {
+            scroller.IsEnabled(true);
+            save.IsEnabled(true);
+            overlay.Visibility(Visibility::Collapsed);
+            ring.IsActive(false);
+            // Park focus on Save so a keyboard user (typically after an
+            // error, where the form is re-enabled but ErrorPanel now
+            // shows) can press Enter to retry without a mouse trip.
+            save.Focus(FocusState::Programmatic);
+        }
     }
 }

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -874,9 +874,23 @@ namespace winrt::TerminalApp::implementation
     //   re-fire the click while we're already saving.
     void FreOverlay::_SetSavingState(bool saving)
     {
-        SettingsFormScroller().IsEnabled(!saving);
-        SavingOverlay().Visibility(saving ? Visibility::Visible : Visibility::Collapsed);
-        SavingProgressRing().IsActive(saving);
-        SaveButton().IsEnabled(!saving);
+        _agentPaneLog(std::string("[FRE] saving state: ") + (saving ? "ON" : "OFF"));
+
+        // Guard against being called before InitializeComponent has populated
+        // the named XAML elements — matches the pattern used elsewhere in
+        // this file (see _UpdateSuggestionEnabledState, _OnAutoDetectToggled).
+        auto scroller = SettingsFormScroller();
+        auto overlay = SavingOverlay();
+        auto ring = SavingProgressRing();
+        auto save = SaveButton();
+        if (!scroller || !overlay || !ring || !save)
+        {
+            return;
+        }
+
+        scroller.IsEnabled(!saving);
+        overlay.Visibility(saving ? Visibility::Visible : Visibility::Collapsed);
+        ring.IsActive(saving);
+        save.IsEnabled(!saving);
     }
 }

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -304,14 +304,15 @@ namespace winrt::TerminalApp::implementation
             PanePositionComboBox(), RS_(L"FreOverlay_PanePositionLabel/Text"));
 
         // Give the SavingProgressRing a localized accessible Name so
-        // Narrator announces "Setting up Intelligent Terminal" when
-        // focus moves to it during a save/install (and "Setting up
-        // Intelligent Terminal, busy" if the user later presses Caps+0
-        // mid-install). Without this, focus reads just "ProgressRing".
-        // Paired with the Focus-before-IsActive(true) ordering in
-        // _SetSavingState so the initial focus announcement does NOT
-        // include the "busy" state prefix — that comes later only on
-        // explicit re-query.
+        // Narrator announces "Setting up Intelligent Terminal, busy"
+        // when focus lands on it during a save/install (and the same
+        // readout on Caps+Tab mid-install). _SetSavingState defers
+        // the ring.Focus() call via Dispatcher().RunAsync(Low) so it
+        // fires after IsActive(true) and the visibility change have
+        // been laid out — the announcement combines this Name with
+        // the "busy" state from the active spinner in a single
+        // readout. Without this Name, Narrator would just read
+        // "ProgressRing".
         Automation::AutomationProperties::SetName(
             SavingProgressRing(), RS_(L"FreOverlay_SettingUp"));
     }
@@ -963,15 +964,22 @@ namespace winrt::TerminalApp::implementation
             // TerminalPage::_ShowFreOverlay (line ~955) for the FRE
             // NextButton: dispatch at Low priority so the focus call
             // runs after the visibility change has been laid out.
+            //
+            // Guard against the fast-success / fast-error race: on a
+            // very quick install the synchronous flow can call
+            // _SetSavingState(false) — collapsing the overlay — before
+            // this deferred lambda fires. Re-check Visibility inside
+            // the lambda so we don't pull focus back to a hidden ring.
             Dispatcher().RunAsync(
                 winrt::Windows::UI::Core::CoreDispatcherPriority::Low,
                 [weak = get_weak()]() {
-                    if (auto self = weak.get())
+                    auto self = weak.get();
+                    if (!self) { return; }
+                    auto o = self->SavingOverlay();
+                    if (!o || o.Visibility() != Visibility::Visible) { return; }
+                    if (auto r = self->SavingProgressRing())
                     {
-                        if (auto r = self->SavingProgressRing())
-                        {
-                            r.Focus(FocusState::Programmatic);
-                        }
+                        r.Focus(FocusState::Programmatic);
                     }
                 });
 

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -606,7 +606,43 @@ namespace winrt::TerminalApp::implementation
         _PopulateAgentComboBox();
 
         // Re-enable editing so the user can adjust selections and retry.
+        // _SetSavingState(false) parks focus on SaveButton as its safe
+        // default — fine for the success path (where the overlay
+        // immediately collapses) but suboptimal here: a Narrator user
+        // would be told the error and then find their focus on the
+        // generic Save button, with no clear cue that they're "on the
+        // error" or what they can do about it. Override the focus to
+        // the help-link inside the ErrorPanel — it's the only
+        // actionable element in the error area, and pressing Enter
+        // there opens the manual-fix docs (the natural next action
+        // after hearing the error). The user can Shift+Tab back to
+        // SaveButton if they want to retry instead.
         _SetSavingState(false);
+
+        // Narrator: order matters. Fire the error notification BEFORE
+        // moving focus to the hyperlink, so the user hears the error
+        // message first and the focus-location ("Learn how to fix,
+        // link") second. Doing it the other way around means the
+        // focus announcement plays first and the error sounds like an
+        // afterthought.
+        //
+        // The ErrorText carries LiveSetting="Assertive" in XAML, but
+        // live regions don't fire reliably for Text changes that
+        // happen while the hosting element is still Collapsed (we set
+        // the text above before flipping Visibility). Uses SaveButton
+        // as the peer source (matches the FRE welcome pattern in
+        // TerminalPage::_ShowFreOverlay) because UserControl peers
+        // don't propagate notifications to Narrator reliably.
+        if (auto peer = Automation::Peers::FrameworkElementAutomationPeer::FromElement(SaveButton()))
+        {
+            peer.RaiseNotificationEvent(
+                Automation::Peers::AutomationNotificationKind::Other,
+                Automation::Peers::AutomationNotificationProcessing::ImportantMostRecent,
+                ErrorText().Text(),
+                L"FreInstallErrorAnnouncement");
+        }
+
+        ErrorHelpLink().Focus(FocusState::Programmatic);
     }
 
     IAsyncAction FreOverlay::_SaveAndInstallAsync()
@@ -902,10 +938,34 @@ namespace winrt::TerminalApp::implementation
         if (saving)
         {
             overlay.Visibility(Visibility::Visible);
-            ring.IsActive(true);
+            // Move focus BEFORE activating the spinner. Narrator
+            // announces the focused control's state on focus change; if
+            // IsActive is already true, the announcement is prefixed
+            // with "busy" which buries the "Setting up..." notification
+            // we fire below. Toggling IsActive after focus tends to
+            // not re-announce.
             ring.Focus(FocusState::Programmatic);
+            ring.IsActive(true);
             scroller.IsEnabled(false);
             save.IsEnabled(false);
+
+            // Narrator: focus moving to the ProgressRing alone reads
+            // "ProgressRing" — a blind user has no idea what's busy.
+            // Announce the operation name explicitly with
+            // ImportantMostRecent so this wins over the focus
+            // announcement. Same RaiseNotificationEvent pattern as
+            // TerminalPage::_ShowFreOverlay (welcome) — uses SaveButton
+            // as the peer source because announcements fired through a
+            // UserControl's automation peer don't propagate to Narrator
+            // reliably; a concrete focusable Control does.
+            if (auto peer = Automation::Peers::FrameworkElementAutomationPeer::FromElement(SaveButton()))
+            {
+                peer.RaiseNotificationEvent(
+                    Automation::Peers::AutomationNotificationKind::Other,
+                    Automation::Peers::AutomationNotificationProcessing::ImportantMostRecent,
+                    RS_(L"FreOverlay_SettingUp"),
+                    L"FreSavingAnnouncement");
+            }
         }
         else
         {

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -724,6 +724,14 @@ namespace winrt::TerminalApp::implementation
         {
             _agentPaneLog("[FRE] Installing GitHub.Copilot via winget");
             bool ok = co_await _WingetInstallAsync(L"GitHub.Copilot");
+            // Helper internally does co_await winrt::resume_background(),
+            // so the continuation may resume on a thread-pool thread.
+            // Hop back to the UI thread before any XAML access (the
+            // _ShowProblem call below touches ErrorText / ErrorPanel /
+            // toggles); without this, RPC_E_WRONG_THREAD is thrown and
+            // silently swallowed by IAsyncAction, leaving the
+            // SavingOverlay stuck.
+            co_await winrt::resume_foreground(Dispatcher());
             auto self = weak.get();
             if (!self) co_return;
             _agentPaneLog("[FRE] Copilot install: " + std::string(ok ? "ok" : "FAILED"));
@@ -737,6 +745,9 @@ namespace winrt::TerminalApp::implementation
         {
             _agentPaneLog("[FRE] Installing Node.js via winget");
             bool ok = co_await _WingetInstallAsync(L"OpenJS.NodeJS.LTS");
+            // See note above for the Copilot install — same threading
+            // concern applies here.
+            co_await winrt::resume_foreground(Dispatcher());
             auto self = weak.get();
             if (!self) co_return;
             _agentPaneLog("[FRE] Node.js install: " + std::string(ok ? "ok" : "FAILED"));
@@ -796,6 +807,15 @@ namespace winrt::TerminalApp::implementation
 
             _agentPaneLog("[FRE] Installing hooks for " + winrt::to_string(agentId));
             bool hooksOk = co_await _InstallHooksAsync(agentId);
+            // Helper internally does co_await winrt::resume_background(),
+            // so the continuation may resume on a thread-pool thread.
+            // Hop back to the UI thread before the subsequent
+            // AutoDetectToggle().IsOn() read and any later _ShowProblem
+            // call. Without this, XAML access from the thread pool
+            // throws RPC_E_WRONG_THREAD, which IAsyncAction swallows —
+            // the SavingOverlay would then be stuck with no error
+            // surfaced.
+            co_await winrt::resume_foreground(Dispatcher());
             self = weak.get();
             if (!self) co_return;
 

--- a/src/cascadia/TerminalApp/FreOverlay.h
+++ b/src/cascadia/TerminalApp/FreOverlay.h
@@ -98,11 +98,13 @@ namespace winrt::TerminalApp::implementation
         winrt::Windows::Foundation::IAsyncAction _SaveAndInstallAsync();
 
         // Flip the overlay between "saving / installing in progress" and
-        // "idle / editable" states. While saving: the settings form is
-        // dimmed + non-interactive, the Save button is disabled, the
-        // inline ProgressRing spins, and the button label switches to
-        // "Setting up...". On error or completion the inverse is applied
-        // so the user can edit and retry (or click Save again).
+        // "idle / editable" states. While saving: a modal SavingOverlay
+        // covers the settings form with a centered ProgressRing +
+        // "Setting up..." text, the form underneath is disabled
+        // (blocks keyboard too — pointer is caught by the overlay's
+        // Background), and the Save button is disabled. On error or
+        // completion the inverse is applied so the user can edit and
+        // retry (or click Save again).
         void _SetSavingState(bool saving);
     };
 }

--- a/src/cascadia/TerminalApp/FreOverlay.h
+++ b/src/cascadia/TerminalApp/FreOverlay.h
@@ -96,6 +96,14 @@ namespace winrt::TerminalApp::implementation
 
         // Perform the full save + install flow asynchronously.
         winrt::Windows::Foundation::IAsyncAction _SaveAndInstallAsync();
+
+        // Flip the overlay between "saving / installing in progress" and
+        // "idle / editable" states. While saving: the settings form is
+        // dimmed + non-interactive, the Save button is disabled, the
+        // inline ProgressRing spins, and the button label switches to
+        // "Setting up...". On error or completion the inverse is applied
+        // so the user can edit and retry (or click Save again).
+        void _SetSavingState(bool saving);
     };
 }
 

--- a/src/cascadia/TerminalApp/FreOverlay.xaml
+++ b/src/cascadia/TerminalApp/FreOverlay.xaml
@@ -194,9 +194,11 @@
                     </TextBlock>
                 </StackPanel>
 
-                <!--  Content: Settings Form. Named so we can disable +
-                      dim it as a group while a save/install is in
-                      progress (see FreOverlay::_SetSavingState).  -->
+                <!--  Content: Settings Form. Named so we can disable it as
+                      a group while a save/install is in progress
+                      (keyboard input blocking — see
+                      FreOverlay::_SetSavingState). A SavingOverlay
+                      sibling sits on top for the visual + spinner.  -->
                 <ScrollViewer x:Name="SettingsFormScroller"
                               Grid.Row="1"
                               HorizontalAlignment="Stretch"
@@ -495,6 +497,41 @@
                     </StackPanel>
                 </ScrollViewer>
 
+                <!--  "Saving / installing in progress" overlay. Sits in
+                      the same Grid cell as SettingsFormScroller and is
+                      rendered after it, so it z-stacks on top. While
+                      visible:
+                        - The opaque-ish Background blocks pointer input
+                          to the form below.
+                        - SettingsFormScroller.IsEnabled is also set to
+                          false in code, which blocks keyboard input
+                          (overlays don't intercept keyboard on their
+                          own — focus would still tab into the form).
+                        - The centered ProgressRing + "Setting up..."
+                          label gives the user an unmissable signal that
+                          a long-running operation is happening.
+                      Collapsed when idle so it doesn't intercept input
+                      or paint pixels.  -->
+                <Border x:Name="SavingOverlay"
+                        Grid.Row="1"
+                        Background="#CC1E1E1E"
+                        Visibility="Collapsed">
+                    <StackPanel Orientation="Vertical"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Spacing="16">
+                        <mux:ProgressRing x:Name="SavingProgressRing"
+                                          Width="48" Height="48"
+                                          IsActive="False" />
+                        <TextBlock x:Name="SavingStatusText"
+                                   FontFamily="Segoe UI Variable Text, Segoe UI"
+                                   FontSize="14"
+                                   Foreground="White"
+                                   HorizontalAlignment="Center"
+                                   AutomationProperties.LiveSetting="Polite" />
+                    </StackPanel>
+                </Border>
+
                 <!--  Bottom: Error text + Save Button  -->
                 <Grid Grid.Row="2">
                     <Grid.ColumnDefinitions>
@@ -522,39 +559,19 @@
                             </Hyperlink>
                         </TextBlock>
                     </StackPanel>
-                    <!--  Save button. While a save/install is in progress
-                          the ring spins inline next to the label and the
-                          settings form above is dimmed + non-interactive
-                          (see FreOverlay::_SetSavingState). Width is fixed
-                          so the bottom row doesn't shift when the label
-                          swaps "Save" ↔ "Setting up..." with a leading
-                          spinner. Label text is set from code so we can
-                          swap it without disturbing the ProgressRing
-                          sibling.  -->
-                    <Button x:Name="SaveButton"
+                    <!--  Save button. Disabled while a save/install is
+                          in progress; the SavingOverlay above the form
+                          carries the spinner + status text. Label
+                          stays "Save" (via x:Uid) — no in-button text
+                          swap is needed since the overlay communicates
+                          the in-progress state.  -->
+                    <Button x:Uid="FreOverlay_SaveButton"
+                            x:Name="SaveButton"
                             Grid.Column="1"
                             HorizontalAlignment="Right" VerticalAlignment="Center"
-                            Width="160" Height="32"
+                            Width="120" Height="32"
                             Style="{ThemeResource AccentButtonStyle}"
-                            Click="_OnSaveButtonClick">
-                        <StackPanel Orientation="Horizontal"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Spacing="8">
-                            <!--  Foreground pinned to the button's text
-                                  brush so the ring is visible against the
-                                  AccentButton fill (its default stroke is
-                                  the system accent color, which would
-                                  blend in).  -->
-                            <mux:ProgressRing x:Name="SaveProgressRing"
-                                              Width="16" Height="16"
-                                              IsActive="False"
-                                              Visibility="Collapsed"
-                                              Foreground="{ThemeResource AccentButtonForeground}" />
-                            <TextBlock x:Name="SaveButtonText"
-                                       VerticalAlignment="Center" />
-                        </StackPanel>
-                    </Button>
+                            Click="_OnSaveButtonClick" />
                 </Grid>
             </Grid>
         </Grid>

--- a/src/cascadia/TerminalApp/FreOverlay.xaml
+++ b/src/cascadia/TerminalApp/FreOverlay.xaml
@@ -194,8 +194,11 @@
                     </TextBlock>
                 </StackPanel>
 
-                <!--  Content: Settings Form  -->
-                <ScrollViewer Grid.Row="1"
+                <!--  Content: Settings Form. Named so we can disable +
+                      dim it as a group while a save/install is in
+                      progress (see FreOverlay::_SetSavingState).  -->
+                <ScrollViewer x:Name="SettingsFormScroller"
+                              Grid.Row="1"
                               HorizontalAlignment="Stretch"
                               VerticalScrollBarVisibility="Auto">
                     <StackPanel Spacing="4"
@@ -519,13 +522,39 @@
                             </Hyperlink>
                         </TextBlock>
                     </StackPanel>
-                    <Button x:Uid="FreOverlay_SaveButton"
-                            x:Name="SaveButton"
+                    <!--  Save button. While a save/install is in progress
+                          the ring spins inline next to the label and the
+                          settings form above is dimmed + non-interactive
+                          (see FreOverlay::_SetSavingState). Width is fixed
+                          so the bottom row doesn't shift when the label
+                          swaps "Save" ↔ "Setting up..." with a leading
+                          spinner. Label text is set from code so we can
+                          swap it without disturbing the ProgressRing
+                          sibling.  -->
+                    <Button x:Name="SaveButton"
                             Grid.Column="1"
                             HorizontalAlignment="Right" VerticalAlignment="Center"
-                            Width="120" Height="32"
+                            Width="160" Height="32"
                             Style="{ThemeResource AccentButtonStyle}"
-                            Click="_OnSaveButtonClick" />
+                            Click="_OnSaveButtonClick">
+                        <StackPanel Orientation="Horizontal"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Spacing="8">
+                            <!--  Foreground pinned to the button's text
+                                  brush so the ring is visible against the
+                                  AccentButton fill (its default stroke is
+                                  the system accent color, which would
+                                  blend in).  -->
+                            <mux:ProgressRing x:Name="SaveProgressRing"
+                                              Width="16" Height="16"
+                                              IsActive="False"
+                                              Visibility="Collapsed"
+                                              Foreground="{ThemeResource AccentButtonForeground}" />
+                            <TextBlock x:Name="SaveButtonText"
+                                       VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
                 </Grid>
             </Grid>
         </Grid>

--- a/src/cascadia/TerminalApp/FreOverlay.xaml
+++ b/src/cascadia/TerminalApp/FreOverlay.xaml
@@ -522,6 +522,7 @@
                                 Spacing="16">
                         <mux:ProgressRing x:Name="SavingProgressRing"
                                           Width="48" Height="48"
+                                          IsTabStop="True"
                                           IsActive="False" />
                         <TextBlock x:Name="SavingStatusText"
                                    FontFamily="Segoe UI Variable Text, Segoe UI"

--- a/src/cascadia/TerminalApp/FreOverlay.xaml
+++ b/src/cascadia/TerminalApp/FreOverlay.xaml
@@ -516,6 +516,13 @@
                         Grid.Row="1"
                         Background="#CC1E1E1E"
                         Visibility="Collapsed">
+                    <!--  Background is the same RGB as RootGrid (#FF1E1E1E
+                          on line 31) with 80 % alpha, by design: the
+                          overlay reads as "FRE dims itself" rather than
+                          an independent panel. Keep these two in sync
+                          if the FRE backdrop ever changes — extracting
+                          both into shared SolidColorBrush resources is
+                          left for a broader FRE theming pass.  -->
                     <StackPanel Orientation="Vertical"
                                 HorizontalAlignment="Center"
                                 VerticalAlignment="Center"


### PR DESCRIPTION
> [!WARNING]
> **The last commit ([db60e94](#)) adds a debug-only `WT_FRE_SAVE_DELAY_MS` env-var test knob to `FreOverlay::_SaveAndInstallAsync`. Drop that commit before merge** — it ships a no-op-by-default delay just for me to actually see the new busy overlay on a fast machine. Easy revert with `git rebase -i origin/main` and drop `db60e944`.

## What

FRE save/install flow can take 30s+ (winget installs, hooks, shell integration), but the only feedback was the Save button text flipping to *"Setting up..."* — easy to miss, and meanwhile every other input (agent picker, toggles, pane-position dropdown) was still fully editable. A user who tweaked a setting mid-install would have it silently overwritten by the values captured when they first clicked Save.

## How

Two iterations to land the right UX:

1. **First pass** (commit [08f96606](#) — inline ProgressRing in the Save button + form dimmed via Opacity) — pushed back by reviewer as not visible / not modal enough.
2. **Final pass** (commit [6452dd2c](#) — modal busy overlay):
   - Add a `SavingOverlay` `Border` in `Grid.Row=1` alongside `SettingsFormScroller` (rendered after it → z-stacks on top). Semi-opaque `#CC1E1E1E`, centred 48px `mux:ProgressRing` + *"Setting up..."* status text.
   - Background blocks pointer input; `SettingsFormScroller.IsEnabled=false` blocks keyboard (Tab / Space / arrows). `IsEnabled` on the ancestor ANDs with each child's own value, so policy-locked toggles stay locked on restore.
   - `SaveButton` reverted to its plain `x:Uid` form — overlay communicates the busy state instead of an in-button spinner.
   - On error (`_ShowProblem`) the form is re-enabled so the user can adjust and retry; on success the same restore happens before `Completed` is raised.
   - All three transitions go through a single `_SetSavingState(bool)` helper.
   - Constructor seeds `SavingStatusText` from the existing `FreOverlay_SettingUp` resource — no new locale keys needed (already present in all 89 .resw files).

3. **Test knob** (commit [db60e944](#) — **drop before merge**): reads `WT_FRE_SAVE_DELAY_MS` env var, holds the overlay that many ms after `_SetSavingState(true)`. Default 0 = no-op. `co_await resume_after(...)` lands on a thread-pool thread, so it `co_await resume_foreground(Dispatcher())` before continuing — otherwise the next XAML access throws `RPC_E_WRONG_THREAD`, IAsyncAction swallows it, and the overlay sticks forever.

## Verification

- Two passes of `code-review` sub-agent on the modal-overlay change (different angles), both returned **HIGH confidence**: no leftover refs to the prior inline approach, pointer + keyboard input both blocked, z-order correct, state machine intact, localization covered.
- Manually verified on Windows with `WT_FRE_SAVE_DELAY_MS=8000`: overlay stays for 8 s, form is fully locked (verified by trying to tab/click/type into toggles and combobox), then install proceeds normally on a fast machine.

## Files

- `src/cascadia/TerminalApp/FreOverlay.xaml` — new `SavingOverlay` Border + named `SettingsFormScroller`
- `src/cascadia/TerminalApp/FreOverlay.cpp` — `_SetSavingState(bool)` helper, all transitions routed through it
- `src/cascadia/TerminalApp/FreOverlay.h` — `_SetSavingState` declaration

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
