### PR TITLE
Clarify shell-integration support (PowerShell/bash/WSL bash) across docs, FRE, and Settings

### DIFF
--- a/doc/installing-dependencies.md
+++ b/doc/installing-dependencies.md
@@ -2,10 +2,10 @@
 
 Intelligent Terminal's **first-run experience (FRE)** is designed to install
 the dependencies it owns for you automatically — the default agent
-(GitHub Copilot), Node.js when it is needed, shell integration for both
-PowerShell flavors, and so on. For most users on a typical Windows
-machine who stay with the default agent, finishing the FRE is all you
-ever need to do.
+(GitHub Copilot), Node.js when it is needed, shell integration for the shells
+it supports (PowerShell, bash, and WSL bash), and so on. For most users on a
+typical Windows machine who stay with the default agent, finishing the FRE is
+all you ever need to do.
 
 This document exists for the circumstances where the FRE cannot do the job
 on its own, including:
@@ -31,7 +31,10 @@ on its own, including:
    - 3.4 [Gemini CLI (bring your own)](#34-gemini-cli-bring-your-own)
    - 3.5 [Signing in to your agent](#35-signing-in-to-your-agent)
    - 3.6 [Agent hooks for session management](#36-agent-hooks-for-session-management)
-4. [PowerShell shell integration](#4-powershell-shell-integration)
+4. [Shell integration](#4-shell-integration) — supported shells + setup
+   - 4.1 [PowerShell](#41-powershell) (PowerShell 7+ and Windows PowerShell 5.1)
+   - 4.2 [Bash (Git Bash)](#42-bash-git-bash)
+   - 4.3 [WSL bash](#43-wsl-bash)
 
 ---
 
@@ -440,17 +443,41 @@ without it) and restart Intelligent Terminal once.
 
 ---
 
-## 4. PowerShell shell integration
+## 4. Shell integration
 
-**Why you need it:** Shell integration teaches PowerShell to emit
-**OSC 133** marks after every prompt. Intelligent Terminal uses these marks
-to detect command boundaries and exit codes, which powers the auto-fix
-feature, command navigation, and the bottom-bar agent state. Without these
-marks Intelligent Terminal cannot tell when a command finished or whether
-it failed.
+**Why you need it:** Shell integration teaches your shell to emit **OSC 133**
+marks after every prompt. Intelligent Terminal uses these marks to detect
+command boundaries and exit codes, which powers the auto-fix feature, command
+navigation, and the bottom-bar agent state. Without these marks Intelligent
+Terminal cannot tell when a command finished or whether it failed.
 
-The first-run experience writes the shell-integration profile snippet for
-you, for both **PowerShell 7+** (`pwsh.exe`) and **Windows PowerShell 5.1**
+The first-run experience installs shell integration automatically for every
+**supported shell it detects** on your system — you usually don't have to do
+anything. This section documents which shells are supported and the only
+manual step you may occasionally need (adjusting the PowerShell execution
+policy).
+
+### What's supported
+
+| Shell | Supported | Where integration is installed |
+|---|---|---|
+| PowerShell 7+ (`pwsh.exe`) | ✅ | `$PROFILE` (see [4.1](#41-powershell)) |
+| Windows PowerShell 5.1 (`powershell.exe`) | ✅ | `$PROFILE` (see [4.1](#41-powershell)) |
+| Bash — Git Bash on Windows | ✅ | `~/.bashrc` (see [4.2](#42-bash-git-bash)) |
+| WSL bash | ✅ | `\\wsl$\<distro>\…\.bashrc` (see [4.3](#43-wsl-bash)) |
+| Command Prompt (`cmd.exe`) | ❌ | `cmd.exe` cannot emit OSC 133 marks |
+| Other shells (zsh, fish, Nushell, …) | ❌ | Not yet supported |
+| Non-bash WSL login shells (zsh, fish, …) | ❌ | Only WSL distros whose login shell is bash are covered |
+
+> [!NOTE]
+> The set of supported shells grows over time. This page is the **authoritative
+> list** — if a shell you use isn't here yet, check back after updating
+> Intelligent Terminal.
+
+### 4.1 PowerShell
+
+The first-run experience writes the shell-integration profile snippet for you,
+for both **PowerShell 7+** (`pwsh.exe`) and **Windows PowerShell 5.1**
 (`powershell.exe`). The snippet is appended to each host's
 **current-user / current-host profile** — the same file `$PROFILE` (also
 known as `$PROFILE.CurrentUserCurrentHost`) points at when you run that
@@ -470,7 +497,7 @@ $PROFILE.CurrentUserCurrentHost
 The only step you may need to perform by hand is adjusting the PowerShell
 execution policy so the profile is allowed to run.
 
-### Step 4.1 — Set the PowerShell execution policy
+#### Set the PowerShell execution policy
 
 Shell-integration scripts are PowerShell `.ps1` files loaded from your
 profile. PowerShell will refuse to run them under the default `Restricted`
@@ -515,12 +542,56 @@ is the recommended Microsoft default for developer machines.
 > shows `Restricted` or `AllSigned` for your scope after running the
 > command above.
 
-### Step 4.2 — Enable auto-error detection and auto-error fix
+### 4.2 Bash (Git Bash)
 
-Once the execution policy is set, open **Settings → AI Agents** inside
-Intelligent Terminal and turn on **Auto-error detection** (and, optionally,
-the auto-fix follow-up). With shell integration loading correctly, the
-agent pane will now:
+For **Git Bash on Windows**, the first-run experience installs a small,
+versioned script under `~/.intelligent-terminal/` (resolved from your
+`%USERPROFILE%`) and sources it from a guarded block appended to **`~/.bashrc`**:
+
+| What | Path |
+|---|---|
+| Integration script | `%USERPROFILE%\.intelligent-terminal\shell-integration_v1.sh` |
+| Sourced from | `%USERPROFILE%\.bashrc` |
+
+There is **no execution-policy equivalent** for bash, so no manual step is
+normally required. A few notes:
+
+- The script targets **bash 3.2+** and is safe to source multiple times. It
+  silently no-ops in non-interactive shells and in non-bash shells, so a
+  `.bashrc` that roams (via dotfiles / OneDrive) to a machine without
+  Intelligent Terminal won't break.
+- To uninstall, remove the Intelligent Terminal block from `~/.bashrc`. The
+  versioned script files under `~/.intelligent-terminal/` are intentionally
+  left in place to support side-by-side rollback; delete that directory by
+  hand if you want a full sweep.
+
+### 4.3 WSL bash
+
+For **WSL** distributions, integration is installed **per distro** using the
+same bash script as above, written through the distro's `\\wsl$\` UNC mount:
+
+| What | Path |
+|---|---|
+| Integration script | `\\wsl$\<distro>\<home>\.intelligent-terminal\shell-integration_v1.sh` |
+| Sourced from | `\\wsl$\<distro>\<home>\.bashrc` |
+
+Notes and limitations:
+
+- The `\\wsl$\` mount requires **Windows 10 1903 (build 18362)+**, which every
+  supported Intelligent Terminal host meets. The first access auto-starts the
+  distro, so the very first install pays a one-time VM cold-start cost.
+- Only distros whose **login shell is bash** are covered (integration is
+  written to `~/.bashrc`). Distros that default to — or where you have
+  changed your default shell to — **zsh, fish, or another non-bash shell**,
+  or that ship **without bash** (for example, Alpine), are **not yet
+  supported**.
+
+### Enable auto-error detection and auto-error fix
+
+Once shell integration is in place (and, for PowerShell, the execution policy
+is set), open **Settings → AI Agents** inside Intelligent Terminal and turn on
+**Auto-error detection** (and, optionally, the auto-fix follow-up). With shell
+integration loading correctly, the agent pane will now:
 
 - Detect failing commands automatically (via the OSC 133 exit-code marks).
 - Offer to diagnose and propose a fix for the most recent failure.

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -2112,7 +2112,7 @@ namespace winrt::TerminalApp::implementation
                     body.Inlines().Append(Documents::LineBreak{});
 
                     Documents::Hyperlink link;
-                    link.NavigateUri(winrt::Windows::Foundation::Uri{ L"https://aka.ms/intelligent-terminal-dependency#4-powershell-shell-integration" });
+                    link.NavigateUri(winrt::Windows::Foundation::Uri{ L"https://aka.ms/intelligent-terminal-dependency#41-powershell" });
                     Documents::Run linkRun;
                     linkRun.Text(RS_(L"FreOverlay_ErrorHelpLink"));
                     link.Inlines().Append(linkRun);

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -1206,7 +1206,7 @@ namespace winrt::TerminalApp::implementation
             break;
         case FreProblemKind::ShellIntegrationExecutionPolicy:
             ErrorText().Text(RS_(L"FreOverlay_InstallErrorShellIntegrationExecutionPolicy"));
-            url += L"#4-powershell-shell-integration";
+            url += L"#41-powershell";
             // Same remediation as generic shell-integration failure: turn
             // off error detection so the user can save and continue. Once
             // they fix execution policy they can re-enable it from Settings.
@@ -1220,7 +1220,7 @@ namespace winrt::TerminalApp::implementation
             break;
         case FreProblemKind::ShellIntegration:
             ErrorText().Text(RS_(L"FreOverlay_InstallErrorShellIntegration"));
-            url += L"#4-powershell-shell-integration";
+            url += L"#4-shell-integration";
             // Remediation: turn off error detection (and its dependent
             // suggestion) so the user can save and continue without it.
             AutoDetectToggle().IsOn(false);

--- a/src/cascadia/TerminalApp/FreOverlay.xaml
+++ b/src/cascadia/TerminalApp/FreOverlay.xaml
@@ -355,7 +355,7 @@
                                                        FontSize="12" Foreground="#99FFFFFF"
                                                        TextWrapping="Wrap">
                                                 <Run x:Name="AutoDetectShellIntegrationHintPrefix" />
-                                                <Hyperlink NavigateUri="https://github.com/microsoft/intelligent-terminal/blob/main/doc/installing-dependencies.md#8-powershell-shell-integration"
+                                                <Hyperlink NavigateUri="https://aka.ms/intelligent-terminal-dependency#4-shell-integration"
                                                            Foreground="#FF99EBFF">
                                                     <Run x:Name="AutoDetectShellIntegrationHintLink" />
                                                 </Hyperlink>

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.cpp
@@ -23,6 +23,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         PageSubtitlePrefix().Text(RS_(L"AIAgents_PageSubtitlePrefix"));
         PageSubtitlePrivacyLink().Text(RS_(L"AIAgents_PageSubtitlePrivacyLink"));
 
+        // Auto-error-detection caption + inline "supported shells" hyperlink.
+        AutoErrorDetectionCaptionPrefix().Text(RS_(L"AIAgents_AutoErrorDetectionCaptionPrefix"));
+        AutoErrorDetectionCaptionLink().Text(RS_(L"AIAgents_AutoErrorDetectionCaptionLink"));
+
         const auto agentHeader = RS_(L"AIAgents_AcpAgent/Header");
         AcpAgentHeaderText().Text(agentHeader);
 

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -203,10 +203,18 @@
                             <TextBlock x:Uid="AIAgents_AutoErrorDetectionTitle"
                                        FontWeight="SemiBold"
                                        TextWrapping="Wrap" />
-                            <TextBlock x:Uid="AIAgents_AutoErrorDetectionCaption"
-                                       Style="{StaticResource CaptionTextBlockStyle}"
+                            <!--  Caption hosts an inline Hyperlink to the full
+                                  supported-shells list, so it is built from
+                                  Run + Hyperlink populated in code-behind (RS_)
+                                  rather than a single x:Uid (x:Uid on inline Run
+                                  is not honored in this codebase).  -->
+                            <TextBlock Style="{StaticResource CaptionTextBlockStyle}"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                       TextWrapping="Wrap" />
+                                       TextWrapping="Wrap">
+                                <Run x:Name="AutoErrorDetectionCaptionPrefix" /><Hyperlink NavigateUri="https://aka.ms/intelligent-terminal-dependency#4-shell-integration">
+                                    <Run x:Name="AutoErrorDetectionCaptionLink" />
+                                </Hyperlink>
+                            </TextBlock>
                         </StackPanel>
                         <ToggleSwitch Grid.Column="1"
                                       MinWidth="0"

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -207,11 +207,15 @@
                                   supported-shells list, so it is built from
                                   Run + Hyperlink populated in code-behind (RS_)
                                   rather than a single x:Uid (x:Uid on inline Run
-                                  is not honored in this codebase).  -->
+                                  is not honored in this codebase). The muted
+                                  "secondary" foreground is applied only to the
+                                  prefix Run so the Hyperlink keeps its full theme
+                                  accent contrast (matches the page-subtitle
+                                  pattern above).  -->
                             <TextBlock Style="{StaticResource CaptionTextBlockStyle}"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                        TextWrapping="Wrap">
-                                <Run x:Name="AutoErrorDetectionCaptionPrefix" /><Hyperlink NavigateUri="https://aka.ms/intelligent-terminal-dependency#4-shell-integration">
+                                <Run x:Name="AutoErrorDetectionCaptionPrefix"
+                                     Foreground="{ThemeResource TextFillColorSecondaryBrush}" /><Hyperlink NavigateUri="https://aka.ms/intelligent-terminal-dependency#4-shell-integration">
                                     <Run x:Name="AutoErrorDetectionCaptionLink" />
                                 </Hyperlink>
                             </TextBlock>

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -2871,13 +2871,16 @@
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Automatische Fehlererkennung</value>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Erlauben Sie Intelligent Terminal, auf Ihre Shell zuzugreifen und Fehler automatisch zu erkennen. Verfügbar in PowerShell und Windows PowerShell.</value>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>Erlauben Sie Intelligentes Terminal, auf Ihre Shell zuzugreifen und Fehler automatisch zu erkennen. Verfügbar in PowerShell, bash und WSL bash. </value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>Alle unterstützten Shells anzeigen</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>Automatischer Fehlervorschlag</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Erlauben Sie Intelligent Terminal, Fehler an Ihren Agent zu senden, um automatisch Korrekturen vorzuschlagen.</value>
+    <value>Erlauben Sie Intelligentes Terminal, Fehler an Ihren Agent zu senden, um automatisch Korrekturen vorzuschlagen.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -758,9 +758,13 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Automatic error detection</value>
     <comment>Title for the master toggle (Expander header) that lets the terminal observe the shell and detect failed commands. The Automatic error suggestion setting is nested under this one.</comment>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
-    <comment>{Locked="PowerShell","Windows PowerShell"} "Intelligent Terminal" is the product name. Caption under the automatic-error-detection title.</comment>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell, bash, and WSL bash. </value>
+    <comment>{Locked="PowerShell","bash","WSL bash"} "Intelligent Terminal" is the product name — localize it to this locale's product name (do not keep it in English). Caption under the automatic-error-detection title; the trailing space separates this prefix from the inline "AIAgents_AutoErrorDetectionCaptionLink" hyperlink that follows.</comment>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>See all supported shells</value>
+    <comment>Inline hyperlink text that follows AIAgents_AutoErrorDetectionCaptionPrefix; opens the documentation listing every shell that supports automatic error detection.</comment>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>Automatic error suggestion</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -2871,13 +2871,16 @@
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Detección automática de errores</value>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Permita que Intelligent Terminal acceda a su shell y detecte errores automáticamente. Disponible en PowerShell y Windows PowerShell.</value>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>Permita que Terminal Inteligente acceda a su shell y detecte errores automáticamente. Disponible en PowerShell, bash y WSL bash. </value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>Ver todos los shells compatibles</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>Sugerencia automática de errores</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Permita que Intelligent Terminal envíe errores a su agente para sugerir correcciones automáticamente.</value>
+    <value>Permita que Terminal Inteligente envíe errores a su agente para sugerir correcciones automáticamente.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -2872,13 +2872,16 @@
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Détection automatique des erreurs</value>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Autorisez Intelligent Terminal à accéder à votre shell et à détecter automatiquement les erreurs. Disponible dans PowerShell et Windows PowerShell.</value>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>Autorisez Terminal Intelligent à accéder à votre shell et à détecter automatiquement les erreurs. Disponible dans PowerShell, bash et WSL bash. </value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>Afficher tous les shells pris en charge</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>Suggestion automatique des erreurs</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Autorisez Intelligent Terminal à envoyer les erreurs à votre agent pour suggérer automatiquement des correctifs.</value>
+    <value>Autorisez Terminal Intelligent à envoyer les erreurs à votre agent pour suggérer automatiquement des correctifs.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -2871,13 +2871,16 @@
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Rilevamento automatico degli errori</value>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Consenti a Intelligent Terminal di accedere alla shell e rilevare automaticamente gli errori. Disponibile in PowerShell e Windows PowerShell.</value>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>Consenti a Terminale Intelligente di accedere alla shell e rilevare automaticamente gli errori. Disponibile in PowerShell, bash e WSL bash. </value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>Visualizza tutte le shell supportate</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>Suggerimento automatico degli errori</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Consenti a Intelligent Terminal di inviare gli errori all'agente per suggerire automaticamente le correzioni.</value>
+    <value>Consenti a Terminale Intelligente di inviare gli errori all'agente per suggerire automaticamente le correzioni.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -2871,13 +2871,16 @@
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>エラーの自動検出</value>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Intelligent Terminal にシェルへのアクセスを許可し、エラーを自動的に検出します。PowerShell および Windows PowerShell で利用できます。</value>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>インテリジェント ターミナルにシェルへのアクセスを許可し、エラーを自動的に検出します。PowerShell、bash、WSL bash で利用できます。 </value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>サポートされているすべてのシェルを表示</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>エラーの自動提案</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Intelligent Terminal がエラーをエージェントに送信して、修正を自動的に提案することを許可します。</value>
+    <value>インテリジェント ターミナルがエラーをエージェントに送信して、修正を自動的に提案することを許可します。</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -2931,13 +2931,16 @@
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>자동 오류 검색</value>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Intelligent Terminal이 셸에 액세스하여 오류를 자동으로 검색하도록 허용합니다. PowerShell 및 Windows PowerShell에서 사용할 수 있습니다.</value>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>지능형 터미널이 셸에 액세스하여 오류를 자동으로 검색하도록 허용합니다. PowerShell, bash 및 WSL bash에서 사용할 수 있습니다. </value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>지원되는 모든 셸 보기</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>자동 오류 제안</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Intelligent Terminal이 오류를 에이전트로 보내 수정 사항을 자동으로 제안하도록 허용합니다.</value>
+    <value>지능형 터미널이 오류를 에이전트로 보내 수정 사항을 자동으로 제안하도록 허용합니다.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -2914,13 +2914,16 @@
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Detecção automática de erros</value>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Permita que o Intelligent Terminal acesse o shell e detecte erros automaticamente. Disponível no PowerShell e no Windows PowerShell.</value>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>Permita que o Terminal Inteligente acesse o shell e detecte erros automaticamente. Disponível no PowerShell, no bash e no WSL bash. </value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>Ver todos os shells com suporte</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>Sugestão automática de erros</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Permita que o Intelligent Terminal envie erros ao agente para sugerir correções automaticamente.</value>
+    <value>Permita que o Terminal Inteligente envie erros ao agente para sugerir correções automaticamente.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -2862,8 +2862,11 @@
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Automatic error detection</value>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell, bash, and WSL bash. </value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>See all supported shells</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>Automatic error suggestion</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -2862,8 +2862,11 @@
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Automatic error detection</value>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell, bash, and WSL bash. </value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>See all supported shells</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>Automatic error suggestion</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -2862,8 +2862,11 @@
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Automatic error detection</value>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell and Windows PowerShell.</value>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>Give Intelligent Terminal permission to access your shell and automatically detect errors. Available in PowerShell, bash, and WSL bash. </value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>See all supported shells</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>Automatic error suggestion</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -2914,13 +2914,16 @@
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Автоматическое обнаружение ошибок</value>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Разрешите Intelligent Terminal доступ к оболочке и автоматическое обнаружение ошибок. Доступно в PowerShell и Windows PowerShell.</value>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>Разрешите Интеллектуальному Терминалу доступ к оболочке и автоматическое обнаружение ошибок. Доступно в PowerShell, bash и WSL bash. </value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>Показать все поддерживаемые оболочки</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>Автоматическое предложение исправлений</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Разрешите Intelligent Terminal отправлять ошибки агенту для автоматического предложения исправлений.</value>
+    <value>Разрешите Интеллектуальному Терминалу отправлять ошибки агенту для автоматического предложения исправлений.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -2929,13 +2929,16 @@
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Аутоматско откривање грешака</value>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Дозволите да Intelligent Terminal приступи вашој командној линији и аутоматски открива грешке. Доступно у PowerShell и Windows PowerShell.</value>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>Дозволите да Интелигентни Терминал приступи вашој командној линији и аутоматски открива грешке. Доступно у PowerShell, bash и WSL bash. </value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>Прикажи све подржане shell-ове</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>Аутоматски предлог исправки</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Дозволите да Intelligent Terminal шаље грешке вашем агенту ради аутоматског предлагања исправки.</value>
+    <value>Дозволите да Интелигентни Терминал шаље грешке вашем агенту ради аутоматског предлагања исправки.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -2575,13 +2575,16 @@
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Автоматичне виявлення помилок</value>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>Дозвольте Intelligent Terminal отримати доступ до оболонки та автоматично виявляти помилки. Доступно в PowerShell і Windows PowerShell.</value>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>Дозвольте Інтелектуальному Терміналу отримати доступ до оболонки та автоматично виявляти помилки. Доступно в PowerShell, bash і WSL bash. </value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>Переглянути всі підтримувані оболонки</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>Автоматична пропозиція виправлень</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>Дозвольте Intelligent Terminal надсилати помилки вашому агенту для автоматичної пропозиції виправлень.</value>
+    <value>Дозвольте Інтелектуальному Терміналу надсилати помилки вашому агенту для автоматичної пропозиції виправлень.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -2931,13 +2931,16 @@
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>自动错误检测</value>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>允许 Intelligent Terminal 访问你的 shell 并自动检测错误。适用于 PowerShell 和 Windows PowerShell。</value>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>允许智能终端访问你的 shell 并自动检测错误。适用于 PowerShell、bash 和 WSL bash。 </value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>查看所有受支持的 shell</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>自动错误建议</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>允许 Intelligent Terminal 将错误发送给你的代理以自动建议修复。</value>
+    <value>允许智能终端将错误发送给你的代理以自动建议修复。</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -2871,13 +2871,16 @@
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>自動錯誤偵測</value>
   </data>
-  <data name="AIAgents_AutoErrorDetectionCaption.Text" xml:space="preserve">
-    <value>允許 Intelligent Terminal 存取您的 shell 並自動偵測錯誤。適用於 PowerShell 和 Windows PowerShell。</value>
+  <data name="AIAgents_AutoErrorDetectionCaptionPrefix" xml:space="preserve">
+    <value>允許 智慧終端機 存取您的 shell 並自動偵測錯誤。適用於 PowerShell、bash 和 WSL bash。 </value>
+  </data>
+  <data name="AIAgents_AutoErrorDetectionCaptionLink" xml:space="preserve">
+    <value>檢視所有支援的 shell</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionTitle.Text" xml:space="preserve">
     <value>自動錯誤建議</value>
   </data>
   <data name="AIAgents_AutoErrorSuggestionCaption.Text" xml:space="preserve">
-    <value>允許 Intelligent Terminal 將錯誤傳送給您的代理程式以自動建議修正。</value>
+    <value>允許 智慧終端機 將錯誤傳送給您的代理程式以自動建議修正。</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary

Docs, the first-run experience (FRE), and Settings previously implied that shell integration / automatic error detection was **PowerShell-only**. It actually supports **PowerShell, bash, and WSL bash** today, and that list keeps growing — so we now name those three explicitly and point users to an aka.ms link for the full, authoritative list.

## Changes

### Docs — `doc/installing-dependencies.md`
- Renamed section 4 *"PowerShell shell integration"* → **"Shell integration"** (anchor `#4-shell-integration`).
- Added a **What's supported** matrix (PowerShell 7+, Windows PowerShell 5.1, bash/Git Bash, WSL bash = supported; `cmd.exe`, zsh/fish/Nushell, non-bash WSL = not yet) and subsections **4.1 PowerShell** (`#41-powershell`), **4.2 Bash (Git Bash)** (`#42-bash-git-bash`), **4.3 WSL bash** (`#43-wsl-bash`).
- Updated the table of contents and intro.

### FRE & Settings deep-links
- `AppActionHandlers.cpp`, `FreOverlay.cpp` (exec-policy) → `…#41-powershell`; `FreOverlay.cpp` (generic) & `FreOverlay.xaml` hint → `…#4-shell-integration` (also fixed a stale `#8-…` GitHub-blob link).
- Settings **auto-error-detection** caption now reads *"Available in PowerShell, bash, and WSL bash."* with an inline **"See all supported shells"** hyperlink to `https://aka.ms/intelligent-terminal-dependency#4-shell-integration` (XAML `Run`+`Hyperlink` split + `AIAgents.cpp` `RS_()` population).

### Localization
- Renamed the caption key and translated the new prefix/link strings across all locales (12 major + 3 pseudo + en-US).
- **Fixed a product-name localization bug:** the auto-error-detection and auto-error-suggestion captions kept "Intelligent Terminal" in English in translated values, inconsistent with the rest of each locale UI. The product name is now localized per locale (e.g. zh-CN 智能终端, de-DE Intelligentes Terminal, ru-RU/uk-UA in the correct dative case).

> [!NOTE]
> The `aka.ms/intelligent-terminal-dependency` redirect still needs registering on the aka.ms portal (pre-existing repo `TODO(IntelligentTerminal)`); the anchors are wired correctly for when it goes live.

## Validation
- All `.resw` edits preserve UTF-8 BOM and are XML-well-formed; locked tokens (`PowerShell`, `bash`, `WSL bash`) preserved.
- Doc anchors match the aka.ms/code fragments; no stale `powershell-shell-integration` references remain.
- Built Debug x64 and verified the Settings page renders the localized captions + working hyperlink.
