### PR TITLE
Add WTA ACP lifecycle telemetry

### DIFF
--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -1250,6 +1250,12 @@ async fn fetch_sessions_from_master(
         init_started.elapsed().as_secs_f64() * 1000.0,
         init_result.is_ok(),
         "SessionsCli",
+        if init_result.is_ok() { "" } else { "AcpError" },
+        init_result
+            .as_ref()
+            .err()
+            .map(|e| e.code.into())
+            .unwrap_or(0),
     );
     init_result.map_err(|_| anyhow::anyhow!(MASTER_NOT_RUNNING))?;
 

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -1236,7 +1236,8 @@ async fn fetch_sessions_from_master(
         let _ = handle_io.await;
     });
 
-    conn.initialize(
+    let init_started = std::time::Instant::now();
+    let init_result = conn.initialize(
         acp::InitializeRequest::new(acp::ProtocolVersion::V1)
             .client_capabilities(acp::ClientCapabilities::new())
             .client_info(
@@ -1244,8 +1245,13 @@ async fn fetch_sessions_from_master(
                     .title("Windows Terminal Agent sessions CLI"),
             ),
     )
-    .await
-    .map_err(|_| anyhow::anyhow!(MASTER_NOT_RUNNING))?;
+    .await;
+    telemetry::log_acp_initialize_complete(
+        init_started.elapsed().as_secs_f64() * 1000.0,
+        init_result.is_ok(),
+        "SessionsCli",
+    );
+    init_result.map_err(|_| anyhow::anyhow!(MASTER_NOT_RUNNING))?;
 
     let req = session_registry::build_sessions_list_request();
     let resp = conn

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -701,22 +701,33 @@ impl HelperHandler {
         timeout: std::time::Duration,
     ) -> acp::Result<acp::NewSessionResponse> {
         let timeout_secs = timeout.as_secs();
-        tokio::time::timeout(timeout, self.agent_conn.new_session(args))
-            .await
-            .map_err(|_| {
-                let message = format!("agent CLI session/new timed out after {timeout_secs}s");
-                tracing::error!(
-                    target: "master",
-                    step = "helper→agent",
-                    op = "new_session",
-                    helper_id = ?self.helper_id,
-                    timeout_secs,
-                    "agent CLI session/new timed out"
-                );
-                acp::Error::new(-32603, message.clone()).data(serde_json::json!({
-                    "message": message
-                }))
-            })?
+        let started = std::time::Instant::now();
+        let result = tokio::time::timeout(timeout, self.agent_conn.new_session(args)).await;
+        let session_id = result
+            .as_ref()
+            .ok()
+            .and_then(|inner| inner.as_ref().ok())
+            .map(|resp| resp.session_id.to_string());
+        crate::telemetry::log_acp_new_session_complete(
+            session_id.as_deref(),
+            started.elapsed().as_secs_f64() * 1000.0,
+            matches!(result, Ok(Ok(_))),
+            "MasterForward",
+        );
+        result.map_err(|_| {
+            let message = format!("agent CLI session/new timed out after {timeout_secs}s");
+            tracing::error!(
+                target: "master",
+                step = "helper→agent",
+                op = "new_session",
+                helper_id = ?self.helper_id,
+                timeout_secs,
+                "agent CLI session/new timed out"
+            );
+            acp::Error::new(-32603, message.clone()).data(serde_json::json!({
+                "message": message
+            }))
+        })?
     }
 }
 
@@ -752,7 +763,14 @@ impl acp::Agent for HelperHandler {
                     helper_id = ?self.helper_id,
                     "cached_init_resp missing; falling back to live agent initialize"
                 );
-                self.agent_conn.initialize(args).await
+                let started = std::time::Instant::now();
+                let result = self.agent_conn.initialize(args).await;
+                crate::telemetry::log_acp_initialize_complete(
+                    started.elapsed().as_secs_f64() * 1000.0,
+                    result.is_ok(),
+                    "MasterFallback",
+                );
+                result
             }
         }
     }
@@ -1647,7 +1665,8 @@ async fn run_master_loop(cli: Cli, pipe_name: String) -> Result<()> {
 
     // 3. Initialize the agent CLI once at master startup.
     let init_timeout_secs = if is_npx { 60 } else { 15 };
-    let init_resp = tokio::time::timeout(
+    let init_started = std::time::Instant::now();
+    let init_result = tokio::time::timeout(
         std::time::Duration::from_secs(init_timeout_secs),
         agent_conn.initialize(
             acp::InitializeRequest::new(acp::ProtocolVersion::V1)
@@ -1658,22 +1677,28 @@ async fn run_master_loop(cli: Cli, pipe_name: String) -> Result<()> {
                 ),
         ),
     )
-    .await
-    .map_err(|_| {
-        tracing::error!(
-            target: "master",
-            timeout_secs = init_timeout_secs,
-            "ACP initialize timed out — agent CLI did not respond"
-        );
-        anyhow!(
-            "ACP initialize timed out after {}s — agent CLI did not respond",
-            init_timeout_secs
-        )
-    })?
-    .map_err(|e| {
-        tracing::error!(target: "master", error = %e, "ACP initialize failed");
-        anyhow!("ACP initialize failed: {e}")
-    })?;
+    .await;
+    crate::telemetry::log_acp_initialize_complete(
+        init_started.elapsed().as_secs_f64() * 1000.0,
+        matches!(init_result, Ok(Ok(_))),
+        "MasterStartup",
+    );
+    let init_resp = init_result
+        .map_err(|_| {
+            tracing::error!(
+                target: "master",
+                timeout_secs = init_timeout_secs,
+                "ACP initialize timed out — agent CLI did not respond"
+            );
+            anyhow!(
+                "ACP initialize timed out after {}s — agent CLI did not respond",
+                init_timeout_secs
+            )
+        })?
+        .map_err(|e| {
+            tracing::error!(target: "master", error = %e, "ACP initialize failed");
+            anyhow!("ACP initialize failed: {e}")
+        })?;
     tracing::info!(
         target: "master",
         ?init_resp,

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -708,11 +708,18 @@ impl HelperHandler {
             .ok()
             .and_then(|inner| inner.as_ref().ok())
             .map(|resp| resp.session_id.to_string());
+        let (failure_kind, acp_error_code) = match &result {
+            Ok(Ok(_)) => ("", 0),
+            Ok(Err(e)) => ("AcpError", e.code.into()),
+            Err(_) => ("Timeout", 0),
+        };
         crate::telemetry::log_acp_new_session_complete(
             session_id.as_deref(),
             started.elapsed().as_secs_f64() * 1000.0,
             matches!(result, Ok(Ok(_))),
             "MasterForward",
+            failure_kind,
+            acp_error_code,
         );
         result.map_err(|_| {
             let message = format!("agent CLI session/new timed out after {timeout_secs}s");
@@ -769,6 +776,8 @@ impl acp::Agent for HelperHandler {
                     started.elapsed().as_secs_f64() * 1000.0,
                     result.is_ok(),
                     "MasterFallback",
+                    if result.is_ok() { "" } else { "AcpError" },
+                    result.as_ref().err().map(|e| e.code.into()).unwrap_or(0),
                 );
                 result
             }
@@ -1682,6 +1691,15 @@ async fn run_master_loop(cli: Cli, pipe_name: String) -> Result<()> {
         init_started.elapsed().as_secs_f64() * 1000.0,
         matches!(init_result, Ok(Ok(_))),
         "MasterStartup",
+        match &init_result {
+            Ok(Ok(_)) => "",
+            Ok(Err(_)) => "AcpError",
+            Err(_) => "Timeout",
+        },
+        match &init_result {
+            Ok(Err(e)) => e.code.into(),
+            _ => 0,
+        },
     );
     let init_resp = init_result
         .map_err(|_| {

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -2069,6 +2069,60 @@ fn inject_wta_pane_meta(meta: &mut Option<acp::Meta>) {
     );
 }
 
+fn elapsed_ms_since(start: std::time::Instant) -> f64 {
+    start.elapsed().as_secs_f64() * 1000.0
+}
+
+fn log_acp_initialize_timeout_result(
+    route: &str,
+    started: std::time::Instant,
+    result: &std::result::Result<
+        acp::Result<acp::InitializeResponse>,
+        tokio::time::error::Elapsed,
+    >,
+) {
+    crate::telemetry::log_acp_initialize_complete(
+        elapsed_ms_since(started),
+        matches!(result, Ok(Ok(_))),
+        route,
+    );
+}
+
+fn log_acp_new_session_result(
+    route: &str,
+    started: std::time::Instant,
+    result: &acp::Result<acp::NewSessionResponse>,
+) {
+    let session_id = result.as_ref().ok().map(|resp| resp.session_id.to_string());
+    crate::telemetry::log_acp_new_session_complete(
+        session_id.as_deref(),
+        elapsed_ms_since(started),
+        result.is_ok(),
+        route,
+    );
+}
+
+fn log_acp_new_session_timeout_result(
+    route: &str,
+    started: std::time::Instant,
+    result: &std::result::Result<
+        acp::Result<acp::NewSessionResponse>,
+        tokio::time::error::Elapsed,
+    >,
+) {
+    let session_id = result
+        .as_ref()
+        .ok()
+        .and_then(|inner| inner.as_ref().ok())
+        .map(|resp| resp.session_id.to_string());
+    crate::telemetry::log_acp_new_session_complete(
+        session_id.as_deref(),
+        elapsed_ms_since(started),
+        matches!(result, Ok(Ok(_))),
+        route,
+    );
+}
+
 /// Handle a `session/load` failure (Err or timeout) in the
 /// `load_session_rx` arm of `run_acp_client_over_pipe`.
 ///
@@ -2112,7 +2166,9 @@ async fn handle_load_failure(
     });
     let mut new_req = acp::NewSessionRequest::new(cwd);
     inject_wta_pane_meta(&mut new_req.meta);
+    let fallback_started = std::time::Instant::now();
     let fallback = conn.new_session(new_req).await;
+    log_acp_new_session_result("HelperPipeFallback", fallback_started, &fallback);
     match fallback {
         Ok(resp) => {
             let new_sid = resp.session_id.clone();
@@ -2339,6 +2395,7 @@ pub async fn run_acp_client_over_pipe(
     // are fast because master just re-forwards.
     let _ = event_tx.send(AppEvent::ConnectionStage("Initializing ACP...".to_string()));
     startup_probe.log("Initializing ACP (over pipe)");
+    let init_started = std::time::Instant::now();
     let init_future = conn.initialize(
         acp::InitializeRequest::new(acp::ProtocolVersion::V1)
             .client_capabilities(acp::ClientCapabilities::new().terminal(true))
@@ -2347,8 +2404,10 @@ pub async fn run_acp_client_over_pipe(
                     .title("Windows Terminal Agent (helper)"),
             ),
     );
-    let init_resp = tokio::time::timeout(std::time::Duration::from_secs(60), init_future)
-        .await
+    let init_result =
+        tokio::time::timeout(std::time::Duration::from_secs(60), init_future).await;
+    log_acp_initialize_timeout_result("HelperPipe", init_started, &init_result);
+    let init_resp = init_result
         .map_err(|_| {
             tracing::error!(
                 target: "helper",
@@ -2467,7 +2526,14 @@ pub async fn run_acp_client_over_pipe(
             startup_probe.log("Creating session (over pipe)");
             let mut new_session_req = acp::NewSessionRequest::new(cwd.clone());
             inject_wta_pane_meta(&mut new_session_req.meta);
-            let session = conn.new_session(new_session_req).await.map_err(|e| {
+            let new_session_started = std::time::Instant::now();
+            let new_session_result = conn.new_session(new_session_req).await;
+            log_acp_new_session_result(
+                "HelperPipeStartup",
+                new_session_started,
+                &new_session_result,
+            );
+            let session = new_session_result.map_err(|e| {
                 // Attach the typed classification so an auth error
                 // (or any ACP code) survives the `?`-collapse into
                 // `anyhow` and can be recovered by `classify_anyhow`
@@ -2731,10 +2797,14 @@ pub async fn run_acp_client_over_pipe(
                     // has the row but no pane GUID to feed wtcli focus-pane.
                     let mut new_session_req = acp::NewSessionRequest::new(cwd);
                     inject_wta_pane_meta(&mut new_session_req.meta);
-                    let new_session = match conn_for_new
-                        .new_session(new_session_req)
-                        .await
-                    {
+                    let new_session_started = std::time::Instant::now();
+                    let new_session_result = conn_for_new.new_session(new_session_req).await;
+                    log_acp_new_session_result(
+                        "HelperPipeNewSessionForTab",
+                        new_session_started,
+                        &new_session_result,
+                    );
+                    let new_session = match new_session_result {
                         Ok(s) => s,
                         Err(e) => {
                             let _ = event_tx_for_new.send(AppEvent::AgentError {
@@ -3279,6 +3349,7 @@ async fn run_inner(
     // fail fast instead of hanging forever.
     let _ = event_tx.send(AppEvent::ConnectionStage("Initializing ACP...".to_string()));
     startup_probe.log("Initializing ACP");
+    let init_started = std::time::Instant::now();
     let init_future = conn.initialize(
         acp::InitializeRequest::new(acp::ProtocolVersion::V1)
             .client_capabilities(acp::ClientCapabilities::new().terminal(true))
@@ -3294,32 +3365,31 @@ async fn run_inner(
     let agent_label: String = adapter_package
         .clone()
         .unwrap_or_else(|| raw_program.to_string());
-    let init_resp = tokio::time::timeout(
-        std::time::Duration::from_secs(init_timeout_secs),
-        init_future,
-    )
-    .await
-    .map_err(|_| {
-        tracing::error!(
-            target: "acp",
-            step = "acp_initialize",
-            timeout_secs = init_timeout_secs,
-            agent = %agent_label,
-            "ACP initialize timed out — agent CLI did not respond"
-        );
-        anyhow::anyhow!(
-            "ACP initialize timed out after {} s — '{}' did not respond. \
-             First-run npx adapters download ~5MB; check network. \
-             Built-in ACP agents: copilot, claude (via @zed-industries/claude-code-acp), \
-             codex (via @zed-industries/codex-acp), gemini.",
-            init_timeout_secs,
-            agent_label
-        )
-    })?
-    .map_err(|e| {
-        tracing::error!(target: "acp", step = "acp_initialize", error = %e, "ACP initialize failed");
-        anyhow::anyhow!("initialize failed: {}", e)
-    })?;
+    let init_result =
+        tokio::time::timeout(std::time::Duration::from_secs(init_timeout_secs), init_future).await;
+    log_acp_initialize_timeout_result("DirectAgent", init_started, &init_result);
+    let init_resp = init_result
+        .map_err(|_| {
+            tracing::error!(
+                target: "acp",
+                step = "acp_initialize",
+                timeout_secs = init_timeout_secs,
+                agent = %agent_label,
+                "ACP initialize timed out — agent CLI did not respond"
+            );
+            anyhow::anyhow!(
+                "ACP initialize timed out after {} s — '{}' did not respond. \
+                 First-run npx adapters download ~5MB; check network. \
+                 Built-in ACP agents: copilot, claude (via @zed-industries/claude-code-acp), \
+                 codex (via @zed-industries/codex-acp), gemini.",
+                init_timeout_secs,
+                agent_label
+            )
+        })?
+        .map_err(|e| {
+            tracing::error!(target: "acp", step = "acp_initialize", error = %e, "ACP initialize failed");
+            anyhow::anyhow!("initialize failed: {}", e)
+        })?;
 
     // Log the agent's initialize response for debugging
     startup_probe.log(&format!("Agent init response received: {:?}", init_resp));
@@ -3330,9 +3400,12 @@ async fn run_inner(
     let cwd = active_pane_cwd
         .clone()
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+    let session_started = std::time::Instant::now();
     let session_future = conn.new_session(acp::NewSessionRequest::new(cwd));
-    let session = tokio::time::timeout(std::time::Duration::from_secs(15), session_future)
-        .await
+    let session_result = tokio::time::timeout(std::time::Duration::from_secs(15), session_future)
+        .await;
+    log_acp_new_session_timeout_result("DirectAgentStartup", session_started, &session_result);
+    let session = session_result
         .map_err(|_| anyhow::anyhow!("new_session timed out after 15 s"))?
         .map_err(|e| anyhow::anyhow!("new_session failed: {}", e))?;
 
@@ -3566,10 +3639,15 @@ async fn run_inner(
                             .await;
                     }
 
-                    let new_session = match conn_for_new
-                        .new_session(acp::NewSessionRequest::new(cwd))
-                        .await
-                    {
+                    let new_session_started = std::time::Instant::now();
+                    let new_session_result =
+                        conn_for_new.new_session(acp::NewSessionRequest::new(cwd)).await;
+                    log_acp_new_session_result(
+                        "DirectAgentNewSessionForTab",
+                        new_session_started,
+                        &new_session_result,
+                    );
+                    let new_session = match new_session_result {
                         Ok(s) => s,
                         Err(e) => {
                             let _ = event_tx_for_new.send(AppEvent::AgentError {
@@ -4107,10 +4185,16 @@ async fn dispatch_prompt_body(
                 .and_then(|c| c.cwd.clone())
                 .map(std::path::PathBuf::from)
                 .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
-            let new_session = match conn_task
+            let new_session_started = std::time::Instant::now();
+            let new_session_result = conn_task
                 .new_session(acp::NewSessionRequest::new(cwd))
-                .await
-            {
+                .await;
+            log_acp_new_session_result(
+                "LazyCreateOnFirstPrompt",
+                new_session_started,
+                &new_session_result,
+            );
+            let new_session = match new_session_result {
                 Ok(s) => s,
                 Err(e) => {
                     let _ = event_tx_task.send(AppEvent::AgentError {

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -2073,6 +2073,22 @@ fn elapsed_ms_since(start: std::time::Instant) -> f64 {
     start.elapsed().as_secs_f64() * 1000.0
 }
 
+fn acp_result_failure_fields<T>(result: &acp::Result<T>) -> (&'static str, i32) {
+    match result {
+        Ok(_) => ("", 0),
+        Err(e) => ("AcpError", e.code.into()),
+    }
+}
+
+fn timeout_result_failure_fields<T>(
+    result: &std::result::Result<acp::Result<T>, tokio::time::error::Elapsed>,
+) -> (&'static str, i32) {
+    match result {
+        Ok(inner) => acp_result_failure_fields(inner),
+        Err(_) => ("Timeout", 0),
+    }
+}
+
 fn log_acp_initialize_timeout_result(
     route: &str,
     started: std::time::Instant,
@@ -2081,10 +2097,13 @@ fn log_acp_initialize_timeout_result(
         tokio::time::error::Elapsed,
     >,
 ) {
+    let (failure_kind, acp_error_code) = timeout_result_failure_fields(result);
     crate::telemetry::log_acp_initialize_complete(
         elapsed_ms_since(started),
         matches!(result, Ok(Ok(_))),
         route,
+        failure_kind,
+        acp_error_code,
     );
 }
 
@@ -2094,11 +2113,14 @@ fn log_acp_new_session_result(
     result: &acp::Result<acp::NewSessionResponse>,
 ) {
     let session_id = result.as_ref().ok().map(|resp| resp.session_id.to_string());
+    let (failure_kind, acp_error_code) = acp_result_failure_fields(result);
     crate::telemetry::log_acp_new_session_complete(
         session_id.as_deref(),
         elapsed_ms_since(started),
         result.is_ok(),
         route,
+        failure_kind,
+        acp_error_code,
     );
 }
 
@@ -2115,11 +2137,14 @@ fn log_acp_new_session_timeout_result(
         .ok()
         .and_then(|inner| inner.as_ref().ok())
         .map(|resp| resp.session_id.to_string());
+    let (failure_kind, acp_error_code) = timeout_result_failure_fields(result);
     crate::telemetry::log_acp_new_session_complete(
         session_id.as_deref(),
         elapsed_ms_since(started),
         matches!(result, Ok(Ok(_))),
         route,
+        failure_kind,
+        acp_error_code,
     );
 }
 

--- a/tools/wta/src/protocol/acp/probe.rs
+++ b/tools/wta/src/protocol/acp/probe.rs
@@ -135,28 +135,46 @@ pub async fn probe_models(agent_cmd: &str) -> Result<ProbeResult> {
             acp::Implementation::new("wta-probe", env!("CARGO_PKG_VERSION"))
                 .title("WTA Model Probe"),
         );
-    let _init_resp = tokio::time::timeout(
-        Duration::from_secs(init_timeout_secs),
-        conn.initialize(init_req),
-    )
-    .await
-    .map_err(|_| {
-        anyhow!(
-            "ACP initialize timed out after {}s during probe (agent={})",
-            init_timeout_secs,
-            spawned.label()
-        )
-    })?
-    .map_err(|e| anyhow!("initialize failed: {}", e))?;
+    let init_started = std::time::Instant::now();
+    let init_result =
+        tokio::time::timeout(Duration::from_secs(init_timeout_secs), conn.initialize(init_req))
+            .await;
+    crate::telemetry::log_acp_initialize_complete(
+        init_started.elapsed().as_secs_f64() * 1000.0,
+        matches!(init_result, Ok(Ok(_))),
+        "Probe",
+    );
+    let _init_resp = init_result
+        .map_err(|_| {
+            anyhow!(
+                "ACP initialize timed out after {}s during probe (agent={})",
+                init_timeout_secs,
+                spawned.label()
+            )
+        })?
+        .map_err(|e| anyhow!("initialize failed: {}", e))?;
 
     let cwd = std::env::current_dir().unwrap_or_default();
-    let session_resp = tokio::time::timeout(
+    let session_started = std::time::Instant::now();
+    let session_result = tokio::time::timeout(
         Duration::from_secs(10),
         conn.new_session(acp::NewSessionRequest::new(cwd)),
     )
-    .await
-    .map_err(|_| anyhow!("new_session timed out after 10s during probe"))?
-    .map_err(|e| anyhow!("new_session failed: {}", e))?;
+    .await;
+    let session_id = session_result
+        .as_ref()
+        .ok()
+        .and_then(|inner| inner.as_ref().ok())
+        .map(|resp| resp.session_id.to_string());
+    crate::telemetry::log_acp_new_session_complete(
+        session_id.as_deref(),
+        session_started.elapsed().as_secs_f64() * 1000.0,
+        matches!(session_result, Ok(Ok(_))),
+        "Probe",
+    );
+    let session_resp = session_result
+        .map_err(|_| anyhow!("new_session timed out after 10s during probe"))?
+        .map_err(|e| anyhow!("new_session failed: {}", e))?;
 
     let (available_models, current_model_id) = match &session_resp.models {
         Some(state) => {

--- a/tools/wta/src/protocol/acp/probe.rs
+++ b/tools/wta/src/protocol/acp/probe.rs
@@ -143,6 +143,15 @@ pub async fn probe_models(agent_cmd: &str) -> Result<ProbeResult> {
         init_started.elapsed().as_secs_f64() * 1000.0,
         matches!(init_result, Ok(Ok(_))),
         "Probe",
+        match &init_result {
+            Ok(Ok(_)) => "",
+            Ok(Err(_)) => "AcpError",
+            Err(_) => "Timeout",
+        },
+        match &init_result {
+            Ok(Err(e)) => e.code.into(),
+            _ => 0,
+        },
     );
     let _init_resp = init_result
         .map_err(|_| {
@@ -171,6 +180,15 @@ pub async fn probe_models(agent_cmd: &str) -> Result<ProbeResult> {
         session_started.elapsed().as_secs_f64() * 1000.0,
         matches!(session_result, Ok(Ok(_))),
         "Probe",
+        match &session_result {
+            Ok(Ok(_)) => "",
+            Ok(Err(_)) => "AcpError",
+            Err(_) => "Timeout",
+        },
+        match &session_result {
+            Ok(Err(e)) => e.code.into(),
+            _ => 0,
+        },
     );
     let session_resp = session_result
         .map_err(|_| anyhow!("new_session timed out after 10s during probe"))?

--- a/tools/wta/src/telemetry.rs
+++ b/tools/wta/src/telemetry.rs
@@ -46,6 +46,8 @@
 // processes only via fields explicitly shared (e.g. `PaneId`).
 //
 // Events emitted from this module:
+//   - AcpInitializeComplete  (ACP initialize RPC completes)
+//   - AcpNewSessionComplete  (ACP session/new RPC completes)
 //   - AgentPromptSent          (WTA dispatches a prompt over ACP)
 //   - AgentResponseFirstToken  (ACP returns the first text chunk)
 //   - AgentResponseComplete    (ACP prompt request completes)
@@ -102,6 +104,52 @@ pub fn register() {
 #[allow(dead_code)]
 pub fn unregister() {
     AGENT_PROVIDER.unregister();
+}
+
+/// Emitted when an ACP `initialize` RPC completes. `duration_ms` is a
+/// monotonic duration measured around the RPC attempt, not wall-clock.
+///
+/// `route` identifies the WTA path that issued the RPC (for example,
+/// master startup versus direct agent mode) so downstream queries can avoid
+/// mixing cached/helper handshakes with agent CLI handshakes.
+pub fn log_acp_initialize_complete(duration_ms: f64, success: bool, route: &str) {
+    let success_i32: i32 = if success { 1 } else { 0 };
+    tlg::write_event!(
+        AGENT_PROVIDER,
+        "AcpInitializeComplete",
+        level(Verbose),
+        keyword(MICROSOFT_KEYWORD_MEASURES),
+        f64("DurationMs", &duration_ms),
+        bool32("Success", &success_i32),
+        str8("Route", route),
+        u64("PartA_PrivTags", &PDT_PRODUCT_AND_SERVICE_PERFORMANCE),
+    );
+}
+
+/// Emitted when an ACP `session/new` RPC completes. `duration_ms` is a
+/// monotonic duration measured around the RPC attempt, not wall-clock.
+///
+/// `session_id` is present only on success. Failed attempts still emit the
+/// event with an empty `SessionId` so the ETW schema remains stable.
+pub fn log_acp_new_session_complete(
+    session_id: Option<&str>,
+    duration_ms: f64,
+    success: bool,
+    route: &str,
+) {
+    let success_i32: i32 = if success { 1 } else { 0 };
+    let session_id = session_id.unwrap_or("");
+    tlg::write_event!(
+        AGENT_PROVIDER,
+        "AcpNewSessionComplete",
+        level(Verbose),
+        keyword(MICROSOFT_KEYWORD_MEASURES),
+        str8("SessionId", session_id),
+        f64("DurationMs", &duration_ms),
+        bool32("Success", &success_i32),
+        str8("Route", route),
+        u64("PartA_PrivTags", &PDT_PRODUCT_AND_SERVICE_PERFORMANCE),
+    );
 }
 
 /// Emitted when WTA dispatches a prompt over the ACP stream to an agent.

--- a/tools/wta/src/telemetry.rs
+++ b/tools/wta/src/telemetry.rs
@@ -112,7 +112,18 @@ pub fn unregister() {
 /// `route` identifies the WTA path that issued the RPC (for example,
 /// master startup versus direct agent mode) so downstream queries can avoid
 /// mixing cached/helper handshakes with agent CLI handshakes.
-pub fn log_acp_initialize_complete(duration_ms: f64, success: bool, route: &str) {
+///
+/// `failure_kind` is empty on success, `Timeout` when no response arrived
+/// before the local timeout, or `AcpError` when the agent returned a
+/// JSON-RPC/ACP error. `acp_error_code` is the agent-provided code for
+/// `AcpError`; otherwise it is 0.
+pub fn log_acp_initialize_complete(
+    duration_ms: f64,
+    success: bool,
+    route: &str,
+    failure_kind: &str,
+    acp_error_code: i32,
+) {
     let success_i32: i32 = if success { 1 } else { 0 };
     tlg::write_event!(
         AGENT_PROVIDER,
@@ -122,6 +133,8 @@ pub fn log_acp_initialize_complete(duration_ms: f64, success: bool, route: &str)
         f64("DurationMs", &duration_ms),
         bool32("Success", &success_i32),
         str8("Route", route),
+        str8("FailureKind", failure_kind),
+        i32("AcpErrorCode", &acp_error_code),
         u64("PartA_PrivTags", &PDT_PRODUCT_AND_SERVICE_PERFORMANCE),
     );
 }
@@ -131,11 +144,18 @@ pub fn log_acp_initialize_complete(duration_ms: f64, success: bool, route: &str)
 ///
 /// `session_id` is present only on success. Failed attempts still emit the
 /// event with an empty `SessionId` so the ETW schema remains stable.
+///
+/// `failure_kind` is empty on success, `Timeout` when no response arrived
+/// before the local timeout, or `AcpError` when the agent returned a
+/// JSON-RPC/ACP error. `acp_error_code` is the agent-provided code for
+/// `AcpError`; otherwise it is 0.
 pub fn log_acp_new_session_complete(
     session_id: Option<&str>,
     duration_ms: f64,
     success: bool,
     route: &str,
+    failure_kind: &str,
+    acp_error_code: i32,
 ) {
     let success_i32: i32 = if success { 1 } else { 0 };
     let session_id = session_id.unwrap_or("");
@@ -148,6 +168,8 @@ pub fn log_acp_new_session_complete(
         f64("DurationMs", &duration_ms),
         bool32("Success", &success_i32),
         str8("Route", route),
+        str8("FailureKind", failure_kind),
+        i32("AcpErrorCode", &acp_error_code),
         u64("PartA_PrivTags", &PDT_PRODUCT_AND_SERVICE_PERFORMANCE),
     );
 }


### PR DESCRIPTION
## Summary
- add WTA TraceLogging events for ACP initialize and session/new completion
- include monotonic duration, success, route, and SessionId when session/new succeeds
- instrument master, helper pipe, direct agent, probe, sessions CLI, /new, and lazy-create paths

## Validation
<img width="901" height="430" alt="image" src="https://github.com/user-attachments/assets/9cc342d5-3c2b-4291-ad02-0351eed8cdea" />

