### PR TITLE
fix(winget): publish fork package Microsoft.IntelligentTerminal

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -18,8 +18,14 @@ jobs:
       - name: Publish Intelligent Terminal
         run: |
           $assets = '${{ toJSON(github.event.release.assets) }}' | ConvertFrom-Json
-          $wingetRelevantAsset = $assets | Where-Object { $_.name -like '*.msixbundle' } | Select-Object -First 1
           $regex = [Regex]::New($env:REGEX)
+          $wingetRelevantAsset = $assets | Where-Object { $regex.IsMatch($_.name) } | Select-Object -First 1
+
+          if (-not $wingetRelevantAsset) {
+            Write-Error "No release asset matched '$env:REGEX'; nothing to publish to WinGet."
+            exit 1
+          }
+
           $version = $regex.Match($wingetRelevantAsset.name).Groups[1].Value
 
           $wingetPackage = "Microsoft.IntelligentTerminal"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  REGEX: 'Microsoft\.WindowsTerminal(?:Preview)?_([\d.]+)_8wekyb3d8bbwe\.msixbundle$'
+  REGEX: 'Microsoft\.IntelligentTerminal_([\d.]+)_8wekyb3d8bbwe\.msixbundle$'
   # winget-create will read the following environment variable to access the GitHub token needed for submitting a PR
   # See https://aka.ms/winget-create-token
   WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
@@ -13,15 +13,16 @@ env:
 jobs:
   publish:
     runs-on: windows-latest # Action can only run on Windows
+    if: ${{ !github.event.release.prerelease }} # Only publish stable releases to WinGet
     steps:
-      - name: Publish Windows Terminal ${{ github.event.release.prerelease && 'Preview' || 'Stable' }}
+      - name: Publish Intelligent Terminal
         run: |
           $assets = '${{ toJSON(github.event.release.assets) }}' | ConvertFrom-Json
           $wingetRelevantAsset = $assets | Where-Object { $_.name -like '*.msixbundle' } | Select-Object -First 1
           $regex = [Regex]::New($env:REGEX)
           $version = $regex.Match($wingetRelevantAsset.name).Groups[1].Value
 
-          $wingetPackage = "Microsoft.WindowsTerminal${{ github.event.release.prerelease && '.Preview' || '' }}"
+          $wingetPackage = "Microsoft.IntelligentTerminal"
 
           & curl.exe -JLO https://aka.ms/wingetcreate/latest
           & .\wingetcreate.exe update $wingetPackage -s -v $version -u $wingetRelevantAsset.browser_download_url


### PR DESCRIPTION
## Problem

The WinGet publish workflow (`.github/workflows/winget.yml`) was still inherited from upstream Windows Terminal: it targeted the **upstream** `Microsoft.WindowsTerminal` / `Microsoft.WindowsTerminal.Preview` package IDs and a `Microsoft.WindowsTerminal*` bundle-name regex.

As a result, fork releases would never update the fork's own WinGet package — `Microsoft.IntelligentTerminal`, which is already live on WinGet (v0.1.1531.0). The regex also would not match the fork's bundle name (`Microsoft.IntelligentTerminal_<version>_8wekyb3d8bbwe.msixbundle`), so the workflow was effectively dead while also pointing at the wrong (upstream) package.

## Change

- Point `REGEX` and `$wingetPackage` at `Microsoft.IntelligentTerminal`.
- Drop the Preview/prerelease path — there is no `Microsoft.IntelligentTerminal.Preview` WinGet package.
- Add `if: ${{ !github.event.release.prerelease }}` so prereleases are skipped and cannot overwrite the stable package.

PFN hash `8wekyb3d8bbwe` is unchanged (the fork is signed under the same publisher); only the package-name prefix differed.

## Verification

```
> winget show Microsoft.IntelligentTerminal --source winget
Installer Url: https://github.com/microsoft/intelligent-terminal/releases/download/v0.1.0/Microsoft.IntelligentTerminal_0.1.1531.0_8wekyb3d8bbwe.msixbundle
```

Confirms both the package ID and the bundle-name pattern the updated regex now matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)