### PR TITLE
FRE: stop on PowerShell execution policy block regardless of profile presence

### DIFF
--- a/src/cascadia/TerminalApp/ShellIntegrationSweep.h
+++ b/src/cascadia/TerminalApp/ShellIntegrationSweep.h
@@ -212,14 +212,23 @@ namespace winrt::TerminalApp::implementation::ShellIntegrationSweep
                                           const std::vector<std::wstring>& wslDistros)
     {
         InstallSweepResults r{};
-        if (shellPresence.pwsh)
-        {
-            r.pwsh = SI::InstallForTarget(SI::Target::Pwsh);
-        }
-        if (shellPresence.windowsPowerShell)
-        {
-            r.windowsPowerShell = SI::InstallForTarget(SI::Target::WindowsPowerShell);
-        }
+        // PowerShell hosts: the $PROFILE WRITE is profile-gated, but the
+        // execution-policy VERDICT is unconditional — a Restricted / AllSigned
+        // policy must stop FRE / Save even when the user has no Windows
+        // Terminal profile for that host, because the shell-integration .ps1
+        // can never run. ExecutionPolicyBlocksShellIntegration() is re-queried
+        // here on every call (never cached), so fixing the policy offline and
+        // clicking Save again on the same FRE re-evaluates cleanly.
+        // See SI::ResolvePowerShellHostInstall for the rationale / regression
+        // guard.
+        r.pwsh = SI::ResolvePowerShellHostInstall(
+            shellPresence.pwsh,
+            SI::ExecutionPolicyBlocksShellIntegration(SI::Target::Pwsh),
+            [] { return SI::InstallForTarget(SI::Target::Pwsh); });
+        r.windowsPowerShell = SI::ResolvePowerShellHostInstall(
+            shellPresence.windowsPowerShell,
+            SI::ExecutionPolicyBlocksShellIntegration(SI::Target::WindowsPowerShell),
+            [] { return SI::InstallForTarget(SI::Target::WindowsPowerShell); });
         if (shellPresence.bash)
         {
             r.bash = SI::InstallForTarget(SI::Target::Bash);

--- a/src/cascadia/TerminalApp/ShellIntegrationSweep.h
+++ b/src/cascadia/TerminalApp/ShellIntegrationSweep.h
@@ -221,14 +221,28 @@ namespace winrt::TerminalApp::implementation::ShellIntegrationSweep
         // clicking Save again on the same FRE re-evaluates cleanly.
         // See SI::ResolvePowerShellHostInstall for the rationale / regression
         // guard.
+        //
+        // The write lambda calls the path-taking install (DiscoverProfilePath +
+        // Install) directly rather than InstallForTarget, which would re-query
+        // the execution policy a second time — ResolvePowerShellHostInstall has
+        // already verified it for this host, so the extra probe is a redundant
+        // PowerShell spawn (pure FRE / Save latency).
+        const auto installSkippingPolicyProbe = [](SI::Target target) -> SI::InstallResult {
+            auto profilePath = SI::DiscoverProfilePath(target);
+            if (profilePath.empty())
+            {
+                return { false, false, L"Could not discover PowerShell profile path" };
+            }
+            return SI::Install(profilePath);
+        };
         r.pwsh = SI::ResolvePowerShellHostInstall(
             shellPresence.pwsh,
             SI::ExecutionPolicyBlocksShellIntegration(SI::Target::Pwsh),
-            [] { return SI::InstallForTarget(SI::Target::Pwsh); });
+            [&] { return installSkippingPolicyProbe(SI::Target::Pwsh); });
         r.windowsPowerShell = SI::ResolvePowerShellHostInstall(
             shellPresence.windowsPowerShell,
             SI::ExecutionPolicyBlocksShellIntegration(SI::Target::WindowsPowerShell),
-            [] { return SI::InstallForTarget(SI::Target::WindowsPowerShell); });
+            [&] { return installSkippingPolicyProbe(SI::Target::WindowsPowerShell); });
         if (shellPresence.bash)
         {
             r.bash = SI::InstallForTarget(SI::Target::Bash);

--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -89,6 +89,14 @@ class TerminalCoreUnitTests::ShellIntegrationTests final
     TEST_METHOD(QueryExecutionPolicy_ParsesStdoutAndLowercases);
     TEST_METHOD(QueryExecutionPolicy_TrimsWhitespaceAndStopsAtFirstLine);
 
+    // ResolvePowerShellHostInstall — pure install/EP verdict for one PS host.
+    // Guards the regression where profile-gating silently skipped the
+    // execution-policy block (FRE no longer stopped on a Restricted host).
+    TEST_METHOD(ResolveHost_NoProfile_PolicyBlocked_StopsWithEpFlagWithoutWriting);
+    TEST_METHOD(ResolveHost_NoProfile_PolicyOk_SucceedsWithoutWriting);
+    TEST_METHOD(ResolveHost_Profile_PolicyOk_PerformsWrite);
+    TEST_METHOD(ResolveHost_Profile_PolicyBlocked_StopsWithEpFlagWithoutWriting);
+
     // ─── Bash flavor ──────────────────────────────────────────────────────
     // FindShellIntegrationBashBlock — pure parser.
     TEST_METHOD(Bash_FindBlock_EmptyContent_ReturnsNpos);
@@ -864,6 +872,77 @@ void ShellIntegrationTests::QueryExecutionPolicy_TrimsWhitespaceAndStopsAtFirstL
     const auto first = details::QueryExecutionPolicy(L"powershell.exe");
     const auto second = details::QueryExecutionPolicy(L"powershell.exe");
     VERIFY_ARE_EQUAL(first, second, L"QueryExecutionPolicy must be deterministic for the same host");
+}
+
+// ─── ResolvePowerShellHostInstall ─────────────────────────────────────────────
+// These cover the seam that the string-only PolicyName_* tests above cannot:
+// the verdict that decides whether FRE / Save stops. The regression (PR #222)
+// profile-gated this verdict so a Restricted host with no matching Windows
+// Terminal profile silently reported success and FRE never stopped. The
+// no-profile + blocked case below fails on that exact bug.
+
+void ShellIntegrationTests::ResolveHost_NoProfile_PolicyBlocked_StopsWithEpFlagWithoutWriting()
+{
+    // The host has NO Windows Terminal profile, but its execution policy
+    // blocks unsigned scripts. The verdict MUST still be a failure carrying
+    // executionPolicyBlocked=true (so FRE shows the policy error + turns auto
+    // detection off), and the $PROFILE write must NOT be attempted.
+    int writeCalls = 0;
+    const auto result = ResolvePowerShellHostInstall(
+        /*profilePresent*/ false,
+        /*executionPolicyBlocked*/ true,
+        [&] { ++writeCalls; return InstallResult{ true, false, {}, false }; });
+
+    VERIFY_IS_FALSE(result.success, L"A blocking policy must fail the verdict even with no profile");
+    VERIFY_IS_TRUE(result.executionPolicyBlocked, L"executionPolicyBlocked must propagate so FRE shows the policy error");
+    VERIFY_ARE_EQUAL(0, writeCalls, L"No $PROFILE write may be attempted when the policy blocks");
+}
+
+void ShellIntegrationTests::ResolveHost_NoProfile_PolicyOk_SucceedsWithoutWriting()
+{
+    // No profile and a permissive policy: nothing to do. Report
+    // success-already-satisfied (so the sweep's all-installed verdict isn't
+    // tripped) without writing.
+    int writeCalls = 0;
+    const auto result = ResolvePowerShellHostInstall(
+        /*profilePresent*/ false,
+        /*executionPolicyBlocked*/ false,
+        [&] { ++writeCalls; return InstallResult{ true, false, {}, false }; });
+
+    VERIFY_IS_TRUE(result.success);
+    VERIFY_IS_FALSE(result.executionPolicyBlocked);
+    VERIFY_ARE_EQUAL(0, writeCalls, L"No write when the user has no profile for this host");
+}
+
+void ShellIntegrationTests::ResolveHost_Profile_PolicyOk_PerformsWrite()
+{
+    // Profile present and policy OK: delegate to the write, returning exactly
+    // what it reports.
+    int writeCalls = 0;
+    const auto result = ResolvePowerShellHostInstall(
+        /*profilePresent*/ true,
+        /*executionPolicyBlocked*/ false,
+        [&] { ++writeCalls; return InstallResult{ true, false, L"sentinel", false }; });
+
+    VERIFY_ARE_EQUAL(1, writeCalls, L"The write must run when a profile is present and the policy is fine");
+    VERIFY_IS_TRUE(result.success);
+    VERIFY_ARE_EQUAL(std::wstring{ L"sentinel" }, result.errorMessage, L"The write's own result must be returned verbatim");
+}
+
+void ShellIntegrationTests::ResolveHost_Profile_PolicyBlocked_StopsWithEpFlagWithoutWriting()
+{
+    // Profile present but policy blocks: short-circuit before writing (the
+    // block would only throw PSSecurityException on every shell start anyway)
+    // and surface the policy verdict.
+    int writeCalls = 0;
+    const auto result = ResolvePowerShellHostInstall(
+        /*profilePresent*/ true,
+        /*executionPolicyBlocked*/ true,
+        [&] { ++writeCalls; return InstallResult{ true, false, {}, false }; });
+
+    VERIFY_IS_FALSE(result.success);
+    VERIFY_IS_TRUE(result.executionPolicyBlocked);
+    VERIFY_ARE_EQUAL(0, writeCalls, L"A blocking policy must short-circuit before the write");
 }
 
 // ═════════════════════════════════════════════════════════════════════════════

--- a/src/cascadia/inc/ShellIntegrationProfileGate.h
+++ b/src/cascadia/inc/ShellIntegrationProfileGate.h
@@ -34,7 +34,7 @@
 #pragma once
 
 #include <string_view>
-
+#include <utility>
 #include "ShellIntegrationCommon.h"
 
 namespace Microsoft::Terminal::ShellIntegration
@@ -290,7 +290,7 @@ namespace Microsoft::Terminal::ShellIntegration
         }
         if (profilePresent)
         {
-            return performWrite();
+            return std::forward<WriteFn>(performWrite)();
         }
         // Policy is fine and the user has no Windows Terminal profile for this
         // host — nothing to write. Report success-already-satisfied so the

--- a/src/cascadia/inc/ShellIntegrationProfileGate.h
+++ b/src/cascadia/inc/ShellIntegrationProfileGate.h
@@ -250,4 +250,51 @@ namespace Microsoft::Terminal::ShellIntegration
         }
         return false;
     }
+
+    // Resolves the install verdict for a single PowerShell host, keeping the
+    // two concerns that must NOT be conflated cleanly separate:
+    //
+    //   * The $PROFILE WRITE is profile-gated — `performWrite` only runs when
+    //     the user actually has a Windows Terminal profile launching this host
+    //     (so we never append a pwsh block for someone who only uses Windows
+    //     PowerShell, and vice-versa).
+    //
+    //   * The execution-policy VERDICT is UNCONDITIONAL. A Restricted /
+    //     AllSigned policy means the shell-integration .ps1 can never run, so
+    //     the FRE / Settings save MUST stop and surface the policy error even
+    //     when no profile triggers a write. Tying this verdict to profile
+    //     presence is exactly the regression this helper exists to prevent:
+    //     the EP block was silently skipped (and reported as success) whenever
+    //     `RunInstall` gated the host out, so the FRE never stopped.
+    //
+    // `executionPolicyBlocked` is supplied by the caller (a freshly-evaluated
+    // `ExecutionPolicyBlocksShellIntegration(target)` probe) rather than
+    // cached, so a user who fixes their policy offline and clicks Save again on
+    // the SAME FRE is re-evaluated and allowed through.
+    //
+    // Order matters: the EP check is evaluated FIRST so a blocking policy
+    // short-circuits before any write is attempted (a write would only
+    // silent-no-op or throw PSSecurityException on every shell start anyway).
+    //
+    // `performWrite` is a callable returning InstallResult (e.g. a lambda
+    // wrapping InstallForTarget); templated so unit tests can inject a counting
+    // / sentinel double without spawning a real PowerShell.
+    template<typename WriteFn>
+    inline InstallResult ResolvePowerShellHostInstall(bool profilePresent,
+                                                      bool executionPolicyBlocked,
+                                                      WriteFn&& performWrite)
+    {
+        if (executionPolicyBlocked)
+        {
+            return { false, false, L"PowerShell execution policy blocks scripts", true };
+        }
+        if (profilePresent)
+        {
+            return performWrite();
+        }
+        // Policy is fine and the user has no Windows Terminal profile for this
+        // host — nothing to write. Report success-already-satisfied so the
+        // sweep's all-installed verdict doesn't flag a missing shell.
+        return { true, true, {}, false };
+    }
 }


### PR DESCRIPTION
## Problem

During FRE (and Settings save), if the user's PowerShell execution policy refuses unsigned local scripts (`Restricted` / `AllSigned`), the shell-integration `$PROFILE` block can never run. The intended behavior is to **stop and surface the policy error** (and turn auto-detection off) rather than silently "succeed" and then fail on every shell start.

This **regressed** in #222. That PR profile-gated the install sweep so the execution-policy probe only ran when the user had a matching Windows Terminal PowerShell profile:

```cpp
if (shellPresence.pwsh)              r.pwsh = InstallForTarget(Target::Pwsh);
if (shellPresence.windowsPowerShell) r.windowsPowerShell = InstallForTarget(Target::WindowsPowerShell);
```

When a host is gated out, `RunInstall` returns the default `InstallSweepResults{ success=true }`, so a blocking policy is reported as success and FRE no longer stops. The existing unit tests only exercise the pure string predicate (`ShellIntegrationTests.cpp` explicitly notes they "NEVER call ... InstallForTarget"), so nothing flagged the regression.

## Fix

Decouple the two concerns in `RunInstall`:

- **`$PROFILE` write** stays profile-gated (don't write a block for a host the user has no WT profile for — #222's intent).
- **Execution-policy verdict** is now **unconditional** for both PowerShell hosts, via the new pure helper `ShellIntegration::ResolvePowerShellHostInstall(profilePresent, executionPolicyBlocked, performWrite)` (EP check first → short-circuit before any write).

`ExecutionPolicyBlocksShellIntegration` is re-queried every call (never cached), so a user who fixes the policy offline and clicks **Save again on the same FRE** is re-evaluated and proceeds. On block, the existing `_ShowProblem(ShellIntegrationExecutionPolicy)` path shows the policy error **and turns auto-detection off**.

<img width="2298" height="1149" alt="image" src="https://github.com/user-attachments/assets/ac91e435-5234-4afa-9f4a-8ea3ce9d35c3" />

## Tests

Adds four deterministic `ResolveHost_*` unit tests covering the regression (no-profile + blocked) plus the other three quadrants — the seam the string-only tests never touched.

## Notes

- Verified locally by building `UnitTests_TerminalCore` and running the new tests (all pass) + the full `ShellIntegrationTests` class.
- Pre-existing, unrelated: `Bash_ScriptContent_HasIdempotencyGuardAndOscSequences` asserts the bash script contains `${PROMPT_COMMAND:-}`, but the script (`BashShellIntegration.h`, from #222) emits `${PROMPT_COMMAND[@]}`. This mismatch exists on `main` and is untouched by this PR — tracking separately.
