### PR TITLE
Use ASCII hyphen instead of em dash in wtcli CLI title

### DIFF
--- a/src/tools/wtcli/main.cpp
+++ b/src/tools/wtcli/main.cpp
@@ -263,7 +263,7 @@ int main()
 {
     winrt::init_apartment(winrt::apartment_type::multi_threaded);
 
-    CLI::App app{ "wtcli — Windows Terminal CLI" };
+    CLI::App app{ "wtcli - Windows Terminal CLI" };
     app.require_subcommand(0, 1);
 
     bool jsonMode = false;
@@ -866,7 +866,7 @@ int main()
     app.callback([&]() {
         if (app.get_subcommands().empty())
         {
-            printf("wtcli — Windows Terminal CLI\n\n");
+            printf("wtcli - Windows Terminal CLI\n\n");
             printf("Usage: wtcli [--json] <subcommand>\n\n");
             printf("Run 'wtcli --help' for available subcommands.\n");
         }


### PR DESCRIPTION
## Summary

The `wtcli - Windows Terminal CLI` banner in `src/tools/wtcli/main.cpp` used an **em dash (U+2014 `—`)** rather than an ASCII hyphen, in two places: the `CLI::App` title and the no-subcommand `printf` banner.

## Why this matters

`wtcli`'s `main()` never calls `SetConsoleOutputCP(CP_UTF8)` / `_setmode`, and the source is UTF-8. The em dash is written to stdout verbatim as the bytes `E2 80 94`. On a default Windows console (CP 437, CP 936/GBK, etc.) that renders as mojibake (e.g. `â€"`) instead of a dash. Only consoles with `chcp 65001` or system-wide UTF-8 enabled show it correctly.

ASCII `-` is the conventional separator for CLI title / usage text and is safe across every code page, pipe, and log.

## Change

- `main.cpp:266` — `CLI::App app{ "wtcli — ..." }` → `"wtcli - ..."`
- `main.cpp:869` — `printf("wtcli — ...")` → `printf("wtcli - ...")`

Two characters changed; only string literals touched. Em dashes / box-drawing characters elsewhere in **comments** are intentionally left untouched (they never reach stdout).
