### PR TITLE
fix(wta): pin /model & /-autocomplete popups directly above the input box

### DIFF
--- a/tools/wta/src/ui/command_popup.rs
+++ b/tools/wta/src/ui/command_popup.rs
@@ -6,14 +6,14 @@
 //! lists every command with full descriptions.
 
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
+use ratatui::widgets::{Clear, List, ListItem, ListState, Paragraph};
 
+use super::popup;
 use crate::app::App;
 use crate::commands::{CommandSpec, REGISTRY};
 use crate::theme;
 
 const POPUP_MAX_VISIBLE: usize = 6;
-const POPUP_BORDER_HEIGHT: u16 = 2;
 
 /// Per-frame state captured from the [`App`] so callers don't need to know
 /// the popup internals.
@@ -37,18 +37,7 @@ pub fn render_popup(frame: &mut Frame, state: PopupState<'_>, input_area: Rect) 
     }
 
     let visible = state.candidates.len().min(POPUP_MAX_VISIBLE) as u16;
-    let height = visible + POPUP_BORDER_HEIGHT;
-    let width = input_area.width;
-
-    // Prefer above; fall back to below if there's no room.
-    let area = if input_area.y >= height {
-        Rect::new(input_area.x, input_area.y - height, width, height)
-    } else {
-        // Anchor right below; clamp to frame so we don't render off-screen.
-        let frame_area = frame.area();
-        let y = (input_area.y + input_area.height).min(frame_area.y + frame_area.height.saturating_sub(height));
-        Rect::new(input_area.x, y, width, height)
-    };
+    let area = popup::anchored_above(frame, input_area, visible);
 
     frame.render_widget(Clear, area);
 
@@ -72,14 +61,8 @@ pub fn render_popup(frame: &mut Frame, state: PopupState<'_>, input_area: Rect) 
         })
         .collect();
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(theme::INPUT_BORDER)
-        .style(Style::default().bg(theme::INPUT_BG))
-        .title(t!("commands.popup_title").into_owned());
-
     let list = List::new(items)
-        .block(block)
+        .block(popup::block(t!("commands.popup_title").into_owned()))
         .highlight_style(theme::SELECTED)
         .highlight_symbol("> ");
 
@@ -126,12 +109,7 @@ pub fn render_help_overlay(frame: &mut Frame, app: &App, area: Rect) {
 
     frame.render_widget(Clear, modal);
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(theme::INPUT_BORDER)
-        .style(Style::default().bg(theme::INPUT_BG))
-        .title(t!("commands.help_title").into_owned());
-
-    let paragraph = Paragraph::new(lines).block(block);
+    let paragraph =
+        Paragraph::new(lines).block(popup::block(t!("commands.help_title").into_owned()));
     frame.render_widget(paragraph, modal);
 }

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -216,17 +216,20 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         debug_panel::render(frame, app, debug_area);
     }
 
-    // Slash-command autocomplete: anchored above the input box. Drawn into
-    // the filler row between the perm panel and the hint row.
+    // Slash-command autocomplete: pinned directly above the input box
+    // (`chunks[6]`). Anchoring to the input box rather than the filler row
+    // keeps the popup glued to the input regardless of how much empty space
+    // sits above it — otherwise a short chat leaves a tall filler and the
+    // popup floats far up the pane (worst in side-by-side layouts).
     if let Some(popup_state) = app.command_popup_state() {
-        command_popup::render_popup(frame, popup_state, chunks[3]);
+        command_popup::render_popup(frame, popup_state, chunks[6]);
     }
 
     // `/model` picker modal: same anchor as the autocomplete popup. The two
     // are mutually exclusive — opening the picker clears the input, so the
     // command popup isn't visible while it's up.
     if let Some(model_state) = app.model_popup_state() {
-        model_popup::render_popup(frame, model_state, chunks[3]);
+        model_popup::render_popup(frame, model_state, chunks[6]);
     }
 
     // `/help` overlay sits on top of everything so the user can always

--- a/tools/wta/src/ui/mod.rs
+++ b/tools/wta/src/ui/mod.rs
@@ -7,6 +7,7 @@ mod input;
 mod layout;
 mod model_popup;
 mod permission;
+mod popup;
 mod recommendations;
 pub mod agents_view;
 pub mod setup;

--- a/tools/wta/src/ui/model_popup.rs
+++ b/tools/wta/src/ui/model_popup.rs
@@ -9,13 +9,13 @@
 //! in `App::handle_key`).
 
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState};
+use ratatui::widgets::{Clear, List, ListItem, ListState};
 
+use super::popup;
 use crate::app::AcpModelInfo;
 use crate::theme;
 
 const POPUP_MAX_VISIBLE: usize = 8;
-const POPUP_BORDER_HEIGHT: u16 = 2;
 /// Marker drawn next to the model the pane is currently on.
 const CURRENT_MARKER: &str = "● ";
 const CURRENT_PAD: &str = "  ";
@@ -37,18 +37,7 @@ pub fn render_popup(frame: &mut Frame, state: ModelPopupState<'_>, input_area: R
     }
 
     let visible = state.models.len().min(POPUP_MAX_VISIBLE) as u16;
-    let height = visible + POPUP_BORDER_HEIGHT;
-    let width = input_area.width;
-
-    // Prefer above; fall back to below if there's no room.
-    let area = if input_area.y >= height {
-        Rect::new(input_area.x, input_area.y - height, width, height)
-    } else {
-        let frame_area = frame.area();
-        let y = (input_area.y + input_area.height)
-            .min(frame_area.y + frame_area.height.saturating_sub(height));
-        Rect::new(input_area.x, y, width, height)
-    };
+    let area = popup::anchored_above(frame, input_area, visible);
 
     frame.render_widget(Clear, area);
 
@@ -73,14 +62,8 @@ pub fn render_popup(frame: &mut Frame, state: ModelPopupState<'_>, input_area: R
         })
         .collect();
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(theme::INPUT_BORDER)
-        .style(Style::default().bg(theme::INPUT_BG))
-        .title(t!("model_picker.title").into_owned());
-
     let list = List::new(items)
-        .block(block)
+        .block(popup::block(t!("model_picker.title").into_owned()))
         .highlight_style(theme::SELECTED)
         .highlight_symbol("> ");
 

--- a/tools/wta/src/ui/popup.rs
+++ b/tools/wta/src/ui/popup.rs
@@ -25,13 +25,16 @@ pub const BORDER_HEIGHT: u16 = 2;
 /// above the input. Falls back to anchoring below — clamped into the frame —
 /// only when there genuinely isn't room above (input box near the top).
 pub fn anchored_above(frame: &Frame, input_area: Rect, content_rows: u16) -> Rect {
-    let height = content_rows + BORDER_HEIGHT;
+    let frame_area = frame.area();
+    // Cap the height at the frame so a popup taller than the screen (tiny
+    // pane) can't extend past the buffer — some ratatui widgets assume the
+    // render area fits, and the below-fallback clamp below relies on this.
+    let height = (content_rows + BORDER_HEIGHT).min(frame_area.height);
     let width = input_area.width;
 
     if input_area.y >= height {
         Rect::new(input_area.x, input_area.y - height, width, height)
     } else {
-        let frame_area = frame.area();
         let y = (input_area.y + input_area.height)
             .min(frame_area.y + frame_area.height.saturating_sub(height));
         Rect::new(input_area.x, y, width, height)

--- a/tools/wta/src/ui/popup.rs
+++ b/tools/wta/src/ui/popup.rs
@@ -1,0 +1,49 @@
+//! Shared chrome for the input-anchored popups (`/`-autocomplete and the
+//! `/model` picker).
+//!
+//! Both popups want the same thing: a bordered, titled box pinned directly
+//! above the input box, using the input-box theme colors. This module owns
+//! that shared logic so the two call sites stay in lockstep — see
+//! [`command_popup`](super::command_popup) and
+//! [`model_popup`](super::model_popup). The centered `/help` overlay reuses
+//! [`block`] for its frame but does its own centering.
+
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders};
+
+use crate::theme;
+
+/// Border rows a popup adds around its content (top + bottom edge).
+pub const BORDER_HEIGHT: u16 = 2;
+
+/// Rect for a popup holding `content_rows` rows of content, pinned just above
+/// `input_area`.
+///
+/// `input_area` must be the **input box** (not a filler region): the popup's
+/// bottom edge lands on the input box's top edge, so it always reads as
+/// "right above where I'm typing" regardless of how much empty space sits
+/// above the input. Falls back to anchoring below — clamped into the frame —
+/// only when there genuinely isn't room above (input box near the top).
+pub fn anchored_above(frame: &Frame, input_area: Rect, content_rows: u16) -> Rect {
+    let height = content_rows + BORDER_HEIGHT;
+    let width = input_area.width;
+
+    if input_area.y >= height {
+        Rect::new(input_area.x, input_area.y - height, width, height)
+    } else {
+        let frame_area = frame.area();
+        let y = (input_area.y + input_area.height)
+            .min(frame_area.y + frame_area.height.saturating_sub(height));
+        Rect::new(input_area.x, y, width, height)
+    }
+}
+
+/// The bordered, titled block shared by every popup — input-box border color
+/// and background so the popup reads as an extension of the input chrome.
+pub fn block(title: String) -> Block<'static> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::INPUT_BORDER)
+        .style(Style::default().bg(theme::INPUT_BG))
+        .title(title)
+}


### PR DESCRIPTION
## What

Two fixes for the input-anchored TUI popups (`/model` picker and the `/`-slash autocomplete):

### 1. Position fix — popups floated too high
Both popups were anchored to the **filler row** (`chunks[3]`, the `Min(0)` gap between the perm panel and the hint row) rather than the input box. The positioning logic pins the popup to the *top* of whatever rect it receives, so when the chat is short the filler is tall and the popup floated far up the pane — worst in **side-by-side layouts** where each pane holds less content.

Now anchored to the **input box** (`chunks[6]`): the popup's bottom edge always lands on the input's top edge, so it stays glued just above where you're typing regardless of how much empty space sits above.

### 2. Refactor — dedup shared popup chrome
The above/below positioning algorithm and the bordered+titled block were copy-pasted across `model_popup.rs` and `command_popup.rs`. Extracted into a new `ui/popup.rs`:
- `popup::anchored_above(frame, input_area, content_rows)` — above-preferred positioning with below fallback + frame clamp
- `popup::block(title)` — the shared `INPUT_BORDER` / `INPUT_BG` bordered block (also adopted by the centered `/help` overlay)
- `popup::BORDER_HEIGHT` — the `+2` border constant

Per-popup bits stay local: `POPUP_MAX_VISIBLE` (8 for `/model`, 6 for autocomplete), list-item rendering, and the `/help` centering.

## Test
- `cargo +stable test` — 712 passed, 0 failed
- Built the x64-msvc triple and deployed into the running dev Terminal for manual check of `/model`, `/` autocomplete, and side-by-side layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)