### PR TITLE
Stop filtering outdated review threads from per-round triage

### DIFF
--- a/.github/skills/copilot-pr-review-loop/SKILL.md
+++ b/.github/skills/copilot-pr-review-loop/SKILL.md
@@ -67,10 +67,13 @@ agent owns sequencing, commits, and the final mutating
   `-F` for numeric/boolean variables. A reply body that happens to be
   `"true"` or all digits otherwise fails silently with a type error. See
   [references/api-quirks.md](references/api-quirks.md).
-- **Reply *and* resolve every thread, including declines.** Resolving
-  without a reply leaves no record of why the issue was considered
-  addressed; replying without resolving keeps the open-threads list
-  non-empty and blocks convergence.
+- **Reply *and* resolve every thread, including declines and outdated
+  ones.** Resolving without a reply leaves no record of why the issue
+  was considered addressed; replying without resolving keeps the
+  open-threads list non-empty and blocks convergence. Outdated threads
+  (whose cited lines have since shifted) still need reply + resolve —
+  they show up in the PR UI as unresolved until you explicitly close
+  them.
 - **One focused commit per round, not one per PR.** Bundling rounds
   destroys the audit trail of which finding drove which change and breaks
   `git bisect`.
@@ -94,7 +97,7 @@ agent owns sequencing, commits, and the final mutating
 | Outdated threads still appear in the open-threads list | Run [scripts/09-cleanup-outdated.ps1](scripts/09-cleanup-outdated.ps1) once at convergence |
 | Unsure whether to fix or decline a finding | Apply the rubric in [references/03-triage-criteria.md](references/03-triage-criteria.md) |
 | Need a reply that conveys "fixed", "declined", or "drift" | Use a template from [references/06-reply-templates.md](references/06-reply-templates.md) |
-| `list-open-threads` still shows resolved-looking threads | Filter is `!isResolved && !isOutdated` only — the script already does this; resolved-looking but still-open threads usually mean someone resolved the GitHub UI conversation without the GraphQL `resolveReviewThread` mutation completing |
+| `list-open-threads` still shows resolved-looking threads | Filter is `!isResolved` only (and excludes `isOutdated` only when `-ExcludeOutdated` is passed) — the script already does this; resolved-looking but still-open threads usually mean someone resolved the GitHub UI conversation without the GraphQL `resolveReviewThread` mutation completing |
 
 ## References
 

--- a/.github/skills/copilot-pr-review-loop/references/api-quirks.md
+++ b/.github/skills/copilot-pr-review-loop/references/api-quirks.md
@@ -73,18 +73,27 @@ up to ~10 minutes. There is no progress signal on the in-flight review,
 and polling more often than every ~3 minutes wastes API budget without
 making the review arrive sooner.
 
-## ⚠️ `isOutdated` ≠ `isResolved`
+## ⚠️ `isOutdated` ≠ `isResolved` — outdated threads still need replies
 
 A review thread can be `isOutdated: true` (Copilot's comment points at
 lines that have since changed) while still `isResolved: false`. These
 threads:
 
-- Are NOT actionable in the current round (the cited code is gone).
-- Will still appear in the PR's open conversations until explicitly
-  resolved.
-- Should be filtered out when listing what needs triage.
-- Should be batch-resolved once at convergence (see
-  `scripts/09-cleanup-outdated.ps1`).
+- **Still need a reply + resolve in the per-round loop.** A thread can
+  start out actionable when Copilot posts it and BECOME outdated
+  mid-round when your own fix shifts the cited lines. Filtering on
+  `!isOutdated` would silently drop those threads from the per-round
+  triage, leaving the PR's open-conversations list non-empty even
+  after the underlying code is fixed.
+- `scripts/02-list-open-threads.ps1` therefore includes outdated
+  threads in its output by default (with an `IsOutdated` column for
+  triage), and exposes a `-ExcludeOutdated` opt-out only for the
+  legacy "what's actionable on current lines" use case.
+- `scripts/09-cleanup-outdated.ps1` remains a safety net for the rare
+  case where an outdated thread slips past the per-round loop entirely
+  (e.g. it became outdated only AFTER your last `02-list-open-threads`
+  fetch). Most loops should reach convergence with nothing for step 9
+  to do.
 
 ## ⚠️ The "no new comments" review is not enough to declare convergence
 

--- a/.github/skills/copilot-pr-review-loop/scripts/02-list-open-threads.ps1
+++ b/.github/skills/copilot-pr-review-loop/scripts/02-list-open-threads.ps1
@@ -1,17 +1,24 @@
 <#
 .SYNOPSIS
-    List open, non-outdated review threads on a pull request.
+    List unresolved review threads on a pull request.
 
 .DESCRIPTION
-    Fetches review threads via the GraphQL API and prints the ones that are
-    both unresolved AND non-outdated — i.e. the ones that still need a
-    decision in the current loop iteration. Threads from all reviewers
-    (Copilot, humans, other bots) are included; the loop's triage step
-    decides what to do with each.
+    Fetches review threads via the GraphQL API and prints every thread
+    that is still `isResolved: false` — including threads marked
+    `isOutdated: true` (e.g. because a prior round's fix shifted the
+    cited lines). Each entry carries an `IsOutdated` column so triage
+    can see the distinction at a glance.
 
-    Outdated threads (earlier comments on lines that have since been
-    rewritten) are not actionable in the current round and should be
-    cleaned up at convergence via 09-cleanup-outdated.ps1.
+    Why outdated threads are NOT filtered out: a thread that was
+    actionable when Copilot posted it can BECOME outdated mid-round
+    when your own fix shifts its cited lines. Filtering on
+    `!isOutdated` would silently drop those threads from the per-round
+    list, leaving them unresolved in the PR UI even after the
+    underlying code is fixed. Reply + resolve every unresolved thread,
+    outdated or not.
+
+    Threads from all reviewers (Copilot, humans, other bots) are
+    included; the loop's triage step decides what to do with each.
 
 .PARAMETER Owner
     Repository owner (org or user). Defaults to the current repo's owner
@@ -27,6 +34,13 @@
     Truncate each comment body to this many characters when printing.
     Defaults to 400.
 
+.PARAMETER ExcludeOutdated
+    Suppress threads whose code has since been rewritten
+    (`isOutdated: true`). Off by default — outdated-but-unresolved
+    threads still need a reply + resolve in the current round. Pass
+    this flag only when you specifically want the legacy filter
+    (e.g. for a quick scan of "what's actionable on current lines").
+
 .EXAMPLE
     pwsh 02-list-open-threads.ps1 -PrNumber 122
 
@@ -41,7 +55,9 @@ param(
     [Parameter(Mandatory = $true)]
     [int]$PrNumber,
 
-    [int]$MaxBodyLength = 400
+    [int]$MaxBodyLength = 400,
+
+    [switch]$ExcludeOutdated
 )
 
 $ErrorActionPreference = 'Stop'
@@ -124,7 +140,7 @@ $threads = $all
 
 $open = $threads | Where-Object {
     -not $_.isResolved -and
-    -not $_.isOutdated
+    (-not $ExcludeOutdated -or -not $_.isOutdated)
 }
 
 if (-not $open) {
@@ -139,10 +155,11 @@ foreach ($t in $open) {
         $body = $body.Substring(0, $MaxBodyLength) + '...'
     }
     [pscustomobject]@{
-        ThreadId  = $t.id
-        Author    = $c.author.login
-        Path      = "$($c.path):$($c.line)"
-        CreatedAt = $c.createdAt
-        Body      = $body -replace "`r?`n", ' '
+        ThreadId   = $t.id
+        Author     = $c.author.login
+        Path       = "$($c.path):$($c.line)"
+        IsOutdated = $t.isOutdated
+        CreatedAt  = $c.createdAt
+        Body       = $body -replace "`r?`n", ' '
     }
 }


### PR DESCRIPTION
## What

Stops the `copilot-pr-review-loop` skill from silently dropping outdated-but-unresolved review threads from the per-round triage list.

## Why (real failure on PR #222)

When I drove PR #222 (bash + WSL shell integration) through the loop, round 1 had three Copilot findings. I fixed all three in one commit, but my fix shifted the line numbers cited by two of those findings, marking them `isOutdated: true`. The next `02-list-open-threads.ps1` call filtered them out, so my round-1 reply batch only addressed one of the three. The other two stayed `isResolved: false` in the PR UI, and the user (correctly) flagged "Why there are still comment haven't reply or resolve?"

The old `api-quirks.md` framed this as intentional design — outdated threads were "not actionable in the current round" and would be cleaned up at step 9 (`09-cleanup-outdated.ps1`). That mental model breaks when the per-round fix itself causes the outdated transition: the thread carries real, unaddressed feedback even though its line anchor has moved.

## Changes

| File | Change |
|---|---|
| `scripts/02-list-open-threads.ps1` | Include outdated-but-unresolved threads by default. Add `IsOutdated` column. New opt-in `-ExcludeOutdated` switch for the legacy "what's actionable on current lines" use case. |
| `references/api-quirks.md` | Flip the guidance: outdated-but-unresolved threads ARE actionable. `09-cleanup-outdated.ps1` becomes a safety net for threads that go outdated AFTER the last fetch, not the primary mechanism. |
| `SKILL.md` | Filter description + reply-and-resolve rule both mention outdated threads explicitly. |

## Verification

Smoke-tested the modified script against PR #222 (which now has 0 unresolved threads after the manual cleanup of the two T5H / T5r threads): outputs `No open threads.` as expected.

## Reviewer notes

`09-cleanup-outdated.ps1` is intentionally left in place — it's still useful as the final-pass safety net for the edge case where a thread becomes outdated AFTER your last per-round fetch but BEFORE convergence. The behavior change is just that most loops should now reach convergence with nothing left for step 9 to do.
