### PR TITLE
Add hooks-fallback agent session watcher (hybrid tracking)

### DIFF
--- a/.github/actions/spelling/patterns/patterns.txt
+++ b/.github/actions/spelling/patterns/patterns.txt
@@ -330,3 +330,17 @@ env_remove\("[A-Z_]+"\)
 
 # test fixture in ShellIntegrationTests.cpp — synthetic exe leaf used to test lookalike-rejection (pwsh + 'ell' suffix)
 \bpwshell\b
+
+# tools/wta/src/proc_bind.rs - Win32 process FFI: Toolhelp32 snapshot APIs, Restart
+# Manager (rstrtmgr.dll), RTL_USER_PROCESS_PARAMETERS (RUPP) PEB offset constants, the
+# TH32CS_* snapshot flags, and the PROCESS_BASIC_INFORMATION local (pbi).
+\bCreateToolhelp32Snapshot\b
+\bToolhelp32\b
+\bTH32CS_[A-Z]+\b
+\brstrtmgr\b
+\bRUPP_[A-Z0-9_]+\b
+\bpbi\b
+
+# tools/wta/src/agent_sessions.rs - lowercased agent tool name (Claude AskUserQuestion)
+# matched as a string literal in is_user_input_tool.
+\baskuserquestion\b

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -617,6 +617,7 @@ if it were canonical for the whole group.
 - **event-listener-strategy** v0.5.4 -- [https://github.com/smol-rs/event-listener-strategy](https://github.com/smol-rs/event-listener-strategy) -- `Apache-2.0 OR MIT`
 - **fancy-regex** v0.11.0 -- [https://github.com/fancy-regex/fancy-regex](https://github.com/fancy-regex/fancy-regex) -- `MIT`
 - **filedescriptor** v0.8.3 -- [https://github.com/wezterm/wezterm](https://github.com/wezterm/wezterm) -- `MIT`
+- **filetime** v0.2.29 -- [https://github.com/alexcrichton/filetime](https://github.com/alexcrichton/filetime) -- `Apache-2.0 OR MIT`
 - **finl_unicode** v1.4.0 -- [https://github.com/dahosek/finl_unicode](https://github.com/dahosek/finl_unicode) -- `(MIT OR Apache-2.0) AND Unicode-DFS-2016`
 - **fixedbitset** v0.4.2 -- [https://github.com/petgraph/fixedbitset](https://github.com/petgraph/fixedbitset) -- `Apache-2.0 OR MIT`
 - **fnv** v1.0.7 -- [https://github.com/servo/rust-fnv](https://github.com/servo/rust-fnv) -- `Apache-2.0 OR MIT`
@@ -665,6 +666,7 @@ if it were canonical for the whole group.
 - **mio** v1.1.1 -- [https://github.com/tokio-rs/mio](https://github.com/tokio-rs/mio) -- `MIT`
 - **nom** v7.1.3 -- [https://github.com/Geal/nom](https://github.com/Geal/nom) -- `MIT`
 - **normpath** v1.5.1 -- [https://github.com/dylni/normpath](https://github.com/dylni/normpath) -- `Apache-2.0 OR MIT`
+- **notify** v6.1.1 -- [https://github.com/notify-rs/notify.git](https://github.com/notify-rs/notify.git) -- `CC0-1.0`
 - **nu-ansi-term** v0.50.3 -- [https://github.com/nushell/nu-ansi-term](https://github.com/nushell/nu-ansi-term) -- `MIT`
 - **num-conv** v0.2.0 -- [https://github.com/jhpratt/num-conv](https://github.com/jhpratt/num-conv) -- `Apache-2.0 OR MIT`
 - **num-derive** v0.4.2 -- [https://github.com/rust-num/num-derive](https://github.com/rust-num/num-derive) -- `Apache-2.0 OR MIT`
@@ -784,8 +786,11 @@ if it were canonical for the whole group.
 - **which** v7.0.3 -- [https://github.com/harryfei/which-rs.git](https://github.com/harryfei/which-rs.git) -- `MIT`
 - **winapi** v0.3.9 -- [https://github.com/retep998/winapi-rs](https://github.com/retep998/winapi-rs) -- `Apache-2.0 OR MIT`
 - **winapi-util** v0.1.11 -- [https://github.com/BurntSushi/winapi-util](https://github.com/BurntSushi/winapi-util) -- `MIT OR Unlicense`
+- **windows_x86_64_msvc** v0.48.5 -- [https://github.com/microsoft/windows-rs](https://github.com/microsoft/windows-rs) -- `Apache-2.0 OR MIT`
 - **windows-link** v0.2.1 -- [https://github.com/microsoft/windows-rs](https://github.com/microsoft/windows-rs) -- `Apache-2.0 OR MIT`
+- **windows-sys** v0.48.0 -- [https://github.com/microsoft/windows-rs](https://github.com/microsoft/windows-rs) -- `Apache-2.0 OR MIT`
 - **windows-sys** v0.61.2 -- [https://github.com/microsoft/windows-rs](https://github.com/microsoft/windows-rs) -- `Apache-2.0 OR MIT`
+- **windows-targets** v0.48.5 -- [https://github.com/microsoft/windows-rs](https://github.com/microsoft/windows-rs) -- `Apache-2.0 OR MIT`
 - **winnow** v0.7.15 -- [https://github.com/winnow-rs/winnow](https://github.com/winnow-rs/winnow) -- `MIT`
 - **winsafe** v0.0.19 -- [https://github.com/rodrigocfd/winsafe](https://github.com/rodrigocfd/winsafe) -- `MIT`
 - **zmij** v1.0.21 -- [https://github.com/dtolnay/zmij](https://github.com/dtolnay/zmij) -- `MIT`
@@ -799,7 +804,7 @@ where applicable, the per-crate copyright notices harvested from upstream.
 
 ### `Apache-2.0`
 
-Applies to 151 crate(s) (directly or via composite identifiers): agent-client-protocol v0.10.0, agent-client-protocol-schema v0.11.0, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, anstyle-query v1.1.5, anstyle-wincon v3.0.11, ... (+143 more)
+Applies to 155 crate(s) (directly or via composite identifiers): agent-client-protocol v0.10.0, agent-client-protocol-schema v0.11.0, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, anstyle-query v1.1.5, anstyle-wincon v3.0.11, ... (+147 more)
 
 _Canonical text reproduced from upstream `SPDX:Apache-2.0`:_
 
@@ -961,9 +966,139 @@ The copyright notices in the Software and this entire statement, including the a
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
+### `CC0-1.0`
+
+Applies to 1 crate(s) (directly or via composite identifiers): notify v6.1.1
+
+_Canonical text reproduced from upstream `SPDX:CC0-1.0`:_
+
+```
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.
+```
+
 ### `MIT`
 
-Applies to 227 crate(s) (directly or via composite identifiers): aho-corasick v1.1.4, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, anstyle-query v1.1.5, anstyle-wincon v3.0.11, anyhow v1.0.102, ... (+219 more)
+Applies to 231 crate(s) (directly or via composite identifiers): aho-corasick v1.1.4, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, anstyle-query v1.1.5, anstyle-wincon v3.0.11, anyhow v1.0.102, ... (+223 more)
 
 _Canonical text reproduced from upstream `SPDX:MIT`:_
 

--- a/doc/specs/hybrid-agent-session-tracking.md
+++ b/doc/specs/hybrid-agent-session-tracking.md
@@ -1,0 +1,333 @@
+# Hooks-Fallback Agent Session Watcher (Hybrid Tracking)
+
+## Abstract
+
+Intelligent Terminal (IT) surfaces a live list of agent-CLI sessions
+(Copilot / Claude / Codex / Gemini) in the `/sessions` view. On `main`, the
+data that powers that list — *which* sessions exist, *which* pane each one runs
+in, and *what* each one is doing (Working / Idle / Attention) — comes from the
+PowerShell `wt-agent-hooks` bridge that every supported CLI loads, plus the
+*born-bound* registration for sessions IT launches itself (see
+[wta-launched-cli-session-binding.md](./wta-launched-cli-session-binding.md)).
+
+That coverage has a hole: a session the user **types themselves** (`codex`,
+`copilot`, … in a normal shell pane) is only tracked **if the hooks plugin is
+installed** for that CLI. If the user never opted in, or uninstalled the hooks,
+the session is invisible.
+
+This spec adds a **file/process watcher as a pure fallback** that fills exactly
+that hole, for all four CLIs, **without changing anything about the hook path**.
+The design principle is one sentence:
+
+> **Hooks (and born-bound) are authoritative when present; the watcher only
+> ever fills the gap, and the two never double-track the same session.**
+
+The C++ side is unchanged — this is entirely a `wta` (Rust) addition: the
+watcher itself, an event-dedup gate, an in-window liveness gate, a liveness
+reaper, and a codex title-extraction fix.
+
+## Background: Class A / Class B
+
+IT classifies every session by `SessionOrigin` (`agent_sessions.rs`):
+
+- **Class A — `AgentPane`**: an ACP session IT created for an agent pane. Bound
+  via ACP `session/new`; activity comes from the ACP stream. Never depends on
+  hooks. **Out of scope here** — the watcher never tracks Class A.
+- **Class B — `Unknown`**: an agent CLI running in an ordinary shell pane. On
+  `main`, Class B is tracked by:
+  - **born-bound** when IT launched it (`?<prompt>` delegation, recommended
+    opens, `/sessions` resume) — see the companion spec; or
+  - **hooks** when the user typed it *and* the CLI has `wt-agent-hooks`.
+
+The watcher targets the **remaining** Class-B sessions: **user-typed CLIs with
+no hooks installed**. It is the last slice of the "de-hook" effort, shipped as
+an opt-out-free fallback rather than a hook replacement.
+
+## Goals
+
+- When hooks are absent, still discover user-typed Class-B sessions, bind them
+  to their pane, show live activity, and reap them when the process exits.
+- Never produce a duplicate, a ghost, or a wrong-pane row when hooks **are**
+  present — the watcher must be a no-op for any session a hook owns.
+- Never surface a session that is not actually running in **this** IT window
+  (the four CLIs write their session state to per-user roots shared by VS Code,
+  language servers, other terminals, and other IT windows).
+
+## Non-goals
+
+- Replacing or modifying the hook path, the born-bound path, or any C++ code.
+- Tracking Class-A agent panes (ACP already does).
+- Perfect, instant fidelity. The watcher is a *fallback*; a few seconds of lag
+  or a missed transient state is acceptable. We deliberately avoid adding
+  polling sweeps or CLI-specific heroics to chase the last 1%.
+
+## Principle: two independent signals, one registry
+
+```
+                       wta-master registry  (one row per session)
+                                  ▲
+            ┌─────────────────────┼─────────────────────┐
+            │ authoritative       │            fallback  │
+   hooks / born-bound ────────────┤            ┌─────────┴── file/process watcher
+   (intellterm.wta/session_hook)  │            │            (in-process, master)
+            │                     │            │
+     marks session in        apply_watcher_event drops the event if the
+     `hook_owned` set ───────► session is already hook_owned OR is Class A
+```
+
+Both signals feed the **same reducer** and the **same registry rows**. A
+master-side `hook_owned: Mutex<HashSet<SessionId>>` is the seam that keeps them
+from fighting (see *Dedup* below). Everything runs always; dedup is what makes
+the watcher a no-op for hook-owned sessions, so there is no "hooks mode" vs
+"watcher mode" switch and no install-state probing.
+
+## Solution design
+
+### The watcher (discovery + activity)
+
+`session_watcher/*` is a [`notify`](https://crates.io/crates/notify)-based
+recursive file watcher over the four CLIs' session-state roots:
+
+| CLI     | Root watched                       | Session key |
+|---------|------------------------------------|-------------|
+| Copilot | `~/.copilot/session-state/`        | state-dir name (uuid) |
+| Claude  | `~/.claude/projects/**/*.jsonl`    | jsonl stem (uuid) |
+| Codex   | `~/.codex/sessions/**/*.jsonl`     | rollout id (last 5 hyphen groups) |
+| Gemini  | `~/.gemini/tmp/**/*.json`          | chat id |
+
+It is **event-driven**: a single `for res in raw_rx` loop reacts to create /
+modify events (`process_change`). There is **no periodic sweep** — an earlier
+3-second hot-set sweep was removed once the watcher became a fallback, to keep
+the cost proportionate. At startup, `seed_existing_progress_in` records the
+files already on disk so a fresh master doesn't replay the user's entire history
+as "new activity".
+
+Each change is handed to the per-CLI classifier
+(`classify_{copilot,codex,claude,gemini}.rs`), which decides whether the file
+represents a real, top-level user session and what activity state it implies.
+Codex subagent rollouts (`multi_agent_v1` / `spawn_agent` forks, identified by
+`source.subagent` in the rollout `session_meta`) are **skipped** — they inherit
+the parent's history and would otherwise appear as a duplicate row with the same
+title.
+
+### Binding & liveness (process-driven)
+
+`proc_bind.rs` resolves the `(pane GUID, owner pid, cwd)` for a watched session,
+best-effort, via Win32:
+
+- `wt_session_for_pid` — reads the `WT_SESSION` environment variable straight
+  out of a process's PEB; this **is** the pane GUID.
+- `copilot_pid_from_lock` — copilot writes `inuse.<pid>.lock` in its session
+  dir, giving an exact session→pid link.
+- `file_owner_pid` — Restart-Manager (`RmStartSession` / `RmGetList`) reports
+  which process holds a rollout file open (used for codex).
+- `pid_alive`, `env_var_for_pid`, `cwd_for_pid` — supporting probes.
+
+Binding confidence differs per CLI, and **this is the core reason hooks remain
+preferred**:
+
+- **Copilot**: lock-file → pid → `WT_SESSION` is exact.
+- **Codex**: RM file-owner → pid → `WT_SESSION` is exact *while codex holds the
+  rollout open*.
+- **Claude / Gemini**: no lock file and no reliable open-file owner, so binding
+  falls back to cwd correlation, which is ambiguous when two panes share a cwd.
+
+A failed bind never blocks the row — it yields `pane = None` / `pid = None`. The
+resolved `pid` is stored on the row as `bound_pid` (`session_registry.rs`) and
+feeds the reaper.
+
+### Dedup: how hooks and the watcher never double-track
+
+`master/mod.rs` holds `hook_owned: Mutex<HashSet<SessionId>>`.
+`handle_session_hook` inserts the session key for **every** inbound
+`intellterm.wta/session_hook` event — which covers both real PowerShell hooks
+**and** born-bound registration, since both arrive through that one method.
+
+`apply_watcher_event` early-returns (drops the watcher event) when **either**:
+
+1. `hook_owned.contains(sid)` — a hook/born-bound has claimed it; or
+2. the existing registry row's `origin == AgentPane` — it's Class A (ACP).
+
+So the moment a hook is heard for a session, the watcher goes silent for it.
+There is no ordering requirement: if the watcher created the row first and a
+hook arrives later, subsequent watcher events are dropped and the hook owns the
+row from then on (the row identity is the same session id, so no duplicate is
+produced).
+
+### Liveness gate: scoping to this IT window
+
+The four CLIs write their session state to **per-user** roots, so the watcher
+sees *every* such session on the machine — VS Code's copilot, the
+copilot-language-server, agent CLIs in other terminals, and sessions in **other
+IT windows**. Surfacing those would pollute this window's list (observed: two
+"Idle" copilot rows appearing before the user opened anything).
+
+The gate (`watcher_row_allowed` + `live_it_pane_guids`) admits a watcher session
+only when its **bound pane is a live pane in *this* IT instance**:
+
+- `live_it_pane_guids` walks `list_windows → list_tabs → list_panes` over the
+  COM `IProtocolServer` channel, lowercases every pane `session_id`, and caches
+  the set for 2 seconds. It returns `None` when there is no WT channel (tests,
+  detached master), in which case the gate is permissive.
+- `watcher_row_allowed(pane, Some(set))` = `pane` is `Some` **and** in `set`.
+
+> **Implementation note (bug class to remember):** the COM JSON returns
+> `window_id` / `tab_id` as **numbers** (`"window_id": 1`), so the walk must
+> match `String | Number`. An earlier `as_str()`-only extraction skipped every
+> window, produced an empty live set, and silently rejected **all** watcher
+> sessions. The cross-shape match is load-bearing.
+
+The gate runs **only** when a row is being created (`None`) or revived from a
+terminal state (`Historical` / `Ended`); already-live rows skip it so a chatty
+session doesn't re-walk COM on every keystroke.
+
+### The 5-second reaper
+
+Hooks emit an explicit close event; the watcher has no such signal, so a
+dedicated `tokio::time::interval(5s)` task (`reap_dead_class_b_sessions`) ends
+fallback rows whose process has gone. It transitions a row to `SessionStopped`
+when **all** hold:
+
+- `origin != AgentPane` (Class B only),
+- `status ∈ {Working, Idle, Attention}` (not already terminal),
+- `bound_pid.is_some()` — and `bound_pid` is set **only** by the watcher bind
+  path, so the reaper effectively only ever reaps watcher-tracked rows, and
+- `!pid_alive(bound_pid)`.
+
+`pid_alive` is ~13 µs for a live pid; the per-tick cost is well under 0.1 ms for
+realistic row counts, so the 5 s cadence is negligible. This is a net-new task
+(master has no other interval; the `/sessions` view's 5 s re-poll is
+helper-side and unrelated).
+
+### Title resolution (and the codex AGENTS.md fix)
+
+A watcher row is created with a **synthetic** title (cwd basename, or empty),
+then upgraded from the CLI's on-disk artefacts by `try_refresh_title_from_disk`
+→ `lookup_title_for_session`, the **same** disk-title path the hook and
+born-bound rows use:
+
+- Copilot → `workspace.yaml` `summary:` (fallback `name:`)
+- Claude / Gemini → first real user message in the jsonl
+- Codex → `codex_title_from_file` (first non-synthetic user turn)
+
+Because the path is shared, a latent codex bug affected **all three origins**,
+not just the watcher: codex auto-loads `AGENTS.md` when the cwd has one and
+prepends it as a synthetic user-role record (`# AGENTS.md instructions for
+<dir>`) *before* the user's first prompt. The old scanner skipped only
+`<environment_context>`, so it titled the session with that 69-character doc
+heading instead of the prompt.
+
+The fix is a shared `codex_user_text_is_synthetic` helper
+(`history_loader.rs`) that recognises codex's injected blocks —
+`<environment_context>`, `<user_instructions>`, `<subagent_notification>`,
+`<turn_aborted>`, and `# AGENTS.md instructions for ` — and is used by **both**
+the title scan (`codex_title_from_file`) and the phantom-session check
+(`codex_session_has_real_content`, so a never-prompted codex opened in an
+`AGENTS.md` repo is correctly treated as empty rather than surfaced with a doc
+title).
+
+### Components & files
+
+| Concern | File(s) |
+|---------|---------|
+| Watcher loop, roots, seed | `tools/wta/src/session_watcher/mod.rs` |
+| Per-CLI discovery / classify | `session_watcher/{discover,classify_copilot,classify_codex,classify_claude,classify_gemini}.rs` |
+| Pane binding helper | `session_watcher/bind.rs` |
+| Win32 probes (PEB, lock, RM) | `tools/wta/src/proc_bind.rs` |
+| Apply / dedup / gate / reaper | `tools/wta/src/master/mod.rs` (`apply_watcher_event`, `ensure_watched_session_row`, `resolve_watched_pane_pid_cwd`, `watcher_row_allowed`, `live_it_pane_guids`, `reap_dead_class_b_sessions`, `hook_owned`) |
+| Row `bound_pid` field | `tools/wta/src/session_registry.rs` |
+| Codex title / subagent / phantom | `tools/wta/src/history_loader.rs` |
+
+### Activity-state mapping
+
+The watcher maps file evidence to the same `AgentStatus` the hook reducer uses:
+a fresh/updated session is `Idle`; the per-CLI classifier promotes to `Working`
+on in-progress turn markers and to `Attention` on a pending user-input prompt;
+the reaper (or a hook taking over) moves it out of those states. Terminal states
+are `Historical` (from the startup history scan) and `Ended` (pane/process
+gone).
+
+## What is explicitly unchanged
+
+- The hook path, born-bound registration, and the `intellterm.wta/session_hook`
+  reducer.
+- All C++ (FRE "Install hooks", Settings UI, `ConptyConnection`,
+  `agent_hooks_installer`, the four hook bundles).
+- Class-A agent-pane tracking.
+- The `/sessions` UI and its 5 s re-poll.
+
+## Edge cases & failure modes
+
+- **Hooks installed mid-session**: the first hook event marks the session
+  `hook_owned`; the watcher row (if any) is adopted by the hook from then on,
+  same session id, no duplicate.
+- **Bind fails (Claude/Gemini shared cwd)**: row is created with `pane = None`;
+  the liveness gate then withholds it (no live pane to match) rather than risk a
+  wrong-window row. This is the conservative, accepted limitation that keeps
+  hooks preferred for those two CLIs.
+- **Codex holds, then releases, the rollout file**: binding is exact only while
+  the file is held; if codex closes it the reaper still ends the row on process
+  exit via `bound_pid`.
+- **Other IT window**: that window's panes aren't in this master's
+  `live_it_pane_guids`, so the gate withholds the row — each window shows only
+  its own.
+- **`notify` miss**: a dropped FS event means a late or missing appearance; the
+  fallback nature makes this acceptable, and the startup seed bounds the blast
+  radius after a restart.
+
+## Capabilities
+
+- **Security / Privacy**: reads only the user's own CLI session-state files and
+  process metadata for the current user; no new network or cross-user access.
+- **Reliability**: best-effort throughout; every probe failure degrades to "no
+  row" rather than a wrong row. Dedup and the liveness gate are the two
+  invariants that prevent duplicates/ghosts.
+- **Performance**: event-driven (no sweep); the only timer is the 5 s reaper
+  (sub-0.1 ms/tick). COM pane walks are cached 2 s and only run on
+  create/revive.
+- **Compatibility**: additive; with hooks installed, behaviour is identical to
+  `main` (watcher events are all deduped).
+
+## Testing
+
+- Unit: `master::tests` (`watcher_event_*`, `watcher_row_allowed_*`,
+  `live_it_pane_guids_*` — incl. numeric `window_id`/`tab_id` mock,
+  `reap_*`, `session_hook_marks_*`), `history_loader::tests`
+  (`codex_title_skips_injected_agents_md_instructions`,
+  `codex_session_with_only_injected_context_is_phantom`, subagent filter), and
+  `session_watcher` discovery/classify tests.
+- Manual matrix:
+  - hooks installed → row tracked by hook; master log shows watcher events
+    deduped.
+  - hooks uninstalled → user-typed codex tracked by the watcher with the correct
+    real-prompt title (verified in an `AGENTS.md` repo); external/non-IT copilot
+    sessions stay hidden; no PowerShell shell-hook events in the master log.
+
+## Diagnostics
+
+`wta-main_master.log` (`target: "session_watcher"`):
+
+- `refreshed live IT pane set panes={…}` — the COM-walked live pane set.
+- `watcher liveness gate decision … resolved_pane=… gated=… live_pane_count=…
+  allowed=…` — per-session admit/withhold.
+- `upgraded synthetic title from on-disk session artefacts … title_len=…` —
+  title resolution (a 69-char codex title was the AGENTS.md regression).
+
+## Rejected / deferred alternatives
+
+- **Hookless for all four CLIs (the original #258 approach)** — rejected:
+  Claude/Gemini binding is too ambiguous and codex's RM binding is fragile, so
+  hooks must stay authoritative. This spec is the salvaged *fallback* half of
+  that work.
+- **Polling sweep for perfect liveness** — rejected: disproportionate for a
+  fallback; event-driven + the 5 s reaper is enough.
+- **Pane-is-some filter instead of the in-window gate** — rejected: machine-wide
+  CLI sessions also carry `WT_SESSION`, so only membership in *this* window's
+  live pane set is sufficient.
+
+## Future considerations
+
+- A stronger Claude/Gemini bind (e.g. a CLI-provided pid file) would let the
+  watcher cover those two as confidently as Copilot/Codex.
+- If a CLI gains a first-class "session ended" file marker, the reaper could
+  react to it instead of polling pid liveness.

--- a/doc/specs/hybrid-agent-session-tracking.md
+++ b/doc/specs/hybrid-agent-session-tracking.md
@@ -19,12 +19,16 @@ This spec adds a **file/process watcher as a pure fallback** that fills exactly
 that hole, for all four CLIs, **without changing anything about the hook path**.
 The design principle is one sentence:
 
-> **Hooks (and born-bound) are authoritative when present; the watcher only
-> ever fills the gap, and the two never double-track the same session.**
+> **A real hook owns a session outright; #266 born-bound owns only its binding;
+> the watcher fills the rest — surfacing user-typed sessions and supplying
+> *status* for born-bound (delegate/resume) sessions that have no hook — and the
+> three never double-track.**
 
 The C++ side is unchanged — this is entirely a `wta` (Rust) addition: the
-watcher itself, an event-dedup gate, an in-window liveness gate, a liveness
-reaper, and a codex title-extraction fix.
+watcher itself, the two-set dedup (`hook_owned` / `born_bound`), an in-window
+liveness gate, a liveness reaper, the born-bound *status* fallback, per-CLI
+status detection (Claude is turn-based on `stop_reason`; Gemini is deferred), and
+a codex title-extraction fix.
 
 ## Background: Class A / Class B
 
@@ -61,24 +65,23 @@ an opt-out-free fallback rather than a hook replacement.
   or a missed transient state is acceptable. We deliberately avoid adding
   polling sweeps or CLI-specific heroics to chase the last 1%.
 
-## Principle: two independent signals, one registry
+## Principle: hooks own, born-bound binds, the watcher fills the gap
 
 ```
-                       wta-master registry  (one row per session)
-                                  ▲
-            ┌─────────────────────┼─────────────────────┐
-            │ authoritative       │            fallback  │
-   hooks / born-bound ────────────┤            ┌─────────┴── file/process watcher
-   (intellterm.wta/session_hook)  │            │            (in-process, master)
-            │                     │            │
-     marks session in        apply_watcher_event drops the event if the
-     `hook_owned` set ───────► session is already hook_owned OR is Class A
+   real hook / ACP event   ──►  `hook_owned`  ──► watcher fully suppressed
+   #266 born-bound              `born_bound`   ──► watcher supplies STATUS only
+   (delegate / resume)     ──►                     (never re-binds)
+   user-typed CLI, no hook ───────────────────► watcher creates + binds the row
+                                  │
+                                  ▼
+                    wta-master registry (one row per session)
 ```
 
-Both signals feed the **same reducer** and the **same registry rows**. A
-master-side `hook_owned: Mutex<HashSet<SessionId>>` is the seam that keeps them
-from fighting (see *Dedup* below). Everything runs always; dedup is what makes
-the watcher a no-op for hook-owned sessions, so there is no "hooks mode" vs
+All paths feed the **same reducer** and the **same registry rows**. Two
+master-side sets are the seam (see *Dedup*): `hook_owned` (a real hook / ACP
+agent-pane event owns binding **and** activity → watcher dropped) and
+`born_bound` (WTA-launched delegate/resume — binding only → the watcher may
+still supply **status**). Everything runs always; there is no "hooks mode" vs
 "watcher mode" switch and no install-state probing.
 
 ## Solution design
@@ -136,23 +139,60 @@ A failed bind never blocks the row — it yields `pane = None` / `pid = None`. T
 resolved `pid` is stored on the row as `bound_pid` (`session_registry.rs`) and
 feeds the reaper.
 
-### Dedup: how hooks and the watcher never double-track
+### Dedup: how the watcher coordinates with hooks and born-bound
 
-`master/mod.rs` holds `hook_owned: Mutex<HashSet<SessionId>>`.
-`handle_session_hook` inserts the session key for **every** inbound
-`intellterm.wta/session_hook` event — which covers both real PowerShell hooks
-**and** born-bound registration, since both arrive through that one method.
+The master keeps **two disjoint** ownership sets (`master/mod.rs`):
 
-`apply_watcher_event` early-returns (drops the watcher event) when **either**:
+- `hook_owned: Mutex<HashSet<SessionId>>` — sessions a **real** producer owns
+  outright (PowerShell hooks, ACP agent-pane events). Owns binding **and**
+  activity.
+- `born_bound: Mutex<HashSet<SessionId>>` — #266 **born-bound** sessions
+  (WTA-launched delegate `?<prompt>` and `/sessions` resume). These provide a
+  pane binding but **no activity** — binding-only.
 
-1. `hook_owned.contains(sid)` — a hook/born-bound has claimed it; or
-2. the existing registry row's `origin == AgentPane` — it's Class A (ACP).
+`handle_session_hook` routes each inbound event: a binding-only event (the
+dedicated `intellterm.wta/session_born_bound` method, or a
+`ResumeDispatched`/`ResumePaneAssigned` resume-binding event) → `born_bound`;
+anything else (a real hook / ACP event) → `hook_owned` (and, if the session was
+born-bound, drops it from `born_bound` — a real hook **takes over**).
 
-So the moment a hook is heard for a session, the watcher goes silent for it.
-There is no ordering requirement: if the watcher created the row first and a
-hook arrives later, subsequent watcher events are dropped and the hook owns the
-row from then on (the row identity is the same session id, so no duplicate is
-produced).
+`apply_watcher_event` then, in order:
+
+1. `hook_owned.contains(sid)` → **drop** (the hook owns binding and activity);
+2. `born_bound.contains(sid)` → **apply status only** (see below), never re-bind;
+3. existing row `origin == AgentPane` → drop (Class A, ACP-driven);
+4. otherwise → the normal create/bind/gate path (user-typed sessions).
+
+There is no ordering requirement and the row identity is the same session id
+throughout, so no duplicate is ever produced.
+
+### Born-bound activity fallback
+
+Born-bound (see [wta-launched-cli-session-binding.md](./wta-launched-cli-session-binding.md))
+registers a WTA-launched session's `(session id → pane)` at launch and records
+it in `born_bound`. It supplies the **binding** but emits **no activity**. With
+hooks installed the CLI's hook supplies activity (and takes over); with **no**
+hooks the row would otherwise sit at `Idle` forever.
+
+Because born-bound hands us the **exact** session id, the watcher already knows
+which transcript to read — the binding ambiguity that limits the *typed*
+Claude/Gemini path doesn't apply. So for a `born_bound` session
+`apply_watcher_event` applies the watcher's **status** event (Working / Idle /
+Attention) to the existing row **without** re-binding the pane or touching the
+origin — `emitted.event` is always a keyed status event (`ToolStarting` /
+`ToolCompleted` / `Notification`), never a `SessionStarted`, so the binding is
+safe. The liveness gate and `ensure_watched_session_row` are skipped (born-bound
+already owns the live, vetted binding).
+
+This covers all born-bound CLIs (**Copilot / Claude / Gemini**); Codex has no
+`--session-id`, is never born-bound, and is naturally excluded.
+
+**Resume.** `/sessions` resume publishes `ResumeDispatched` / `ResumePaneAssigned`
+over the generic `session_hook` method (not the born-bound method). These are
+the hook-free resume binding, so `handle_session_hook` records them in
+`born_bound` rather than `hook_owned` — without this, a resumed session would be
+treated as hook-owned and its row would sit at `Idle` forever even as the watcher
+saw activity.
 
 ### Liveness gate: scoping to this IT window
 
@@ -234,23 +274,58 @@ title).
 | Per-CLI discovery / classify | `session_watcher/{discover,classify_copilot,classify_codex,classify_claude,classify_gemini}.rs` |
 | Pane binding helper | `session_watcher/bind.rs` |
 | Win32 probes (PEB, lock, RM) | `tools/wta/src/proc_bind.rs` |
-| Apply / dedup / gate / reaper | `tools/wta/src/master/mod.rs` (`apply_watcher_event`, `ensure_watched_session_row`, `resolve_watched_pane_pid_cwd`, `watcher_row_allowed`, `live_it_pane_guids`, `reap_dead_class_b_sessions`, `hook_owned`) |
+| Apply / dedup / gate / reaper | `tools/wta/src/master/mod.rs` (`apply_watcher_event`, `handle_session_hook`, `ensure_watched_session_row`, `watcher_row_allowed`, `live_it_pane_guids`, `reap_dead_class_b_sessions`, `hook_owned` + `born_bound` sets) |
+| Born-bound registration | `session_registry.rs` (`build_born_bound_request`, `INTELLTERM_METHOD_SESSION_BORN_BOUND`), `main.rs` (`register_launched_session_with_master`) |
 | Row `bound_pid` field | `tools/wta/src/session_registry.rs` |
 | Codex title / subagent / phantom | `tools/wta/src/history_loader.rs` |
+| User-input tool heuristic | `agent_sessions.rs` (`is_user_input_tool`) |
 
-### Activity-state mapping
+### Status detection (per-CLI)
 
-The watcher maps file evidence to the same `AgentStatus` the hook reducer uses:
-a fresh/updated session is `Idle`; the per-CLI classifier promotes to `Working`
-on in-progress turn markers and to `Attention` on a pending user-input prompt;
-the reaper (or a hook taking over) moves it out of those states. Terminal states
-are `Historical` (from the startup history scan) and `Ended` (pane/process
-gone).
+The watcher maps each CLI's on-disk transcript to the same `AgentStatus` the
+hook reducer uses, via three events: `ToolStarting` → **Working**,
+`ToolCompleted` → **Idle**, `Notification` → **Attention**. A fresh/bound session
+starts `Idle`; terminal states are `Historical` (startup history scan) and
+`Ended` (pane/process gone); the 5 s reaper or a hook taking over moves a row out
+of the live states.
+
+- **Claude** (`classify_claude.rs`) — **turn-based, keyed on `stop_reason`**.
+  Claude re-writes the same assistant message id several times as it streams
+  (text first, then `+tool_use`), so classifying by content presence flickers;
+  `stop_reason` is stable across the stream. A `type:user` record (typed prompt
+  or `tool_result`) → Working; an assistant `stop_reason == "tool_use"` →
+  Working, unless a `tool_use` names a user-input tool (`AskUserQuestion`) →
+  Attention; any other `stop_reason` (`end_turn`, …) → Idle.
+- **Copilot / Codex** (`classify_copilot.rs` / `classify_codex.rs`) — tool-based
+  classify over their append-only logs: tool start → Working, turn/tool end →
+  Idle, user-input tool → Attention.
+- **Gemini — DEFERRED (no reliable status from the log).** Gemini is the
+  weakest-bound CLI (no lock file, no reliable open-file owner → cwd
+  correlation) **and** has the messiest transcript: each `gemini` message is
+  appended **twice** under the same id (text/thoughts, then `+toolCalls`),
+  interleaved with `$set:lastUpdated` metadata lines, with **no turn-completion
+  signal** (no `stop_reason`/`finishReason`). A `gemini`-without-`toolCalls`
+  line is therefore ambiguous — the first phase of a tool turn, or a final text
+  response — so Idle vs Working can't be told from one line. The current snapshot
+  classifier also yields nothing when the file ends on a `$set:lastUpdated` op
+  (no `messages` array). A clean turn-based status for Gemini is not achievable
+  from the log alone, so it is **deferred**: Gemini's born-bound rows still bind,
+  they just won't reflect live status without hooks.
+
+**Limitation — permission prompts.** A tool that pauses for **permission** (e.g.
+`Bash`/`Edit` in `default` mode) is **indistinguishable** in the transcript from
+a tool that is merely running — there is no approval/pending marker (only
+`permissionMode`). So a permission wait shows as **Working**, not Attention;
+only an explicit user-input tool (`AskUserQuestion`) is Attention. Reliable
+permission → Attention would require hooks. (A `dangerous-tool → Attention`
+name heuristic was considered and rejected: it is wrong under auto-approve and
+conflates a running write-tool with a wait.)
 
 ## What is explicitly unchanged
 
-- The hook path, born-bound registration, and the `intellterm.wta/session_hook`
-  reducer.
+- The PowerShell hook path and the `intellterm.wta/session_hook` reducer
+  semantics. (Born-bound now uses its own `…/session_born_bound` method so it can
+  be treated as binding-only — see *Dedup* — but the wire body is identical.)
 - All C++ (FRE "Install hooks", Settings UI, `ConptyConnection`,
   `agent_hooks_installer`, the four hook bundles).
 - Class-A agent-pane tracking.
@@ -291,17 +366,23 @@ gone).
 ## Testing
 
 - Unit: `master::tests` (`watcher_event_*`, `watcher_row_allowed_*`,
-  `live_it_pane_guids_*` — incl. numeric `window_id`/`tab_id` mock,
-  `reap_*`, `session_hook_marks_*`), `history_loader::tests`
-  (`codex_title_skips_injected_agents_md_instructions`,
-  `codex_session_with_only_injected_context_is_phantom`, subagent filter), and
-  `session_watcher` discovery/classify tests.
+  `live_it_pane_guids_*` — incl. numeric `window_id`/`tab_id` mock, `reap_*`,
+  `session_hook_marks_*`; born-bound: `session_born_bound_marks_born_bound_not_hook_owned`,
+  `born_bound_session_gets_watcher_activity_without_rebinding`,
+  `real_hook_takes_over_born_bound_session`, `resume_binding_events_are_born_bound_not_hook_owned`),
+  `history_loader::tests` (codex title / subagent / phantom), and
+  `session_watcher` discovery/classify tests (incl. `classify_claude` turn-based:
+  user→Working, `stop_reason` end_turn→Idle / tool_use→Working, streaming-partial
+  stays Working, AskUserQuestion→Attention).
 - Manual matrix:
   - hooks installed → row tracked by hook; master log shows watcher events
     deduped.
   - hooks uninstalled → user-typed codex tracked by the watcher with the correct
     real-prompt title (verified in an `AGENTS.md` repo); external/non-IT copilot
     sessions stay hidden; no PowerShell shell-hook events in the master log.
+  - hooks uninstalled → a **delegate** (`?<prompt>`) and a **resumed** Claude
+    session show live status (Working/Idle/Attention) from the watcher, not a
+    frozen `Idle`.
 
 ## Diagnostics
 
@@ -324,10 +405,19 @@ gone).
 - **Pane-is-some filter instead of the in-window gate** — rejected: machine-wide
   CLI sessions also carry `WT_SESSION`, so only membership in *this* window's
   live pane set is sufficient.
+- **Gemini turn-based status** — **deferred** (see *Status detection*): Gemini's
+  transcript has no turn-completion signal and a 2-phase / `$set`-interleaved
+  shape that makes Idle-vs-Working ambiguous from the log. Its rows still bind;
+  live status awaits hooks or a cleaner Gemini format.
+- **`dangerous-tool → Attention` heuristic** — rejected: a permission wait is
+  indistinguishable from a running tool in the transcript, and the heuristic is
+  wrong under auto-approve.
 
 ## Future considerations
 
 - A stronger Claude/Gemini bind (e.g. a CLI-provided pid file) would let the
   watcher cover those two as confidently as Copilot/Codex.
+- A reliable Gemini turn signal (a `finishReason`, or a stable per-message
+  completion marker) would let Gemini join the turn-based status model.
 - If a CLI gains a first-class "session ended" file marker, the reaper could
   react to it instead of polling pid liveness.

--- a/doc/specs/hybrid-agent-session-tracking.md
+++ b/doc/specs/hybrid-agent-session-tracking.md
@@ -27,8 +27,9 @@ The design principle is one sentence:
 The C++ side is unchanged — this is entirely a `wta` (Rust) addition: the
 watcher itself, the two-set dedup (`hook_owned` / `born_bound`), an in-window
 liveness gate, a liveness reaper, the born-bound *status* fallback, per-CLI
-status detection (Claude is turn-based on `stop_reason`; Gemini is deferred), and
-a codex title-extraction fix.
+status detection (all four turn-based; Gemini is Working-only — it shows live
+Working/Attention but defers the turn-end → Idle), and a codex
+title-extraction fix.
 
 ## Background: Class A / Class B
 
@@ -432,10 +433,11 @@ of the live states.
 - **Pane-is-some filter instead of the in-window gate** — rejected: machine-wide
   CLI sessions also carry `WT_SESSION`, so only membership in *this* window's
   live pane set is sufficient.
-- **Gemini turn-based status** — **deferred** (see *Status detection*): Gemini's
+- **Gemini turn-end → Idle** — **deferred** (see *Status detection*): Gemini's
   transcript has no turn-completion signal and a 2-phase / `$set`-interleaved
-  shape that makes Idle-vs-Working ambiguous from the log. Its rows still bind;
-  live status awaits hooks or a cleaner Gemini format.
+  shape, so the *end* of a turn can't be told from the log. Gemini already shows
+  live **Working/Attention** (read per record from the append log); only the
+  turn-end → Idle transition awaits hooks or a cleaner Gemini format.
 - **`dangerous-tool → Attention` heuristic** — rejected: a permission wait is
   indistinguishable from a running tool in the transcript, and the heuristic is
   wrong under auto-approve.

--- a/doc/specs/hybrid-agent-session-tracking.md
+++ b/doc/specs/hybrid-agent-session-tracking.md
@@ -307,32 +307,46 @@ of the live states.
   because Idle is owned by the turn end. An explicit permission/escalation
   record (`permission.requested` for Copilot, sandbox `require_escalated` for
   Codex) → Attention.
-- **Gemini — best-effort only; reliable turn-based status deferred.** Gemini is
-  the weakest-bound CLI (no lock file, no reliable open-file owner → cwd
-  correlation) **and** has the messiest transcript: each `gemini` message is
-  appended **twice** under the same id (text/thoughts, then `+toolCalls`),
-  interleaved with `$set:lastUpdated` metadata lines, with **no turn-completion
-  signal** (no `stop_reason`/`finishReason`). The existing snapshot classifier
-  still runs and is best-effort (`toolCalls` → Working, `ask_user` → Attention,
-  `functionResponse` → Idle), but it is unreliable: a `gemini`-without-`toolCalls`
-  line is ambiguous (first phase of a tool turn, or a final text response — Idle
-  vs Working can't be told from one line), and it yields nothing when the file
-  ends on a `$set:lastUpdated` op (no `messages` array). A clean turn-based
-  status for Gemini is not achievable from the log alone, so that rewrite is
-  **deferred**; Gemini's born-bound rows still bind, only the live status is
-  unreliable without hooks.
+- **Gemini** (`classify_gemini.rs`) — **Working-only; turn-based Idle deferred.**
+  Gemini's `session-*.jsonl` is an **append log** (re-verified 2026-06-14): every
+  line is a standalone `{"id","type":"user"|"gemini",…}` record or a `$set` op,
+  so the watcher reads it by byte offset like the other three CLIs. Each `gemini`
+  message is appended **twice** under the same id (phase 1 text/thoughts, phase 2
+  `+toolCalls`), interleaved with `$set:lastUpdated` bumps; a full
+  `$set:{messages:[…]}` snapshot is written only at session **start** and
+  **resume**. `classify_record` **skips every `$set` op** — crucially the resume
+  snapshot, which would otherwise replay the entire prior conversation — and maps
+  each activity record to **Working**: a `type:user` record (typed prompt *or* a
+  `functionResponse` tool result), a `type:gemini` text record (phase 1 / final
+  answer), or a `type:gemini` with `toolCalls` (tool name surfaced; a user-input
+  `ask_user` → **Attention** instead). It **never emits Idle**: Gemini writes no
+  turn-completion signal (no `stop_reason`/`finishReason`), and a `toolCall`
+  carrying a `result` does **not** mean the turn ended — so a `gemini`-without-
+  `toolCalls` line is ambiguous (intermediate text vs final answer). A Gemini row
+  therefore stays **Working** through the conversation and only leaves the live
+  state on `PaneClosed`; a clean turn-based Idle is **deferred** (needs a
+  turn-end marker Gemini doesn't write, or hooks).
 
-**Limitation — permission prompts (Claude).** In Claude's transcript a tool that
-pauses for **permission** (e.g. `Bash`/`Edit` in `default` mode) is
-**indistinguishable** from a tool that is merely running — there is no
-approval/pending marker (only `permissionMode`). So a Claude permission wait
-shows as **Working**, not Attention; only an explicit user-input tool
-(`AskUserQuestion`) is Attention. Reliable permission → Attention for Claude
-would require hooks. (A `dangerous-tool → Attention` name heuristic was
-considered and rejected: it is wrong under auto-approve and conflates a running
-write-tool with a wait.) Copilot and Codex are **not** affected — they write
-explicit `permission.requested` / `require_escalated` records that map to
-Attention.
+**Limitation — permission / ask-for-input prompts.**
+
+- **Claude.** A tool that pauses for **permission** (e.g. `Bash`/`Edit` in
+  `default` mode) is **indistinguishable** from a tool that is merely running —
+  there is no approval/pending marker (only `permissionMode`). So a Claude
+  permission wait shows as **Working**, not Attention; only an explicit
+  user-input tool (`AskUserQuestion`) is Attention. (A `dangerous-tool →
+  Attention` name heuristic was considered and rejected: it is wrong under
+  auto-approve and conflates a running write-tool with a wait.)
+- **Gemini.** The transcript is written **post-completion** — every on-disk
+  `toolCall` is `status:"success"` with its `result` inlined, and an `ask_user`
+  record already contains the user's answer. So the `ask_user` line lands only
+  *after* the user replied; during the actual wait the file is silent and the
+  last record (the agent's phase-1 text) shows **Working**. The `ask_user` →
+  Attention mapping is kept (and is correct if a future Gemini build writes a
+  pending state), but in today's transcript it is typically superseded by the
+  immediately-following result record → the wait effectively shows Working,
+  same class of limitation as Claude. Reliable wait-state Attention needs hooks.
+- **Copilot / Codex** are **not** affected — they write explicit
+  `permission.requested` / `require_escalated` records that map to Attention.
 
 ## What is explicitly unchanged
 

--- a/doc/specs/hybrid-agent-session-tracking.md
+++ b/doc/specs/hybrid-agent-session-tracking.md
@@ -296,30 +296,43 @@ of the live states.
   or `tool_result`) → Working; an assistant `stop_reason == "tool_use"` →
   Working, unless a `tool_use` names a user-input tool (`AskUserQuestion`) →
   Attention; any other `stop_reason` (`end_turn`, …) → Idle.
-- **Copilot / Codex** (`classify_copilot.rs` / `classify_codex.rs`) — tool-based
-  classify over their append-only logs: tool start → Working, turn/tool end →
-  Idle, user-input tool → Attention.
-- **Gemini — DEFERRED (no reliable status from the log).** Gemini is the
-  weakest-bound CLI (no lock file, no reliable open-file owner → cwd
+- **Copilot / Codex** (`classify_copilot.rs` / `classify_codex.rs`) —
+  **turn-based**, not tool-based. One user prompt drives one or more agent
+  *turns*; the agent is Working for the whole turn (thinking + streaming text +
+  tool runs), so Working is bracketed by the turn boundary
+  (`assistant.turn_start` → `assistant.turn_end` for Copilot,
+  `event_msg/task_started` → `task_complete` for Codex), not by the brief
+  tool-execution windows. Tool starts only refine the picture (current tool, or
+  Attention for a user-input tool); the tool-completion record is ignored
+  because Idle is owned by the turn end. An explicit permission/escalation
+  record (`permission.requested` for Copilot, sandbox `require_escalated` for
+  Codex) → Attention.
+- **Gemini — best-effort only; reliable turn-based status deferred.** Gemini is
+  the weakest-bound CLI (no lock file, no reliable open-file owner → cwd
   correlation) **and** has the messiest transcript: each `gemini` message is
   appended **twice** under the same id (text/thoughts, then `+toolCalls`),
   interleaved with `$set:lastUpdated` metadata lines, with **no turn-completion
-  signal** (no `stop_reason`/`finishReason`). A `gemini`-without-`toolCalls`
-  line is therefore ambiguous — the first phase of a tool turn, or a final text
-  response — so Idle vs Working can't be told from one line. The current snapshot
-  classifier also yields nothing when the file ends on a `$set:lastUpdated` op
-  (no `messages` array). A clean turn-based status for Gemini is not achievable
-  from the log alone, so it is **deferred**: Gemini's born-bound rows still bind,
-  they just won't reflect live status without hooks.
+  signal** (no `stop_reason`/`finishReason`). The existing snapshot classifier
+  still runs and is best-effort (`toolCalls` → Working, `ask_user` → Attention,
+  `functionResponse` → Idle), but it is unreliable: a `gemini`-without-`toolCalls`
+  line is ambiguous (first phase of a tool turn, or a final text response — Idle
+  vs Working can't be told from one line), and it yields nothing when the file
+  ends on a `$set:lastUpdated` op (no `messages` array). A clean turn-based
+  status for Gemini is not achievable from the log alone, so that rewrite is
+  **deferred**; Gemini's born-bound rows still bind, only the live status is
+  unreliable without hooks.
 
-**Limitation — permission prompts.** A tool that pauses for **permission** (e.g.
-`Bash`/`Edit` in `default` mode) is **indistinguishable** in the transcript from
-a tool that is merely running — there is no approval/pending marker (only
-`permissionMode`). So a permission wait shows as **Working**, not Attention;
-only an explicit user-input tool (`AskUserQuestion`) is Attention. Reliable
-permission → Attention would require hooks. (A `dangerous-tool → Attention`
-name heuristic was considered and rejected: it is wrong under auto-approve and
-conflates a running write-tool with a wait.)
+**Limitation — permission prompts (Claude).** In Claude's transcript a tool that
+pauses for **permission** (e.g. `Bash`/`Edit` in `default` mode) is
+**indistinguishable** from a tool that is merely running — there is no
+approval/pending marker (only `permissionMode`). So a Claude permission wait
+shows as **Working**, not Attention; only an explicit user-input tool
+(`AskUserQuestion`) is Attention. Reliable permission → Attention for Claude
+would require hooks. (A `dangerous-tool → Attention` name heuristic was
+considered and rejected: it is wrong under auto-approve and conflates a running
+write-tool with a wait.) Copilot and Codex are **not** affected — they write
+explicit `permission.requested` / `require_escalated` records that map to
+Attention.
 
 ## What is explicitly unchanged
 

--- a/doc/specs/wta-launched-cli-session-binding.md
+++ b/doc/specs/wta-launched-cli-session-binding.md
@@ -101,10 +101,14 @@ At each in-scope launch:
 
 No file discovery, no hooks, no PEB read — the row is **born bound** to the pane.
 
-> **As built:** that "register" step is the existing
-> `intellterm.wta/session_hook` ext-method with a `SessionStarted` event — the
-> master reducer already turns it into a born-bound Class-B row, so no new
-> message type was needed.
+> **As built:** the register step sends a `SessionStarted` over a dedicated
+> `intellterm.wta/session_born_bound` ext-method (same wire body as
+> `…/session_hook`). The distinct method lets the master record the session as
+> *binding-only* (`born_bound`) rather than hook-owned, so the file/process
+> watcher can still supply **status** (Working/Idle/Attention) for it when no
+> hook is installed — without re-binding the pane. Resume's
+> `ResumeDispatched`/`ResumePaneAssigned` get the same binding-only treatment.
+> See [hybrid-agent-session-tracking.md](./hybrid-agent-session-tracking.md).
 
 **Precedent**: master already records `(session_id, pane_session_id)` for Class A
 agent panes (`agent_pane_origin.rs` v2), and the registry already carries the

--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -325,8 +325,32 @@ and `liveness()` derive from it (see `agent_sessions.rs`).
   immediately, even if master's `session_removed` notification
   hasn't landed yet.
 
-* **Class B** is driven entirely by hooks + WT pane events
-  (`SessionStarted` / `SessionStopped` / `PaneClosed`).
+* **Class B** is tracked by a **hybrid** of three producers (full design:
+  [`doc/specs/hybrid-agent-session-tracking.md`](../../doc/specs/hybrid-agent-session-tracking.md)):
+  a real PowerShell **hook** owns a session outright; #266 **born-bound**
+  (delegate `?<prompt>` / `/sessions` resume) owns only its pane binding; and a
+  file/process **watcher** is the fallback — it surfaces user-typed sessions and
+  supplies **status** for born-bound sessions that have no hook. The master keeps
+  two disjoint sets, `hook_owned` and `born_bound`, so the three never
+  double-track (`master/mod.rs`: `apply_watcher_event` / `handle_session_hook`).
+
+### Status (Working / Idle / Attention) from the log
+
+When a Class-B session has no hook, the watcher derives status from the CLI's
+transcript (`session_watcher/classify_*.rs` -> `ToolStarting` = Working /
+`ToolCompleted` = Idle / `Notification` = Attention):
+
+* **Claude** — turn-based, keyed on `stop_reason` (a `user` record -> Working;
+  assistant `stop_reason:tool_use` -> Working, `AskUserQuestion` -> Attention;
+  `end_turn` -> Idle). Claude re-writes the same message id while streaming, so
+  keying on content would flicker — `stop_reason` is stable.
+* **Copilot / Codex** — tool-based over their append-only logs.
+* **Gemini — deferred**: no turn-completion signal + a 2-phase / `$set`-
+  interleaved transcript make Idle-vs-Working ambiguous from the log; its rows
+  bind but won't show live status without hooks.
+* **Limitation**: a permission prompt (`Bash`/`Edit` in default mode) is
+  indistinguishable from a running tool in the transcript -> shows **Working**,
+  not Attention (only the explicit `AskUserQuestion` tool is Attention).
 
 ### Cold-startup race
 

--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -349,17 +349,27 @@ transcript (`session_watcher/classify_*.rs` -> `ToolStarting` = Working /
   `event_msg/task_started`/`task_complete` for Codex), not by the brief tool
   windows; a user-input tool *or* an explicit permission/escalation record
   (`permission.requested` / sandbox `require_escalated`) -> Attention.
-* **Gemini — best-effort only (turn-based rewrite deferred)**: a snapshot
-  classifier still runs (`toolCalls` -> Working, `ask_user` -> Attention,
-  `functionResponse` -> Idle), but it is unreliable — no turn-completion signal
-  plus a 2-phase / `$set`-interleaved transcript leave Idle-vs-Working
-  ambiguous, and it yields nothing when the file ends on a `$set:lastUpdated`
-  line. Rows still bind; only the live status is unreliable without hooks.
-* **Limitation (Claude only)**: Claude's transcript has no permission marker
-  (only `permissionMode`), so a permission prompt (`Bash`/`Edit` in default
-  mode) is indistinguishable from a running tool -> shows **Working**, not
-  Attention (only the explicit `AskUserQuestion` tool is Attention). Copilot and
-  Codex *do* surface permission waits as Attention via the records above.
+* **Gemini — Working-only (turn-based Idle deferred)**: Gemini's
+  `session-*.jsonl` is an append log (single-message records + `$set` ops),
+  read by byte offset like the others. `classify_record` **skips every `$set`
+  op** (crucially the start/resume `$set:messages` snapshot, so a resume can't
+  replay history) and maps each activity record to Working: a `user` record
+  (prompt or `functionResponse`), a `gemini` text record, or a `gemini` with
+  `toolCalls` (`ask_user` -> Attention). It **never emits Idle** — Gemini writes
+  no turn-completion signal and a completed `toolCall` doesn't mean the turn
+  ended, so a row stays Working until `PaneClosed`. A clean turn-based Idle is
+  deferred (needs a turn-end marker Gemini doesn't write).
+* **Limitation (permission / ask-for-input)**:
+  * **Claude** — no permission marker (only `permissionMode`), so a permission
+    prompt (`Bash`/`Edit` in default mode) is indistinguishable from a running
+    tool -> **Working** (only the explicit `AskUserQuestion` tool is Attention).
+  * **Gemini** — the transcript is written **post-completion** (every on-disk
+    `toolCall` is `status:success` with its result, and `ask_user` already holds
+    the answer), so the wait window shows **Working**; the `ask_user` ->
+    Attention mapping is kept but is typically superseded by the following result
+    record. Reliable wait-state Attention needs hooks.
+  * **Copilot / Codex** *do* surface permission waits as Attention via
+    `permission.requested` / `require_escalated`.
 
 ### Cold-startup race
 

--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -344,13 +344,22 @@ transcript (`session_watcher/classify_*.rs` -> `ToolStarting` = Working /
   assistant `stop_reason:tool_use` -> Working, `AskUserQuestion` -> Attention;
   `end_turn` -> Idle). Claude re-writes the same message id while streaming, so
   keying on content would flicker — `stop_reason` is stable.
-* **Copilot / Codex** — tool-based over their append-only logs.
-* **Gemini — deferred**: no turn-completion signal + a 2-phase / `$set`-
-  interleaved transcript make Idle-vs-Working ambiguous from the log; its rows
-  bind but won't show live status without hooks.
-* **Limitation**: a permission prompt (`Bash`/`Edit` in default mode) is
-  indistinguishable from a running tool in the transcript -> shows **Working**,
-  not Attention (only the explicit `AskUserQuestion` tool is Attention).
+* **Copilot / Codex** — turn-based over their append-only logs. Working is
+  bracketed by the turn boundary (`assistant.turn_start`/`turn_end` for Copilot,
+  `event_msg/task_started`/`task_complete` for Codex), not by the brief tool
+  windows; a user-input tool *or* an explicit permission/escalation record
+  (`permission.requested` / sandbox `require_escalated`) -> Attention.
+* **Gemini — best-effort only (turn-based rewrite deferred)**: a snapshot
+  classifier still runs (`toolCalls` -> Working, `ask_user` -> Attention,
+  `functionResponse` -> Idle), but it is unreliable — no turn-completion signal
+  plus a 2-phase / `$set`-interleaved transcript leave Idle-vs-Working
+  ambiguous, and it yields nothing when the file ends on a `$set:lastUpdated`
+  line. Rows still bind; only the live status is unreliable without hooks.
+* **Limitation (Claude only)**: Claude's transcript has no permission marker
+  (only `permissionMode`), so a permission prompt (`Bash`/`Edit` in default
+  mode) is indistinguishable from a running tool -> shows **Working**, not
+  Attention (only the explicit `AskUserQuestion` tool is Attention). Copilot and
+  Codex *do* surface permission waits as Attention via the records above.
 
 ### Cold-startup race
 

--- a/tools/wta/Cargo.lock
+++ b/tools/wta/Cargo.lock
@@ -84,7 +84,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -95,7 +95,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -380,7 +380,7 @@ dependencies = [
  "derive_more",
  "document-features",
  "futures-core",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "rustix",
  "signal-hook",
@@ -539,7 +539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -594,6 +594,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +632,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -858,6 +877,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +958,26 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
 ]
 
 [[package]]
@@ -1038,6 +1097,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
@@ -1045,7 +1116,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1077,7 +1148,26 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9985ef7269fa99f3b12437bb698381da2428743ab90f20393f399fa14cab21a"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1086,7 +1176,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1558,7 +1648,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1732,7 +1822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio",
+ "mio 1.1.1",
  "signal-hook",
 ]
 
@@ -1777,7 +1867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2041,13 +2131,13 @@ checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2533,7 +2623,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2550,12 +2640,78 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
@@ -2670,6 +2826,7 @@ dependencies = [
  "clap",
  "crossterm",
  "futures",
+ "notify",
  "ratatui",
  "rust-i18n",
  "serde",
@@ -2685,7 +2842,7 @@ dependencies = [
  "unicode-width",
  "uuid",
  "which",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/tools/wta/Cargo.toml
+++ b/tools/wta/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 ratatui = "0.30"
 crossterm = { version = "0.29", features = ["event-stream"] }
+notify = "6"
 futures = "0.3"
 unicode-width = "0.2"
 textwrap = "0.16"

--- a/tools/wta/cgmanifest.json
+++ b/tools/wta/cgmanifest.json
@@ -554,6 +554,15 @@
       "component": {
         "type": "cargo",
         "cargo": {
+          "name": "filetime",
+          "version": "0.2.29"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
           "name": "finl_unicode",
           "version": "1.4.0"
         }
@@ -979,6 +988,15 @@
         "cargo": {
           "name": "normpath",
           "version": "1.5.1"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "notify",
+          "version": "6.1.1"
         }
       }
     },
@@ -2057,6 +2075,15 @@
       "component": {
         "type": "cargo",
         "cargo": {
+          "name": "windows_x86_64_msvc",
+          "version": "0.48.5"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
           "name": "windows-link",
           "version": "0.2.1"
         }
@@ -2067,7 +2094,25 @@
         "type": "cargo",
         "cargo": {
           "name": "windows-sys",
+          "version": "0.48.0"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "windows-sys",
           "version": "0.61.2"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "windows-targets",
+          "version": "0.48.5"
         }
       }
     },

--- a/tools/wta/src/agent_sessions.rs
+++ b/tools/wta/src/agent_sessions.rs
@@ -291,8 +291,9 @@ pub enum SessionEvent {
 /// block until the user answers — so the row should show ATTENTION, not
 /// WORKING. Match list is case-insensitive.
 ///
-/// Known matches (verified against actual hook payloads):
+/// Known matches (verified against actual hook payloads / transcripts):
 ///   - Copilot CLI: `ask_user` (carries `tool_input.question` + `choices`)
+///   - Claude CLI: `AskUserQuestion` (assistant `tool_use`, `caller.type=direct`)
 /// Speculative aliases for other CLIs are included so the heuristic catches
 /// the common variants without needing per-CLI plumbing.
 pub fn is_user_input_tool(name: &str) -> bool {
@@ -302,6 +303,8 @@ pub fn is_user_input_tool(name: &str) -> bool {
         | "ask-user"
         | "ask_question"
         | "askquestion"
+        | "askuserquestion"
+        | "ask_user_question"
         | "ask_for_clarification"
         | "request_input"
         | "request_user_input"

--- a/tools/wta/src/agent_sessions.rs
+++ b/tools/wta/src/agent_sessions.rs
@@ -402,6 +402,7 @@ impl AgentSessionRegistry {
                     }
                 }
 
+                let is_new_entry = !self.sessions.contains_key(&key);
                 let entry = self.sessions.entry(key.clone()).or_insert_with(|| AgentSession {
                     key:               key.clone(),
                     cli_source:        cli_source.clone(),
@@ -460,10 +461,26 @@ impl AgentSessionRegistry {
                 } else {
                     entry.pane_session_id  = None;
                 }
-                entry.status           = AgentStatus::Idle;
-                entry.last_error       = None;
-                entry.attention_reason = None;
-                entry.current_tool     = None;
+                // Status baseline. A brand-new row starts Idle. For a row that
+                // ALREADY exists, preserve a live status instead of clobbering
+                // it: some CLIs fire activity hooks BEFORE `session.start` — e.g.
+                // Copilot sends `prompt.submit` (→ Working) ~2 s before its
+                // `session.start`, so an unconditional reset here would blank the
+                // row to Idle for the rest of the turn (until the next
+                // `tool.starting`). Only (re)baseline to Idle when the row is new
+                // or being revived from a non-live state (Ended/Error/Historical,
+                // e.g. resume / reconnect); Working/Attention/Idle are preserved.
+                if is_new_entry
+                    || matches!(
+                        entry.status,
+                        AgentStatus::Ended | AgentStatus::Error | AgentStatus::Historical
+                    )
+                {
+                    entry.status           = AgentStatus::Idle;
+                    entry.last_error       = None;
+                    entry.attention_reason = None;
+                    entry.current_tool     = None;
+                }
                 entry.last_activity_at = now;
                 if pane_known {
                     self.active_by_pane.insert(pane_session_id, key);
@@ -1568,6 +1585,63 @@ mod tests {
         assert_eq!(new.status, AgentStatus::Idle);
         assert_eq!(new.pane_session_id.as_deref(), Some(pane("p").as_str()));
         assert_eq!(reg.active_by_pane.get(&pane("p")), Some(&k("new")));
+    }
+
+    #[test]
+    fn session_started_preserves_working_set_by_earlier_prompt_submit() {
+        // bcec31b5 ordering bug: Copilot fires `prompt.submit` (→ Working) a
+        // couple seconds BEFORE its `session.start` for the same session id.
+        // A `SessionStarted` for an already-Working row must NOT reset it to
+        // Idle — otherwise the row sits at Idle from `session.start` until the
+        // next `tool.starting`, mid-turn.
+        let mut reg = AgentSessionRegistry::new();
+        // prompt.submit lands first as Working (route synthesizes a
+        // SessionStarted, then ToolStarting flips it to Working).
+        reg.apply(SessionEvent::SessionStarted {
+            key: k("s"), cli_source: CliSource::Copilot,
+            pane_session_id: pane("p"), cwd: PathBuf::from("/x"),
+            title: "t".into(),
+        });
+        reg.apply(SessionEvent::ToolStarting { key: k("s"), tool_name: "prompt".into() });
+        assert_eq!(reg.sessions.get("s").unwrap().status, AgentStatus::Working);
+
+        // The real session.start arrives ~2 s later for the SAME key.
+        reg.apply(SessionEvent::SessionStarted {
+            key: k("s"), cli_source: CliSource::Copilot,
+            pane_session_id: pane("p"), cwd: PathBuf::from("/x"),
+            title: "t".into(),
+        });
+        assert_eq!(
+            reg.sessions.get("s").unwrap().status,
+            AgentStatus::Working,
+            "a late SessionStarted must preserve the live Working status",
+        );
+    }
+
+    #[test]
+    fn session_started_revives_ended_row_to_idle() {
+        // Counterpart to the preserve case: a SessionStarted for a row that is
+        // in a non-live terminal state (Ended) must still (re)baseline it to
+        // Idle — e.g. a resume / reconnect of a previously-ended session id.
+        let mut reg = AgentSessionRegistry::new();
+        reg.apply(SessionEvent::SessionStarted {
+            key: k("s"), cli_source: CliSource::Copilot,
+            pane_session_id: pane("p"), cwd: PathBuf::from("/x"),
+            title: "t".into(),
+        });
+        reg.apply(SessionEvent::PaneClosed { pane_session_id: pane("p") });
+        assert_eq!(reg.sessions.get("s").unwrap().status, AgentStatus::Ended);
+
+        reg.apply(SessionEvent::SessionStarted {
+            key: k("s"), cli_source: CliSource::Copilot,
+            pane_session_id: pane("p2"), cwd: PathBuf::from("/x"),
+            title: "t".into(),
+        });
+        assert_eq!(
+            reg.sessions.get("s").unwrap().status,
+            AgentStatus::Idle,
+            "a SessionStarted reviving an Ended row must reset it to Idle",
+        );
     }
 
     #[test]

--- a/tools/wta/src/agent_sessions.rs
+++ b/tools/wta/src/agent_sessions.rs
@@ -1589,7 +1589,7 @@ mod tests {
 
     #[test]
     fn session_started_preserves_working_set_by_earlier_prompt_submit() {
-        // bcec31b5 ordering bug: Copilot fires `prompt.submit` (→ Working) a
+        // Prompt-before-start ordering bug: Copilot fires `prompt.submit` (→ Working) a
         // couple seconds BEFORE its `session.start` for the same session id.
         // A `SessionStarted` for an already-Working row must NOT reset it to
         // Idle — otherwise the row sits at Idle from `session.start` until the

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -676,11 +676,22 @@ where
             key,
             tool_name: "prompt".to_string(),
         },
-        "agent.tool.completed"
-        | "agent.tool.finished"
-        | "agent.tool.failed"
-        | "agent.stop"
-        | "agent.subagent.stop" => SessionEvent::ToolCompleted { key },
+        // Tool completion does NOT end the turn. Copilot and Gemini fire a
+        // `tool.finished` per tool — often several per turn, in parallel
+        // batches — but the agent keeps working (thinking, streaming text,
+        // running the next tool) until it emits `agent.stop`. Mapping each
+        // `tool.finished` to `ToolCompleted` made multi-tool turns flicker to
+        // Idle and, worse, sit at Idle during the agent's between-tool thinking
+        // (Copilot fires only one `prompt.submit` + one `agent.stop` per user
+        // request, with many tool pairs in between). So ignore tool completions
+        // here and let `agent.stop` own the turn-end → Idle, mirroring the
+        // watcher's turn-based `classify_copilot` / `classify_codex`, which also
+        // ignore `tool.execution_complete`. Claude/Codex don't emit `tool.*`
+        // hook events at all, so this only affects Copilot/Gemini.
+        "agent.tool.completed" | "agent.tool.finished" | "agent.tool.failed" => {
+            return reg.take_dirty();
+        }
+        "agent.stop" | "agent.subagent.stop" => SessionEvent::ToolCompleted { key },
         "agent.notification" => SessionEvent::Notification {
             key,
             message: payload
@@ -9464,6 +9475,70 @@ mod tests {
                 SessionEvent::Notification { key, .. } if key.starts_with("pane:")
             )),
             "no synthetic-key Notification should leak to master",
+        );
+    }
+
+    /// Turn-based hook status (bcec31b5 bug): Copilot/Gemini fire a
+    /// `tool.finished` per tool — several per turn, in parallel batches — but
+    /// the agent keeps working until `agent.stop`. A `tool.finished` must NOT
+    /// demote the row to Idle (only `agent.stop` ends the turn), otherwise a
+    /// multi-tool turn flickers to (and sits at) Idle while the agent is busy.
+    #[test]
+    fn copilot_tool_finished_keeps_working_only_agent_stop_idles() {
+        use crate::agent_sessions::{
+            AgentSessionRegistry, AgentStatus, CliSource, SessionEvent,
+        };
+        let mut reg = AgentSessionRegistry::new();
+        let pane = "11111111-1111-1111-1111-111111111111";
+        let sid = "copilot-sid";
+        reg.apply(SessionEvent::SessionStarted {
+            key: sid.into(),
+            cli_source: CliSource::Copilot,
+            pane_session_id: pane.into(),
+            cwd: std::path::PathBuf::from("/work"),
+            title: "copilot".into(),
+        });
+        reg.take_dirty();
+
+        let route = |reg: &mut AgentSessionRegistry, event: &str| {
+            let params = json!({
+                "event": event,
+                "cli_source": "copilot",
+                "agent_session_id": sid,
+                "payload": { "tool_name": "read_file" }
+            });
+            route_agent_event_to_registry_with_hook_sink(reg, pane, &params, |_| {});
+        };
+
+        // User prompt → Working (turn start).
+        route(&mut reg, "agent.prompt.submit");
+        assert_eq!(reg.get(&sid.to_string()).unwrap().status, AgentStatus::Working);
+
+        // A parallel batch: three starts, then three finishes.
+        route(&mut reg, "agent.tool.starting");
+        route(&mut reg, "agent.tool.starting");
+        route(&mut reg, "agent.tool.starting");
+        assert_eq!(reg.get(&sid.to_string()).unwrap().status, AgentStatus::Working);
+        route(&mut reg, "agent.tool.finished");
+        assert_eq!(
+            reg.get(&sid.to_string()).unwrap().status,
+            AgentStatus::Working,
+            "first tool.finished must NOT demote while siblings run / the turn continues",
+        );
+        route(&mut reg, "agent.tool.finished");
+        route(&mut reg, "agent.tool.finished");
+        assert_eq!(
+            reg.get(&sid.to_string()).unwrap().status,
+            AgentStatus::Working,
+            "tool completions never end the turn",
+        );
+
+        // Only agent.stop ends the turn → Idle.
+        route(&mut reg, "agent.stop");
+        assert_eq!(
+            reg.get(&sid.to_string()).unwrap().status,
+            AgentStatus::Idle,
+            "agent.stop owns the turn-end → Idle",
         );
     }
 

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -9481,7 +9481,7 @@ mod tests {
     /// Turn-based hook status (bcec31b5 bug): Copilot/Gemini fire a
     /// `tool.finished` per tool — several per turn, in parallel batches — but
     /// the agent keeps working until `agent.stop`. A `tool.finished` must NOT
-    /// demote the row to Idle (only `agent.stop` ends the turn), otherwise a
+    /// demote the row to Idle (only `agent.stop` ends the turn); otherwise a
     /// multi-tool turn flickers to (and sits at) Idle while the agent is busy.
     #[test]
     fn copilot_tool_finished_keeps_working_only_agent_stop_idles() {

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -9478,7 +9478,7 @@ mod tests {
         );
     }
 
-    /// Turn-based hook status (bcec31b5 bug): Copilot/Gemini fire a
+    /// Turn-based hook status (multi-tool turn bug): Copilot/Gemini fire a
     /// `tool.finished` per tool — several per turn, in parallel batches — but
     /// the agent keeps working until `agent.stop`. A `tool.finished` must NOT
     /// demote the row to Idle (only `agent.stop` ends the turn); otherwise a

--- a/tools/wta/src/history_loader.rs
+++ b/tools/wta/src/history_loader.rs
@@ -42,13 +42,16 @@
 //             - cwd          = `session_meta` payload.cwd
 //             - title        = first `event_msg` payload.user_message,
 //                              else first `response_item` role=user content
-//                              (skipping synthetic `<environment_context>`
-//                              prefixes injected by the CLI)
+//                              (skipping codex's synthetic injections —
+//                              `<environment_context>` & friends plus the
+//                              `# AGENTS.md instructions for <dir>` block;
+//                              see `codex_user_text_is_synthetic`)
 //             - last_activity= `session_meta` payload.timestamp (fallback file mtime)
 //             - skip "phantom" sessions whose jsonl contains only the
-//               `session_meta` header and/or synthetic
-//               `<environment_context>` response_items (no real user
-//               turn). `codex resume <id>` would reject these as having
+//               `session_meta` header and/or synthetic injected
+//               response_items (`<environment_context>`, AGENTS.md docs, …;
+//               see `codex_user_text_is_synthetic`) with no real user
+//               turn. `codex resume <id>` would reject these as having
 //               no conversation to resume.
 //
 // (Note: per-subagent JSONL files may live in nested `<UUID>/` subdirs of
@@ -681,6 +684,10 @@ fn load_codex(home: &Path) -> Vec<AgentSession> {
                     if !name.starts_with("rollout-") || !name.ends_with(".jsonl") { continue; }
                     if !codex_session_has_real_content(&path) { continue; }
                     let Some(meta) = read_codex_session_meta(&path) else { continue; };
+                    // Skip Codex internal multi-agent subagent forks: they get
+                    // their own rollout file but inherit the parent's history
+                    // (same title) and are not user-facing sessions.
+                    if meta.is_subagent { continue; }
                     let title = codex_title_from_file(&path)
                         .unwrap_or_else(|| short_id(&meta.id, "codex"));
                     let last_activity_at = meta.timestamp
@@ -712,9 +719,10 @@ fn load_codex(home: &Path) -> Vec<AgentSession> {
 }
 
 struct CodexSessionMeta {
-    id:        String,
-    cwd:       PathBuf,
-    timestamp: Option<SystemTime>,
+    id:          String,
+    cwd:         PathBuf,
+    timestamp:   Option<SystemTime>,
+    is_subagent: bool,
 }
 
 fn read_codex_session_meta(path: &Path) -> Option<CodexSessionMeta> {
@@ -728,10 +736,31 @@ fn read_codex_session_meta(path: &Path) -> Option<CodexSessionMeta> {
     let payload = v.get("payload")?;
     let ts_str = payload.get("timestamp").and_then(|s| s.as_str());
     Some(CodexSessionMeta {
-        id:        payload.get("id")?.as_str()?.to_string(),
-        cwd:       PathBuf::from(payload.get("cwd")?.as_str()?),
-        timestamp: ts_str.and_then(parse_iso_to_system_time),
+        id:          payload.get("id")?.as_str()?.to_string(),
+        cwd:         PathBuf::from(payload.get("cwd")?.as_str()?),
+        timestamp:   ts_str.and_then(parse_iso_to_system_time),
+        is_subagent: codex_payload_is_subagent(payload),
     })
+}
+
+/// True if a Codex rollout record is the `session_meta` of an internal
+/// multi-agent subagent / forked thread. Codex's `multi_agent_v1` / `spawn_agent`
+/// tool forks a child thread that gets its own `rollout-*.jsonl` (carrying
+/// `source.subagent` in its meta) and inherits the parent's full history — so it
+/// shows the same first user message / title. It is a codex-internal worker, not
+/// a user-facing session, and must not surface as its own session row.
+pub(crate) fn codex_record_is_subagent_meta(v: &serde_json::Value) -> bool {
+    v.get("type").and_then(|t| t.as_str()) == Some("session_meta")
+        && v.get("payload").map(codex_payload_is_subagent).unwrap_or(false)
+}
+
+/// True if a Codex `session_meta` payload's `source` is the subagent variant
+/// (`{"subagent": …}`) rather than a top-level session (`"cli"` / `"user"`).
+pub(crate) fn codex_payload_is_subagent(payload: &serde_json::Value) -> bool {
+    payload
+        .get("source")
+        .and_then(|s| s.get("subagent"))
+        .is_some()
 }
 
 fn codex_session_has_real_content(path: &Path) -> bool {
@@ -759,7 +788,7 @@ fn codex_session_has_real_content(path: &Path) -> bool {
                         .and_then(|c0| c0.get("text"))
                         .and_then(|s| s.as_str())
                         .unwrap_or("");
-                    if !text.starts_with("<environment_context>") { return true; }
+                    if !codex_user_text_is_synthetic(text) { return true; }
                 }
             }
             _ => {}
@@ -792,7 +821,7 @@ fn codex_title_from_file(path: &Path) -> Option<String> {
                         .and_then(|c0| c0.get("text"))
                         .and_then(|s| s.as_str())
                         .unwrap_or("");
-                    if !text.starts_with("<environment_context>") {
+                    if !codex_user_text_is_synthetic(text) {
                         let title = first_nonblank_line(text);
                         if !title.is_empty() { return Some(title); }
                     }
@@ -808,9 +837,50 @@ fn first_nonblank_line(raw: &str) -> String {
     raw.lines().find(|l| !l.trim().is_empty()).unwrap_or("").trim().to_string()
 }
 
+/// Is this codex user-role `content.text` a *synthetic* record codex injects
+/// around the real conversation rather than something the user typed?
+///
+/// Codex prepends/interleaves several non-prompt user-role records: XML-ish
+/// wrapper blocks (`<environment_context>`, `<user_instructions>`,
+/// `<subagent_notification>`, `<turn_aborted>`, …) and one
+/// `# AGENTS.md instructions for <dir>` block per project doc it auto-loads.
+/// These appear *before* the user's first real prompt in the rollout, so both
+/// the title scanner and the "has real content" (phantom) check must skip them
+/// — otherwise a freshly opened, never-prompted codex session is treated as
+/// real and titled with a doc heading (e.g.
+/// `# AGENTS.md instructions for C:\…\intelligent-terminal`) instead of the
+/// user's prompt. Add new codex wrapper tags to `WRAPPER_TAGS` as they appear.
+fn codex_user_text_is_synthetic(text: &str) -> bool {
+    const WRAPPER_TAGS: &[&str] = &[
+        "<environment_context",
+        "<user_instructions",
+        "<subagent_notification",
+        "<turn_aborted",
+    ];
+    let t = text.trim_start();
+    WRAPPER_TAGS.iter().any(|tag| t.starts_with(tag))
+        || t.starts_with("# AGENTS.md instructions for ")
+}
+
 pub fn codex_title_for_key(home: &Path, key: &str) -> Option<String> {
     let path = find_codex_rollout_by_id(home, key)?;
     codex_title_from_file(&path)
+}
+
+/// Read a Codex session's working directory from its rollout `session_meta`
+/// record (always the first line). Shell-pane Codex rows have no path-encoded
+/// cwd (unlike Claude), and Codex writes no title until the user's first
+/// message — so without this the row would have an empty cwd and the session
+/// view's cwd-basename title fallback would render a placeholder for the ~20s
+/// before that first message. Returns `None` if the file/field is absent.
+pub(crate) fn codex_cwd_from_rollout(path: &Path) -> Option<PathBuf> {
+    let first = stream_jsonl_lines(path, CLASSIFY_SCAN_BYTES_CAP)?.next()?;
+    let v: serde_json::Value = serde_json::from_str(&first).ok()?;
+    let cwd = v.get("payload")?.get("cwd")?.as_str()?;
+    if cwd.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(cwd))
 }
 
 /// Locate the rollout file for a given session UUID.
@@ -823,7 +893,7 @@ pub fn codex_title_for_key(home: &Path, key: &str) -> Option<String> {
 /// The filename suffix `<id>.jsonl` is a fast pre-filter; we still verify
 /// `payload.id == id` to guard against renamed files or UUID-prefix
 /// collisions.
-fn find_codex_rollout_by_id(home: &Path, id: &str) -> Option<PathBuf> {
+pub(crate) fn find_codex_rollout_by_id(home: &Path, id: &str) -> Option<PathBuf> {
     let root = home.join(".codex").join("sessions");
     let Ok(years) = fs::read_dir(&root) else { return None };
     for y in years.flatten() {
@@ -1421,6 +1491,29 @@ mod tests {
         assert_eq!(parse_simple_yaml(text, "summary_count").as_deref(), Some("0"));
         // Querying a nonexistent prefix must not partial-match a longer key.
         assert_eq!(parse_simple_yaml(text, "summa"), None);
+    }
+
+    #[test]
+    fn codex_cwd_from_rollout_reads_session_meta() {
+        let dir = tmp_root("codex-cwd");
+        let path = dir.join("rollout-x.jsonl");
+        write_file(
+            &path,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"abc\",\"cwd\":\"C:\\\\Users\\\\yuazha\"}}\n\
+             {\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\"}}\n",
+        );
+        assert_eq!(
+            codex_cwd_from_rollout(&path),
+            Some(PathBuf::from("C:\\Users\\yuazha"))
+        );
+    }
+
+    #[test]
+    fn codex_cwd_from_rollout_none_when_absent() {
+        let dir = tmp_root("codex-cwd-none");
+        let path = dir.join("rollout-y.jsonl");
+        write_file(&path, "{\"type\":\"session_meta\",\"payload\":{\"id\":\"abc\"}}\n");
+        assert_eq!(codex_cwd_from_rollout(&path), None);
     }
 
     #[test]
@@ -2228,6 +2321,14 @@ mod tests {
 \"originator\":\"codex-tui\",\"cli_version\":\"0.1.0\",\"source\":\"cli\"}}}}\n")
     }
 
+    fn codex_subagent_meta_line(id: &str, parent: &str, ts: &str, cwd: &str) -> String {
+        format!(
+            "{{\"timestamp\":\"{ts}\",\"type\":\"session_meta\",\
+\"payload\":{{\"id\":\"{id}\",\"forked_from_id\":\"{parent}\",\"timestamp\":\"{ts}\",\"cwd\":\"{cwd}\",\
+\"originator\":\"codex-tui\",\"cli_version\":\"0.1.0\",\
+\"source\":{{\"subagent\":{{\"thread_spawn\":{{\"parent_thread_id\":\"{parent}\",\"depth\":1}}}}}}}}}}\n")
+    }
+
     fn codex_user_msg_line(ts: &str, text: &str) -> String {
         format!(
             "{{\"timestamp\":\"{ts}\",\"type\":\"event_msg\",\
@@ -2260,6 +2361,42 @@ mod tests {
         write_file(&path, &codex_meta_line(id, "2026-05-28T11:00:00Z", "C:/x"));
         assert_eq!(load_codex(&home).len(), 0, "phantom (meta-only) must be filtered out");
         let _ = fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn load_codex_skips_subagent_fork() {
+        // Codex's multi_agent_v1/spawn_agent forks a child thread that gets its
+        // own rollout (source.subagent) and inherits the parent's first user
+        // message — so it has an identical title. It is a codex-internal worker,
+        // not a user session, and must not appear as a (duplicate) row.
+        let home = tmp_root("load-codex-subagent");
+        let parent = "11111111-2222-3333-4444-555555555555";
+        let child  = "99999999-2222-3333-4444-555555555555";
+        let pp = codex_session_path(&home, "2026", "06", "10", "2026-06-10T13-14-32", parent);
+        write_file(
+            &pp,
+            &(codex_meta_line(parent, "2026-06-10T13:14:32Z", "C:/w")
+                + &codex_user_msg_line("2026-06-10T13:14:43Z", "start new tab agent pane session")),
+        );
+        let cp = codex_session_path(&home, "2026", "06", "10", "2026-06-10T13-15-12", child);
+        write_file(
+            &cp,
+            &(codex_subagent_meta_line(child, parent, "2026-06-10T13:15:12Z", "C:/w")
+                + &codex_user_msg_line("2026-06-10T13:15:12Z", "start new tab agent pane session")),
+        );
+
+        let rows = load_codex(&home);
+        assert_eq!(rows.len(), 1, "subagent fork must be filtered, got {:?}", rows);
+        assert_eq!(rows[0].key, parent, "only the top-level session should survive");
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn codex_payload_is_subagent_discriminates_source() {
+        let cli = serde_json::json!({ "source": "cli" });
+        assert!(!codex_payload_is_subagent(&cli), "top-level source=\"cli\" is not a subagent");
+        let sub = serde_json::json!({ "source": { "subagent": { "thread_spawn": { "depth": 1 } } } });
+        assert!(codex_payload_is_subagent(&sub), "source.subagent must be detected");
     }
 
     #[test]
@@ -2346,6 +2483,51 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert!(rows[0].title.contains("refactor the parser"),
                 "got title: {:?}", rows[0].title);
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn codex_title_skips_injected_agents_md_instructions() {
+        // codex auto-loads AGENTS.md when the cwd has one and prepends it as a
+        // synthetic user-role response_item ("# AGENTS.md instructions for …")
+        // BEFORE the real prompt. It must not become the session title — the
+        // real prompt must win. Regression for the 69-char AGENTS.md-heading
+        // title seen on sessions run inside the intelligent-terminal repo.
+        let home = tmp_root("codex-title-agents-md");
+        let id = "abcdef00-4444-4444-4444-444444444444";
+        let path = codex_session_path(&home, "2026", "05", "28", "2026-05-28T14-00-00", id);
+        let agents = format!(
+            "{{\"type\":\"response_item\",\"payload\":{{\"role\":\"user\",\
+\"content\":[{{\"text\":\"# AGENTS.md instructions for C:/proj\\n\\n<INSTRUCTIONS>\\nstuff\\n</INSTRUCTIONS>\"}}]}}}}\n");
+        let real = format!(
+            "{{\"type\":\"response_item\",\"payload\":{{\"role\":\"user\",\
+\"content\":[{{\"text\":\"friday is wonderful\"}}]}}}}\n");
+        write_file(&path, &(codex_meta_line(id, "2026-05-28T14:00:00Z", "C:/proj") + &agents + &real));
+        let rows = load_codex(&home);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].title, "friday is wonderful",
+                   "AGENTS.md injection must be skipped; got: {:?}", rows[0].title);
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn codex_session_with_only_injected_context_is_phantom() {
+        // meta + <environment_context> + AGENTS.md injection, but no real user
+        // turn → phantom (must not surface as a resumable session titled with a
+        // doc heading). Guards the shared `codex_user_text_is_synthetic` used by
+        // `codex_session_has_real_content`.
+        let home = tmp_root("codex-phantom-agents-md");
+        let id = "abcdef00-5555-5555-5555-555555555555";
+        let path = codex_session_path(&home, "2026", "05", "28", "2026-05-28T15-00-00", id);
+        let env = format!(
+            "{{\"type\":\"response_item\",\"payload\":{{\"role\":\"user\",\
+\"content\":[{{\"text\":\"<environment_context>cwd=C:/proj</environment_context>\"}}]}}}}\n");
+        let agents = format!(
+            "{{\"type\":\"response_item\",\"payload\":{{\"role\":\"user\",\
+\"content\":[{{\"text\":\"# AGENTS.md instructions for C:/proj\"}}]}}}}\n");
+        write_file(&path, &(codex_meta_line(id, "2026-05-28T15:00:00Z", "C:/proj") + &env + &agents));
+        assert_eq!(load_codex(&home).len(), 0,
+                   "meta + env_context + AGENTS.md injection alone must be phantom");
         let _ = fs::remove_dir_all(&home);
     }
 

--- a/tools/wta/src/history_loader.rs
+++ b/tools/wta/src/history_loader.rs
@@ -1499,12 +1499,12 @@ mod tests {
         let path = dir.join("rollout-x.jsonl");
         write_file(
             &path,
-            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"abc\",\"cwd\":\"C:\\\\Users\\\\yuazha\"}}\n\
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"abc\",\"cwd\":\"C:\\\\Users\\\\user\"}}\n\
              {\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\"}}\n",
         );
         assert_eq!(
             codex_cwd_from_rollout(&path),
-            Some(PathBuf::from("C:\\Users\\yuazha"))
+            Some(PathBuf::from("C:\\Users\\user"))
         );
     }
 
@@ -2498,7 +2498,7 @@ mod tests {
         let path = codex_session_path(&home, "2026", "05", "28", "2026-05-28T14-00-00", id);
         let agents = format!(
             "{{\"type\":\"response_item\",\"payload\":{{\"role\":\"user\",\
-\"content\":[{{\"text\":\"# AGENTS.md instructions for C:/proj\\n\\n<INSTRUCTIONS>\\nstuff\\n</INSTRUCTIONS>\"}}]}}}}\n");
+\"content\":[{{\"text\":\"# AGENTS.md instructions for C:/proj\\n\\n<INSTRUCTIONS>\\n be concise \\n</INSTRUCTIONS>\"}}]}}}}\n");
         let real = format!(
             "{{\"type\":\"response_item\",\"payload\":{{\"role\":\"user\",\
 \"content\":[{{\"text\":\"friday is wonderful\"}}]}}}}\n");

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -20,11 +20,13 @@ mod locale_parity_tests;
 mod master;
 mod osc52;
 mod pane_context;
+mod proc_bind;
 mod protocol;
 mod rtl;
 mod runtime_paths;
 mod session_mgmt;
 mod session_registry;
+mod session_watcher;
 mod shell;
 mod telemetry;
 #[cfg(test)]

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -1278,12 +1278,14 @@ async fn fetch_sessions_from_master(
 }
 
 /// Best-effort: register a WTA-launched CLI session with `wta-master` as a
-/// *born-bound* row — bound to its pane, with no hooks involved. Reuses the
-/// existing `intellterm.wta/session_hook` path with a `SessionStarted` event,
-/// which the master reducer turns into a Class-B (`origin = Unknown`) row whose
-/// `pane_session_id` is the pane we just created. Best-effort: if master is
-/// unreachable there is no registry to populate, so the registration is
-/// dropped (logged at `warn`) and the tab still opens normally.
+/// *born-bound* row — bound to its pane, with no hooks involved. Sends a
+/// `SessionStarted` over the `intellterm.wta/session_born_bound` method, which
+/// the master turns into a Class-B (`origin = Unknown`) row whose
+/// `pane_session_id` is the pane we just created and records as binding-only
+/// (so the file watcher may still supply activity/status when no hook is
+/// installed). Best-effort: if master is unreachable there is no registry to
+/// populate, so the registration is dropped (logged at `warn`) and the tab
+/// still opens normally.
 async fn register_launched_session_with_master(
     session_id: &str,
     pane_session_id: &str,
@@ -1301,7 +1303,7 @@ async fn register_launched_session_with_master(
         // on-disk session artefacts once they appear.
         title: String::new(),
     };
-    let req = session_registry::build_session_hook_request(&event);
+    let req = session_registry::build_born_bound_request(&event);
 
     // Own LocalSet so the `spawn_local` transport works regardless of how the
     // delegate's runtime was set up (mirrors `run_sessions_list`).

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -4744,7 +4744,7 @@ mod tests {
         let state = make_state();
         seed_row_with_pid(
             &state,
-            "sid-nopid",
+            "sid-no-pid",
             crate::agent_sessions::SessionOrigin::Unknown,
             crate::agent_sessions::AgentStatus::Idle,
             None,
@@ -4756,7 +4756,7 @@ mod tests {
 
         let row = state
             .registry
-            .lookup(&acp::SessionId::new("sid-nopid".to_string()))
+            .lookup(&acp::SessionId::new("sid-no-pid".to_string()))
             .await
             .unwrap();
         assert_eq!(row.status, Some(crate::agent_sessions::AgentStatus::Idle));
@@ -4816,17 +4816,17 @@ mod tests {
         let state = make_state();
         seed_session_row(
             &state,
-            "sid-agentpane",
+            "sid-agent-pane",
             crate::agent_sessions::SessionOrigin::AgentPane,
             crate::agent_sessions::AgentStatus::Idle,
         )
         .await;
 
-        apply_watcher_event(&state, codex_emitted("sid-agentpane")).await;
+        apply_watcher_event(&state, codex_emitted("sid-agent-pane")).await;
 
         let row = state
             .registry
-            .lookup(&acp::SessionId::new("sid-agentpane".to_string()))
+            .lookup(&acp::SessionId::new("sid-agent-pane".to_string()))
             .await
             .unwrap();
         // Still Idle — the watcher's ToolStarting (Working) was dropped.

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -220,10 +220,12 @@ struct MasterStateInner {
     /// routing hot path never contends on it.
     pub(crate) helper_meta: Mutex<HashMap<HelperId, HelperRecoveryMeta>>,
     /// Session ids claimed by an *authoritative* producer — a PowerShell agent
-    /// hook or a #266 born-bound registration, both of which arrive via
-    /// `intellterm.wta/session_hook`. The hookless file watcher is a **fallback**
-    /// only: once a session id appears here, its watcher-emitted events are
-    /// dropped in [`apply_watcher_event`] so hooks and the watcher never
+    /// hook (arrives via `intellterm.wta/session_hook`) or an ACP agent-pane
+    /// session (driven by ACP `session/*`), both of which fully own binding and
+    /// activity. The hookless file watcher is a **fallback** only: once a session
+    /// id appears here, its watcher-emitted events are dropped in
+    /// [`apply_watcher_event`] so hooks and the watcher never double-track the
+    /// same session.
     /// double-track the same session. This is what lets a CLI that ships hooks
     /// (and the WTA-launched born-bound sessions) keep their exact, hook-sourced
     /// pane binding while the watcher still covers user-typed CLIs that have no

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -35,6 +35,7 @@
 //     `ShellManager`, etc.).
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock, Weak};
 
@@ -218,6 +219,30 @@ struct MasterStateInner {
     /// Independent lock from `session_to_helper` so the per-session
     /// routing hot path never contends on it.
     pub(crate) helper_meta: Mutex<HashMap<HelperId, HelperRecoveryMeta>>,
+    /// Session ids claimed by an *authoritative* producer — a PowerShell agent
+    /// hook or a #266 born-bound registration, both of which arrive via
+    /// `intellterm.wta/session_hook`. The hookless file watcher is a **fallback**
+    /// only: once a session id appears here, its watcher-emitted events are
+    /// dropped in [`apply_watcher_event`] so hooks and the watcher never
+    /// double-track the same session. This is what lets a CLI that ships hooks
+    /// (and the WTA-launched born-bound sessions) keep their exact, hook-sourced
+    /// pane binding while the watcher still covers user-typed CLIs that have no
+    /// hook installed (notably Codex's Restart-Manager fallback).
+    ///
+    /// Grow-only for the master's lifetime: a dead session id costs a few bytes
+    /// and re-adding is idempotent, so no eviction is needed. Independent lock —
+    /// touched only on the session_hook ingest path and the watcher apply path.
+    hook_owned: Mutex<HashSet<acp::SessionId>>,
+    /// Short-lived cache of the live pane GUIDs in THIS IT instance (lowercased),
+    /// from a `list_windows`→`list_tabs`→`list_panes` walk over the master's WT
+    /// channel. Used by [`apply_watcher_event`] to gate watcher-discovered
+    /// sessions: a file-watched CLI is only surfaced if it binds to a pane that
+    /// is currently live here — otherwise it's a copilot/claude/… running in
+    /// VS Code, a background host, or another terminal (its session file is on
+    /// disk machine-wide, but it is not an IT shell-pane session). Cached for a
+    /// couple seconds so a startup burst of session files triggers at most one
+    /// COM walk. `None` until first populated.
+    live_panes_cache: Mutex<Option<(std::time::Instant, HashSet<String>)>>,
 }
 
 /// Per-helper recovery metadata stashed in
@@ -1563,6 +1588,8 @@ async fn run_master_loop(cli: Cli, pipe_name: String) -> Result<()> {
         cached_init_resp: OnceLock::new(),
         cli_source,
         helper_meta: Mutex::new(HashMap::new()),
+        hook_owned: Mutex::new(HashSet::new()),
+        live_panes_cache: Mutex::new(None),
     });
 
     // Seed the registry with historical sessions scanned from
@@ -1611,6 +1638,62 @@ async fn run_master_loop(cli: Cli, pipe_name: String) -> Result<()> {
             .await;
         }
     });
+
+    // ── Hookless Class-B session watcher ──────────────────────────────
+    // A blocking `notify` watcher runs on its own OS thread; a bridge thread
+    // forwards emitted events into this LocalSet via a tokio channel, where
+    // they're applied to master's registry (same reducer as session_hook).
+    {
+        let (sync_tx, sync_rx) = std::sync::mpsc::channel::<crate::session_watcher::Emitted>();
+        std::thread::Builder::new()
+            .name("wta-session-watch".into())
+            .spawn(move || {
+                if let Err(err) = crate::session_watcher::watch(sync_tx) {
+                    tracing::warn!(target: "session_watcher", error = %err, "watcher exited");
+                }
+            })
+            .ok();
+
+        let (async_tx, mut async_rx) =
+            tokio::sync::mpsc::unbounded_channel::<crate::session_watcher::Emitted>();
+        std::thread::Builder::new()
+            .name("wta-session-watch-bridge".into())
+            .spawn(move || {
+                for emitted in sync_rx {
+                    if async_tx.send(emitted).is_err() {
+                        break;
+                    }
+                }
+            })
+            .ok();
+
+        let inner_for_watch = Arc::clone(&inner);
+        tokio::task::spawn_local(async move {
+            while let Some(emitted) = async_rx.recv().await {
+                apply_watcher_event(&inner_for_watch, emitted).await;
+            }
+        });
+    }
+
+    // ── Class-B liveness poll ───────────────────────────────────────────
+    // Shell-pane CLIs (codex/claude/gemini) write no "session ended" record
+    // and don't all hold a lock file, so a `Ctrl+C` leaves the row stuck at
+    // its last status. Poll the bound pids every few seconds and end any whose
+    // owning process has exited. Each tick is cheap — an O(1) `OpenProcess`
+    // per bound Class-B session (~tens of microseconds) — so the fixed 5s
+    // interval adds no meaningful idle cost. `Skip` missed ticks so a busy
+    // executor never queues a backlog of polls.
+    {
+        let inner_for_reap = Arc::clone(&inner);
+        tokio::task::spawn_local(async move {
+            let mut ticker = tokio::time::interval(std::time::Duration::from_secs(5));
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                ticker.tick().await;
+                reap_dead_class_b_sessions(&inner_for_reap).await;
+            }
+        });
+    }
 
     // WT event subscriber: drive PaneClosed / ConnectionFailed into the
     // master registry directly off WT's `connection_state` events. This
@@ -2180,6 +2263,19 @@ async fn handle_session_hook(
     // the refresh is fine.
     let refresh_key = session_event_key(&event).map(str::to_owned);
 
+    // Mark this session as hook-owned so the file watcher (the fallback
+    // producer) stops tracking it — hooks and #266 born-bound registrations are
+    // authoritative. Keyed variants only (PaneClosed / ConnectionFailed carry no
+    // session key); those are pane-keyed terminal transitions, not a claim of
+    // ownership, so they don't belong in the set.
+    if let Some(key) = &refresh_key {
+        state
+            .hook_owned
+            .lock()
+            .await
+            .insert(acp::SessionId::new(key.clone()));
+    }
+
     let applied = state.registry.apply_event(event).await;
 
     let title_upgraded = if let Some(key) = refresh_key {
@@ -2197,6 +2293,359 @@ async fn handle_session_hook(
     }
 
     Ok(crate::session_registry::build_session_hook_response(applied))
+}
+
+/// Apply one watcher-emitted session event to master's registry and, if it
+/// changed state, broadcast `sessions/changed` so helpers refetch. Mirrors
+/// `handle_session_hook` but for the in-process file watcher (no ext-request
+/// round-trip). `SessionStarted` synthesis + pane binding happens in
+/// `ensure_watched_session_row` before the activity event is applied; the
+/// post-apply title refresh upgrades the synthetic (cwd-basename / empty)
+/// title from the CLI's on-disk artefacts, same as the hook path.
+async fn apply_watcher_event(
+    state: &MasterStateInner,
+    emitted: crate::session_watcher::Emitted,
+) {
+    let sid = acp::SessionId::new(emitted.key.clone());
+
+    // Hybrid dedup — the watcher is a *fallback*. Drop its event when an
+    // authoritative producer already owns this session:
+    //   1. a hook / #266 born-bound registration recorded it in `hook_owned`, or
+    //   2. it's an agent-pane (Class A) session, driven by ACP `session/update`.
+    // Either way the file watcher must not double-track or fight the binding.
+    if state.hook_owned.lock().await.contains(&sid) {
+        return;
+    }
+    let existing = state.registry.lookup(&sid).await;
+    if let Some(ref e) = existing {
+        if e.origin == Some(crate::agent_sessions::SessionOrigin::AgentPane) {
+            return;
+        }
+    }
+
+    // Liveness gate (only when we'd CREATE a new row or REVIVE a terminal one).
+    // The file watcher sees session files machine-wide, so the same on-disk CLI
+    // (copilot/claude/…) may be running in VS Code, a background host, or another
+    // terminal — not an IT shell pane. Only surface it if its resolved pane is a
+    // pane that is currently live in THIS IT instance. Already-live rows skip the
+    // gate (vetted at creation) so a chatty turn doesn't re-resolve every event.
+    let needs_gate = match &existing {
+        None => true,
+        Some(e) => matches!(
+            e.status,
+            Some(crate::agent_sessions::AgentStatus::Historical | crate::agent_sessions::AgentStatus::Ended)
+        ),
+    };
+    if needs_gate {
+        let home = std::env::var("USERPROFILE")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_default();
+        let (pane, _pid, _cwd) = resolve_watched_pane_pid_cwd(&home, &emitted);
+        let live = live_it_pane_guids(state).await;
+        let allowed = watcher_row_allowed(pane.as_deref(), live.as_ref());
+        tracing::debug!(
+            target: "session_watcher",
+            cli = ?emitted.cli,
+            key = %emitted.key,
+            resolved_pane = ?pane,
+            gated = live.is_some(),
+            live_pane_count = live.as_ref().map(|s| s.len()).unwrap_or(0),
+            allowed,
+            "watcher liveness gate decision"
+        );
+        if !allowed {
+            return;
+        }
+    }
+
+    ensure_watched_session_row(state, &emitted).await;
+    let key = emitted.key.clone();
+    let applied = state.registry.apply_event(emitted.event).await;
+    let title_upgraded =
+        try_refresh_title_from_disk(&state.registry, &acp::SessionId::new(key)).await;
+    if applied || title_upgraded {
+        broadcast_ext_to_helpers(
+            state,
+            crate::session_registry::build_sessions_changed_notification(),
+        )
+        .await;
+    }
+}
+
+/// Pure decision for the watcher liveness gate: should a watcher-discovered
+/// session be surfaced, given its resolved `pane` and the set of `live_panes`
+/// in this IT instance?
+///
+/// * `live_panes == None` → liveness is unknown (no WT channel — e.g. unit
+///   tests); don't gate, allow.
+/// * `live_panes == Some(set)` → allow only if `pane` is `Some` and present in
+///   the set (case-insensitive). A `None` pane (CLI not in any terminal, e.g.
+///   VS Code / background host) or a pane absent from this IT (another terminal
+///   / closed pane) is rejected.
+fn watcher_row_allowed(pane: Option<&str>, live_panes: Option<&HashSet<String>>) -> bool {
+    match live_panes {
+        None => true,
+        Some(set) => pane.is_some_and(|p| set.contains(&p.to_ascii_lowercase())),
+    }
+}
+
+/// The pane GUIDs (lowercased) currently live in this IT instance, via a
+/// `list_windows`→`list_tabs`→`list_panes` walk over the master WT channel,
+/// cached for [`LIVE_PANES_TTL`]. Returns `None` when there is no WT channel
+/// (unit tests) so callers skip the gate. On a COM error it serves the last
+/// cached set if any, else an empty set (the gate then skips, self-healing on a
+/// later event once COM succeeds).
+async fn live_it_pane_guids(state: &MasterStateInner) -> Option<HashSet<String>> {
+    const LIVE_PANES_TTL: std::time::Duration = std::time::Duration::from_secs(2);
+    let wt = state.wt.as_ref()?;
+
+    {
+        let cache = state.live_panes_cache.lock().await;
+        if let Some((at, set)) = cache.as_ref() {
+            if at.elapsed() < LIVE_PANES_TTL {
+                return Some(set.clone());
+            }
+        }
+    }
+
+    let mut guids = HashSet::new();
+    let mut com_ok = false;
+    if let Ok(windows) = wt.request("list_windows", serde_json::json!({})).await {
+        com_ok = true;
+        if let Some(ws) = windows.get("windows").and_then(|v| v.as_array()) {
+            for w in ws {
+                // `window_id` / `tab_id` come back as JSON *numbers* from COM
+                // (e.g. `"window_id": 1`), so match String|Number — `as_str()`
+                // alone silently skips every window and yields an empty set,
+                // which would make the liveness gate reject every session.
+                let wid = match w.get("window_id") {
+                    Some(serde_json::Value::String(s)) => s.clone(),
+                    Some(serde_json::Value::Number(n)) => n.to_string(),
+                    _ => continue,
+                };
+                let Ok(tabs) = wt
+                    .request("list_tabs", serde_json::json!({ "window_id": wid }))
+                    .await
+                else { continue };
+                let Some(ts) = tabs.get("tabs").and_then(|v| v.as_array()) else { continue };
+                for t in ts {
+                    let tid = match t.get("tab_id") {
+                        Some(serde_json::Value::String(s)) => s.clone(),
+                        Some(serde_json::Value::Number(n)) => n.to_string(),
+                        _ => continue,
+                    };
+                    let Ok(panes) = wt
+                        .request("list_panes", serde_json::json!({ "tab_id": tid }))
+                        .await
+                    else { continue };
+                    if let Some(ps) = panes.get("panes").and_then(|v| v.as_array()) {
+                        for p in ps {
+                            let guid = match p.get("session_id") {
+                                Some(serde_json::Value::String(s)) => Some(s.clone()),
+                                Some(serde_json::Value::Number(n)) => Some(n.to_string()),
+                                _ => None,
+                            };
+                            if let Some(g) = guid {
+                                guids.insert(g.to_ascii_lowercase());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if com_ok {
+        tracing::debug!(
+            target: "session_watcher",
+            panes = ?guids,
+            "refreshed live IT pane set"
+        );
+        let mut cache = state.live_panes_cache.lock().await;
+        *cache = Some((std::time::Instant::now(), guids.clone()));
+        Some(guids)
+    } else {
+        // COM failed: serve the last good set if we have one, else empty.
+        let cache = state.live_panes_cache.lock().await;
+        Some(cache.as_ref().map(|(_, s)| s.clone()).unwrap_or_default())
+    }
+}
+
+/// Ensure master's registry has a row for the event's session key, creating a
+/// minimal one (with a best-effort pane binding) on first sight, OR reviving a
+/// Class-B (shell-pane) row the user just resumed. Binding per the spec's
+/// Decision #3: Copilot=lock, Codex=Restart Manager, Claude=cwd-correlation,
+/// Gemini=unbound (cwd not path-encoded). All resolver calls are best-effort —
+/// a failed bind never blocks row creation/revival, it just leaves
+/// `pane_session_id = None`.
+///
+/// Revival: a resumed shell-pane session is `Historical` (from the startup
+/// history scan) or `Ended`; the watcher event flips it back to `Idle` and
+/// rebinds its pane so the activity event applied immediately after can mark it
+/// `Working`. This is done here, in the watcher path, rather than by loosening
+/// the shared reducer's terminal-state guard, so Class-A agent-pane ghost rows
+/// stay protected.
+async fn ensure_watched_session_row(
+    state: &MasterStateInner,
+    emitted: &crate::session_watcher::Emitted,
+) {
+    use crate::agent_sessions::{AgentStatus, SessionOrigin};
+    let sid = acp::SessionId::new(emitted.key.clone());
+    let home = std::env::var("USERPROFILE")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_default();
+
+    match state.registry.lookup(&sid).await {
+        None => {
+            // First sight: create the row with a best-effort pane binding.
+            let (pane, pid, cwd) = resolve_watched_pane_pid_cwd(&home, emitted);
+            let mut info = crate::session_registry::SessionInfo::new(sid, cwd);
+            info.cli_source = Some(emitted.cli.clone());
+            info.status = Some(AgentStatus::Idle);
+            info.origin = Some(SessionOrigin::Unknown);
+            info.pane_session_id = pane;
+            info.bound_pid = pid;
+            state.registry.upsert(info).await;
+        }
+        Some(existing) => {
+            // Revive a Class-B (non-agent-pane) row that the user just resumed
+            // in a shell pane: it's Historical (from the startup history scan)
+            // or Ended (pane previously closed). Rebind its pane and clear the
+            // terminal status to Idle so the activity event applied right after
+            // this can mark it Working. Doing the revival here — in the watcher
+            // path — keeps the shared reducer's terminal-state guard untouched,
+            // so Class-A agent-pane ghost rows stay protected.
+            let is_class_b = existing.origin != Some(SessionOrigin::AgentPane);
+            let is_terminal = matches!(
+                existing.status,
+                Some(AgentStatus::Historical | AgentStatus::Ended)
+            );
+            if is_class_b && is_terminal {
+                let (pane, pid, _cwd) = resolve_watched_pane_pid_cwd(&home, emitted);
+                let mut revived = existing;
+                revived.status = Some(AgentStatus::Idle);
+                // Only overwrite the pane binding / pid when we resolved a
+                // fresh one; never clobber a good binding with None.
+                if pane.is_some() {
+                    revived.pane_session_id = pane;
+                }
+                if pid.is_some() {
+                    revived.bound_pid = pid;
+                }
+                revived.last_error = None;
+                revived.attention_reason = None;
+                revived.current_tool = None;
+                state.registry.upsert(revived).await;
+            }
+            // Class-A rows, and already-live Class-B rows, are left as-is.
+        }
+    }
+}
+
+/// Best-effort `(pane GUID, owner pid, cwd)` for a watched session, per the
+/// spec's Decision #3 binding strategy. All resolver calls are best-effort — a
+/// failed bind yields `pane = None` / `pid = None` and never blocks row
+/// creation/revival. The pid feeds master's Class-B liveness poll.
+fn resolve_watched_pane_pid_cwd(
+    home: &std::path::Path,
+    emitted: &crate::session_watcher::Emitted,
+) -> (Option<String>, Option<u32>, std::path::PathBuf) {
+    use crate::agent_sessions::CliSource;
+    match &emitted.cli {
+        CliSource::Copilot => {
+            let dir = crate::history_loader::copilot_session_dir_for_key(home, &emitted.key);
+            let (pane, pid) = crate::session_watcher::bind::bind_copilot(&dir);
+            (pane, pid, emitted.cwd.clone().unwrap_or_default())
+        }
+        CliSource::Codex => {
+            match crate::history_loader::find_codex_rollout_by_id(home, &emitted.key) {
+                Some(path) => {
+                    let (pane, pid) = crate::session_watcher::bind::bind_codex(&path);
+                    // Codex's emitted.cwd is None (not path-encoded); read it
+                    // from the rollout's session_meta so the row has a
+                    // cwd-basename title fallback before the user's first
+                    // message (which is what the title is derived from) lands.
+                    let cwd = crate::history_loader::codex_cwd_from_rollout(&path)
+                        .or_else(|| emitted.cwd.clone())
+                        .unwrap_or_default();
+                    (pane, pid, cwd)
+                }
+                None => (None, None, emitted.cwd.clone().unwrap_or_default()),
+            }
+        }
+        CliSource::Claude => match &emitted.cwd {
+            Some(cwd) => {
+                let (pane, pid) = crate::session_watcher::bind::bind_by_cwd(&emitted.cli, cwd);
+                (pane, pid, cwd.clone())
+            }
+            None => (None, None, std::path::PathBuf::new()),
+        },
+        // Gemini's cwd is not path-encoded (MVP: unbound); Unknown likewise.
+        CliSource::Gemini | CliSource::Unknown(_) => {
+            (None, None, emitted.cwd.clone().unwrap_or_default())
+        }
+    }
+}
+
+/// Demote shell-pane (Class-B) sessions whose owning CLI process has exited
+/// without writing a "session ended" record — e.g. the user `Ctrl+C`'d a
+/// `codex` / `claude` / `gemini` running directly in a pane. Those CLIs leave
+/// the rollout/transcript file frozen at its last turn, so process death is the
+/// only end signal; master polls the bound pids and ends any that are gone.
+///
+/// Agent-pane (Class-A) sessions are managed by the ACP / alive-mirror path and
+/// are never touched here. Rows without a `bound_pid` (binding failed, or
+/// Gemini which is unbound) can't be polled and are left as-is. Returns the
+/// number of sessions reaped (for the caller / tests).
+async fn reap_dead_class_b_sessions(state: &MasterStateInner) -> usize {
+    use crate::agent_sessions::{AgentStatus, SessionOrigin};
+    let dead: Vec<String> = state
+        .registry
+        .snapshot()
+        .await
+        .into_iter()
+        .filter(|s| s.origin != Some(SessionOrigin::AgentPane))
+        .filter(|s| {
+            matches!(
+                s.status,
+                Some(AgentStatus::Working | AgentStatus::Idle | AgentStatus::Attention)
+            )
+        })
+        .filter_map(|s| s.bound_pid.map(|pid| (s.session_id.0.to_string(), pid)))
+        .filter(|(_, pid)| !crate::proc_bind::pid_alive(*pid))
+        .map(|(key, _)| key)
+        .collect();
+
+    if dead.is_empty() {
+        return 0;
+    }
+
+    let mut reaped = 0;
+    for key in &dead {
+        let applied = state
+            .registry
+            .apply_event(crate::agent_sessions::SessionEvent::SessionStopped {
+                key: key.clone(),
+                reason: "process exited".to_string(),
+            })
+            .await;
+        if applied {
+            reaped += 1;
+            tracing::info!(
+                target: "session_watcher",
+                session_id = %key,
+                "reaped Class-B session: owning process exited"
+            );
+        }
+    }
+    if reaped > 0 {
+        broadcast_ext_to_helpers(
+            state,
+            crate::session_registry::build_sessions_changed_notification(),
+        )
+        .await;
+    }
+    reaped
 }
 
 /// Master-side WT event subscriber. Bridges `connection_state`
@@ -2693,6 +3142,8 @@ mod tests {
             cached_init_resp: OnceLock::new(),
             cli_source: Some(crate::agent_sessions::CliSource::Copilot),
             helper_meta: Mutex::new(HashMap::new()),
+            hook_owned: Mutex::new(HashSet::new()),
+            live_panes_cache: Mutex::new(None),
         })
     }
 
@@ -3603,6 +4054,8 @@ mod tests {
             cached_init_resp: OnceLock::new(),
             cli_source: Some(crate::agent_sessions::CliSource::Copilot),
             helper_meta: Mutex::new(HashMap::new()),
+            hook_owned: Mutex::new(HashSet::new()),
+            live_panes_cache: Mutex::new(None),
         })
     }
 
@@ -3992,4 +4445,415 @@ mod tests {
             assert_eq!(session_event_key(&event), expected, "event={event:?}");
         }
     }
+    // ── ensure_watched_session_row: Class-B resume revival ──────────
+
+    async fn seed_session_row(
+        state: &MasterStateInner,
+        key: &str,
+        origin: crate::agent_sessions::SessionOrigin,
+        status: crate::agent_sessions::AgentStatus,
+    ) {
+        let mut info = crate::session_registry::SessionInfo::new(
+            acp::SessionId::new(key.to_string()),
+            std::path::PathBuf::from("C:\\repo"),
+        );
+        info.cli_source = Some(crate::agent_sessions::CliSource::Codex);
+        info.origin = Some(origin);
+        info.status = Some(status);
+        state.registry.upsert(info).await;
+    }
+
+    fn codex_emitted(key: &str) -> crate::session_watcher::Emitted {
+        crate::session_watcher::Emitted {
+            cli: crate::agent_sessions::CliSource::Codex,
+            key: key.to_string(),
+            cwd: None,
+            event: crate::agent_sessions::SessionEvent::ToolStarting {
+                key: key.to_string(),
+                tool_name: String::new(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn ensure_row_revives_class_b_historical_session() {
+        // A shell-pane (Class B) session the user resumed is Historical from
+        // the startup history scan. The watcher's first event must revive it
+        // (Historical -> Idle) so the following activity event can mark it
+        // Working — otherwise the reducer's terminal-state guard keeps it
+        // stuck at "no status".
+        let state = make_state();
+        seed_session_row(
+            &state,
+            "sid-resumed",
+            crate::agent_sessions::SessionOrigin::Unknown,
+            crate::agent_sessions::AgentStatus::Historical,
+        )
+        .await;
+
+        ensure_watched_session_row(&state, &codex_emitted("sid-resumed")).await;
+
+        let row = state
+            .registry
+            .lookup(&acp::SessionId::new("sid-resumed".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(row.status, Some(crate::agent_sessions::AgentStatus::Idle));
+    }
+
+    #[tokio::test]
+    async fn ensure_row_does_not_revive_agent_pane_session() {
+        // Class A (agent pane) terminal rows must NOT be revived by a watcher
+        // event — that's the ghost-row case the reducer guard protects
+        // against. Keep the revival scoped to Class B.
+        let state = make_state();
+        seed_session_row(
+            &state,
+            "sid-agent",
+            crate::agent_sessions::SessionOrigin::AgentPane,
+            crate::agent_sessions::AgentStatus::Historical,
+        )
+        .await;
+
+        ensure_watched_session_row(&state, &codex_emitted("sid-agent")).await;
+
+        let row = state
+            .registry
+            .lookup(&acp::SessionId::new("sid-agent".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(
+            row.status,
+            Some(crate::agent_sessions::AgentStatus::Historical),
+            "Class A agent-pane rows must stay terminal"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_row_leaves_live_class_b_session_untouched() {
+        // A live (non-terminal) Class-B row must not be re-bound or reset on
+        // every event — revival applies only to terminal rows.
+        let state = make_state();
+        let mut info = crate::session_registry::SessionInfo::new(
+            acp::SessionId::new("sid-live".to_string()),
+            std::path::PathBuf::from("C:\\repo"),
+        );
+        info.cli_source = Some(crate::agent_sessions::CliSource::Codex);
+        info.origin = Some(crate::agent_sessions::SessionOrigin::Unknown);
+        info.status = Some(crate::agent_sessions::AgentStatus::Working);
+        info.pane_session_id = Some("pane-live".to_string());
+        state.registry.upsert(info).await;
+
+        ensure_watched_session_row(&state, &codex_emitted("sid-live")).await;
+
+        let row = state
+            .registry
+            .lookup(&acp::SessionId::new("sid-live".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(row.status, Some(crate::agent_sessions::AgentStatus::Working));
+        assert_eq!(row.pane_session_id.as_deref(), Some("pane-live"));
+    }
+
+    // ── reap_dead_class_b_sessions: Ctrl+C liveness poll ────────────
+
+    async fn seed_row_with_pid(
+        state: &MasterStateInner,
+        key: &str,
+        origin: crate::agent_sessions::SessionOrigin,
+        status: crate::agent_sessions::AgentStatus,
+        pid: Option<u32>,
+    ) {
+        let mut info = crate::session_registry::SessionInfo::new(
+            acp::SessionId::new(key.to_string()),
+            std::path::PathBuf::from("C:\\repo"),
+        );
+        info.cli_source = Some(crate::agent_sessions::CliSource::Codex);
+        info.origin = Some(origin);
+        info.status = Some(status);
+        info.bound_pid = pid;
+        state.registry.upsert(info).await;
+    }
+
+    // A pid that is essentially guaranteed not to exist, so pid_alive is false.
+    const DEAD_PID: u32 = 0x7FFF_FFF0;
+
+    #[tokio::test]
+    async fn reap_ends_class_b_with_dead_pid() {
+        let state = make_state();
+        seed_row_with_pid(
+            &state,
+            "sid-dead",
+            crate::agent_sessions::SessionOrigin::Unknown,
+            crate::agent_sessions::AgentStatus::Idle,
+            Some(DEAD_PID),
+        )
+        .await;
+
+        let reaped = reap_dead_class_b_sessions(&state).await;
+        assert_eq!(reaped, 1);
+
+        let row = state
+            .registry
+            .lookup(&acp::SessionId::new("sid-dead".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(row.status, Some(crate::agent_sessions::AgentStatus::Ended));
+    }
+
+    #[tokio::test]
+    async fn reap_keeps_class_b_with_live_pid() {
+        let state = make_state();
+        // Our own process is alive — the session must survive the poll.
+        seed_row_with_pid(
+            &state,
+            "sid-alive",
+            crate::agent_sessions::SessionOrigin::Unknown,
+            crate::agent_sessions::AgentStatus::Working,
+            Some(std::process::id()),
+        )
+        .await;
+
+        let reaped = reap_dead_class_b_sessions(&state).await;
+        assert_eq!(reaped, 0);
+
+        let row = state
+            .registry
+            .lookup(&acp::SessionId::new("sid-alive".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(row.status, Some(crate::agent_sessions::AgentStatus::Working));
+    }
+
+    #[tokio::test]
+    async fn reap_ignores_agent_pane_sessions() {
+        // Class A (agent pane) rows are managed by the ACP / alive-mirror path;
+        // the liveness poll must never touch them even with a dead pid.
+        let state = make_state();
+        seed_row_with_pid(
+            &state,
+            "sid-a",
+            crate::agent_sessions::SessionOrigin::AgentPane,
+            crate::agent_sessions::AgentStatus::Idle,
+            Some(DEAD_PID),
+        )
+        .await;
+
+        let reaped = reap_dead_class_b_sessions(&state).await;
+        assert_eq!(reaped, 0);
+
+        let row = state
+            .registry
+            .lookup(&acp::SessionId::new("sid-a".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(row.status, Some(crate::agent_sessions::AgentStatus::Idle));
+    }
+
+    #[tokio::test]
+    async fn reap_ignores_rows_without_bound_pid() {
+        // A Class-B row we couldn't bind to a pid (or Gemini, which is unbound)
+        // can't be polled, so it's left alone.
+        let state = make_state();
+        seed_row_with_pid(
+            &state,
+            "sid-nopid",
+            crate::agent_sessions::SessionOrigin::Unknown,
+            crate::agent_sessions::AgentStatus::Idle,
+            None,
+        )
+        .await;
+
+        let reaped = reap_dead_class_b_sessions(&state).await;
+        assert_eq!(reaped, 0);
+
+        let row = state
+            .registry
+            .lookup(&acp::SessionId::new("sid-nopid".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(row.status, Some(crate::agent_sessions::AgentStatus::Idle));
+    }
+
+    // ── Hybrid event-dedup: hooks / born-bound win, watcher is fallback ──
+
+    #[tokio::test]
+    async fn watcher_event_dropped_when_session_is_hook_owned() {
+        // A session a hook (or #266 born-bound) already claimed is recorded in
+        // `hook_owned`. The watcher is a fallback and must not double-track it:
+        // its event is dropped before any row is created.
+        let state = make_state();
+        state
+            .hook_owned
+            .lock()
+            .await
+            .insert(acp::SessionId::new("sid-hooked".to_string()));
+
+        apply_watcher_event(&state, codex_emitted("sid-hooked")).await;
+
+        assert!(
+            state
+                .registry
+                .lookup(&acp::SessionId::new("sid-hooked".to_string()))
+                .await
+                .is_none(),
+            "watcher must not create a row for a hook-owned session"
+        );
+    }
+
+    #[tokio::test]
+    async fn watcher_event_applied_when_not_hook_owned() {
+        // The fallback path: a user-typed CLI with no hook installed is tracked
+        // by the watcher, which creates a Class-B row.
+        let state = make_state();
+
+        apply_watcher_event(&state, codex_emitted("sid-typed")).await;
+
+        let row = state
+            .registry
+            .lookup(&acp::SessionId::new("sid-typed".to_string()))
+            .await
+            .expect("watcher creates a row for a non-hook-owned session");
+        assert_eq!(
+            row.origin,
+            Some(crate::agent_sessions::SessionOrigin::Unknown)
+        );
+        assert_eq!(row.status, Some(crate::agent_sessions::AgentStatus::Working));
+    }
+
+    #[tokio::test]
+    async fn watcher_event_dropped_for_agent_pane_session() {
+        // Agent-pane (Class A) sessions are driven by ACP session/update; the
+        // watcher must defer to ACP even though the agent CLI also writes the
+        // on-disk session file the watcher sees.
+        let state = make_state();
+        seed_session_row(
+            &state,
+            "sid-agentpane",
+            crate::agent_sessions::SessionOrigin::AgentPane,
+            crate::agent_sessions::AgentStatus::Idle,
+        )
+        .await;
+
+        apply_watcher_event(&state, codex_emitted("sid-agentpane")).await;
+
+        let row = state
+            .registry
+            .lookup(&acp::SessionId::new("sid-agentpane".to_string()))
+            .await
+            .unwrap();
+        // Still Idle — the watcher's ToolStarting (Working) was dropped.
+        assert_eq!(row.status, Some(crate::agent_sessions::AgentStatus::Idle));
+    }
+
+    #[tokio::test]
+    async fn session_hook_marks_session_hook_owned_then_watcher_is_ignored() {
+        // End-to-end: a hook SessionStarted claims the session (recording it in
+        // `hook_owned`), after which the watcher's events for that session are
+        // dropped — so the hook-sourced pane binding is never clobbered.
+        let state = make_state();
+        let event = crate::agent_sessions::SessionEvent::SessionStarted {
+            key: "sid-claimed".to_string(),
+            cli_source: crate::agent_sessions::CliSource::Codex,
+            pane_session_id: "pane-from-hook".to_string(),
+            cwd: std::path::PathBuf::from("C:\\repo"),
+            title: String::new(),
+        };
+        let req = crate::session_registry::build_session_hook_request(&event);
+        handle_session_hook(&state, &req.params)
+            .await
+            .expect("valid session_hook accepted");
+
+        assert!(
+            state
+                .hook_owned
+                .lock()
+                .await
+                .contains(&acp::SessionId::new("sid-claimed".to_string())),
+            "a keyed session_hook event must mark the session hook-owned"
+        );
+
+        // A subsequent watcher event must not disturb the hook-bound row.
+        apply_watcher_event(&state, codex_emitted("sid-claimed")).await;
+        let row = state
+            .registry
+            .lookup(&acp::SessionId::new("sid-claimed".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(
+            row.pane_session_id.as_deref(),
+            Some("pane-from-hook"),
+            "watcher must not clobber the hook-sourced pane binding"
+        );
+    }
+
+    // ── Liveness gate: only surface watcher sessions bound to a live IT pane ──
+
+    #[test]
+    fn watcher_row_allowed_no_live_set_is_permissive() {
+        // No WT channel (unit tests / master without a wt channel) → can't gate
+        // → allow, preserving the watcher's create-on-first-sight behavior.
+        assert!(watcher_row_allowed(Some("pane-1"), None));
+        assert!(watcher_row_allowed(None, None));
+    }
+
+    #[test]
+    fn watcher_row_allowed_requires_membership_when_gating() {
+        let live: HashSet<String> = ["aaaa-bbbb", "cccc-dddd"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        // In the live set (case-insensitive) → allowed.
+        assert!(watcher_row_allowed(Some("aaaa-bbbb"), Some(&live)));
+        assert!(watcher_row_allowed(Some("AAAA-BBBB"), Some(&live)));
+        // Not a live IT pane (another terminal / closed pane) → rejected.
+        assert!(!watcher_row_allowed(Some("9999-9999"), Some(&live)));
+        // No pane at all (VS Code / background host, no WT_SESSION) → rejected.
+        assert!(!watcher_row_allowed(None, Some(&live)));
+    }
+
+    /// WtChannel mock that scripts a windows→tabs→panes topology so
+    /// `live_it_pane_guids` can be exercised without COM. Uses **numeric**
+    /// `window_id`/`tab_id` to match the real COM JSON shape (`"window_id": 1`),
+    /// so the walk's String|Number handling is actually covered.
+    struct PaneTopoMock;
+
+    #[async_trait::async_trait]
+    impl crate::shell::wt_channel::WtChannel for PaneTopoMock {
+        async fn request(
+            &self,
+            method: &str,
+            _params: serde_json::Value,
+        ) -> anyhow::Result<serde_json::Value> {
+            Ok(match method {
+                "list_windows" => serde_json::json!({ "windows": [ { "window_id": 1 } ] }),
+                "list_tabs" => serde_json::json!({ "tabs": [ { "tab_id": 0 } ] }),
+                "list_panes" => serde_json::json!({ "panes": [
+                    { "session_id": "PANE-AAAA", "pid": 10 },
+                    { "session_id": "pane-bbbb", "pid": 20 }
+                ] }),
+                _ => serde_json::json!({ "ok": true }),
+            })
+        }
+        fn is_available(&self) -> bool {
+            true
+        }
+    }
+
+    #[tokio::test]
+    async fn live_it_pane_guids_collects_lowercased_set() {
+        let state = make_state_with_wt(Arc::new(PaneTopoMock));
+        let set = live_it_pane_guids(&state).await.expect("wt present → Some");
+        assert!(set.contains("pane-aaaa"), "GUIDs are lowercased; got {:?}", set);
+        assert!(set.contains("pane-bbbb"));
+        assert_eq!(set.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn live_it_pane_guids_none_without_wt_channel() {
+        // No WT channel → None so callers skip the gate (unit-test path).
+        let state = make_state();
+        assert!(live_it_pane_guids(&state).await.is_none());
+    }
+
 }

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -233,6 +233,13 @@ struct MasterStateInner {
     /// and re-adding is idempotent, so no eviction is needed. Independent lock —
     /// touched only on the session_hook ingest path and the watcher apply path.
     hook_owned: Mutex<HashSet<acp::SessionId>>,
+    /// #266 born-bound sessions (WTA-launched delegate/resume — copilot/claude/
+    /// gemini). **Binding-only**: unlike `hook_owned`, the file watcher may
+    /// still supply STATUS for these when no real hook is installed
+    /// (activity-only, never re-binding the pane). A subsequent real hook moves
+    /// the session into `hook_owned` and out of here, after which the watcher
+    /// fully backs off.
+    born_bound: Mutex<HashSet<acp::SessionId>>,
     /// Short-lived cache of the live pane GUIDs in THIS IT instance (lowercased),
     /// from a `list_windows`→`list_tabs`→`list_panes` walk over the master's WT
     /// channel. Used by [`apply_watcher_event`] to gate watcher-discovered
@@ -1258,7 +1265,17 @@ impl acp::Agent for HelperHandler {
                 helper_id = ?self.helper_id,
                 "handling intellterm.wta/session_hook locally"
             );
-            return handle_session_hook(&self.state, &args.params).await;
+            return handle_session_hook(&self.state, &args.params, false).await;
+        }
+        if method == crate::session_registry::INTELLTERM_METHOD_SESSION_BORN_BOUND {
+            tracing::info!(
+                target: "master",
+                op = "ext_method",
+                method = %method,
+                helper_id = ?self.helper_id,
+                "handling intellterm.wta/session_born_bound locally"
+            );
+            return handle_session_hook(&self.state, &args.params, true).await;
         }
         if method == crate::session_registry::INTELLTERM_METHOD_SESSION_RESUME_DISPATCHED {
             return handle_session_resume_dispatched(&self.state, &args.params).await;
@@ -1589,6 +1606,7 @@ async fn run_master_loop(cli: Cli, pipe_name: String) -> Result<()> {
         cli_source,
         helper_meta: Mutex::new(HashMap::new()),
         hook_owned: Mutex::new(HashSet::new()),
+        born_bound: Mutex::new(HashSet::new()),
         live_panes_cache: Mutex::new(None),
     });
 
@@ -2239,6 +2257,7 @@ where
 async fn handle_session_hook(
     state: &MasterStateInner,
     params: &serde_json::value::RawValue,
+    is_born_bound: bool,
 ) -> acp::Result<acp::ExtResponse> {
     let event = crate::session_registry::parse_session_hook_params(params).map_err(|err| {
         tracing::warn!(
@@ -2263,17 +2282,41 @@ async fn handle_session_hook(
     // the refresh is fine.
     let refresh_key = session_event_key(&event).map(str::to_owned);
 
-    // Mark this session as hook-owned so the file watcher (the fallback
-    // producer) stops tracking it — hooks and #266 born-bound registrations are
-    // authoritative. Keyed variants only (PaneClosed / ConnectionFailed carry no
-    // session key); those are pane-keyed terminal transitions, not a claim of
-    // ownership, so they don't belong in the set.
+    // Resume binding events (`ResumeDispatched` / `ResumePaneAssigned`) are the
+    // hook-free born-bound binding for `/sessions` resume (published over the
+    // generic `session_hook` method by the helper). Treat them as binding-only —
+    // same as a #266 delegate registration — so the watcher can still supply
+    // status for a resumed session when no real hook is installed. Without this
+    // they'd mark the session `hook_owned` and the resumed row would sit at Idle
+    // forever (the delegate path already works because it uses the dedicated
+    // born-bound method).
+    let binding_only = is_born_bound
+        || matches!(
+            &event,
+            crate::agent_sessions::SessionEvent::ResumeDispatched { .. }
+                | crate::agent_sessions::SessionEvent::ResumePaneAssigned { .. }
+        );
+
+    // Record ownership so the file watcher (the fallback producer) coordinates
+    // with this authoritative event. Keyed variants only (PaneClosed /
+    // ConnectionFailed carry no session key — pane-keyed terminal transitions,
+    // not an ownership claim).
+    //
+    //  * binding-only (#266 delegate born-bound + resume binding events): record
+    //    in `born_bound` so the watcher may still supply STATUS when no real hook
+    //    is installed — without re-binding the pane.
+    //  * real hook / ACP agent-pane event: authoritative for binding AND
+    //    activity. Record in `hook_owned` (full watcher suppression) and, if the
+    //    session was previously born-bound, drop it from `born_bound` — the real
+    //    hook now owns it.
     if let Some(key) = &refresh_key {
-        state
-            .hook_owned
-            .lock()
-            .await
-            .insert(acp::SessionId::new(key.clone()));
+        let sid = acp::SessionId::new(key.clone());
+        if binding_only {
+            state.born_bound.lock().await.insert(sid);
+        } else {
+            state.hook_owned.lock().await.insert(sid.clone());
+            state.born_bound.lock().await.remove(&sid);
+        }
     }
 
     let applied = state.registry.apply_event(event).await;
@@ -2308,14 +2351,40 @@ async fn apply_watcher_event(
 ) {
     let sid = acp::SessionId::new(emitted.key.clone());
 
-    // Hybrid dedup — the watcher is a *fallback*. Drop its event when an
-    // authoritative producer already owns this session:
-    //   1. a hook / #266 born-bound registration recorded it in `hook_owned`, or
-    //   2. it's an agent-pane (Class A) session, driven by ACP `session/update`.
-    // Either way the file watcher must not double-track or fight the binding.
+    // Hybrid dedup — the watcher is a *fallback*. Coordinate with authoritative
+    // producers:
+    //   1. a real hook / ACP agent-pane event recorded the session in
+    //      `hook_owned` → drop (the hook owns binding AND activity); or
+    //   2. it's a #266 born-bound row (`born_bound`) → the watcher owns no
+    //      binding here, but with no real hook it supplies STATUS only (handled
+    //      just below); or
+    //   3. it's an agent-pane (Class A) session, driven by ACP `session/update`.
     if state.hook_owned.lock().await.contains(&sid) {
         return;
     }
+
+    // Born-bound activity-only fallback: the row already exists and is bound to
+    // its pane by #266 born-bound. Born-bound emits no activity, so when no real
+    // hook is installed the watcher supplies STATUS. `emitted.event` is always a
+    // keyed status event (ToolStarting/ToolCompleted/Notification), so applying
+    // it updates the row's status without touching the pane binding / origin.
+    // Skip the liveness gate and `ensure_watched_session_row` — born-bound owns
+    // the (live, vetted) binding; we only move the status.
+    if state.born_bound.lock().await.contains(&sid) {
+        let key = emitted.key.clone();
+        let applied = state.registry.apply_event(emitted.event).await;
+        let title_upgraded =
+            try_refresh_title_from_disk(&state.registry, &acp::SessionId::new(key)).await;
+        if applied || title_upgraded {
+            broadcast_ext_to_helpers(
+                state,
+                crate::session_registry::build_sessions_changed_notification(),
+            )
+            .await;
+        }
+        return;
+    }
+
     let existing = state.registry.lookup(&sid).await;
     if let Some(ref e) = existing {
         if e.origin == Some(crate::agent_sessions::SessionOrigin::AgentPane) {
@@ -3143,6 +3212,7 @@ mod tests {
             cli_source: Some(crate::agent_sessions::CliSource::Copilot),
             helper_meta: Mutex::new(HashMap::new()),
             hook_owned: Mutex::new(HashSet::new()),
+            born_bound: Mutex::new(HashSet::new()),
             live_panes_cache: Mutex::new(None),
         })
     }
@@ -4055,6 +4125,7 @@ mod tests {
             cli_source: Some(crate::agent_sessions::CliSource::Copilot),
             helper_meta: Mutex::new(HashMap::new()),
             hook_owned: Mutex::new(HashSet::new()),
+            born_bound: Mutex::new(HashSet::new()),
             live_panes_cache: Mutex::new(None),
         })
     }
@@ -4213,7 +4284,7 @@ mod tests {
         }))
         .unwrap();
 
-        let err = handle_session_hook(&state, &garbage)
+        let err = handle_session_hook(&state, &garbage, false)
             .await
             .expect_err("malformed session_hook params must error");
         assert_eq!(err.code, acp::ErrorCode::InvalidParams);
@@ -4238,7 +4309,7 @@ mod tests {
         };
         let req = crate::session_registry::build_session_hook_request(&event);
 
-        let response = handle_session_hook(&state, &req.params)
+        let response = handle_session_hook(&state, &req.params, false)
             .await
             .expect("valid session_hook accepted");
         assert_eq!(response.0.get(), r#"{"applied":true}"#);
@@ -4760,7 +4831,7 @@ mod tests {
             title: String::new(),
         };
         let req = crate::session_registry::build_session_hook_request(&event);
-        handle_session_hook(&state, &req.params)
+        handle_session_hook(&state, &req.params, false)
             .await
             .expect("valid session_hook accepted");
 
@@ -4785,6 +4856,161 @@ mod tests {
             Some("pane-from-hook"),
             "watcher must not clobber the hook-sourced pane binding"
         );
+    }
+
+    #[tokio::test]
+    async fn session_born_bound_marks_born_bound_not_hook_owned() {
+        // #266 born-bound (WTA-launched delegate/resume) is binding-only: it must
+        // land in `born_bound`, NOT `hook_owned`, so the watcher can still supply
+        // status for it when no real hook is installed.
+        let state = make_state();
+        let event = crate::agent_sessions::SessionEvent::SessionStarted {
+            key: "bb-mark".to_string(),
+            cli_source: crate::agent_sessions::CliSource::Claude,
+            pane_session_id: "pane-bb".to_string(),
+            cwd: std::path::PathBuf::from("C:\\repo"),
+            title: String::new(),
+        };
+        let req = crate::session_registry::build_born_bound_request(&event);
+        handle_session_hook(&state, &req.params, true)
+            .await
+            .expect("valid born-bound accepted");
+
+        let sid = acp::SessionId::new("bb-mark".to_string());
+        assert!(
+            state.born_bound.lock().await.contains(&sid),
+            "born-bound registration must record the session in `born_bound`"
+        );
+        assert!(
+            !state.hook_owned.lock().await.contains(&sid),
+            "born-bound is binding-only — must NOT be hook-owned"
+        );
+    }
+
+    #[tokio::test]
+    async fn born_bound_session_gets_watcher_activity_without_rebinding() {
+        // The whole point: a born-bound row (no hook) gets STATUS from the
+        // watcher, while its pane binding (owned by born-bound) is untouched.
+        let state = make_state();
+        let sid = acp::SessionId::new("bb-activity".to_string());
+
+        let mut info =
+            crate::session_registry::SessionInfo::new(sid.clone(), std::path::PathBuf::from("C:\\repo"));
+        info.cli_source = Some(crate::agent_sessions::CliSource::Claude);
+        info.origin = Some(crate::agent_sessions::SessionOrigin::Unknown);
+        info.status = Some(crate::agent_sessions::AgentStatus::Idle);
+        info.pane_session_id = Some("born-pane".to_string());
+        state.registry.upsert(info).await;
+        state.born_bound.lock().await.insert(sid.clone());
+
+        // Watcher observes a tool start (the Emitted's cli is irrelevant on the
+        // born-bound path — binding/gate are skipped).
+        apply_watcher_event(&state, codex_emitted("bb-activity")).await;
+
+        let row = state.registry.lookup(&sid).await.unwrap();
+        assert_eq!(
+            row.status,
+            Some(crate::agent_sessions::AgentStatus::Working),
+            "watcher must supply status for a born-bound row with no hook"
+        );
+        assert_eq!(
+            row.pane_session_id.as_deref(),
+            Some("born-pane"),
+            "watcher must NOT re-bind a born-bound row's pane"
+        );
+    }
+
+    #[tokio::test]
+    async fn real_hook_takes_over_born_bound_session() {
+        // If a real hook later fires for a born-bound session (hooks installed
+        // after launch), it becomes fully hook-owned and leaves `born_bound`, so
+        // the watcher backs off entirely.
+        let state = make_state();
+        let sid = acp::SessionId::new("bb-takeover".to_string());
+
+        let bb = crate::agent_sessions::SessionEvent::SessionStarted {
+            key: "bb-takeover".to_string(),
+            cli_source: crate::agent_sessions::CliSource::Claude,
+            pane_session_id: "pane-bb".to_string(),
+            cwd: std::path::PathBuf::from("C:\\repo"),
+            title: String::new(),
+        };
+        handle_session_hook(
+            &state,
+            &crate::session_registry::build_born_bound_request(&bb).params,
+            true,
+        )
+        .await
+        .expect("born-bound accepted");
+        assert!(state.born_bound.lock().await.contains(&sid));
+
+        // A real hook event arrives via session_hook (is_born_bound = false).
+        let hook = crate::agent_sessions::SessionEvent::ToolStarting {
+            key: "bb-takeover".to_string(),
+            tool_name: "Bash".to_string(),
+        };
+        handle_session_hook(
+            &state,
+            &crate::session_registry::build_session_hook_request(&hook).params,
+            false,
+        )
+        .await
+        .expect("real hook accepted");
+
+        assert!(
+            state.hook_owned.lock().await.contains(&sid),
+            "the real hook must take ownership"
+        );
+        assert!(
+            !state.born_bound.lock().await.contains(&sid),
+            "the real hook must remove the stale born-bound claim"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_binding_events_are_born_bound_not_hook_owned() {
+        // `/sessions` resume publishes ResumeDispatched / ResumePaneAssigned over
+        // the generic session_hook method. These are the hook-free resume binding,
+        // so they must record `born_bound` (watcher can supply status), NOT
+        // `hook_owned` — otherwise the resumed row sits at Idle forever.
+        let state = make_state();
+        let sid = acp::SessionId::new("sid-resume".to_string());
+
+        let dispatched = crate::agent_sessions::SessionEvent::ResumeDispatched {
+            key: "sid-resume".to_string(),
+        };
+        handle_session_hook(
+            &state,
+            &crate::session_registry::build_session_hook_request(&dispatched).params,
+            false,
+        )
+        .await
+        .expect("resume dispatched accepted");
+        assert!(
+            state.born_bound.lock().await.contains(&sid),
+            "ResumeDispatched must be born_bound"
+        );
+        assert!(
+            !state.hook_owned.lock().await.contains(&sid),
+            "ResumeDispatched must NOT be hook_owned"
+        );
+
+        let assigned = crate::agent_sessions::SessionEvent::ResumePaneAssigned {
+            key: "sid-resume".to_string(),
+            pane_session_id: "pane-resume".to_string(),
+        };
+        handle_session_hook(
+            &state,
+            &crate::session_registry::build_session_hook_request(&assigned).params,
+            false,
+        )
+        .await
+        .expect("resume pane assigned accepted");
+        assert!(
+            state.born_bound.lock().await.contains(&sid),
+            "ResumePaneAssigned must be born_bound"
+        );
+        assert!(!state.hook_owned.lock().await.contains(&sid));
     }
 
     // ── Liveness gate: only surface watcher sessions bound to a live IT pane ──

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -1663,18 +1663,24 @@ async fn run_master_loop(cli: Cli, pipe_name: String) -> Result<()> {
     // they're applied to master's registry (same reducer as session_hook).
     {
         let (sync_tx, sync_rx) = std::sync::mpsc::channel::<crate::session_watcher::Emitted>();
-        std::thread::Builder::new()
+        if let Err(err) = std::thread::Builder::new()
             .name("wta-session-watch".into())
             .spawn(move || {
                 if let Err(err) = crate::session_watcher::watch(sync_tx) {
                     tracing::warn!(target: "session_watcher", error = %err, "watcher exited");
                 }
             })
-            .ok();
+        {
+            tracing::warn!(
+                target: "session_watcher",
+                error = %err,
+                "failed to spawn session-watch thread; hookless fallback disabled"
+            );
+        }
 
         let (async_tx, mut async_rx) =
             tokio::sync::mpsc::unbounded_channel::<crate::session_watcher::Emitted>();
-        std::thread::Builder::new()
+        if let Err(err) = std::thread::Builder::new()
             .name("wta-session-watch-bridge".into())
             .spawn(move || {
                 for emitted in sync_rx {
@@ -1683,7 +1689,13 @@ async fn run_master_loop(cli: Cli, pipe_name: String) -> Result<()> {
                     }
                 }
             })
-            .ok();
+        {
+            tracing::warn!(
+                target: "session_watcher",
+                error = %err,
+                "failed to spawn session-watch bridge thread; watcher events will not reach master"
+            );
+        }
 
         let inner_for_watch = Arc::clone(&inner);
         tokio::task::spawn_local(async move {
@@ -2461,9 +2473,11 @@ fn watcher_row_allowed(pane: Option<&str>, live_panes: Option<&HashSet<String>>)
 /// The pane GUIDs (lowercased) currently live in this IT instance, via a
 /// `list_windows`→`list_tabs`→`list_panes` walk over the master WT channel,
 /// cached for [`LIVE_PANES_TTL`]. Returns `None` when there is no WT channel
-/// (unit tests) so callers skip the gate. On a COM error it serves the last
-/// cached set if any, else an empty set (the gate then skips, self-healing on a
-/// later event once COM succeeds).
+/// (unit tests) so callers skip the gate entirely. On a COM error it serves the
+/// last cached set if any; with no cache it returns `Some(empty)`, which makes
+/// the gate *reject* every watcher row (conservative — suppress rather than
+/// surface a possibly-dead pane), self-healing on a later event once COM
+/// succeeds and the live set repopulates.
 async fn live_it_pane_guids(state: &MasterStateInner) -> Option<HashSet<String>> {
     const LIVE_PANES_TTL: std::time::Duration = std::time::Duration::from_secs(2);
     let wt = state.wt.as_ref()?;

--- a/tools/wta/src/proc_bind.rs
+++ b/tools/wta/src/proc_bind.rs
@@ -571,7 +571,7 @@ mod tests {
     #[test]
     fn copilot_pid_from_lock_ignores_malformed() {
         let dir = tmp_dir("copilot-bad");
-        std::fs::write(dir.join("inuse.notanumber.lock"), b"").unwrap();
+        std::fs::write(dir.join("inuse.bad.lock"), b"").unwrap();
         assert_eq!(copilot_pid_from_lock(&dir), None);
     }
 

--- a/tools/wta/src/proc_bind.rs
+++ b/tools/wta/src/proc_bind.rs
@@ -1,0 +1,720 @@
+//! proc_bind.rs — Win32 primitives that link a session file/dir to the
+//! process that owns it, and that process to its hosting Windows Terminal
+//! pane.
+//!
+//! Four primitives, each validated against live agent CLIs on 2026-06-09
+//! (see `doc/specs/hookless-agent-session-tracking.md` → Verification):
+//!
+//!   * [`copilot_pid_from_lock`] — Copilot's `inuse.<pid>.lock` marker (pure fs).
+//!   * [`parent_pid`]            — `InheritedFromUniqueProcessId` via NtQueryInformationProcess.
+//!   * [`env_var_for_pid`] / [`wt_session_for_pid`] — read an env var from a
+//!     process's PEB environment block (→ the pane GUID).
+//!   * [`file_holders`] / [`file_owner_pid`] — Restart Manager "who holds this
+//!     file open" (used for Codex, which keeps its rollout file open).
+//!
+//! FFI is declared inline rather than via `windows-sys` features because the
+//! rarer calls (`NtQueryInformationProcess`, the `Rm*` family) are not all
+//! covered by the crate's currently-enabled feature set, and inline `extern`
+//! blocks keep this module self-contained and version-independent. Every
+//! `unsafe` block is documented.
+
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
+
+// ── Win32 FFI (inline; see module docs for why not windows-sys) ──────────
+
+/// Subset of `PROCESS_BASIC_INFORMATION` we read. Layout matches the OS
+/// struct on x64; we only touch `peb_base_address` and
+/// `inherited_from_unique_process_id`.
+#[allow(non_snake_case)]
+#[repr(C)]
+struct ProcessBasicInformation {
+    exit_status: i32,
+    peb_base_address: usize,
+    affinity_mask: usize,
+    base_priority: i32,
+    unique_process_id: usize,
+    inherited_from_unique_process_id: usize,
+}
+
+// PROCESS_QUERY_INFORMATION (0x0400) | PROCESS_VM_READ (0x0010). A superset
+// of QUERY_LIMITED_INFORMATION, sufficient for NtQueryInformationProcess and
+// ReadProcessMemory on same-user processes.
+const PROCESS_ACCESS: u32 = 0x0410;
+
+#[link(name = "ntdll")]
+extern "system" {
+    fn NtQueryInformationProcess(
+        handle: isize,
+        info_class: i32,
+        process_info: *mut core::ffi::c_void,
+        process_info_len: u32,
+        return_len: *mut u32,
+    ) -> i32;
+}
+
+#[link(name = "kernel32")]
+extern "system" {
+    fn OpenProcess(desired_access: u32, inherit: i32, pid: u32) -> isize;
+    fn CloseHandle(handle: isize) -> i32;
+    fn GetExitCodeProcess(handle: isize, exit_code: *mut u32) -> i32;
+    fn GetLastError() -> u32;
+    fn ReadProcessMemory(
+        handle: isize,
+        base_address: usize,
+        buffer: *mut core::ffi::c_void,
+        size: usize,
+        bytes_read: *mut usize,
+    ) -> i32;
+}
+
+// PROCESS_QUERY_LIMITED_INFORMATION — the lightest right that still lets us
+// read a process's exit code; works on same-user processes we can't open with
+// the heavier PROCESS_ACCESS mask.
+const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
+const STILL_ACTIVE: u32 = 259;
+const ERROR_ACCESS_DENIED: u32 = 5;
+
+/// Whether `pid` refers to a still-running process. Returns `false` only when
+/// the process has exited or never existed; a process that exists but can't be
+/// opened (access denied, e.g. elevation) is reported **alive** so the caller
+/// never reaps a live session by mistake. Used by master's Class-B liveness
+/// poll to demote shell-pane sessions whose CLI was `Ctrl+C`'d — those CLIs
+/// write no "session ended" record, so process death is the only signal.
+pub fn pid_alive(pid: u32) -> bool {
+    // SAFETY: query-only access right; OpenProcess returns 0 (NULL) on failure.
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle == 0 {
+        // SAFETY: GetLastError only reads the thread-local last-error code.
+        let err = unsafe { GetLastError() };
+        // ACCESS_DENIED means the process exists but is unqueryable → alive.
+        // Any other error (typically ERROR_INVALID_PARAMETER) → no such pid.
+        return err == ERROR_ACCESS_DENIED;
+    }
+    let mut code: u32 = 0;
+    // SAFETY: `handle` is a valid process handle; `code` is a valid out-param.
+    let ok = unsafe { GetExitCodeProcess(handle, &mut code) };
+    // SAFETY: `handle` came from OpenProcess and is closed exactly once here.
+    unsafe { CloseHandle(handle) };
+    ok != 0 && code == STILL_ACTIVE
+}
+
+/// RAII wrapper so we never leak a process handle across an early return.
+struct ProcHandle(isize);
+
+impl ProcHandle {
+    /// Open `pid` for query + VM read. Returns `None` if the process is
+    /// gone or access is denied (e.g. a different user / elevation).
+    fn open(pid: u32) -> Option<Self> {
+        // SAFETY: OpenProcess with a valid access mask; returns 0 on failure.
+        let h = unsafe { OpenProcess(PROCESS_ACCESS, 0, pid) };
+        if h == 0 {
+            None
+        } else {
+            Some(ProcHandle(h))
+        }
+    }
+}
+
+impl Drop for ProcHandle {
+    fn drop(&mut self) {
+        // SAFETY: self.0 is a handle from OpenProcess, closed exactly once.
+        unsafe {
+            CloseHandle(self.0);
+        }
+    }
+}
+
+/// Query `PROCESS_BASIC_INFORMATION` for an open handle.
+fn basic_information(handle: isize) -> Option<ProcessBasicInformation> {
+    // SAFETY: zeroed POD is a valid initial value; the struct is repr(C) and
+    // sized to match what NtQueryInformationProcess(0, ...) writes.
+    let mut pbi: ProcessBasicInformation = unsafe { std::mem::zeroed() };
+    let mut ret_len: u32 = 0;
+    let size = std::mem::size_of::<ProcessBasicInformation>() as u32;
+    // SAFETY: handle is valid; pbi/ret_len are valid out-params of the
+    // declared sizes; info_class 0 == ProcessBasicInformation.
+    let status = unsafe {
+        NtQueryInformationProcess(
+            handle,
+            0,
+            &mut pbi as *mut _ as *mut core::ffi::c_void,
+            size,
+            &mut ret_len,
+        )
+    };
+    if status == 0 {
+        Some(pbi)
+    } else {
+        None
+    }
+}
+
+/// The parent process id of `pid` (`InheritedFromUniqueProcessId`), or
+/// `None` if the process is gone / inaccessible. Note: Windows reuses pids,
+/// so a returned parent may have exited and been replaced — callers that
+/// walk the chain should bound their iterations.
+pub fn parent_pid(pid: u32) -> Option<u32> {
+    let handle = ProcHandle::open(pid)?;
+    let pbi = basic_information(handle.0)?;
+    Some(pbi.inherited_from_unique_process_id as u32)
+}
+
+// x64 PEB offsets, validated 2026-06-09 against live agent CLIs.
+//   PEB + 0x20                      -> ProcessParameters pointer
+//   RTL_USER_PROCESS_PARAMETERS + 0x80   -> Environment pointer
+//   RTL_USER_PROCESS_PARAMETERS + 0x3F0  -> EnvironmentSize (bytes)
+const PEB_OFFSET_PROCESS_PARAMETERS: usize = 0x20;
+const RUPP_OFFSET_ENVIRONMENT: usize = 0x80;
+const RUPP_OFFSET_ENVIRONMENT_SIZE: usize = 0x3F0;
+// Cap an implausible EnvironmentSize so a corrupt read can't allocate wildly.
+const MAX_ENV_BYTES: usize = 1 << 20;
+
+/// Read a pointer-sized value (`usize`) from another process's address space.
+fn read_remote_ptr(handle: isize, address: usize) -> Option<usize> {
+    let mut buf = [0u8; std::mem::size_of::<usize>()];
+    let mut read: usize = 0;
+    // SAFETY: handle is valid; buf is sized exactly size_of::<usize>().
+    let ok = unsafe {
+        ReadProcessMemory(
+            handle,
+            address,
+            buf.as_mut_ptr() as *mut core::ffi::c_void,
+            buf.len(),
+            &mut read,
+        )
+    };
+    if ok != 0 && read == buf.len() {
+        Some(usize::from_ne_bytes(buf))
+    } else {
+        None
+    }
+}
+
+/// Read `len` bytes from another process's address space.
+fn read_remote_bytes(handle: isize, address: usize, len: usize) -> Option<Vec<u8>> {
+    let mut buf = vec![0u8; len];
+    let mut read: usize = 0;
+    // SAFETY: handle is valid; buf has capacity `len`.
+    let ok = unsafe {
+        ReadProcessMemory(
+            handle,
+            address,
+            buf.as_mut_ptr() as *mut core::ffi::c_void,
+            len,
+            &mut read,
+        )
+    };
+    if ok != 0 {
+        buf.truncate(read);
+        Some(buf)
+    } else {
+        None
+    }
+}
+
+// RTL_USER_PROCESS_PARAMETERS + 0x38 -> CurrentDirectory.DosPath (UNICODE_STRING)
+//   +0x38: Length (u16, bytes)   +0x40: Buffer (ptr to UTF-16)
+const RUPP_OFFSET_CURDIR_LENGTH: usize = 0x38;
+const RUPP_OFFSET_CURDIR_BUFFER: usize = 0x40;
+
+/// Read a process's current working directory from its PEB. `None` if the
+/// process is inaccessible or the path is empty.
+// Consumed by Plan C (master wiring); unused within Plan B.
+#[allow(dead_code)]
+pub fn cwd_for_pid(pid: u32) -> Option<std::path::PathBuf> {
+    let handle = ProcHandle::open(pid)?;
+    let pbi = basic_information(handle.0)?;
+    let pp = read_remote_ptr(
+        handle.0,
+        pbi.peb_base_address + PEB_OFFSET_PROCESS_PARAMETERS,
+    )?;
+
+    // Length is the low u16 of the pointer-sized read at the UNICODE_STRING base.
+    let len_word = read_remote_ptr(handle.0, pp + RUPP_OFFSET_CURDIR_LENGTH)?;
+    let len_bytes = len_word & 0xFFFF;
+    if len_bytes == 0 || len_bytes > 0x8000 {
+        return None;
+    }
+    let buf_ptr = read_remote_ptr(handle.0, pp + RUPP_OFFSET_CURDIR_BUFFER)?;
+    let raw = read_remote_bytes(handle.0, buf_ptr, len_bytes)?;
+    let utf16: Vec<u16> = raw
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    let s = String::from_utf16_lossy(&utf16);
+    let trimmed = s.trim_end_matches(['\\', '\0']);
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(std::path::PathBuf::from(trimmed))
+    }
+}
+
+/// Read and decode the full environment block of `pid` as a single string
+/// with embedded NUL separators (one `NAME=VALUE` entry per NUL-delimited
+/// segment). Returns `None` if the process can't be opened or the PEB walk
+/// fails.
+fn read_process_env_block(pid: u32) -> Option<String> {
+    let handle = ProcHandle::open(pid)?;
+    let pbi = basic_information(handle.0)?;
+    let pp = read_remote_ptr(
+        handle.0,
+        pbi.peb_base_address + PEB_OFFSET_PROCESS_PARAMETERS,
+    )?;
+    let env_addr = read_remote_ptr(handle.0, pp + RUPP_OFFSET_ENVIRONMENT)?;
+    let mut env_size = read_remote_ptr(handle.0, pp + RUPP_OFFSET_ENVIRONMENT_SIZE)?;
+    if env_size == 0 || env_size > MAX_ENV_BYTES {
+        env_size = 1 << 16;
+    }
+    let raw = read_remote_bytes(handle.0, env_addr, env_size)?;
+    // The block is UTF-16LE; build a u16 vec from byte pairs, then decode.
+    let utf16: Vec<u16> = raw
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    Some(String::from_utf16_lossy(&utf16))
+}
+
+/// Find the value of env var `name` (ASCII-case-insensitive on the name) in a
+/// decoded environment block — a string of `NAME=VALUE` entries separated by
+/// NUL. Pure + panic-free: matches the `name=` prefix by bytes so a non-ASCII
+/// character straddling the boundary can never trigger a char-boundary slice
+/// panic. Extracted from `env_var_for_pid` so it can be unit-tested directly.
+fn find_env_value(block: &str, name: &str) -> Option<String> {
+    let prefix_len = name.len() + 1; // "name="
+    for entry in block.split('\0') {
+        let bytes = entry.as_bytes();
+        if bytes.len() < prefix_len {
+            continue;
+        }
+        // Compare the "name=" prefix by bytes (ASCII-case-insensitive on the
+        // name; the trailing '=' matches itself). Never slices a &str.
+        let (head, sep) = bytes.split_at(name.len());
+        if sep.first() == Some(&b'=') && head.eq_ignore_ascii_case(name.as_bytes()) {
+            // The value starts right after the ASCII '=', a valid boundary.
+            return Some(entry[prefix_len..].to_string());
+        }
+    }
+    None
+}
+
+/// Read environment variable `name` (case-insensitive) from `pid`'s PEB.
+/// Returns `None` if the process is inaccessible or the variable is unset.
+pub fn env_var_for_pid(pid: u32, name: &str) -> Option<String> {
+    let block = read_process_env_block(pid)?;
+    find_env_value(&block, name)
+}
+
+/// Convenience wrapper: read `WT_SESSION` (the hosting pane's GUID) from a
+/// process's PEB. Every CLI process WT launches inherits this, so it is the
+/// cheapest path from a bound pid to its pane.
+pub fn wt_session_for_pid(pid: u32) -> Option<String> {
+    env_var_for_pid(pid, "WT_SESSION")
+}
+
+// ── Restart Manager FFI (rstrtmgr.dll) ───────────────────────────────────
+
+const ERROR_MORE_DATA: u32 = 234;
+const CCH_RM_MAX_APP_NAME: usize = 255;
+const CCH_RM_MAX_SVC_NAME: usize = 63;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct Filetime {
+    low: u32,
+    high: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct RmUniqueProcess {
+    process_id: u32,
+    process_start_time: Filetime,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct RmProcessInfo {
+    process: RmUniqueProcess,
+    app_name: [u16; CCH_RM_MAX_APP_NAME + 1],
+    service_short_name: [u16; CCH_RM_MAX_SVC_NAME + 1],
+    application_type: i32,
+    app_status: u32,
+    ts_session_id: u32,
+    restartable: i32,
+}
+
+#[link(name = "rstrtmgr")]
+extern "system" {
+    fn RmStartSession(session_handle: *mut u32, flags: u32, session_key: *mut u16) -> u32;
+    fn RmRegisterResources(
+        session_handle: u32,
+        num_files: u32,
+        files: *const *const u16,
+        num_apps: u32,
+        apps: *const core::ffi::c_void,
+        num_services: u32,
+        service_names: *const *const u16,
+    ) -> u32;
+    fn RmGetList(
+        session_handle: u32,
+        proc_info_needed: *mut u32,
+        proc_info: *mut u32,
+        affected_apps: *mut RmProcessInfo,
+        reboot_reasons: *mut u32,
+    ) -> u32;
+    fn RmEndSession(session_handle: u32) -> u32;
+}
+
+/// Restart Manager: every process id currently holding `path` open. Empty
+/// vec if nothing holds it (the common case for append-then-close writers
+/// like Copilot/Claude/Gemini) or on any RM error. Used for Codex, which
+/// keeps its rollout file open for the whole session.
+pub fn file_holders(path: &Path) -> Vec<u32> {
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    let mut session: u32 = 0;
+    // Session key buffer must be >= CCH_RM_SESSION_KEY+1 (33) wide chars.
+    let mut key = [0u16; 64];
+    // SAFETY: session out-param and key buffer are valid for the declared sizes.
+    let rc = unsafe { RmStartSession(&mut session, 0, key.as_mut_ptr()) };
+    if rc != 0 {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    let files = [wide.as_ptr()];
+    // SAFETY: one file resource; no apps/services (null + 0 counts).
+    let reg = unsafe {
+        RmRegisterResources(
+            session,
+            1,
+            files.as_ptr(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+        )
+    };
+    if reg == 0 {
+        let mut needed: u32 = 0;
+        let mut count: u32 = 0;
+        let mut reason: u32 = 0;
+        // First call probes the required array length.
+        // SAFETY: null array with count 0 is the documented probe form.
+        let probe = unsafe {
+            RmGetList(
+                session,
+                &mut needed,
+                &mut count,
+                std::ptr::null_mut(),
+                &mut reason,
+            )
+        };
+        if (probe == 0 || probe == ERROR_MORE_DATA) && needed > 0 {
+            // SAFETY: zeroed RmProcessInfo is valid POD; vec has `needed` slots.
+            let mut arr: Vec<RmProcessInfo> = vec![unsafe { std::mem::zeroed() }; needed as usize];
+            count = needed;
+            // SAFETY: arr has capacity `count`; out-params valid.
+            let got = unsafe {
+                RmGetList(
+                    session,
+                    &mut needed,
+                    &mut count,
+                    arr.as_mut_ptr(),
+                    &mut reason,
+                )
+            };
+            if got == 0 {
+                for info in arr.iter().take(count as usize) {
+                    out.push(info.process.process_id);
+                }
+            }
+        }
+    }
+
+    // SAFETY: session is a handle returned by RmStartSession.
+    unsafe {
+        RmEndSession(session);
+    }
+    out
+}
+
+/// First process id holding `path` open, or `None`. Thin wrapper over
+/// [`file_holders`] for the common single-holder case (Codex).
+#[allow(dead_code)] // consumed by Plan B's session binder, not yet wired here
+pub fn file_owner_pid(path: &Path) -> Option<u32> {
+    file_holders(path).into_iter().next()
+}
+
+// ── Toolhelp32 process enumeration (kernel32) ────────────────────────────
+
+const TH32CS_SNAPPROCESS: u32 = 0x0000_0002;
+const MAX_PATH: usize = 260;
+const INVALID_HANDLE_VALUE: isize = -1;
+
+#[repr(C)]
+struct ProcessEntry32W {
+    dw_size: u32,
+    cnt_usage: u32,
+    th32_process_id: u32,
+    th32_default_heap_id: usize,
+    th32_module_id: u32,
+    cnt_threads: u32,
+    th32_parent_process_id: u32,
+    pc_pri_class_base: i32,
+    dw_flags: u32,
+    sz_exe_file: [u16; MAX_PATH],
+}
+
+#[link(name = "kernel32")]
+extern "system" {
+    fn CreateToolhelp32Snapshot(flags: u32, pid: u32) -> isize;
+    fn Process32FirstW(snapshot: isize, entry: *mut ProcessEntry32W) -> i32;
+    fn Process32NextW(snapshot: isize, entry: *mut ProcessEntry32W) -> i32;
+}
+
+/// Every running process whose executable file name equals `exe_name`
+/// (case-insensitive, e.g. `"copilot.exe"` / `"node.exe"`). Empty on error.
+pub fn pids_for_exe(exe_name: &str) -> Vec<u32> {
+    let mut out = Vec::new();
+    // SAFETY: snapshot flag + pid 0 (all processes); returns INVALID_HANDLE_VALUE on failure.
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return out;
+    }
+    // SAFETY: zeroed POD; dw_size must be set before Process32FirstW.
+    let mut entry: ProcessEntry32W = unsafe { std::mem::zeroed() };
+    entry.dw_size = std::mem::size_of::<ProcessEntry32W>() as u32;
+    let want = exe_name.to_ascii_lowercase();
+
+    // SAFETY: snapshot + entry valid; iterate until Process32NextW returns 0.
+    let mut ok = unsafe { Process32FirstW(snapshot, &mut entry) };
+    while ok != 0 {
+        let end = entry.sz_exe_file.iter().position(|&c| c == 0).unwrap_or(MAX_PATH);
+        let name = String::from_utf16_lossy(&entry.sz_exe_file[..end]);
+        if name.to_ascii_lowercase() == want {
+            out.push(entry.th32_process_id);
+        }
+        ok = unsafe { Process32NextW(snapshot, &mut entry) };
+    }
+    // SAFETY: snapshot is a handle from CreateToolhelp32Snapshot.
+    unsafe { CloseHandle(snapshot) };
+    out
+}
+
+/// Parse Copilot's in-use marker. Copilot writes a zero-byte file named
+/// `inuse.<pid>.lock` into its session-state directory while a session is
+/// live; the owning process id is encoded in the file name. Returns the
+/// first such pid found, or `None` if the directory has no marker (or
+/// cannot be read).
+pub fn copilot_pid_from_lock(session_dir: &Path) -> Option<u32> {
+    let entries = std::fs::read_dir(session_dir).ok()?;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if let Some(pid) = name
+            .strip_prefix("inuse.")
+            .and_then(|rest| rest.strip_suffix(".lock"))
+            .and_then(|digits| digits.parse::<u32>().ok())
+        {
+            return Some(pid);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_dir(label: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("wta-proc-bind-{}-{}", label, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn copilot_pid_from_lock_reads_marker() {
+        let dir = tmp_dir("copilot-lock");
+        std::fs::write(dir.join("inuse.12345.lock"), b"").unwrap();
+        std::fs::write(dir.join("events.jsonl"), b"{}\n").unwrap();
+        assert_eq!(copilot_pid_from_lock(&dir), Some(12345));
+    }
+
+    #[test]
+    fn copilot_pid_from_lock_none_without_marker() {
+        let dir = tmp_dir("copilot-nolock");
+        std::fs::write(dir.join("events.jsonl"), b"{}\n").unwrap();
+        assert_eq!(copilot_pid_from_lock(&dir), None);
+    }
+
+    #[test]
+    fn copilot_pid_from_lock_ignores_malformed() {
+        let dir = tmp_dir("copilot-bad");
+        std::fs::write(dir.join("inuse.notanumber.lock"), b"").unwrap();
+        assert_eq!(copilot_pid_from_lock(&dir), None);
+    }
+
+    /// Spawn a long-lived child we can probe, inheriting `envs` and `cwd`.
+    /// `ping -n 30 127.0.0.1` sleeps ~29 s with no stdin needed; the test
+    /// kills it as soon as the assertion is done.
+    fn spawn_probe_child(
+        envs: &[(&str, &str)],
+        cwd: Option<&std::path::Path>,
+    ) -> std::process::Child {
+        let mut cmd = std::process::Command::new("cmd.exe");
+        cmd.args(["/c", "ping", "-n", "30", "127.0.0.1"]);
+        cmd.stdout(std::process::Stdio::null());
+        cmd.stderr(std::process::Stdio::null());
+        for (k, v) in envs {
+            cmd.env(k, v);
+        }
+        if let Some(d) = cwd {
+            cmd.current_dir(d);
+        }
+        cmd.spawn().expect("spawn probe child")
+    }
+
+    #[test]
+    fn parent_pid_of_child_is_current_process() {
+        let mut child = spawn_probe_child(&[], None);
+        let child_pid = child.id();
+        let got = parent_pid(child_pid);
+        let _ = child.kill();
+        let _ = child.wait();
+        assert_eq!(got, Some(std::process::id()));
+    }
+
+    #[test]
+    fn env_var_for_pid_reads_child_environment() {
+        let mut child = spawn_probe_child(&[("WTA_TEST_BIND", "marker-value-42")], None);
+        let pid = child.id();
+        // Give the child a moment to finish initializing its PEB.
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        let got = env_var_for_pid(pid, "WTA_TEST_BIND");
+        let got_ci = env_var_for_pid(pid, "wta_test_bind"); // case-insensitive name
+        let missing = env_var_for_pid(pid, "WTA_NOT_SET_XYZ");
+        let _ = child.kill();
+        let _ = child.wait();
+        assert_eq!(got.as_deref(), Some("marker-value-42"));
+        assert_eq!(got_ci.as_deref(), Some("marker-value-42"));
+        assert_eq!(missing, None);
+    }
+
+    #[test]
+    fn file_holders_includes_current_process() {
+        let dir = tmp_dir("rm-hold");
+        let path = dir.join("held.jsonl");
+        std::fs::write(&path, b"{}\n").unwrap();
+        // Keep a read handle open for the duration of the query.
+        let _held = std::fs::File::open(&path).unwrap();
+        let holders = file_holders(&path);
+        assert!(
+            holders.contains(&std::process::id()),
+            "expected current pid {} among holders {:?}",
+            std::process::id(),
+            holders
+        );
+    }
+
+    #[test]
+    fn find_env_value_basic_and_case_insensitive() {
+        let block = "FOO=1\0WT_SESSION=abc-123\0BAR=2\0";
+        assert_eq!(
+            find_env_value(block, "WT_SESSION").as_deref(),
+            Some("abc-123")
+        );
+        assert_eq!(
+            find_env_value(block, "wt_session").as_deref(),
+            Some("abc-123")
+        );
+        assert_eq!(find_env_value(block, "MISSING"), None);
+    }
+
+    #[test]
+    fn find_env_value_non_ascii_entry_does_not_panic() {
+        // An entry whose name has a multi-byte char straddling byte index
+        // name.len() must NOT panic (regression for the char-boundary bug).
+        // "123456789€" is 9 ASCII bytes + a 3-byte '€' (bytes 9..12).
+        let block = "123456789\u{20ac}=value\0WT_SESSION=guid-42\0";
+        // The query length 10 (WT_SESSION) lands inside '€' of the first entry.
+        assert_eq!(
+            find_env_value(block, "WT_SESSION").as_deref(),
+            Some("guid-42")
+        );
+    }
+
+    #[test]
+    fn find_env_value_empty_value() {
+        let block = "EMPTY=\0X=1\0";
+        assert_eq!(find_env_value(block, "EMPTY").as_deref(), Some(""));
+    }
+
+    #[test]
+    fn cwd_for_pid_reads_child_working_dir() {
+        let dir = tmp_dir("cwd-child");
+        // Canonicalize so the comparison is robust to short/long path forms.
+        let canonical = std::fs::canonicalize(&dir).unwrap();
+        let mut child = spawn_probe_child(&[], Some(&canonical));
+        let pid = child.id();
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        let got = cwd_for_pid(pid);
+        let _ = child.kill();
+        let _ = child.wait();
+        let got = got.expect("cwd_for_pid returned None");
+        // Compare case-insensitively on the final component to avoid
+        // \\?\ prefix / drive-letter-case differences.
+        assert!(
+            got.to_string_lossy()
+                .to_lowercase()
+                .contains(&dir.file_name().unwrap().to_string_lossy().to_lowercase()),
+            "expected cwd containing {:?}, got {:?}",
+            dir.file_name().unwrap(),
+            got
+        );
+    }
+
+    #[test]
+    fn pids_for_exe_finds_spawned_cmd() {
+        let mut child = spawn_probe_child(&[], None);
+        let pid = child.id();
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        let pids = pids_for_exe("cmd.exe");
+        let _ = child.kill();
+        let _ = child.wait();
+        assert!(pids.contains(&pid), "expected {} in {:?}", pid, pids);
+    }
+
+    #[test]
+    fn file_holders_empty_for_unheld_file() {
+        let dir = tmp_dir("rm-free");
+        let path = dir.join("free.jsonl");
+        std::fs::write(&path, b"{}\n").unwrap();
+        // No handle held -> Restart Manager reports no holders.
+        let holders = file_holders(&path);
+        assert!(holders.is_empty(), "expected no holders, got {:?}", holders);
+    }
+
+    #[test]
+    fn pid_alive_true_for_self_false_for_dead() {
+        // Our own process is alive.
+        assert!(pid_alive(std::process::id()));
+        // Spawn a child, kill it, confirm it reports dead.
+        let mut child = spawn_probe_child(&[], None);
+        let pid = child.id();
+        assert!(pid_alive(pid), "freshly spawned child should be alive");
+        let _ = child.kill();
+        let _ = child.wait();
+        // Give the OS a moment to tear the process down.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        assert!(!pid_alive(pid), "killed child should report dead");
+    }
+}

--- a/tools/wta/src/proc_bind.rs
+++ b/tools/wta/src/proc_bind.rs
@@ -87,7 +87,7 @@ pub fn pid_alive(pid: u32) -> bool {
     if handle == 0 {
         // SAFETY: GetLastError only reads the thread-local last-error code.
         let err = unsafe { GetLastError() };
-        // ACCESS_DENIED means the process exists but is unqueryable → alive.
+        // ACCESS_DENIED means the process exists but is inaccessible → alive.
         // Any other error (typically ERROR_INVALID_PARAMETER) → no such pid.
         return err == ERROR_ACCESS_DENIED;
     }

--- a/tools/wta/src/proc_bind.rs
+++ b/tools/wta/src/proc_bind.rs
@@ -223,6 +223,12 @@ const RUPP_OFFSET_CURDIR_BUFFER: usize = 0x40;
 // Consumed by Plan C (master wiring); unused within Plan B.
 #[allow(dead_code)]
 pub fn cwd_for_pid(pid: u32) -> Option<std::path::PathBuf> {
+    // The PEB / RTL_USER_PROCESS_PARAMETERS offsets below are x64-specific. On
+    // another Windows arch (e.g. ARM64) they would point into the wrong remote
+    // memory, so bail rather than return a garbage path.
+    if !cfg!(target_arch = "x86_64") {
+        return None;
+    }
     let handle = ProcHandle::open(pid)?;
     let pbi = basic_information(handle.0)?;
     let pp = read_remote_ptr(
@@ -256,6 +262,12 @@ pub fn cwd_for_pid(pid: u32) -> Option<std::path::PathBuf> {
 /// segment). Returns `None` if the process can't be opened or the PEB walk
 /// fails.
 fn read_process_env_block(pid: u32) -> Option<String> {
+    // x64-specific PEB / RTL_USER_PROCESS_PARAMETERS offsets (see `cwd_for_pid`);
+    // return None on other arches rather than read the wrong remote memory. This
+    // gates `env_var_for_pid` and `wt_session_for_pid`, which both route here.
+    if !cfg!(target_arch = "x86_64") {
+        return None;
+    }
     let handle = ProcHandle::open(pid)?;
     let pbi = basic_information(handle.0)?;
     let pp = read_remote_ptr(

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -694,6 +694,14 @@ pub struct SessionInfo {
     pub origin: Option<SessionOrigin>,
     #[serde(default)]
     pub last_error: Option<String>,
+    /// PID of the process that owns this Class-B session (Copilot worker /
+    /// Codex rollout holder / cwd-matched Claude), captured at bind time.
+    /// Master's liveness poll checks it to demote shell-pane sessions whose
+    /// CLI exited without writing a "session ended" record (e.g. `Ctrl+C`).
+    /// `None` for agent-pane sessions and any session we couldn't bind to a
+    /// pid. Master-internal — skipped on the wire.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bound_pid: Option<u32>,
 }
 
 impl SessionInfo {
@@ -713,6 +721,7 @@ impl SessionInfo {
             last_activity_at_ms: None,
             origin: None,
             last_error: None,
+            bound_pid: None,
         }
     }
 
@@ -751,6 +760,9 @@ pub fn agent_session_to_session_info(s: &AgentSession) -> SessionInfo {
         last_activity_at_ms,
         origin: Some(s.origin.clone()),
         last_error: s.last_error.clone(),
+        // History-scan / helper-sourced rows have no bound pid; only the
+        // file watcher's bind step populates it.
+        bound_pid: None,
     }
 }
 
@@ -1783,6 +1795,7 @@ mod tests {
             last_activity_at_ms: Some(1717012345678),
             origin: Some(crate::agent_sessions::SessionOrigin::AgentPane),
             last_error: Some("previous failure".into()),
+            bound_pid: None,
         };
 
         let json = serde_json::to_string(&row).expect("serialize SessionInfo");
@@ -1826,6 +1839,7 @@ mod tests {
             last_activity_at_ms: Some(123),
             origin: Some(crate::agent_sessions::SessionOrigin::AgentPane),
             last_error: None,
+            bound_pid: None,
         };
         let raw = build_sessions_list_response(vec![row.clone()]);
         let parsed = parse_sessions_list_response(&raw).expect("response parses");
@@ -1960,6 +1974,7 @@ mod tests {
             last_activity_at_ms: Some(1),
             origin: Some(crate::agent_sessions::SessionOrigin::AgentPane),
             last_error: None,
+            bound_pid: None,
         }).await;
         reg.apply_event(crate::agent_sessions::SessionEvent::ResumeDispatched { key: "sid".into() }).await;
 

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -1101,6 +1101,7 @@ fn apply_event_locked(state: &mut RegistryState, ev: SessionEvent) -> bool {
                 }
             }
 
+            let is_new_entry = !state.sessions.contains_key(&sid);
             let entry = state
                 .sessions
                 .entry(sid.clone())
@@ -1115,10 +1116,29 @@ fn apply_event_locked(state: &mut RegistryState, ev: SessionEvent) -> bool {
                 entry.title = Some(title);
             }
             entry.cli_source = Some(cli_source);
-            entry.status = Some(AgentStatus::Idle);
-            entry.last_error = None;
-            entry.attention_reason = None;
-            entry.current_tool = None;
+            // Status baseline. Preserve a live status on an EXISTING row instead
+            // of clobbering it to Idle: some CLIs fire activity hooks before
+            // `session.start` — e.g. Copilot sends `prompt.submit` (→ Working)
+            // ~2 s before its `session.start`, so an unconditional reset here
+            // blanks the row to Idle for the rest of the turn (until the next
+            // `tool.starting`). This is the authoritative reducer behind
+            // `sessions/list`, so the clobber is what the user actually saw.
+            // Only (re)baseline to Idle for a new row or one being revived from a
+            // non-live terminal state (Ended/Error/Historical, e.g. resume /
+            // reconnect); Working/Attention/Idle are preserved. Mirrors the
+            // resurrection guards on ToolStarting/ToolCompleted below and the
+            // helper-side reducer in `agent_sessions.rs`.
+            if is_new_entry
+                || matches!(
+                    entry.status,
+                    Some(AgentStatus::Ended | AgentStatus::Error | AgentStatus::Historical)
+                )
+            {
+                entry.status = Some(AgentStatus::Idle);
+                entry.last_error = None;
+                entry.attention_reason = None;
+                entry.current_tool = None;
+            }
             entry.last_activity_at_ms = Some(now);
             if pane_known {
                 entry.pane_session_id = Some(pane_session_id.clone());
@@ -1912,6 +1932,76 @@ mod tests {
         assert_eq!(row.status, Some(crate::agent_sessions::AgentStatus::Idle));
         assert!(row.current_tool.is_none());
         assert!(row.attention_reason.is_none());
+    }
+
+    #[tokio::test]
+    async fn master_reducer_session_started_preserves_live_working_status() {
+        // bcec31b5 ordering bug, authoritative reducer: Copilot fires
+        // `prompt.submit` (→ Working) ~2 s BEFORE its `session.start` for the
+        // same session id. A late SessionStarted must NOT reset the row to Idle —
+        // this is the reducer behind `sessions/list`, so the clobber is exactly
+        // what the user saw on screen.
+        use crate::agent_sessions::{AgentStatus, CliSource, SessionEvent};
+        let reg = InMemoryRegistry::new();
+        // prompt.submit path: synthetic SessionStarted, then ToolStarting.
+        reg.apply_event(SessionEvent::SessionStarted {
+            key: "sid".into(),
+            cli_source: CliSource::Copilot,
+            pane_session_id: "p".into(),
+            cwd: PathBuf::from("C:\\x"),
+            title: "t".into(),
+        }).await;
+        reg.apply_event(SessionEvent::ToolStarting { key: "sid".into(), tool_name: "prompt".into() }).await;
+        assert_eq!(
+            reg.lookup(&acp::SessionId::new("sid")).await.unwrap().status,
+            Some(AgentStatus::Working),
+        );
+
+        // The real session.start arrives later for the SAME key.
+        reg.apply_event(SessionEvent::SessionStarted {
+            key: "sid".into(),
+            cli_source: CliSource::Copilot,
+            pane_session_id: "p".into(),
+            cwd: PathBuf::from("C:\\x"),
+            title: "t".into(),
+        }).await;
+        assert_eq!(
+            reg.lookup(&acp::SessionId::new("sid")).await.unwrap().status,
+            Some(AgentStatus::Working),
+            "a late SessionStarted must preserve the live Working status",
+        );
+    }
+
+    #[tokio::test]
+    async fn master_reducer_session_started_revives_ended_row_to_idle() {
+        // Counterpart: a SessionStarted for a row in a terminal state (Ended)
+        // must still re-baseline it to Idle (resume / reconnect).
+        use crate::agent_sessions::{AgentStatus, CliSource, SessionEvent};
+        let reg = InMemoryRegistry::new();
+        reg.apply_event(SessionEvent::SessionStarted {
+            key: "sid".into(),
+            cli_source: CliSource::Copilot,
+            pane_session_id: "p".into(),
+            cwd: PathBuf::from("C:\\x"),
+            title: "t".into(),
+        }).await;
+        reg.apply_event(SessionEvent::PaneClosed { pane_session_id: "p".into() }).await;
+        assert_eq!(
+            reg.lookup(&acp::SessionId::new("sid")).await.unwrap().status,
+            Some(AgentStatus::Ended),
+        );
+        reg.apply_event(SessionEvent::SessionStarted {
+            key: "sid".into(),
+            cli_source: CliSource::Copilot,
+            pane_session_id: "p2".into(),
+            cwd: PathBuf::from("C:\\x"),
+            title: "t".into(),
+        }).await;
+        assert_eq!(
+            reg.lookup(&acp::SessionId::new("sid")).await.unwrap().status,
+            Some(AgentStatus::Idle),
+            "a SessionStarted reviving an Ended row must reset it to Idle",
+        );
     }
 
     #[tokio::test]

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -719,8 +719,10 @@ pub struct SessionInfo {
     /// Master's liveness poll checks it to demote shell-pane sessions whose
     /// CLI exited without writing a "session ended" record (e.g. `Ctrl+C`).
     /// `None` for agent-pane sessions and any session we couldn't bind to a
-    /// pid. Master-internal — skipped on the wire.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// pid. Master-internal — never serialized (`#[serde(skip)]`), so it can
+    /// never leak into a `sessions/list` response, which serializes
+    /// `SessionInfo` directly.
+    #[serde(skip)]
     pub bound_pid: Option<u32>,
 }
 

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -443,6 +443,14 @@ pub fn parse_focus_session_params(
 /// ExtRequest method for "helper observed a SessionEvent; master should apply it".
 pub const INTELLTERM_METHOD_SESSION_HOOK: &str = "intellterm.wta/session_hook";
 
+/// ExtRequest method for a #266 *born-bound* registration — a WTA-launched CLI
+/// session (delegate `?<prompt>` / resume) that IT bound to its pane at launch.
+/// Same body as `session_hook`, distinct method so the master records it as
+/// *binding-only* (`born_bound`) rather than hook-owned: with no real hook
+/// installed the file watcher may still supply activity/status for it (never
+/// re-binding). A later real `session_hook` event moves it to hook-owned.
+pub const INTELLTERM_METHOD_SESSION_BORN_BOUND: &str = "intellterm.wta/session_born_bound";
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum SessionHookCliSource {
@@ -635,6 +643,18 @@ pub fn build_session_hook_request(event: &crate::agent_sessions::SessionEvent) -
     let raw = serde_json::value::RawValue::from_string(json)
         .expect("serde_json::to_string always produces valid JSON");
     acp::ExtRequest::new(INTELLTERM_METHOD_SESSION_HOOK, Arc::from(raw))
+}
+
+/// Build a #266 *born-bound* registration ExtRequest. Identical body to
+/// [`build_session_hook_request`] but a distinct method
+/// ([`INTELLTERM_METHOD_SESSION_BORN_BOUND`]) so the master treats it as
+/// binding-only (watcher may still supply status), not hook-owned.
+pub fn build_born_bound_request(event: &crate::agent_sessions::SessionEvent) -> acp::ExtRequest {
+    let params = SessionHookParams::from(event);
+    let json = serde_json::to_string(&params).expect("SessionHookParams serialization is infallible");
+    let raw = serde_json::value::RawValue::from_string(json)
+        .expect("serde_json::to_string always produces valid JSON");
+    acp::ExtRequest::new(INTELLTERM_METHOD_SESSION_BORN_BOUND, Arc::from(raw))
 }
 
 /// Parse a master-bound `session_hook` body into the canonical reducer event.
@@ -2413,6 +2433,28 @@ mod tests {
         let request = build_session_hook_request(&event);
         let parsed = parse_session_hook_params(&request.params)
             .expect("unknown cli_source must round-trip");
+        assert_eq!(parsed, event);
+    }
+
+    #[test]
+    fn build_born_bound_request_uses_distinct_method_and_round_trips() {
+        use crate::agent_sessions::{CliSource, SessionEvent};
+        let event = SessionEvent::SessionStarted {
+            key: "bb-1".to_string(),
+            cli_source: CliSource::Claude,
+            pane_session_id: "pane-bb".to_string(),
+            cwd: PathBuf::from(r#"C:\repo"#),
+            title: String::new(),
+        };
+        let request = build_born_bound_request(&event);
+        assert_eq!(
+            &*request.method,
+            INTELLTERM_METHOD_SESSION_BORN_BOUND,
+            "born-bound must use its own method, not session_hook"
+        );
+        // Body is the same wire shape, so the master parses it identically.
+        let parsed =
+            parse_session_hook_params(&request.params).expect("born-bound body must round-trip");
         assert_eq!(parsed, event);
     }
 

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -1936,7 +1936,7 @@ mod tests {
 
     #[tokio::test]
     async fn master_reducer_session_started_preserves_live_working_status() {
-        // bcec31b5 ordering bug, authoritative reducer: Copilot fires
+        // Prompt-before-start ordering bug, authoritative reducer: Copilot fires
         // `prompt.submit` (→ Working) ~2 s BEFORE its `session.start` for the
         // same session id. A late SessionStarted must NOT reset the row to Idle —
         // this is the reducer behind `sessions/list`, so the clobber is exactly

--- a/tools/wta/src/session_watcher/bind.rs
+++ b/tools/wta/src/session_watcher/bind.rs
@@ -110,32 +110,32 @@ mod tests {
 
     #[test]
     fn unique_cwd_match_binds() {
-        let cands = vec![cand(10, r"C:\Users\u\proj"), cand(20, r"C:\Users\u\other")];
+        let candidates = vec![cand(10, r"C:\Users\u\proj"), cand(20, r"C:\Users\u\other")];
         assert_eq!(
-            correlate_by_cwd(&cands, Path::new(r"C:\Users\u\proj")),
+            correlate_by_cwd(&candidates, Path::new(r"C:\Users\u\proj")),
             Some(10)
         );
     }
 
     #[test]
     fn case_and_trailing_sep_insensitive() {
-        let cands = vec![cand(10, r"c:\users\u\proj\")];
+        let candidates = vec![cand(10, r"c:\users\u\proj\")];
         assert_eq!(
-            correlate_by_cwd(&cands, Path::new(r"C:\Users\U\Proj")),
+            correlate_by_cwd(&candidates, Path::new(r"C:\Users\U\Proj")),
             Some(10)
         );
     }
 
     #[test]
     fn ambiguous_same_cwd_returns_none() {
-        let cands = vec![cand(10, r"C:\p"), cand(20, r"C:\p")];
-        assert_eq!(correlate_by_cwd(&cands, Path::new(r"C:\p")), None);
+        let candidates = vec![cand(10, r"C:\p"), cand(20, r"C:\p")];
+        assert_eq!(correlate_by_cwd(&candidates, Path::new(r"C:\p")), None);
     }
 
     #[test]
     fn no_match_returns_none() {
-        let cands = vec![cand(10, r"C:\a")];
-        assert_eq!(correlate_by_cwd(&cands, Path::new(r"C:\b")), None);
+        let candidates = vec![cand(10, r"C:\a")];
+        assert_eq!(correlate_by_cwd(&candidates, Path::new(r"C:\b")), None);
     }
 
     #[test]

--- a/tools/wta/src/session_watcher/bind.rs
+++ b/tools/wta/src/session_watcher/bind.rs
@@ -1,0 +1,157 @@
+//! Bind a discovered session to its hosting WT pane.
+//!
+//! Strategy per the spec's finalized Decision #3:
+//!   * Copilot → `inuse.<pid>.lock` in the session dir (exact).
+//!   * Codex   → Restart Manager owner of the rollout file (exact).
+//!   * Claude/Gemini → cwd correlation: among live CLI processes, pick the
+//!     one whose working directory matches the session's cwd; ties (same cwd)
+//!     are left unresolved (returns None) to avoid a wrong bind.
+//!
+//! Once a pid is chosen, the pane GUID comes from `proc_bind::wt_session_for_pid`.
+
+use crate::agent_sessions::CliSource;
+use crate::proc_bind;
+use std::path::{Path, PathBuf};
+
+/// A candidate live CLI process for correlation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Candidate {
+    pub pid: u32,
+    pub cwd: PathBuf,
+}
+
+/// Pure core: pick the unique candidate whose cwd matches `target`. Returns
+/// `None` when there is no match OR more than one match (ambiguous — never
+/// guess). Comparison is case-insensitive with trailing separators ignored
+/// (Windows paths).
+pub fn correlate_by_cwd(candidates: &[Candidate], target: &Path) -> Option<u32> {
+    let norm = |p: &Path| {
+        p.to_string_lossy()
+            .trim_end_matches(['\\', '/'])
+            .to_lowercase()
+    };
+    let want = norm(target);
+    let mut hits = candidates.iter().filter(|c| norm(&c.cwd) == want);
+    let first = hits.next()?;
+    if hits.next().is_some() {
+        None // ambiguous: two same-cwd candidates
+    } else {
+        Some(first.pid)
+    }
+}
+
+/// Resolve the `(pane GUID, owner pid)` of a Copilot session via its lock file,
+/// then the pane GUID from that pid's PEB. The pid is returned for liveness
+/// polling; the pane may be `None` if the PEB read fails even when the pid is
+/// known.
+pub fn bind_copilot(session_dir: &Path) -> (Option<String>, Option<u32>) {
+    let Some(pid) = proc_bind::copilot_pid_from_lock(session_dir) else {
+        return (None, None);
+    };
+    (proc_bind::wt_session_for_pid(pid), Some(pid))
+}
+
+/// Resolve the `(pane GUID, owner pid)` of a Codex session via Restart Manager,
+/// then the pane GUID from that pid's PEB. See [`bind_copilot`] for the
+/// pane-vs-pid contract.
+pub fn bind_codex(rollout_path: &Path) -> (Option<String>, Option<u32>) {
+    let Some(pid) = proc_bind::file_owner_pid(rollout_path) else {
+        return (None, None);
+    };
+    (proc_bind::wt_session_for_pid(pid), Some(pid))
+}
+
+/// Process exe names to enumerate per CLI when correlating by cwd. Copilot
+/// (lock) and Codex (Restart Manager) bind exactly and need no enumeration.
+fn exe_names(cli: &CliSource) -> &'static [&'static str] {
+    match cli {
+        CliSource::Claude => &["claude.exe"],
+        CliSource::Gemini => &["node.exe"], // gemini runs as a node bundle
+        _ => &[],
+    }
+}
+
+/// Gather live candidate processes for a cwd-correlated CLI: `(pid, cwd)` for
+/// every matching exe that has a readable working directory.
+pub fn gather_candidates(cli: &CliSource) -> Vec<Candidate> {
+    let mut out = Vec::new();
+    for name in exe_names(cli) {
+        for pid in proc_bind::pids_for_exe(name) {
+            if let Some(cwd) = proc_bind::cwd_for_pid(pid) {
+                out.push(Candidate { pid, cwd });
+            }
+        }
+    }
+    out
+}
+
+/// Resolve the `(pane GUID, owner pid)` hosting `cli`'s session, given the
+/// session's cwd (path-encoded; available for Claude). Returns `(None, None)`
+/// when there is no unique cwd match. For Copilot/Codex use
+/// [`bind_copilot`]/[`bind_codex`].
+pub fn bind_by_cwd(cli: &CliSource, session_cwd: &Path) -> (Option<String>, Option<u32>) {
+    let candidates = gather_candidates(cli);
+    let Some(pid) = correlate_by_cwd(&candidates, session_cwd) else {
+        return (None, None);
+    };
+    (proc_bind::wt_session_for_pid(pid), Some(pid))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cand(pid: u32, cwd: &str) -> Candidate {
+        Candidate {
+            pid,
+            cwd: PathBuf::from(cwd),
+        }
+    }
+
+    #[test]
+    fn unique_cwd_match_binds() {
+        let cands = vec![cand(10, r"C:\Users\u\proj"), cand(20, r"C:\Users\u\other")];
+        assert_eq!(
+            correlate_by_cwd(&cands, Path::new(r"C:\Users\u\proj")),
+            Some(10)
+        );
+    }
+
+    #[test]
+    fn case_and_trailing_sep_insensitive() {
+        let cands = vec![cand(10, r"c:\users\u\proj\")];
+        assert_eq!(
+            correlate_by_cwd(&cands, Path::new(r"C:\Users\U\Proj")),
+            Some(10)
+        );
+    }
+
+    #[test]
+    fn ambiguous_same_cwd_returns_none() {
+        let cands = vec![cand(10, r"C:\p"), cand(20, r"C:\p")];
+        assert_eq!(correlate_by_cwd(&cands, Path::new(r"C:\p")), None);
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        let cands = vec![cand(10, r"C:\a")];
+        assert_eq!(correlate_by_cwd(&cands, Path::new(r"C:\b")), None);
+    }
+
+    #[test]
+    fn gather_candidates_empty_for_cli_without_exe_names() {
+        // Copilot/Codex bind by lock/RM, not cwd — no exe names to enumerate,
+        // so this is deterministic regardless of what's running.
+        assert!(gather_candidates(&CliSource::Copilot).is_empty());
+        assert!(gather_candidates(&CliSource::Codex).is_empty());
+    }
+
+    #[test]
+    fn bind_by_cwd_none_without_candidates() {
+        // No exe_names -> no candidates -> never binds, regardless of cwd.
+        assert_eq!(
+            bind_by_cwd(&CliSource::Copilot, Path::new(r"C:\whatever")),
+            (None, None)
+        );
+    }
+}

--- a/tools/wta/src/session_watcher/classify_claude.rs
+++ b/tools/wta/src/session_watcher/classify_claude.rs
@@ -1,56 +1,77 @@
-//! Claude `<id>.jsonl` classifier.
+//! Claude `<id>.jsonl` classifier — turn-based status, keyed on `stop_reason`.
 //!
-//! Record shapes (verified 2026-06-08):
-//!   * assistant tool call:
-//!     `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash"}]}}`
-//!   * tool result:
-//!     `{"type":"user","message":{"content":[{"type":"tool_result","is_error":false}]}}`
+//! Claude appends to the transcript AND **re-writes the same assistant message
+//! id several times as it streams** (verified 2026-06-13: one `msg_…` appears as
+//! text-only, then with a `tool_use`, etc.). Classifying by *content presence*
+//! would flicker Idle↔Working across those partial frames, so we key on the
+//! assistant message's `stop_reason`, which is stable across the stream:
 //!
-//! Meta records (`permission-mode`, `file-history-snapshot`, `system`, ...)
-//! yield nothing.
+//!   * `{"type":"user","message":{"role":"user", …}}` — a typed prompt
+//!     (`content` is a string) OR a `tool_result` handed back to the agent →
+//!     the agent has input to process → **Working**.
+//!   * `{"type":"assistant","message":{"role":"assistant","stop_reason":…}}`:
+//!     - `stop_reason == "tool_use"`:
+//!         * a `tool_use` named with a user-input tool (`AskUserQuestion`, …)
+//!           → **Attention** (the agent is waiting on the user);
+//!         * otherwise → **Working** (running / streaming toward a tool).
+//!     - any other `stop_reason` (`end_turn`, …) → the turn is complete → **Idle**.
+//!   * everything else (`system`, `file-history-snapshot`, meta) → nothing.
+//!
+//! Status rides the crate's existing events: `ToolStarting` is the "→Working"
+//! signal (tool name empty for a user turn), `ToolCompleted` the "→Idle" signal,
+//! `Notification` the "→Attention" signal.
+//!
+//! NOTE: a tool that *prompts for permission* (e.g. `Bash` in `default` mode)
+//! is indistinguishable from a tool that is merely *running* — the transcript
+//! has no approval/pending marker — so a permission wait shows as Working, not
+//! Attention. Only an explicit user-input tool (AskUserQuestion) is Attention.
 
 use crate::agent_sessions::{is_user_input_tool, AgentKey, SessionEvent};
 
 pub fn classify(record: &serde_json::Value, key: &AgentKey) -> Vec<SessionEvent> {
-    let kind = record.get("type").and_then(|v| v.as_str()).unwrap_or("");
-    let content = record
-        .get("message")
-        .and_then(|m| m.get("content"))
-        .and_then(|c| c.as_array());
-
-    match (kind, content) {
-        ("assistant", Some(items)) => {
-            let mut out = Vec::new();
-            for item in items {
-                if item.get("type").and_then(|v| v.as_str()) == Some("tool_use") {
-                    let tool = item
-                        .get("name")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    if is_user_input_tool(&tool) {
-                        out.push(SessionEvent::Notification {
-                            key: key.clone(),
-                            message: tool,
-                        });
-                    } else {
-                        out.push(SessionEvent::ToolStarting {
-                            key: key.clone(),
-                            tool_name: tool,
-                        });
-                    }
-                }
+    match record.get("type").and_then(|v| v.as_str()).unwrap_or("") {
+        // User turn (typed prompt or tool_result): the agent has work to do.
+        "user" => vec![SessionEvent::ToolStarting {
+            key: key.clone(),
+            tool_name: String::new(),
+        }],
+        // Assistant turn: classify by `stop_reason` (stable across streamed
+        // re-writes of the same message id).
+        "assistant" => {
+            let msg = record.get("message");
+            let stop = msg
+                .and_then(|m| m.get("stop_reason"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if stop != "tool_use" {
+                // end_turn (or any non-tool stop) → the turn is complete.
+                return vec![SessionEvent::ToolCompleted { key: key.clone() }];
             }
-            out
-        }
-        ("user", Some(items)) => {
-            let has_result = items
-                .iter()
-                .any(|i| i.get("type").and_then(|v| v.as_str()) == Some("tool_result"));
-            if has_result {
-                vec![SessionEvent::ToolCompleted { key: key.clone() }]
+            // The assistant stopped to call a tool (possibly still streaming
+            // toward it, so the tool_use content may not be present yet).
+            let tool_names: Vec<&str> = msg
+                .and_then(|m| m.get("content"))
+                .and_then(|c| c.as_array())
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter(|i| i.get("type").and_then(|v| v.as_str()) == Some("tool_use"))
+                        .filter_map(|i| i.get("name").and_then(|v| v.as_str()))
+                        .collect()
+                })
+                .unwrap_or_default();
+            if let Some(q) = tool_names.iter().find(|t| is_user_input_tool(t)) {
+                // The agent is asking the user (e.g. AskUserQuestion).
+                vec![SessionEvent::Notification {
+                    key: key.clone(),
+                    message: (*q).to_string(),
+                }]
             } else {
-                Vec::new()
+                // Running (or streaming toward) a tool — still Working.
+                vec![SessionEvent::ToolStarting {
+                    key: key.clone(),
+                    tool_name: tool_names.first().map(|s| (*s).to_string()).unwrap_or_default(),
+                }]
             }
         }
         _ => Vec::new(),
@@ -66,13 +87,52 @@ mod tests {
     }
 
     #[test]
-    fn tool_use_maps_to_tool_starting() {
-        let r = rec(
-            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash"}]}}"#,
-        );
-        let out = classify(&r, &"k".to_string());
+    fn user_prompt_maps_to_working() {
+        let r = rec(r#"{"type":"user","message":{"role":"user","content":"installed hooks"}}"#);
         assert_eq!(
-            out,
+            classify(&r, &"k".to_string()),
+            vec![SessionEvent::ToolStarting {
+                key: "k".to_string(),
+                tool_name: String::new()
+            }]
+        );
+    }
+
+    #[test]
+    fn user_tool_result_also_maps_to_working() {
+        // A tool_result is a user-role record too — the agent resumes → Working.
+        let r = rec(
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"ok"}]}}"#,
+        );
+        assert_eq!(
+            classify(&r, &"k".to_string()),
+            vec![SessionEvent::ToolStarting {
+                key: "k".to_string(),
+                tool_name: String::new()
+            }]
+        );
+    }
+
+    #[test]
+    fn assistant_text_only_maps_to_idle() {
+        let r = rec(
+            r#"{"type":"assistant","message":{"role":"assistant","stop_reason":"end_turn","content":[{"type":"text","text":"done"}]}}"#,
+        );
+        assert_eq!(
+            classify(&r, &"k".to_string()),
+            vec![SessionEvent::ToolCompleted {
+                key: "k".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn assistant_normal_tool_use_maps_to_working() {
+        let r = rec(
+            r#"{"type":"assistant","message":{"role":"assistant","stop_reason":"tool_use","content":[{"type":"tool_use","name":"Bash"}]}}"#,
+        );
+        assert_eq!(
+            classify(&r, &"k".to_string()),
             vec![SessionEvent::ToolStarting {
                 key: "k".to_string(),
                 tool_name: "Bash".to_string()
@@ -81,23 +141,39 @@ mod tests {
     }
 
     #[test]
-    fn tool_result_maps_to_tool_completed() {
+    fn assistant_streaming_partial_tool_use_is_working_not_idle() {
+        // A streamed frame of an assistant message can carry only text so far but
+        // already have stop_reason=tool_use (the tool_use content lands in a later
+        // re-write of the same id). Keying on stop_reason avoids an Idle flicker.
         let r = rec(
-            r#"{"type":"user","message":{"content":[{"type":"tool_result","is_error":false}]}}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","stop_reason":"tool_use","content":[{"type":"text","text":"Let me check"}]}}"#,
         );
-        let out = classify(&r, &"k".to_string());
         assert_eq!(
-            out,
-            vec![SessionEvent::ToolCompleted {
-                key: "k".to_string()
+            classify(&r, &"k".to_string()),
+            vec![SessionEvent::ToolStarting {
+                key: "k".to_string(),
+                tool_name: String::new()
             }]
         );
     }
 
     #[test]
-    fn text_only_assistant_yields_nothing() {
-        let r = rec(r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}"#);
-        assert!(classify(&r, &"k".to_string()).is_empty());
+    fn assistant_ask_user_question_maps_to_attention() {
+        // Claude's AskUserQuestion tool_use → Attention, not Working — even when
+        // the same message also carries explanatory text.
+        let r = rec(
+            r#"{"type":"assistant","message":{"role":"assistant","stop_reason":"tool_use","content":[
+                {"type":"text","text":"Let me check"},
+                {"type":"tool_use","id":"toolu_1","caller":{"type":"direct"},"name":"AskUserQuestion","input":{}}
+            ]}}"#,
+        );
+        assert_eq!(
+            classify(&r, &"k".to_string()),
+            vec![SessionEvent::Notification {
+                key: "k".to_string(),
+                message: "AskUserQuestion".to_string()
+            }]
+        );
     }
 
     #[test]

--- a/tools/wta/src/session_watcher/classify_claude.rs
+++ b/tools/wta/src/session_watcher/classify_claude.rs
@@ -164,7 +164,7 @@ mod tests {
         let r = rec(
             r#"{"type":"assistant","message":{"role":"assistant","stop_reason":"tool_use","content":[
                 {"type":"text","text":"Let me check"},
-                {"type":"tool_use","id":"toolu_1","caller":{"type":"direct"},"name":"AskUserQuestion","input":{}}
+                {"type":"tool_use","id":"tool_use_1","caller":{"type":"direct"},"name":"AskUserQuestion","input":{}}
             ]}}"#,
         );
         assert_eq!(

--- a/tools/wta/src/session_watcher/classify_claude.rs
+++ b/tools/wta/src/session_watcher/classify_claude.rs
@@ -1,0 +1,108 @@
+//! Claude `<id>.jsonl` classifier.
+//!
+//! Record shapes (verified 2026-06-08):
+//!   * assistant tool call:
+//!     `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash"}]}}`
+//!   * tool result:
+//!     `{"type":"user","message":{"content":[{"type":"tool_result","is_error":false}]}}`
+//!
+//! Meta records (`permission-mode`, `file-history-snapshot`, `system`, ...)
+//! yield nothing.
+
+use crate::agent_sessions::{is_user_input_tool, AgentKey, SessionEvent};
+
+pub fn classify(record: &serde_json::Value, key: &AgentKey) -> Vec<SessionEvent> {
+    let kind = record.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    let content = record
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_array());
+
+    match (kind, content) {
+        ("assistant", Some(items)) => {
+            let mut out = Vec::new();
+            for item in items {
+                if item.get("type").and_then(|v| v.as_str()) == Some("tool_use") {
+                    let tool = item
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    if is_user_input_tool(&tool) {
+                        out.push(SessionEvent::Notification {
+                            key: key.clone(),
+                            message: tool,
+                        });
+                    } else {
+                        out.push(SessionEvent::ToolStarting {
+                            key: key.clone(),
+                            tool_name: tool,
+                        });
+                    }
+                }
+            }
+            out
+        }
+        ("user", Some(items)) => {
+            let has_result = items
+                .iter()
+                .any(|i| i.get("type").and_then(|v| v.as_str()) == Some("tool_result"));
+            if has_result {
+                vec![SessionEvent::ToolCompleted { key: key.clone() }]
+            } else {
+                Vec::new()
+            }
+        }
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(s: &str) -> serde_json::Value {
+        serde_json::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn tool_use_maps_to_tool_starting() {
+        let r = rec(
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash"}]}}"#,
+        );
+        let out = classify(&r, &"k".to_string());
+        assert_eq!(
+            out,
+            vec![SessionEvent::ToolStarting {
+                key: "k".to_string(),
+                tool_name: "Bash".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn tool_result_maps_to_tool_completed() {
+        let r = rec(
+            r#"{"type":"user","message":{"content":[{"type":"tool_result","is_error":false}]}}"#,
+        );
+        let out = classify(&r, &"k".to_string());
+        assert_eq!(
+            out,
+            vec![SessionEvent::ToolCompleted {
+                key: "k".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn text_only_assistant_yields_nothing() {
+        let r = rec(r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}"#);
+        assert!(classify(&r, &"k".to_string()).is_empty());
+    }
+
+    #[test]
+    fn meta_record_yields_nothing() {
+        let r = rec(r#"{"type":"file-history-snapshot","messageId":"x"}"#);
+        assert!(classify(&r, &"k".to_string()).is_empty());
+    }
+}

--- a/tools/wta/src/session_watcher/classify_codex.rs
+++ b/tools/wta/src/session_watcher/classify_codex.rs
@@ -1,0 +1,202 @@
+//! Codex rollout classifier.
+//!
+//! Activity model — **turn-based** (same as Copilot). A Codex session writes a
+//! per-task `event_msg/task_started` … `event_msg/task_complete` bracket; the
+//! agent is busy for that whole turn (thinking + tool calls + text). So:
+//!   * turn start: `{"type":"event_msg","payload":{"type":"task_started"}}`   → WORKING
+//!   * turn end:   `{"type":"event_msg","payload":{"type":"task_complete"}}`   → IDLE
+//!   * tool start: `{"type":"response_item","payload":{"type":"function_call","name":"shell_command"}}`
+//!   * tool end:   `{"type":"response_item","payload":{"type":"function_call_output",...}}` (ignored)
+//!
+//! task_started is what makes the row appear in the session view *immediately*
+//! (the first `function_call` can be 10-30s into the turn). task_complete is a
+//! per-turn boundary → IDLE, NOT a session end — the session stays resumable;
+//! `function_call_output` is ignored because IDLE is owned by task_complete.
+
+use crate::agent_sessions::{is_user_input_tool, AgentKey, SessionEvent};
+
+pub fn classify(record: &serde_json::Value, key: &AgentKey) -> Vec<SessionEvent> {
+    let kind = record.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    let payload_type = record
+        .get("payload")
+        .and_then(|p| p.get("type"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    match (kind, payload_type) {
+        // Turn boundaries. task_started → WORKING surfaces the session in the
+        // view immediately and brackets the whole working turn; task_complete
+        // → IDLE (a per-turn boundary, NOT a session end — the session stays
+        // resumable, unlike the previous SessionStopped mapping which drove a
+        // Class-B row to Ended / "no status").
+        ("event_msg", "task_started") => vec![SessionEvent::ToolStarting {
+            key: key.clone(),
+            tool_name: String::new(),
+        }],
+        ("event_msg", "task_complete") => vec![SessionEvent::ToolCompleted { key: key.clone() }],
+        ("response_item", "function_call")
+        | ("response_item", "local_shell_call")
+        | ("response_item", "custom_tool_call") => {
+            let payload = record.get("payload");
+            let tool = payload
+                .and_then(|p| p.get("name"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            // Codex's permission gate lives inside the call's `arguments`: a
+            // command requesting escalated sandbox permissions is blocked on
+            // the user → ATTENTION. Check it before the generic tool handling.
+            if let Some(reason) = codex_permission_reason(payload) {
+                vec![SessionEvent::Notification {
+                    key: key.clone(),
+                    message: reason,
+                }]
+            } else if is_user_input_tool(&tool) {
+                vec![SessionEvent::Notification {
+                    key: key.clone(),
+                    message: tool,
+                }]
+            } else {
+                vec![SessionEvent::ToolStarting {
+                    key: key.clone(),
+                    tool_name: tool,
+                }]
+            }
+        }
+        // function_call_output / custom_tool_call_output intentionally dropped:
+        // IDLE is owned by task_complete, so a tool finishing mid-turn must not
+        // flip the row to IDLE while the agent keeps working.
+        _ => Vec::new(),
+    }
+}
+
+/// If a Codex function_call requests escalated sandbox permissions, return the
+/// human-readable approval prompt (`justification`, falling back to a generic
+/// message). `None` otherwise. `arguments` is a JSON *string* nested inside the
+/// payload, so it needs a second parse.
+fn codex_permission_reason(payload: Option<&serde_json::Value>) -> Option<String> {
+    let args_str = payload?.get("arguments")?.as_str()?;
+    let args: serde_json::Value = serde_json::from_str(args_str).ok()?;
+    let needs_escalation = args
+        .get("sandbox_permissions")
+        .and_then(|v| v.as_str())
+        .map(|s| s == "require_escalated")
+        .unwrap_or(false);
+    if !needs_escalation {
+        return None;
+    }
+    let reason = args
+        .get("justification")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("permission requested")
+        .to_string();
+    Some(reason)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(s: &str) -> serde_json::Value {
+        serde_json::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn function_call_maps_to_tool_starting() {
+        let r = rec(
+            r#"{"type":"response_item","payload":{"type":"function_call","name":"shell_command"}}"#,
+        );
+        let out = classify(&r, &"k".to_string());
+        assert_eq!(
+            out,
+            vec![SessionEvent::ToolStarting {
+                key: "k".to_string(),
+                tool_name: "shell_command".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn require_escalated_function_call_maps_to_attention() {
+        // Codex embeds its permission gate inside the function_call's
+        // `arguments` (a JSON *string*): a command needing escalated sandbox
+        // permissions is waiting for the user to approve/deny → ATTENTION,
+        // with the human-readable `justification` as the reason.
+        let r = rec(
+            r#"{"type":"response_item","payload":{"type":"function_call","name":"shell_command","arguments":"{\"command\":\"ls\",\"sandbox_permissions\":\"require_escalated\",\"justification\":\"Allow listing System32?\"}"}}"#,
+        );
+        assert_eq!(
+            classify(&r, &"k".to_string()),
+            vec![SessionEvent::Notification {
+                key: "k".to_string(),
+                message: "Allow listing System32?".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn require_escalated_without_justification_uses_fallback() {
+        let r = rec(
+            r#"{"type":"response_item","payload":{"type":"function_call","name":"shell_command","arguments":"{\"sandbox_permissions\":\"require_escalated\"}"}}"#,
+        );
+        assert!(matches!(
+            classify(&r, &"k".to_string()).as_slice(),
+            [SessionEvent::Notification { message, .. }] if message == "permission requested"
+        ));
+    }
+
+    #[test]
+    fn normal_sandbox_function_call_stays_working() {
+        // A command that does NOT require escalation is autonomous → WORKING.
+        let r = rec(
+            r#"{"type":"response_item","payload":{"type":"function_call","name":"shell_command","arguments":"{\"command\":\"ls\",\"sandbox_permissions\":\"auto\"}"}}"#,
+        );
+        assert!(matches!(
+            classify(&r, &"k".to_string()).as_slice(),
+            [SessionEvent::ToolStarting { .. }]
+        ));
+    }
+
+    #[test]
+    fn task_started_maps_to_working() {
+        // task_started makes the session appear immediately (before the first
+        // function_call, which can be 10-30s in) and marks the whole turn
+        // WORKING. Reuses ToolStarting with an empty tool name.
+        let r = rec(r#"{"type":"event_msg","payload":{"type":"task_started"}}"#);
+        assert_eq!(
+            classify(&r, &"k".to_string()),
+            vec![SessionEvent::ToolStarting {
+                key: "k".to_string(),
+                tool_name: String::new()
+            }]
+        );
+    }
+
+    #[test]
+    fn function_call_output_is_dropped() {
+        // IDLE is owned by task_complete; a tool finishing mid-turn must not
+        // flip the row to IDLE while the agent keeps working.
+        let r = rec(r#"{"type":"response_item","payload":{"type":"function_call_output"}}"#);
+        assert!(classify(&r, &"k".to_string()).is_empty());
+    }
+
+    #[test]
+    fn task_complete_maps_to_idle() {
+        // task_complete is a per-turn boundary → IDLE, NOT a session end. The
+        // session stays in the registry as Idle (resumable).
+        let r = rec(r#"{"type":"event_msg","payload":{"type":"task_complete"}}"#);
+        assert_eq!(
+            classify(&r, &"k".to_string()),
+            vec![SessionEvent::ToolCompleted {
+                key: "k".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn plain_message_yields_nothing() {
+        let r = rec(r#"{"type":"response_item","payload":{"type":"message","role":"user"}}"#);
+        assert!(classify(&r, &"k".to_string()).is_empty());
+    }
+}

--- a/tools/wta/src/session_watcher/classify_copilot.rs
+++ b/tools/wta/src/session_watcher/classify_copilot.rs
@@ -1,0 +1,193 @@
+//! Copilot `events.jsonl` classifier.
+//!
+//! Record shapes (verified 2026-06-09 against a live `events.jsonl`):
+//!   * `{"type":"assistant.turn_start","data":{"turnId":"0",...}}`
+//!   * `{"type":"assistant.turn_end","data":{"turnId":"0"}}`
+//!   * `{"type":"tool.execution_start","data":{"toolName":"skill",...}}`
+//!   * `{"type":"tool.execution_complete","data":{"success":true,...}}`
+//!
+//! Activity model — **turn-based**, not tool-based. One user prompt drives one
+//! or more assistant *turns*; the agent is busy for the whole turn (thinking,
+//! streaming text, AND running tools), so WORKING is bracketed by
+//! `assistant.turn_start` → `assistant.turn_end`, not by the brief
+//! `tool.execution_*` windows. Tool starts only refine the picture (the
+//! current tool, or ATTENTION for a user-input tool); `tool.execution_complete`
+//! is ignored because IDLE is owned by `turn_end`. A `permission.requested`
+//! record (the agent waiting for the user to approve/deny a command) also maps
+//! to ATTENTION.
+//!
+//! The session key is the session-state directory name (supplied by the
+//! watcher from the file path), never the record body.
+
+use crate::agent_sessions::{is_user_input_tool, AgentKey, SessionEvent};
+
+/// Map one parsed Copilot `events.jsonl` record to zero or more events.
+pub fn classify(record: &serde_json::Value, key: &AgentKey) -> Vec<SessionEvent> {
+    let kind = record.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    match kind {
+        // A turn spans the agent's whole working period for one prompt
+        // (thinking + streaming text + tool runs). turn_start → WORKING for
+        // the entire turn; turn_end → IDLE. This is what keeps the row WORKING
+        // during text generation, not just the brief tool windows. WORKING is
+        // surfaced by reusing `ToolStarting` with an empty tool name —
+        // `current_tool` is not rendered in the session view, so the empty
+        // name is invisible and only the WORKING status takes effect.
+        "assistant.turn_start" => vec![SessionEvent::ToolStarting {
+            key: key.clone(),
+            tool_name: String::new(),
+        }],
+        "assistant.turn_end" => vec![SessionEvent::ToolCompleted { key: key.clone() }],
+        // The agent paused to ask the user to approve/deny a command (the
+        // permission y/n gate) → ATTENTION. The pending command only runs after
+        // approval, at which point the resulting `tool.execution_start`
+        // (→ WORKING) or the turn's `turn_end` (→ IDLE) clears the attention.
+        "permission.requested" => {
+            let reason = record
+                .get("data")
+                .and_then(|d| d.get("permissionRequest"))
+                .and_then(|p| p.get("intention"))
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .unwrap_or("permission requested")
+                .to_string();
+            vec![SessionEvent::Notification {
+                key: key.clone(),
+                message: reason,
+            }]
+        }
+        "tool.execution_start" => {
+            let tool = record
+                .get("data")
+                .and_then(|d| d.get("toolName"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            // A user-input tool (ask_user, ...) means the agent is blocked on
+            // the user → Attention; everything else keeps the turn WORKING and
+            // just refreshes the current tool.
+            if is_user_input_tool(&tool) {
+                vec![SessionEvent::Notification {
+                    key: key.clone(),
+                    message: tool,
+                }]
+            } else {
+                vec![SessionEvent::ToolStarting {
+                    key: key.clone(),
+                    tool_name: tool,
+                }]
+            }
+        }
+        // tool.execution_complete is intentionally NOT mapped: returning to
+        // IDLE is driven by `assistant.turn_end`, so a tool finishing mid-turn
+        // must not flip the row to IDLE while the agent keeps working.
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_sessions::SessionEvent;
+
+    fn rec(s: &str) -> serde_json::Value {
+        serde_json::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn tool_start_maps_to_tool_starting() {
+        let r = rec(r#"{"type":"tool.execution_start","data":{"toolName":"skill"}}"#);
+        let out = classify(&r, &"sess-1".to_string());
+        assert_eq!(
+            out,
+            vec![SessionEvent::ToolStarting {
+                key: "sess-1".to_string(),
+                tool_name: "skill".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn ask_user_tool_maps_to_notification() {
+        let r = rec(r#"{"type":"tool.execution_start","data":{"toolName":"ask_user"}}"#);
+        let out = classify(&r, &"sess-1".to_string());
+        assert!(matches!(
+            out.as_slice(),
+            [SessionEvent::Notification { .. }]
+        ));
+    }
+
+    #[test]
+    fn permission_requested_maps_to_attention() {
+        // Copilot writes a `permission.requested` record while it waits for the
+        // user to approve/deny a command → ATTENTION. The human-readable
+        // `intention` becomes the (non-rendered) attention reason.
+        let r = rec(
+            r#"{"type":"permission.requested","data":{"permissionRequest":{"kind":"shell","intention":"run git log"}}}"#,
+        );
+        let out = classify(&r, &"sess-1".to_string());
+        assert_eq!(
+            out,
+            vec![SessionEvent::Notification {
+                key: "sess-1".to_string(),
+                message: "run git log".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn permission_requested_without_intention_uses_fallback() {
+        let r = rec(r#"{"type":"permission.requested","data":{"permissionRequest":{"kind":"shell"}}}"#);
+        let out = classify(&r, &"sess-1".to_string());
+        assert!(matches!(
+            out.as_slice(),
+            [SessionEvent::Notification { message, .. }] if message == "permission requested"
+        ));
+    }
+
+    #[test]
+    fn turn_start_maps_to_working() {
+        // A turn beginning means the agent is busy for the whole turn —
+        // thinking, streaming text, and running tools — not just during the
+        // brief tool windows. We surface that as WORKING by reusing
+        // ToolStarting with an empty tool name (current_tool isn't rendered,
+        // so the empty name is invisible; only the WORKING status matters).
+        let r = rec(r#"{"type":"assistant.turn_start","data":{"turnId":"0"}}"#);
+        let out = classify(&r, &"sess-1".to_string());
+        assert_eq!(
+            out,
+            vec![SessionEvent::ToolStarting {
+                key: "sess-1".to_string(),
+                tool_name: String::new()
+            }]
+        );
+    }
+
+    #[test]
+    fn turn_end_maps_to_tool_completed() {
+        // turn_end is the authoritative "agent is done" signal → IDLE.
+        let r = rec(r#"{"type":"assistant.turn_end","data":{"turnId":"0"}}"#);
+        let out = classify(&r, &"sess-1".to_string());
+        assert_eq!(
+            out,
+            vec![SessionEvent::ToolCompleted {
+                key: "sess-1".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn tool_complete_is_dropped_in_turn_model() {
+        // Returning to IDLE is driven by turn_end, NOT by individual tool
+        // completion — a tool finishing mid-turn must not flip the row to
+        // IDLE while the agent keeps working. So tool.execution_complete is
+        // intentionally ignored.
+        let r = rec(r#"{"type":"tool.execution_complete","data":{"success":true}}"#);
+        assert!(classify(&r, &"sess-1".to_string()).is_empty());
+    }
+
+    #[test]
+    fn unrelated_record_yields_nothing() {
+        let r = rec(r#"{"type":"assistant.message","data":{"content":"hi"}}"#);
+        assert!(classify(&r, &"sess-1".to_string()).is_empty());
+    }
+}

--- a/tools/wta/src/session_watcher/classify_gemini.rs
+++ b/tools/wta/src/session_watcher/classify_gemini.rs
@@ -1,42 +1,74 @@
-//! Gemini chat-snapshot classifier.
+//! Gemini chat-transcript classifier.
 //!
-//! Gemini's `session-*.jsonl` is NOT an append log: each turn rewrites a
-//! trailing `{"$set":{"messages":[…]}}` snapshot in place. We therefore parse
-//! the latest snapshot and diff the `messages` array by length, classifying
-//! only the messages appended since `prev_len`.
+//! File format (re-verified 2026-06-14 against a live `session-*.jsonl`): the
+//! file **is an append log** — every line is a record appended at the end, never
+//! an in-place rewrite. Lines are a mix of:
+//!   * per-message records `{"id","type":"gemini"|"user","content",…}` — the
+//!     `type` is top-level, *not* inside a `messages` array;
+//!   * a `{"$set":{"lastUpdated":…}}` bump after almost every message;
+//!   * a `{"$set":{"messages":[…full history…]}}` FULL snapshot only at session
+//!     **start** and **resume** — NOT once per turn.
+//! A `gemini` assistant message is appended **twice** under the same id: phase 1
+//! carries text/thoughts only, phase 2 re-appends the same id WITH `toolCalls`.
 //!
-//! Message shapes (verified 2026-06-08):
-//!   * assistant w/ tools: `{"type":"gemini","toolCalls":[{"name":"update_topic",...}]}`
-//!   * tool result:        `{"type":"user","content":[{"functionResponse":{...}}]}`
+//! We therefore read the file by **byte offset** (like Copilot/Codex/Claude) and
+//! classify each appended single-message record in [`classify_record`], skipping
+//! every `$set` op — crucially the resume `$set.messages` snapshot, which would
+//! otherwise replay the entire prior conversation. See [`classify_record`] for
+//! the status model (Working-only; Idle deferred — no turn-completion signal)
+//! and the post-hoc Attention caveat.
 
 use crate::agent_sessions::{is_user_input_tool, AgentKey, SessionEvent};
 
-/// Extract the messages array from the latest snapshot line. The watcher
-/// passes the *last non-empty line* of the file (the freshest `$set`).
-fn messages_of(snapshot_line: &serde_json::Value) -> Option<&Vec<serde_json::Value>> {
-    snapshot_line
-        .get("$set")
-        .and_then(|s| s.get("messages"))
-        .and_then(|m| m.as_array())
-        .or_else(|| snapshot_line.get("messages").and_then(|m| m.as_array()))
-}
-
-/// Classify messages appended since `prev_len`. Returns the new events and the
-/// updated message count to remember for next time.
-pub fn classify_snapshot(
-    snapshot_line: &serde_json::Value,
-    key: &AgentKey,
-    prev_len: usize,
-) -> (Vec<SessionEvent>, usize) {
-    let messages = match messages_of(snapshot_line) {
-        Some(m) => m,
-        None => return (Vec::new(), prev_len),
-    };
+/// Classify ONE appended record from Gemini's `session-*.jsonl`. The watcher
+/// reads the file by byte offset (append model) and hands each new line here.
+///
+/// We process only single-message records (`{"id","type":"user"|"gemini",…}`)
+/// and **skip every `$set` op** — including the full `{"$set":{"messages":[…]}}`
+/// history snapshot Gemini writes at session start and resume, which would
+/// otherwise replay the entire prior conversation (re-emitting Working for old
+/// activity) the first time we read a resumed file.
+///
+/// ## Status model — Working-only (turn-based Idle deferred)
+/// Every record that represents activity maps to **Working**:
+///   * `type:user` (a typed prompt *or* a `functionResponse` tool result),
+///   * `type:gemini` text (phase 1 or a final answer),
+///   * `type:gemini` with `toolCalls` (tool name surfaced for display); a
+///     user-input tool (`ask_user`) maps to **Attention** instead.
+///
+/// We deliberately **never emit `ToolCompleted`/Idle**. Gemini's transcript has
+/// no turn-completion signal, and a `toolCall` carrying a `result` does NOT mean
+/// the turn ended — the agent keeps going (more tools / a final answer follow).
+/// So a Gemini row stays Working through the conversation and only leaves the
+/// live state on `PaneClosed`. Telling "still working" from "final answer" needs
+/// a turn-end marker Gemini doesn't write, so that (and thus Idle) is deferred.
+///
+/// ## Attention caveat (post-hoc transcript)
+/// Gemini writes tool records **after** the tool completes — every on-disk
+/// `toolCall` is `status:"success"` with its `result` inlined, and an `ask_user`
+/// record already contains the user's answer. So the `ask_user` line appears
+/// only *after* the user replied; during the actual wait the file is silent and
+/// the last record (the agent's phase-1 text) shows **Working**. The `ask_user`
+/// → Attention mapping is kept (and is correct if a future Gemini build writes a
+/// pending state), but in today's transcript it is typically superseded by the
+/// immediately-following result record. Reliable wait-state Attention needs
+/// hooks — the same limitation as Claude's permission prompts.
+///
+/// Message shapes (verified 2026-06-14 against a live transcript):
+///   * typed prompt:  `{"type":"user","content":[{"text":"…"}]}`
+///   * tool result:   `{"type":"user","content":[{"functionResponse":{…}}]}`
+///   * assistant text:`{"type":"gemini","content":"…","thoughts":…}`  (no tools)
+///   * assistant tool:`{"type":"gemini","toolCalls":[{"name":"ask_user","status":"success",…}]}`
+pub fn classify_record(record: &serde_json::Value, key: &AgentKey) -> Vec<SessionEvent> {
+    // Skip all `$set` ops (lastUpdated / messages snapshot / summary / …).
+    if record.get("$set").is_some() {
+        return Vec::new();
+    }
     let mut out = Vec::new();
-    for msg in messages.iter().skip(prev_len) {
-        let ty = msg.get("type").and_then(|v| v.as_str()).unwrap_or("");
-        if ty == "gemini" {
-            if let Some(calls) = msg.get("toolCalls").and_then(|c| c.as_array()) {
+    match record.get("type").and_then(|v| v.as_str()).unwrap_or("") {
+        "gemini" => {
+            let mut input_tool: Option<String> = None;
+            if let Some(calls) = record.get("toolCalls").and_then(|c| c.as_array()) {
                 for call in calls {
                     let tool = call
                         .get("name")
@@ -44,35 +76,43 @@ pub fn classify_snapshot(
                         .unwrap_or("")
                         .to_string();
                     if is_user_input_tool(&tool) {
-                        out.push(SessionEvent::Notification {
-                            key: key.clone(),
-                            message: tool,
-                        });
+                        // Remember it; emit Attention last so it wins over any
+                        // sibling tool in the same record.
+                        input_tool = Some(tool);
                     } else {
                         out.push(SessionEvent::ToolStarting {
                             key: key.clone(),
                             tool_name: tool,
                         });
                     }
-                    // Gemini embeds the result inline once the tool returns;
-                    // a call carrying `result` is already complete.
-                    if call.get("result").is_some() {
-                        out.push(SessionEvent::ToolCompleted { key: key.clone() });
-                    }
                 }
             }
-        } else if ty == "user" {
-            let has_resp = msg
-                .get("content")
-                .and_then(|c| c.as_array())
-                .map(|items| items.iter().any(|i| i.get("functionResponse").is_some()))
-                .unwrap_or(false);
-            if has_resp {
-                out.push(SessionEvent::ToolCompleted { key: key.clone() });
+            if let Some(tool) = input_tool {
+                out.push(SessionEvent::Notification {
+                    key: key.clone(),
+                    message: tool,
+                });
+            } else if out.is_empty() {
+                // Text-only (phase 1 / final answer) or an empty toolCalls array
+                // — the agent is still producing output → Working.
+                out.push(SessionEvent::ToolStarting {
+                    key: key.clone(),
+                    tool_name: String::new(),
+                });
             }
         }
+        "user" => {
+            // A typed prompt or a `functionResponse` tool result — both mean the
+            // agent is actively in a turn → Working. (We can't, and needn't,
+            // tell them apart for status.)
+            out.push(SessionEvent::ToolStarting {
+                key: key.clone(),
+                tool_name: String::new(),
+            });
+        }
+        _ => {}
     }
-    (out, messages.len())
+    out
 }
 
 #[cfg(test)]
@@ -84,62 +124,112 @@ mod tests {
     }
 
     #[test]
-    fn new_tool_call_message_emits_tool_starting() {
+    fn set_op_is_skipped() {
+        // `$set` lines (lastUpdated / messages snapshot / summary) emit nothing —
+        // this is what prevents the resume snapshot from replaying history.
         let snap = rec(r#"{"$set":{"messages":[
             {"type":"user","content":[{"text":"hi"}]},
-            {"type":"gemini","toolCalls":[{"name":"run_shell_command"}]}
+            {"type":"gemini","toolCalls":[{"name":"read_file"}]}
         ]}}"#);
-        let (out, new_len) = classify_snapshot(&snap, &"k".to_string(), 1);
-        assert_eq!(new_len, 2);
+        assert!(classify_record(&snap, &"k".to_string()).is_empty());
+        let bump = rec(r#"{"$set":{"lastUpdated":"2026-06-14T00:00:00Z"}}"#);
+        assert!(classify_record(&bump, &"k".to_string()).is_empty());
+    }
+
+    #[test]
+    fn user_prompt_is_working() {
+        let r = rec(r#"{"type":"user","content":[{"text":"explore the repo"}]}"#);
         assert_eq!(
-            out,
+            classify_record(&r, &"k".to_string()),
             vec![SessionEvent::ToolStarting {
                 key: "k".to_string(),
-                tool_name: "run_shell_command".to_string()
+                tool_name: String::new()
             }]
         );
     }
 
     #[test]
-    fn tool_call_with_inline_result_also_completes() {
-        let snap = rec(r#"{"$set":{"messages":[
-            {"type":"gemini","toolCalls":[{"name":"run_shell_command","result":[{"functionResponse":{}}]}]}
-        ]}}"#);
-        let (out, _len) = classify_snapshot(&snap, &"k".to_string(), 0);
+    fn user_function_response_is_working_not_completed() {
+        // A tool result means the agent is continuing the turn → Working. We do
+        // NOT emit ToolCompleted (Idle is deferred for Gemini).
+        let r = rec(r#"{"type":"user","content":[{"functionResponse":{"name":"read_file"}}]}"#);
         assert_eq!(
-            out,
+            classify_record(&r, &"k".to_string()),
+            vec![SessionEvent::ToolStarting {
+                key: "k".to_string(),
+                tool_name: String::new()
+            }]
+        );
+    }
+
+    #[test]
+    fn gemini_text_only_is_working() {
+        let r = rec(r#"{"type":"gemini","content":"here is my analysis","thoughts":"…"}"#);
+        assert_eq!(
+            classify_record(&r, &"k".to_string()),
+            vec![SessionEvent::ToolStarting {
+                key: "k".to_string(),
+                tool_name: String::new()
+            }]
+        );
+    }
+
+    #[test]
+    fn gemini_tool_call_is_working_with_name_no_completion() {
+        // The on-disk toolCall is already `status:success` with a result, but we
+        // must NOT emit ToolCompleted — the turn isn't over.
+        let r = rec(r#"{"type":"gemini","toolCalls":[
+            {"name":"read_file","status":"success","result":[{"functionResponse":{}}]}
+        ]}"#);
+        assert_eq!(
+            classify_record(&r, &"k".to_string()),
+            vec![SessionEvent::ToolStarting {
+                key: "k".to_string(),
+                tool_name: "read_file".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn gemini_ask_user_is_attention() {
+        let r = rec(r#"{"type":"gemini","toolCalls":[
+            {"name":"ask_user","status":"success","result":[{"functionResponse":{}}]}
+        ]}"#);
+        assert_eq!(
+            classify_record(&r, &"k".to_string()),
+            vec![SessionEvent::Notification {
+                key: "k".to_string(),
+                message: "ask_user".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn gemini_mixed_tools_attention_wins() {
+        // A record carrying both a normal tool and ask_user → Attention is
+        // emitted last so it wins in the reducer.
+        let r = rec(r#"{"type":"gemini","toolCalls":[
+            {"name":"glob","status":"success"},
+            {"name":"ask_user","status":"success"}
+        ]}"#);
+        assert_eq!(
+            classify_record(&r, &"k".to_string()),
             vec![
                 SessionEvent::ToolStarting {
                     key: "k".to_string(),
-                    tool_name: "run_shell_command".to_string()
+                    tool_name: "glob".to_string()
                 },
-                SessionEvent::ToolCompleted {
-                    key: "k".to_string()
+                SessionEvent::Notification {
+                    key: "k".to_string(),
+                    message: "ask_user".to_string()
                 },
             ]
         );
     }
 
     #[test]
-    fn already_seen_messages_are_not_reclassified() {
-        let snap = rec(r#"{"$set":{"messages":[
-            {"type":"gemini","toolCalls":[{"name":"x"}]}
-        ]}}"#);
-        let (out, _len) = classify_snapshot(&snap, &"k".to_string(), 1);
-        assert!(out.is_empty());
-    }
-
-    #[test]
-    fn user_function_response_completes() {
-        let snap = rec(r#"{"$set":{"messages":[
-            {"type":"user","content":[{"functionResponse":{"name":"x"}}]}
-        ]}}"#);
-        let (out, _len) = classify_snapshot(&snap, &"k".to_string(), 0);
-        assert_eq!(
-            out,
-            vec![SessionEvent::ToolCompleted {
-                key: "k".to_string()
-            }]
-        );
+    fn header_and_unknown_types_emit_nothing() {
+        let header = rec(r#"{"sessionId":"e42015ce-7b10-49f1-ad9d-dca02e033cd7","projectHash":"x"}"#);
+        assert!(classify_record(&header, &"k".to_string()).is_empty());
     }
 }

--- a/tools/wta/src/session_watcher/classify_gemini.rs
+++ b/tools/wta/src/session_watcher/classify_gemini.rs
@@ -1,0 +1,145 @@
+//! Gemini chat-snapshot classifier.
+//!
+//! Gemini's `session-*.jsonl` is NOT an append log: each turn rewrites a
+//! trailing `{"$set":{"messages":[…]}}` snapshot in place. We therefore parse
+//! the latest snapshot and diff the `messages` array by length, classifying
+//! only the messages appended since `prev_len`.
+//!
+//! Message shapes (verified 2026-06-08):
+//!   * assistant w/ tools: `{"type":"gemini","toolCalls":[{"name":"update_topic",...}]}`
+//!   * tool result:        `{"type":"user","content":[{"functionResponse":{...}}]}`
+
+use crate::agent_sessions::{is_user_input_tool, AgentKey, SessionEvent};
+
+/// Extract the messages array from the latest snapshot line. The watcher
+/// passes the *last non-empty line* of the file (the freshest `$set`).
+fn messages_of(snapshot_line: &serde_json::Value) -> Option<&Vec<serde_json::Value>> {
+    snapshot_line
+        .get("$set")
+        .and_then(|s| s.get("messages"))
+        .and_then(|m| m.as_array())
+        .or_else(|| snapshot_line.get("messages").and_then(|m| m.as_array()))
+}
+
+/// Classify messages appended since `prev_len`. Returns the new events and the
+/// updated message count to remember for next time.
+pub fn classify_snapshot(
+    snapshot_line: &serde_json::Value,
+    key: &AgentKey,
+    prev_len: usize,
+) -> (Vec<SessionEvent>, usize) {
+    let messages = match messages_of(snapshot_line) {
+        Some(m) => m,
+        None => return (Vec::new(), prev_len),
+    };
+    let mut out = Vec::new();
+    for msg in messages.iter().skip(prev_len) {
+        let ty = msg.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if ty == "gemini" {
+            if let Some(calls) = msg.get("toolCalls").and_then(|c| c.as_array()) {
+                for call in calls {
+                    let tool = call
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    if is_user_input_tool(&tool) {
+                        out.push(SessionEvent::Notification {
+                            key: key.clone(),
+                            message: tool,
+                        });
+                    } else {
+                        out.push(SessionEvent::ToolStarting {
+                            key: key.clone(),
+                            tool_name: tool,
+                        });
+                    }
+                    // Gemini embeds the result inline once the tool returns;
+                    // a call carrying `result` is already complete.
+                    if call.get("result").is_some() {
+                        out.push(SessionEvent::ToolCompleted { key: key.clone() });
+                    }
+                }
+            }
+        } else if ty == "user" {
+            let has_resp = msg
+                .get("content")
+                .and_then(|c| c.as_array())
+                .map(|items| items.iter().any(|i| i.get("functionResponse").is_some()))
+                .unwrap_or(false);
+            if has_resp {
+                out.push(SessionEvent::ToolCompleted { key: key.clone() });
+            }
+        }
+    }
+    (out, messages.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(s: &str) -> serde_json::Value {
+        serde_json::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn new_tool_call_message_emits_tool_starting() {
+        let snap = rec(r#"{"$set":{"messages":[
+            {"type":"user","content":[{"text":"hi"}]},
+            {"type":"gemini","toolCalls":[{"name":"run_shell_command"}]}
+        ]}}"#);
+        let (out, new_len) = classify_snapshot(&snap, &"k".to_string(), 1);
+        assert_eq!(new_len, 2);
+        assert_eq!(
+            out,
+            vec![SessionEvent::ToolStarting {
+                key: "k".to_string(),
+                tool_name: "run_shell_command".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn tool_call_with_inline_result_also_completes() {
+        let snap = rec(r#"{"$set":{"messages":[
+            {"type":"gemini","toolCalls":[{"name":"run_shell_command","result":[{"functionResponse":{}}]}]}
+        ]}}"#);
+        let (out, _len) = classify_snapshot(&snap, &"k".to_string(), 0);
+        assert_eq!(
+            out,
+            vec![
+                SessionEvent::ToolStarting {
+                    key: "k".to_string(),
+                    tool_name: "run_shell_command".to_string()
+                },
+                SessionEvent::ToolCompleted {
+                    key: "k".to_string()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn already_seen_messages_are_not_reclassified() {
+        let snap = rec(r#"{"$set":{"messages":[
+            {"type":"gemini","toolCalls":[{"name":"x"}]}
+        ]}}"#);
+        let (out, _len) = classify_snapshot(&snap, &"k".to_string(), 1);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn user_function_response_completes() {
+        let snap = rec(r#"{"$set":{"messages":[
+            {"type":"user","content":[{"functionResponse":{"name":"x"}}]}
+        ]}}"#);
+        let (out, _len) = classify_snapshot(&snap, &"k".to_string(), 0);
+        assert_eq!(
+            out,
+            vec![SessionEvent::ToolCompleted {
+                key: "k".to_string()
+            }]
+        );
+    }
+}

--- a/tools/wta/src/session_watcher/discover.rs
+++ b/tools/wta/src/session_watcher/discover.rs
@@ -102,7 +102,7 @@ mod tests {
 
     #[test]
     fn codex_path_uses_full_uuid_key() {
-        let p = Path::new(r"C:\Users\u\.codex\sessions\2026\06\08\rollout-2026-06-08T21-29-13-019ea76c-4c47-7da1-9c47-5f814a9e3640.jsonl");
+        let p = Path::new(r"C:/Users/u/.codex/sessions/2026/06/08/rollout-2026-06-08T21-29-13-019ea76c-4c47-7da1-9c47-5f814a9e3640.jsonl");
         let d = identify(p).unwrap();
         assert_eq!(d.cli, CliSource::Codex);
         assert_eq!(d.key, "019ea76c-4c47-7da1-9c47-5f814a9e3640");

--- a/tools/wta/src/session_watcher/discover.rs
+++ b/tools/wta/src/session_watcher/discover.rs
@@ -1,0 +1,135 @@
+//! Map a changed session-file path under one of the four watched roots to the
+//! CLI, session key, and (where the path encodes it) the session's cwd.
+//!
+//! Path → identity, verified against real layouts:
+//!   Copilot : ~/.copilot/session-state/<UUID>/events.jsonl        key=<UUID>
+//!   Claude  : ~/.claude/projects/<encoded-cwd>/<UUID>.jsonl       key=<UUID>, cwd=decode(<encoded-cwd>)
+//!   Codex   : ~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<UUID>.jsonl  key=<UUID>
+//!   Gemini  : ~/.gemini/tmp/<slug>/chats/session-*.jsonl          key=<file-stem>
+
+use crate::agent_sessions::CliSource;
+use crate::history_loader::decode_claude_cwd;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Discovered {
+    pub cli: CliSource,
+    pub key: String,
+    /// Path-encoded cwd when available (Claude only, today).
+    pub cwd: Option<PathBuf>,
+}
+
+/// Classify a changed path. Returns `None` for paths that are not a
+/// recognized session file (e.g. a sibling `workspace.yaml`).
+pub fn identify(path: &Path) -> Option<Discovered> {
+    let name = path.file_name()?.to_str()?;
+
+    // Copilot: .../session-state/<UUID>/events.jsonl
+    if name == "events.jsonl" {
+        let key = path.parent()?.file_name()?.to_str()?.to_string();
+        if path.components().any(|c| c.as_os_str() == "session-state") {
+            return Some(Discovered {
+                cli: CliSource::Copilot,
+                key,
+                cwd: None,
+            });
+        }
+    }
+
+    // Codex: rollout-<ts>-<UUID>.jsonl
+    if name.starts_with("rollout-") && name.ends_with(".jsonl") {
+        // rollout-<iso-ts>-<uuid>.jsonl — the UUID is the last 5
+        // hyphen-delimited groups (8-4-4-4-12); the ISO timestamp before it
+        // also contains hyphens, so we can't just split on the last '-'.
+        let stem = name.trim_end_matches(".jsonl");
+        let parts: Vec<&str> = stem.split('-').collect();
+        let key = if parts.len() >= 5 {
+            parts[parts.len() - 5..].join("-")
+        } else {
+            // Unexpected shape — fall back to the whole stem so we still
+            // produce *some* stable key rather than dropping the session.
+            stem.to_string()
+        };
+        return Some(Discovered {
+            cli: CliSource::Codex,
+            key,
+            cwd: None,
+        });
+    }
+
+    // Gemini: .../tmp/<slug>/chats/session-*.jsonl
+    if name.starts_with("session-")
+        && name.ends_with(".jsonl")
+        && path.components().any(|c| c.as_os_str() == "chats")
+    {
+        let key = name.trim_end_matches(".jsonl").to_string();
+        return Some(Discovered {
+            cli: CliSource::Gemini,
+            key,
+            cwd: None,
+        });
+    }
+
+    // Claude: .../projects/<encoded-cwd>/<UUID>.jsonl
+    if name.ends_with(".jsonl") && path.components().any(|c| c.as_os_str() == "projects") {
+        let key = name.trim_end_matches(".jsonl").to_string();
+        let cwd = path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|d| d.to_str())
+            .map(decode_claude_cwd);
+        return Some(Discovered {
+            cli: CliSource::Claude,
+            key,
+            cwd,
+        });
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn copilot_path() {
+        let p = Path::new(r"C:\Users\u\.copilot\session-state\abc-123\events.jsonl");
+        let d = identify(p).unwrap();
+        assert_eq!(d.cli, CliSource::Copilot);
+        assert_eq!(d.key, "abc-123");
+    }
+
+    #[test]
+    fn codex_path_uses_full_uuid_key() {
+        let p = Path::new(r"C:\Users\u\.codex\sessions\2026\06\08\rollout-2026-06-08T21-29-13-019ea76c-4c47-7da1-9c47-5f814a9e3640.jsonl");
+        let d = identify(p).unwrap();
+        assert_eq!(d.cli, CliSource::Codex);
+        assert_eq!(d.key, "019ea76c-4c47-7da1-9c47-5f814a9e3640");
+    }
+
+    #[test]
+    fn gemini_path() {
+        let p = Path::new(r"C:\Users\u\.gemini\tmp\slug\chats\session-2026-06-08T14-01-d6ce.jsonl");
+        let d = identify(p).unwrap();
+        assert_eq!(d.cli, CliSource::Gemini);
+        assert_eq!(d.key, "session-2026-06-08T14-01-d6ce");
+    }
+
+    #[test]
+    fn claude_path_decodes_cwd() {
+        let p = Path::new(r"C:\Users\u\.claude\projects\C--Users-u\aaaa-bbbb.jsonl");
+        let d = identify(p).unwrap();
+        assert_eq!(d.cli, CliSource::Claude);
+        assert_eq!(d.key, "aaaa-bbbb");
+        assert!(d.cwd.is_some());
+    }
+
+    #[test]
+    fn unrelated_path_is_none() {
+        assert!(identify(Path::new(
+            r"C:\Users\u\.copilot\session-state\abc\workspace.yaml"
+        ))
+        .is_none());
+    }
+}

--- a/tools/wta/src/session_watcher/mod.rs
+++ b/tools/wta/src/session_watcher/mod.rs
@@ -1,0 +1,477 @@
+//! session_watcher — turn each agent CLI's on-disk session records into the
+//! crate's existing [`crate::agent_sessions::SessionEvent`]s, hook-free.
+//!
+//! The per-CLI `classify_*` functions are the pure, testable core: they take
+//! one parsed record (or, for Gemini, the rewritten snapshot) plus the
+//! session key and return zero or more `SessionEvent`s. The watch loop
+//! ([`watch`]) is the thin impure shell that tails files and feeds records
+//! through them. Binding a discovered session to its pane lives in
+//! [`bind`]; path → identity in [`discover`].
+
+pub mod bind;
+pub mod classify_claude;
+pub mod classify_codex;
+pub mod classify_copilot;
+pub mod classify_gemini;
+pub mod discover;
+
+use std::collections::HashMap;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+/// Read the bytes appended to `path` since byte offset `from`, returning the
+/// decoded text and the new end offset. Used for the append-only CLIs.
+pub fn read_appended(path: &Path, from: u64) -> std::io::Result<(String, u64)> {
+    let mut file = std::fs::File::open(path)?;
+    let len = file.metadata()?.len();
+    if len <= from {
+        return Ok((String::new(), len));
+    }
+    file.seek(SeekFrom::Start(from))?;
+    let mut buf = Vec::with_capacity((len - from) as usize);
+    file.take(len - from).read_to_end(&mut buf)?;
+    Ok((String::from_utf8_lossy(&buf).into_owned(), len))
+}
+
+use crate::agent_sessions::{CliSource, SessionEvent};
+
+/// One emitted event with its routing identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Emitted {
+    pub cli: CliSource,
+    pub key: String,
+    /// Path-encoded session cwd when available (Claude only today; `None`
+    /// for Copilot/Codex/Gemini). Consumed by master pane-binding.
+    pub cwd: Option<PathBuf>,
+    pub event: SessionEvent,
+}
+
+/// Per-file progress so we only classify new records.
+#[derive(Default)]
+pub(crate) struct Progress {
+    /// Byte offset for append-only CLIs.
+    offset: u64,
+    /// Message count for Gemini's snapshot model.
+    gemini_msgs: usize,
+    /// Set once if this file is a Codex multi-agent subagent fork — its records
+    /// are then ignored wholesale (it inherits the parent's history and is not a
+    /// user-facing session, so surfacing it would duplicate the parent's row).
+    ignored: bool,
+}
+
+/// Process one changed file path into emitted events, advancing `progress`.
+/// Pure w.r.t. everything except the on-disk file and the passed-in map.
+pub fn process_change(path: &Path, progress: &mut HashMap<PathBuf, Progress>) -> Vec<Emitted> {
+    let Some(disc) = discover::identify(path) else {
+        return Vec::new();
+    };
+    let entry = progress.entry(path.to_path_buf()).or_default();
+    if entry.ignored {
+        // A Codex subagent fork detected on a previous read — skip wholesale.
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+
+    match disc.cli {
+        CliSource::Gemini => {
+            // Reparse the whole file; take the last non-empty snapshot line.
+            let Ok(text) = std::fs::read_to_string(path) else {
+                return out;
+            };
+            // Canonical key = header `sessionId` (the filename only carries the
+            // first 8 hex chars). Fall back to the path-derived key if absent.
+            let key = text
+                .lines()
+                .next()
+                .and_then(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+                .and_then(|v| v.get("sessionId").and_then(|s| s.as_str()).map(str::to_string))
+                .unwrap_or_else(|| disc.key.clone());
+            let Some(last) = text.lines().rev().find(|l| !l.trim().is_empty()) else {
+                return out;
+            };
+            let Ok(val) = serde_json::from_str::<serde_json::Value>(last) else {
+                return out;
+            };
+            let (events, new_len) =
+                classify_gemini::classify_snapshot(&val, &key, entry.gemini_msgs);
+            entry.gemini_msgs = new_len;
+            for event in events {
+                out.push(Emitted { cli: disc.cli.clone(), key: key.clone(), cwd: disc.cwd.clone(), event });
+            }
+        }
+        _ => {
+            let from = entry.offset;
+            let Ok((text, len)) = read_appended(path, from) else {
+                return out;
+            };
+            if len < from {
+                // File shrank/rotated — resync to the new end, drop nothing
+                // further this tick.
+                entry.offset = len;
+                return out;
+            }
+            // Only consume through the last newline; a trailing partial line is
+            // a record still being written — leave its bytes for the next tick.
+            let consumed = text.rfind('\n').map(|i| i + 1).unwrap_or(0);
+            entry.offset = from + consumed as u64;
+            for line in text[..consumed].lines() {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                let Ok(val) = serde_json::from_str::<serde_json::Value>(line) else {
+                    continue;
+                };
+                // A Codex multi-agent subagent fork carries `source.subagent` in
+                // its session_meta (always the first record). Mark the file
+                // ignored and drop everything: it inherits the parent's history,
+                // so tracking it would duplicate the parent's row.
+                if matches!(disc.cli, CliSource::Codex)
+                    && crate::history_loader::codex_record_is_subagent_meta(&val)
+                {
+                    entry.ignored = true;
+                    return Vec::new();
+                }
+                let events = match disc.cli {
+                    CliSource::Copilot => classify_copilot::classify(&val, &disc.key),
+                    CliSource::Claude => classify_claude::classify(&val, &disc.key),
+                    CliSource::Codex => classify_codex::classify(&val, &disc.key),
+                    _ => Vec::new(),
+                };
+                for event in events {
+                    out.push(Emitted { cli: disc.cli.clone(), key: disc.key.clone(), cwd: disc.cwd.clone(), event });
+                }
+            }
+        }
+    }
+    out
+}
+
+/// The four watched roots under the user profile.
+pub fn watched_roots() -> Vec<PathBuf> {
+    let home = std::env::var("USERPROFILE")
+        .map(PathBuf::from)
+        .unwrap_or_default();
+    vec![
+        home.join(".copilot").join("session-state"),
+        home.join(".claude").join("projects"),
+        home.join(".codex").join("sessions"),
+        home.join(".gemini").join("tmp"),
+    ]
+}
+
+use std::sync::mpsc::Sender;
+
+/// Seed per-file progress to each existing session file's current end, so the
+/// watcher only processes content appended *after* it starts. Without this, the
+/// first `notify` event for a pre-existing historical file (which the OS can
+/// deliver spuriously — e.g. an indexer/AV touch, or a delayed
+/// ReadDirectoryChangesW batch) would make `process_change` replay that file's
+/// entire record stream from offset 0. Each replayed record revives its
+/// historical Class-B session and re-broadcasts `sessions/changed`, flooding
+/// master with thousands of redundant notifications and stalling live updates.
+///
+/// Files created *after* the watcher starts are not seeded (not present here),
+/// so their first sighting is still read from offset 0 — correctly catching a
+/// new session's opening `session_meta` / `task_started` records.
+pub(crate) fn seed_existing_progress_in(
+    roots: &[PathBuf],
+    progress: &mut HashMap<PathBuf, Progress>,
+) {
+    for root in roots {
+        let mut stack = vec![root.clone()];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                match entry.file_type() {
+                    Ok(ft) if ft.is_dir() => stack.push(path),
+                    Ok(_) => {
+                        let Some(disc) = discover::identify(&path) else {
+                            continue;
+                        };
+                        let prog = if matches!(disc.cli, CliSource::Gemini) {
+                            // Gemini's snapshot model counts messages, not bytes.
+                            Progress {
+                                offset: 0,
+                                gemini_msgs: gemini_msg_count(&path),
+                                ..Default::default()
+                            }
+                        } else {
+                            Progress {
+                                offset: std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0),
+                                gemini_msgs: 0,
+                                ..Default::default()
+                            }
+                        };
+                        progress.insert(path, prog);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+/// Current message count in a Gemini snapshot file (the last non-empty
+/// `$set.messages` array). `0` on any read/parse failure.
+fn gemini_msg_count(path: &Path) -> usize {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return 0;
+    };
+    let Some(last) = text.lines().rev().find(|l| !l.trim().is_empty()) else {
+        return 0;
+    };
+    let Ok(val) = serde_json::from_str::<serde_json::Value>(last) else {
+        return 0;
+    };
+    val.get("$set")
+        .and_then(|s| s.get("messages"))
+        .and_then(|m| m.as_array())
+        .or_else(|| val.get("messages").and_then(|m| m.as_array()))
+        .map(|a| a.len())
+        .unwrap_or(0)
+}
+
+/// Spawn a blocking `notify` watcher over the four roots. Each emitted event
+/// is sent on `tx`. Runs until `tx` is dropped or the watcher errors.
+///
+/// Recursive mode is required: session files live several levels below each
+/// root (e.g. `.codex/sessions/YYYY/MM/DD/...`).
+///
+/// Purely event-driven: a `notify` event for a file runs the incremental
+/// [`process_change`]. The watcher is a hookless **fallback** producer, so we
+/// deliberately do NOT add a periodic catch-up sweep — `notify`
+/// (ReadDirectoryChangesW) can coalesce/drop the event for a turn's final write
+/// (e.g. Codex `task_complete`), which may briefly leave a fallback row on its
+/// last status until the next file write; that imperfection is acceptable for a
+/// fallback, and Ctrl+C cleanup is handled by master's pid-liveness poll.
+pub fn watch(tx: Sender<Emitted>) -> notify::Result<()> {
+    use notify::{RecursiveMode, Watcher};
+
+    let (raw_tx, raw_rx) = std::sync::mpsc::channel::<notify::Result<notify::Event>>();
+    let mut watcher = notify::recommended_watcher(move |res| {
+        let _ = raw_tx.send(res);
+    })?;
+    for root in watched_roots() {
+        // A missing root is fine (the user may not have that CLI) — log + skip.
+        if root.exists() {
+            if let Err(err) = watcher.watch(&root, RecursiveMode::Recursive) {
+                tracing::warn!(
+                    target: "session_watcher",
+                    root = %root.display(),
+                    error = %err,
+                    "watch failed"
+                );
+            }
+        }
+    }
+
+    let mut progress: HashMap<PathBuf, Progress> = HashMap::new();
+    // Skip every record that already existed when we started watching — only
+    // track genuinely new activity. Startup-only (not polling); prevents a
+    // spurious notify on a pre-existing file from replaying its whole history
+    // and flooding master with revive broadcasts. See `seed_existing_progress_in`.
+    seed_existing_progress_in(&watched_roots(), &mut progress);
+
+    for res in raw_rx {
+        let event = match res {
+            Ok(event) => event,
+            Err(err) => {
+                tracing::warn!(target: "session_watcher", error = %err, "notify error");
+                continue;
+            }
+        };
+        for path in event.paths {
+            for emitted in process_change(&path, &mut progress) {
+                if tx.send(emitted).is_err() {
+                    return Ok(()); // receiver gone
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn read_appended_returns_only_new_bytes() {
+        let dir = std::env::temp_dir().join(format!("wta-watch-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("a.jsonl");
+        std::fs::write(&path, b"line1\n").unwrap();
+        let (first, off1) = read_appended(&path, 0).unwrap();
+        assert_eq!(first, "line1\n");
+        assert_eq!(off1, 6);
+        // Append more, read only the delta.
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(b"line2\n")
+            .unwrap();
+        let (second, off2) = read_appended(&path, off1).unwrap();
+        assert_eq!(second, "line2\n");
+        assert_eq!(off2, 12);
+    }
+
+    #[test]
+    fn process_change_emits_copilot_events_incrementally() {
+        let dir = std::env::temp_dir()
+            .join(format!("wta-pc-{}", std::process::id()))
+            .join("session-state")
+            .join("sess-9");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("events.jsonl");
+        std::fs::write(
+            &path,
+            b"{\"type\":\"tool.execution_start\",\"data\":{\"toolName\":\"bash\"}}\n",
+        )
+        .unwrap();
+        let mut progress = HashMap::new();
+        let first = process_change(&path, &mut progress);
+        assert_eq!(first.len(), 1);
+        assert!(matches!(first[0].event, SessionEvent::ToolStarting { .. }));
+        // No new bytes -> no duplicate events.
+        let second = process_change(&path, &mut progress);
+        assert!(second.is_empty());
+    }
+
+    #[test]
+    fn process_change_does_not_lose_a_partial_line() {
+        let dir = std::env::temp_dir()
+            .join(format!("wta-partial-{}", std::process::id()))
+            .join("session-state")
+            .join("sess-partial");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("events.jsonl");
+        // One complete record + a half-written second record (no newline yet).
+        std::fs::write(
+            &path,
+            b"{\"type\":\"tool.execution_start\",\"data\":{\"toolName\":\"bash\"}}\n{\"type\":\"assistant.turn",
+        )
+        .unwrap();
+        let mut progress = std::collections::HashMap::new();
+        let first = process_change(&path, &mut progress);
+        assert_eq!(first.len(), 1, "only the complete line should classify");
+        assert!(matches!(first[0].event, SessionEvent::ToolStarting { .. }));
+        // Complete the partial record (turn_end → ToolCompleted under the
+        // turn-based Copilot model).
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(b"_end\",\"data\":{\"turnId\":\"0\"}}\n")
+            .unwrap();
+        let second = process_change(&path, &mut progress);
+        assert_eq!(second.len(), 1, "the completed record must now classify (not be lost)");
+        assert!(matches!(second[0].event, SessionEvent::ToolCompleted { .. }));
+    }
+
+    #[test]
+    fn seed_skips_preexisting_history_then_tracks_new_appends() {
+        // A pre-existing Codex rollout (history) must be seeded to EOF so it is
+        // NOT replayed from offset 0 — the bug that flooded master with revive
+        // broadcasts. New content appended after seeding is still tracked.
+        let root = std::env::temp_dir().join(format!("wta-seed-{}", std::process::id()));
+        let day = root.join("2026").join("06").join("10");
+        std::fs::create_dir_all(&day).unwrap();
+        let path =
+            day.join("rollout-2026-06-10T00-00-00-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl");
+        std::fs::write(
+            &path,
+            b"{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\"}}\n\
+              {\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"shell\"}}\n",
+        )
+        .unwrap();
+
+        let mut progress = HashMap::new();
+        seed_existing_progress_in(&[root.clone()], &mut progress);
+
+        // History is skipped — no replay on the first change.
+        let replay = process_change(&path, &mut progress);
+        assert!(
+            replay.is_empty(),
+            "seeded historical file must not replay, got {:?}",
+            replay
+        );
+
+        // A genuinely new appended record IS processed.
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(b"{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_complete\"}}\n")
+            .unwrap();
+        let fresh = process_change(&path, &mut progress);
+        assert_eq!(fresh.len(), 1, "new appended record must be classified");
+        assert!(matches!(fresh[0].event, SessionEvent::ToolCompleted { .. }));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn seed_does_not_skip_files_created_after_start() {
+        // A file absent at seed time (new session created after the watcher
+        // started) is not seeded, so it's read in full on first sight.
+        let root = std::env::temp_dir().join(format!("wta-seed-new-{}", std::process::id()));
+        std::fs::create_dir_all(&root).unwrap();
+        let mut progress = HashMap::new();
+        seed_existing_progress_in(&[root.clone()], &mut progress); // empty root
+
+        let path =
+            root.join("rollout-2026-06-10T00-00-00-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl");
+        std::fs::write(
+            &path,
+            b"{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\"}}\n",
+        )
+        .unwrap();
+        let out = process_change(&path, &mut progress);
+        assert_eq!(out.len(), 1, "a new file must be read from offset 0");
+        assert!(matches!(out[0].event, SessionEvent::ToolStarting { .. }));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn process_change_ignores_codex_subagent_rollout() {
+        // Codex's multi_agent_v1/spawn_agent forks a child thread with its own
+        // rollout (source.subagent) that inherits the parent's history — it must
+        // never surface as its own (duplicate) row.
+        let root = std::env::temp_dir().join(format!("wta-subagent-{}", std::process::id()));
+        let dir = root.join("2026").join("06").join("10");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path =
+            dir.join("rollout-2026-06-10T13-15-12-99999999-2222-3333-4444-555555555555.jsonl");
+        std::fs::write(
+            &path,
+            b"{\"type\":\"session_meta\",\"payload\":{\"id\":\"99999999-2222-3333-4444-555555555555\",\"forked_from_id\":\"p\",\"source\":{\"subagent\":{\"thread_spawn\":{\"depth\":1}}}}}\n\
+              {\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\"}}\n",
+        )
+        .unwrap();
+
+        let mut progress = HashMap::new();
+        let out = process_change(&path, &mut progress);
+        assert!(out.is_empty(), "subagent rollout must emit nothing, got {:?}", out);
+
+        // Even after the subagent does work, it stays ignored.
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(b"{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_complete\"}}\n")
+            .unwrap();
+        assert!(
+            process_change(&path, &mut progress).is_empty(),
+            "a file flagged as a subagent stays ignored on later reads"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/tools/wta/src/session_watcher/mod.rs
+++ b/tools/wta/src/session_watcher/mod.rs
@@ -2,10 +2,10 @@
 //! crate's existing [`crate::agent_sessions::SessionEvent`]s, hook-free.
 //!
 //! The per-CLI `classify_*` functions are the pure, testable core: they take
-//! one parsed record (or, for Gemini, the rewritten snapshot) plus the
-//! session key and return zero or more `SessionEvent`s. The watch loop
-//! ([`watch`]) is the thin impure shell that tails files and feeds records
-//! through them. Binding a discovered session to its pane lives in
+//! one parsed record plus the session key and return zero or more
+//! `SessionEvent`s. The watch loop ([`watch`]) is the thin impure shell that
+//! tails files (by byte offset — all four CLIs are append logs) and feeds
+//! records through them. Binding a discovered session to its pane lives in
 //! [`bind`]; path → identity in [`discover`].
 
 pub mod bind;
@@ -49,10 +49,14 @@ pub struct Emitted {
 /// Per-file progress so we only classify new records.
 #[derive(Default)]
 pub(crate) struct Progress {
-    /// Byte offset for append-only CLIs.
+    /// Byte offset for append-only CLIs (all four are append logs).
     offset: u64,
-    /// Message count for Gemini's snapshot model.
-    gemini_msgs: usize,
+    /// Gemini's canonical session id, resolved once from the file header's
+    /// `sessionId` (the filename only carries the first 8 hex chars) and cached
+    /// so every emitted event keys to the same id the registry binds. `None`
+    /// until first read; falls back to the path-derived key if the header is
+    /// unreadable.
+    gemini_key: Option<String>,
     /// Set once if this file is a Codex multi-agent subagent fork — its records
     /// are then ignored wholesale (it inherits the parent's history and is not a
     /// user-facing session, so surfacing it would duplicate the parent's row).
@@ -74,29 +78,49 @@ pub fn process_change(path: &Path, progress: &mut HashMap<PathBuf, Progress>) ->
 
     match disc.cli {
         CliSource::Gemini => {
-            // Reparse the whole file; take the last non-empty snapshot line.
-            let Ok(text) = std::fs::read_to_string(path) else {
-                return out;
-            };
-            // Canonical key = header `sessionId` (the filename only carries the
-            // first 8 hex chars). Fall back to the path-derived key if absent.
-            let key = text
-                .lines()
-                .next()
-                .and_then(|l| serde_json::from_str::<serde_json::Value>(l).ok())
-                .and_then(|v| v.get("sessionId").and_then(|s| s.as_str()).map(str::to_string))
+            // Gemini's `session-*.jsonl` is an append log (re-verified
+            // 2026-06-14): single-message records and `$set` ops are appended at
+            // the end; the only rewrites are full `$set.messages` snapshots at
+            // start/resume, which `classify_record` skips so a resume can't
+            // replay history. Read it by byte offset like the other CLIs.
+            //
+            // Canonical key = the header `sessionId` (the filename only carries
+            // the first 8 hex chars). Resolve + cache it once; fall back to the
+            // path-derived key until the header is readable.
+            if entry.gemini_key.is_none() {
+                entry.gemini_key = read_gemini_session_id(path);
+            }
+            let key = entry
+                .gemini_key
+                .clone()
                 .unwrap_or_else(|| disc.key.clone());
-            let Some(last) = text.lines().rev().find(|l| !l.trim().is_empty()) else {
+
+            let from = entry.offset;
+            let Ok((text, len)) = read_appended(path, from) else {
                 return out;
             };
-            let Ok(val) = serde_json::from_str::<serde_json::Value>(last) else {
+            if len < from {
+                entry.offset = len;
                 return out;
-            };
-            let (events, new_len) =
-                classify_gemini::classify_snapshot(&val, &key, entry.gemini_msgs);
-            entry.gemini_msgs = new_len;
-            for event in events {
-                out.push(Emitted { cli: disc.cli.clone(), key: key.clone(), cwd: disc.cwd.clone(), event });
+            }
+            let consumed = text.rfind('\n').map(|i| i + 1).unwrap_or(0);
+            entry.offset = from + consumed as u64;
+            for line in text[..consumed].lines() {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                let Ok(val) = serde_json::from_str::<serde_json::Value>(line) else {
+                    continue;
+                };
+                for event in classify_gemini::classify_record(&val, &key) {
+                    out.push(Emitted {
+                        cli: CliSource::Gemini,
+                        key: key.clone(),
+                        cwd: disc.cwd.clone(),
+                        event,
+                    });
+                }
             }
         }
         _ => {
@@ -192,22 +216,15 @@ pub(crate) fn seed_existing_progress_in(
                 match entry.file_type() {
                     Ok(ft) if ft.is_dir() => stack.push(path),
                     Ok(_) => {
-                        let Some(disc) = discover::identify(&path) else {
+                        let Some(_disc) = discover::identify(&path) else {
                             continue;
                         };
-                        let prog = if matches!(disc.cli, CliSource::Gemini) {
-                            // Gemini's snapshot model counts messages, not bytes.
-                            Progress {
-                                offset: 0,
-                                gemini_msgs: gemini_msg_count(&path),
-                                ..Default::default()
-                            }
-                        } else {
-                            Progress {
-                                offset: std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0),
-                                gemini_msgs: 0,
-                                ..Default::default()
-                            }
+                        // All four CLIs are append logs — seed each file's
+                        // progress to its current end so the watcher only
+                        // processes content appended after it starts.
+                        let prog = Progress {
+                            offset: std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0),
+                            ..Default::default()
                         };
                         progress.insert(path, prog);
                     }
@@ -218,24 +235,18 @@ pub(crate) fn seed_existing_progress_in(
     }
 }
 
-/// Current message count in a Gemini snapshot file (the last non-empty
-/// `$set.messages` array). `0` on any read/parse failure.
-fn gemini_msg_count(path: &Path) -> usize {
-    let Ok(text) = std::fs::read_to_string(path) else {
-        return 0;
-    };
-    let Some(last) = text.lines().rev().find(|l| !l.trim().is_empty()) else {
-        return 0;
-    };
-    let Ok(val) = serde_json::from_str::<serde_json::Value>(last) else {
-        return 0;
-    };
-    val.get("$set")
-        .and_then(|s| s.get("messages"))
-        .and_then(|m| m.as_array())
-        .or_else(|| val.get("messages").and_then(|m| m.as_array()))
-        .map(|a| a.len())
-        .unwrap_or(0)
+/// Gemini's canonical session id, read from the file header's `sessionId`
+/// field (the first line). `None` on any read/parse failure or if the header
+/// lacks the field. Reads only the first line, not the whole (often large) file.
+fn read_gemini_session_id(path: &Path) -> Option<String> {
+    use std::io::BufRead;
+    let file = std::fs::File::open(path).ok()?;
+    let mut first = String::new();
+    std::io::BufReader::new(file).read_line(&mut first).ok()?;
+    let val: serde_json::Value = serde_json::from_str(first.trim()).ok()?;
+    val.get("sessionId")
+        .and_then(|s| s.as_str())
+        .map(str::to_string)
 }
 
 /// Spawn a blocking `notify` watcher over the four roots. Each emitted event

--- a/tools/wta/src/session_watcher/mod.rs
+++ b/tools/wta/src/session_watcher/mod.rs
@@ -147,11 +147,14 @@ pub fn process_change(path: &Path, progress: &mut HashMap<PathBuf, Progress>) ->
     out
 }
 
-/// The four watched roots under the user profile.
+/// The four watched roots under the user profile. Empty when `USERPROFILE` is
+/// unset: returning relative `.copilot/...` paths would make the watcher
+/// observe directories under the process CWD, so we disable the watcher cleanly
+/// (watch nothing) instead.
 pub fn watched_roots() -> Vec<PathBuf> {
-    let home = std::env::var("USERPROFILE")
-        .map(PathBuf::from)
-        .unwrap_or_default();
+    let Some(home) = std::env::var_os("USERPROFILE").map(PathBuf::from) else {
+        return Vec::new();
+    };
     vec![
         home.join(".copilot").join("session-state"),
         home.join(".claude").join("projects"),

--- a/tools/wta/src/session_watcher/mod.rs
+++ b/tools/wta/src/session_watcher/mod.rs
@@ -191,7 +191,7 @@ use std::sync::mpsc::Sender;
 
 /// Seed per-file progress to each existing session file's current end, so the
 /// watcher only processes content appended *after* it starts. Without this, the
-/// first `notify` event for a pre-existing historical file (which the OS can
+/// first `notify` event for a preexisting historical file (which the OS can
 /// deliver spuriously — e.g. an indexer/AV touch, or a delayed
 /// ReadDirectoryChangesW batch) would make `process_change` replay that file's
 /// entire record stream from offset 0. Each replayed record revives its
@@ -286,7 +286,7 @@ pub fn watch(tx: Sender<Emitted>) -> notify::Result<()> {
     let mut progress: HashMap<PathBuf, Progress> = HashMap::new();
     // Skip every record that already existed when we started watching — only
     // track genuinely new activity. Startup-only (not polling); prevents a
-    // spurious notify on a pre-existing file from replaying its whole history
+    // spurious notify on a preexisting file from replaying its whole history
     // and flooding master with revive broadcasts. See `seed_existing_progress_in`.
     seed_existing_progress_in(&watched_roots(), &mut progress);
 
@@ -390,7 +390,7 @@ mod tests {
 
     #[test]
     fn seed_skips_preexisting_history_then_tracks_new_appends() {
-        // A pre-existing Codex rollout (history) must be seeded to EOF so it is
+        // A preexisting Codex rollout (history) must be seeded to EOF so it is
         // NOT replayed from offset 0 — the bug that flooded master with revive
         // broadcasts. New content appended after seeding is still tracked.
         let root = std::env::temp_dir().join(format!("wta-seed-{}", std::process::id()));


### PR DESCRIPTION
## Summary

Adds a file/process **watcher as a fallback** for tracking shell-pane agent CLI
sessions (Copilot, Claude, Codex, Gemini) when the PowerShell `wt-agent-hooks`
bridge is **not** installed, so the sessions list keeps working without hooks.

**Hybrid model:** a real hook owns a session outright; #266 **born-bound**
(delegate `?<prompt>` / `/sessions` resume) owns only its pane binding; the
watcher fills the rest — surfacing user-typed sessions and supplying **status**
for born-bound sessions that have no hook. Two master-side sets (`hook_owned`,
`born_bound`) keep the three from ever double-tracking.

## What's in it

**Watcher fallback**
- **Watcher** (`session_watcher/*`, `proc_bind.rs`): `notify`-based, event-driven
  (no polling sweep), per-CLI classify + best-effort pane binding (WT_SESSION from
  the PEB, the copilot lock file, Restart-Manager file ownership).
- **Liveness gate**: only surface a watcher session whose bound pane is a *live
  pane in this IT window* (COM windows→tabs→panes walk, 2s cache) — keeps
  machine-wide copilot sessions (VS Code, language server, other terminals) out of
  the list. `window_id`/`tab_id` come back as JSON numbers, so the walk matches
  `String|Number`.
- **5s reaper**: ends fallback rows whose bound pid has exited.
- **Codex fixes**: skip subagent rollouts that duplicate the parent's title; stop
  titling sessions with codex's injected `# AGENTS.md instructions for <dir>` /
  `<environment_context>` blocks (shared `codex_user_text_is_synthetic`, fixes the
  hook path too).

**Born-bound status fallback** (`intellterm.wta/session_born_bound` method +
`born_bound` set)
- Born-bound rows carry a binding but no activity, so without a hook they sat at
  Idle forever. The watcher now supplies **status** (Working/Idle/Attention) to a
  `born_bound` row **without re-binding** the pane; a real hook firing later takes
  over (`born_bound → hook_owned`). Covers Copilot/Claude/Gemini; codex (no
  `--session-id`) is excluded.
- **Resume fix**: `ResumeDispatched` / `ResumePaneAssigned` are the hook-free
  resume binding, now recorded in `born_bound` (not `hook_owned`) — resumed rows
  were previously stuck at Idle while the watcher saw activity.

**Hook-path status fixes** (both reducers — helper `agent_sessions.rs` and master
`session_registry.rs`, the latter behind `sessions/list`)
- **Turn-based hook status**: `agent.tool.finished`/`completed`/`failed` no longer
  demote a row to Idle. Copilot/Gemini fire a tool-finished per tool — often
  several per turn, in parallel batches — but the agent keeps working until
  `agent.stop`; mapping each finish to Idle made a multi-tool turn flicker to (and
  sit at) Idle during the agent's between-tool thinking. `agent.stop` /
  `subagent.stop` now own the turn-end → Idle, matching the watcher's turn-based
  classifiers. Claude/Codex emit no `tool.*` hooks, so this only affects
  Copilot/Gemini.
- **`SessionStarted` preserves live status**: a `SessionStarted` for an existing
  row no longer clobbers it to Idle. Copilot fires `prompt.submit` (→ Working)
  ~2s *before* its `session.start`, so the late start blanked the row to Idle for
  the rest of the turn. Both reducers now (re)baseline to Idle only for a new row
  or one revived from a terminal state (Ended/Error/Historical, e.g.
  resume/reconnect); Working/Attention/Idle are preserved.

**Per-CLI status detection** — all four are **turn-based** (Working spans the
whole turn — thinking + streaming text + tools — not just the brief tool windows):
- **Claude** — keyed on `stop_reason` (a `user` record → Working; assistant
  `stop_reason:tool_use` → Working, `AskUserQuestion` → Attention; `end_turn` →
  Idle). Keyed on `stop_reason` because Claude re-writes the same message id while
  streaming (content-based classification flickered).
- **Copilot / Codex** — **turn-based, not tool-based**: Working is bracketed by
  the turn boundary (`assistant.turn_start`/`turn_end` for Copilot,
  `event_msg/task_started`/`task_complete` for Codex), not the brief
  `tool.*`/`function_call` windows; a user-input tool *or* an explicit
  permission/escalation record (`permission.requested` / sandbox
  `require_escalated`) → Attention.
- **Gemini — Working-only (turn-end Idle deferred)**: its `session-*.jsonl` is an
  append log, read per record — a `user`/`gemini` record or `toolCalls` → Working,
  `ask_user` → Attention. It does **not** emit Idle: Gemini writes no
  turn-completion signal (no `stop_reason`/`finishReason`), so a row stays Working
  until the pane closes. (No longer "deferred" — born-bound Gemini rows now show
  live Working/Attention; only the turn-end → Idle transition is deferred.)

## Test plan

- [x] `cargo test` — 812 pass.
- [x] Manual (hooks installed): sessions tracked by the hook path; watcher events
      deduped; a Copilot multi-tool turn stays **Working** across the whole turn
      (no mid-turn Idle flicker) and shows Working immediately on prompt submit.
- [x] Manual (hooks uninstalled): shell-pane codex tracked with the correct
      real-prompt title (even in `AGENTS.md` repos); external / non-IT copilot
      sessions stay hidden via the liveness gate; a **delegate** (`?<prompt>`) and
      a **resumed** Claude session show live status instead of a frozen Idle.
- [x] Regenerated `tools/wta/cgmanifest.json` + `/NOTICE.md` for the `notify`
      dependency.

## Docs

- `doc/specs/hybrid-agent-session-tracking.md` — full design (principle, two-set
  dedup, born-bound status fallback, per-CLI turn-based status detection,
  Gemini Working-only status, limitations).
- `doc/specs/wta-launched-cli-session-binding.md` — note the born-bound method
  change.
- `tools/wta/AGENTS.md` — session-tracking + status summary.

## Known follow-ups

- **Gemini turn-end → Idle** — deferred (no turn-completion signal; 2-phase /
  `$set` transcript). Gemini already shows live **Working/Attention**; only the
  turn-end → Idle transition awaits hooks or a cleaner Gemini format.