### PR TITLE
ci: default nightly build to Release branding, disable auto-publish

### DIFF
--- a/build/pipelines/1espt-nightly.yml
+++ b/build/pipelines/1espt-nightly.yml
@@ -12,14 +12,14 @@ parameters:
   - name: branding
     displayName: "Branding"
     type: string
-    default: Canary
+    default: Release
     values:
       - Canary
       - Release
   - name: publishToAzure
     displayName: "Deploy to **PUBLIC** Azure Storage"
     type: boolean
-    default: true
+    default: false
   - name: official
     displayName: "Run on Official 1ES Pipeline Templates"
     type: boolean


### PR DESCRIPTION
Change the scheduled daily build defaults so the nightly produces Release-branded builds without publishing to Azure Storage.

- Branding: Canary → Release
- Deploy to PUBLIC Azure Storage: true → false