### PR TITLE
Pin PGO database package version to upstream 1.26

### DIFF
--- a/build/pgo/Terminal.PGO.props
+++ b/build/pgo/Terminal.PGO.props
@@ -14,11 +14,16 @@
     <!-- Mandatory.  Name of the NuGet package which will contain PGO databases for consumption by build system. -->
     <PGOPackageName>Microsoft.Internal.Windows.Terminal.PGODatabase</PGOPackageName>
 
-    <!-- Mandatory.  Major version number of the PGO database which should match the version of the product.  This can be hard-coded or obtained from other sources in build system. -->
-    <PGOPackageVersionMajor>$(VersionMajor)</PGOPackageVersionMajor>
+    <!-- Mandatory.  Major/Minor version number of the PGO database. This is normally derived from the
+         product version ($(VersionMajor).$(VersionMinor)), but the Intelligent Terminal fork rebranded to
+         0.1, and no 0.1.x PGODatabase exists on the TerminalDependencies feed (which only carries upstream
+         Windows Terminal versions, currently up to 1.26.0). Pin to the latest available upstream PGO data so
+         Optimize builds can find a matching package. Revisit when newer upstream PGO data is published, or
+         once the fork publishes its own PGODatabase via the instrumentation pipeline (build/pipelines/pgo.yml). -->
+    <PGOPackageVersionMajor>1</PGOPackageVersionMajor>
 
-    <!-- Mandatory.  Minor version number of the PGO database which should match the version of the product.  This can be hard-coded or obtained from other sources in build system. -->
-    <PGOPackageVersionMinor>$(VersionMinor)</PGOPackageVersionMinor>
+    <!-- Mandatory.  Minor version number of the PGO database.  See note above on PGOPackageVersionMajor. -->
+    <PGOPackageVersionMinor>26</PGOPackageVersionMinor>
 
     <!-- Mandatory, defaults to 0.  Patch version number of the PGO database which should match the version of the product.  This can be hard-coded or obtained from other sources in build system. -->
     <PGOPackageVersionPatch>0</PGOPackageVersionPatch>

--- a/build/pgo/Terminal.PGO.props
+++ b/build/pgo/Terminal.PGO.props
@@ -14,15 +14,9 @@
     <!-- Mandatory.  Name of the NuGet package which will contain PGO databases for consumption by build system. -->
     <PGOPackageName>Microsoft.Internal.Windows.Terminal.PGODatabase</PGOPackageName>
 
-    <!-- Mandatory.  Major/Minor version number of the PGO database. This is normally derived from the
-         product version ($(VersionMajor).$(VersionMinor)), but the Intelligent Terminal fork rebranded to
-         0.1, and no 0.1.x PGODatabase exists on the TerminalDependencies feed (which only carries upstream
-         Windows Terminal versions, currently up to 1.26.0). Pin to the latest available upstream PGO data so
-         Optimize builds can find a matching package. Revisit when newer upstream PGO data is published, or
-         once the fork publishes its own PGODatabase via the instrumentation pipeline (build/pipelines/pgo.yml). -->
+    <!-- Pinned to upstream 1.26 instead of $(VersionMajor).$(VersionMinor): the fork's 0.1
+         product version has no matching PGODatabase on the TerminalDependencies feed. -->
     <PGOPackageVersionMajor>1</PGOPackageVersionMajor>
-
-    <!-- Mandatory.  Minor version number of the PGO database.  See note above on PGOPackageVersionMajor. -->
     <PGOPackageVersionMinor>26</PGOPackageVersionMinor>
 
     <!-- Mandatory, defaults to 0.  Patch version number of the PGO database which should match the version of the product.  This can be hard-coded or obtained from other sources in build system. -->


### PR DESCRIPTION
## Problem
The nightly build (`IT-NightlyBuild`) fails in **Build OpenConsole.slnx** for both `Release_x64` and `Release_arm64` with:

```
Microsoft.PGO-Helpers.Cpp.targets(15,5): Error : Could not find matching PGO package.
```

`build/pgo/Terminal.PGO.props` derives the PGO database NuGet version from `$(VersionMajor).$(VersionMinor)`. The Intelligent Terminal rebrand set these to **0.1** in `custom.props`, but no `0.1.x` `Microsoft.Internal.Windows.Terminal.PGODatabase` exists on the `TerminalDependencies` feed — it only carries upstream Windows Terminal versions (currently up to **1.26.0**, e.g. `1.26.0-2606112202-main`).

## Fix
Pin `PGOPackageVersionMajor`/`Minor` to **1.26** so `Optimize` builds resolve a matching upstream PGO database, decoupling the PGO package version from the rebranded product version.

## Why a PR (not just a local edit)
This exact pin was applied before but only ever as a **local, uncommitted working-tree edit** — it was lost on every fresh clone / upstream sync, so the nightly kept re-breaking. Committing it makes the fix durable.

## Caveats / follow-ups
- The pin uses **upstream** profile data against diverged fork code; the later PGO *verify* step (`PGOVerifyFailureTreatedAsError=true`) could still complain. Will confirm on the next nightly. If it fails, the fallback is `pgoBuildMode: None` in `1espt-nightly.yml` (loses ~5–15% perf).
- Revisit when newer upstream PGO data is published, or once the fork publishes its own PGODatabase via `build/pipelines/pgo.yml`.

🤖 Diagnosed and prepared with GitHub Copilot CLI.