### PR TITLE
Hot-reload acp-model & delegate settings without restarting the agent pane

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -358,36 +358,16 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        // Auto-suggest toggle hot-reload: when the effective auto-fix
-        // value changes between settings reloads, push the new value
-        // to WTA over the protocol. Tracks `EffectiveAutoFixEnabled`
-        // (not the raw user pref) so GPO Forced/Blocked transitions
-        // also propagate. WTA's `autofix_enabled` flag would
-        // otherwise stay pinned to whatever `--no-autofix` value it
-        // was launched with.
-        {
-            const bool currentAutoFix = _settings.GlobalSettings().EffectiveAutoFixEnabled();
-            if (!_autoFixEnabledSnapshotInitialized)
-            {
-                _lastAutoFixEnabled = currentAutoFix;
-                _autoFixEnabledSnapshotInitialized = true;
-            }
-            else if (_lastAutoFixEnabled != currentAutoFix)
-            {
-                _lastAutoFixEnabled = currentAutoFix;
-                Json::Value evt;
-                evt["type"] = "event";
-                evt["method"] = "autofix_enabled_changed";
-                Json::Value params;
-                params["enabled"] = currentAutoFix;
-                evt["params"] = params;
-                Json::StreamWriterBuilder wb;
-                wb["indentation"] = "";
-                ProtocolVtSequenceReceived.raise(
-                    *this,
-                    winrt::to_hstring(Json::writeString(wb, evt)));
-            }
-        }
+        // Hot-reload of runtime agent config (autofix gate, acp-model,
+        // delegate agent/model). When any of these change between settings
+        // reloads we push a single consolidated `agent_config_changed`
+        // event to the running wta-helper(s) so they update in place,
+        // WITHOUT tearing down and restarting the agent pane. This is the
+        // unified dispatch for every hot-updatable agent setting — adding a
+        // new one means adding a field to AgentRuntimeConfigSnapshot, not a
+        // bespoke diff/emit block here. (Agent *identity* changes still go
+        // through _RebuildAgentStack in _RefreshUIForSettingsReload.)
+        _EmitAgentRuntimeConfigIfChanged();
 
         // Make sure to call SetCommands before _RefreshUIForSettingsReload.
         // SetCommands will make sure the KeyChordText of Commands is updated, which needs
@@ -1385,12 +1365,89 @@ namespace winrt::TerminalApp::implementation
 
     bool TerminalPage::_AgentSettingsChanged(const AgentSettingsSnapshot& a, const AgentSettingsSnapshot& b)
     {
+        // Only the agent-CLI *identity* (which binary + agent-id) forces a
+        // master respawn. acp-model and the delegate-* fields are hot-updated
+        // over the protocol by _EmitAgentRuntimeConfigIfChanged and must NOT
+        // trigger a teardown/rebuild here — that was the bug where changing
+        // the delegate agent restarted the whole agent pane connection.
         return a.acpAgent != b.acpAgent ||
-               a.acpModel != b.acpModel ||
-               a.acpCustomCommand != b.acpCustomCommand ||
-               a.delegateAgent != b.delegateAgent ||
-               a.delegateModel != b.delegateModel ||
-               a.delegateCustomCommand != b.delegateCustomCommand;
+               a.acpCustomCommand != b.acpCustomCommand;
+    }
+
+    TerminalPage::AgentRuntimeConfigSnapshot TerminalPage::_CaptureAgentRuntimeConfig() const
+    {
+        const auto& globals = _settings.GlobalSettings();
+        return AgentRuntimeConfigSnapshot{
+            std::wstring{ globals.AcpModel() },
+            std::wstring{ _ResolveEffectiveDelegateAgent(globals) },
+            std::wstring{ globals.DelegateModel() },
+            globals.EffectiveAutoFixEnabled(),
+        };
+    }
+
+    // Hot-propagate runtime agent config to the running wta-helper(s) over
+    // the protocol event channel. Unlike agent *identity* changes (which
+    // require a master respawn via _RebuildAgentStack), these take effect
+    // without tearing down the agent pane. A single consolidated
+    // `agent_config_changed` event carries only the fields that changed:
+    //   - autofix_enabled : the auto-suggest gate (was its own event)
+    //   - acp_model        : the main ACP agent's model override
+    //   - delegate_agent + delegate_model : the delegate-tab agent identity;
+    //     both travel together so the helper can rebuild its delegate
+    //     runtime table in one shot.
+    void TerminalPage::_EmitAgentRuntimeConfigIfChanged()
+    {
+        const auto current = _CaptureAgentRuntimeConfig();
+
+        // First call just seeds the baseline — there's no running helper to
+        // notify yet, and on first load the helper picks these values up
+        // from its spawn cmdline.
+        if (!_agentRuntimeConfigInitialized)
+        {
+            _lastAgentRuntimeConfig = current;
+            _agentRuntimeConfigInitialized = true;
+            return;
+        }
+
+        const auto& last = _lastAgentRuntimeConfig;
+        const bool autofixChanged = last.autofixEnabled != current.autofixEnabled;
+        const bool acpModelChanged = last.acpModel != current.acpModel;
+        const bool delegateChanged = last.delegateAgent != current.delegateAgent ||
+                                     last.delegateModel != current.delegateModel;
+
+        if (!autofixChanged && !acpModelChanged && !delegateChanged)
+        {
+            return;
+        }
+
+        Json::Value params{ Json::objectValue };
+        if (autofixChanged)
+        {
+            params["autofix_enabled"] = current.autofixEnabled;
+        }
+        if (acpModelChanged)
+        {
+            params["acp_model"] = winrt::to_string(current.acpModel);
+        }
+        if (delegateChanged)
+        {
+            params["delegate_agent"] = winrt::to_string(current.delegateAgent);
+            params["delegate_model"] = winrt::to_string(current.delegateModel);
+        }
+
+        Json::Value evt{ Json::objectValue };
+        evt["type"] = "event";
+        evt["method"] = "agent_config_changed";
+        evt["params"] = params;
+
+        Json::StreamWriterBuilder wb;
+        wb["indentation"] = "";
+        _agentPaneLog("emitting agent_config_changed (hot settings update)");
+        ProtocolVtSequenceReceived.raise(
+            *this,
+            winrt::to_hstring(Json::writeString(wb, evt)));
+
+        _lastAgentRuntimeConfig = current;
     }
 
     // Close the agent pane in a specific tab, if it has one.

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1435,19 +1435,28 @@ namespace winrt::TerminalApp::implementation
             params["delegate_model"] = winrt::to_string(current.delegateModel);
         }
 
+        _agentPaneLog("emitting agent_config_changed (hot settings update)");
+        _RaiseProtocolEvent("agent_config_changed", params);
+
+        _lastAgentRuntimeConfig = current;
+    }
+
+    // Single source of the wta protocol-event wire shape. Wraps `params` in a
+    // `{type:"event", method, params}` envelope, serializes it compactly, and
+    // raises it on ProtocolVtSequenceReceived (which fans out to the agent
+    // helper(s) over the COM event bus).
+    void TerminalPage::_RaiseProtocolEvent(std::string_view method, const Json::Value& params)
+    {
         Json::Value evt{ Json::objectValue };
         evt["type"] = "event";
-        evt["method"] = "agent_config_changed";
+        evt["method"] = std::string{ method };
         evt["params"] = params;
 
         Json::StreamWriterBuilder wb;
         wb["indentation"] = "";
-        _agentPaneLog("emitting agent_config_changed (hot settings update)");
         ProtocolVtSequenceReceived.raise(
             *this,
             winrt::to_hstring(Json::writeString(wb, evt)));
-
-        _lastAgentRuntimeConfig = current;
     }
 
     // Close the agent pane in a specific tab, if it has one.
@@ -1526,17 +1535,9 @@ namespace winrt::TerminalApp::implementation
             return;
         }
 
-        Json::Value tabEvt;
-        tabEvt["type"] = "event";
-        tabEvt["method"] = "reset_tab_session";
         Json::Value tabParams;
         tabParams["tab_id"] = winrt::to_string(tabId);
-        tabEvt["params"] = tabParams;
-        Json::StreamWriterBuilder wb;
-        wb["indentation"] = "";
-        ProtocolVtSequenceReceived.raise(
-            *this,
-            winrt::to_hstring(Json::writeString(wb, tabEvt)));
+        _RaiseProtocolEvent("reset_tab_session", tabParams);
     }
 
     // Tells wta that a tab has been destroyed so it can drop the per-tab
@@ -1548,18 +1549,10 @@ namespace winrt::TerminalApp::implementation
             return;
         }
 
-        Json::Value tabEvt;
-        tabEvt["type"] = "event";
-        tabEvt["method"] = "tab_closed";
         Json::Value tabParams;
         tabParams["tab_id"] = winrt::to_string(tabId);
         tabParams["window_id"] = std::to_string(_WindowProperties.WindowId());
-        tabEvt["params"] = tabParams;
-        Json::StreamWriterBuilder wb;
-        wb["indentation"] = "";
-        ProtocolVtSequenceReceived.raise(
-            *this,
-            winrt::to_hstring(Json::writeString(wb, tabEvt)));
+        _RaiseProtocolEvent("tab_closed", tabParams);
     }
 
     // Tells wta that the focused tab changed so it can re-project per-tab
@@ -1575,18 +1568,10 @@ namespace winrt::TerminalApp::implementation
             return;
         }
 
-        Json::Value tabEvt;
-        tabEvt["type"] = "event";
-        tabEvt["method"] = "tab_changed";
         Json::Value tabParams;
         tabParams["tab_id"] = winrt::to_string(tabId);
         tabParams["window_id"] = std::to_string(_WindowProperties.WindowId());
-        tabEvt["params"] = tabParams;
-        Json::StreamWriterBuilder wb;
-        wb["indentation"] = "";
-        ProtocolVtSequenceReceived.raise(
-            *this,
-            winrt::to_hstring(Json::writeString(wb, tabEvt)));
+        _RaiseProtocolEvent("tab_changed", tabParams);
     }
 
     // C++ → wta request for changing per-tab agent-pane UI state. The target
@@ -1597,9 +1582,6 @@ namespace winrt::TerminalApp::implementation
                                                 std::optional<std::string_view> view,
                                                 std::optional<bool> paneOpen)
     {
-        Json::Value evt;
-        evt["type"] = "event";
-        evt["method"] = "set_agent_state";
         Json::Value params;
         params["window_id"] = std::to_string(_WindowProperties.WindowId());
 
@@ -1623,13 +1605,8 @@ namespace winrt::TerminalApp::implementation
             params["pane_open"] = *paneOpen;
             logSuffix += " pane_open=" + std::string{ *paneOpen ? "true" : "false" };
         }
-        evt["params"] = params;
-        Json::StreamWriterBuilder wb;
-        wb["indentation"] = "";
         _agentPaneLog(std::string{ "requesting set_agent_state:" } + logSuffix);
-        ProtocolVtSequenceReceived.raise(
-            *this,
-            winrt::to_hstring(Json::writeString(wb, evt)));
+        _RaiseProtocolEvent("set_agent_state", params);
     }
 
     // Builds the per-process flag/value pairs that wta-master inherits
@@ -2138,17 +2115,9 @@ namespace winrt::TerminalApp::implementation
             // "Ask the agent for a fix": open/focus the pane so the user
             // watches the analysis, then fire the LLM call. No auto-inject.
             openAgentPaneForReview();
-            Json::Value evt;
-            evt["type"] = "event";
-            evt["method"] = "autofix_execute_from_detected";
             Json::Value params;
             params["pane_id"] = winrt::to_string(paneId);
-            evt["params"] = params;
-            Json::StreamWriterBuilder wb;
-            wb["indentation"] = "";
-            ProtocolVtSequenceReceived.raise(
-                *this,
-                winrt::to_hstring(Json::writeString(wb, evt)));
+            _RaiseProtocolEvent("autofix_execute_from_detected", params);
             break;
         }
         case AS::Review:
@@ -7099,9 +7068,6 @@ namespace winrt::TerminalApp::implementation
                             const auto newTabId = focusedTab->StableId();
                             if (!newTabId.empty() && newTabId != oldTabId)
                             {
-                                Json::Value evt;
-                                evt["type"] = "event";
-                                evt["method"] = "tab_renamed";
                                 Json::Value params;
                                 params["old_tab_id"] = winrt::to_string(oldTabId);
                                 params["new_tab_id"] = winrt::to_string(newTabId);
@@ -7111,14 +7077,10 @@ namespace winrt::TerminalApp::implementation
                                 // set_agent_state events from the new window
                                 // pass the per-tab window filter.
                                 params["window_id"] = std::to_string(_WindowProperties.WindowId());
-                                evt["params"] = params;
-                                Json::StreamWriterBuilder wb;
-                                wb["indentation"] = "";
-                                const auto payload = winrt::to_hstring(Json::writeString(wb, evt));
                                 _agentPaneLog(
                                     std::string{ "_MakeTerminalPane: emitting tab_renamed old=" } +
                                     winrt::to_string(oldTabId) + " new=" + winrt::to_string(newTabId));
-                                ProtocolVtSequenceReceived.raise(*this, payload);
+                                _RaiseProtocolEvent("tab_renamed", params);
                             }
                             else
                             {

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -359,6 +359,12 @@ namespace winrt::TerminalApp::implementation
         // Hot-reload of agent/model settings. Snapshot is captured on first
         // SetSettings and after every rebuild; a diff drives teardown/rebuild
         // of the agent pane.
+        //
+        // Only the agent-CLI *identity* (acpAgent / acpCustomCommand, which
+        // resolve --agent + --agent-id = the actual agent binary) forces a
+        // master respawn via _RebuildAgentStack. Model + delegate config are
+        // hot-updated over the event channel (see AgentRuntimeConfigSnapshot
+        // + _EmitAgentRuntimeConfigIfChanged) and must NOT restart the pane.
         struct AgentSettingsSnapshot
         {
             std::wstring acpAgent;
@@ -370,12 +376,22 @@ namespace winrt::TerminalApp::implementation
         };
         AgentSettingsSnapshot _lastAgentSettings{};
         bool _agentSettingsSnapshotInitialized{ false };
-        // Snapshot of AutoFixEnabled at last SetSettings call. When the
-        // user toggles "Auto-suggest fixes" we send the new value to WTA
-        // over the protocol so it can update its in-memory gate without
-        // requiring the agent pane to be torn down and restarted.
-        bool _lastAutoFixEnabled{ false };
-        bool _autoFixEnabledSnapshotInitialized{ false };
+        // Hot-updatable runtime agent config. When any of these change we
+        // push a single consolidated `agent_config_changed` event to the
+        // running wta-helper(s) so they update in place — no agent-pane
+        // teardown/restart. This is the unified dispatch point for every
+        // hot-reloadable agent setting (autofix gate, acp-model, delegate
+        // agent/model). `delegateAgent` holds the *resolved effective*
+        // value (custom-command ids already expanded).
+        struct AgentRuntimeConfigSnapshot
+        {
+            std::wstring acpModel;
+            std::wstring delegateAgent;
+            std::wstring delegateModel;
+            bool autofixEnabled{ false };
+        };
+        AgentRuntimeConfigSnapshot _lastAgentRuntimeConfig{};
+        bool _agentRuntimeConfigInitialized{ false };
         // Snapshot of EffectiveAutoErrorDetectionEnabled at last
         // SetSettings call. Drives the silent shell-integration reconcile
         // (Install when ON, Uninstall when OFF) on first-load and on
@@ -435,7 +451,15 @@ namespace winrt::TerminalApp::implementation
         // expire after a few seconds.
         std::unordered_map<winrt::hstring, std::chrono::steady_clock::time_point> _agentPaneRestartSuppression;
         AgentSettingsSnapshot _CaptureAgentSettingsSnapshot() const;
+        // Compares only agent-CLI *identity* fields — the change that forces
+        // a master respawn. Model/delegate changes are handled by
+        // _EmitAgentRuntimeConfigIfChanged instead.
         static bool _AgentSettingsChanged(const AgentSettingsSnapshot& a, const AgentSettingsSnapshot& b);
+        AgentRuntimeConfigSnapshot _CaptureAgentRuntimeConfig() const;
+        // Diffs the hot-updatable runtime config against the last snapshot
+        // and, on change, emits one `agent_config_changed` event carrying
+        // only the changed fields. No agent-pane teardown.
+        void _EmitAgentRuntimeConfigIfChanged();
         void _TeardownAgentPane(const winrt::com_ptr<Tab>& tab, bool suppressMasterRestart = true);
         void _RebuildAgentStack();
         void _FlushPendingAgentRebuild();

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -380,8 +380,8 @@ namespace winrt::TerminalApp::implementation
         // push a single consolidated `agent_config_changed` event to the
         // running wta-helper(s) so they update in place — no agent-pane
         // teardown/restart. This is the unified dispatch point for every
-        // hot-reloadable agent setting (autofix gate, acp-model, delegate
-        // agent/model). `delegateAgent` holds the *resolved effective*
+        // agent setting that can be hot-reloaded (autofix gate, acp-model,
+        // delegate agent/model). `delegateAgent` holds the *resolved effective*
         // value (custom-command ids already expanded).
         struct AgentRuntimeConfigSnapshot
         {

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -29,6 +29,11 @@ namespace Microsoft::Terminal::Core
     class ControlKeyStates;
 }
 
+namespace Json
+{
+    class Value;
+}
+
 namespace winrt::Microsoft::Terminal::Settings
 {
     struct TerminalSettingsCreateResult;
@@ -460,6 +465,10 @@ namespace winrt::TerminalApp::implementation
         // and, on change, emits one `agent_config_changed` event carrying
         // only the changed fields. No agent-pane teardown.
         void _EmitAgentRuntimeConfigIfChanged();
+        // Serialize and raise a `{type:"event", method, params}` envelope on
+        // ProtocolVtSequenceReceived. Single source of the wta protocol-event
+        // wire shape — callers just supply the method name and a params object.
+        void _RaiseProtocolEvent(std::string_view method, const Json::Value& params);
         void _TeardownAgentPane(const winrt::com_ptr<Tab>& tab, bool suppressMasterRestart = true);
         void _RebuildAgentStack();
         void _FlushPendingAgentRebuild();

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1933,6 +1933,22 @@ pub struct App {
     agent_event_tx: Option<mpsc::UnboundedSender<AppEvent>>,
     /// Helper-mode fire-and-forget publisher for `intellterm.wta/session_hook`.
     session_hook_tx: Option<mpsc::UnboundedSender<crate::agent_sessions::SessionEvent>>,
+    /// Hot-updatable delegate config, shared with the recommendation
+    /// executor (`run_recommendation_executor`). Rebuilt in place on an
+    /// `agent_config_changed` settings event so the configured delegate
+    /// agent/model can change without restarting the agent pane. None in
+    /// tests / manual runs where no executor is wired.
+    delegate_agents:
+        Option<Arc<std::sync::Mutex<Vec<crate::coordinator::DelegateAgentRuntime>>>>,
+    /// The helper's own `--agent` cmdline. Needed to re-derive the delegate
+    /// runtime commandline when only the delegate agent/model change.
+    delegate_base_agent_cmd: String,
+    /// The configured ACP model override (the `--acp-model` setting). Seeded
+    /// from the spawn cmdline and updated on `agent_config_changed`. Re-applied
+    /// to every freshly-created session (via `SessionAttached`) so `/new` and
+    /// lazy-first-prompt sessions stay on the configured model, not just the
+    /// bootstrap one. None = "agent default" (no override).
+    acp_model: Option<String>,
     /// Test-only: last command issued via the agent session view's Enter
     /// dispatch (`dispatch_resume` / focus). Used by unit tests in
     /// place of a live wtcli; not compiled into release builds.
@@ -2152,6 +2168,9 @@ impl App {
             install_request_tx: None,
             agent_event_tx: None,
             session_hook_tx: None,
+            delegate_agents: None,
+            delegate_base_agent_cmd: String::new(),
+            acp_model: None,
             #[cfg(test)]
             last_dispatched_command: None,
             source_session_id: None,
@@ -2307,6 +2326,56 @@ impl App {
         tx: mpsc::UnboundedSender<crate::agent_sessions::SessionEvent>,
     ) {
         self.session_hook_tx = Some(tx);
+    }
+
+    /// Seed the hot-updatable runtime agent config: the delegate runtime
+    /// table shared with the recommendation executor, the helper's own
+    /// agent cmdline (used to re-derive the delegate commandline on partial
+    /// updates), and the configured acp-model override.
+    pub fn set_runtime_agent_config(
+        &mut self,
+        delegate_agents: Arc<std::sync::Mutex<Vec<crate::coordinator::DelegateAgentRuntime>>>,
+        base_agent_cmd: String,
+        acp_model: Option<String>,
+    ) {
+        self.delegate_agents = Some(delegate_agents);
+        self.delegate_base_agent_cmd = base_agent_cmd;
+        self.acp_model = acp_model.filter(|s| !s.trim().is_empty());
+    }
+
+    /// Push the currently-configured acp-model to the ACP client task so it
+    /// applies it (via `set_session_model`) to this helper's live session(s).
+    /// No-op when no override is configured ("agent default").
+    fn send_acp_model_update(&self) {
+        if let Some(model) = self.acp_model.as_ref().filter(|s| !s.trim().is_empty()) {
+            let _ = self.master_request_tx.send(
+                crate::protocol::acp::client::MasterExtRequest::SetSessionModel {
+                    model: model.clone(),
+                },
+            );
+        }
+    }
+
+    /// Rebuild the shared delegate runtime table from a settings change.
+    /// `delegate_agent` / `delegate_model` are the new effective values
+    /// (empty string = unset → fall back to deriving from the base agent
+    /// cmd). No-op when no executor is wired (tests / manual runs).
+    fn apply_delegate_config(&self, delegate_agent: &str, delegate_model: &str) {
+        let Some(shared) = &self.delegate_agents else {
+            return;
+        };
+        let runtimes = crate::coordinator::default_delegate_agent_runtimes(
+            Some(delegate_agent).filter(|s| !s.is_empty()),
+            Some(self.delegate_base_agent_cmd.as_str()),
+            Some(delegate_model).filter(|s| !s.is_empty()),
+        );
+        *shared.lock().unwrap() = runtimes;
+        tracing::info!(
+            target: "autofix",
+            delegate_agent,
+            delegate_model,
+            "delegate config hot-updated from settings change"
+        );
     }
 
     fn publish_session_hook(&self, event: crate::agent_sessions::SessionEvent) {
@@ -4133,6 +4202,14 @@ impl App {
                 if current_model_id.is_some() {
                     self.current_model_id = current_model_id;
                 }
+                // Keep freshly-created sessions on the configured acp-model.
+                // A resumed (loaded) session keeps whatever model it was
+                // saved with; only fresh `/new` and lazy-first-prompt
+                // sessions adopt the global override. The bootstrap session
+                // is already model-applied by the client at startup.
+                if !is_load_target {
+                    self.send_acp_model_update();
+                }
                 self.publish_agent_status();
             }
             AppEvent::TabError { tab_id, message } => {
@@ -4773,22 +4850,59 @@ impl App {
                     return;
                 }
 
-                if method == "autofix_enabled_changed" {
-                    // C++ pushes this when the user toggles "Auto-suggest
-                    // fixes" in settings while WTA is already running.
-                    // Without it the flag would stay pinned to whatever
-                    // `--no-autofix` value WTA was launched with.
-                    let enabled = params
-                        .get("enabled")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false);
-                    tracing::info!(
-                        target: "autofix",
-                        old = self.autofix_enabled,
-                        new = enabled,
-                        "autofix_enabled hot-reloaded from settings change",
-                    );
-                    self.autofix_enabled = enabled;
+                if method == "agent_config_changed" {
+                    // C++ pushes this when the user changes a hot-updatable
+                    // agent setting (auto-suggest gate, acp-model, delegate
+                    // agent/model) while WTA is already running. Unified
+                    // dispatch: each field is optional and only present when
+                    // it actually changed, so we apply exactly what's set
+                    // — all in place, with NO agent-pane teardown/restart.
+                    // (Agent *identity* changes go through a master respawn
+                    // on the C++ side, not this event.)
+                    if let Some(enabled) =
+                        params.get("autofix_enabled").and_then(|v| v.as_bool())
+                    {
+                        tracing::info!(
+                            target: "autofix",
+                            old = self.autofix_enabled,
+                            new = enabled,
+                            "autofix_enabled hot-reloaded from settings change",
+                        );
+                        self.autofix_enabled = enabled;
+                    }
+
+                    // delegate_agent + delegate_model travel together so the
+                    // delegate runtime table can be rebuilt in one shot.
+                    if params.get("delegate_agent").is_some()
+                        || params.get("delegate_model").is_some()
+                    {
+                        let delegate_agent = params
+                            .get("delegate_agent")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+                        let delegate_model = params
+                            .get("delegate_model")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+                        self.apply_delegate_config(delegate_agent, delegate_model);
+                    }
+
+                    // acp-model: remember the new override and hot-swap it on
+                    // the running ACP session(s) via the client task
+                    // (set_session_model). Storing it also keeps future
+                    // sessions (/new, lazy-first-prompt) on the new model —
+                    // see the SessionAttached re-apply. Empty = "agent
+                    // default" (can't be expressed as set_session_model), so
+                    // we clear the override and send nothing.
+                    if let Some(raw) = params.get("acp_model").and_then(|v| v.as_str()) {
+                        self.acp_model = Some(raw.to_string()).filter(|s| !s.trim().is_empty());
+                        tracing::info!(
+                            target: "autofix",
+                            model = raw,
+                            "acp-model hot-update requested from settings change",
+                        );
+                        self.send_acp_model_update();
+                    }
                     return;
                 }
 

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2364,10 +2364,12 @@ impl App {
         let Some(shared) = &self.delegate_agents else {
             return;
         };
+        // Treat whitespace-only values as unset so the fallback-to-derived
+        // path kicks in (matches the acp_model handling in handle_event).
         let runtimes = crate::coordinator::default_delegate_agent_runtimes(
-            Some(delegate_agent).filter(|s| !s.is_empty()),
+            Some(delegate_agent).filter(|s| !s.trim().is_empty()),
             Some(self.delegate_base_agent_cmd.as_str()),
-            Some(delegate_model).filter(|s| !s.is_empty()),
+            Some(delegate_model).filter(|s| !s.trim().is_empty()),
         );
         *shared.lock().unwrap() = runtimes;
         tracing::info!(

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -321,9 +321,14 @@ pub async fn run_recommendation_executor(
     mut rx: mpsc::UnboundedReceiver<ChoiceExecution>,
     event_tx: mpsc::UnboundedSender<AppEvent>,
     shell_mgr: Arc<ShellManager>,
-    delegate_agents: Vec<DelegateAgentRuntime>,
+    // Shared so the App can hot-swap the configured delegate agent/model on
+    // an `agent_config_changed` settings update without respawning anything.
+    // Snapshotted (cloned) under the lock per choice — the table is tiny
+    // (one entry) and the lock is never held across an await.
+    delegate_agents: Arc<std::sync::Mutex<Vec<DelegateAgentRuntime>>>,
 ) {
     while let Some(exec) = rx.recv().await {
+        let delegate_agents = delegate_agents.lock().unwrap().clone();
         match execute_choice(&exec.choice, exec.insert_only, &shell_mgr, &delegate_agents, &event_tx).await {
             Ok(()) => {}
             Err(err) => {

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2335,20 +2335,36 @@ async fn run_acp_app(
 
             // Spawn the recommendation executor so selected choices actually run.
             let rec_event_tx = event_tx.clone();
-            let delegate_agents = crate::coordinator::default_delegate_agent_runtimes(
-                cli.delegate_agent.as_deref(),
-                Some(cli.agent.as_str()),
-                cli.delegate_model.as_deref(),
-            );
+            // Shared so a runtime `agent_config_changed` settings update can
+            // hot-swap the configured delegate agent/model in place (handled
+            // in App::handle_event) without restarting the agent pane. The
+            // executor snapshots it per choice; the App rebuilds it on change.
+            let delegate_agents = Arc::new(std::sync::Mutex::new(
+                crate::coordinator::default_delegate_agent_runtimes(
+                    cli.delegate_agent.as_deref(),
+                    Some(cli.agent.as_str()),
+                    cli.delegate_model.as_deref(),
+                ),
+            ));
             tokio::spawn(crate::coordinator::run_recommendation_executor(
                 recommendation_rx,
                 rec_event_tx,
                 shell_mgr_for_recs,
-                delegate_agents,
+                Arc::clone(&delegate_agents),
             ));
 
             let autofix_enabled = !cli.no_autofix;
             let mut app_state = app::App::new(prompt_tx, recommendation_tx, permission_tx, cancel_tx, new_session_tx, load_session_tx, drop_session_tx, rename_session_tx, restart_tx, master_ext_tx, debug_capture_enabled, wt_connected, autofix_enabled, Arc::clone(&shell_mgr));
+            // Seed the hot-updatable runtime agent config: the shared
+            // delegate runtime table, the helper's own agent_cmd (needed to
+            // re-derive the delegate commandline when only the delegate
+            // agent/model change), and the configured acp-model override
+            // (re-applied to future sessions so /new stays on the model).
+            app_state.set_runtime_agent_config(
+                Arc::clone(&delegate_agents),
+                cli.agent.clone(),
+                cli.acp_model.clone(),
+            );
             if let Some(session_hook_tx) = session_hook_tx_opt {
                 app_state.set_session_hook_tx(session_hook_tx);
             }

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -3903,13 +3903,13 @@ fn dispatch_master_ext_request(
                         .await
                     {
                         Ok(_) => tracing::info!(
-                            target: "autofix",
+                            target: "acp",
                             session_id = %sid.0,
                             model = %model,
                             "acp-model hot-applied to live session"
                         ),
                         Err(err) => tracing::warn!(
-                            target: "autofix",
+                            target: "acp",
                             session_id = %sid.0,
                             model = %model,
                             error = ?err,

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -133,6 +133,13 @@ pub enum MasterExtRequest {
         request_id: u64,
         sid: acp::SessionId,
     },
+    /// Hot-swap the ACP model on this helper's live session(s). Emitted by
+    /// `App::handle_event` when the user changes `acp-model` in settings
+    /// while the agent pane is already running — applied via
+    /// `set_session_model` without restarting anything.
+    SetSessionModel {
+        model: String,
+    },
 }
 
 /// User-initiated request to resume a historical agent session by calling
@@ -2551,7 +2558,7 @@ pub async fn run_acp_client_over_pipe(
                 });
             }
             Some(req) = master_ext_rx.recv() => {
-                dispatch_master_ext_request(req, &conn, &event_tx);
+                dispatch_master_ext_request(req, &conn, &event_tx, &tab_to_session);
             }
             Some(req) = restart_rx.recv() => {
                 // Helper can't restart the agent CLI in-process — master owns
@@ -3403,7 +3410,7 @@ async fn run_inner(
             // /restart: priority over other arms via `biased;` so a
             // queued prompt can't sneak in front of a kill request.
             Some(req) = master_ext_rx.recv() => {
-                dispatch_master_ext_request(req, &conn, &event_tx);
+                dispatch_master_ext_request(req, &conn, &event_tx, &tab_to_session);
             }
             Some(req) = restart_rx.recv() => {
                 tracing::info!(target: "acp_restart", "restart requested, new_agent={:?}", req.agent_cmd);
@@ -3771,9 +3778,11 @@ fn dispatch_master_ext_request(
     req: MasterExtRequest,
     conn: &Arc<acp::ClientSideConnection>,
     event_tx: &mpsc::UnboundedSender<AppEvent>,
+    tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::SessionId>>>,
 ) {
     let conn = Arc::clone(conn);
     let event_tx = event_tx.clone();
+    let tab_to_session = Arc::clone(tab_to_session);
     tokio::task::spawn_local(async move {
         match req {
             MasterExtRequest::SessionsList { request_id } => {
@@ -3875,6 +3884,39 @@ fn dispatch_master_ext_request(
                     }
                 }
                 let _ = event_tx.send(AppEvent::MasterMutationCompleted { request_id });
+            }
+            MasterExtRequest::SetSessionModel { model } => {
+                // Apply to every live session this helper owns (normally
+                // just the one bound to its owner tab). Best-effort: a
+                // failure on one session is logged, not fatal — the next
+                // prompt still works on the previously-selected model.
+                let sessions: Vec<acp::SessionId> = {
+                    let g = tab_to_session.lock().await;
+                    g.values().cloned().collect()
+                };
+                for sid in sessions {
+                    match conn
+                        .set_session_model(acp::SetSessionModelRequest::new(
+                            sid.clone(),
+                            model.clone(),
+                        ))
+                        .await
+                    {
+                        Ok(_) => tracing::info!(
+                            target: "autofix",
+                            session_id = %sid.0,
+                            model = %model,
+                            "acp-model hot-applied to live session"
+                        ),
+                        Err(err) => tracing::warn!(
+                            target: "autofix",
+                            session_id = %sid.0,
+                            model = %model,
+                            error = ?err,
+                            "set_session_model hot-update failed"
+                        ),
+                    }
+                }
             }
         }
     });


### PR DESCRIPTION
## What

Changing the **delegate agent** (or **acp-model**) used to tear down and respawn the whole agent pane: `TerminalPage::_AgentSettingsChanged` lumped the `delegate-*` and `acp-model` fields in with the agent-CLI identity, so any such change drove `_RebuildAgentStack` → `_TeardownAgentPane` + `SharedWta::Restart`.

This splits agent settings into two buckets routed through one dispatch point:

- **Identity** (`acpAgent` / `acpCustomCommand` = the agent binary): still respawns the master via `_RebuildAgentStack` — the only change that genuinely needs a fresh agent CLI subprocess.
- **Runtime** (acp-model, delegate agent/model, autofix gate): hot-updated in place over the protocol via a single consolidated `agent_config_changed` event (replaces the bespoke `autofix_enabled_changed` emit). No pane teardown.

### wta (helper) side
- `delegate_agents` is now shared (`Arc<Mutex<…>>`) with the recommendation executor and rebuilt on `agent_config_changed`.
- acp-model is hot-applied to live sessions via a new `MasterExtRequest::SetSessionModel`, and remembered so future sessions (`/new`, lazy-first-prompt) adopt it too (re-applied on `SessionAttached`; resumed/loaded sessions keep their saved model).

## Test plan

Verified in the packaged build: switching `gpt-5.5/low` → `gpt-5.5/medium` → `gpt-5.4/high` hot-applied to the **same helper PID and ACP session** with no respawn. Logs show `acp-model hot-applied to live session` and master `forwarding set_session_model` on the same session id; two conversations ran across the switch with context preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)