### PR TITLE
feat(wta): show all session origins in session management picker

### DIFF
--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -399,19 +399,19 @@ all the side effects:
 * on-failure `PaneClosed` rebroadcast (so a stuck Live row
   transitions to Ended after `wtcli focus-pane` returns NotFound).
 
-### MVP origin filter (session management picker shows shell-pane sessions only)
+### Sessions origin filter (session management picker shows every origin)
 
-The session management picker currently ships in MVP mode: it only surfaces
-**Class B** (shell-pane) sessions — the user manually ran `copilot`
-/ `claude` / `gemini` in a regular shell. **Class A** (agent-pane)
-sessions stay in the registry so Enter routing, alive-mirror
-reconciliation, `intellterm.wta/session_added|removed`, and
-`wta sessions list` all keep seeing every row; they just don't
-render in the picker and aren't reachable by the cursor.
+The session management picker surfaces **every** session WTA knows
+about regardless of origin: both **Class B** (shell-pane) sessions —
+the user manually ran `copilot` / `claude` / `gemini` in a regular
+shell — and **Class A** (agent-pane) sessions that WTA spawned on
+behalf of an Intelligent Terminal agent pane. The Enter / Shift+Enter
+dispatch table (`session_mgmt::decide_enter_action`) routes both
+classes, so neither is hidden from the cursor.
 
-The gate is a single constant — `app.rs::MVP_SESSIONS_ORIGIN_FILTER` —
-threaded through `App::sessions_origin_filter` so that the three places
-that have to stay in sync read the same value:
+The default is a single constant — `app.rs::DEFAULT_SESSIONS_ORIGIN_FILTER`
+(`OriginFilter::All`) — threaded through `App::sessions_origin_filter`
+so that the three places that have to stay in sync read the same value:
 
 1. `App::agents_rows_for_tab` (cursor / Enter dispatch source of
    truth) — applies the filter to both the snapshot path and the
@@ -426,24 +426,16 @@ is the public surface; `iter_sorted_with_filters` is the registry
 API. `iter_sorted_filtered` is preserved as a thin wrapper
 (`origin = All`) so existing call sites keep their behavior.
 
-**Debug overrides** (no rebuild required):
+**Slicing the out-of-band debug list** (`wta sessions list`):
 
-| Surface | How to see everything |
+| Surface | Command |
 |---|---|
-| session management picker, single helper | `WTA_SESSIONS_SHOW_AGENT_PANE=1` in that helper's env |
-| Out-of-band debug list | `wta sessions list` (defaults to `--origin all`) |
+| Everything (default) | `wta sessions list` (defaults to `--origin all`) |
 | Slice to shell only | `wta sessions list --origin shell` |
 | Slice to agent-pane only | `wta sessions list --origin agent-pane` |
 
 `wta sessions list` always asks master for the full registry and
-filters client-side, so it can act as the eye-of-god view even
-while every helper's session management picker stays in `ShellOnly`. The table
-output gains an `ORIGIN` column (`Shell` / `AgentPane` / `-` for
-untagged legacy rows); JSON output is unchanged because the field
-was already serialized.
-
-**Removing MVP gate.** When agent-pane session management is
-ready, flip `MVP_SESSIONS_ORIGIN_FILTER` to `OriginFilter::All` and
-delete `WTA_SESSIONS_SHOW_AGENT_PANE` handling in
-`resolve_sessions_origin_filter`. No other call site needs to change.
+filters client-side. The table output has an `ORIGIN` column
+(`Shell` / `AgentPane` / `-` for untagged legacy rows); JSON output
+carries the same field.
 

--- a/tools/wta/src/agent_sessions.rs
+++ b/tools/wta/src/agent_sessions.rs
@@ -145,14 +145,15 @@ pub enum SessionOrigin {
 }
 
 /// View-layer filter for `SessionOrigin`. Used by the `/sessions`
-/// picker so an MVP build can restrict the list to shell-pane sessions
-/// (user typed `copilot` in a normal shell) and hide WTA-spawned
-/// agent-pane sessions, without removing the data from the registry.
+/// picker and by `wta sessions list` to optionally restrict the list to
+/// one origin class — shell-pane sessions (user typed `copilot` in a
+/// normal shell) or WTA-spawned agent-pane sessions — without removing
+/// the data from the registry.
 ///
-/// Set the MVP default in `app.rs::MVP_SESSIONS_ORIGIN_FILTER`. Set
-/// `WTA_SESSIONS_SHOW_AGENT_PANE=1` to flip a single helper process to
-/// `All` for debugging. The `wta sessions list` CLI also accepts
-/// `--origin <shell|agent-pane|all>` for the same purpose.
+/// The `/sessions` picker defaults to `All` (see
+/// `app.rs::DEFAULT_SESSIONS_ORIGIN_FILTER`), so every origin is shown.
+/// The `wta sessions list` CLI accepts `--origin <shell|agent-pane|all>`
+/// to slice the out-of-band debug list.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum OriginFilter {
     /// Keep rows whose origin is `Unknown` (the user ran the CLI
@@ -161,8 +162,8 @@ pub enum OriginFilter {
     ShellOnly,
     /// Keep only `AgentPane` rows (sessions WTA spawned for an
     /// Intelligent Terminal agent pane). Hide `Unknown` and untagged
-    /// rows. Provided for symmetry / future un-MVP toggle; not used
-    /// by the default UX today.
+    /// rows. Provided for symmetry and for `wta sessions list
+    /// --origin agent-pane`; not used by the default picker UX.
     AgentPaneOnly,
     /// Keep every row regardless of origin. The historical default
     /// and the right setting for debug tooling that wants to see
@@ -2219,7 +2220,7 @@ mod tests {
     fn iter_sorted_with_filters_partitions_by_origin() {
         // Two rows, identical CLI, different SessionOrigin. ShellOnly
         // must hide the AgentPane row; AgentPaneOnly is the inverse;
-        // All keeps both. Confirms the MVP sessions filter contract.
+        // All keeps both. Confirms the origin filter contract.
         let mut reg = AgentSessionRegistry::new();
         reg.apply(SessionEvent::SessionStarted {
             key: k("shell-row"),

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -47,45 +47,24 @@ use autofix::*;
 
 pub use turn_state::{AutofixContext, ChunkKind, SubmittedPrompt, TurnOutcome, TurnState};
 
-// ─── MVP sessions origin filter ────────────────────────────────────────────────────
+// ─── Sessions origin filter ─────────────────────────────────────────────────────────
 //
-// The session management view (`/sessions`) currently ships in MVP
-// mode: it only surfaces shell-pane sessions (the user manually ran
-// `copilot` / `claude` / `gemini` in a regular shell). Agent-pane
-// sessions (Class A — created by WTA on behalf of an Intelligent
-// Terminal agent pane) stay in the registry so Enter routing,
-// alive-mirror reconciliation, and `wta sessions list` continue to
-// work; they just don't render in the picker.
+// The session management view (`/sessions`) surfaces every session WTA
+// knows about regardless of origin: both shell-pane sessions (Class B —
+// the user manually ran `copilot` / `claude` / `gemini` in a regular
+// shell) and agent-pane sessions (Class A — created by WTA on behalf of
+// an Intelligent Terminal agent pane). The Enter / Shift+Enter dispatch
+// table in `session_mgmt::decide_enter_action` knows how to route both
+// classes, so neither is hidden from the picker.
 //
-// To bring agent-pane sessions back into the picker once the manage UX
-// is ready, flip this constant to `OriginFilter::All` and delete the
-// `WTA_SESSIONS_SHOW_AGENT_PANE` env override below. No other call sites
-// need to change — all consumers go through
-// `App::sessions_origin_filter`.
-const MVP_SESSIONS_ORIGIN_FILTER: crate::agent_sessions::OriginFilter =
-    crate::agent_sessions::OriginFilter::ShellOnly;
-
-/// Resolve the `/sessions` origin filter for this process.
-///
-/// Defaults to [`MVP_SESSIONS_ORIGIN_FILTER`]. The `WTA_SESSIONS_SHOW_AGENT_PANE`
-/// env var (set to `1` / `true`) flips a single helper to
-/// `OriginFilter::All` for debugging — matches the existing
-/// `WTA_LOG_AGENT_EVENT` / `WTA_SOURCE_*` convention. Each helper is
-/// a separate process so the override only affects the pane that
-/// launched with the env var set; the rest of the Terminal keeps the
-/// MVP default.
-pub fn resolve_sessions_origin_filter() -> crate::agent_sessions::OriginFilter {
-    match std::env::var("WTA_SESSIONS_SHOW_AGENT_PANE")
-        .ok()
-        .as_deref()
-        .map(str::trim)
-    {
-        Some("1") | Some("true") | Some("TRUE") | Some("True") | Some("yes") => {
-            crate::agent_sessions::OriginFilter::All
-        }
-        _ => MVP_SESSIONS_ORIGIN_FILTER,
-    }
-}
+// `App::sessions_origin_filter` is still the single knob threaded through
+// the three places that must agree on which rows are visible
+// (`agents_rows_for_tab`, the post-history-scan auto-select / Delete
+// clamp, and `agents_view::render`); it just defaults to
+// [`OriginFilter::All`] now. The `wta sessions list --origin` CLI flag
+// continues to slice the out-of-band debug list by origin.
+const DEFAULT_SESSIONS_ORIGIN_FILTER: crate::agent_sessions::OriginFilter =
+    crate::agent_sessions::OriginFilter::All;
 
 use crate::commands::{self, CommandKind, CommandSpec, ParseOutcome, ParsedCommand};
 use crate::coordinator::{
@@ -1955,12 +1934,13 @@ pub struct App {
     /// can't rehydrate ACP sessions. Set on `AgentConnected`.
     pub agent_supports_load_session: bool,
     /// Origin filter for the `/sessions` picker. Captured once at
-    /// `App::new` time via [`resolve_sessions_origin_filter`] so the value is
-    /// stable for the lifetime of this helper process. Read by
-    /// [`Self::agents_rows_for_tab`] (the cursor / Enter source of
-    /// truth), the post-history-scan auto-select, the Delete clamp,
-    /// and the `agents_view::render` call in `ui/layout.rs`. See
-    /// [`MVP_SESSIONS_ORIGIN_FILTER`] for the gate to flip when un-MVP.
+    /// `App::new` time so the value is stable for the lifetime of this
+    /// helper process. Read by [`Self::agents_rows_for_tab`] (the cursor
+    /// / Enter source of truth), the post-history-scan auto-select, the
+    /// Delete clamp, and the `agents_view::render` call in
+    /// `ui/layout.rs`. Defaults to [`DEFAULT_SESSIONS_ORIGIN_FILTER`]
+    /// (`All` — every origin is shown); tests override it to exercise
+    /// the per-origin slicing.
     pub sessions_origin_filter: crate::agent_sessions::OriginFilter,
     // Onboarding: signals main.rs to install agent hook plugins on demand.
     install_request_tx: Option<mpsc::UnboundedSender<()>>,
@@ -2204,7 +2184,7 @@ impl App {
             agent_sessions: crate::agent_sessions::AgentSessionRegistry::new(),
             history_load_state: HistoryLoadState::NotStarted,
             agent_supports_load_session: false,
-            sessions_origin_filter: resolve_sessions_origin_filter(),
+            sessions_origin_filter: DEFAULT_SESSIONS_ORIGIN_FILTER,
             install_request_tx: None,
             agent_event_tx: None,
             session_hook_tx: None,
@@ -3599,7 +3579,7 @@ impl App {
             if let Some(want) = filter.as_ref() {
                 rows.retain(|s| &s.cli_source == want || matches!(&s.cli_source, crate::agent_sessions::CliSource::Unknown(v) if v.is_empty()));
             }
-            // Apply the MVP origin filter on top of the cli filter.
+            // Apply the origin filter on top of the cli filter.
             // Snapshot rows come from master via SessionInfo where origin
             // is Option<SessionOrigin>; session_info_to_agent_session
             // collapses None -> SessionOrigin::Unknown so a registry-style
@@ -6423,7 +6403,7 @@ impl App {
                                 // Keep the cursor in-bounds after eviction.
                                 // Re-query through the same filters so the
                                 // selection clamp matches the rendered list
-                                // (both cli + MVP origin filter).
+                                // (both cli + origin filter).
                                 let new_count = self
                                     .agent_sessions
                                     .iter_sorted_with_filters(
@@ -11026,11 +11006,13 @@ mod tests {
         );
     }
 
-    /// MVP sessions origin filter: with `ShellOnly`, agent-pane rows must
+    /// Sessions origin filter: with `ShellOnly`, agent-pane rows must
     /// be hidden from `agents_rows_for_tab` (the cursor / Enter
     /// dispatch source of truth) — *not just* from `agents_view::render`.
     /// A bug where render filtered but `agents_rows_for_tab` didn't
-    /// would let Enter on visible row N activate hidden row M.
+    /// would let Enter on visible row N activate hidden row M. (The
+    /// shipping default is `All`; this test drives the filter axis
+    /// explicitly.)
     #[test]
     fn shell_only_filter_hides_agent_pane_rows_from_cursor_model() {
         use crate::agent_sessions::{OriginFilter, SessionOrigin};
@@ -11051,8 +11033,8 @@ mod tests {
         assert_eq!(rows.len(), 1, "only the Class B row is visible: {rows:?}");
         assert_eq!(rows[0].key, "class-b");
 
-        // Flip to All — both rows must reappear so the un-MVP toggle
-        // brings agent-pane rows back without any other code change.
+        // Flip to All (the shipping default) — both rows must appear so
+        // agent-pane sessions are reachable in the picker.
         app.sessions_origin_filter = OriginFilter::All;
         let rows = app.agents_rows_for_tab(DEFAULT_TAB_ID);
         assert_eq!(rows.len(), 2);
@@ -11067,7 +11049,7 @@ mod tests {
     /// Registry path (no snapshot): the same filter must apply when
     /// `agents_rows_for_tab` falls back to `agent_sessions` directly.
     /// Without this, helpers that haven't received a master snapshot
-    /// yet would show every row regardless of the MVP filter.
+    /// yet would show every row regardless of the configured filter.
     #[test]
     fn shell_only_filter_applies_to_registry_fallback_path() {
         use crate::agent_sessions::{CliSource, OriginFilter, SessionEvent, SessionOrigin};
@@ -11095,37 +11077,6 @@ mod tests {
         let rows = app.agents_rows_for_tab(DEFAULT_TAB_ID);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].key, "shell-key");
-    }
-
-    /// `resolve_sessions_origin_filter` reads the `WTA_SESSIONS_SHOW_AGENT_PANE`
-    /// env var. With it unset (or 0/false) the MVP default
-    /// (`ShellOnly`) wins; with it set to a truthy value we flip to
-    /// `All` so a single debug helper can see everything without a
-    /// rebuild.
-    ///
-    /// Env vars are process-global, so this test serializes via the
-    /// `WTA_SESSIONS_SHOW_AGENT_PANE_TEST_LOCK` mutex shared with any other
-    /// future test that touches the same var.
-    #[test]
-    fn resolve_sessions_origin_filter_respects_env_override() {
-        use crate::agent_sessions::OriginFilter;
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
-
-        std::env::remove_var("WTA_SESSIONS_SHOW_AGENT_PANE");
-        assert_eq!(crate::app::resolve_sessions_origin_filter(), MVP_SESSIONS_ORIGIN_FILTER);
-        assert_eq!(MVP_SESSIONS_ORIGIN_FILTER, OriginFilter::ShellOnly);
-
-        std::env::set_var("WTA_SESSIONS_SHOW_AGENT_PANE", "1");
-        assert_eq!(crate::app::resolve_sessions_origin_filter(), OriginFilter::All);
-
-        std::env::set_var("WTA_SESSIONS_SHOW_AGENT_PANE", "true");
-        assert_eq!(crate::app::resolve_sessions_origin_filter(), OriginFilter::All);
-
-        std::env::set_var("WTA_SESSIONS_SHOW_AGENT_PANE", "0");
-        assert_eq!(crate::app::resolve_sessions_origin_filter(), MVP_SESSIONS_ORIGIN_FILTER);
-
-        std::env::remove_var("WTA_SESSIONS_SHOW_AGENT_PANE");
     }
 
     #[test]
@@ -11743,10 +11694,9 @@ mod tests {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         use std::path::PathBuf;
         let mut app = test_app();
-        // This test exercises the Class A (AgentPane) Enter routing,
-        // which the MVP sessions filter hides. Opt out so the row is
-        // visible to the cursor; the dispatch logic under test is
-        // unchanged by the filter.
+        // This test exercises the Class A (AgentPane) Enter routing.
+        // The picker now defaults to showing every origin; set it
+        // explicitly here so the test is robust to that default.
         app.sessions_origin_filter = OriginFilter::All;
         app.agent_supports_load_session = true;
         app.agent_sessions.apply(SessionEvent::SessionStarted {
@@ -11831,9 +11781,9 @@ mod tests {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         use std::path::PathBuf;
         let mut app = test_app();
-        // Same rationale as the Class A dead-row tests above:
-        // MVP sessions filter hides AgentPane rows, this test verifies the
-        // dispatch logic for when they are visible.
+        // Same as the Class A dead-row tests above: set the filter
+        // explicitly so the AgentPane row is visible regardless of the
+        // picker default (which now shows every origin).
         app.sessions_origin_filter = OriginFilter::All;
         app.agent_sessions.apply(SessionEvent::SessionStarted {
             key: "live-class-a".into(),

--- a/tools/wta/src/cli_tests.rs
+++ b/tools/wta/src/cli_tests.rs
@@ -55,10 +55,10 @@ fn sessions_list_cli_parses_json_and_master_override() {
         Some(Command::Sessions { action: SessionsAction::List { master, origin } }) => {
             assert_eq!(master.as_deref(), Some(r"\\.\pipe\wta-master-test"));
             // Default keeps the historical debug behavior — show
-            // every origin. MVP sessions picker has its own default in
-            // `app::resolve_sessions_origin_filter`; this CLI default is
-            // intentionally divergent so `wta sessions list` is
-            // the "see everything" debug tool.
+            // every origin, matching the `/sessions` picker default
+            // (`app::DEFAULT_SESSIONS_ORIGIN_FILTER`). `wta sessions
+            // list` is the "see everything" debug tool; `--origin
+            // shell|agent-pane` slices it.
             assert_eq!(origin, SessionsOriginArg::All);
         }
         other => panic!("expected sessions list command, got {other:?}"),

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -476,9 +476,9 @@ enum SessionsAction {
         master: Option<String>,
 
         /// Restrict the list to a session origin. `all` (default) shows
-        /// every row — that matches the historical debug behavior.
-        /// `shell` shows only user-started shell-pane sessions (the
-        /// MVP sessions default). `agent-pane` shows only sessions that
+        /// every row — that matches the historical debug behavior and
+        /// the `/sessions` picker. `shell` shows only user-started
+        /// shell-pane sessions; `agent-pane` shows only sessions that
         /// WTA spawned for an Intelligent Terminal agent pane.
         #[arg(long, value_enum, default_value_t = SessionsOriginArg::All)]
         origin: SessionsOriginArg,
@@ -491,10 +491,10 @@ enum SessionsAction {
 /// crate with clap as a dependency.
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
 enum SessionsOriginArg {
-    /// Shell-pane sessions only (Class B). Matches the MVP sessions picker.
+    /// Shell-pane sessions only (Class B).
     Shell,
-    /// Agent-pane sessions only (Class A). Hidden from the MVP sessions
-    /// picker; surfaced here for debugging.
+    /// Agent-pane sessions only (Class A) — sessions WTA spawned for
+    /// an Intelligent Terminal agent pane.
     AgentPane,
     /// Every row in the registry — historical debug default.
     All,
@@ -1207,9 +1207,9 @@ async fn run_sessions_list(
         .await?;
     // Origin filter is applied client-side: master always returns the
     // full registry so this command can act as the debug eye-of-god
-    // view (default `--origin all`). `--origin shell` matches what
-    // the MVP sessions picker shows; `--origin agent-pane` surfaces the
-    // rows MVP sessions hides.
+    // view (default `--origin all`, matching the `/sessions` picker).
+    // `--origin shell` slices to shell-pane sessions; `--origin
+    // agent-pane` slices to agent-pane sessions.
     let filtered: Vec<session_registry::SessionInfo> = sessions
         .into_iter()
         .filter(|s| origin_filter.matches_opt(s.origin.as_ref()))

--- a/tools/wta/src/ui/agents_view.rs
+++ b/tools/wta/src/ui/agents_view.rs
@@ -33,8 +33,8 @@ pub fn render(
     history_load_state: HistoryLoadState,
     activity_frame: usize,
     cli_filter: Option<&CliSource>,
-    // MVP origin filter — `ShellOnly` by default, see
-    // `app.rs::MVP_SESSIONS_ORIGIN_FILTER`. Must match whatever filter
+    // Origin filter — `All` by default (see
+    // `app.rs::DEFAULT_SESSIONS_ORIGIN_FILTER`). Must match whatever filter
     // `App::agents_rows_for_tab` applies so the rendered rows line
     // up with the cursor / Enter dispatch model. Caller threads the
     // stored `app.sessions_origin_filter`.
@@ -119,7 +119,7 @@ pub fn render(
                     || matches!(&s.cli_source, CliSource::Unknown(v) if v.is_empty())
             });
         }
-        // MVP origin filter. Stays in sync with the same retain inside
+        // Origin filter. Stays in sync with the same retain inside
         // `App::agents_rows_for_tab` (which feeds the cursor / Enter
         // dispatch); both call sites read `app.sessions_origin_filter`.
         // `session_info_to_agent_session` collapses None origin to


### PR DESCRIPTION
## Summary

The `/sessions` session-management picker shipped in ""MVP"" mode that surfaced only **Class B** (shell-pane) sessions — the user manually ran `copilot` / `claude` / `gemini` in a regular shell — and hid **Class A** (agent-pane) sessions that WTA spawned on behalf of an Intelligent Terminal agent pane. Both classes already route correctly through `session_mgmt::decide_enter_action`, so there's no reason to keep agent-pane sessions out of the picker.

This PR makes the picker **show all session origins**.

## Changes

- **`app.rs`** — Replace the `MVP_SESSIONS_ORIGIN_FILTER` (`ShellOnly`) constant and the `resolve_sessions_origin_filter()` env-override resolver with `DEFAULT_SESSIONS_ORIGIN_FILTER = OriginFilter::All`; the field is initialized to it directly. Remove the obsolete `WTA_SESSIONS_SHOW_AGENT_PANE` env-override and its test.
- **`agent_sessions.rs` / `main.rs` / `cli_tests.rs` / `ui/agents_view.rs` / `tools/wta/AGENTS.md`** — Update doc comments to reflect the new default.

The `OriginFilter` axis, the `App::sessions_origin_filter` field, and `wta sessions list --origin shell|agent-pane|all` slicing are all preserved — only the picker's **default** changes. No Enter/Shift+Enter dispatch logic needed to change.

## Verification

- `cargo build` — succeeds
- `cargo test` — **711 passed, 0 failed**
- No remaining references to the removed symbols anywhere in the tree