### PR TITLE
Remove duplicate Default Terminal policy from ADMX (#212)

### DIFF
--- a/policies/IntelligentTerminal.admx
+++ b/policies/IntelligentTerminal.admx
@@ -28,7 +28,7 @@
     <!-- Note: The "Default terminal application" policy is intentionally NOT defined here.
          It is provided by the Windows Terminal ADMX and writes to the same registry key
          (Console\%%Startup\DelegationTerminal), so duplicating it here would surface two
-         identical "Default Terminal" entries in gpedit. See issue #212. -->
+         identical "Default Terminal" entries in the Group Policy Editor. See issue #212. -->
     <!-- Agent GPO policies -->
     <policy name="AllowedAgents" class="Both" displayName="$(string.AllowedAgents)" explainText="$(string.AllowedAgentsText)" presentation="$(presentation.AllowedAgents)" key="Software\Policies\Microsoft\IntelligentTerminal">
       <parentCategory ref="IntelligentTerminal" />

--- a/policies/IntelligentTerminal.admx
+++ b/policies/IntelligentTerminal.admx
@@ -9,7 +9,6 @@
   <supportedOn>
     <definitions>
       <definition name="SUPPORTED_IntelligentTerminal_1_21" displayName="$(string.SUPPORTED_IntelligentTerminal_1_21)" />
-      <definition name="SUPPORTED_DefaultTerminalApplication" displayName="$(string.SUPPORTED_DefaultTerminalApplication)" />
       <definition name="SUPPORTED_IntelligentTerminal_AgentPolicy" displayName="$(string.SUPPORTED_IntelligentTerminal_AgentPolicy)" />
     </definitions>
   </supportedOn>
@@ -26,62 +25,10 @@
         <multiText id="DisabledProfileSources" valueName="DisabledProfileSources" required="true" />
       </elements>
     </policy>
-    <policy name="DefaultTerminalApplication" class="User" displayName="$(string.DefaultTerminalApplication)" explainText="$(string.DefaultTerminalApplicationText)" presentation="$(presentation.TermAppSelection)" key="Console\%%Startup">
-      <parentCategory ref="IntelligentTerminal" />
-      <supportedOn ref="SUPPORTED_DefaultTerminalApplication" />
-      <elements>
-        <enum id="TermAppSelect" required="true" valueName="DelegationTerminal">
-          <item displayName="$(string.TermAppAutomatic)">
-            <value>
-              <string>{00000000-0000-0000-0000-000000000000}</string>
-            </value>
-            <valueList>
-              <item key="Console\%%Startup" valueName="DelegationConsole">
-                <value>
-                  <string>{00000000-0000-0000-0000-000000000000}</string>
-                </value>
-              </item>
-            </valueList>
-          </item>
-          <item displayName="$(string.TermAppConsoleHost)">
-            <value>
-              <string>{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}</string>
-            </value>
-            <valueList>
-              <item key="Console\%%Startup" valueName="DelegationConsole">
-                <value>
-                  <string>{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}</string>
-                </value>
-              </item>
-            </valueList>
-          </item>
-          <item displayName="$(string.TermAppWindowsTerminal)">
-            <value>
-              <string>{E12CFF52-A866-4C77-9A90-F570A7AA2C6B}</string>
-            </value>
-            <valueList>
-              <item key="Console\%%Startup" valueName="DelegationConsole">
-                <value>
-                  <string>{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}</string>
-                </value>
-              </item>
-            </valueList>
-          </item>
-          <item displayName="$(string.TermAppWindowsTerminalPreview)">
-            <value>
-              <string>{86633F1F-6454-40EC-89CE-DA4EBA977EE2}</string>
-            </value>
-            <valueList>
-              <item key="Console\%%Startup" valueName="DelegationConsole">
-                <value>
-                  <string>{06EC847C-C0A5-46B8-92CB-7C92F6E35CD5}</string>
-                </value>
-              </item>
-            </valueList>
-          </item>
-        </enum>
-      </elements>
-    </policy>
+    <!-- Note: The "Default terminal application" policy is intentionally NOT defined here.
+         It is provided by the Windows Terminal ADMX and writes to the same registry key
+         (Console\%%Startup\DelegationTerminal), so duplicating it here would surface two
+         identical "Default Terminal" entries in gpedit. See issue #212. -->
     <!-- Agent GPO policies -->
     <policy name="AllowedAgents" class="Both" displayName="$(string.AllowedAgents)" explainText="$(string.AllowedAgentsText)" presentation="$(presentation.AllowedAgents)" key="Software\Policies\Microsoft\IntelligentTerminal">
       <parentCategory ref="IntelligentTerminal" />

--- a/policies/en-US/IntelligentTerminal.adml
+++ b/policies/en-US/IntelligentTerminal.adml
@@ -7,7 +7,6 @@
     <stringTable>
       <string id="IntelligentTerminal">Intelligent Terminal</string>
       <string id="SUPPORTED_IntelligentTerminal_1_21">At least Intelligent Terminal 1.21</string>
-      <string id="SUPPORTED_DefaultTerminalApplication">At least Windows 11 22H2 or Windows 10 22H2 (Build 19045.3031, KB5026435) with Windows Terminal 1.17</string>
       <string id="SUPPORTED_IntelligentTerminal_AgentPolicy">Intelligent Terminal with agent support</string>
       <string id="DisabledProfileSources">Disabled Profile Sources</string>
       <string id="DisabledProfileSourcesText">Profiles will not be generated from any sources listed here. Source names can be arbitrary strings. Potential candidates can be found as the "source" property on profile definitions in Intelligent Terminal's settings.json file.
@@ -20,14 +19,6 @@ Common sources are:
 For instance, setting this policy to Windows.Terminal.Wsl will disable the builtin WSL integration of Intelligent Terminal.
 
 Note: Existing profiles will disappear from Intelligent Terminal after adding their source to this policy.</string>
-      <string id="DefaultTerminalApplication">Default terminal application</string>
-      <string id="DefaultTerminalApplicationText">Select the default terminal application used in Windows.
-
-If you select Windows Terminal Preview and it is not installed the system will fall back to the legacy Windows Console Host. (Please note that the settings interfaces showing "Let windows decide" in this case as configuration.)</string>
-      <string id="TermAppAutomatic">Automatic selection (Windows Terminal, if available)</string>
-      <string id="TermAppConsoleHost">Windows Console Host (legacy)</string>
-      <string id="TermAppWindowsTerminal">Windows Terminal</string>
-      <string id="TermAppWindowsTerminalPreview">Windows Terminal Preview (if available)</string>
       <!-- Agent GPO policies -->
       <string id="AllowedAgents">Allowed AI Agents</string>
       <string id="AllowedAgentsText">Specifies which built-in AI agents are allowed for the agent pane and command palette delegation. Enter one agent identifier per line.
@@ -59,9 +50,6 @@ If you enable this policy or do not configure it, users can install and manage a
     <presentationTable>
       <presentation id="DisabledProfileSources">
         <multiTextBox refId="DisabledProfileSources">List of disabled sources (one per line)</multiTextBox>
-      </presentation>
-      <presentation id="TermAppSelection">
-        <dropdownList refId="TermAppSelect" noSort="true" defaultItem="0">Select from the following options:</dropdownList>
       </presentation>
       <presentation id="AllowedAgents">
         <multiTextBox refId="AllowedAgents">Allowed agent identifiers, one per line (copilot, claude, codex, gemini)</multiTextBox>


### PR DESCRIPTION
## Summary

Fixes #212.

Removes the duplicate `DefaultTerminalApplication` policy from Intelligent Terminal's ADMX. It wrote to the same registry value (`Console\%Startup\DelegationTerminal`) under the same `"Default terminal application"` display name as the policy shipped by **Windows Terminal**'s ADMX, so administrators who imported both templates saw two identical entries under *Administrative Templates → Windows Components* in gpedit.

Per the reporter's recommendation, the canonical definition stays in Windows Terminal's ADMX (it has been there longer, ships with WT, and writes the same OS-level setting). If Intelligent Terminal ever needs to appear as a selectable option in that dropdown, the right place is upstream in WT's ADMX, not a duplicate here.

## Changes

- `policies/IntelligentTerminal.admx` — removed the `DefaultTerminalApplication` policy, its `SUPPORTED_DefaultTerminalApplication` supportedOn definition, and added a short XML comment explaining the deliberate omission.
- `policies/en-US/IntelligentTerminal.adml` — removed the 7 associated strings (`DefaultTerminalApplication`, `DefaultTerminalApplicationText`, `TermAppAutomatic`, `TermAppConsoleHost`, `TermAppWindowsTerminal`, `TermAppWindowsTerminalPreview`, `SUPPORTED_DefaultTerminalApplication`) and the `TermAppSelection` presentation.

Net diff: **4 insertions, 69 deletions**, no behavior change for the remaining IT-specific policies (`DisabledProfileSources`, `AllowedAgents`, `AllowCustomAgents`, `AllowAutoFix`, `AllowAgentSessionHooks`).

## Validation

- ADMX and ADML parse as well-formed XML.
- No orphan references to any removed symbol anywhere in the repo.
- Existing admin configurations are unaffected: the registry value is unchanged, and Windows Terminal's ADMX continues to manage it.
