### PR TITLE
Hook-independent pane↔session binding for WTA-launched CLI sessions

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -156,6 +156,7 @@ parallelizable
 passthrough
 peekable
 perlw
+pinnable
 pkgver
 postmodern
 Powerline

--- a/doc/specs/wta-launched-cli-session-binding.md
+++ b/doc/specs/wta-launched-cli-session-binding.md
@@ -1,0 +1,227 @@
+# Hook-Independent Pane ↔ Session Binding for WTA-Launched CLI Sessions
+
+> Status: **Draft — design approved 2026-06-10.** Base branch: **`main`**.
+> Intended to merge **independently and ahead of** the hookless watcher work
+> (`dev/yuazha/hookless-agent-session-tracking`). Next step: implementation plan
+> (writing-plans).
+
+## Context & problem
+
+Intelligent Terminal classifies agent sessions by `SessionOrigin`
+(`agent_sessions.rs`):
+
+- **Class A — `AgentPane`**: an ACP session WTA created for an agent pane. Bound
+  via ACP `session/new`. WTA already records `(session_id, pane_session_id)` for
+  these in `agent_pane_origin.rs` (v2 index).
+- **Class B — `Unknown`**: an agent CLI (`copilot` / `claude` / `gemini` /
+  `codex`) running in a normal shell pane. **On `main`, Class B is tracked by
+  hooks**: each CLI's `wt-agent-hooks` plugin reports `agent_session_id` plus
+  `WT_SESSION` (the pane GUID), so today's binding is exact — but it depends on
+  hooks.
+
+The wider "de-hook" effort removes hooks. Once they are gone, Class-B binding
+must be reconstructed. The hookless branch does that for **user-typed** sessions
+with a file watcher + per-CLI pid heuristics (exact for Copilot/Codex, but
+ambiguous cwd-correlation for Claude/Gemini).
+
+A subset of Class-B sessions are **not** user-typed — **WTA launches them
+itself**:
+
+- **(a)** `?<prompt>` delegation and the no-prompt background-agent action
+  (`openBackgroundAgent`, Alt+Shift+B) → `wta delegate` opens a new tab whose
+  command line is the agent's own interactive CLI.
+- **(b)** Agent-pane recommendations that open a CLI in a new tab/panel
+  (`RecommendedAction::OpenAndSend { agent }` / `Open { agent }`).
+- **(c)** `/sessions` resume via the CLI's own resume flag (`ResumeCliFlag` → new
+  pane running `<cli> --resume <key>`).
+
+For these, WTA controls the launch, so it can bind deterministically **without
+hooks** — by pinning the session id (`--session-id`) and reading the pane GUID
+back from `create_tab`. This is the cleanest, most independent slice of the
+de-hook work, so it ships **first, on `main`**.
+
+## Goal
+
+For WTA-launched CLI sessions whose agent supports `--session-id`
+(**Copilot / Claude / Gemini**), establish the `(session id → pane GUID)`
+binding **at launch, with no hooks**, by registering a *born-bound* session row
+directly into the `wta-master` registry. Independently mergeable on `main`,
+ahead of the hookless watcher.
+
+## Non-goals
+
+- **Not removing hooks.** This branch coexists with `main`'s hooks; it only adds
+  a hook-independent binding *source* for the WTA-launched, pinnable subset.
+- **No watcher.** No dependency on the hookless `session_watcher` (which does not
+  exist on `main`).
+- **No `SessionOrigin` / UI change.** Sessions stay `Unknown` (Class B); no
+  change to `OriginFilter`, `/sessions` rendering or Enter/Resume routing,
+  registry serialization, or `history_loader`.
+- **Codex is out of scope.** It cannot pin `--session-id`, so it keeps using
+  `main`'s existing Codex hook (`wt-agent-hooks/codex/.../send-event.ps1`)
+  unchanged. Codex's hook-independent binding arrives later via the hookless
+  watcher (Restart Manager, already exact for Codex).
+- **User-typed (non-WTA-launched) sessions** are likewise untouched here — they
+  stay on hooks until the hookless branch.
+- Not fixing CLI resume addressability (Gemini `--resume` is index-based; Codex
+  has no resume flag) — a pre-existing property of `ResumeCliFlag`.
+
+## Scope: which launches
+
+(a) `?<prompt>` delegation + `openBackgroundAgent` (`wta delegate`).
+(b) agent-pane recommendation opens (`OpenAndSend { agent }` / `Open { agent }`).
+(c) `/sessions` `ResumeCliFlag` (`<cli> --resume <key>`; id known = the resume key).
+
+For all three, **only the pinnable agents (Copilot / Claude / Gemini)**. Codex
+launches are left on the existing path.
+
+## Key enabling facts (empirically verified 2026-06-10, Windows)
+
+**1. `--session-id <uuid>` pins a chosen id for a NEW session:**
+
+| CLI | pins a new id? | file lands at | id recoverable from filename? |
+|---|---|---|---|
+| Copilot | yes | `~/.copilot/session-state/<uuid>/events.jsonl` | yes — dir name `<uuid>` |
+| Claude  | yes | `~/.claude/projects/<enc-cwd>/<uuid>.jsonl` | yes — stem `<uuid>` |
+| Gemini  | yes | `~/.gemini/tmp/<cwd-slug>/chats/session-<ts>-<uuid[0:8]>.jsonl` (full uuid in content) | partial — only `uuid[0:8]` in the name |
+| Codex   | no | `rollout-<ts>-<uuid>.jsonl` | n/a (cannot choose the id) |
+
+(The Gemini filename caveat is irrelevant on this branch — we never discover the
+file here; we register by the full pinned uuid. It matters only for the hookless
+watcher's later reconciliation.)
+
+**2. `create_tab` / `split_pane` return the new pane's identity:**
+`TabCreationResult { UInt32 TabId; Guid SessionId; UInt64 WindowId; UInt32 Pid }`
+(`TerminalProtocol.idl`). WTA receives the **pane GUID (`SessionId`) and the
+pane's root Pid** synchronously at launch.
+
+## Design
+
+### Mechanism — born-bound registration at launch
+
+At each in-scope launch:
+
+```
+1. id  = (a,b) generate a v4 UUID  |  (c) the resume key
+2. cmd = <cli> ... <new_session_id_flag> <id>          (flag from agent_registry)
+3. TabCreationResult = COM create_tab / split_pane(cmd)   -> pane GUID + Pid
+4. tell wta-master:  RegisterLaunchedSession { id, cli, cwd, pane_guid }
+       -> master upserts a SessionInfo with
+            pane_session_id = pane_guid,
+            cli_source      = cli,
+            origin          = Unknown,        (Class B — unchanged)
+            status          = Idle
+```
+
+No file discovery, no hooks, no PEB read — the row is **born bound** to the pane.
+
+**Precedent**: master already records `(session_id, pane_session_id)` for Class A
+agent panes (`agent_pane_origin.rs` v2), and the registry already carries the
+`pane_session_id` field. This reuses that shape for the
+(`Unknown`-origin) WTA-launched shell CLIs.
+
+### `agent_registry` change
+
+Add a capability field, mirroring the existing `resume_flag`:
+
+```rust
+/// Flag the CLI uses to pin a caller-chosen id on a NEW session,
+/// e.g. "--session-id". None when unsupported.
+pub new_session_id_flag: Option<&'static str>,
+```
+
+`Some("--session-id")` for copilot / claude / gemini; `None` for codex (and
+unknown/custom). The launch path only does born-bound registration when this is
+`Some`.
+
+### Transport
+
+- **(b)/(c)** originate in a helper, already connected to master → send
+  `RegisterLaunchedSession` over the existing pipe.
+- **(a)** originates in the short-lived `wta delegate` process → connect to the
+  master pipe (`master-pipe.txt` rendezvous), send, exit. Master not running →
+  no-op (no registry to populate; harmless).
+
+### Storage / lifetime
+
+The binding lives in master's **in-memory** registry row (`pane_session_id`).
+**Ephemeral** — pane GUIDs are regenerated each WT run, so the binding is **never
+persisted to disk**. Conversation history still lives in the CLI's own session
+files and is reconstructed by `history_loader` as today; the pane binding is not
+needed after a restart.
+
+### Liveness — unchanged on this branch
+
+`main`'s `SessionInfo` has no `bound_pid` field and no liveness reaper — that is a
+hookless-branch concept. A born-bound row's liveness continues via the existing
+source (hooks) until the hookless watcher lands. The `create_tab` Pid is captured
+for diagnostics/logging only; pid-based liveness is deferred to the hookless branch.
+
+### Coexistence with hooks (on this branch)
+
+On `main` the pinnable CLIs' hooks still fire and report the same session id
+(= the pinned uuid) and `WT_SESSION`. Because both key by the same id, a hook
+event merges into the born-bound row (same pane) — no conflict. The born-bound
+registration is the part that keeps binding working once hooks are removed.
+
+### Scope boundary — binding vs activity (decided: binding-only)
+
+This branch makes **binding** hook-independent. **Activity** (Working / Idle /
+Attention) for these sessions continues via the existing source (hooks on
+`main`) until the hookless watcher lands. So here a WTA-launched session is born
+**bound + Live with coarse status**; fine-grained activity still arrives via
+hooks. **Decided 2026-06-10: binding-only on this branch** — keeping it the
+smallest, most independent slice; activity is intentionally left to
+hooks/hookless.
+
+## What is explicitly unchanged
+
+`SessionOrigin` (stays `Unknown`), `OriginFilter`, `/sessions` UI + routing,
+registry serialization, `history_loader`, user-typed Class-B binding, and Codex.
+
+## Edge cases & failure modes
+
+- **Master not running at (a) launch** → register is a no-op; harmless.
+- **`create_tab` returns no/unexpected pane** → skip registration; the session,
+  if it surfaces at all, falls to the existing path.
+- **(c) resume reuses an existing row** (same id = resume key) → re-bind that
+  Ended/Historical row to the new pane and flip it Live; no duplicate row.
+- **Pinnable CLI with hook also present** (this branch) → hook event merges into
+  the born-bound row by id; consistent (same pane).
+- **Codex / user-typed** → untouched (existing hooks path).
+- **Gemini filename only carries `uuid[0:8]`** → irrelevant here (we register by
+  the full pinned uuid; no discovery). Becomes relevant only when the hookless
+  watcher must reconcile its discovered key to this row — deferred there.
+
+## Testing
+
+- **Unit**: `new_session_id_flag` per CLI; the launch→command builder (contains
+  `<flag> <uuid>` for pinnable agents, absent for Codex); `RegisterLaunchedSession`
+  upserts a `SessionInfo` with `pane_session_id` + `origin = Unknown`.
+- **Integration** (run 2026-06-10; keep as a documented manual test): each
+  pinnable CLI launched headless with `--session-id <uuid>` writes its session
+  under that uuid (Copilot dir / Claude stem `== uuid`; Gemini filename trailing
+  group `== uuid[0:8]`, full uuid in content); `create_tab` returns a pane GUID.
+- **End-to-end**: `?<prompt>` a Copilot/Claude/Gemini delegate; assert the
+  `/sessions` row is born bound to the `create_tab` pane GUID with no hook
+  involved in the binding, and Focus targets that pane.
+
+## Rejected / deferred alternatives
+
+- **New `SessionOrigin::Delegated` (three-way enum).** Rejected: conflates *who
+  owns the conversation* (shell CLI vs agent pane) with *who initiated the
+  launch* (user vs WTA). If a future requirement needs to surface delegate
+  sessions distinctly, prefer an orthogonal provenance field
+  (`initiated_by: User | Wta`). Not needed for the binding goal.
+- **On-disk launch-intent index.** Rejected: the binding is ephemeral (pane
+  GUIDs are per-WT-run); the in-memory registry row suffices.
+- **Watcher-consults-intent join.** That is the *hookless-branch* design and
+  presumes a `session_watcher` that does not exist on `main`. Not applicable
+  here.
+- **Codex via `--session-id`.** Unsupported by the CLI; deferred to the hookless
+  watcher (Restart Manager, already exact).
+
+## Open questions
+
+- Should (a)'s `wta delegate` register over the master pipe, or be
+  re-architected to launch *through* master (larger change, deferred)?

--- a/doc/specs/wta-launched-cli-session-binding.md
+++ b/doc/specs/wta-launched-cli-session-binding.md
@@ -1,10 +1,5 @@
 # Hook-Independent Pane ↔ Session Binding for WTA-Launched CLI Sessions
 
-> Status: **Draft — design approved 2026-06-10.** Base branch: **`main`**.
-> Intended to merge **independently and ahead of** the hookless watcher work
-> (`dev/yuazha/hookless-agent-session-tracking`). Next step: implementation plan
-> (writing-plans).
-
 ## Context & problem
 
 Intelligent Terminal classifies agent sessions by `SessionOrigin`
@@ -19,13 +14,9 @@ Intelligent Terminal classifies agent sessions by `SessionOrigin`
   `WT_SESSION` (the pane GUID), so today's binding is exact — but it depends on
   hooks.
 
-The wider "de-hook" effort removes hooks. Once they are gone, Class-B binding
-must be reconstructed. The hookless branch does that for **user-typed** sessions
-with a file watcher + per-CLI pid heuristics (exact for Copilot/Codex, but
-ambiguous cwd-correlation for Claude/Gemini).
-
-A subset of Class-B sessions are **not** user-typed — **WTA launches them
-itself**:
+The wider "de-hook" effort aims to stop relying on hooks for that binding. The
+easiest part to tackle first is the subset of Class-B sessions that are **not**
+user-typed — the ones **WTA launches itself**:
 
 - **(a)** `?<prompt>` delegation and the no-prompt background-agent action
   (`openBackgroundAgent`, Alt+Shift+B) → `wta delegate` opens a new tab whose
@@ -45,26 +36,22 @@ de-hook work, so it ships **first, on `main`**.
 For WTA-launched CLI sessions whose agent supports `--session-id`
 (**Copilot / Claude / Gemini**), establish the `(session id → pane GUID)`
 binding **at launch, with no hooks**, by registering a *born-bound* session row
-directly into the `wta-master` registry. Independently mergeable on `main`,
-ahead of the hookless watcher.
+directly into the `wta-master` registry. Independently mergeable on `main`.
 
 ## Non-goals
 
 - **Not removing hooks.** This branch coexists with `main`'s hooks; it only adds
   a hook-independent binding *source* for the WTA-launched, pinnable subset.
-- **No watcher.** No dependency on the hookless `session_watcher` (which does not
-  exist on `main`).
+- **No new background scanning.** Binding is established synchronously at launch;
+  nothing polls processes or tails session files.
 - **No `SessionOrigin` / UI change.** Sessions stay `Unknown` (Class B); no
   change to `OriginFilter`, `/sessions` rendering or Enter/Resume routing,
   registry serialization, or `history_loader`.
 - **Codex is out of scope.** It cannot pin `--session-id`, so it keeps using
   `main`'s existing Codex hook (`wt-agent-hooks/codex/.../send-event.ps1`)
-  unchanged. Codex's hook-independent binding arrives later via the hookless
-  watcher (Restart Manager, already exact for Codex).
-- **User-typed (non-WTA-launched) sessions** are likewise untouched here — they
-  stay on hooks until the hookless branch.
-- Not fixing CLI resume addressability (Gemini `--resume` is index-based; Codex
-  has no resume flag) — a pre-existing property of `ResumeCliFlag`.
+  unchanged.
+- **User-typed (non-WTA-launched) sessions** are untouched here — they stay on
+  the existing hook path.
 
 ## Scope: which launches
 
@@ -86,9 +73,8 @@ launches are left on the existing path.
 | Gemini  | yes | `~/.gemini/tmp/<cwd-slug>/chats/session-<ts>-<uuid[0:8]>.jsonl` (full uuid in content) | partial — only `uuid[0:8]` in the name |
 | Codex   | no | `rollout-<ts>-<uuid>.jsonl` | n/a (cannot choose the id) |
 
-(The Gemini filename caveat is irrelevant on this branch — we never discover the
-file here; we register by the full pinned uuid. It matters only for the hookless
-watcher's later reconciliation.)
+(The Gemini filename caveat is irrelevant here: we register by the full pinned
+uuid — this feature never discovers the file by name.)
 
 **2. `create_tab` / `split_pane` return the new pane's identity:**
 `TabCreationResult { UInt32 TabId; Guid SessionId; UInt64 WindowId; UInt32 Pid }`
@@ -105,7 +91,7 @@ At each in-scope launch:
 1. id  = (a,b) generate a v4 UUID  |  (c) the resume key
 2. cmd = <cli> ... <new_session_id_flag> <id>          (flag from agent_registry)
 3. TabCreationResult = COM create_tab / split_pane(cmd)   -> pane GUID + Pid
-4. tell wta-master:  RegisterLaunchedSession { id, cli, cwd, pane_guid }
+4. register the session with wta-master   { id, cli, cwd, pane_guid }
        -> master upserts a SessionInfo with
             pane_session_id = pane_guid,
             cli_source      = cli,
@@ -114,6 +100,11 @@ At each in-scope launch:
 ```
 
 No file discovery, no hooks, no PEB read — the row is **born bound** to the pane.
+
+> **As built:** that "register" step is the existing
+> `intellterm.wta/session_hook` ext-method with a `SessionStarted` event — the
+> master reducer already turns it into a born-bound Class-B row, so no new
+> message type was needed.
 
 **Precedent**: master already records `(session_id, pane_session_id)` for Class A
 agent panes (`agent_pane_origin.rs` v2), and the registry already carries the
@@ -136,11 +127,16 @@ unknown/custom). The launch path only does born-bound registration when this is
 
 ### Transport
 
-- **(b)/(c)** originate in a helper, already connected to master → send
-  `RegisterLaunchedSession` over the existing pipe.
-- **(a)** originates in the short-lived `wta delegate` process → connect to the
-  master pipe (`master-pipe.txt` rendezvous), send, exit. Master not running →
-  no-op (no registry to populate; harmless).
+- **(a)** runs in the short-lived `wta delegate` process. It opens its own
+  connection to the master pipe (`master-pipe.txt` rendezvous), registers, and
+  exits — the same transport `wta sessions list` already uses. Master not
+  running → no-op (no registry to populate; harmless).
+- **(c)** runs in the helper, which already creates the resume tab and binds its
+  pane (`ResumePaneAssigned`) — it is born-bound today, so no new transport is
+  needed.
+- **(b)** runs in the recommendation executor (`coordinator.rs`), which only
+  holds an `AppEvent` channel back to the app, **not** a direct master
+  connection — see *Deferred* below.
 
 ### Storage / lifetime
 
@@ -150,12 +146,12 @@ persisted to disk**. Conversation history still lives in the CLI's own session
 files and is reconstructed by `history_loader` as today; the pane binding is not
 needed after a restart.
 
-### Liveness — unchanged on this branch
+### Liveness — unchanged here
 
-`main`'s `SessionInfo` has no `bound_pid` field and no liveness reaper — that is a
-hookless-branch concept. A born-bound row's liveness continues via the existing
-source (hooks) until the hookless watcher lands. The `create_tab` Pid is captured
-for diagnostics/logging only; pid-based liveness is deferred to the hookless branch.
+`main`'s `SessionInfo` has no `bound_pid` field and no liveness reaper, so this
+feature does not change liveness: a born-bound row's Live/Ended state keeps
+coming from the existing hooks + WT pane events. The `create_tab` Pid is captured
+for diagnostics/logging only.
 
 ### Coexistence with hooks (on this branch)
 
@@ -166,13 +162,12 @@ registration is the part that keeps binding working once hooks are removed.
 
 ### Scope boundary — binding vs activity (decided: binding-only)
 
-This branch makes **binding** hook-independent. **Activity** (Working / Idle /
-Attention) for these sessions continues via the existing source (hooks on
-`main`) until the hookless watcher lands. So here a WTA-launched session is born
-**bound + Live with coarse status**; fine-grained activity still arrives via
-hooks. **Decided 2026-06-10: binding-only on this branch** — keeping it the
-smallest, most independent slice; activity is intentionally left to
-hooks/hookless.
+This feature makes **binding** hook-independent. **Activity** (Working / Idle /
+Attention) for these sessions still comes from the existing hook path. So a
+WTA-launched session is born **bound + Live with coarse status**; fine-grained
+activity arrives via hooks as today. **Decided 2026-06-10: binding-only** —
+keeping this the smallest, most independent slice; activity is intentionally
+left on the existing path.
 
 ## What is explicitly unchanged
 
@@ -189,14 +184,13 @@ registry serialization, `history_loader`, user-typed Class-B binding, and Codex.
 - **Pinnable CLI with hook also present** (this branch) → hook event merges into
   the born-bound row by id; consistent (same pane).
 - **Codex / user-typed** → untouched (existing hooks path).
-- **Gemini filename only carries `uuid[0:8]`** → irrelevant here (we register by
-  the full pinned uuid; no discovery). Becomes relevant only when the hookless
-  watcher must reconcile its discovered key to this row — deferred there.
+- **Gemini filename only carries `uuid[0:8]`** → irrelevant here: we register by
+  the full pinned uuid; this feature never discovers the file by name.
 
 ## Testing
 
 - **Unit**: `new_session_id_flag` per CLI; the launch→command builder (contains
-  `<flag> <uuid>` for pinnable agents, absent for Codex); `RegisterLaunchedSession`
+  `<flag> <uuid>` for pinnable agents, absent for Codex); the registration step
   upserts a `SessionInfo` with `pane_session_id` + `origin = Unknown`.
 - **Integration** (run 2026-06-10; keep as a documented manual test): each
   pinnable CLI launched headless with `--session-id <uuid>` writes its session
@@ -215,13 +209,26 @@ registry serialization, `history_loader`, user-typed Class-B binding, and Codex.
   (`initiated_by: User | Wta`). Not needed for the binding goal.
 - **On-disk launch-intent index.** Rejected: the binding is ephemeral (pane
   GUIDs are per-WT-run); the in-memory registry row suffices.
-- **Watcher-consults-intent join.** That is the *hookless-branch* design and
-  presumes a `session_watcher` that does not exist on `main`. Not applicable
-  here.
-- **Codex via `--session-id`.** Unsupported by the CLI; deferred to the hookless
-  watcher (Restart Manager, already exact).
+- **Codex via `--session-id`.** The CLI can't pin a chosen id on a new session,
+  so Codex isn't covered here; it stays on its existing path.
 
-## Open questions
+## Deferred: (b) the recommendation-open path
 
-- Should (a)'s `wta delegate` register over the master pipe, or be
-  re-architected to launch *through* master (larger change, deferred)?
+(a) and (c) are implemented; (b) is intentionally left for a follow-up — not
+because its logic differs, but because it's the awkward one to wire. The
+difference is **where the launch runs and what it can reach**:
+
+| Path | Runs in | Has at hand | Registering the binding |
+|---|---|---|---|
+| **(a)** `?delegate` / `Alt+Shift+B` | a dedicated, short-lived `wta delegate` process | creates the tab itself (gets the pane GUID); can open its own master connection | clean — **done** |
+| **(c)** `/sessions` resume | the helper (`dispatch_resume`) | already creates the tab and binds the pane (`ResumePaneAssigned`) | already born-bound — **nothing to add** |
+| **(b)** agent-pane recommendation `OpenAndSend{agent}` | the recommendation executor in `coordinator.rs` | creates the tab (gets the pane id) but only holds an `AppEvent` channel, **not** a master connection | a registration route must be chosen |
+
+So (b)'s extra cost is **plumbing, not logic**: its executor is embedded in the
+running helper alongside the recommendation's other actions, and it has no direct
+line to master. Registering its born-bound row means either (i) emitting an
+`AppEvent` that the app turns into the existing master publish, or (ii) giving the
+executor its own master sender like (a)'s. Threading that through without
+disturbing the recommendation's other steps is why (b) is deferred to its own
+change. It will reuse the exact same id-pinning and born-bound registration as
+(a); only the transport differs.

--- a/tools/wta/Cargo.lock
+++ b/tools/wta/Cargo.lock
@@ -2683,6 +2683,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "unicode-width",
+ "uuid",
  "which",
  "windows-sys",
 ]

--- a/tools/wta/Cargo.toml
+++ b/tools/wta/Cargo.toml
@@ -40,5 +40,6 @@ tracing-appender = "0.2"
 # for the event-emission style we mirror here.
 tracelogging = "1"
 which = "7"
+uuid = { version = "1", features = ["v4"] }
 rust-i18n = "3"
 sys-locale = "0.3"

--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -72,6 +72,9 @@ pub struct AgentProfile {
     /// Flag the CLI uses to resume a session, e.g. `"--resume"` for Claude.
     /// Empty when resume is unsupported.
     pub resume_flag: &'static str,
+    /// Flag the CLI uses to pin a caller-chosen id on a NEW session,
+    /// e.g. "--session-id". `None` when unsupported.
+    pub new_session_id_flag: Option<&'static str>,
 }
 
 // ─── Registry ────────────────────────────────────────────────────────────────
@@ -91,6 +94,7 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         auth_check_command: "",
         auth_hint: "Run 'copilot' to launch the CLI, then type /login to sign in.",
         resume_flag: "--resume",
+        new_session_id_flag: Some("--session-id"),
     },
     AgentProfile {
         id: "claude",
@@ -109,6 +113,7 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         auth_check_command: "",
         auth_hint: "Run: claude login",
         resume_flag: "--resume",
+        new_session_id_flag: Some("--session-id"),
     },
     AgentProfile {
         id: "codex",
@@ -127,6 +132,7 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         // the command-synthesis template `format!("{cli} {flag} {key}")`
         // produces `codex resume <uuid>` which Codex CLI accepts.
         resume_flag: "resume",
+        new_session_id_flag: None,
         auth_hint: "Run: codex auth (or set OPENAI_API_KEY)",
     },
     AgentProfile {
@@ -143,6 +149,7 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         auth_check_command: "",
         auth_hint: "Authentication is handled in-protocol during connection.",
         resume_flag: "--resume",
+        new_session_id_flag: Some("--session-id"),
     },
 ];
 
@@ -160,6 +167,7 @@ pub const DEFAULT_PROFILE: AgentProfile = AgentProfile {
     auth_check_command: "",
     auth_hint: "",
     resume_flag: "",
+    new_session_id_flag: None,
 };
 
 /// Default ACP command used when no agent is configured.
@@ -514,6 +522,24 @@ mod tests {
             "Codex CLI uses `codex resume <id>` (subcommand form, no dash). \
              An empty resume_flag would make session_mgmt classify Codex rows \
              as Class B (not-resumable) and silently break F2 Enter."
+        );
+    }
+
+    #[test]
+    fn pinnable_agents_advertise_session_id_flag() {
+        let pinnable = ["copilot", "claude", "gemini"];
+        for id in pinnable {
+            let p = lookup_profile(id);
+            assert_eq!(
+                p.new_session_id_flag,
+                Some("--session-id"),
+                "{id} should pin via --session-id"
+            );
+        }
+        assert_eq!(
+            lookup_profile("codex").new_session_id_flag,
+            None,
+            "codex cannot pin"
         );
     }
 }

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -1245,11 +1245,11 @@ mod tests {
         };
 
         let commandline =
-            build_delegate_launch_commandline_with_session(&runtime, Some("hi"), Some("THEUUID"))
+            build_delegate_launch_commandline_with_session(&runtime, Some("hi"), Some("11111111-2222-3333-4444-555555555555"))
                 .unwrap();
 
         assert!(
-            commandline.contains("--session-id THEUUID"),
+            commandline.contains("--session-id 11111111-2222-3333-4444-555555555555"),
             "pinned flag missing: {commandline}"
         );
         let agent_pos = commandline.find("copilot").expect("agent name present");

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -688,10 +688,19 @@ fn build_delegate_launch_commandline(
     // always see the current PATH, not a stale snapshot from process startup.
     let resolved = resolve_commandline_executable(commandline);
 
-    // Resolve the agent profile once from the *unwrapped* exe so flag lookups
-    // (model, session id) see the real CLI — not a later `cmd /c` wrapper.
-    let exe = resolved.split_whitespace().next().unwrap_or("");
-    let profile = agent_registry::lookup_profile(exe);
+    // Identify the agent profile from the *raw* command line so flag lookups
+    // (model, session id) see the real CLI -- not a later `cmd /c` wrapper, and
+    // not the PATH-resolved exe (which may be a quoted path containing spaces
+    // that a naive whitespace split would mangle into `"C:\Program`).
+    // `resolve_agent_id_from_cmd` tokenizes correctly and also recognizes
+    // adapter launches (e.g. `npx -y @zed-industries/claude-code-acp` -> claude).
+    // Using the same raw command line that `delegate_with_context` inspects to
+    // decide whether to pin a session id keeps that decision and the flag we
+    // append here in agreement -- otherwise we could register a born-bound id
+    // that the CLI was never actually launched with.
+    let profile = agent_registry::lookup_profile_by_id(agent_registry::resolve_agent_id_from_cmd(
+        commandline,
+    ));
 
     // If a model is configured, append --model <value> using the agent's model flags.
     let with_model = if let Some(ref model) = runtime.model {
@@ -1244,9 +1253,12 @@ mod tests {
             model: None,
         };
 
-        let commandline =
-            build_delegate_launch_commandline_with_session(&runtime, Some("hi"), Some("11111111-2222-3333-4444-555555555555"))
-                .unwrap();
+        let commandline = build_delegate_launch_commandline_with_session(
+            &runtime,
+            Some("hi"),
+            Some("11111111-2222-3333-4444-555555555555"),
+        )
+        .unwrap();
 
         assert!(
             commandline.contains("--session-id 11111111-2222-3333-4444-555555555555"),
@@ -1257,6 +1269,36 @@ mod tests {
         assert!(
             flag_pos > agent_pos,
             "--session-id must follow the agent, not attach to a cmd wrapper: {commandline}"
+        );
+    }
+
+    #[test]
+    fn pinned_session_id_appended_for_adapter_launch_command() {
+        // Regression for the agent-identification bug behind PR review: an
+        // adapter-style launch ("npx -y @zed-industries/claude-code-acp" ->
+        // claude) must still be recognized as a pinnable agent. The old
+        // `split_whitespace().next()` + lookup_profile saw "npx" ->
+        // DEFAULT_PROFILE -> no --session-id; `resolve_agent_id_from_cmd`
+        // resolves the adapter command to claude, which advertises the flag.
+        let runtime = DelegateAgentRuntime {
+            id: "claude".to_string(),
+            name: "Claude".to_string(),
+            description: "Launches claude as a delegate agent.".to_string(),
+            commandline: "npx -y @zed-industries/claude-code-acp".to_string(),
+            prompt_delivery: DelegatePromptDelivery::LaunchWithStartupPrompt,
+            model: None,
+        };
+
+        let commandline = build_delegate_launch_commandline_with_session(
+            &runtime,
+            Some("hi"),
+            Some("11111111-2222-3333-4444-555555555555"),
+        )
+        .unwrap();
+
+        assert!(
+            commandline.contains("--session-id 11111111-2222-3333-4444-555555555555"),
+            "adapter launch must be identified as a pinnable agent: {commandline}"
         );
     }
 

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -663,24 +663,6 @@ fn lookup_delegate_agent<'a>(
         .ok_or_else(|| anyhow!("no delegate agent configured"))
 }
 
-/// Build the full commandline for launching a delegate agent with a prompt.
-pub fn build_delegate_commandline(
-    runtime: &DelegateAgentRuntime,
-    input: &str,
-) -> Result<String> {
-    build_delegate_launch_commandline_with_session(runtime, Some(input), None)
-}
-
-/// Build the commandline for launching a delegate agent interactively, with
-/// no startup prompt. The agent's own CLI/TUI fills the new tab and waits for
-/// user input. Used by the "open background agent" hotkey (Alt+Shift+B), the
-/// no-prompt sibling of `?<prompt>` delegation.
-pub fn build_delegate_interactive_commandline(
-    runtime: &DelegateAgentRuntime,
-) -> Result<String> {
-    build_delegate_launch_commandline_with_session(runtime, None, None)
-}
-
 /// Build the delegate launch command line, optionally pinning a session id.
 /// When `session_id` is `Some` and the resolved agent advertises
 /// `new_session_id_flag`, append `<flag> <session_id>` so WTA controls the id
@@ -1098,7 +1080,7 @@ fn extract_balanced_json_object(text: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_delegate_interactive_commandline, build_delegate_launch_commandline,
+        build_delegate_launch_commandline,
         build_delegate_launch_commandline_with_session, default_delegate_agent_runtimes,
         parse_autofix_response, parse_recommendation_set, resolve_created_pane_id,
         validate_recommendation_set_for_coordinator_target, AutofixDecision, DelegateAgentRuntime,
@@ -1215,7 +1197,8 @@ mod tests {
         .find(|runtime| runtime.id == "copilot")
         .expect("copilot runtime should exist");
 
-        let commandline = build_delegate_interactive_commandline(&runtime).unwrap();
+        let commandline =
+            build_delegate_launch_commandline_with_session(&runtime, None, None).unwrap();
 
         // May be wrapped as "cmd /c copilot ..." if copilot.exe isn't on PATH.
         assert!(commandline.contains("copilot"));

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -439,7 +439,7 @@ async fn execute_choice(
                     None => format!("Opening {}.", target_label),
                 }));
                 let commandline = runtime
-                    .map(|runtime| build_delegate_launch_commandline(runtime, Some(input)))
+                    .map(|runtime| build_delegate_launch_commandline(runtime, Some(input), None))
                     .transpose()?;
                 let pane_id = match target {
                     OpenTarget::Tab => {
@@ -668,7 +668,7 @@ pub fn build_delegate_commandline(
     runtime: &DelegateAgentRuntime,
     input: &str,
 ) -> Result<String> {
-    build_delegate_launch_commandline(runtime, Some(input))
+    build_delegate_launch_commandline_with_session(runtime, Some(input), None)
 }
 
 /// Build the commandline for launching a delegate agent interactively, with
@@ -678,12 +678,25 @@ pub fn build_delegate_commandline(
 pub fn build_delegate_interactive_commandline(
     runtime: &DelegateAgentRuntime,
 ) -> Result<String> {
-    build_delegate_launch_commandline(runtime, None)
+    build_delegate_launch_commandline_with_session(runtime, None, None)
+}
+
+/// Build the delegate launch command line, optionally pinning a session id.
+/// When `session_id` is `Some` and the resolved agent advertises
+/// `new_session_id_flag`, append `<flag> <session_id>` so WTA controls the id
+/// the CLI writes its session under (enables hook-independent binding).
+pub fn build_delegate_launch_commandline_with_session(
+    runtime: &DelegateAgentRuntime,
+    input: Option<&str>,
+    session_id: Option<&str>,
+) -> Result<String> {
+    build_delegate_launch_commandline(runtime, input, session_id)
 }
 
 fn build_delegate_launch_commandline(
     runtime: &DelegateAgentRuntime,
     input: Option<&str>,
+    session_id: Option<&str>,
 ) -> Result<String> {
     let commandline = runtime.commandline.trim();
     if commandline.is_empty() {
@@ -693,10 +706,13 @@ fn build_delegate_launch_commandline(
     // always see the current PATH, not a stale snapshot from process startup.
     let resolved = resolve_commandline_executable(commandline);
 
+    // Resolve the agent profile once from the *unwrapped* exe so flag lookups
+    // (model, session id) see the real CLI — not a later `cmd /c` wrapper.
+    let exe = resolved.split_whitespace().next().unwrap_or("");
+    let profile = agent_registry::lookup_profile(exe);
+
     // If a model is configured, append --model <value> using the agent's model flags.
     let with_model = if let Some(ref model) = runtime.model {
-        let exe = resolved.split_whitespace().next().unwrap_or("");
-        let profile = agent_registry::lookup_profile(exe);
         if let Some(flag) = profile.model_flags.first() {
             format!("{} {} {}", resolved, flag, model)
         } else {
@@ -705,7 +721,16 @@ fn build_delegate_launch_commandline(
     } else {
         resolved.clone()
     };
-    let resolved_ref = with_model.as_str();
+
+    // Pin a caller-chosen session id when the agent supports it, so the launched
+    // CLI writes its session under a known id (enables hook-independent binding).
+    // Appended here — before any `cmd /c` wrap below — so the flag lands on the
+    // agent CLI, not on `cmd`.
+    let with_session = match (session_id, profile.new_session_id_flag) {
+        (Some(sid), Some(flag)) => format!("{} {} {}", with_model, flag, sid),
+        _ => with_model,
+    };
+    let resolved_ref = with_session.as_str();
 
     let raw = match input {
         // Interactive (no prompt): launch the bare agent CLI regardless of
@@ -1074,9 +1099,9 @@ fn extract_balanced_json_object(text: &str) -> Option<&str> {
 mod tests {
     use super::{
         build_delegate_interactive_commandline, build_delegate_launch_commandline,
-        default_delegate_agent_runtimes, parse_autofix_response,
-        parse_recommendation_set, resolve_created_pane_id,
-        validate_recommendation_set_for_coordinator_target, AutofixDecision,
+        build_delegate_launch_commandline_with_session, default_delegate_agent_runtimes,
+        parse_autofix_response, parse_recommendation_set, resolve_created_pane_id,
+        validate_recommendation_set_for_coordinator_target, AutofixDecision, DelegateAgentRuntime,
         DelegatePromptDelivery, OpenTarget, RecommendedAction,
     };
     use serde_json::json;
@@ -1103,7 +1128,8 @@ mod tests {
             .expect("copilot runtime should exist");
 
         let commandline =
-            build_delegate_launch_commandline(&runtime, Some("Fix the build and report back")).unwrap();
+            build_delegate_launch_commandline(&runtime, Some("Fix the build and report back"), None)
+                .unwrap();
 
         assert!(!commandline.contains("--model"));
         // May be wrapped as "cmd /c copilot ..." if copilot.exe isn't on PATH.
@@ -1168,6 +1194,7 @@ mod tests {
         let commandline = build_delegate_launch_commandline(
             &runtime,
             Some("Fix the Rust build error and run cargo build"),
+            None,
         )
         .unwrap();
 
@@ -1199,6 +1226,75 @@ mod tests {
     }
 
     #[test]
+    fn delegate_commandline_appends_pinned_session_id_for_copilot() {
+        let runtime = DelegateAgentRuntime {
+            id: "copilot".to_string(),
+            name: "Copilot".to_string(),
+            description: "Launches copilot as a delegate agent.".to_string(),
+            commandline: "copilot".to_string(),
+            prompt_delivery: DelegatePromptDelivery::LaunchWithStartupPrompt,
+            model: None,
+        };
+
+        let commandline = build_delegate_launch_commandline_with_session(
+            &runtime,
+            Some("hi"),
+            Some("11111111-2222-3333-4444-555555555555"),
+        )
+        .unwrap();
+
+        assert!(commandline.contains("--session-id 11111111-2222-3333-4444-555555555555"));
+    }
+
+    #[test]
+    fn pinned_session_id_follows_agent_not_cmd_wrapper() {
+        // copilot may or may not be `cmd /c`-wrapped depending on whether
+        // copilot.exe vs copilot.cmd is on PATH. Either way the pinned flag must
+        // be present and positioned *after* the agent name — never lost to a
+        // first-token lookup that sees `cmd` instead of the agent.
+        let runtime = DelegateAgentRuntime {
+            id: "copilot".to_string(),
+            name: "Copilot".to_string(),
+            description: "Launches copilot as a delegate agent.".to_string(),
+            commandline: "copilot".to_string(),
+            prompt_delivery: DelegatePromptDelivery::LaunchWithStartupPrompt,
+            model: None,
+        };
+
+        let commandline =
+            build_delegate_launch_commandline_with_session(&runtime, Some("hi"), Some("THEUUID"))
+                .unwrap();
+
+        assert!(
+            commandline.contains("--session-id THEUUID"),
+            "pinned flag missing: {commandline}"
+        );
+        let agent_pos = commandline.find("copilot").expect("agent name present");
+        let flag_pos = commandline.find("--session-id").unwrap();
+        assert!(
+            flag_pos > agent_pos,
+            "--session-id must follow the agent, not attach to a cmd wrapper: {commandline}"
+        );
+    }
+
+    #[test]
+    fn delegate_commandline_omits_session_id_when_unset() {
+        let runtime = DelegateAgentRuntime {
+            id: "copilot".to_string(),
+            name: "Copilot".to_string(),
+            description: "Launches copilot as a delegate agent.".to_string(),
+            commandline: "copilot".to_string(),
+            prompt_delivery: DelegatePromptDelivery::LaunchWithStartupPrompt,
+            model: None,
+        };
+
+        let commandline =
+            build_delegate_launch_commandline_with_session(&runtime, Some("hi"), None).unwrap();
+
+        assert!(!commandline.contains("--session-id"));
+    }
+
+    #[test]
     fn delegate_launch_commandline_preserves_explicit_exe_path_with_startup_prompt() {
         let runtime = default_delegate_agent_runtimes(
             Some(
@@ -1212,7 +1308,8 @@ mod tests {
         .expect("copilot runtime should exist");
 
         let commandline =
-            build_delegate_launch_commandline(&runtime, Some("Inspect the repo and summarize")).unwrap();
+            build_delegate_launch_commandline(&runtime, Some("Inspect the repo and summarize"), None)
+                .unwrap();
 
         assert_eq!(
             commandline,

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -1676,6 +1676,16 @@ async fn delegate_with_context(
         .first()
         .ok_or_else(|| anyhow::anyhow!("no delegate agent configured"))?;
 
+    // Pin a session id we choose, so the launched CLI writes its session under a
+    // known id and we can bind it to the pane without hooks. Only for agents that
+    // advertise `--session-id` (Copilot/Claude/Gemini); `None` otherwise. The
+    // command builder appends the flag using the same registry lookup, so the
+    // pinned id and the actual launch flag always agree.
+    let resolved_exe = runtime.commandline.split_whitespace().next().unwrap_or("");
+    let pinned_session_id: Option<String> = crate::agent_registry::lookup_profile(resolved_exe)
+        .new_session_id_flag
+        .map(|_| uuid::Uuid::new_v4().to_string());
+
     let commandline = match prompt {
         // Prompt present → enrich it with the active pane's recent output and
         // bake it into the new tab's agent CLI (the `?<prompt>` path).
@@ -1710,10 +1720,18 @@ async fn delegate_with_context(
                 _ => prompt.to_string(),
             };
 
-            crate::coordinator::build_delegate_commandline(runtime, &full_prompt)?
+            crate::coordinator::build_delegate_launch_commandline_with_session(
+                runtime,
+                Some(&full_prompt),
+                pinned_session_id.as_deref(),
+            )?
         }
         // No prompt → open the delegate agent interactively in the new tab.
-        _ => crate::coordinator::build_delegate_interactive_commandline(runtime)?,
+        _ => crate::coordinator::build_delegate_launch_commandline_with_session(
+            runtime,
+            None,
+            pinned_session_id.as_deref(),
+        )?,
     };
 
     // The commandline bakes in the user prompt (`-i "<prompt>"`); keep it out
@@ -1721,9 +1739,22 @@ async fn delegate_with_context(
     tracing::debug!(cwd, "delegate_with_context: launching");
     tracing::trace!(target: "delegate.content", commandline, cwd, "delegate_with_context commandline");
 
-    shell_mgr
+    let create_resp = shell_mgr
         .wt_create_tab(Some(&commandline), cwd, None)
         .await?;
+    let pane_guid = create_resp
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    tracing::info!(
+        target: "delegate",
+        pane_guid = ?pane_guid,
+        pinned = ?pinned_session_id,
+        "delegate tab created",
+    );
+
+    // Phase 5 will register (pinned_session_id, pane_guid) with master here so
+    // the session is born bound to the pane without hooks.
 
     Ok(())
 }

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -1257,6 +1257,77 @@ async fn fetch_sessions_from_master(
     Ok(parsed.sessions)
 }
 
+/// Best-effort: register a WTA-launched CLI session with `wta-master` as a
+/// *born-bound* row — bound to its pane, with no hooks involved. Reuses the
+/// existing `intellterm.wta/session_hook` path with a `SessionStarted` event,
+/// which the master reducer turns into a Class-B (`origin = Unknown`) row whose
+/// `pane_session_id` is the pane we just created. Silent no-op when master is
+/// unreachable: without master there is no registry to populate, so dropping
+/// the registration is harmless (the tab still opened).
+async fn register_launched_session_with_master(
+    session_id: &str,
+    pane_session_id: &str,
+    cli_id: &str,
+    cwd: Option<&str>,
+) {
+    let event = crate::agent_sessions::SessionEvent::SessionStarted {
+        key: session_id.to_string(),
+        cli_source: crate::agent_sessions::CliSource::from(
+            crate::session_registry::SessionHookCliSource::Known(cli_id.to_string()),
+        ),
+        pane_session_id: pane_session_id.to_string(),
+        cwd: cwd.map(std::path::PathBuf::from).unwrap_or_default(),
+        // Empty title: the master refreshes the row's title from the CLI's
+        // on-disk session artefacts once they appear.
+        title: String::new(),
+    };
+    let req = session_registry::build_session_hook_request(&event);
+
+    // Own LocalSet so the `spawn_local` transport works regardless of how the
+    // delegate's runtime was set up (mirrors `run_sessions_list`).
+    let local = tokio::task::LocalSet::new();
+    let result: Result<()> = local
+        .run_until(async move {
+            let pipe_name = resolve_master_pipe(None).await?;
+            let pipe = open_master_pipe_for_cli(&pipe_name).await?;
+            let (read_half, write_half) = tokio::io::split(pipe);
+            let outgoing = write_half.compat_write();
+            let incoming = read_half.compat();
+            let (conn, handle_io) =
+                acp::ClientSideConnection::new(SessionsCliClient, outgoing, incoming, |fut| {
+                    tokio::task::spawn_local(fut);
+                });
+            tokio::task::spawn_local(async move {
+                let _ = handle_io.await;
+            });
+
+            conn.initialize(
+                acp::InitializeRequest::new(acp::ProtocolVersion::V1)
+                    .client_capabilities(acp::ClientCapabilities::new())
+                    .client_info(
+                        acp::Implementation::new("wta-delegate", env!("CARGO_PKG_VERSION"))
+                            .title("Windows Terminal Agent delegate"),
+                    ),
+            )
+            .await
+            .map_err(|_| anyhow::anyhow!(MASTER_NOT_RUNNING))?;
+
+            conn.ext_method(req)
+                .await
+                .map_err(|_| anyhow::anyhow!(MASTER_NOT_RUNNING))?;
+            Ok(())
+        })
+        .await;
+
+    if let Err(e) = result {
+        tracing::warn!(
+            target: "delegate",
+            error = %e,
+            "register born-bound session with master failed (best-effort)"
+        );
+    }
+}
+
 async fn resolve_master_pipe(master_override: Option<String>) -> Result<String> {
     if let Some(pipe) = master_override.filter(|s| !s.trim().is_empty()) {
         return Ok(pipe);
@@ -1753,8 +1824,13 @@ async fn delegate_with_context(
         "delegate tab created",
     );
 
-    // Phase 5 will register (pinned_session_id, pane_guid) with master here so
-    // the session is born bound to the pane without hooks.
+    // Born-bound registration: WTA created this tab and pinned the CLI's
+    // session id, so we know (session id, pane) at launch. Tell master to
+    // bind them with no hooks (best-effort). Only when both are known —
+    // i.e. a pinnable agent (Copilot/Claude/Gemini) whose tab was created.
+    if let (Some(sid), Some(pane)) = (pinned_session_id.as_deref(), pane_guid.as_deref()) {
+        register_launched_session_with_master(sid, pane, &runtime.id, cwd).await;
+    }
 
     Ok(())
 }

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -1261,9 +1261,9 @@ async fn fetch_sessions_from_master(
 /// *born-bound* row — bound to its pane, with no hooks involved. Reuses the
 /// existing `intellterm.wta/session_hook` path with a `SessionStarted` event,
 /// which the master reducer turns into a Class-B (`origin = Unknown`) row whose
-/// `pane_session_id` is the pane we just created. Silent no-op when master is
-/// unreachable: without master there is no registry to populate, so dropping
-/// the registration is harmless (the tab still opened).
+/// `pane_session_id` is the pane we just created. Best-effort: if master is
+/// unreachable there is no registry to populate, so the registration is
+/// dropped (logged at `warn`) and the tab still opens normally.
 async fn register_launched_session_with_master(
     session_id: &str,
     pane_session_id: &str,
@@ -1749,13 +1749,17 @@ async fn delegate_with_context(
 
     // Pin a session id we choose, so the launched CLI writes its session under a
     // known id and we can bind it to the pane without hooks. Only for agents that
-    // advertise `--session-id` (Copilot/Claude/Gemini); `None` otherwise. The
-    // command builder appends the flag using the same registry lookup, so the
-    // pinned id and the actual launch flag always agree.
-    let resolved_exe = runtime.commandline.split_whitespace().next().unwrap_or("");
-    let pinned_session_id: Option<String> = crate::agent_registry::lookup_profile(resolved_exe)
-        .new_session_id_flag
-        .map(|_| uuid::Uuid::new_v4().to_string());
+    // advertise `--session-id` (Copilot/Claude/Gemini); `None` otherwise. We
+    // identify the agent with `resolve_agent_id_from_cmd` (not a naive
+    // `split_whitespace`) so quoted/space-containing paths and adapter launches
+    // resolve correctly -- and so this decision matches the one the command
+    // builder makes when it appends the flag, keeping the pinned id and the
+    // actual launch flag in agreement.
+    let pinned_session_id: Option<String> = crate::agent_registry::lookup_profile_by_id(
+        crate::agent_registry::resolve_agent_id_from_cmd(&runtime.commandline),
+    )
+    .new_session_id_flag
+    .map(|_| uuid::Uuid::new_v4().to_string());
 
     let commandline = match prompt {
         // Prompt present → enrich it with the active pane's recent output and

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -2019,6 +2019,34 @@ async fn handle_sessions_list(
     state: &MasterStateInner,
     params: &serde_json::value::RawValue,
 ) -> acp::Result<acp::ExtResponse> {
+    handle_sessions_list_with(state, params, |cli, key| {
+        crate::history_loader::lookup_title_for_session(cli, key)
+    })
+    .await
+}
+
+/// Testable inner of [`handle_sessions_list`]: the per-CLI disk title lookup is
+/// injected so tests can avoid touching `USERPROFILE`. Production uses the
+/// wrapper above pinned to `history_loader::lookup_title_for_session`.
+///
+/// Before returning the snapshot, opportunistically upgrade any row whose title
+/// is still synthetic (empty / cwd-basename) from the CLI's on-disk artefacts.
+/// This is what gets a title onto **born-bound** rows — e.g. `?<prompt>`
+/// delegate sessions, which register a single `SessionStarted` with an empty
+/// title at launch (before the CLI has written its generated `name:`) and, being
+/// hook-independent, receive no follow-up events to re-trigger
+/// `handle_session_hook`'s refresh. The `/sessions` view re-polls `sessions/list`
+/// every 5s, so refreshing here surfaces the title once the CLI writes it. The
+/// `is_synthetic` early-out inside `try_refresh_title_from_disk_with` keeps this
+/// cheap: a row is read from disk only while it still lacks a real title.
+async fn handle_sessions_list_with<F>(
+    state: &MasterStateInner,
+    params: &serde_json::value::RawValue,
+    lookup: F,
+) -> acp::Result<acp::ExtResponse>
+where
+    F: Fn(crate::agent_sessions::CliSource, &str) -> Option<String> + Copy,
+{
     crate::session_registry::parse_sessions_list_params(params).map_err(|err| {
         tracing::warn!(
             target: "master",
@@ -2028,6 +2056,13 @@ async fn handle_sessions_list(
         );
         acp::Error::invalid_params().data(serde_json::json!({ "message": err.to_string() }))
     })?;
+
+    for row in state.registry.snapshot().await {
+        // `try_refresh_title_from_disk_with` no-ops internally unless the title
+        // is still synthetic and a `cli_source` is present, so we can call it
+        // for every row without pre-filtering.
+        try_refresh_title_from_disk_with(&state.registry, &row.session_id, lookup).await;
+    }
 
     let mut sessions = state.registry.snapshot().await;
     sessions.sort_by(|l, r| l.session_id.0.cmp(&r.session_id.0));
@@ -3132,6 +3167,49 @@ mod tests {
             .expect("response parses");
 
         assert_eq!(parsed.sessions, vec![row]);
+    }
+
+    #[tokio::test]
+    async fn sessions_list_upgrades_synthetic_title_from_disk() {
+        // Born-bound rows (e.g. ?<prompt> delegate sessions) register a single
+        // SessionStarted with an empty title — before the CLI has written its
+        // generated `name:` — and, being hook-independent, get no follow-up
+        // events to re-trigger the per-hook title refresh. The /sessions view
+        // re-polls sessions/list every 5s, so the list handler must surface the
+        // CLI-generated title once it lands on disk.
+        use crate::session_registry::{self, SessionInfo};
+        use std::path::PathBuf;
+
+        let state = make_state();
+        let mut row = SessionInfo::new(
+            SessionId::new("born-bound"),
+            PathBuf::from("C:\\Windows\\system32"),
+        );
+        row.cli_source = Some(crate::agent_sessions::CliSource::Copilot);
+        // title left None → synthetic, exactly as at born-bound launch time.
+        state.registry.upsert(row).await;
+
+        let req = session_registry::build_sessions_list_request();
+        let resp = handle_sessions_list_with(&state, &req.params, |cli, key| {
+            assert_eq!(cli, crate::agent_sessions::CliSource::Copilot);
+            assert_eq!(key, "born-bound");
+            Some("Implement Greeting Function".to_string())
+        })
+        .await
+        .expect("sessions/list succeeds");
+        let parsed =
+            session_registry::parse_sessions_list_response(&resp.0).expect("response parses");
+
+        let upgraded = parsed
+            .sessions
+            .iter()
+            .find(|s| s.session_id == SessionId::new("born-bound"))
+            .expect("born-bound row present in snapshot");
+        assert_eq!(
+            upgraded.title.as_deref(),
+            Some("Implement Greeting Function"),
+            "synthetic born-bound title should be upgraded from on-disk artefacts"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Hook-independent **pane ↔ session binding** for the CLI sessions that **WTA itself launches** — so binding survives once shell-integration hooks are removed.

When you run `?<prompt>` (delegate) or `Alt+Shift+B` (`openBackgroundAgent`), WTA now:
1. pins a self-generated `--session-id <uuid>` for agents that support it (**Copilot / Claude / Gemini**),
2. captures the new pane GUID from `create_tab`'s `TabCreationResult`,
3. registers a **born-bound** Class-B row directly into `wta-master` (reusing the existing `intellterm.wta/session_hook` / `SessionStarted` path) — bound to the pane, **no hooks involved**.

The `/sessions` `ResumeCliFlag` path (c) was already born-bound via `ResumePaneAssigned` — verified, unchanged.

## Scope

- **In:** `?<prompt>` + `Alt+Shift+B` delegate (paths a), `/sessions` resume (path c). Copilot/Claude/Gemini only.
- **Out (deferred):** the agent-pane recommendation-open path `OpenAndSend{agent}` (path b) — it runs in the recommendation executor with no direct master connection; see the *Deferred* section in the spec. **Codex** stays on its existing hook path (it can't pin `--session-id`).
- **Unchanged:** `SessionOrigin` (rows stay `Unknown` = Class B), `OriginFilter`, `/sessions` UI/routing, serialization, `history_loader`, activity/Working-Idle source.

## Key facts (empirically verified on Windows, 2026-06-10)

- `--session-id <uuid>` pins a NEW session's id for Copilot/Claude/Gemini; Codex cannot.
- `create_tab` / `split_pane` return `TabCreationResult { TabId, SessionId(=pane GUID), WindowId, Pid }`.

## Design / commits

- `agent_registry`: new `new_session_id_flag` capability.
- `coordinator`: delegate command builder appends `--session-id` (placed before any `cmd /c` wrap so the flag lands on the agent, not `cmd`).
- `main` (`delegate_with_context`): generate uuid, capture pane GUID, best-effort register with master (silent no-op if master is down).

Design doc: `doc/specs/wta-launched-cli-session-binding.md`.

## Testing

- `cargo test` — **716 passed, 0 failed**.
- `cargo build --target x86_64-pc-windows-msvc` — clean (pre-existing warnings only).
- New unit tests: registry flag per CLI; command builder pins/omits `--session-id`; flag-follows-agent-not-cmd-wrapper invariant.
- Manual `--session-id` spike confirmed on-disk session files land under the pinned uuid for all three CLIs.
