### PR TITLE
Add Ollama provider support

### DIFF
--- a/src/cascadia/inc/AgentRegistry.h
+++ b/src/cascadia/inc/AgentRegistry.h
@@ -37,22 +37,24 @@ namespace Microsoft::Terminal::Settings::Model::AgentRegistry
     // (claude via @agentclientprotocol/claude-agent-acp, codex via
     // @zed-industries/codex-acp).
     // Only these agents can be hosted in an agent pane.
-    inline constexpr std::array<BuiltinAgent, 4> BuiltinAcpAgents{ {
+    inline constexpr std::array<BuiltinAgent, 5> BuiltinAcpAgents{ {
         { L"copilot", L"GitHub Copilot" },
         { L"claude", L"Claude" },
         { L"codex", L"Codex" },
         { L"gemini", L"Gemini" },
+        { L"ollama", L"Ollama" },
     } };
 
     // Delegate agents. Invoked for `?<prompt>` background delegation and
     // similar flows. The set is broader than ACP because delegation doesn't
     // require an ACP-speaking agent — any CLI agent that accepts a prompt
     // as input works.
-    inline constexpr std::array<BuiltinAgent, 4> BuiltinDelegateAgents{ {
+    inline constexpr std::array<BuiltinAgent, 5> BuiltinDelegateAgents{ {
         { L"copilot", L"GitHub Copilot" },
         { L"claude", L"Claude" },
         { L"codex", L"Codex" },
         { L"gemini", L"Gemini" },
+        { L"ollama", L"Ollama" },
     } };
 
     // Return only agents whose IDs are permitted by GPO policy.

--- a/src/cascadia/inc/AgentRegistry.h
+++ b/src/cascadia/inc/AgentRegistry.h
@@ -37,12 +37,13 @@ namespace Microsoft::Terminal::Settings::Model::AgentRegistry
     // (claude via @agentclientprotocol/claude-agent-acp, codex via
     // @zed-industries/codex-acp).
     // Only these agents can be hosted in an agent pane.
-    inline constexpr std::array<BuiltinAgent, 5> BuiltinAcpAgents{ {
+    // Ollama is intentionally absent: it has no ACP adapter and cannot be
+    // hosted in an agent pane. It is delegate-only (see BuiltinDelegateAgents).
+    inline constexpr std::array<BuiltinAgent, 4> BuiltinAcpAgents{ {
         { L"copilot", L"GitHub Copilot" },
         { L"claude", L"Claude" },
         { L"codex", L"Codex" },
         { L"gemini", L"Gemini" },
-        { L"ollama", L"Ollama" },
     } };
 
     // Delegate agents. Invoked for `?<prompt>` background delegation and

--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -156,7 +156,7 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
     AgentProfile {
         id: "ollama",
         display_name: "Ollama",
-        exe_search_order: &[".exe", ".cmd"],
+        exe_search_order: &[".exe", ".cmd", ""],
         acp_flags: &[],
         acp_launch_command: "",
         acp_auth_flow: AcpAuthFlow::None,

--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -153,6 +153,22 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         resume_flag: "--resume",
         new_session_id_flag: Some("--session-id"),
     },
+    AgentProfile {
+        id: "ollama",
+        display_name: "Ollama",
+        exe_search_order: &[".exe", ".cmd"],
+        acp_flags: &[],
+        acp_launch_command: "",
+        acp_auth_flow: AcpAuthFlow::None,
+        delegate_prompt_flag: PromptFlag::Positional,
+        model_flags: &[],
+        install_hint: "Install Ollama from https://ollama.com",
+        install_url: "https://ollama.com",
+        auth_check_command: "",
+        auth_hint: "Install Ollama and ensure `ollama` is on PATH.",
+        resume_flag: "",
+        new_session_id_flag: None,
+    },
 ];
 
 pub const DEFAULT_PROFILE: AgentProfile = AgentProfile {
@@ -475,6 +491,12 @@ mod tests {
         assert_eq!(resolve_agent_id_from_cmd("copilot --acp --stdio"), "copilot");
         assert_eq!(resolve_agent_id_from_cmd("gemini --experimental-acp"), "gemini");
         assert_eq!(resolve_agent_id_from_cmd("claude --resume foo"), "claude");
+    }
+
+    #[test]
+    fn resolve_agent_id_from_cmd_recognises_ollama_as_a_known_delegate_agent() {
+        assert_eq!(resolve_agent_id_from_cmd("ollama"), "ollama");
+        assert_eq!(lookup_profile_by_id("ollama").display_name, "Ollama");
     }
 
     #[test]


### PR DESCRIPTION
Adds Ollama to the built-in ACP/delegate agent registry and covers recognition with a Rust regression test.