### PR TITLE
fix(wta): route find_state_json through GetCurrentPackageFamilyName

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -9199,23 +9199,17 @@ fn set_welcome_shown_in_state() {
     let _ = std::fs::write(&path, &updated);
 }
 
-/// Find the packaged app's state.json.
+/// Find the packaged WT app's state.json.
+///
+/// Delegates to `runtime_paths::wt_state_json_path`, which:
+/// - prefers `GetCurrentPackageFamilyName` when wta itself is packaged
+///   (production: dev-sideload **or** store family — both resolve correctly), and
+/// - falls back to scanning the `Packages` subdirectory under
+///   `%LOCALAPPDATA%` (or `%APPDATA%` when `%LOCALAPPDATA%` is unset)
+///   for either known WT family prefix when wta is unpackaged (dev tree
+///   launched by packaged WT via `TerminalPage::_DetectWtaPath`).
 fn find_state_json() -> Option<std::path::PathBuf> {
-    let local_app_data = std::env::var("LOCALAPPDATA").ok()?;
-    let packages_dir = std::path::Path::new(&local_app_data).join("Packages");
-    if let Ok(entries) = std::fs::read_dir(&packages_dir) {
-        for entry in entries.flatten() {
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-            if name_str.starts_with("IntelligentTerminal_") {
-                let candidate = entry.path().join("LocalState").join("state.json");
-                if candidate.exists() {
-                    return Some(candidate);
-                }
-            }
-        }
-    }
-    None
+    crate::runtime_paths::wt_state_json_path()
 }
 
 fn truncate(s: &str, max: usize) -> String {

--- a/tools/wta/src/runtime_paths.rs
+++ b/tools/wta/src/runtime_paths.rs
@@ -67,9 +67,11 @@ fn resolve_root(package_subdir: &[&str]) -> Option<PathBuf> {
 }
 
 /// Returns the current process's package family name (e.g.
-/// `IntelligentTerminal_rd9vj3e6a2mbr`), or `None` when the process has no
-/// package identity (unpackaged) or the OS call fails for any other reason.
-fn current_package_family_name() -> Option<std::ffi::OsString> {
+/// `IntelligentTerminal_rd9vj3e6a2mbr` for dev-sideload, or
+/// `Microsoft.IntelligentTerminal_8wekyb3d8bbwe` for the store family), or
+/// `None` when the process has no package identity (unpackaged) or the OS
+/// call fails for any other reason.
+pub(crate) fn current_package_family_name() -> Option<std::ffi::OsString> {
     use std::os::windows::ffi::OsStringExt;
     use windows_sys::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER;
     use windows_sys::Win32::Storage::Packaging::Appx::GetCurrentPackageFamilyName;
@@ -114,6 +116,70 @@ pub fn runtime_log_path(file_name: &str) -> PathBuf {
 
 pub fn master_pipe_file_path() -> Option<PathBuf> {
     intelligent_terminal_root().map(|root| root.join("master-pipe.txt"))
+}
+
+/// Resolve the C++ Windows Terminal app's `state.json`.
+///
+/// Resolution order:
+///
+/// 1. If the *current* process has package identity (the production case —
+///    `wta.exe` deployed inside CascadiaPackage), use
+///    [`current_package_family_name`] so we read the state.json belonging to
+///    our own install (dev-sideload **or** store) rather than guessing.
+///
+/// 2. When the process is unpackaged (dev tree: unpackaged `wta.exe`
+///    launched by a packaged WT via `TerminalPage::_DetectWtaPath`), scan
+///    the `Packages` subdirectory under `%LOCALAPPDATA%` (or `%APPDATA%`
+///    when `%LOCALAPPDATA%` is unset — mirrors `resolve_root`'s env-var
+///    fallback) for any directory whose name matches a *known* WT
+///    package family: `IntelligentTerminal_*` (dev sideload — suffix
+///    varies per signing cert) or `Microsoft.IntelligentTerminal_*`
+///    (store). Return the first one whose `state.json` exists.
+///
+/// Returns `None` when neither `%LOCALAPPDATA%` nor `%APPDATA%` is set or
+/// no candidate `state.json` exists on disk.
+pub fn wt_state_json_path() -> Option<PathBuf> {
+    let local = std::env::var_os("LOCALAPPDATA")
+        .or_else(|| std::env::var_os("APPDATA"))
+        .map(PathBuf::from)?;
+
+    if let Some(family) = current_package_family_name() {
+        let candidate = local
+            .join("Packages")
+            .join(family)
+            .join("LocalState")
+            .join("state.json");
+        return candidate.exists().then_some(candidate);
+    }
+
+    let packages = local.join("Packages");
+    // Collect matches, then pick deterministically by family priority:
+    // dev-sideload first (`IntelligentTerminal_*`), then store
+    // (`Microsoft.IntelligentTerminal_*`). `read_dir` enumeration order is
+    // unspecified, so without an explicit priority the choice between
+    // two installed families would non-deterministically vary across
+    // machines and runs. Dev wins because unpackaged wta is itself a
+    // dev-only scenario — devs running out-of-package overwhelmingly have
+    // the dev-sideload install.
+    let mut dev_match: Option<PathBuf> = None;
+    let mut store_match: Option<PathBuf> = None;
+    for entry in std::fs::read_dir(&packages).ok()?.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let candidate = entry.path().join("LocalState").join("state.json");
+        if !candidate.exists() {
+            continue;
+        }
+        if dev_match.is_none() && name.starts_with("IntelligentTerminal_") {
+            dev_match = Some(candidate);
+        } else if store_match.is_none() && name.starts_with("Microsoft.IntelligentTerminal_") {
+            store_match = Some(candidate);
+        }
+        if dev_match.is_some() && store_match.is_some() {
+            break;
+        }
+    }
+    dev_match.or(store_match)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Audit of the `tools/wta/` Rust crate against the newly added [`rust.instructions.md`](.github/instructions/rust.instructions.md) and [`rust-wta.instructions.md`](.github/instructions/rust-wta.instructions.md). Spawned five parallel sub-agents across the codebase and triaged every finding. Only **one** finding warranted a code change; the rest were idiomatic Rust or documented invariants that fit the instructions'' "absolutely necessary" carve-out.

## The fix

`app::find_state_json` hand-rolled the prohibited pattern:

```rust
let local_app_data = std::env::var("LOCALAPPDATA").ok()?;
let packages_dir = std::path::Path::new(&local_app_data).join("Packages");
// …
if name_str.starts_with("IntelligentTerminal_") { … }
```

That wildcard matches the dev-sideload family (`IntelligentTerminal_rd9vj3e6a2mbr`) but **silently misses the store family** `Microsoft.IntelligentTerminal_8wekyb3d8bbwe` — so welcome-state persistence would break on store-distributed builds.

### Refactor

- Promoted `runtime_paths::current_package_family_name` from `fn` → `pub(crate)`.
- Added `runtime_paths::wt_state_json_path()` with two-step resolution:
  1. If wta itself is packaged, use `GetCurrentPackageFamilyName` so we read our own install''s `state.json` — works for both dev-sideload and store families.
  2. Otherwise (unpackaged wta launched by packaged WT via `TerminalPage::_DetectWtaPath`), scan the `Packages` subdirectory under `%LOCALAPPDATA%` (or `%APPDATA%` when LOCALAPPDATA is unset — mirrors `resolve_root`''s env-var fallback). Match either known WT family prefix and pick deterministically: dev-sideload first, then store. Dev wins because unpackaged wta is itself a dev-only scenario.
- Rewrote `find_state_json` to delegate; both branches honor the documented contract by checking `.exists()`.

## Findings explicitly skipped (with rationale)

| Finding | Verdict | Why skipped |
|---|---|---|
| `main.rs:2259` `.expect()` on documented invariant | Skip | "Absolutely necessary" carve-out — documented `Some` invariant in helper-mode branch. |
| `app.rs:8595` WinGet/npm/claude-cli install dirs | Skip | False positive — not an `IntelligentTerminal` path; `runtime_paths.rs` doesn''t cover third-party CLI lookup. |
| `shell_manager.rs` `Mutex.lock().unwrap()` (×17) | Skip | Idiomatic Rust; mutex poisoning is unrecoverable in practice. |
| `session_registry.rs:201-218` `.expect()` on infallible serde | Skip | Already documented as invariant in source comments. |

## Verification

- `cargo build`: clean.
- `cargo test`: **712 passed; 0 failed**.

## Diff

2 files changed, 79 insertions(+), 19 deletions(-).
