### PR TITLE
Fix shell integration skipped for unquoted Git Bash path with spaces

### DIFF
--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -1540,13 +1540,23 @@ void ShellIntegrationTests::ProfileGate_PwshCommandlineLeafExeMatches()
     // on the full leaf token, not any substring).
     VERIFY_IS_FALSE(ProfileMatchesShell(Target::Pwsh, L"", L"pwshell.exe"));
     VERIFY_IS_FALSE(ProfileMatchesShell(Target::Pwsh, L"", L"pwsh-preview.exe"));
-    // Unquoted path containing a space is malformed Windows commandline
-    // (CommandLineToArgvW would split on the space). We don't match it
-    // — the user's profile won't launch anyway. WT always emits the
-    // quoted form for paths with spaces.
+    // Unquoted path containing spaces (e.g. the default Git/PowerShell
+    // install under "C:\Program Files\…"). CreateProcessW still launches
+    // these by probing progressively longer space-split prefixes, so the
+    // profile DOES run — and we must recognize it. The matcher extends the
+    // launch-exe token across spaces to the first ".exe" boundary when the
+    // commandline begins at a filesystem root.
+    VERIFY_IS_TRUE(ProfileMatchesShell(Target::Pwsh,
+                                        L"",
+                                        L"C:\\Program Files\\PowerShell\\7\\pwsh.exe"));
+    VERIFY_IS_TRUE(ProfileMatchesShell(Target::Pwsh,
+                                        L"",
+                                        L"C:\\Program Files\\PowerShell\\7\\pwsh.exe -NoLogo"));
+    // Bare command whose launch exe is NOT a path-root MUST NOT absorb a
+    // later `.exe` arg: launch is cmd, not pwsh.
     VERIFY_IS_FALSE(ProfileMatchesShell(Target::Pwsh,
                                          L"",
-                                         L"C:\\Program Files\\PowerShell\\7\\pwsh.exe"));
+                                         L"cmd /c C:\\Program Files\\PowerShell\\7\\pwsh.exe"));
 }
 
 void ShellIntegrationTests::ProfileGate_WindowsPowerShellOnlyWhenNotPwsh()
@@ -1588,6 +1598,18 @@ void ShellIntegrationTests::ProfileGate_BashOnlyForGitBashNotWsl()
     VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash,
                                         L"",
                                         L"\"C:\\Program Files\\Git\\bin\\bash.exe\" -i -l"));
+    // Git Bash — UNQUOTED full path with spaces. This is the default
+    // Git-for-Windows install location ("C:\Program Files\Git") and the
+    // exact form a user gets when they type/paste the path into the
+    // profile commandline without quotes. CreateProcessW launches it by
+    // probing space-split prefixes, so it runs — and integration MUST be
+    // recognized. Regression guard for the silent "leaf=Program" skip.
+    VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash,
+                                        L"",
+                                        L"C:\\Program Files\\Git\\bin\\bash.exe"));
+    VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash,
+                                        L"",
+                                        L"C:\\Program Files\\Git\\bin\\bash.exe -i -l"));
     // Bare leaf — user with bash on PATH.
     VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash, L"", L"bash"));
     VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash, L"", L"bash.exe -i"));
@@ -1604,6 +1626,11 @@ void ShellIntegrationTests::ProfileGate_BashOnlyForGitBashNotWsl()
     VERIFY_IS_FALSE(ProfileMatchesShell(Target::Bash,
                                          L"",
                                          L"wsl.exe -d Ubuntu -e bash.exe -l"));
+    // Unquoted path-root launch is wsl.exe; the first ".exe" boundary wins
+    // so a trailing bash.exe arg still does NOT match Bash.
+    VERIFY_IS_FALSE(ProfileMatchesShell(Target::Bash,
+                                         L"",
+                                         L"C:\\Windows\\System32\\wsl.exe -d Ubuntu -e bash.exe"));
 }
 
 void ShellIntegrationTests::ProfileGate_AnyProfileEmptyCollection()

--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -1552,6 +1552,16 @@ void ShellIntegrationTests::ProfileGate_PwshCommandlineLeafExeMatches()
     VERIFY_IS_TRUE(ProfileMatchesShell(Target::Pwsh,
                                         L"",
                                         L"C:\\Program Files\\PowerShell\\7\\pwsh.exe -NoLogo"));
+    // Extensionless rooted pwsh path with spaces — resolved by .exe probing.
+    VERIFY_IS_TRUE(ProfileMatchesShell(Target::Pwsh,
+                                        L"",
+                                        L"C:\\Program Files\\PowerShell\\7\\pwsh -NoLogo"));
+    // The "PowerShell" directory component must NOT be mistaken for a
+    // `powershell` launch leaf (the leaf scan requires a trailing
+    // whitespace/end after the segment, which "\PowerShell\" lacks).
+    VERIFY_IS_FALSE(ProfileMatchesShell(Target::WindowsPowerShell,
+                                         L"Windows.Terminal.PowershellCore",
+                                         L"C:\\Program Files\\PowerShell\\7\\pwsh -NoLogo"));
     // Bare command whose launch exe is NOT a path-root MUST NOT absorb a
     // later `.exe` arg: launch is cmd, not pwsh.
     VERIFY_IS_FALSE(ProfileMatchesShell(Target::Pwsh,
@@ -1610,6 +1620,21 @@ void ShellIntegrationTests::ProfileGate_BashOnlyForGitBashNotWsl()
     VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash,
                                         L"",
                                         L"C:\\Program Files\\Git\\bin\\bash.exe -i -l"));
+    // Git Bash — UNQUOTED rooted path with spaces and NO `.exe` extension.
+    // CreateProcessW resolves it by probing space-split prefixes and
+    // appending `.exe`, so the profile launches bash and integration MUST
+    // be recognized (regression guard for the reviewer-flagged gap).
+    VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash,
+                                        L"",
+                                        L"C:\\Program Files\\Git\\bin\\bash -i -l"));
+    VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash,
+                                        L"",
+                                        L"C:\\Program Files\\Git\\bin\\bash"));
+    // Extensionless rooted bash path must NOT be mistaken for pwsh — the
+    // leaf scan only matches `\<leaf>` segments terminated by whitespace/end.
+    VERIFY_IS_FALSE(ProfileMatchesShell(Target::Pwsh,
+                                         L"",
+                                         L"C:\\Program Files\\Git\\bin\\bash -i -l"));
     // Bare leaf — user with bash on PATH.
     VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash, L"", L"bash"));
     VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash, L"", L"bash.exe -i"));

--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -1567,6 +1567,13 @@ void ShellIntegrationTests::ProfileGate_PwshCommandlineLeafExeMatches()
     VERIFY_IS_FALSE(ProfileMatchesShell(Target::Pwsh,
                                          L"",
                                          L"cmd /c C:\\Program Files\\PowerShell\\7\\pwsh.exe"));
+    // Degenerate inputs: empty commandline, and a non-empty commandline
+    // matched against an empty leaf, both return false without crashing.
+    VERIFY_IS_FALSE(ProfileMatchesShell(Target::Pwsh, L"", L""));
+    // Leading whitespace before a rooted unquoted path is tolerated.
+    VERIFY_IS_TRUE(ProfileMatchesShell(Target::Pwsh,
+                                        L"",
+                                        L"   C:\\Program Files\\PowerShell\\7\\pwsh.exe"));
 }
 
 void ShellIntegrationTests::ProfileGate_WindowsPowerShellOnlyWhenNotPwsh()
@@ -1635,6 +1642,23 @@ void ShellIntegrationTests::ProfileGate_BashOnlyForGitBashNotWsl()
     VERIFY_IS_FALSE(ProfileMatchesShell(Target::Pwsh,
                                          L"",
                                          L"C:\\Program Files\\Git\\bin\\bash -i -l"));
+    // UNC path root (\\server\share\...) — another filesystem root the
+    // unquoted-with-spaces heuristic must accept, both with and without
+    // the `.exe` extension.
+    VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash,
+                                        L"",
+                                        L"\\\\server\\share\\Git\\bin\\bash.exe -i"));
+    VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash,
+                                        L"",
+                                        L"\\\\server\\share\\Git\\bin\\bash -i"));
+    // Forward-slash separators with a drive root (C:/...). Both the root
+    // detection and the leaf/`.exe` boundary scans must treat `/` like `\`.
+    VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash,
+                                        L"",
+                                        L"C:/Program Files/Git/bin/bash.exe"));
+    VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash,
+                                        L"",
+                                        L"C:/Program Files/Git/bin/bash -i -l"));
     // Bare leaf — user with bash on PATH.
     VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash, L"", L"bash"));
     VERIFY_IS_TRUE(ProfileMatchesShell(Target::Bash, L"", L"bash.exe -i"));

--- a/src/cascadia/inc/ShellIntegrationProfileGate.h
+++ b/src/cascadia/inc/ShellIntegrationProfileGate.h
@@ -59,6 +59,80 @@ namespace Microsoft::Terminal::ShellIntegration
         //     class of false positive.
         //   * `pwshell.exe` — launch leaf is pwshell.exe, not pwsh or
         //     pwsh.exe, no match ✓.
+        inline wchar_t FoldAsciiLower(wchar_t c) noexcept
+        {
+            return (c >= L'A' && c <= L'Z') ? static_cast<wchar_t>(c + (L'a' - L'A')) : c;
+        }
+
+        // True if `commandline` at `pos` begins at a filesystem root: a
+        // drive path (`X:\` or `X:/`) or a UNC path (`\\`). Only such an
+        // unquoted launch executable can legitimately contain spaces
+        // (e.g. `C:\Program Files\Git\bin\bash.exe`). A bare command like
+        // `cmd /c ...` does NOT start at a root, so its launch exe stays
+        // the first whitespace-delimited token.
+        inline bool BeginsAtPathRoot(std::wstring_view commandline, size_t pos) noexcept
+        {
+            const size_t n = commandline.size();
+            // UNC: \\server\share
+            if (pos + 1 < n && commandline[pos] == L'\\' && commandline[pos + 1] == L'\\')
+            {
+                return true;
+            }
+            // Drive: X:\ or X:/
+            if (pos + 2 < n)
+            {
+                const wchar_t d = commandline[pos];
+                const bool isAlpha = (d >= L'A' && d <= L'Z') || (d >= L'a' && d <= L'z');
+                if (isAlpha && commandline[pos + 1] == L':' &&
+                    (commandline[pos + 2] == L'\\' || commandline[pos + 2] == L'/'))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Returns the index just past the FIRST ".exe" (case-insensitive)
+        // that is immediately followed by whitespace or end-of-string,
+        // scanning from `start`. This locates the launch-executable
+        // boundary in an unquoted path that contains spaces. Returns
+        // std::wstring_view::npos when no such boundary exists.
+        //
+        // The launch exe wins over any ".exe" appearing later in the
+        // arguments because we stop at the FIRST match: in
+        // `C:\…\wsl.exe -e bash.exe` the scan stops at `wsl.exe`.
+        inline size_t FindUnquotedLaunchExeEnd(std::wstring_view commandline, size_t start) noexcept
+        {
+            constexpr std::wstring_view dotExe{ L".exe" };
+            const size_t n = commandline.size();
+            if (n < dotExe.size())
+            {
+                return std::wstring_view::npos;
+            }
+            for (size_t i = start; i + dotExe.size() <= n; ++i)
+            {
+                bool extMatch = true;
+                for (size_t j = 0; j < dotExe.size(); ++j)
+                {
+                    if (FoldAsciiLower(commandline[i + j]) != dotExe[j])
+                    {
+                        extMatch = false;
+                        break;
+                    }
+                }
+                if (!extMatch)
+                {
+                    continue;
+                }
+                const size_t after = i + dotExe.size();
+                if (after == n || commandline[after] == L' ' || commandline[after] == L'\t')
+                {
+                    return after;
+                }
+            }
+            return std::wstring_view::npos;
+        }
+
         inline bool CommandlineHasExeToken(std::wstring_view commandline, std::wstring_view leaf) noexcept
         {
             if (leaf.empty())
@@ -80,17 +154,55 @@ namespace Microsoft::Terminal::ShellIntegration
                 quoted = true;
                 ++start;
             }
-            // First token ends at the matching close-quote OR
-            // whitespace OR end-of-string.
+            // Determine the end of the launch-executable token.
             size_t end = start;
-            while (end < commandline.size())
+            if (quoted)
             {
-                const wchar_t c = commandline[end];
-                if (quoted ? (c == L'"') : (c == L' ' || c == L'\t'))
+                // Quoted: token ends at the matching close-quote.
+                while (end < commandline.size() && commandline[end] != L'"')
                 {
-                    break;
+                    ++end;
                 }
-                ++end;
+            }
+            else if (BeginsAtPathRoot(commandline, start))
+            {
+                // Unquoted path beginning at a filesystem root. The launch
+                // executable may legitimately contain spaces, e.g.
+                //   C:\Program Files\Git\bin\bash.exe -i -l
+                // which CreateProcessW launches by probing progressively
+                // longer space-split prefixes (…\Program.exe,
+                // …\Program Files\Git.exe, … \bash.exe). Git installs under
+                // "C:\Program Files\Git" by default, so this is the COMMON
+                // form — NOT a malformed edge case. Splitting on the first
+                // space would yield leaf "Program" and silently skip Git
+                // Bash integration. Extend the token to the first ".exe"
+                // boundary; fall back to first-whitespace when the path has
+                // no extension (rare — CreateProcess would auto-append .exe).
+                const size_t exeEnd = FindUnquotedLaunchExeEnd(commandline, start);
+                if (exeEnd != std::wstring_view::npos)
+                {
+                    end = exeEnd;
+                }
+                else
+                {
+                    while (end < commandline.size() &&
+                           commandline[end] != L' ' && commandline[end] != L'\t')
+                    {
+                        ++end;
+                    }
+                }
+            }
+            else
+            {
+                // Bare command (e.g. `pwsh -arg`, `bash.exe -i`, `cmd /c …`):
+                // the launch exe is the first whitespace-delimited token.
+                // It must NOT absorb a later `.exe` token in the arguments,
+                // so we never run the path-root extension scan here.
+                while (end < commandline.size() &&
+                       commandline[end] != L' ' && commandline[end] != L'\t')
+                {
+                    ++end;
+                }
             }
             if (end <= start)
             {

--- a/src/cascadia/inc/ShellIntegrationProfileGate.h
+++ b/src/cascadia/inc/ShellIntegrationProfileGate.h
@@ -133,6 +133,58 @@ namespace Microsoft::Terminal::ShellIntegration
             return std::wstring_view::npos;
         }
 
+        // Fallback for an unquoted rooted path whose launch executable is
+        // written WITHOUT the `.exe` extension, e.g.
+        //   C:\Program Files\Git\bin\bash -i -l
+        // CreateProcessW resolves this by probing space-split prefixes and
+        // auto-appending `.exe` (…\Program.exe fails, …\bin\bash.exe
+        // resolves), so the profile launches `bash` — we must recognize it.
+        // Returns the index just past the FIRST path segment `[\\/]<leaf>`
+        // (case-insensitive) that is immediately followed by whitespace or
+        // end-of-string, scanning from `start`; std::wstring_view::npos when
+        // none exists.
+        //
+        // Requiring a leading separator AND a trailing whitespace/end keeps
+        // this from matching a directory component (e.g. the "\PowerShell\"
+        // folder when looking for `powershell`) or a bare argument token.
+        // Only reached after FindUnquotedLaunchExeEnd has already failed, so
+        // no earlier `.exe`-terminated launch exe can be shadowed. (A
+        // contrived commandline with two rooted extensionless paths — a
+        // launcher plus a path-shaped argument ending in `\<leaf>` — could
+        // still false-match, but such a form never appears in a real profile
+        // commandline.)
+        inline size_t FindUnquotedLeafEnd(std::wstring_view commandline, size_t start, std::wstring_view leaf) noexcept
+        {
+            const size_t n = commandline.size();
+            // Need at least a separator + the leaf.
+            for (size_t i = start; i + 1 + leaf.size() <= n; ++i)
+            {
+                if (commandline[i] != L'\\' && commandline[i] != L'/')
+                {
+                    continue;
+                }
+                bool leafMatch = true;
+                for (size_t j = 0; j < leaf.size(); ++j)
+                {
+                    if (FoldAsciiLower(commandline[i + 1 + j]) != FoldAsciiLower(leaf[j]))
+                    {
+                        leafMatch = false;
+                        break;
+                    }
+                }
+                if (!leafMatch)
+                {
+                    continue;
+                }
+                const size_t after = i + 1 + leaf.size();
+                if (after == n || commandline[after] == L' ' || commandline[after] == L'\t')
+                {
+                    return after;
+                }
+            }
+            return std::wstring_view::npos;
+        }
+
         inline bool CommandlineHasExeToken(std::wstring_view commandline, std::wstring_view leaf) noexcept
         {
             if (leaf.empty())
@@ -182,6 +234,15 @@ namespace Microsoft::Terminal::ShellIntegration
                 if (exeEnd != std::wstring_view::npos)
                 {
                     end = exeEnd;
+                }
+                else if (const size_t leafEnd = FindUnquotedLeafEnd(commandline, start, leaf);
+                         leafEnd != std::wstring_view::npos)
+                {
+                    // Extensionless rooted launch exe (e.g.
+                    // `C:\Program Files\Git\bin\bash -i -l`): match on the
+                    // `\<leaf>` segment CreateProcess would resolve via
+                    // .exe probing.
+                    end = leafEnd;
                 }
                 else
                 {

--- a/src/cascadia/inc/ShellIntegrationProfileGate.h
+++ b/src/cascadia/inc/ShellIntegrationProfileGate.h
@@ -280,14 +280,11 @@ namespace Microsoft::Terminal::ShellIntegration
                 }
             }
             const std::wstring_view leafToken = commandline.substr(leafStart, end - leafStart);
-            const auto fold = [](wchar_t c) noexcept -> wchar_t {
-                return (c >= L'A' && c <= L'Z') ? static_cast<wchar_t>(c + (L'a' - L'A')) : c;
-            };
-            const auto equalsCi = [&](std::wstring_view a, std::wstring_view b) noexcept -> bool {
+            const auto equalsCi = [](std::wstring_view a, std::wstring_view b) noexcept -> bool {
                 if (a.size() != b.size()) return false;
                 for (size_t i = 0; i < a.size(); ++i)
                 {
-                    if (fold(a[i]) != fold(b[i])) return false;
+                    if (FoldAsciiLower(a[i]) != FoldAsciiLower(b[i])) return false;
                 }
                 return true;
             };
@@ -302,13 +299,13 @@ namespace Microsoft::Terminal::ShellIntegration
                 bool exeMatch = true;
                 for (size_t i = 0; i < leaf.size(); ++i)
                 {
-                    if (fold(leafToken[i]) != fold(leaf[i])) { exeMatch = false; break; }
+                    if (FoldAsciiLower(leafToken[i]) != FoldAsciiLower(leaf[i])) { exeMatch = false; break; }
                 }
                 if (exeMatch)
                 {
                     for (size_t i = 0; i < dotExe.size(); ++i)
                     {
-                        if (fold(leafToken[leaf.size() + i]) != fold(dotExe[i])) { exeMatch = false; break; }
+                        if (FoldAsciiLower(leafToken[leaf.size() + i]) != dotExe[i]) { exeMatch = false; break; }
                     }
                     if (exeMatch) return true; // <leaf>.exe form
                 }


### PR DESCRIPTION
## Problem

Shell integration (and therefore autofix) was **silently never installed for Git Bash** when the profile commandline was an **unquoted path containing a space** — the default Git for Windows form:

```
C:\Program Files\Git\bin\bash.exe
```

`CommandlineHasExeToken` (`ShellIntegrationProfileGate.h`) extracts the *launch executable* leaf from a profile commandline to decide whether a profile is bash / pwsh / powershell. For an unquoted commandline it terminated the token at the **first whitespace**, so the leaf parsed as `Program` (not `bash.exe`):

- `ProfileMatchesShell(Target::Bash)` → false
- `SnapshotShellPresence.bash` → false
- the profile-gated install / FRE / reconcile sweep **skipped Git Bash entirely** → `~/.bashrc` was never written, OSC 133 marks were never emitted, autofix never fired in Git Bash.

The old code (and its test) assumed *"an unquoted path with a space is a malformed commandline that won't launch"*. That assumption is wrong: `CreateProcessW` launches such paths by probing progressively longer space-split prefixes (`C:\Program.exe` → `C:\Program Files\Git.exe` → … → `…\bash.exe`). So the profile **runs**, but integration is **skipped**. Git installs under `C:\Program Files\Git` (a space) by default, so this hit essentially **every Git Bash user** who pasted the path without quotes. Reproduced on two machines; quoting the path was the only workaround.

## Before vs after (the parsing logic)

The fix aligns leaf extraction with how `CreateProcessW` actually resolves the launch executable.

| commandline | before (split at 1st space) | after |
|---|---|---|
| `"C:\Program Files\Git\bin\bash.exe"` | `bash.exe` ✅ | `bash.exe` ✅ |
| `C:\Tools\Git\bin\bash.exe` (no space) | `bash.exe` ✅ | `bash.exe` ✅ |
| `C:\Program Files\Git\bin\bash.exe` | **`Program` ❌** | **`bash.exe` ✅** |
| `C:\Program Files\Git\bin\bash -i -l` (no ext) | **`Program` ❌** | **`bash` ✅** |
| `cmd /c …\pwsh.exe` (bare command) | `cmd` ✅ | `cmd` ✅ |
| `C:\…\wsl.exe -e bash.exe` | `wsl.exe` ✅ | `wsl.exe` ✅ |

**After** splits the unquoted branch into:

1. **Commandline begins at a filesystem root** (`X:\`, `X:/`, or UNC `\\`) → treat the launch exe as a path that may contain spaces:
   - scan to the **first `.exe`** boundary (terminated by whitespace/end) → `…\bash.exe` → `bash.exe`;
   - if there is no `.exe` (user omitted the extension) → fall back to the first `[\\/]<leaf>` segment terminated by whitespace/end → `…\bin\bash` → `bash`.
2. **Bare command** (`pwsh -arg`, `cmd /c …`) → unchanged: the launch exe is the first whitespace-delimited token.

Anti-false-match guarantees that are preserved:

- bare commands never run the path scan, so a later `.exe` **argument** can't be mistaken for the launch exe (`cmd /c …pwsh.exe` stays `cmd`);
- **first `.exe` wins**, so `C:\…\wsl.exe -e bash.exe` resolves to `wsl.exe`, not bash;
- the extensionless leaf scan requires a **leading separator + trailing whitespace/end**, so a directory component (e.g. `\PowerShell\`) or a bare arg is never mistaken for the launch leaf.

Public signature (`ProfileMatchesShell` / `AnyProfileUsesShell`) is unchanged — this is purely internal token-extraction logic.

## Tests

- Corrected a stale assertion that required the unquoted-spaced path to **not** match (it must).
- Added full-branch ProfileGate coverage: quoted, unquoted-with-spaces, extensionless rooted (pwsh + bash), UNC root, forward-slash root, leading whitespace, empty commandline / empty leaf, plus the bare-command and `wsl … bash.exe` / `\PowerShell\` false-positive guards.
- Built `UnitTests_TerminalCore` (VS2022 v143) and ran TAEF: **ProfileGate 8/8 pass**. Also built the full solution (`TerminalAppLib` consumers `AppActionHandlers.cpp` / `FreOverlay.cpp` compile) — 0 errors.

## Review iterations

1. Core fix — `.exe` boundary scan + path-root detection; corrected the stale test.
2. Copilot review #1 — flagged the extensionless form still falling back to first-whitespace → added `FindUnquotedLeafEnd` + regression tests.
3. Copilot review #2 — flagged `FoldAsciiLower` duplicating a local `fold` lambda → consolidated to a single helper.

> Note: one unrelated, **pre-existing** failure on `origin/main` (`Bash_ScriptContent_HasIdempotencyGuardAndOscSequences` asserts `${PROMPT_COMMAND:-}`, which the script dropped in #222 for the array-walk form) is **not** addressed here — it's a separate stale-test issue.
