### PR TITLE
fix(wt): correct dev-tree path lookup in WtaProcess::ResolveWtaExePath

### DIFF
--- a/src/cascadia/inc/WtaProcess.h
+++ b/src/cascadia/inc/WtaProcess.h
@@ -19,7 +19,7 @@ namespace Microsoft::Terminal::WtaProcess
 {
     // Locate wta.exe using the same strategy as TerminalPage::_DetectWtaPath:
     //   1. Co-located next to the running module (MSIX / packaged)
-    //   2. Walk up from module dir looking for wta/target/{debug,release}/wta.exe (dev build)
+    //   2. Walk up from module dir looking for tools/wta/target/{debug,release}/wta.exe (dev build)
     //   3. SearchPathW fallback
     inline std::wstring ResolveWtaExePath()
     {
@@ -36,13 +36,19 @@ namespace Microsoft::Terminal::WtaProcess
             }
         }
 
-        // 2. Dev-tree walk
+        // 2. Dev-tree walk. Relative path must match the canonical layout
+        //    `tools\wta\target\<profile>\wta.exe` produced by
+        //    `cargo build --manifest-path tools\wta\Cargo.toml` and
+        //    matched by TerminalPage::_DetectWtaPath. Keep this list in
+        //    sync with that function — diverging here silently makes
+        //    `wta hooks status` / FRE "Install hooks" fall through to
+        //    the PATH fallback in dev (unpackaged) builds.
         auto cursor = moduleDir;
         while (!cursor.empty())
         {
             for (const auto& relative : {
-                     std::filesystem::path{ L"wta\\target\\debug\\wta.exe" },
-                     std::filesystem::path{ L"wta\\target\\release\\wta.exe" },
+                     std::filesystem::path{ L"tools\\wta\\target\\debug\\wta.exe" },
+                     std::filesystem::path{ L"tools\\wta\\target\\release\\wta.exe" },
                  })
             {
                 const auto candidate = cursor / relative;


### PR DESCRIPTION
## Problem

`WtaProcess::ResolveWtaExePath`'s dev-tree fallback (`src/cascadia/inc/WtaProcess.h:43-46`) walked parents looking for `wta\target\{debug,release}\wta.exe` — **missing the `tools\` prefix** that the actual repo layout uses. The companion function it claims to mirror (`TerminalPage::_DetectWtaPath`, `src/cascadia/TerminalApp/TerminalPage.cpp:853-854`) correctly looks for `tools\wta\target\{debug,release}\wta.exe`.

This is a copy-paste typo introduced when `WtaProcess.h` was extracted as a shared header.

## Impact

| Build | Step that found wta.exe | Effect of the bug |
|---|---|---|
| Packaged (MSIX) | Step 1 — co-located next to `WindowsTerminal.exe` | **None.** Step 1 always succeeds; the dev-tree walk is never consulted. |
| Unpackaged dev WT, with `wta` on PATH | Step 3 — `SearchPathW` | Functional but slow; falls all the way through Step 2. |
| Unpackaged dev WT, without `wta` on PATH | Returns empty string | **Silent feature breakage.** Every consumer below treated this as "wta unavailable" and no-op'd. |

Affected user-action sites — all of which only fail in the dev-without-PATH scenario:

- `FreOverlay.cpp:519` — FRE "Install hooks" button
- `AIAgentsViewModel.cpp:936` — hooks status query for Settings UI
- `AIAgentsViewModel.cpp:1012` — hooks install/uninstall toggle
- `AIAgentsViewModel.cpp:1132` — `wta hooks probe-models` for Settings UI

`TerminalPage::_DetectWtaPath` is the separate code path that spawns `wta-master` for agent panes, autofix, and the `SharedWta` lifecycle — that function was already correct, so those features were never affected.

## Fix

One-line change to both relative paths in the dev-tree walk loop:

```diff
-                     std::filesystem::path{ L"wta\\target\\debug\\wta.exe" },
-                     std::filesystem::path{ L"wta\\target\\release\\wta.exe" },
+                     std::filesystem::path{ L"tools\\wta\\target\\debug\\wta.exe" },
+                     std::filesystem::path{ L"tools\\wta\\target\\release\\wta.exe" },
```

Plus a comment block above the loop pointing at `TerminalPage::_DetectWtaPath` as the source of truth, so future divergence is caught at review time.

## Not changed

- Fallback ordering (co-located → dev-tree walk → PATH) is unchanged.
- `TerminalPage::_DetectWtaPath` is unchanged.
- `CascadiaPackage.wapproj`'s Content-Include lookup for the package-layout `wta.exe` is unchanged.

## Verification

Cross-checked all `wta\target` / `wta/target` references in the codebase — every remaining site now uses the `tools\` prefix:

```
WtaProcess.h:50-51          tools\wta\target\{debug,release}\wta.exe  ← this PR
TerminalPage.cpp:853-854    tools\wta\target\{debug,release}\wta.exe
CascadiaPackage.wapproj     $(SolutionDir)tools\wta\target\...
tools\wta\AGENTS.md         tools/wta/target/debug/wta.exe
```

(`tools\wta\OVERVIEW.md` and `tools\wta\README.md` already documented the correct path.)
