### PR TITLE
Add Execution Policy setting command note for both PS hosts

### DIFF
--- a/doc/installing-dependencies.md
+++ b/doc/installing-dependencies.md
@@ -481,6 +481,12 @@ to **at least** `RemoteSigned`:
 Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
 ```
 
+> [!IMPORTANT]
+> Make sure to run this command in **both** hosts:
+>
+> - **PowerShell 7+** (`pwsh.exe`)
+> - **Windows PowerShell 5.1** (`powershell.exe`)
+
 `RemoteSigned` allows local scripts (such as your profile) to run while
 still requiring a signature on scripts downloaded from the internet, which
 is the recommended Microsoft default for developer machines.


### PR DESCRIPTION
## Summary of the Pull Request

Even though it may be relatively clear the execution policy setting command has to be run on both PowerShell hosts (Windows PowerShell 5.1 and PowerShell 7+), it wasn't in my case.

Making it clear for any user going through the same issue I did.

## References and Relevant Issues

[Installing Dependencies: Set the PowerShell Execution Policy](https://github.com/microsoft/intelligent-terminal/blob/main/doc/installing-dependencies.md#step-41--set-the-powershell-execution-policy)
[Shell Integration](https://github.com/microsoft/intelligent-terminal/blob/main/src/cascadia/inc/ShellIntegration.h)

## Detailed Description of the Pull Request / Additional comments

Added an "important" callout note to help users understand the execution policy setting command (`Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned`) on both Windows PowerShell 5.1 and PowerShell 7+.

## Validation Steps Performed

Verified the FRE was able of successfully setting both hosts' shell integration after setting the execution policy on both.

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)

> [!NOTE]
> I didn't check "Documentation updated" above because I don't know if docs for this specific fork already exist in the docs repo.