### PR TITLE
perf(wt-agent-hooks): strip user prompt + unused metadata from wtcli send-event payload

### DIFF
--- a/tools/wta/wt-agent-hooks/claude/.claude-plugin/marketplace.json
+++ b/tools/wta/wt-agent-hooks/claude/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "wt-agent-hooks",
       "description": "Forward CLI agent hook events to Windows Terminal for WTA display",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "source": "./wt-agent-hooks"
     }
   ]

--- a/tools/wta/wt-agent-hooks/claude/wt-agent-hooks/.claude-plugin/plugin.json
+++ b/tools/wta/wt-agent-hooks/claude/wt-agent-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wt-agent-hooks",
   "description": "Forward CLI agent hook events to Windows Terminal for WTA display",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "Agentic Terminal"
   },

--- a/tools/wta/wt-agent-hooks/claude/wt-agent-hooks/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/claude/wt-agent-hooks/hooks/send-event.ps1
@@ -191,12 +191,32 @@ try {
             'toolResult', 'toolResponse', 'toolOutput',
             'prompt', 'user_prompt', 'userPrompt',
             'transcript_path', 'transcriptPath',
-            'cwd', 'hook_event_name', 'hookEventName',
+            'hook_event_name', 'hookEventName',
             'permission_mode', 'permissionMode',
             'model', 'model_info', 'modelInfo',
             'output_style', 'outputStyle',
-            'version', 'source', 'apiKeySource'
+            'version', 'source', 'apiKeySource',
+            # Large per-session context that some CLIs (notably Copilot)
+            # bundle into SessionStart / Stop hook stdin when restoring or
+            # snapshotting a conversation. None of these are consumed by
+            # wta — the SessionStart/SessionEnd handlers only flip state
+            # and need `session_id`. Without this strip a single long
+            # conversation puts SessionStart over the CreateProcess argv
+            # cap and the hook silently fails ("filename or extension is
+            # too long").
+            'transcript', 'messages', 'history', 'conversation',
+            'systemPrompt', 'system_prompt', 'instructions', 'context',
+            'files', 'attachments', 'events', 'chat', 'chatHistory'
         )
+        # NOTE: `cwd` is intentionally NOT stripped. wta's route_one_hook
+        # (app.rs ~582) reads `payload["cwd"]` to populate
+        # SessionStarted.cwd and to derive a synthetic title (the cwd
+        # basename) for events that arrive before the real
+        # `agent.session.started` lands. Stripping it here would empty
+        # the cwd field for every session whose first hook is not
+        # SessionStart (every Copilot session, since prompt.submit fires
+        # first in that CLI's run model) and produce blank rows in the
+        # session-management picker.
         foreach ($key in $alwaysStrip) {
             if ($parsed.PSObject.Properties[$key]) {
                 $parsed.PSObject.Properties.Remove($key)
@@ -215,7 +235,8 @@ try {
         $userInputTools = @(
             'ask_user', 'askuser', 'ask-user',
             'ask_question', 'askquestion', 'ask_for_clarification',
-            'request_input', 'request_user_input', 'user_input'
+            'request_input', 'request_user_input', 'user_input',
+            'prompt_user', 'clarification_request'
         )
         if (-not ($userInputTools -contains $toolNameLower)) {
             foreach ($key in @('tool_input', 'toolInput')) {
@@ -233,6 +254,43 @@ try {
     }
 
     $payload = $wrapper | ConvertTo-Json -Compress -Depth 5
+
+    # Size guard — final defense against CreateProcess argv overflow.
+    #
+    # Even with the aggressive strip above, a CLI we don't know about can
+    # bundle unexpectedly large state into stdin (a new Copilot experiment
+    # ships full conversation context on SessionStart; a custom agent
+    # might dump anything). When that happens, the argv-escaped JSON below
+    # would push past Windows' ~32 768-char CreateProcess command-line cap
+    # and the `Process.Start` call throws "filename or extension is too
+    # long", silently dropping the event.
+    #
+    # When the wrapper is too big we keep the bare-minimum envelope —
+    # cli_source + agent_session_id — which is all wta's SessionStart /
+    # SessionEnd / agent.prompt.submit / agent.stop handlers actually
+    # consume. Notification and agent.error lose their `message` /
+    # `error` text in this rare case; that's a deliberate trade-off vs.
+    # the alternative of dropping the event entirely.
+    #
+    # Threshold: 25 000 raw-JSON chars leaves ~7 KB of headroom for the
+    # wtcli.exe path (~80), the surrounding `send-event -e <event>
+    # -p "<pane>" "..."` framing (~80), and worst-case 2x growth from
+    # the CommandLineToArgvW backslash-doubling escape below.
+    $MAX_PAYLOAD_CHARS = 25000
+    $payloadTruncated  = $false
+    $originalSize      = $payload.Length
+    if ($payload.Length -gt $MAX_PAYLOAD_CHARS) {
+        $payloadTruncated = $true
+        $wrapper = @{
+            cli_source       = $cliSource
+            agent_session_id = $agentSessionId
+            payload          = @{
+                _truncated     = $true
+                _original_size = $originalSize
+            }
+        }
+        $payload = $wrapper | ConvertTo-Json -Compress -Depth 3
+    }
 
     # CommandLineToArgvW-correct escape for a quoted argument:
     #   * Every backslash run that precedes a `"` (or end of string) is doubled.
@@ -284,7 +342,8 @@ try {
     [void][System.Diagnostics.Process]::Start($psi)
     $stamp = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss.fff')
     $sessIdShort = if ($agentSessionId) { $agentSessionId.Substring(0, [Math]::Min(8, $agentSessionId.Length)) } else { '<none>' }
-    Add-Content -LiteralPath $tracePath -Value "$stamp | DISPATCHED cli=$cliSource event=$EventType sessId=$sessIdShort wtcli=$wtcliPath" -ErrorAction SilentlyContinue
+    $truncTag = if ($payloadTruncated) { " TRUNCATED orig=$originalSize" } else { "" }
+    Add-Content -LiteralPath $tracePath -Value "$stamp | DISPATCHED cli=$cliSource event=$EventType sessId=$sessIdShort wtcli=$wtcliPath$truncTag" -ErrorAction SilentlyContinue
 } catch {
     # Single error sink. Best-effort ERROR breadcrumb; if Add-Content
     # itself throws, the `trap { exit 0 }` at the top catches it.

--- a/tools/wta/wt-agent-hooks/claude/wt-agent-hooks/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/claude/wt-agent-hooks/hooks/send-event.ps1
@@ -167,12 +167,61 @@ try {
     }
     $cliSource = $CliSource
 
-    # Drop large model-bound fields wta never reads, so multi-KB tool output
-    # doesn't ride the hook -> wtcli -> COM -> wta pipeline for nothing.
+    # Drop large / model-bound fields wta never reads, so multi-KB tool output
+    # and the user's prompt text don't ride the
+    # hook -> wtcli -> COM -> wta pipeline for nothing.
+    #
+    # Why this matters even though dispatch is async (ShellExecuteEx, hidden
+    # window): every prompt spawns a new wtcli.exe, and the wrapped JSON is
+    # passed as a single CreateProcess argv. Windows caps the command-line
+    # near 32 768 chars, so a long pasted prompt or a Write/Edit tool_input
+    # carrying file contents can truncate the JSON (or silently fail to
+    # spawn). The COM SendEvent broadcast also has to marshal the HString
+    # to every listener (TerminalPage + every `wtcli listen` subscriber).
+    #
+    # Authoritative list of fields wta consumes lives in tools/wta/src/app.rs
+    # (route_one_hook switch). Anything outside that list is pure overhead.
     if ($parsed -is [System.Management.Automation.PSCustomObject]) {
-        foreach ($key in @('tool_result', 'tool_response', 'tool_output', 'toolResult', 'toolResponse', 'toolOutput')) {
+        # Always-strip: large tool-call results, the user's prompt text
+        # (UserPromptSubmit / BeforeAgent — wta only needs the state flip,
+        # never the body), and CLI-side metadata wta never reads (paths,
+        # model info, permission mode, hook bookkeeping, etc).
+        $alwaysStrip = @(
+            'tool_result', 'tool_response', 'tool_output',
+            'toolResult', 'toolResponse', 'toolOutput',
+            'prompt', 'user_prompt', 'userPrompt',
+            'transcript_path', 'transcriptPath',
+            'cwd', 'hook_event_name', 'hookEventName',
+            'permission_mode', 'permissionMode',
+            'model', 'model_info', 'modelInfo',
+            'output_style', 'outputStyle',
+            'version', 'source', 'apiKeySource'
+        )
+        foreach ($key in $alwaysStrip) {
             if ($parsed.PSObject.Properties[$key]) {
                 $parsed.PSObject.Properties.Remove($key)
+            }
+        }
+
+        # tool_input is only consumed by wta when tool_name is a user-input
+        # tool (mirrors `is_user_input_tool` in agent_sessions.rs, where wta
+        # pulls `tool_input.{question,prompt,message}` to surface the
+        # question text in a Notification). For every other tool — Bash
+        # commands, Write/Edit file contents, MCP arg payloads — it's pure
+        # overhead and can be many KB.
+        $toolNameProp = $parsed.PSObject.Properties['tool_name']
+        if (-not $toolNameProp) { $toolNameProp = $parsed.PSObject.Properties['toolName'] }
+        $toolNameLower = if ($toolNameProp) { ([string]$toolNameProp.Value).ToLowerInvariant() } else { '' }
+        $userInputTools = @(
+            'ask_user', 'askuser', 'ask-user',
+            'ask_question', 'askquestion', 'ask_for_clarification',
+            'request_input', 'request_user_input', 'user_input'
+        )
+        if (-not ($userInputTools -contains $toolNameLower)) {
+            foreach ($key in @('tool_input', 'toolInput')) {
+                if ($parsed.PSObject.Properties[$key]) {
+                    $parsed.PSObject.Properties.Remove($key)
+                }
             }
         }
     }

--- a/tools/wta/wt-agent-hooks/codex/wt-agent-hooks/.codex-plugin/plugin.json
+++ b/tools/wta/wt-agent-hooks/codex/wt-agent-hooks/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wt-agent-hooks",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Forward Codex hook events to Windows Terminal for session-management UI.",
   "author": {
     "name": "Agentic Terminal"

--- a/tools/wta/wt-agent-hooks/codex/wt-agent-hooks/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/codex/wt-agent-hooks/hooks/send-event.ps1
@@ -191,12 +191,32 @@ try {
             'toolResult', 'toolResponse', 'toolOutput',
             'prompt', 'user_prompt', 'userPrompt',
             'transcript_path', 'transcriptPath',
-            'cwd', 'hook_event_name', 'hookEventName',
+            'hook_event_name', 'hookEventName',
             'permission_mode', 'permissionMode',
             'model', 'model_info', 'modelInfo',
             'output_style', 'outputStyle',
-            'version', 'source', 'apiKeySource'
+            'version', 'source', 'apiKeySource',
+            # Large per-session context that some CLIs (notably Copilot)
+            # bundle into SessionStart / Stop hook stdin when restoring or
+            # snapshotting a conversation. None of these are consumed by
+            # wta — the SessionStart/SessionEnd handlers only flip state
+            # and need `session_id`. Without this strip a single long
+            # conversation puts SessionStart over the CreateProcess argv
+            # cap and the hook silently fails ("filename or extension is
+            # too long").
+            'transcript', 'messages', 'history', 'conversation',
+            'systemPrompt', 'system_prompt', 'instructions', 'context',
+            'files', 'attachments', 'events', 'chat', 'chatHistory'
         )
+        # NOTE: `cwd` is intentionally NOT stripped. wta's route_one_hook
+        # (app.rs ~582) reads `payload["cwd"]` to populate
+        # SessionStarted.cwd and to derive a synthetic title (the cwd
+        # basename) for events that arrive before the real
+        # `agent.session.started` lands. Stripping it here would empty
+        # the cwd field for every session whose first hook is not
+        # SessionStart (every Copilot session, since prompt.submit fires
+        # first in that CLI's run model) and produce blank rows in the
+        # session-management picker.
         foreach ($key in $alwaysStrip) {
             if ($parsed.PSObject.Properties[$key]) {
                 $parsed.PSObject.Properties.Remove($key)
@@ -215,7 +235,8 @@ try {
         $userInputTools = @(
             'ask_user', 'askuser', 'ask-user',
             'ask_question', 'askquestion', 'ask_for_clarification',
-            'request_input', 'request_user_input', 'user_input'
+            'request_input', 'request_user_input', 'user_input',
+            'prompt_user', 'clarification_request'
         )
         if (-not ($userInputTools -contains $toolNameLower)) {
             foreach ($key in @('tool_input', 'toolInput')) {
@@ -233,6 +254,43 @@ try {
     }
 
     $payload = $wrapper | ConvertTo-Json -Compress -Depth 5
+
+    # Size guard — final defense against CreateProcess argv overflow.
+    #
+    # Even with the aggressive strip above, a CLI we don't know about can
+    # bundle unexpectedly large state into stdin (a new Copilot experiment
+    # ships full conversation context on SessionStart; a custom agent
+    # might dump anything). When that happens, the argv-escaped JSON below
+    # would push past Windows' ~32 768-char CreateProcess command-line cap
+    # and the `Process.Start` call throws "filename or extension is too
+    # long", silently dropping the event.
+    #
+    # When the wrapper is too big we keep the bare-minimum envelope —
+    # cli_source + agent_session_id — which is all wta's SessionStart /
+    # SessionEnd / agent.prompt.submit / agent.stop handlers actually
+    # consume. Notification and agent.error lose their `message` /
+    # `error` text in this rare case; that's a deliberate trade-off vs.
+    # the alternative of dropping the event entirely.
+    #
+    # Threshold: 25 000 raw-JSON chars leaves ~7 KB of headroom for the
+    # wtcli.exe path (~80), the surrounding `send-event -e <event>
+    # -p "<pane>" "..."` framing (~80), and worst-case 2x growth from
+    # the CommandLineToArgvW backslash-doubling escape below.
+    $MAX_PAYLOAD_CHARS = 25000
+    $payloadTruncated  = $false
+    $originalSize      = $payload.Length
+    if ($payload.Length -gt $MAX_PAYLOAD_CHARS) {
+        $payloadTruncated = $true
+        $wrapper = @{
+            cli_source       = $cliSource
+            agent_session_id = $agentSessionId
+            payload          = @{
+                _truncated     = $true
+                _original_size = $originalSize
+            }
+        }
+        $payload = $wrapper | ConvertTo-Json -Compress -Depth 3
+    }
 
     # CommandLineToArgvW-correct escape for a quoted argument:
     #   * Every backslash run that precedes a `"` (or end of string) is doubled.
@@ -284,7 +342,8 @@ try {
     [void][System.Diagnostics.Process]::Start($psi)
     $stamp = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss.fff')
     $sessIdShort = if ($agentSessionId) { $agentSessionId.Substring(0, [Math]::Min(8, $agentSessionId.Length)) } else { '<none>' }
-    Add-Content -LiteralPath $tracePath -Value "$stamp | DISPATCHED cli=$cliSource event=$EventType sessId=$sessIdShort wtcli=$wtcliPath" -ErrorAction SilentlyContinue
+    $truncTag = if ($payloadTruncated) { " TRUNCATED orig=$originalSize" } else { "" }
+    Add-Content -LiteralPath $tracePath -Value "$stamp | DISPATCHED cli=$cliSource event=$EventType sessId=$sessIdShort wtcli=$wtcliPath$truncTag" -ErrorAction SilentlyContinue
 } catch {
     # Single error sink. Best-effort ERROR breadcrumb; if Add-Content
     # itself throws, the `trap { exit 0 }` at the top catches it.

--- a/tools/wta/wt-agent-hooks/codex/wt-agent-hooks/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/codex/wt-agent-hooks/hooks/send-event.ps1
@@ -167,12 +167,61 @@ try {
     }
     $cliSource = $CliSource
 
-    # Drop large model-bound fields wta never reads, so multi-KB tool output
-    # doesn't ride the hook -> wtcli -> COM -> wta pipeline for nothing.
+    # Drop large / model-bound fields wta never reads, so multi-KB tool output
+    # and the user's prompt text don't ride the
+    # hook -> wtcli -> COM -> wta pipeline for nothing.
+    #
+    # Why this matters even though dispatch is async (ShellExecuteEx, hidden
+    # window): every prompt spawns a new wtcli.exe, and the wrapped JSON is
+    # passed as a single CreateProcess argv. Windows caps the command-line
+    # near 32 768 chars, so a long pasted prompt or a Write/Edit tool_input
+    # carrying file contents can truncate the JSON (or silently fail to
+    # spawn). The COM SendEvent broadcast also has to marshal the HString
+    # to every listener (TerminalPage + every `wtcli listen` subscriber).
+    #
+    # Authoritative list of fields wta consumes lives in tools/wta/src/app.rs
+    # (route_one_hook switch). Anything outside that list is pure overhead.
     if ($parsed -is [System.Management.Automation.PSCustomObject]) {
-        foreach ($key in @('tool_result', 'tool_response', 'tool_output', 'toolResult', 'toolResponse', 'toolOutput')) {
+        # Always-strip: large tool-call results, the user's prompt text
+        # (UserPromptSubmit / BeforeAgent — wta only needs the state flip,
+        # never the body), and CLI-side metadata wta never reads (paths,
+        # model info, permission mode, hook bookkeeping, etc).
+        $alwaysStrip = @(
+            'tool_result', 'tool_response', 'tool_output',
+            'toolResult', 'toolResponse', 'toolOutput',
+            'prompt', 'user_prompt', 'userPrompt',
+            'transcript_path', 'transcriptPath',
+            'cwd', 'hook_event_name', 'hookEventName',
+            'permission_mode', 'permissionMode',
+            'model', 'model_info', 'modelInfo',
+            'output_style', 'outputStyle',
+            'version', 'source', 'apiKeySource'
+        )
+        foreach ($key in $alwaysStrip) {
             if ($parsed.PSObject.Properties[$key]) {
                 $parsed.PSObject.Properties.Remove($key)
+            }
+        }
+
+        # tool_input is only consumed by wta when tool_name is a user-input
+        # tool (mirrors `is_user_input_tool` in agent_sessions.rs, where wta
+        # pulls `tool_input.{question,prompt,message}` to surface the
+        # question text in a Notification). For every other tool — Bash
+        # commands, Write/Edit file contents, MCP arg payloads — it's pure
+        # overhead and can be many KB.
+        $toolNameProp = $parsed.PSObject.Properties['tool_name']
+        if (-not $toolNameProp) { $toolNameProp = $parsed.PSObject.Properties['toolName'] }
+        $toolNameLower = if ($toolNameProp) { ([string]$toolNameProp.Value).ToLowerInvariant() } else { '' }
+        $userInputTools = @(
+            'ask_user', 'askuser', 'ask-user',
+            'ask_question', 'askquestion', 'ask_for_clarification',
+            'request_input', 'request_user_input', 'user_input'
+        )
+        if (-not ($userInputTools -contains $toolNameLower)) {
+            foreach ($key in @('tool_input', 'toolInput')) {
+                if ($parsed.PSObject.Properties[$key]) {
+                    $parsed.PSObject.Properties.Remove($key)
+                }
             }
         }
     }

--- a/tools/wta/wt-agent-hooks/copilot/.claude-plugin/marketplace.json
+++ b/tools/wta/wt-agent-hooks/copilot/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "wt-agent-hooks",
       "description": "Forward CLI agent hook events to Windows Terminal for WTA display",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "source": "./wt-agent-hooks"
     }
   ]

--- a/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/.claude-plugin/plugin.json
+++ b/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wt-agent-hooks",
   "description": "Forward CLI agent hook events to Windows Terminal for WTA display",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "Agentic Terminal"
   },

--- a/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.ps1
@@ -191,12 +191,32 @@ try {
             'toolResult', 'toolResponse', 'toolOutput',
             'prompt', 'user_prompt', 'userPrompt',
             'transcript_path', 'transcriptPath',
-            'cwd', 'hook_event_name', 'hookEventName',
+            'hook_event_name', 'hookEventName',
             'permission_mode', 'permissionMode',
             'model', 'model_info', 'modelInfo',
             'output_style', 'outputStyle',
-            'version', 'source', 'apiKeySource'
+            'version', 'source', 'apiKeySource',
+            # Large per-session context that some CLIs (notably Copilot)
+            # bundle into SessionStart / Stop hook stdin when restoring or
+            # snapshotting a conversation. None of these are consumed by
+            # wta — the SessionStart/SessionEnd handlers only flip state
+            # and need `session_id`. Without this strip a single long
+            # conversation puts SessionStart over the CreateProcess argv
+            # cap and the hook silently fails ("filename or extension is
+            # too long").
+            'transcript', 'messages', 'history', 'conversation',
+            'systemPrompt', 'system_prompt', 'instructions', 'context',
+            'files', 'attachments', 'events', 'chat', 'chatHistory'
         )
+        # NOTE: `cwd` is intentionally NOT stripped. wta's route_one_hook
+        # (app.rs ~582) reads `payload["cwd"]` to populate
+        # SessionStarted.cwd and to derive a synthetic title (the cwd
+        # basename) for events that arrive before the real
+        # `agent.session.started` lands. Stripping it here would empty
+        # the cwd field for every session whose first hook is not
+        # SessionStart (every Copilot session, since prompt.submit fires
+        # first in that CLI's run model) and produce blank rows in the
+        # session-management picker.
         foreach ($key in $alwaysStrip) {
             if ($parsed.PSObject.Properties[$key]) {
                 $parsed.PSObject.Properties.Remove($key)
@@ -215,7 +235,8 @@ try {
         $userInputTools = @(
             'ask_user', 'askuser', 'ask-user',
             'ask_question', 'askquestion', 'ask_for_clarification',
-            'request_input', 'request_user_input', 'user_input'
+            'request_input', 'request_user_input', 'user_input',
+            'prompt_user', 'clarification_request'
         )
         if (-not ($userInputTools -contains $toolNameLower)) {
             foreach ($key in @('tool_input', 'toolInput')) {
@@ -233,6 +254,43 @@ try {
     }
 
     $payload = $wrapper | ConvertTo-Json -Compress -Depth 5
+
+    # Size guard — final defense against CreateProcess argv overflow.
+    #
+    # Even with the aggressive strip above, a CLI we don't know about can
+    # bundle unexpectedly large state into stdin (a new Copilot experiment
+    # ships full conversation context on SessionStart; a custom agent
+    # might dump anything). When that happens, the argv-escaped JSON below
+    # would push past Windows' ~32 768-char CreateProcess command-line cap
+    # and the `Process.Start` call throws "filename or extension is too
+    # long", silently dropping the event.
+    #
+    # When the wrapper is too big we keep the bare-minimum envelope —
+    # cli_source + agent_session_id — which is all wta's SessionStart /
+    # SessionEnd / agent.prompt.submit / agent.stop handlers actually
+    # consume. Notification and agent.error lose their `message` /
+    # `error` text in this rare case; that's a deliberate trade-off vs.
+    # the alternative of dropping the event entirely.
+    #
+    # Threshold: 25 000 raw-JSON chars leaves ~7 KB of headroom for the
+    # wtcli.exe path (~80), the surrounding `send-event -e <event>
+    # -p "<pane>" "..."` framing (~80), and worst-case 2x growth from
+    # the CommandLineToArgvW backslash-doubling escape below.
+    $MAX_PAYLOAD_CHARS = 25000
+    $payloadTruncated  = $false
+    $originalSize      = $payload.Length
+    if ($payload.Length -gt $MAX_PAYLOAD_CHARS) {
+        $payloadTruncated = $true
+        $wrapper = @{
+            cli_source       = $cliSource
+            agent_session_id = $agentSessionId
+            payload          = @{
+                _truncated     = $true
+                _original_size = $originalSize
+            }
+        }
+        $payload = $wrapper | ConvertTo-Json -Compress -Depth 3
+    }
 
     # CommandLineToArgvW-correct escape for a quoted argument:
     #   * Every backslash run that precedes a `"` (or end of string) is doubled.
@@ -284,7 +342,8 @@ try {
     [void][System.Diagnostics.Process]::Start($psi)
     $stamp = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss.fff')
     $sessIdShort = if ($agentSessionId) { $agentSessionId.Substring(0, [Math]::Min(8, $agentSessionId.Length)) } else { '<none>' }
-    Add-Content -LiteralPath $tracePath -Value "$stamp | DISPATCHED cli=$cliSource event=$EventType sessId=$sessIdShort wtcli=$wtcliPath" -ErrorAction SilentlyContinue
+    $truncTag = if ($payloadTruncated) { " TRUNCATED orig=$originalSize" } else { "" }
+    Add-Content -LiteralPath $tracePath -Value "$stamp | DISPATCHED cli=$cliSource event=$EventType sessId=$sessIdShort wtcli=$wtcliPath$truncTag" -ErrorAction SilentlyContinue
 } catch {
     # Single error sink. Best-effort ERROR breadcrumb; if Add-Content
     # itself throws, the `trap { exit 0 }` at the top catches it.

--- a/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.ps1
@@ -167,12 +167,61 @@ try {
     }
     $cliSource = $CliSource
 
-    # Drop large model-bound fields wta never reads, so multi-KB tool output
-    # doesn't ride the hook -> wtcli -> COM -> wta pipeline for nothing.
+    # Drop large / model-bound fields wta never reads, so multi-KB tool output
+    # and the user's prompt text don't ride the
+    # hook -> wtcli -> COM -> wta pipeline for nothing.
+    #
+    # Why this matters even though dispatch is async (ShellExecuteEx, hidden
+    # window): every prompt spawns a new wtcli.exe, and the wrapped JSON is
+    # passed as a single CreateProcess argv. Windows caps the command-line
+    # near 32 768 chars, so a long pasted prompt or a Write/Edit tool_input
+    # carrying file contents can truncate the JSON (or silently fail to
+    # spawn). The COM SendEvent broadcast also has to marshal the HString
+    # to every listener (TerminalPage + every `wtcli listen` subscriber).
+    #
+    # Authoritative list of fields wta consumes lives in tools/wta/src/app.rs
+    # (route_one_hook switch). Anything outside that list is pure overhead.
     if ($parsed -is [System.Management.Automation.PSCustomObject]) {
-        foreach ($key in @('tool_result', 'tool_response', 'tool_output', 'toolResult', 'toolResponse', 'toolOutput')) {
+        # Always-strip: large tool-call results, the user's prompt text
+        # (UserPromptSubmit / BeforeAgent — wta only needs the state flip,
+        # never the body), and CLI-side metadata wta never reads (paths,
+        # model info, permission mode, hook bookkeeping, etc).
+        $alwaysStrip = @(
+            'tool_result', 'tool_response', 'tool_output',
+            'toolResult', 'toolResponse', 'toolOutput',
+            'prompt', 'user_prompt', 'userPrompt',
+            'transcript_path', 'transcriptPath',
+            'cwd', 'hook_event_name', 'hookEventName',
+            'permission_mode', 'permissionMode',
+            'model', 'model_info', 'modelInfo',
+            'output_style', 'outputStyle',
+            'version', 'source', 'apiKeySource'
+        )
+        foreach ($key in $alwaysStrip) {
             if ($parsed.PSObject.Properties[$key]) {
                 $parsed.PSObject.Properties.Remove($key)
+            }
+        }
+
+        # tool_input is only consumed by wta when tool_name is a user-input
+        # tool (mirrors `is_user_input_tool` in agent_sessions.rs, where wta
+        # pulls `tool_input.{question,prompt,message}` to surface the
+        # question text in a Notification). For every other tool — Bash
+        # commands, Write/Edit file contents, MCP arg payloads — it's pure
+        # overhead and can be many KB.
+        $toolNameProp = $parsed.PSObject.Properties['tool_name']
+        if (-not $toolNameProp) { $toolNameProp = $parsed.PSObject.Properties['toolName'] }
+        $toolNameLower = if ($toolNameProp) { ([string]$toolNameProp.Value).ToLowerInvariant() } else { '' }
+        $userInputTools = @(
+            'ask_user', 'askuser', 'ask-user',
+            'ask_question', 'askquestion', 'ask_for_clarification',
+            'request_input', 'request_user_input', 'user_input'
+        )
+        if (-not ($userInputTools -contains $toolNameLower)) {
+            foreach ($key in @('tool_input', 'toolInput')) {
+                if ($parsed.PSObject.Properties[$key]) {
+                    $parsed.PSObject.Properties.Remove($key)
+                }
             }
         }
     }

--- a/tools/wta/wt-agent-hooks/gemini-extension/gemini-extension.json
+++ b/tools/wta/wt-agent-hooks/gemini-extension/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "wt-agent-hooks",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Forward Gemini CLI hook events to Windows Terminal for WTA display"
 }

--- a/tools/wta/wt-agent-hooks/gemini-extension/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/gemini-extension/hooks/send-event.ps1
@@ -191,12 +191,32 @@ try {
             'toolResult', 'toolResponse', 'toolOutput',
             'prompt', 'user_prompt', 'userPrompt',
             'transcript_path', 'transcriptPath',
-            'cwd', 'hook_event_name', 'hookEventName',
+            'hook_event_name', 'hookEventName',
             'permission_mode', 'permissionMode',
             'model', 'model_info', 'modelInfo',
             'output_style', 'outputStyle',
-            'version', 'source', 'apiKeySource'
+            'version', 'source', 'apiKeySource',
+            # Large per-session context that some CLIs (notably Copilot)
+            # bundle into SessionStart / Stop hook stdin when restoring or
+            # snapshotting a conversation. None of these are consumed by
+            # wta — the SessionStart/SessionEnd handlers only flip state
+            # and need `session_id`. Without this strip a single long
+            # conversation puts SessionStart over the CreateProcess argv
+            # cap and the hook silently fails ("filename or extension is
+            # too long").
+            'transcript', 'messages', 'history', 'conversation',
+            'systemPrompt', 'system_prompt', 'instructions', 'context',
+            'files', 'attachments', 'events', 'chat', 'chatHistory'
         )
+        # NOTE: `cwd` is intentionally NOT stripped. wta's route_one_hook
+        # (app.rs ~582) reads `payload["cwd"]` to populate
+        # SessionStarted.cwd and to derive a synthetic title (the cwd
+        # basename) for events that arrive before the real
+        # `agent.session.started` lands. Stripping it here would empty
+        # the cwd field for every session whose first hook is not
+        # SessionStart (every Copilot session, since prompt.submit fires
+        # first in that CLI's run model) and produce blank rows in the
+        # session-management picker.
         foreach ($key in $alwaysStrip) {
             if ($parsed.PSObject.Properties[$key]) {
                 $parsed.PSObject.Properties.Remove($key)
@@ -215,7 +235,8 @@ try {
         $userInputTools = @(
             'ask_user', 'askuser', 'ask-user',
             'ask_question', 'askquestion', 'ask_for_clarification',
-            'request_input', 'request_user_input', 'user_input'
+            'request_input', 'request_user_input', 'user_input',
+            'prompt_user', 'clarification_request'
         )
         if (-not ($userInputTools -contains $toolNameLower)) {
             foreach ($key in @('tool_input', 'toolInput')) {
@@ -233,6 +254,43 @@ try {
     }
 
     $payload = $wrapper | ConvertTo-Json -Compress -Depth 5
+
+    # Size guard — final defense against CreateProcess argv overflow.
+    #
+    # Even with the aggressive strip above, a CLI we don't know about can
+    # bundle unexpectedly large state into stdin (a new Copilot experiment
+    # ships full conversation context on SessionStart; a custom agent
+    # might dump anything). When that happens, the argv-escaped JSON below
+    # would push past Windows' ~32 768-char CreateProcess command-line cap
+    # and the `Process.Start` call throws "filename or extension is too
+    # long", silently dropping the event.
+    #
+    # When the wrapper is too big we keep the bare-minimum envelope —
+    # cli_source + agent_session_id — which is all wta's SessionStart /
+    # SessionEnd / agent.prompt.submit / agent.stop handlers actually
+    # consume. Notification and agent.error lose their `message` /
+    # `error` text in this rare case; that's a deliberate trade-off vs.
+    # the alternative of dropping the event entirely.
+    #
+    # Threshold: 25 000 raw-JSON chars leaves ~7 KB of headroom for the
+    # wtcli.exe path (~80), the surrounding `send-event -e <event>
+    # -p "<pane>" "..."` framing (~80), and worst-case 2x growth from
+    # the CommandLineToArgvW backslash-doubling escape below.
+    $MAX_PAYLOAD_CHARS = 25000
+    $payloadTruncated  = $false
+    $originalSize      = $payload.Length
+    if ($payload.Length -gt $MAX_PAYLOAD_CHARS) {
+        $payloadTruncated = $true
+        $wrapper = @{
+            cli_source       = $cliSource
+            agent_session_id = $agentSessionId
+            payload          = @{
+                _truncated     = $true
+                _original_size = $originalSize
+            }
+        }
+        $payload = $wrapper | ConvertTo-Json -Compress -Depth 3
+    }
 
     # CommandLineToArgvW-correct escape for a quoted argument:
     #   * Every backslash run that precedes a `"` (or end of string) is doubled.
@@ -284,7 +342,8 @@ try {
     [void][System.Diagnostics.Process]::Start($psi)
     $stamp = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss.fff')
     $sessIdShort = if ($agentSessionId) { $agentSessionId.Substring(0, [Math]::Min(8, $agentSessionId.Length)) } else { '<none>' }
-    Add-Content -LiteralPath $tracePath -Value "$stamp | DISPATCHED cli=$cliSource event=$EventType sessId=$sessIdShort wtcli=$wtcliPath" -ErrorAction SilentlyContinue
+    $truncTag = if ($payloadTruncated) { " TRUNCATED orig=$originalSize" } else { "" }
+    Add-Content -LiteralPath $tracePath -Value "$stamp | DISPATCHED cli=$cliSource event=$EventType sessId=$sessIdShort wtcli=$wtcliPath$truncTag" -ErrorAction SilentlyContinue
 } catch {
     # Single error sink. Best-effort ERROR breadcrumb; if Add-Content
     # itself throws, the `trap { exit 0 }` at the top catches it.

--- a/tools/wta/wt-agent-hooks/gemini-extension/hooks/send-event.ps1
+++ b/tools/wta/wt-agent-hooks/gemini-extension/hooks/send-event.ps1
@@ -167,12 +167,61 @@ try {
     }
     $cliSource = $CliSource
 
-    # Drop large model-bound fields wta never reads, so multi-KB tool output
-    # doesn't ride the hook -> wtcli -> COM -> wta pipeline for nothing.
+    # Drop large / model-bound fields wta never reads, so multi-KB tool output
+    # and the user's prompt text don't ride the
+    # hook -> wtcli -> COM -> wta pipeline for nothing.
+    #
+    # Why this matters even though dispatch is async (ShellExecuteEx, hidden
+    # window): every prompt spawns a new wtcli.exe, and the wrapped JSON is
+    # passed as a single CreateProcess argv. Windows caps the command-line
+    # near 32 768 chars, so a long pasted prompt or a Write/Edit tool_input
+    # carrying file contents can truncate the JSON (or silently fail to
+    # spawn). The COM SendEvent broadcast also has to marshal the HString
+    # to every listener (TerminalPage + every `wtcli listen` subscriber).
+    #
+    # Authoritative list of fields wta consumes lives in tools/wta/src/app.rs
+    # (route_one_hook switch). Anything outside that list is pure overhead.
     if ($parsed -is [System.Management.Automation.PSCustomObject]) {
-        foreach ($key in @('tool_result', 'tool_response', 'tool_output', 'toolResult', 'toolResponse', 'toolOutput')) {
+        # Always-strip: large tool-call results, the user's prompt text
+        # (UserPromptSubmit / BeforeAgent — wta only needs the state flip,
+        # never the body), and CLI-side metadata wta never reads (paths,
+        # model info, permission mode, hook bookkeeping, etc).
+        $alwaysStrip = @(
+            'tool_result', 'tool_response', 'tool_output',
+            'toolResult', 'toolResponse', 'toolOutput',
+            'prompt', 'user_prompt', 'userPrompt',
+            'transcript_path', 'transcriptPath',
+            'cwd', 'hook_event_name', 'hookEventName',
+            'permission_mode', 'permissionMode',
+            'model', 'model_info', 'modelInfo',
+            'output_style', 'outputStyle',
+            'version', 'source', 'apiKeySource'
+        )
+        foreach ($key in $alwaysStrip) {
             if ($parsed.PSObject.Properties[$key]) {
                 $parsed.PSObject.Properties.Remove($key)
+            }
+        }
+
+        # tool_input is only consumed by wta when tool_name is a user-input
+        # tool (mirrors `is_user_input_tool` in agent_sessions.rs, where wta
+        # pulls `tool_input.{question,prompt,message}` to surface the
+        # question text in a Notification). For every other tool — Bash
+        # commands, Write/Edit file contents, MCP arg payloads — it's pure
+        # overhead and can be many KB.
+        $toolNameProp = $parsed.PSObject.Properties['tool_name']
+        if (-not $toolNameProp) { $toolNameProp = $parsed.PSObject.Properties['toolName'] }
+        $toolNameLower = if ($toolNameProp) { ([string]$toolNameProp.Value).ToLowerInvariant() } else { '' }
+        $userInputTools = @(
+            'ask_user', 'askuser', 'ask-user',
+            'ask_question', 'askquestion', 'ask_for_clarification',
+            'request_input', 'request_user_input', 'user_input'
+        )
+        if (-not ($userInputTools -contains $toolNameLower)) {
+            foreach ($key in @('tool_input', 'toolInput')) {
+                if ($parsed.PSObject.Properties[$key]) {
+                    $parsed.PSObject.Properties.Remove($key)
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem

`tools/wta/wt-agent-hooks/{copilot,claude,gemini-extension,codex}/.../send-event.ps1` wraps the agent CLI's entire stdin JSON into the argv of `wtcli send-event`, which then flows `wtcli.exe -> COM IProtocolServer::SendEvent -> broadcast to TerminalPage + every wtcli listen subscriber`. The payload includes the **full user prompt** on every `UserPromptSubmit` / `BeforeAgent` fire, the full `tool_input` on every `PreToolUse` (Bash commands, Write/Edit file contents, MCP arg payloads), a bunch of CLI-side metadata (`transcript_path`, `hook_event_name`, `permission_mode`, `model`, `output_style`, `version`, `source`, `apiKeySource`), and — for some CLIs — **the full conversation context** bundled into `SessionStart` / `Stop` stdin (`transcript`, `messages`, `history`, `conversation`, `systemPrompt`, `instructions`, `context`, `files`, `attachments`, `events`, `chat`).

Cross-referencing against `tools/wta/src/app.rs::route_one_hook`, the only payload fields wta actually consumes are:

| Event | Fields wta reads |
|---|---|
| `agent.prompt.submit` | **nothing** — only used to flip state to Working |
| `agent.session.started` | `cwd` (populates `SessionStarted.cwd` + synthetic title from cwd basename) |
| `agent.tool.starting` | `tool_name` / `toolName`; `tool_input.{question,prompt,message}` only when `tool_name` ∈ `is_user_input_tool` |
| `agent.notification` | `message` |
| `agent.session.stopped/end` | `reason` |
| `agent.error` | `error` or `message` |
| `agent.tool.completed/finished/failed/stop` | nothing |
| All events | top-level `session_id` (already extracted into the wrapper); `cwd` (used as synthetic title fallback when a session is first seen via a non-`session.started` event) |

Everything else — most notably the **full user prompt text** and the **per-session conversation context** — is pure overhead.

### Concrete risk

The hook is fire-and-forget via `ShellExecuteEx` (hidden window) so it doesn't *block* the agent CLI in the normal case. But the wrapped JSON is passed as a single `CreateProcess` argv:

- **Windows caps `CreateProcess` argv near 32 768 chars.** A long pasted prompt, a `Write`/`Edit` `tool_input` carrying a multi-KB file, or — observed in dogfood — a Copilot `SessionStart` carrying restored conversation context can truncate the JSON or silently fail to spawn `wtcli.exe` with "filename or extension is too long". The existing `CommandLineToArgvW`-escape comment in `send-event.ps1` already calls out this risk.
- Every fire spawns a new `wtcli.exe` process **and** marshals an `HString` across COM to **every** listener, so the cost scales with payload size × subscriber count.

## Change

Extends the existing `tool_result/tool_response/tool_output` strip in all 4 `send-event.ps1` copies (claude / codex / copilot / gemini-extension) with three defenses:

1. **Always-strip** the user-prompt text fields and CLI-side metadata wta never reads:
   - prompt text: `prompt`, `user_prompt`, `userPrompt`
   - bookkeeping: `transcript_path`, `cwd`-less metadata (`hook_event_name`, `permission_mode`, `model`, `model_info`, `output_style`, `version`, `source`, `apiKeySource`)
   - per-session context bundled by some CLIs (notably Copilot) into `SessionStart` / `Stop` stdin: `transcript`, `messages`, `history`, `conversation`, `systemPrompt` / `system_prompt`, `instructions`, `context`, `files`, `attachments`, `events`, `chat`, `chatHistory`

   `cwd` is **intentionally preserved** — wta's `route_one_hook` reads `payload["cwd"]` to populate `SessionStarted.cwd` and derive a synthetic title (the cwd basename) for events that arrive before the real `agent.session.started` lands. Stripping it would empty the cwd for every session whose first hook is `prompt.submit` (every Copilot session, given that CLI's run model) and produce blank rows in the session-management picker.

2. **Conditionally drop `tool_input` / `toolInput`** when `tool_name` is NOT a user-input tool. The whitelist is the full 11-entry mirror of `is_user_input_tool` in `agent_sessions.rs`:
   `ask_user`, `askuser`, `ask-user`, `ask_question`, `askquestion`, `ask_for_clarification`, `request_input`, `request_user_input`, `user_input`, `prompt_user`, `clarification_request` (case-insensitive). Preserves `tool_input.{question, prompt, message}` + `choices` so wta still surfaces the dialog text in a Notification.

3. **Size guard** — final defense against `CreateProcess` argv overflow even when a future CLI ships a brand-new large field we haven't named in the strip list. If the wrapped JSON exceeds **25 000 chars** (leaves ~7 KB headroom for the wtcli path, the `send-event -e <event> -p "<pane>"` framing, and worst-case 2× growth from the backslash-doubling escape), we degrade to a minimal envelope: `{ cli_source, agent_session_id, payload: { _truncated: true, _original_size: N } }`. wta's `SessionStart` / `SessionEnd` / `agent.prompt.submit` / `agent.stop` handlers only need `session_id`, so they still work; `Notification` / `agent.error` lose their text in this rare case — a deliberate trade-off vs. dropping the event entirely. The original_size + the `_truncated` flag stay observable in COM listeners and `wta-acp-debug.log`.

Plus the obligatory **bundle version bump 0.1.2 → 0.1.3** across all 6 plugin/marketplace manifests. The bundle version is what `agent_hooks_installer::upgrade_installed_hooks` compares against `hooks-upgrade-state.json` to decide whether to re-land `send-event.ps1` into each opted-in CLI (see `AGENTS.md` § "Hooks plugin auto-upgrade"). Without the bump, existing users would never pick up the new pruning logic.

## Verification

Direct unit-test of the pruning + size-guard block on 8 representative payload shapes:

| # | Payload | Result |
|---|---|---|
| 1 | UserPromptSubmit, 200-char Claude prompt + 5 metadata fields | Prompt body + `transcript_path` + `permission_mode` all dropped; `session_id` + `cwd` preserved. |
| 2 | PreToolUse Bash with 200-char `tool_input.command` | `tool_input` dropped (Bash is not user-input); `tool_name` + `cwd` preserved. |
| 3 | PreToolUse `ask_user` with question + choices | `tool_input.question` + `choices` preserved so wta still shows the dialog text. |
| 4 | PreToolUse `Prompt-User` (camelCase + hyphen variant of `prompt_user`) | `tool_input` preserved via case-insensitive 11-entry whitelist. |
| 5 | Notification with message + transcript_path | `message` preserved; `transcript_path` dropped. |
| 6 | PostToolUse Bash with both `tool_input` and `tool_response` | Both dropped. |
| 7 | Copilot SessionStart with full restored conversation (~120 KB of `messages` + `transcript`) | Large fields dropped; wrapped JSON drops from ~120 KB to ~300 chars; `session_id` + `cwd` preserved. |
| 8 | Pathological SessionStart still > 25 000 chars after strip (custom CLI dumps unknown blob) | Falls through to minimal envelope: `payload = { _truncated: true, _original_size: <N> }`; `cli_source` + `agent_session_id` preserved so state transitions still fire. |

Also:
- `agent.session.started` round-trip: PS-stripped payload → `route_agent_event_to_registry` reads `payload["cwd"]` → `AgentSession.cwd` populated correctly (no regression on session-management row's "directory" label or Resume default cwd).
- All 4 scripts pass PowerShell's `Parser::ParseFile` clean (no syntax errors).
- All 6 manifests parse as valid JSON and report version `"0.1.3"`.
- `cargo test --bin wta -- agent_hooks_installer::` — 123 tests pass.

## Commits

1. `perf(wt-agent-hooks): strip user prompt + unused metadata before wtcli send-event` — initial always-strip + conditional `tool_input` drop.
2. `chore(wt-agent-hooks): bump plugin version 0.1.2 -> 0.1.3 for send-event.ps1 change` — the auto-upgrade trigger.
3. `fix(wt-agent-hooks): add size guard + extend always-strip for SessionStart payloads` — dogfood fix: keeps `cwd`, extends the always-strip list with the per-session context fields Copilot ships in SessionStart, adds the 25 000-char truncation fallback, and rounds the user-input whitelist out to the full 11 aliases to match `is_user_input_tool`.
