### PR TITLE
fix(skill): verify Copilot re-request actually landed in copilot-pr-review-loop

### DIFF
--- a/.github/skills/copilot-pr-review-loop/scripts/01-request-review.ps1
+++ b/.github/skills/copilot-pr-review-loop/scripts/01-request-review.ps1
@@ -44,7 +44,61 @@ if (-not $Owner -or -not $Repo) {
 }
 
 $repoArg = "$Owner/$Repo"
-gh pr edit $PrNumber --repo $repoArg --add-reviewer copilot-pull-request-reviewer
-if ($LASTEXITCODE -ne 0) {
-    throw "gh pr edit failed with exit code $LASTEXITCODE while requesting Copilot review on PR #$PrNumber."
+
+# Snapshot the latest review_requested event timestamp BEFORE making the
+# request, so we can verify a fresh event landed afterward. Both
+# `gh pr edit --add-reviewer` and REST `requested_reviewers` can return
+# success while silently no-op'ing (e.g. the bot login isn't resolvable
+# in this gh-cli session, or GitHub already considers the bot requested).
+# Without this check the loop can spin forever waiting for a review that
+# was never queued.
+function Get-LatestReviewerEvent {
+    $json = gh api "repos/$Owner/$Repo/issues/$PrNumber/events" `
+        --jq '[.[] | select(.event=="review_requested" and (.requested_reviewer.login // "" | ascii_downcase | contains("copilot"))) | .created_at] | sort | .[-1] // ""'
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh api events failed (exit $LASTEXITCODE) while snapshotting reviewer events."
+    }
+    return $json.Trim()
 }
+
+$beforeTs = Get-LatestReviewerEvent
+
+# Primary path: documented in api-quirks.md. May fail with "not found" in
+# some gh-cli versions / accounts because the Copilot bot is not a regular
+# collaborator.
+$primaryOk = $true
+gh pr edit $PrNumber --repo $repoArg --add-reviewer copilot-pull-request-reviewer 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    $primaryOk = $false
+    Write-Host "Primary path (gh pr edit --add-reviewer copilot-pull-request-reviewer) failed; trying REST fallback."
+}
+
+# REST fallback: `reviewers[]=Copilot` (capital C, the bot's display name).
+# Documented in api-quirks.md as a working fallback in some orgs.
+if (-not $primaryOk) {
+    gh api -X POST "repos/$Owner/$Repo/pulls/$PrNumber/requested_reviewers" `
+        -f "reviewers[]=Copilot" --silent 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Both gh pr edit and REST requested_reviewers failed for Copilot on PR #$PrNumber."
+    }
+}
+
+# Verify: a new review_requested event for Copilot must appear within a
+# few seconds. If not, the request was silently dropped (most often
+# because Copilot already reviewed this exact HEAD and is suppressing a
+# redundant review, or the bot was just unrequested in the same call).
+Start-Sleep -Seconds 4
+$afterTs = Get-LatestReviewerEvent
+if ($afterTs -eq $beforeTs) {
+    throw @"
+Copilot review re-request returned success but no new `review_requested` event landed.
+Latest event timestamp is still '$afterTs'.
+Possible causes:
+  * Copilot has already reviewed the current HEAD and is suppressing a redundant review.
+  * The PR is in a state that blocks bot review (draft, closed, merge conflict).
+  * The bot was requested and unrequested in the same API call.
+Push a new commit, mark the PR ready, or wait a few minutes and retry.
+"@
+}
+
+Write-Host "Copilot review requested on PR #$PrNumber (event timestamp: $afterTs)."


### PR DESCRIPTION
## What

`scripts/01-request-review.ps1` previously only checked `gh pr edit`'s
exit code. In practice it can succeed silently while the Copilot bot is
*not* added to the reviewer queue:

- Some `gh-cli` versions / accounts resolve `copilot-pull-request-reviewer`
  as `not found`.
- REST `POST /pulls/{n}/requested_reviewers` can return `201 Created` and
  silently no-op when GitHub already considers the bot recently requested
  or has nothing new to review.

When this happens, the loop spins on `02-list-open-threads.ps1` forever
waiting for a review that was never queued — no error, no signal.

## How

The script now snapshots the latest `review_requested` event timestamp,
tries the documented path, falls back to REST `reviewers[]=Copilot`, and
**throws** if no new event lands within ~4 seconds. Throw message lists
the common root causes (Copilot suppression for unchanged HEAD,
draft/closed/conflicted PR, request-then-unrequest in the same call).

## Caught in practice

Found while running the loop on PR #221: the original script reported
success while the bot was never queued. The user had to notice manually.

## Verification

Ran against PR #221 — script now correctly throws with diagnostics when
the no-op happens, instead of silently succeeding.
