### PR TITLE
feat(wta): add /fix slash command to run the auto-fix prompt on demand

### DIFF
--- a/tools/wta/locales/en-US.yml
+++ b/tools/wta/locales/en-US.yml
@@ -82,12 +82,13 @@ commands.help_header: "Slash commands — type / in the input box."
 commands.help_escape_hint: "  //text     Send a literal '/' (escapes the command parser)"  # {Locked="//text","/"}
 commands.help_close_hint: "  Esc        Close this help"  # {Locked="Esc"}
 # Slash-command summaries shown in the popup and /help overlay.
-# Command names (/help, /clear, /new, /restart, /stop, /sessions) stay in
-# English. Only the descriptions are localized.
+# Command names (/help, /clear, /new, /fix, /restart, /stop, /sessions) stay
+# in English. Only the descriptions are localized.
 # {Locked="ACP","Ctrl+Shift+/"} - protocol name and shortcut, do not translate
 commands.help.summary: "Show this command list"
 commands.clear.summary: "Clear the chat scrollback (keeps session)"
 commands.new.summary: "Start a fresh ACP session (drops history)"  # {Locked="ACP"}
+commands.fix.summary: "Diagnose the active terminal and suggest a fix (/fix <hint>)"  # {Locked="/fix","<hint>"}
 commands.restart.summary: "Restart agent"
 commands.stop.summary: "Cancel the in-flight prompt"
 commands.sessions.summary: "Open the historical sessions picker (Ctrl+Shift+/)"  # {Locked="Ctrl+Shift+/"}

--- a/tools/wta/prompts/auto-fix.md
+++ b/tools/wta/prompts/auto-fix.md
@@ -16,7 +16,7 @@ Use when you can write a single shell command (including in-place file edits) th
 {"action": "fix", "title": "<≤6 word summary>", "command": "<single-line shell command>", "rationale": "<one sentence>"}
 ```
 
-- Pick syntax from `Shell Context.profile` (PowerShell / Command Prompt / Ubuntu / WSL / etc.). When `profile` is missing, default to PowerShell.
+- Pick syntax from `Shell Context.shell` — the actual shell executable (`pwsh.exe`/`powershell.exe` → PowerShell, `cmd.exe` → Command Prompt, `bash.exe`/`wsl.exe` → Bash/WSL). It is authoritative because the user can rename a profile. Fall back to `Shell Context.profile` when `shell` is missing, and default to PowerShell if both are absent.
 - Resolve file paths against `Shell Context.cwd`. Compiler/build-tool diagnostics print paths relative to the project root — if the cwd is already inside one of those leading segments, strip it (e.g. cwd `…\app\src` + tool path `src\main.rs` → use `main.rs`).
 - One line only; the user applies with a single keystroke.
 

--- a/tools/wta/prompts/auto-fix.md
+++ b/tools/wta/prompts/auto-fix.md
@@ -16,7 +16,7 @@ Use when you can write a single shell command (including in-place file edits) th
 {"action": "fix", "title": "<≤6 word summary>", "command": "<single-line shell command>", "rationale": "<one sentence>"}
 ```
 
-- Pick syntax from `Shell Context.shell` — the actual shell executable (`pwsh.exe`/`powershell.exe` → PowerShell, `cmd.exe` → Command Prompt, `bash.exe`/`wsl.exe` → Bash/WSL). It is authoritative because the user can rename a profile. Fall back to `Shell Context.profile` when `shell` is missing, and default to PowerShell if both are absent.
+- The `command` is injected and run **directly in the user's current shell session** — `Shell Context.shell` is that shell's executable (`pwsh.exe`/`powershell.exe` → PowerShell, `cmd.exe` → Command Prompt, `bash.exe`/`wsl.exe` → Bash/WSL). It MUST be a single valid command for that exact shell, as-is: match its syntax and built-ins (`Get-ChildItem` vs `ls`, `Set-Location` vs `cd`), and do NOT wrap it in, or assume, a different shell. When `shell` is missing, default to PowerShell.
 - Resolve file paths against `Shell Context.cwd`. Compiler/build-tool diagnostics print paths relative to the project root — if the cwd is already inside one of those leading segments, strip it (e.g. cwd `…\app\src` + tool path `src\main.rs` → use `main.rs`).
 - One line only; the user applies with a single keystroke.
 

--- a/tools/wta/prompts/terminal-agent.md
+++ b/tools/wta/prompts/terminal-agent.md
@@ -4,7 +4,7 @@ You are Terminal Agent, a capable terminal-native assistant inside Windows Termi
 
 ## Mode Decision (do this first, in order)
 
-Read the runtime context (cwd, profile, activeTarget, buffer, supported delegate agents) and the user's input. Then walk this decision tree top-to-bottom and stop at the FIRST match:
+Read the runtime context (cwd, profile, shell, activeTarget, buffer, supported delegate agents) and the user's input. Then walk this decision tree top-to-bottom and stop at the FIRST match:
 
 1. **Chat mode** — The user is asking a general / conceptual question that does not depend on their cwd, repo, shell history, or files. Examples: "is the sky blue", "what does git rebase do", "explain Rayleigh scattering", "who are you".
    → Answer in prose. No tool calls. No JSON.
@@ -43,7 +43,7 @@ These rules exist because cwd can be ambiguous across tool calls. When Terminal 
    - **Or use absolute paths inside the command**: `Get-ChildItem '<cwd>' -Force`, `cargo build --manifest-path '<cwd>\Cargo.toml'`, etc.
    Pick whichever fits the command. If you run more than one related command, prefer the `Set-Location` prefix once on the first call rather than repeating absolute paths. If `cwd` is missing or you are not confident the session is rooted correctly, establish location explicitly before relying on pathless commands.
 
-3. **Match the active pane's `profile`** when choosing shell syntax for `execute_command`: PowerShell uses `Set-Location` / `Get-ChildItem` / `Get-Content`; Bash/WSL uses `cd` / `ls` / `cat`. Default to PowerShell if `profile` is missing.
+3. **Match the active pane's shell** when choosing shell syntax for `execute_command`: prefer `shell` (the actual executable — `pwsh.exe`/`powershell.exe`, `cmd.exe`, `bash.exe`/`wsl.exe`), falling back to `profile` (which the user can rename). PowerShell uses `Set-Location` / `Get-ChildItem` / `Get-Content`; Bash/WSL uses `cd` / `ls` / `cat`. Default to PowerShell if both are missing.
 
 4. **Do not bail out to a recommendation card just because one tool call failed or returned unexpected output.** Diagnose: was the cwd wrong? Was the path wrong? Retry with the fix. Only emit a card if you genuinely conclude the task is shell-command shaped after all (which means you should have picked A originally — go back and re-decide).
 
@@ -67,7 +67,7 @@ Rules:
 
 `send` rules (Mode A):
 - `parent` MUST be the literal `activeTarget` value from the Terminal Context JSON. Never invent pane IDs.
-- `input` must match the active pane's shell. PowerShell/pwsh → `Get-ChildItem`, `Get-Location`, `Set-Location`, `Get-Content`, `Remove-Item`. cmd → `dir`, `cd`, `type`, `del`. bash/WSL → `ls`, `pwd`, `cd`, `cat`, `rm`. Default to PowerShell when `profile` is missing.
+- `input` must match the active pane's shell — determine it from `shell` (the actual executable) first, then `profile`. PowerShell/pwsh → `Get-ChildItem`, `Get-Location`, `Set-Location`, `Get-Content`, `Remove-Item`. cmd → `dir`, `cd`, `type`, `del`. bash/WSL → `ls`, `pwd`, `cd`, `cat`, `rm`. Default to PowerShell when both are missing.
 - For Mode A inspection commands, prefer a single `send` choice on the active pane unless the user explicitly asked for isolation.
 
 `open_and_send` rules (Mode C, or new-destination A):
@@ -154,6 +154,6 @@ Rules:
 The following sections are injected by WTA at runtime:
 
 - supported delegate agents
-- terminal context JSON (fields: `activeTarget`, `window_title`, `cwd`, `profile`, `locale`, `buffer`)
+- terminal context JSON (fields: `activeTarget`, `window_title`, `cwd`, `profile`, `shell`, `locale`, `buffer`)
 
 <!-- WTA_RUNTIME_CONTEXT -->

--- a/tools/wta/prompts/terminal-agent.md
+++ b/tools/wta/prompts/terminal-agent.md
@@ -4,7 +4,7 @@ You are Terminal Agent, a capable terminal-native assistant inside Windows Termi
 
 ## Mode Decision (do this first, in order)
 
-Read the runtime context (cwd, profile, shell, activeTarget, buffer, supported delegate agents) and the user's input. Then walk this decision tree top-to-bottom and stop at the FIRST match:
+Read the runtime context (cwd, shell, activeTarget, buffer, supported delegate agents) and the user's input. Then walk this decision tree top-to-bottom and stop at the FIRST match:
 
 1. **Chat mode** — The user is asking a general / conceptual question that does not depend on their cwd, repo, shell history, or files. Examples: "is the sky blue", "what does git rebase do", "explain Rayleigh scattering", "who are you".
    → Answer in prose. No tool calls. No JSON.
@@ -43,7 +43,7 @@ These rules exist because cwd can be ambiguous across tool calls. When Terminal 
    - **Or use absolute paths inside the command**: `Get-ChildItem '<cwd>' -Force`, `cargo build --manifest-path '<cwd>\Cargo.toml'`, etc.
    Pick whichever fits the command. If you run more than one related command, prefer the `Set-Location` prefix once on the first call rather than repeating absolute paths. If `cwd` is missing or you are not confident the session is rooted correctly, establish location explicitly before relying on pathless commands.
 
-3. **Match the active pane's shell** when choosing shell syntax for `execute_command`: prefer `shell` (the actual executable — `pwsh.exe`/`powershell.exe`, `cmd.exe`, `bash.exe`/`wsl.exe`), falling back to `profile` (which the user can rename). PowerShell uses `Set-Location` / `Get-ChildItem` / `Get-Content`; Bash/WSL uses `cd` / `ls` / `cat`. Default to PowerShell if both are missing.
+3. **Match the active pane's shell** when choosing shell syntax for `execute_command`: use `shell` — the actual executable (`pwsh.exe`/`powershell.exe`, `cmd.exe`, `bash.exe`/`wsl.exe`). PowerShell uses `Set-Location` / `Get-ChildItem` / `Get-Content`; Bash/WSL uses `cd` / `ls` / `cat`. Default to PowerShell if `shell` is missing.
 
 4. **Do not bail out to a recommendation card just because one tool call failed or returned unexpected output.** Diagnose: was the cwd wrong? Was the path wrong? Retry with the fix. Only emit a card if you genuinely conclude the task is shell-command shaped after all (which means you should have picked A originally — go back and re-decide).
 
@@ -67,7 +67,7 @@ Rules:
 
 `send` rules (Mode A):
 - `parent` MUST be the literal `activeTarget` value from the Terminal Context JSON. Never invent pane IDs.
-- `input` must match the active pane's shell — determine it from `shell` (the actual executable) first, then `profile`. PowerShell/pwsh → `Get-ChildItem`, `Get-Location`, `Set-Location`, `Get-Content`, `Remove-Item`. cmd → `dir`, `cd`, `type`, `del`. bash/WSL → `ls`, `pwd`, `cd`, `cat`, `rm`. Default to PowerShell when both are missing.
+- `input` must match the active pane's shell — determine it from `shell` (the actual executable). PowerShell/pwsh → `Get-ChildItem`, `Get-Location`, `Set-Location`, `Get-Content`, `Remove-Item`. cmd → `dir`, `cd`, `type`, `del`. bash/WSL → `ls`, `pwd`, `cd`, `cat`, `rm`. Default to PowerShell when `shell` is missing.
 - For Mode A inspection commands, prefer a single `send` choice on the active pane unless the user explicitly asked for isolation.
 
 `open_and_send` rules (Mode C, or new-destination A):
@@ -154,6 +154,6 @@ Rules:
 The following sections are injected by WTA at runtime:
 
 - supported delegate agents
-- terminal context JSON (fields: `activeTarget`, `window_title`, `cwd`, `profile`, `shell`, `locale`, `buffer`)
+- terminal context JSON (fields: `activeTarget`, `window_title`, `cwd`, `shell`, `locale`, `buffer`)
 
 <!-- WTA_RUNTIME_CONTEXT -->

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1085,6 +1085,16 @@ pub enum AppEvent {
     PromptTemplateLoaded {
         name: String,
     },
+    /// The working pane a manual `/fix` resolved to, plumbed back from the ACP
+    /// client task so the App can fill `AutofixContext.target_pane_id` on the
+    /// in-flight turn. The host fills `Send.parent` from it at execute time —
+    /// the agent never echoes a pane id for autofix turns. Routed by
+    /// `prompt_id` so a superseded turn (a newer `/fix`) is left untouched.
+    AutofixTargetResolved {
+        tab_id: Option<String>,
+        prompt_id: u64,
+        pane_id: String,
+    },
     /// Errors raised before a session exists carry None for `session_id`
     /// and route to the active tab; in-flight failures route to the
     /// session's tab. `failure` is the typed classification that drives
@@ -3919,6 +3929,7 @@ impl App {
             AppEvent::TabError { .. } => "tab_error",
             AppEvent::TabSystemMessage { .. } => "tab_system_message",
             AppEvent::PromptTemplateLoaded { .. } => "prompt_template_loaded",
+            AppEvent::AutofixTargetResolved { .. } => "autofix_target_resolved",
             AppEvent::AgentError { .. } => "agent_error",
             AppEvent::AgentSoftStop { .. } => "agent_soft_stop",
             AppEvent::AgentBusy { .. } => "agent_busy",
@@ -4158,6 +4169,13 @@ impl App {
             }
             AppEvent::PromptTemplateLoaded { name } => {
                 self.prompt_name = Some(name);
+            }
+            AppEvent::AutofixTargetResolved {
+                tab_id,
+                prompt_id,
+                pane_id,
+            } => {
+                self.apply_autofix_target_resolved(tab_id, prompt_id, pane_id);
             }
             AppEvent::AgentBusy { tab_id } => {
                 let tab = self.tab_mut(&tab_id);
@@ -6702,6 +6720,49 @@ impl App {
         );
         self.turn_submit_prompt_for_tab(&target_tab_id, submitted);
         let _ = self.prompt_tx.send(prompt);
+    }
+
+    /// Late-bind a manual `/fix`'s target pane. The working pane is resolved
+    /// in the ACP client task (it isn't known when `cmd_fix` submits) and
+    /// plumbed back via [`AppEvent::AutofixTargetResolved`]. We patch the
+    /// matching in-flight turn's `AutofixContext.target_pane_id` so that
+    /// `turn_execute_card` fills `Send.parent` with a real pane — without it,
+    /// the host's send has no destination ("sendinput failed: no parent").
+    ///
+    /// Routed by `prompt_id`: a superseded turn (the user fired a newer `/fix`)
+    /// won't match, so a stale resolution is dropped. The event is emitted
+    /// before the agent responds, so the patch lands while the turn is still
+    /// `Submitted` — well before the fix card surfaces or the user executes it.
+    fn apply_autofix_target_resolved(
+        &mut self,
+        tab_id: Option<String>,
+        prompt_id: u64,
+        pane_id: String,
+    ) {
+        if pane_id.is_empty() {
+            return;
+        }
+        let key = tab_id.unwrap_or_else(|| self.active_tab_key().to_string());
+        let Some(tab) = self.tab_sessions.get_mut(&key) else {
+            return;
+        };
+        let Some(prompt) = tab.turn.prompt_mut() else {
+            return;
+        };
+        if prompt.id != prompt_id {
+            return;
+        }
+        let Some(autofix) = prompt.autofix.as_mut() else {
+            return;
+        };
+        autofix.target_pane_id = pane_id.clone();
+        tracing::info!(
+            target: "slash_cmd",
+            tab = %key,
+            prompt_id,
+            pane = %pane_id,
+            "bound /fix target pane",
+        );
     }
 
     /// `/sessions` — open the Agents picker for the active tab.
@@ -12412,6 +12473,58 @@ mod tests {
             }),
         };
         app.turn_submit_prompt(DEFAULT_TAB_ID, prompt);
+    }
+
+    /// Submit a manual-`/fix`-style autofix turn: an autofix context whose
+    /// `target_pane_id` is empty (the App doesn't know the working pane until
+    /// the client task resolves it and plumbs it back).
+    fn submit_fix_prompt(app: &mut App, id: u64) {
+        let gen = {
+            let tab = app.tab_mut(DEFAULT_TAB_ID);
+            tab.autofix.generation = tab.autofix.generation.wrapping_add(1);
+            tab.autofix.generation
+        };
+        let prompt = SubmittedPrompt {
+            id,
+            text: String::new(),
+            submitted_at_unix_s: 0.0,
+            autofix: Some(AutofixContext {
+                target_pane_id: String::new(),
+                generation: gen,
+            }),
+        };
+        app.turn_submit_prompt(DEFAULT_TAB_ID, prompt);
+    }
+
+    fn fix_target_pane(app: &App) -> String {
+        app.current_tab()
+            .turn
+            .prompt()
+            .unwrap()
+            .autofix
+            .as_ref()
+            .unwrap()
+            .target_pane_id
+            .clone()
+    }
+
+    #[test]
+    fn fix_target_pane_is_late_bound_by_prompt_id() {
+        let mut app = test_app();
+        submit_fix_prompt(&mut app, 42);
+        assert_eq!(fix_target_pane(&app), "", "starts unbound");
+
+        // A resolution for a different prompt id (a superseded /fix) is ignored.
+        app.apply_autofix_target_resolved(Some(DEFAULT_TAB_ID.into()), 7, "pane-X".into());
+        assert_eq!(fix_target_pane(&app), "", "stale prompt_id must not patch");
+
+        // An empty pane id is a no-op.
+        app.apply_autofix_target_resolved(Some(DEFAULT_TAB_ID.into()), 42, String::new());
+        assert_eq!(fix_target_pane(&app), "", "empty pane id is ignored");
+
+        // The matching prompt id binds the resolved working pane.
+        app.apply_autofix_target_resolved(Some(DEFAULT_TAB_ID.into()), 42, "pane-7".into());
+        assert_eq!(fix_target_pane(&app), "pane-7", "matching id binds the pane");
     }
 
     #[test]

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -7583,7 +7583,13 @@ impl App {
         let target_tab = self.tab_for_session(session_id);
         let tab = self.session_tab_mut(session_id);
         let prompt = tab.turn.prompt().cloned().expect("prompt set");
-        let autofix_pane = prompt.autofix.as_ref().map(|a| a.target_pane_id.clone());
+        // Empty `target_pane_id` (manual `/fix`) is not a real pane — filter
+        // it out so an empty-response turn doesn't emit a bottom-bar event.
+        let autofix_pane = prompt
+            .autofix
+            .as_ref()
+            .map(|a| a.target_pane_id.clone())
+            .filter(|s| !s.is_empty());
         tab.turn = TurnState::Surfaced {
             prompt,
             outcome: TurnOutcome::Empty,
@@ -7968,20 +7974,26 @@ impl App {
         recommendations: RecommendationSet,
         phase_name: &str,
     ) {
-        let pane_id = self
+        let target_pane_id = self
             .session_tab(session_id)
             .turn
             .prompt()
             .and_then(|p| p.autofix.as_ref())
             .map(|a| a.target_pane_id.clone());
-        let Some(pane_id) = pane_id else {
+        // Defensive: only autofix turns surface a fix card here.
+        let Some(target_pane_id) = target_pane_id else {
             return;
         };
+        // An empty `target_pane_id` is a manually-invoked `/fix` with no
+        // concrete failing pane. Still surface the card below, but skip the
+        // bottom-bar / suggested-pane side effects — they key off a real
+        // failing pane (the Review pill, the Ctrl+Alt+. hotkey target).
+        let bar_pane = (!target_pane_id.is_empty()).then_some(target_pane_id);
         self.log_selection_phase_for(
             session_id,
             phase_name,
             &format!(
-                "pane={pane_id} title={:?}",
+                "pane={bar_pane:?} title={:?}",
                 recommendations.choices.first().map(|c| &c.title)
             ),
         );
@@ -7991,13 +8003,15 @@ impl App {
         // pane is closed, Idle when it's already open). The recommendation
         // card still lives in the turn below so the user can act on it
         // inside the pane — autofix no longer auto-executes.
-        {
-            let autofix = &mut self.tab_mut(&target_tab).autofix;
-            autofix.suggested_pane_id = Some(pane_id.clone());
-            autofix.pane_id = None;
-            autofix.armed_at = None;
+        if let Some(pane_id) = bar_pane.as_ref() {
+            {
+                let autofix = &mut self.tab_mut(&target_tab).autofix;
+                autofix.suggested_pane_id = Some(pane_id.clone());
+                autofix.pane_id = None;
+                autofix.armed_at = None;
+            }
+            self.emit_autofix_state_result(&target_tab, pane_id);
         }
-        self.emit_autofix_state_result(&target_tab, &pane_id);
         let rec_idx = recommended_choice_index(&recommendations);
         let summary = format_recommendations_for_chat(&recommendations);
         let turn_prompt_label = t!("chat.autofix_prompt_label").into_owned();
@@ -8039,20 +8053,25 @@ impl App {
         explanation: String,
         phase_name: &str,
     ) {
-        let pane_id = self
+        let target_pane_id = self
             .session_tab(session_id)
             .turn
             .prompt()
             .and_then(|p| p.autofix.as_ref())
             .map(|a| a.target_pane_id.clone());
-        let Some(pane_id) = pane_id else {
+        // Defensive: only autofix turns surface an explain answer here.
+        let Some(target_pane_id) = target_pane_id else {
             return;
         };
+        // Empty `target_pane_id` = a manually-invoked `/fix` with no concrete
+        // failing pane: surface the explanation, but skip the bottom-bar /
+        // suggested-pane side effects below.
+        let bar_pane = (!target_pane_id.is_empty()).then_some(target_pane_id);
         self.log_selection_phase_for(
             session_id,
             phase_name,
             &format!(
-                "pane={pane_id} title={title:?} chars={}",
+                "pane={bar_pane:?} title={title:?} chars={}",
                 explanation.chars().count()
             ),
         );
@@ -8081,13 +8100,15 @@ impl App {
         // Explanation lives in the chat above; mark the tab as having a
         // result pending review and surface the bar (Review when the pane
         // is closed, Idle when already open).
-        {
-            let tab = self.session_tab_mut(session_id);
-            tab.autofix.suggested_pane_id = Some(pane_id.clone());
-            tab.autofix.pane_id = None;
-            tab.autofix.armed_at = None;
+        if let Some(pane_id) = bar_pane.as_ref() {
+            {
+                let tab = self.session_tab_mut(session_id);
+                tab.autofix.suggested_pane_id = Some(pane_id.clone());
+                tab.autofix.pane_id = None;
+                tab.autofix.armed_at = None;
+            }
+            self.emit_autofix_state_result(&target_tab, pane_id);
         }
-        self.emit_autofix_state_result(&target_tab, &pane_id);
 
         let tab = self.session_tab_mut(session_id);
         let prompt = tab.turn.prompt().cloned().expect("prompt set");

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -6660,10 +6660,12 @@ impl App {
     /// resolved in the ACP client task — `PaneContext.source_pane_id` is left
     /// `None` and `build_prompt_text` falls back to WT's active pane, which
     /// GetActivePane maps from the agent pane to the user's working pane; and
-    /// (2) `target_pane_id` is left empty so the eventual fix is routed to the
-    /// agent's default working pane ("no override"). The bottom-bar Pending
-    /// pill is *not* armed — that UI is tied to a specific failing pane, and a
-    /// command typed into the agent pane surfaces its result there directly.
+    /// (2) `target_pane_id` starts empty and is late-bound once the client task
+    /// resolves that working pane (`AppEvent::AutofixTargetResolved` →
+    /// `apply_autofix_target_resolved`), so `turn_execute_card` fills
+    /// `Send.parent` with a real pane. The bottom-bar Pending pill is *not*
+    /// armed — that UI is tied to a specific failing pane, and a command typed
+    /// into the agent pane surfaces its result there directly.
     ///
     /// Refuses while a turn is in flight; the user should `/stop` first.
     fn cmd_fix(&mut self, in_flight: bool, hint: String) {

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -6705,8 +6705,10 @@ impl App {
             text: prompt.text.clone(),
             submitted_at_unix_s: prompt.submitted_at_unix_s,
             autofix: Some(AutofixContext {
-                // Empty → `turn_execute_card` leaves `Send.parent` blank, which
-                // the host treats as "no override" and routes to the working pane.
+                // Placeholder — the working pane isn't known synchronously here.
+                // The ACP client task resolves it and `apply_autofix_target_resolved`
+                // late-binds it (matched by prompt id) before the card surfaces,
+                // so `turn_execute_card` fills `Send.parent` with a real pane.
                 target_pane_id: String::new(),
                 generation,
             }),
@@ -6727,7 +6729,7 @@ impl App {
     /// plumbed back via [`AppEvent::AutofixTargetResolved`]. We patch the
     /// matching in-flight turn's `AutofixContext.target_pane_id` so that
     /// `turn_execute_card` fills `Send.parent` with a real pane — without it,
-    /// the host's send has no destination ("sendinput failed: no parent").
+    /// the host's send has no destination ("SendInput failed: no parent").
     ///
     /// Routed by `prompt_id`: a superseded turn (the user fired a newer `/fix`)
     /// won't match, so a stale resolution is dropped. The event is emitted

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -6560,6 +6560,7 @@ impl App {
             CommandKind::Clear => self.cmd_clear(),
             CommandKind::Stop => self.cmd_stop(in_flight),
             CommandKind::New => self.cmd_new(in_flight),
+            CommandKind::Fix => self.cmd_fix(in_flight, cmd.rest),
             CommandKind::Sessions => self.cmd_sessions(),
             CommandKind::Restart => self.cmd_restart(),
         }
@@ -6628,6 +6629,79 @@ impl App {
         tab.selected_completed_turn_idx = None;
         tab.session_id = None;
         tab.scroll_to_bottom();
+    }
+
+    /// `/fix [hint]` — run the auto-fix prompt on demand against the active
+    /// terminal pane. Reuses the error-triggered autofix pipeline
+    /// (`PromptSubmission::is_autofix`): the agent receives the `auto-fix.md`
+    /// template plus the working pane's recent output, and any `hint` typed
+    /// after `/fix` is appended as an extra steer.
+    ///
+    /// Differences from auto-triggered autofix (`maybe_trigger_autofix`):
+    /// there is no failing-pane notification, so (1) the source pane is
+    /// resolved in the ACP client task — `PaneContext.source_pane_id` is left
+    /// `None` and `build_prompt_text` falls back to WT's active pane, which
+    /// GetActivePane maps from the agent pane to the user's working pane; and
+    /// (2) `target_pane_id` is left empty so the eventual fix is routed to the
+    /// agent's default working pane ("no override"). The bottom-bar Pending
+    /// pill is *not* armed — that UI is tied to a specific failing pane, and a
+    /// command typed into the agent pane surfaces its result there directly.
+    ///
+    /// Refuses while a turn is in flight; the user should `/stop` first.
+    fn cmd_fix(&mut self, in_flight: bool, hint: String) {
+        if in_flight {
+            let tab = self.current_tab_mut();
+            tab.messages
+                .push(ChatMessage::System(t!("system.busy_use_stop").into_owned()));
+            tab.scroll_to_bottom();
+            return;
+        }
+
+        let target_tab_id = self
+            .tab_id
+            .clone()
+            .unwrap_or_else(|| DEFAULT_TAB_ID.to_string());
+
+        // Bump generation so any stale in-flight autofix response is dropped,
+        // and clear a leftover suggestion — mirrors `maybe_trigger_autofix`.
+        let generation = {
+            let tab = self.tab_mut(&target_tab_id);
+            tab.autofix.generation = tab.autofix.generation.wrapping_add(1);
+            tab.autofix.suggested_pane_id = None;
+            tab.autofix.generation
+        };
+
+        let pane_context = PaneContext {
+            pane_id: self.pane_id.clone(),
+            tab_id: Some(target_tab_id.clone()),
+            window_id: self.window_id.clone(),
+            cwd: None,
+            // None → the client task resolves the active working pane itself.
+            source_pane_id: None,
+        };
+
+        let hint = hint.trim().to_string();
+        let prompt = PromptSubmission::new_autofix(hint.clone(), Some(pane_context));
+        let submitted = SubmittedPrompt {
+            id: prompt.id,
+            text: prompt.text.clone(),
+            submitted_at_unix_s: prompt.submitted_at_unix_s,
+            autofix: Some(AutofixContext {
+                // Empty → `turn_execute_card` leaves `Send.parent` blank, which
+                // the host treats as "no override" and routes to the working pane.
+                target_pane_id: String::new(),
+                generation,
+            }),
+        };
+        tracing::info!(
+            target: "slash_cmd",
+            tab_id = %target_tab_id,
+            generation,
+            has_hint = !hint.is_empty(),
+            "dispatching /fix",
+        );
+        self.turn_submit_prompt_for_tab(&target_tab_id, submitted);
+        let _ = self.prompt_tx.send(prompt);
     }
 
     /// `/sessions` — open the Agents picker for the active tab.

--- a/tools/wta/src/app/turn_state.rs
+++ b/tools/wta/src/app/turn_state.rs
@@ -140,6 +140,19 @@ impl TurnState {
         }
     }
 
+    /// Mutable prompt info for the in-flight or just-surfaced turn. Used to
+    /// late-bind a manual `/fix`'s `AutofixContext.target_pane_id` once the
+    /// client task has resolved the working pane (see
+    /// `App::apply_autofix_target_resolved`).
+    pub fn prompt_mut(&mut self) -> Option<&mut SubmittedPrompt> {
+        match self {
+            TurnState::Idle => None,
+            TurnState::Submitted(p) => Some(p),
+            TurnState::Streaming { prompt, .. } => Some(prompt),
+            TurnState::Surfaced { prompt, .. } => Some(prompt),
+        }
+    }
+
     /// Autofix generation snapshot for the current turn, if any.
     pub fn autofix_generation(&self) -> Option<u64> {
         self.prompt()

--- a/tools/wta/src/commands.rs
+++ b/tools/wta/src/commands.rs
@@ -14,6 +14,14 @@ pub enum CommandKind {
     Clear,
     Stop,
     New,
+    /// Run the auto-fix prompt on demand.
+    ///
+    /// Submits the dedicated `auto-fix.md` template plus the active
+    /// terminal pane's recent output to the agent — the same pipeline the
+    /// error-triggered autofix uses (`PromptSubmission::is_autofix`), but
+    /// invoked manually. Any text after `/fix` is passed through as an
+    /// extra hint to steer the diagnosis (`/fix the path looks wrong`).
+    Fix,
     /// Reset the agent CLI subprocess.
     ///
     /// * Standalone wta: tears down + respawns the agent CLI in-process;
@@ -77,6 +85,13 @@ pub const REGISTRY: &[CommandSpec] = &[
         takes_args: false,
     },
     CommandSpec {
+        name: "fix",
+        summary_key: "commands.fix.summary",
+        kind: CommandKind::Fix,
+        // `/fix <hint>` — free-form text after the name steers the fix.
+        takes_args: true,
+    },
+    CommandSpec {
         name: "restart",
         summary_key: "commands.restart.summary",
         kind: CommandKind::Restart,
@@ -100,9 +115,8 @@ pub const REGISTRY: &[CommandSpec] = &[
 pub struct ParsedCommand {
     pub kind: CommandKind,
     pub spec: &'static CommandSpec,
-    /// Anything after the command name (trimmed, may be empty).
-    /// MVP commands ignore this; reserved for future `/model`, `/cwd`, …
-    #[allow(dead_code)]
+    /// Anything after the command name (trimmed, may be empty). Consumed by
+    /// arg-taking commands (`/fix <hint>`); zero-arg commands ignore it.
     pub rest: String,
 }
 
@@ -254,6 +268,20 @@ mod tests {
         let s_matches: Vec<&str> = matches("s").into_iter().map(|c| c.name).collect();
         assert!(s_matches.contains(&"stop"));
         assert!(s_matches.contains(&"sessions"));
+    }
+
+    #[test]
+    fn fix_parses_with_optional_hint() {
+        // Bare /fix: no hint.
+        let bare = parse("/fix").unwrap();
+        assert_eq!(bare.kind, CommandKind::Fix);
+        assert_eq!(bare.rest, "");
+        // /fix <hint>: the trailing text is captured verbatim.
+        let hinted = parse("/fix the path looks wrong").unwrap();
+        assert_eq!(hinted.kind, CommandKind::Fix);
+        assert_eq!(hinted.rest, "the path looks wrong");
+        // takes_args is advertised so Tab-completion leaves a trailing space.
+        assert!(lookup("fix").unwrap().takes_args);
     }
 
     #[test]

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1324,9 +1324,10 @@ async fn build_prompt_text(
             .join("\n\n")
     };
     let prompt = if is_autofix {
-        // Auto-triggered autofix carries no user text — the template + terminal
-        // output is the whole prompt. A manual `/fix <hint>` passes the hint as
-        // `user_text`; append it so the agent can use it to steer the diagnosis.
+        // Autofix prompts historically ignored `user_text` — the template +
+        // terminal output was the whole prompt. Now a non-empty `user_text` is
+        // appended as a `## User Request`: a manual `/fix <hint>` passes the
+        // hint here, and the error-triggered path passes its failure summary.
         if user_text.trim().is_empty() {
             prompt_body
         } else {

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1165,9 +1165,14 @@ async fn build_prompt_text(
     shell_mgr: &ShellManager,
     wt_connected: bool,
     pane_context: Option<&PaneContext>,
-) -> (String, String, String) {
+) -> (String, String, String, Option<String>) {
     let total_started = std::time::Instant::now();
     let mut runtime_sections = Vec::new();
+    // Working pane resolved from the active pane for a manual `/fix` (one with
+    // no explicit `source_pane_id`). Plumbed back to the App so it can fill
+    // `AutofixContext.target_pane_id` — empty otherwise (auto-fix carries its
+    // failing pane explicitly; planner turns let the agent fill `Send.parent`).
+    let mut resolved_fix_pane: Option<String> = None;
 
     let template_started = std::time::Instant::now();
     let planner_template = if is_autofix {
@@ -1270,21 +1275,26 @@ async fn build_prompt_text(
             // fall back to the resolved active working pane (`/fix`). An
             // active pane that is itself an agent pane is skipped — there's
             // no terminal output to read there.
-            let source_pane_id = pane_context
-                .and_then(|ctx| ctx.source_pane_id.clone())
-                .or_else(|| {
-                    active.as_ref().and_then(|a| {
-                        let is_agent = a
-                            .get("is_agent_pane")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false);
-                        if is_agent {
-                            None
-                        } else {
-                            json_str_or_num(a.get("session_id"))
-                        }
-                    })
-                });
+            let explicit_source = pane_context.and_then(|ctx| ctx.source_pane_id.clone());
+            let source_pane_id = explicit_source.clone().or_else(|| {
+                active.as_ref().and_then(|a| {
+                    let is_agent = a
+                        .get("is_agent_pane")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    if is_agent {
+                        None
+                    } else {
+                        json_str_or_num(a.get("session_id"))
+                    }
+                })
+            });
+            // When we resolved the pane ourselves (manual `/fix`, no explicit
+            // source), remember it so the App can fill `target_pane_id` — that
+            // is the pane the eventual fix command is sent to.
+            if explicit_source.is_none() {
+                resolved_fix_pane = source_pane_id.clone();
+            }
 
             if let Some(source_pane_id) = source_pane_id {
                 tracing::debug!(
@@ -1354,6 +1364,7 @@ async fn build_prompt_text(
         prompt,
         planner_template.source_label,
         planner_template.display_name,
+        resolved_fix_pane,
     )
 }
 
@@ -4066,7 +4077,7 @@ async fn dispatch_prompt_body(
         .await;
 
     prompt_timing_task.activate(&prompt_session_id_str, &prompt);
-    let (text, prompt_source, prompt_name) = build_prompt_text(
+    let (text, prompt_source, prompt_name, resolved_fix_pane) = build_prompt_text(
         prompt.id,
         prompt.submitted_at_unix_s,
         &prompt.text,
@@ -4077,6 +4088,19 @@ async fn dispatch_prompt_body(
         prompt.pane_context.as_ref(),
     )
     .await;
+    // A manual `/fix` resolved its working pane in build_prompt_text (it had no
+    // explicit source pane). Plumb it back so the App fills the turn's
+    // `target_pane_id`; the host fills `Send.parent` from it at execute time.
+    if let Some(pane_id) = resolved_fix_pane {
+        let _ = event_tx_task.send(AppEvent::AutofixTargetResolved {
+            tab_id: prompt
+                .pane_context
+                .as_ref()
+                .and_then(|c| c.tab_id.clone()),
+            prompt_id: prompt.id,
+            pane_id,
+        });
+    }
     let _ = event_tx_task.send(AppEvent::PromptTemplateLoaded { name: prompt_name });
     prompt_timing_task.mark_context_ready(&prompt_session_id_str, text.len());
     acp_log_built_prompt(

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1127,7 +1127,8 @@ fn process_image_name(_pid: u32) -> Option<String> {
 
 /// Resolve the canonical shell exe from an active-pane JSON object's `pid`
 /// field (already present in `get_active_pane`/`get_panes` responses). The
-/// agent gets this as the `shell` field alongside the renamable `profile`.
+/// agent gets this as the `shell` field — the sole shell-type signal, since
+/// the WT profile *name* is user-renamable and no longer shipped.
 fn shell_from_active(active: &serde_json::Value) -> Option<String> {
     active
         .get("pid")
@@ -1160,25 +1161,16 @@ async fn build_terminal_context_json(shell_mgr: &ShellManager) -> Option<String>
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string());
-    // Shell profile (e.g. "PowerShell", "Command Prompt", "Ubuntu") is
-    // load-bearing for the planner: any `send` action it emits has to
-    // match the active pane's shell syntax (`Get-ChildItem` vs `ls`,
-    // `Set-Location` vs `cd`, etc.). Without this the agent has to
-    // guess from the buffer's prompt prefix, which silently fails on
-    // renamed or unusual profiles.
-    let target_profile = active
-        .get("profile")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string());
     // Canonical shell exe (pwsh.exe / cmd.exe / wsl.exe …) from the pane's pid.
-    // Survives a renamed profile, so it's the reliable syntax signal.
+    // Load-bearing for the planner: any `send` action it emits has to match the
+    // active pane's shell syntax (`Get-ChildItem` vs `ls`, `Set-Location` vs
+    // `cd`, etc.). We use the real process rather than the WT profile name,
+    // which the user can rename.
     let target_shell = shell_from_active(&active);
 
     tracing::debug!(
         target: "acp.terminal_context",
         target_pane_id = %target_pane_id,
-        profile = ?target_profile,
         shell = ?target_shell,
         "terminal_context_target_resolved"
     );
@@ -1195,7 +1187,6 @@ async fn build_terminal_context_json(shell_mgr: &ShellManager) -> Option<String>
         "activeTarget": target_pane_id,
         "window_title": target_window_title,
         "cwd": target_cwd,
-        "profile": target_profile,
         "shell": target_shell,
         "locale": user_locale_tag(),
         "buffer": buffer,
@@ -1307,15 +1298,9 @@ async fn build_prompt_text(
             // from its notification.
             let active = shell_mgr.wt_get_active_pane().await.ok();
 
-            // Shell context — best-effort. WT returns the profile name
-            // (e.g. "PowerShell", "Command Prompt", "Ubuntu") which is a
-            // strong signal even when the user has renamed the profile.
+            // Shell context — best-effort. The canonical shell exe (from the
+            // pane's pid) tells the agent which syntax the fix command must use.
             if let Some(active) = active.as_ref() {
-                let profile = active
-                    .get("profile")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
                 let cwd = active
                     .get("cwd")
                     .and_then(|v| v.as_str())
@@ -1324,7 +1309,6 @@ async fn build_prompt_text(
                 // Canonical shell exe from the pane's pid — see `shell_from_active`.
                 let shell = shell_from_active(active);
                 let json = serde_json::to_string(&serde_json::json!({
-                    "profile": profile,
                     "shell": shell,
                     "cwd": cwd,
                     "locale": user_locale_tag(),
@@ -1364,10 +1348,6 @@ async fn build_prompt_text(
                     source_pane_id = %source_pane_id,
                     // The shell type shipped in `### Shell Context` above; log it
                     // here too so a `/fix` run shows what the agent received.
-                    profile = ?active
-                        .as_ref()
-                        .and_then(|a| a.get("profile"))
-                        .and_then(|v| v.as_str()),
                     shell = ?active.as_ref().and_then(shell_from_active),
                     mode = "autofix",
                     "terminal_context_target_resolved"

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1235,42 +1235,67 @@ async fn build_prompt_text(
         // header so the agent can choose PowerShell vs bash vs cmd syntax for
         // any file-edit fix it suggests.
         if wt_connected {
-            if let Some(source_pane_id) =
-                pane_context.and_then(|ctx| ctx.effective_source_pane_id())
-            {
+            // Resolve the active pane once: it supplies the shell-context
+            // header and — for a manual `/fix`, which carries no explicit
+            // `source_pane_id` — doubles as the source-pane resolver. WT's
+            // GetActivePane already maps the agent pane to the user's working
+            // pane, so this is the same target the error-triggered path gets
+            // from its notification.
+            let active = shell_mgr.wt_get_active_pane().await.ok();
+
+            // Shell context — best-effort. WT returns the profile name
+            // (e.g. "PowerShell", "Command Prompt", "Ubuntu") which is a
+            // strong signal even when the user has renamed the profile.
+            if let Some(active) = active.as_ref() {
+                let profile = active
+                    .get("profile")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let cwd = active
+                    .get("cwd")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let json = serde_json::to_string(&serde_json::json!({
+                    "profile": profile,
+                    "cwd": cwd,
+                    "locale": user_locale_tag(),
+                }))
+                .unwrap_or_else(|_| "{}".to_string());
+                runtime_sections.push(format!("### Shell Context\n```json\n{}\n```", json));
+            }
+
+            // Explicit source pane (error-triggered autofix) wins; otherwise
+            // fall back to the resolved active working pane (`/fix`). An
+            // active pane that is itself an agent pane is skipped — there's
+            // no terminal output to read there.
+            let source_pane_id = pane_context
+                .and_then(|ctx| ctx.source_pane_id.clone())
+                .or_else(|| {
+                    active.as_ref().and_then(|a| {
+                        let is_agent = a
+                            .get("is_agent_pane")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                        if is_agent {
+                            None
+                        } else {
+                            json_str_or_num(a.get("session_id"))
+                        }
+                    })
+                });
+
+            if let Some(source_pane_id) = source_pane_id {
                 tracing::debug!(
                     target: "acp.terminal_context",
-                    source_pane_id,
+                    source_pane_id = %source_pane_id,
                     mode = "autofix",
                     "terminal_context_target_resolved"
                 );
-
-                // Shell context — best-effort. WT returns the profile name
-                // (e.g. "PowerShell", "Command Prompt", "Ubuntu") which is a
-                // strong signal even when the user has renamed the profile.
-                if let Ok(active) = shell_mgr.wt_get_active_pane().await {
-                    let profile = active
-                        .get("profile")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let cwd = active
-                        .get("cwd")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let json = serde_json::to_string(&serde_json::json!({
-                        "profile": profile,
-                        "cwd": cwd,
-                        "locale": user_locale_tag(),
-                    }))
-                    .unwrap_or_else(|_| "{}".to_string());
-                    runtime_sections.push(format!("### Shell Context\n```json\n{}\n```", json));
-                }
-
                 if let Some(content) = read_pane_last_message(
                     shell_mgr,
-                    source_pane_id,
+                    &source_pane_id,
                     30,
                     ACTIVE_PANE_CONTEXT_MAX_CHARS,
                 )
@@ -1299,7 +1324,14 @@ async fn build_prompt_text(
             .join("\n\n")
     };
     let prompt = if is_autofix {
-        prompt_body
+        // Auto-triggered autofix carries no user text — the template + terminal
+        // output is the whole prompt. A manual `/fix <hint>` passes the hint as
+        // `user_text`; append it so the agent can use it to steer the diagnosis.
+        if user_text.trim().is_empty() {
+            prompt_body
+        } else {
+            format!("{}\n\n## User Request\n{}", prompt_body, user_text)
+        }
     } else if prompt_body.is_empty() {
         format!("## User Request\n{}", user_text)
     } else {

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1081,6 +1081,60 @@ async fn resolve_active_pane_cwd(
         .map(std::path::PathBuf::from)
 }
 
+/// Best-effort canonical shell executable for a pid — e.g. `pwsh.exe`,
+/// `powershell.exe`, `cmd.exe`, `bash.exe`, `wsl.exe`. Unlike the WT profile
+/// *name* (which the user can rename), this is the actual running process, so
+/// the agent can reliably pick shell syntax. Returns the file name only;
+/// `None` on any failure (or off Windows).
+#[cfg(windows)]
+fn process_image_name(pid: u32) -> Option<String> {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32,
+        PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    if pid == 0 {
+        return None;
+    }
+    // SAFETY: a standard Win32 handle dance. The handle from OpenProcess is
+    // closed on every return path; the buffer is sized up front and the
+    // written length comes back in `size`.
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return None;
+        }
+        let mut buf = [0u16; 260]; // MAX_PATH
+        let mut size = buf.len() as u32;
+        let ok =
+            QueryFullProcessImageNameW(handle, PROCESS_NAME_WIN32, buf.as_mut_ptr(), &mut size);
+        CloseHandle(handle);
+        if ok == 0 || size == 0 {
+            return None;
+        }
+        let full = String::from_utf16_lossy(&buf[..size as usize]);
+        full.rsplit(['\\', '/'])
+            .next()
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+    }
+}
+
+#[cfg(not(windows))]
+fn process_image_name(_pid: u32) -> Option<String> {
+    None
+}
+
+/// Resolve the canonical shell exe from an active-pane JSON object's `pid`
+/// field (already present in `get_active_pane`/`get_panes` responses). The
+/// agent gets this as the `shell` field alongside the renamable `profile`.
+fn shell_from_active(active: &serde_json::Value) -> Option<String> {
+    active
+        .get("pid")
+        .and_then(|v| v.as_u64())
+        .and_then(|pid| process_image_name(pid as u32))
+}
+
 async fn build_terminal_context_json(shell_mgr: &ShellManager) -> Option<String> {
     // WT's GetActivePane already resolves the agent pane to the user's working
     // pane (the "source"), so a single active-pane query gives us the right
@@ -1117,11 +1171,15 @@ async fn build_terminal_context_json(shell_mgr: &ShellManager) -> Option<String>
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string());
+    // Canonical shell exe (pwsh.exe / cmd.exe / wsl.exe …) from the pane's pid.
+    // Survives a renamed profile, so it's the reliable syntax signal.
+    let target_shell = shell_from_active(&active);
 
     tracing::debug!(
         target: "acp.terminal_context",
         target_pane_id = %target_pane_id,
         profile = ?target_profile,
+        shell = ?target_shell,
         "terminal_context_target_resolved"
     );
 
@@ -1138,6 +1196,7 @@ async fn build_terminal_context_json(shell_mgr: &ShellManager) -> Option<String>
         "window_title": target_window_title,
         "cwd": target_cwd,
         "profile": target_profile,
+        "shell": target_shell,
         "locale": user_locale_tag(),
         "buffer": buffer,
     }))
@@ -1262,8 +1321,11 @@ async fn build_prompt_text(
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string();
+                // Canonical shell exe from the pane's pid — see `shell_from_active`.
+                let shell = shell_from_active(active);
                 let json = serde_json::to_string(&serde_json::json!({
                     "profile": profile,
+                    "shell": shell,
                     "cwd": cwd,
                     "locale": user_locale_tag(),
                 }))
@@ -1306,6 +1368,7 @@ async fn build_prompt_text(
                         .as_ref()
                         .and_then(|a| a.get("profile"))
                         .and_then(|v| v.as_str()),
+                    shell = ?active.as_ref().and_then(shell_from_active),
                     mode = "autofix",
                     "terminal_context_target_resolved"
                 );
@@ -4207,12 +4270,29 @@ async fn dispatch_prompt_body(
 #[cfg(test)]
 mod tests {
     use super::{
-        complete_prompt_request, inject_wta_pane_meta, requested_model_id,
+        complete_prompt_request, inject_wta_pane_meta, requested_model_id, shell_from_active,
         summarize_agent_identity, user_locale_tag, PromptTimingState, SoftStopReason,
     };
     use super::acp;
     use crate::app::AppEvent;
     use tokio::sync::mpsc;
+
+    /// `shell_from_active` resolves our own pid to a real exe name (the test
+    /// binary). Proves the pid → image-name path works end to end on Windows;
+    /// a missing/zero pid yields `None`.
+    #[cfg(windows)]
+    #[test]
+    fn shell_from_active_resolves_pid() {
+        let me = serde_json::json!({ "pid": std::process::id() });
+        let name = shell_from_active(&me).expect("own pid should resolve");
+        assert!(
+            name.to_ascii_lowercase().ends_with(".exe"),
+            "expected an .exe image name, got {name:?}"
+        );
+
+        assert_eq!(shell_from_active(&serde_json::json!({ "pid": 0 })), None);
+        assert_eq!(shell_from_active(&serde_json::json!({})), None);
+    }
 
     /// Helper-only: round-trip a `_meta` blob through `inject_wta_pane_meta`
     /// and report the `pane_session_id` that the master would see in

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1300,6 +1300,12 @@ async fn build_prompt_text(
                 tracing::debug!(
                     target: "acp.terminal_context",
                     source_pane_id = %source_pane_id,
+                    // The shell type shipped in `### Shell Context` above; log it
+                    // here too so a `/fix` run shows what the agent received.
+                    profile = ?active
+                        .as_ref()
+                        .and_then(|a| a.get("profile"))
+                        .and_then(|v| v.as_str()),
                     mode = "autofix",
                     "terminal_context_target_resolved"
                 );

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1104,8 +1104,13 @@ fn process_image_name(pid: u32) -> Option<String> {
         if handle.is_null() {
             return None;
         }
-        let mut buf = [0u16; 260]; // MAX_PATH
-        let mut size = buf.len() as u32;
+        // Not MAX_PATH: QueryFullProcessImageNameW can return paths longer than
+        // 260 for processes under long roots (WindowsApps installs, `\\?\`
+        // extended paths). Use the extended-length max so a valid pid never
+        // silently drops the `shell` field. Heap-allocated to keep it off the
+        // (smaller) task stack.
+        let mut size: u32 = 32768;
+        let mut buf = vec![0u16; size as usize];
         let ok =
             QueryFullProcessImageNameW(handle, PROCESS_NAME_WIN32, buf.as_mut_ptr(), &mut size);
         CloseHandle(handle);
@@ -1128,7 +1133,7 @@ fn process_image_name(_pid: u32) -> Option<String> {
 /// Resolve the canonical shell exe from an active-pane JSON object's `pid`
 /// field (already present in `get_active_pane`/`get_panes` responses). The
 /// agent gets this as the `shell` field — the sole shell-type signal, since
-/// the WT profile *name* is user-renamable and no longer shipped.
+/// the WT profile *name* (which the user can rename) is no longer shipped.
 fn shell_from_active(active: &serde_json::Value) -> Option<String> {
     active
         .get("pid")


### PR DESCRIPTION
## Why
 * user don't need to turn on autofix while gain the easiness of autofix
 * autofix can support other shell than powershell

## What
Adds a `/fix [hint]` slash command to the agent pane that **manually triggers the existing auto-fix pipeline** — the same path the error-triggered autofix uses, just on demand.

```
/fix [hint]  →  cmd_fix  →  PromptSubmission::new_autofix (is_autofix=true)
             →  build_prompt_text (loads auto-fix.md + Shell Context + Terminal Output)
             →  ACP conn.prompt()  →  LLM  →  parse_autofix_response  →  fix card
```

`/fix` alone diagnoses the active terminal's recent output; `/fix <hint>` (e.g. `/fix the path looks wrong`) appends the hint to steer the diagnosis.

<img width="1112" height="628" alt="image" src="https://github.com/user-attachments/assets/9175263d-7dd3-4493-b910-c10391cb10f6" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)