### PR TITLE
perf(wta): speed up session-view history scan (two-phase + per-CLI filtering)

### DIFF
--- a/doc/specs/per-cli-history-filtering.md
+++ b/doc/specs/per-cli-history-filtering.md
@@ -103,9 +103,11 @@ Dispatch on the filter:
 | `Some(Copilot)` / `Claude` / `Gemini` / `Codex` | that one CLI's loader |
 | `None` or `Some(Unknown(_))` (custom / unrecognized agent) | all four (current behavior) |
 
-`load_all()` is retained as a thin wrapper `load_for_cli(None)` for tests and
-the "scan everything" path. The two-phase scan internals (per-CLI cap by
-mtime, Class A skip) are unchanged.
+The "scan everything" path is `load_for_cli(None)`, reached via master when
+the agent is custom / unrecognized. The dispatch decision lives in a small
+testable helper, `cli_scan_flags`. (The old unparameterized `load_all()` is
+removed — every caller now passes a filter.) The two-phase scan internals
+(per-CLI cap by mtime, Class A skip) are unchanged.
 
 Master passes its already-resolved CLI:
 
@@ -124,8 +126,12 @@ The helper no longer scans history. Remove:
   (`main.rs` ACP TUI path) and the lazy calls from the `/sessions` open path,
 - `ensure_history_loaded` itself,
 - the `AppEvent::HistoricalSessionsLoaded` variant, its handler, and the
-  `merge_historical` call site. If `merge_historical` becomes unused, remove
-  it too (avoid dead-code warnings); keep it if a test still exercises it.
+  `merge_historical` call site. `merge_historical` is now used only by registry
+  tests (seeding Historical rows to exercise the still-live alive-join logic),
+  so it is gated `#[cfg(test)]`. The `HistoryLoadState` enum / field and the
+  unparameterized `load_all()` are removed; the loading-shimmer animation now
+  keys off `App::agents_view_awaiting_snapshot()` (open agents view + empty
+  placeholder snapshot + in-flight refetch) instead of the old scan state.
 
 The helper's `agent_sessions` registry continues to exist and is populated by
 live `apply(...)` events (SessionStarted hooks, new_session, pane events) and
@@ -188,15 +194,16 @@ cover it.
 
 ## Testing
 
-- `load_for_cli(Some(CliSource::Copilot))` returns only Copilot rows;
+- `cli_scan_flags(Some(CliSource::Copilot))` selects only the Copilot loader;
   `Some(Gemini)` only Gemini.
-- `load_for_cli(None)` equals `load_all()` (all four).
-- `load_for_cli(Some(CliSource::Unknown("custom:x".into())))` scans all four.
-- Helper-side: with an empty local registry, the agents view renders from the
-  master snapshot; Enter / delete / resume on snapshot rows still dispatch;
-  selection seeds on snapshot arrival.
+- `cli_scan_flags(None)` and `Some(CliSource::Unknown("custom:x"))` select all
+  four (the custom / unrecognized-agent path).
+- Helper-side: `App::agents_view_awaiting_snapshot()` is true only while the
+  agents view is open and waiting on its first `session/list` reply; the
+  existing snapshot tests already exercise the (now always empty) local
+  registry rendering from the master snapshot.
 - Existing two-phase / per-loader history tests are unaffected (they call
-  `load_copilot` etc. directly or `load_all`).
+  `load_copilot` etc. directly).
 
 ## Out of scope
 

--- a/doc/specs/per-cli-history-filtering.md
+++ b/doc/specs/per-cli-history-filtering.md
@@ -37,6 +37,11 @@ Three facts make most of that work wasteful:
 
 ## Background: how the session view gets its data
 
+> This section describes the data flow **before** this change, to establish
+> why the helper's local scan is redundant. The Design section below removes
+> the helper scan; afterward the helper's local registry holds only live
+> rows (no `load_all`).
+
 There are two stores in a helper:
 
 | Store | Populated by | Role |
@@ -108,6 +113,13 @@ the agent is custom / unrecognized. The dispatch decision lives in a small
 testable helper, `cli_scan_flags`. (The old unconditional `load_all()` is
 removed — every caller now passes a filter.) The two-phase scan internals
 (per-CLI cap by mtime, Class A skip) are unchanged.
+
+`MAX_PER_CLI` (= 50) is a *discovery-phase acquisition cap*, not a
+guaranteed post-filter row count: the cheap phase keeps the newest 50
+candidates, then the expensive phase drops any phantoms among them, so a
+CLI can finish with fewer than 50 rows. This is intentional — it bounds
+phase-2 content reads at 50 per CLI, and we deliberately do not back-fill
+from older candidates to refill to 50.
 
 Master passes its already-resolved CLI:
 

--- a/doc/specs/per-cli-history-filtering.md
+++ b/doc/specs/per-cli-history-filtering.md
@@ -29,7 +29,7 @@ Three facts make most of that work wasteful:
    `CliSource::from_agent_id(current_agent_id)`), so 3 of the 4 CLIs scanned
    are never shown.
 2. The view renders from **master's snapshot** (a `session/list` reply
-   refetched every time the view opens), **not** from the helper's local
+   issued fresh every time the view opens), **not** from the helper's local
    registry. The helper's local scan result is shadowed.
 3. Switching the agent in Settings **restarts** master + all helpers, so a
    fresh process re-scans automatically — no runtime "agent switched" signal
@@ -105,7 +105,7 @@ Dispatch on the filter:
 
 The "scan everything" path is `load_for_cli(None)`, reached via master when
 the agent is custom / unrecognized. The dispatch decision lives in a small
-testable helper, `cli_scan_flags`. (The old unparameterized `load_all()` is
+testable helper, `cli_scan_flags`. (The old unconditional `load_all()` is
 removed — every caller now passes a filter.) The two-phase scan internals
 (per-CLI cap by mtime, Class A skip) are unchanged.
 
@@ -129,7 +129,7 @@ The helper no longer scans history. Remove:
   `merge_historical` call site. `merge_historical` is now used only by registry
   tests (seeding Historical rows to exercise the still-live alive-join logic),
   so it is gated `#[cfg(test)]`. The `HistoryLoadState` enum / field and the
-  unparameterized `load_all()` are removed; the loading-shimmer animation now
+  unconditional `load_all()` are removed; the loading-shimmer animation now
   keys off `App::agents_view_awaiting_snapshot()` (open agents view + empty
   placeholder snapshot + in-flight refetch) instead of the old scan state.
 

--- a/doc/specs/per-cli-history-filtering.md
+++ b/doc/specs/per-cli-history-filtering.md
@@ -1,0 +1,205 @@
+# Per-CLI history filtering
+
+## Summary
+
+The agent **session management view** only ever displays sessions for the
+**currently configured agent CLI** (Copilot / Claude / Gemini / Codex). Yet
+both processes that scan on-disk session history —
+`wta-master` and every per-tab `wta-helper` — load **all four CLIs** every
+time. This spec narrows the history scan to the current CLI and removes the
+helper's redundant local scan entirely, so the whole WT process performs
+**one** filtered history scan (in master) instead of `N+1` full scans
+(`N` helpers + master).
+
+## Motivation
+
+`history_loader::load_all()` opens and parses every session transcript on
+disk for all four CLIs. After the two-phase optimization
+(`per-CLI cap by mtime, skip Class A`) this is ~940 ms on a populated
+machine; before it was ~3.5 s. That cost is paid:
+
+- **once per `wta-master`** at startup (seeds the registry), and
+- **once per `wta-helper`** — eagerly, at helper startup
+  (`ensure_history_loaded` → `load_all`), for **every pre-warmed tab**, even
+  tabs whose session view the user never opens.
+
+Three facts make most of that work wasteful:
+
+1. The view filters to the current CLI (`current_cli_filter()` =
+   `CliSource::from_agent_id(current_agent_id)`), so 3 of the 4 CLIs scanned
+   are never shown.
+2. The view renders from **master's snapshot** (a `session/list` reply
+   refetched every time the view opens), **not** from the helper's local
+   registry. The helper's local scan result is shadowed.
+3. Switching the agent in Settings **restarts** master + all helpers, so a
+   fresh process re-scans automatically — no runtime "agent switched" signal
+   exists or is needed.
+
+## Background: how the session view gets its data
+
+There are two stores in a helper:
+
+| Store | Populated by | Role |
+|---|---|---|
+| local registry `App::agent_sessions` | helper's own `load_all` (`HistoricalSessionsLoaded` → `merge_historical`) + live `apply(...)` events | fallback / live-session tracker |
+| per-tab `agents_view.snapshot` | master's `session/list` reply (`AgentsSnapshotLoaded`) | **the rendered source** |
+
+`agents_view::render` and `agents_rows_for_tab` use the snapshot when it is
+`Some`, and fall back to the local registry only when it is `None`
+(`app.rs` `agents_rows_for_tab`).
+
+Snapshot lifecycle:
+
+- **open view** (`open_agents_view_for_tab`) → sets `snapshot = Some(vec![])`
+  and fires a `session/list` refetch to master.
+- **master replies** → `snapshot = Some(rows)`.
+- **close view** → `snapshot = None` (but then `current_view != Agents`, so
+  the agents view is not rendered at all).
+- **refetch fails / times out** (`handle_agents_snapshot_failed`) → snapshot
+  is **left untouched** ("rendered rows stay on the last good data instead of
+  flashing empty").
+
+Consequence: whenever the agents view is on screen, `snapshot` is always
+`Some` (a loading placeholder, the last good rows, or fresh master rows). The
+local-registry `else` branch is effectively never rendered. The local scan
+therefore drives **display** for nothing; its only live effects are:
+
+- the instant-open cursor pre-selection (see *Consumer audit*), and
+- being the upgrade target for `apply_alive_session_join` (Historical → Live).
+
+Both are non-critical, because master's snapshot already carries liveness and
+seeds selection on arrival.
+
+### Why live / watcher sessions are unaffected
+
+Filtering the history scan only drops **historical** (on-disk, dead) rows of
+other CLIs. Live rows do not come from `load_all`:
+
+- Sessions created through master are all the current CLI (master spawns a
+  single agent CLI).
+- The hookless **watcher** discovers Class B shell sessions **machine-wide /
+  cross-CLI** (`master/mod.rs` "the file watcher sees session files
+  machine-wide"). Those are narrowed to the current CLI by the **view filter**
+  (`cli_filter` retain), not by `load_all`.
+
+So the existing view filter remains the mechanism that keeps live/watcher
+cross-CLI sessions out of the display. This spec does not touch it.
+
+## Design
+
+### 1. Master side — filter the authoritative scan (primary lever)
+
+Add a filtered entry point to `history_loader`:
+
+```rust
+/// Scan on-disk history for a single CLI, or all CLIs when `None`.
+pub fn load_for_cli(cli_filter: Option<&CliSource>) -> Vec<AgentSession>;
+```
+
+Dispatch on the filter:
+
+| `cli_filter` | scans |
+|---|---|
+| `Some(Copilot)` / `Claude` / `Gemini` / `Codex` | that one CLI's loader |
+| `None` or `Some(Unknown(_))` (custom / unrecognized agent) | all four (current behavior) |
+
+`load_all()` is retained as a thin wrapper `load_for_cli(None)` for tests and
+the "scan everything" path. The two-phase scan internals (per-CLI cap by
+mtime, Class A skip) are unchanged.
+
+Master passes its already-resolved CLI:
+
+- `master/mod.rs` history-seed task → `load_for_cli(inner.cli_source.as_ref())`
+  (`cli_source` is resolved once at startup from the `--agent` arg via
+  `resolve_agent_id_from_cmd` → `CliSource::from_agent_id`).
+
+Master's registry, its `sessions/changed` broadcasts, and the `session/list`
+snapshot the view renders are now scoped to the current CLI.
+
+### 2. Helper side — remove the redundant local scan
+
+The helper no longer scans history. Remove:
+
+- the eager `ensure_history_loaded()` calls at helper startup
+  (`main.rs` ACP TUI path) and the lazy calls from the `/sessions` open path,
+- `ensure_history_loaded` itself,
+- the `AppEvent::HistoricalSessionsLoaded` variant, its handler, and the
+  `merge_historical` call site. If `merge_historical` becomes unused, remove
+  it too (avoid dead-code warnings); keep it if a test still exercises it.
+
+The helper's `agent_sessions` registry continues to exist and is populated by
+live `apply(...)` events (SessionStarted hooks, new_session, pane events) and
+`apply_alive_session_join`. It now holds only **live** rows this helper learns
+about — used by pane lookups (`key_for_pane`, `origin_for_pane`). Display
+comes from master's snapshot.
+
+### 3. Re-load on agent switch — automatic
+
+Changing `acpAgent` in Settings runs
+`_AgentSettingsChanged → _RebuildAgentStack → SharedWta::Restart` (kill +
+respawn master with the new `--agent`) and tears down + re-warms all helper
+agent panes. The new master re-runs `load_for_cli` with the new CLI; helpers
+have no scan to redo. No runtime "switch" message is added.
+
+## Consumer audit (local registry with no historical rows)
+
+| Consumer | Behavior after removal |
+|---|---|
+| Display render (`agents_view::render`) | Safe — renders from master snapshot; local-registry branch was already unreachable while the view is visible. |
+| Enter / resume / delete dispatch | Safe — operate on `agents_rows_for_tab`, which uses the snapshot while the view is open. |
+| `key_for_pane` / `origin_for_pane` | Safe — live-only pane lookups, never depended on historical rows. |
+| Instant-open cursor pre-selection (`open_agents_view_for_tab`, the `rows_available` check) | Degrades gracefully — local registry is empty at that instant so no instant pre-select; `restore_agents_selection` seeds row 0 when master's snapshot arrives a moment later. Cosmetic. |
+| `apply_alive_session_join` | No-op without historical rows to upgrade; display liveness comes from the snapshot regardless. |
+| Optimistic resume flip on a dead historical row (`apply(resume_event)`) | Applies to a row not in the local registry → local no-op; real state arrives on the next snapshot refetch. Cosmetic. |
+| `wta sessions list --origin all` (asks master) | Now shows only the current CLI's history (master is filtered). Accepted — debug eye-of-god view narrows to the current agent. |
+
+## Decisions
+
+- **Custom / unrecognized agent** (`CliSource` resolves to `None`): scan all
+  four CLIs, matching the view's behavior when `current_cli_filter()` is
+  `None` (it shows all CLIs).
+- **`wta sessions list --origin all`** narrowing to the current CLI's history
+  is accepted; it reads master's (now filtered) registry. Live rows are
+  unaffected.
+- **Setup / FRE mode** (`current_agent_id` empty before an agent is picked):
+  not applicable to the helper scan anymore (the helper no longer scans);
+  master is launched with a concrete `--agent` so its filter is always
+  resolved.
+
+## Edge case: cold-open latency
+
+Master scans history asynchronously at startup (~520 ms filtered for Copilot,
+much less for other CLIs). If the user opens a session view before that scan
+completes, the first `session/list` reply returns only the live rows scanned
+so far; the loading shimmer shows until master finishes and broadcasts
+`sessions/changed`, which triggers a refetch that fills in the historicals.
+The window is small because master starts scanning at process startup, well
+before a user typically opens the view. No local helper scan is needed to
+cover it.
+
+## Performance
+
+| | Before | After |
+|---|---|---|
+| master history scan | all 4 CLIs (~940 ms) | 1 CLI (Copilot ~520 ms; Gemini ~50 ms) |
+| helper history scan | all 4 CLIs, **per pre-warmed tab**, eager | **none** |
+| total scans per WT process | `N` helpers + master, full | **1** (master), filtered |
+| master registry / broadcast / snapshot size | up to ~200 historical rows | up to ~50 (one CLI) |
+
+## Testing
+
+- `load_for_cli(Some(CliSource::Copilot))` returns only Copilot rows;
+  `Some(Gemini)` only Gemini.
+- `load_for_cli(None)` equals `load_all()` (all four).
+- `load_for_cli(Some(CliSource::Unknown("custom:x".into())))` scans all four.
+- Helper-side: with an empty local registry, the agents view renders from the
+  master snapshot; Enter / delete / resume on snapshot rows still dispatch;
+  selection seeds on snapshot arrival.
+- Existing two-phase / per-loader history tests are unaffected (they call
+  `load_copilot` etc. directly or `load_all`).
+
+## Out of scope
+
+- Changing the view's CLI filter or the MVP origin filter.
+- Any runtime (non-restart) agent-switch mechanism.
+- Reworking the watcher's machine-wide discovery.

--- a/tools/wta/src/agent_sessions.rs
+++ b/tools/wta/src/agent_sessions.rs
@@ -1130,7 +1130,14 @@ impl AgentSessionRegistry {
 
     /// Insert historical entries loaded from disk, skipping any whose key
     /// is already present (the live registry wins). Idempotent — safe to
-    /// call multiple times. Used at startup.
+    /// call multiple times.
+    ///
+    /// Test-only: production no longer scans on-disk history into the
+    /// helper's registry (the view renders from master's `session/list`
+    /// snapshot — see doc/specs/per-cli-history-filtering.md). Retained as a
+    /// setup helper for registry tests that seed Historical rows to exercise
+    /// the still-live alive-join / liveness logic.
+    #[cfg(test)]
     pub fn merge_historical(&mut self, loaded: Vec<AgentSession>) {
         for s in loaded {
             if self.sessions.contains_key(&s.key) {

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1275,13 +1275,6 @@ pub enum AppEvent {
     /// Posting via the main loop keeps `agent_sessions` access single-threaded
     /// and lets `tracing::*` calls emit on a stable thread.
     AgentSessionEvent(crate::agent_sessions::SessionEvent),
-    /// Historical agent sessions scanned off the main thread by a
-    /// `spawn_blocking` task wrapping `history_loader::load_all()`. Posted
-    /// instead of running the scan inline so a large `~/.copilot/session-state`
-    /// (hundreds of dirs, each with an `events.jsonl` to sniff) doesn't block
-    /// the LocalSet — which would otherwise stall the ACP client loop,
-    /// the first frame, and therefore the user-visible "connecting" state.
-    HistoricalSessionsLoaded(Vec<crate::agent_sessions::AgentSession>),
     /// Initial bootstrap of the alive-session mirror from master, in
     /// response to the helper's startup `session/list` request. The
     /// payload replaces any existing entries and flips `alive_loaded`
@@ -1300,18 +1293,10 @@ pub enum AppEvent {
     AliveSessionRemoved(agent_client_protocol::SessionId),
     /// Apply an "upgrade Historical/Ended → Live" join between the
     /// historical-row registry (`agent_sessions`) and the alive-session
-    /// mirror. Posted from either of two places:
-    ///
-    ///   * `AliveSnapshotLoaded` (master's bootstrap reply) — the
-    ///     handler converts each `SessionInfo` into a `(sid, pane)`
-    ///     pair, dispatches `AliveJoinUpgrade`, and lets the main
-    ///     loop apply it serialized w.r.t. other agent-sessions
-    ///     mutations.
-    ///   * `HistoricalSessionsLoaded` (background `history_loader::load_all`)
-    ///     — the handler spawns a one-shot async task to snapshot the
-    ///     current alive registry and posts this event so the join can
-    ///     happen even when the on-disk scan finishes after the alive
-    ///     bootstrap.
+    /// mirror. Posted from `AliveSnapshotLoaded` (master's bootstrap
+    /// reply): the handler converts each `SessionInfo` into a `(sid, pane)`
+    /// pair, dispatches `AliveJoinUpgrade`, and lets the main loop apply it
+    /// serialized w.r.t. other agent-sessions mutations.
     ///
     /// See [`crate::agent_sessions::AgentSessionRegistry::apply_alive_session_join`].
     AliveJoinUpgrade(Vec<(String, Option<String>)>),
@@ -1982,12 +1967,6 @@ pub struct App {
     /// session list itself is global; only the *picker view* (open state
     /// + selected row) lives per-tab on `TabSession`.
     pub agent_sessions: crate::agent_sessions::AgentSessionRegistry,
-    /// Tracks the lazy load of historical sessions. Flipped to Loading
-    /// on first session management-view open; flipped to Loaded when
-    /// `HistoricalSessionsLoaded` arrives. The agents_view reads this to
-    /// render a "Loading..." row instead of an empty list during the
-    /// scan.
-    pub history_load_state: HistoryLoadState,
     /// Whether the connected ACP agent advertised the `loadSession`
     /// capability in its initialize response. Used by the
     /// session management view's Shift+Enter handler to short-circuit
@@ -2103,31 +2082,9 @@ pub struct AgentsViewState {
     pub latest_request_id: Option<u64>,
 }
 
-/// Lazy-load tracking for the historical `agent_sessions` registry.
-///
-/// `history_loader::load_all()` scans `~/.copilot/session-state`,
-/// `~/.claude/projects`, `~/.gemini/tmp` and reads `events.jsonl`
-/// from each Copilot session to sniff the wta-internal autofix
-/// fingerprint. On a populated machine that's hundreds of file
-/// opens — observed ~10 seconds.
-///
-/// Doing that eagerly on every wta spawn (including every model
-/// switch, which kills the old wta and starts a new one) is wasted
-/// work — the data is only consumed by the agent session view. We
-/// defer the scan to the first Ctrl+Shift+/ press and cache the result for
-/// the rest of this wta's lifetime.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HistoryLoadState {
-    NotStarted,
-    Loading,
-    Loaded,
-}
-
-impl Default for HistoryLoadState {
-    fn default() -> Self {
-        HistoryLoadState::NotStarted
-    }
-}
+// (Historical-session load-state tracking was removed: the helper no longer
+// scans on-disk history; the session view renders from master's `session/list`
+// snapshot. See doc/specs/per-cli-history-filtering.md.)
 
 /// Reverse of `CliSource::from_agent_id` — yields the lowercase CLI id
 /// used by the command-synthesis template and dispatch routing.
@@ -2242,7 +2199,6 @@ impl App {
             tab_sessions,
             session_to_tab: HashMap::new(),
             agent_sessions: crate::agent_sessions::AgentSessionRegistry::new(),
-            history_load_state: HistoryLoadState::NotStarted,
             agent_supports_load_session: false,
             sessions_origin_filter: resolve_sessions_origin_filter(),
             install_request_tx: None,
@@ -3662,45 +3618,6 @@ impl App {
         self.event_tx = Some(tx);
     }
 
-    /// First-call: spawn a blocking task to scan `~/.copilot`, `~/.claude`,
-    /// `~/.gemini` for historical agent sessions and merge the result into
-    /// `agent_sessions` via `AppEvent::HistoricalSessionsLoaded`. Subsequent
-    /// calls are no-ops — the registry is cached for this wta's lifetime.
-    ///
-    /// Called eagerly from `run_acp_app` right after `set_event_tx` so the
-    /// scan starts overlapping with ACP startup and is usually done by the
-    /// time the user first opens the agent session view. Also called defensively
-    /// from the `/sessions` toggle in case startup raced ahead of
-    /// `set_event_tx` (Setup/FRE mode — `event_tx` not yet wired, so the
-    /// eager call early-returns and the Ctrl+Shift+/ press picks it up).
-    ///
-    /// Pre-eager-load this was strictly lazy because each wta restart
-    /// (model switch, new agent pane) re-pays the ~10s scan. The eager
-    /// kick is gated to the ACP TUI mode for the same reason — short-lived
-    /// modes (`delegate`, `mcp`, CLI helpers) never call this.
-    pub fn ensure_history_loaded(&mut self) {
-        if self.history_load_state != HistoryLoadState::NotStarted {
-            return;
-        }
-        let Some(tx) = self.event_tx.clone() else {
-            // No event channel yet — Setup mode at startup. The first Ctrl+Shift+/
-            // press post-FRE will retry. Safe to leave state as NotStarted.
-            return;
-        };
-        self.history_load_state = HistoryLoadState::Loading;
-        tokio::task::spawn_blocking(move || {
-            let scan_started = std::time::Instant::now();
-            let sessions = crate::history_loader::load_all();
-            tracing::info!(
-                target: "history_loader",
-                count = sessions.len(),
-                elapsed_ms = scan_started.elapsed().as_millis() as u64,
-                "background history scan complete (lazy)"
-            );
-            let _ = tx.send(AppEvent::HistoricalSessionsLoaded(sessions));
-        });
-    }
-
     fn spawn_login(&self, agent_id: &str, login_command: &str) {
         if let Some(ref tx) = self.event_tx {
             let tx = tx.clone();
@@ -4356,7 +4273,6 @@ impl App {
             AppEvent::LoginComplete { .. } => "login_complete",
             AppEvent::PreflightComplete(_) => "preflight_complete",
             AppEvent::AgentSessionEvent(_) => "agent_session_event",
-            AppEvent::HistoricalSessionsLoaded(_) => "historical_sessions_loaded",
             AppEvent::AliveSnapshotLoaded(_) => "alive_snapshot_loaded",
             AppEvent::AliveSessionAdded(_) => "alive_session_added",
             AppEvent::AliveSessionRemoved(_) => "alive_session_removed",
@@ -4402,11 +4318,11 @@ impl App {
                 }
                 // Setup-mode spinner: ticks while we're showing the wizard
                 // (e.g. spinning during a `winget install` background job).
-                // Also advance while the agents-view history scan is in
-                // flight so the "Loading" shimmer keeps animating.
+                // Also advance while the agents view waits on its first
+                // session/list snapshot so the "Loading" shimmer keeps animating.
                 if self.mode == AppMode::Setup
                     || self.mode == AppMode::Auth
-                    || self.history_load_state == HistoryLoadState::Loading
+                    || self.agents_view_awaiting_snapshot()
                     // Keep the connecting indicator animating during the
                     // pipe-connect → ACP init → session/new handshake so a cold
                     // start (which can run tens of seconds) doesn't look frozen
@@ -4976,55 +4892,6 @@ impl App {
                     crate::app::prune_phantom_session_if_ended(&mut self.agent_sessions, &k);
                 }
             }
-            AppEvent::HistoricalSessionsLoaded(sessions) => {
-                tracing::info!(
-                    target: "history_loader",
-                    count = sessions.len(),
-                    "historical sessions merged from background scan"
-                );
-                self.agent_sessions.merge_historical(sessions);
-                self.history_load_state = HistoryLoadState::Loaded;
-
-                // B-9: kick off an async snapshot of the alive mirror and
-                // post `AliveJoinUpgrade` so rows whose ACP session_id is
-                // still alive (e.g. this WTA process attached to an
-                // existing master in another WT window and never saw the
-                // SessionStarted hook) get upgraded Historical → Live.
-                // Skip until alive_loaded so we don't run the join over
-                // an empty registry on cold startup — the AliveSnapshotLoaded
-                // handler will fire its own join when bootstrap returns.
-                if self.alive_loaded.load(std::sync::atomic::Ordering::Relaxed) {
-                    if let Some(tx) = self.event_tx.clone() {
-                        let reg = std::sync::Arc::clone(&self.alive);
-                        tokio::task::spawn_local(async move {
-                            let items = reg.snapshot().await;
-                            let tuples: Vec<(String, Option<String>)> = items
-                                .into_iter()
-                                .map(|i| (i.session_id.0.to_string(), i.pane_session_id))
-                                .collect();
-                            let _ = tx.send(AppEvent::AliveJoinUpgrade(tuples));
-                        });
-                    }
-                }
-
-                // If the user is already on the agent session view (e.g. they were
-                // dropped there by --initial-view sessions, or they pressed
-                // Ctrl+Shift+/ before the scan finished) and nothing
-                // is selected yet, seed selection on row 0 so Enter
-                // activates immediately. Mirrors the session management enter-Agents path.
-                if self.current_tab().current_view == View::Agents
-                    && self.current_tab().agents_list_state.selected().is_none()
-                    && !self
-                        .agent_sessions
-                        .iter_sorted_with_filters(
-                            self.current_cli_filter().as_ref(),
-                            self.sessions_origin_filter,
-                        )
-                        .is_empty()
-                {
-                    self.current_tab_mut().agents_list_state.select(Some(0));
-                }
-            }
             AppEvent::AliveSnapshotLoaded(items) => {
                 let count = items.len();
                 tracing::info!(
@@ -5577,14 +5444,6 @@ impl App {
                                 if self.show_welcome_hint {
                                     self.show_welcome_hint = false;
                                     set_welcome_shown_in_state();
-                                }
-                                let entering_agents = self
-                                    .tab_sessions
-                                    .get(&target_tab)
-                                    .map(|t| t.current_view != View::Agents)
-                                    .unwrap_or(true);
-                                if entering_agents {
-                                    self.ensure_history_loaded();
                                 }
                                 self.open_agents_view_for_tab(target_tab.clone());
                             }
@@ -6146,10 +6005,6 @@ impl App {
             AppEvent::RevealTick => self.has_reveal_backlog(),
             AppEvent::AgentMessageChunk { .. } => true,
             AppEvent::DebugPipeMessage(_) => self.show_debug_panel,
-            // History only affects the agent session view; chat doesn't read it.
-            // A redraw is cheap enough that we don't bother gating on which
-            // view is showing — pay the one frame.
-            AppEvent::HistoricalSessionsLoaded(_) => true,
             _ => true,
         }
     }
@@ -6918,11 +6773,29 @@ impl App {
         self.current_tab_mut().scroll_to_bottom();
     }
 
+    /// True while the open agents view is waiting on its first `session/list`
+    /// reply from master — the placeholder snapshot is still the empty Vec
+    /// primed by `open_agents_view_for_tab` and a refetch is in flight. Drives
+    /// the loading-shimmer animation while the first snapshot is in flight.
+    fn agents_view_awaiting_snapshot(&self) -> bool {
+        let tab = self.current_tab();
+        if tab.current_view != View::Agents {
+            return false;
+        }
+        tab.agents_view.refetch_in_flight
+            && tab
+                .agents_view
+                .snapshot
+                .as_deref()
+                .map(|s| s.is_empty())
+                .unwrap_or(false)
+    }
+
     fn has_activity_indicator(&self) -> bool {
         if self.mode == AppMode::Setup || self.mode == AppMode::Auth {
             return true; // spinner always ticks in setup/auth mode
         }
-        if self.history_load_state == HistoryLoadState::Loading {
+        if self.agents_view_awaiting_snapshot() {
             return true; // agents-view "Loading" shimmer
         }
         let tab = self.current_tab();
@@ -7303,10 +7176,6 @@ impl App {
         // Per-tab — only flips the active tab's view state.
         let tab_id = self.active_tab_key().to_string();
         self.open_agents_view_for_tab(tab_id);
-        // session management path also kicks the lazy history scan here. Without this,
-        // /sessions left the registry empty and rendered a blank view
-        // forever (state stuck at NotStarted, no Loading row, no rows).
-        self.ensure_history_loaded();
         self.project_active_tab_state();
     }
 
@@ -11403,6 +11272,36 @@ mod tests {
             app.current_tab().agents_view.refetch_in_flight,
             "stale failure must not clear the fresh in-flight gate"
         );
+    }
+
+    /// The loading-shimmer signal: true only while the agents view is open
+    /// and waiting on its first `session/list` reply (empty placeholder
+    /// snapshot + in-flight refetch). Replaces the removed on-disk-scan
+    /// `HistoryLoadState::Loading` signal.
+    #[test]
+    fn agents_view_awaiting_snapshot_tracks_first_session_list() {
+        let (mut app, _master_rx) = test_app_with_master_rx();
+        // Chat view → never awaiting (the shimmer is agents-view only).
+        assert!(!app.agents_view_awaiting_snapshot());
+
+        // Opening the agents view primes an empty placeholder snapshot and an
+        // in-flight refetch — exactly the loading-shimmer window.
+        app.open_agents_view_for_tab(DEFAULT_TAB_ID.to_string());
+        assert!(
+            app.agents_view_awaiting_snapshot(),
+            "awaiting the first session/list snapshot right after open"
+        );
+
+        // A non-empty snapshot (master replied with rows) ends the awaiting
+        // state even while a follow-up refetch is in flight.
+        app.current_tab_mut().agents_view.snapshot = Some(vec![session_info_for_test("a")]);
+        assert!(!app.agents_view_awaiting_snapshot());
+
+        // An empty reply with the refetch finished is the genuine empty
+        // state, not loading.
+        app.current_tab_mut().agents_view.snapshot = Some(Vec::new());
+        app.current_tab_mut().agents_view.refetch_in_flight = false;
+        assert!(!app.agents_view_awaiting_snapshot());
     }
 
     fn session_info_for_test(id: &str) -> crate::session_registry::SessionInfo {

--- a/tools/wta/src/history_loader.rs
+++ b/tools/wta/src/history_loader.rs
@@ -68,6 +68,10 @@ use std::time::SystemTime;
 
 use crate::agent_sessions::{AgentSession, AgentStatus, CliSource};
 
+/// Per-CLI discovery-phase acquisition cap: at most this many newest
+/// candidates survive `select_top_candidates` into the expensive content
+/// parse. It bounds phase-2 IO, so it is a pre-filter threshold — not a
+/// guaranteed post-filter row count. See `select_top_candidates`.
 const MAX_PER_CLI: usize = 50;
 const TITLE_TAIL_BYTES: u64 = 64 * 1024;
 
@@ -525,6 +529,15 @@ struct Candidate {
 /// keep at most `n`. This is the cheap pre-filter that lets the expensive
 /// content parse touch only the most-recent `n` shell-pane sessions per
 /// CLI instead of every file on disk.
+///
+/// `n` is a *discovery-phase acquisition cap*, not a guaranteed result
+/// count. The caller's phase-2 content filter — which drops phantom
+/// sessions that hold no real turn — runs *after* this truncation, so the
+/// final row count can be fewer than `n` when some of the newest `n`
+/// candidates turn out to be phantoms. That is intentional: keeping the
+/// truncation ahead of the content read bounds phase-2 at `n` content
+/// reads per CLI. We deliberately do not back-fill from older candidates
+/// to top the result back up to `n`.
 fn select_top_candidates(
     mut candidates: Vec<Candidate>,
     agent_pane_index: &HashSet<String>,
@@ -1823,10 +1836,13 @@ mod tests {
         assert_eq!(s.title, "Refactor parser");
         assert_eq!(s.cwd, PathBuf::from("C:\\Users\\me\\proj"));
         assert_eq!(s.status, AgentStatus::Historical);
-        // `load_copilot` itself never consults the agent-pane index — the
-        // join is layered on top by `load_all`. So scanner output should
-        // always default to Unknown regardless of any index that may exist
-        // in the host's real %LOCALAPPDATA%.
+        // `load_copilot` is the index-free test shim
+        // (`load_copilot_indexed(.., &empty_index)`): the loader never
+        // consults the agent-pane index itself. The real scan threads the
+        // index through `select_top_candidates`, which *skips* Class A
+        // candidates up front rather than stamping origin afterward. So
+        // scanner output here always defaults to Unknown regardless of any
+        // index that may exist in the host's real %LOCALAPPDATA%.
         assert_eq!(s.origin, crate::agent_sessions::SessionOrigin::Unknown);
         let _ = fs::remove_dir_all(&home);
     }

--- a/tools/wta/src/history_loader.rs
+++ b/tools/wta/src/history_loader.rs
@@ -82,146 +82,10 @@ const TITLE_TAIL_BYTES: u64 = 64 * 1024;
 /// case (treated as phantom — conservative but safe).
 const CLASSIFY_SCAN_BYTES_CAP: u64 = 8 * 1024 * 1024;
 
-// ─── Profiling instrumentation (diagnostic) ─────────────────────────────
-//
-// Temporary instrumentation to measure where `load_all` spends its time:
-// reading + parsing file *content* (the work a two-phase "filter by a
-// cheap time signal, then read only the survivors" optimization would
-// eliminate) versus directory traversal + `stat`. Every content-reading
-// call site is wrapped in `prof_content`; the per-thread accumulator is
-// sampled around each per-CLI loader in `load_all_profiled`.
-// "traversal/stat" is derived as `total - content`, so it also absorbs
-// the (negligible) sort/push cost.
-
-thread_local! {
-    static PROF_CONTENT_NS: std::cell::Cell<u128> = const { std::cell::Cell::new(0) };
-    static PROF_CONTENT_CALLS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
-}
-
-/// Time `f` (a file content read + parse) and add it to the per-thread
-/// content-IO accumulator. Returns `f`'s result unchanged.
-fn prof_content<T>(f: impl FnOnce() -> T) -> T {
-    let started = std::time::Instant::now();
-    let out = f();
-    let elapsed = started.elapsed().as_nanos();
-    PROF_CONTENT_NS.with(|c| c.set(c.get().saturating_add(elapsed)));
-    PROF_CONTENT_CALLS.with(|c| c.set(c.get() + 1));
-    out
-}
-
-fn prof_content_snapshot() -> (u128, u64) {
-    (
-        PROF_CONTENT_NS.with(|c| c.get()),
-        PROF_CONTENT_CALLS.with(|c| c.get()),
-    )
-}
-
-/// Per-CLI timing slice produced by [`load_all_profiled`].
-#[derive(Default, Clone)]
-pub(crate) struct CliTiming {
-    pub total: std::time::Duration,
-    pub content: std::time::Duration,
-    pub content_calls: u64,
-    pub rows: usize,
-}
-
-impl CliTiming {
-    /// Time spent on directory traversal + `stat` (everything that is not
-    /// reading file content), derived so it also absorbs sort/push cost.
-    fn traversal_stat(&self) -> std::time::Duration {
-        self.total.saturating_sub(self.content)
-    }
-}
-
-impl std::fmt::Debug for CliTiming {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "rows={} total={:.1}ms content={:.1}ms({} reads) traversal_stat={:.1}ms",
-            self.rows,
-            self.total.as_secs_f64() * 1000.0,
-            self.content.as_secs_f64() * 1000.0,
-            self.content_calls,
-            self.traversal_stat().as_secs_f64() * 1000.0,
-        )
-    }
-}
-
-/// Whole-scan timing breakdown produced by [`load_all_profiled`].
-#[derive(Default)]
-pub(crate) struct LoadProfile {
-    pub total: std::time::Duration,
-    pub copilot: CliTiming,
-    pub claude: CliTiming,
-    pub gemini: CliTiming,
-    pub codex: CliTiming,
-}
-
-impl LoadProfile {
-    fn content(&self) -> std::time::Duration {
-        self.copilot.content + self.claude.content + self.gemini.content + self.codex.content
-    }
-
-    fn content_calls(&self) -> u64 {
-        self.copilot.content_calls
-            + self.claude.content_calls
-            + self.gemini.content_calls
-            + self.codex.content_calls
-    }
-
-    fn traversal_stat(&self) -> std::time::Duration {
-        self.total.saturating_sub(self.content())
-    }
-}
-
-/// Run one per-CLI loader, capturing its wall-clock total and the slice of
-/// that spent reading file content (via the `prof_content` accumulator).
-fn run_cli_profiled(
-    loader: impl FnOnce() -> Vec<AgentSession>,
-) -> (Vec<AgentSession>, CliTiming) {
-    let (content_ns_before, content_calls_before) = prof_content_snapshot();
-    let started = std::time::Instant::now();
-    let rows = loader();
-    let total = started.elapsed();
-    let (content_ns_after, content_calls_after) = prof_content_snapshot();
-    let content_ns = content_ns_after.saturating_sub(content_ns_before);
-    let timing = CliTiming {
-        total,
-        content: std::time::Duration::from_nanos(content_ns as u64),
-        content_calls: content_calls_after.saturating_sub(content_calls_before),
-        rows: rows.len(),
-    };
-    (rows, timing)
-}
-
 pub fn load_all() -> Vec<AgentSession> {
-    let (sessions, profile) = load_all_profiled();
-    tracing::info!(
-        target: "history_loader",
-        total_ms = profile.total.as_secs_f64() * 1000.0,
-        content_ms = profile.content().as_secs_f64() * 1000.0,
-        content_reads = profile.content_calls(),
-        traversal_stat_ms = profile.traversal_stat().as_secs_f64() * 1000.0,
-        copilot = ?profile.copilot,
-        claude = ?profile.claude,
-        gemini = ?profile.gemini,
-        codex = ?profile.codex,
-        "load_all timing distribution: content-read vs traversal/stat"
-    );
-    sessions
-}
-
-/// [`load_all`] plus a [`LoadProfile`] breaking down where the scan spent
-/// its time. Kept separate so the profiling test and the production
-/// `tracing` line share one measured code path.
-pub(crate) fn load_all_profiled() -> (Vec<AgentSession>, LoadProfile) {
-    let mut out = Vec::new();
-    let mut profile = LoadProfile::default();
     let scan_started = std::time::Instant::now();
-    let Some(home) = home_dir() else {
-        profile.total = scan_started.elapsed();
-        return (out, profile);
-    };
+    let mut out = Vec::new();
+    let Some(home) = home_dir() else { return out };
 
     // Load the agent-pane (Class A) index once. Each per-CLI loader uses it
     // to skip WTA-created agent-pane sessions in its cheap discovery phase,
@@ -232,27 +96,19 @@ pub(crate) fn load_all_profiled() -> (Vec<AgentSession>, LoadProfile) {
     // off Gemini's many seeded-prompt agent-pane phantoms.
     let agent_pane_index = crate::agent_pane_origin::load_default_set();
 
-    let (copilot, copilot_timing) =
-        run_cli_profiled(|| load_copilot_indexed(&home, &agent_pane_index));
-    let (claude, claude_timing) =
-        run_cli_profiled(|| load_claude_indexed(&home, &agent_pane_index));
-    let (gemini, gemini_timing) =
-        run_cli_profiled(|| load_gemini_indexed(&home, &agent_pane_index));
-    let (codex, codex_timing) =
-        run_cli_profiled(|| load_codex_indexed(&home, &agent_pane_index));
-    profile.copilot = copilot_timing;
-    profile.claude = claude_timing;
-    profile.gemini = gemini_timing;
-    profile.codex = codex_timing;
-
     // Each loader already caps at MAX_PER_CLI; take_n is a defensive no-op.
-    out.extend(take_n(copilot, MAX_PER_CLI));
-    out.extend(take_n(claude, MAX_PER_CLI));
-    out.extend(take_n(gemini, MAX_PER_CLI));
-    out.extend(take_n(codex, MAX_PER_CLI));
+    out.extend(take_n(load_copilot_indexed(&home, &agent_pane_index), MAX_PER_CLI));
+    out.extend(take_n(load_claude_indexed(&home, &agent_pane_index), MAX_PER_CLI));
+    out.extend(take_n(load_gemini_indexed(&home, &agent_pane_index), MAX_PER_CLI));
+    out.extend(take_n(load_codex_indexed(&home, &agent_pane_index), MAX_PER_CLI));
 
-    profile.total = scan_started.elapsed();
-    (out, profile)
+    tracing::info!(
+        target: "history_loader",
+        total_ms = scan_started.elapsed().as_secs_f64() * 1000.0,
+        rows = out.len(),
+        "history scan complete"
+    );
+    out
 }
 
 /// Best-effort title lookup for a single live session. Reads the same
@@ -717,7 +573,7 @@ fn load_copilot_indexed(home: &Path, agent_pane_index: &HashSet<String>) -> Vec<
         let started_at = workspace.metadata()
             .and_then(|m| m.modified()).ok()
             .unwrap_or(c.sort_time);
-        let yaml = prof_content(|| fs::read_to_string(&workspace)).unwrap_or_default();
+        let yaml = fs::read_to_string(&workspace).unwrap_or_default();
         let cwd = parse_simple_yaml(&yaml, "cwd")
             .map(PathBuf::from)
             .unwrap_or_default();
@@ -796,7 +652,7 @@ fn load_claude_indexed(home: &Path, agent_pane_index: &HashSet<String>) -> Vec<A
         // <id>` rejects it with `No conversation found with session ID:
         // <id>`. Mirror the Copilot ghost-session filter so these rows never
         // appear in the session management view, where Enter would dead-end.
-        if !prof_content(|| claude_session_has_real_content(&path)) { continue; }
+        if !claude_session_has_real_content(&path) { continue; }
         // Claude's directory-name encoding (`\` -> `-`) is lossy: paths whose
         // segments contain `-` can't be recovered from the directory name
         // alone. Use it only as a fallback — prefer the per-record `cwd`
@@ -806,9 +662,9 @@ fn load_claude_indexed(home: &Path, agent_pane_index: &HashSet<String>) -> Vec<A
             .and_then(|n| n.to_str())
             .map(decode_claude_cwd)
             .unwrap_or_default();
-        let title = prof_content(|| first_user_text_jsonl(&path, ClaudeOrGemini::Claude))
+        let title = first_user_text_jsonl(&path, ClaudeOrGemini::Claude)
             .unwrap_or_else(|| short_id(&c.id, "claude"));
-        let cwd = prof_content(|| read_cwd_from_claude_jsonl(&path)).unwrap_or(cwd_fallback);
+        let cwd = read_cwd_from_claude_jsonl(&path).unwrap_or(cwd_fallback);
 
         out.push(AgentSession {
             key:               c.id,
@@ -862,7 +718,7 @@ fn load_gemini_indexed(home: &Path, agent_pane_index: &HashSet<String>) -> Vec<A
             // A JSONL with content must have a resolvable `sessionId` in its
             // header; if we can't parse it, skip rather than synthesise an
             // un-resumable key (Enter on such rows used to silently no-op).
-            let Some(sid) = prof_content(|| gemini_session_id_from_header(&path)) else { continue; };
+            let Some(sid) = gemini_session_id_from_header(&path) else { continue; };
             let sort_time = path.metadata().and_then(|m| m.modified()).ok()
                 .unwrap_or(SystemTime::UNIX_EPOCH);
             candidates.push(Candidate { id: sid, sort_time, path, cwd: None });
@@ -878,7 +734,7 @@ fn load_gemini_indexed(home: &Path, agent_pane_index: &HashSet<String>) -> Vec<A
         // exchanging a turn leaves a JSONL containing only header line(s) —
         // `gemini --resume <id>` would reject it. Mirrors the Claude and
         // Copilot loader-side filters.
-        if !prof_content(|| gemini_jsonl_has_real_content(&path)) { continue; }
+        if !gemini_jsonl_has_real_content(&path) { continue; }
         // cwd: `~/.gemini/tmp/<slug>/chats/session-*.jsonl` → look up <slug>.
         let cwd = path.parent()
             .and_then(|p| p.parent())
@@ -886,7 +742,7 @@ fn load_gemini_indexed(home: &Path, agent_pane_index: &HashSet<String>) -> Vec<A
             .and_then(|n| n.to_str())
             .and_then(|slug| cwd_lookup.get(slug).cloned())
             .unwrap_or_default();
-        let title = prof_content(|| first_user_text_jsonl(&path, ClaudeOrGemini::Gemini))
+        let title = first_user_text_jsonl(&path, ClaudeOrGemini::Gemini)
             .unwrap_or_else(|| short_id(&c.id, "gemini"));
 
         out.push(AgentSession {
@@ -959,7 +815,7 @@ fn load_codex_indexed(home: &Path, agent_pane_index: &HashSet<String>) -> Vec<Ag
                     let path = f.path();
                     let Some(name) = path.file_name().and_then(|s| s.to_str()) else { continue };
                     if !name.starts_with("rollout-") || !name.ends_with(".jsonl") { continue; }
-                    let Some(meta) = prof_content(|| read_codex_session_meta(&path)) else { continue; };
+                    let Some(meta) = read_codex_session_meta(&path) else { continue; };
                     // Skip Codex internal multi-agent subagent forks: they get
                     // their own rollout file but inherit the parent's history
                     // (same title) and are not user-facing sessions.
@@ -983,8 +839,8 @@ fn load_codex_indexed(home: &Path, agent_pane_index: &HashSet<String>) -> Vec<Ag
     let mut out = Vec::new();
     for c in select_top_candidates(candidates, agent_pane_index, MAX_PER_CLI) {
         let path = c.path;
-        if !prof_content(|| codex_session_has_real_content(&path)) { continue; }
-        let title = prof_content(|| codex_title_from_file(&path))
+        if !codex_session_has_real_content(&path) { continue; }
+        let title = codex_title_from_file(&path)
             .unwrap_or_else(|| short_id(&c.id, "codex"));
         let cwd = c.cwd.unwrap_or_default();
         out.push(AgentSession {
@@ -1755,39 +1611,6 @@ fn truncate_chars(s: &str, n: usize) -> String {
 mod tests {
     use super::*;
     use std::io::Write;
-
-    /// Diagnostic profiling (run manually): prints where `load_all` spends
-    /// its time against the *real* user home, so we can see the
-    /// content-read vs traversal/stat split before/after the two-phase
-    /// optimization.
-    ///
-    /// Ignored by default — it reads the real `~/.copilot`, `~/.claude`,
-    /// `~/.gemini`, `~/.codex`, and is meaningless on an empty CI home.
-    /// Run with:
-    ///   cargo test --manifest-path tools/wta/Cargo.toml \
-    ///       profile_load_all_distribution -- --ignored --nocapture
-    #[test]
-    #[ignore = "diagnostic: profiles load_all against the real home; run with --ignored --nocapture"]
-    fn profile_load_all_distribution() {
-        let (sessions, profile) = load_all_profiled();
-        eprintln!("\n=== load_all() timing distribution (real home) ===");
-        eprintln!("rows returned : {}", sessions.len());
-        eprintln!("TOTAL         : {:.1} ms", profile.total.as_secs_f64() * 1000.0);
-        eprintln!(
-            "  content read : {:.1} ms ({} reads)",
-            profile.content().as_secs_f64() * 1000.0,
-            profile.content_calls(),
-        );
-        eprintln!(
-            "  traversal/stat: {:.1} ms",
-            profile.traversal_stat().as_secs_f64() * 1000.0,
-        );
-        eprintln!("per-CLI (rows / total / content / traversal+stat):");
-        eprintln!("  copilot: {:?}", profile.copilot);
-        eprintln!("  claude : {:?}", profile.claude);
-        eprintln!("  gemini : {:?}", profile.gemini);
-        eprintln!("  codex  : {:?}", profile.codex);
-    }
 
     fn tmp_root(label: &str) -> PathBuf {
         let mut p = std::env::temp_dir();

--- a/tools/wta/src/history_loader.rs
+++ b/tools/wta/src/history_loader.rs
@@ -102,7 +102,11 @@ pub fn load_all() -> Vec<AgentSession> {
     out.extend(take_n(load_gemini_indexed(&home, &agent_pane_index), MAX_PER_CLI));
     out.extend(take_n(load_codex_indexed(&home, &agent_pane_index), MAX_PER_CLI));
 
-    tracing::info!(
+    // Single low-overhead timing line for this scan. Kept at debug: the
+    // two callers (`App::ensure_history_loaded`, master startup) already
+    // emit an info-level scan-complete with `elapsed_ms`, so info here
+    // would just duplicate that on every scan in release builds.
+    tracing::debug!(
         target: "history_loader",
         total_ms = scan_started.elapsed().as_secs_f64() * 1000.0,
         rows = out.len(),
@@ -2466,13 +2470,13 @@ mod tests {
         let mut index = HashSet::new();
         index.insert("class-a".to_string());
 
-        let cands = vec![
+        let candidates = vec![
             mk("old", 100),
             mk("class-a", 999), // newest, but Class A → must be dropped
             mk("new", 300),
             mk("mid", 200),
         ];
-        let top = select_top_candidates(cands, &index, 2);
+        let top = select_top_candidates(candidates, &index, 2);
         // Class A dropped, remaining sorted newest-first, truncated to 2.
         assert_eq!(
             top.iter().map(|c| c.id.as_str()).collect::<Vec<_>>(),
@@ -2482,7 +2486,7 @@ mod tests {
 
     #[test]
     fn load_copilot_indexed_skips_agent_pane_sessions() {
-        let home = tmp_root("copilot-classa");
+        let home = tmp_root("copilot-class-a");
         let base = home.join(".copilot").join("session-state");
         for sid in ["shell-1", "agent-pane-1"] {
             let d = base.join(sid);

--- a/tools/wta/src/history_loader.rs
+++ b/tools/wta/src/history_loader.rs
@@ -82,7 +82,27 @@ const TITLE_TAIL_BYTES: u64 = 64 * 1024;
 /// case (treated as phantom — conservative but safe).
 const CLASSIFY_SCAN_BYTES_CAP: u64 = 8 * 1024 * 1024;
 
-pub fn load_all() -> Vec<AgentSession> {
+/// Decide which per-CLI loaders to run for a given filter.
+///
+/// The session management view only ever shows the current agent's CLI, so
+/// callers that know their CLI pass it to avoid scanning (and parsing) the
+/// other three CLIs' transcripts. `None` — or a custom / unrecognized agent
+/// (`CliSource::Unknown`) — scans everything, matching the view, which shows
+/// all CLIs when `current_cli_filter()` is `None`.
+fn cli_scan_flags(cli_filter: Option<&CliSource>) -> (bool, bool, bool, bool) {
+    match cli_filter {
+        Some(CliSource::Copilot) => (true, false, false, false),
+        Some(CliSource::Claude) => (false, true, false, false),
+        Some(CliSource::Gemini) => (false, false, true, false),
+        Some(CliSource::Codex) => (false, false, false, true),
+        None | Some(CliSource::Unknown(_)) => (true, true, true, true),
+    }
+}
+
+/// Scan on-disk session history, restricted to a single CLI when
+/// `cli_filter` is `Some(known)`. See [`cli_scan_flags`] for the dispatch
+/// rules (custom / unknown agents scan all four).
+pub fn load_for_cli(cli_filter: Option<&CliSource>) -> Vec<AgentSession> {
     let scan_started = std::time::Instant::now();
     let mut out = Vec::new();
     let Some(home) = home_dir() else { return out };
@@ -97,17 +117,26 @@ pub fn load_all() -> Vec<AgentSession> {
     let agent_pane_index = crate::agent_pane_origin::load_default_set();
 
     // Each loader already caps at MAX_PER_CLI; take_n is a defensive no-op.
-    out.extend(take_n(load_copilot_indexed(&home, &agent_pane_index), MAX_PER_CLI));
-    out.extend(take_n(load_claude_indexed(&home, &agent_pane_index), MAX_PER_CLI));
-    out.extend(take_n(load_gemini_indexed(&home, &agent_pane_index), MAX_PER_CLI));
-    out.extend(take_n(load_codex_indexed(&home, &agent_pane_index), MAX_PER_CLI));
+    let (cop, cla, gem, cod) = cli_scan_flags(cli_filter);
+    if cop {
+        out.extend(take_n(load_copilot_indexed(&home, &agent_pane_index), MAX_PER_CLI));
+    }
+    if cla {
+        out.extend(take_n(load_claude_indexed(&home, &agent_pane_index), MAX_PER_CLI));
+    }
+    if gem {
+        out.extend(take_n(load_gemini_indexed(&home, &agent_pane_index), MAX_PER_CLI));
+    }
+    if cod {
+        out.extend(take_n(load_codex_indexed(&home, &agent_pane_index), MAX_PER_CLI));
+    }
 
     // Single low-overhead timing line for this scan. Kept at debug: the
-    // two callers (`App::ensure_history_loaded`, master startup) already
-    // emit an info-level scan-complete with `elapsed_ms`, so info here
-    // would just duplicate that on every scan in release builds.
+    // master startup caller already emits an info-level scan-complete with
+    // `elapsed_ms`, so info here would just duplicate that in release builds.
     tracing::debug!(
         target: "history_loader",
+        cli = ?cli_filter,
         total_ms = scan_started.elapsed().as_secs_f64() * 1000.0,
         rows = out.len(),
         "history scan complete"
@@ -2481,6 +2510,26 @@ mod tests {
         assert_eq!(
             top.iter().map(|c| c.id.as_str()).collect::<Vec<_>>(),
             ["new", "mid"]
+        );
+    }
+
+    #[test]
+    fn cli_scan_flags_selects_one_loader_per_known_cli() {
+        assert_eq!(cli_scan_flags(Some(&CliSource::Copilot)), (true, false, false, false));
+        assert_eq!(cli_scan_flags(Some(&CliSource::Claude)), (false, true, false, false));
+        assert_eq!(cli_scan_flags(Some(&CliSource::Gemini)), (false, false, true, false));
+        assert_eq!(cli_scan_flags(Some(&CliSource::Codex)), (false, false, false, true));
+    }
+
+    #[test]
+    fn cli_scan_flags_scans_all_for_none_or_custom_agent() {
+        // None (no resolvable CLI) and a custom/unknown agent both scan all
+        // four — matching the view, which shows every CLI when the
+        // current_cli_filter() is None.
+        assert_eq!(cli_scan_flags(None), (true, true, true, true));
+        assert_eq!(
+            cli_scan_flags(Some(&CliSource::Unknown("custom:my-agent".to_string()))),
+            (true, true, true, true)
         );
     }
 

--- a/tools/wta/src/history_loader.rs
+++ b/tools/wta/src/history_loader.rs
@@ -8,7 +8,7 @@
 //   Copilot:  ~/.copilot/session-state/<UUID>/{workspace.yaml,events.jsonl}
 //             - session id   = directory name
 //             - cwd          = workspace.yaml `cwd:` field
-//             - title        = workspace.yaml `summary:` (fallback `name:`)
+//             - title        = workspace.yaml `name:` (legacy fallback `summary:`)
 //             - last_activity= events.jsonl mtime (fallback workspace.yaml mtime)
 //             - in-use marker= inuse.<PID>.lock files (skip those)
 //
@@ -159,7 +159,7 @@ pub fn load_for_cli(cli_filter: Option<&CliSource>) -> Vec<AgentSession> {
 /// Best-effort title lookup for a single live session. Reads the same
 /// per-CLI on-disk artefacts that `load_all` scans, but only for the
 /// specific `key`. Used to upgrade synthetic titles (cwd basename) into
-/// real ones (workspace.yaml summary / first user prompt) once the CLI
+/// real ones (workspace.yaml name / first user prompt) once the CLI
 /// has had a chance to write that data — typically a few seconds after
 /// the first hook event arrives. Returns `None` if no usable title is
 /// on disk (caller keeps whatever synthetic title it had).
@@ -191,8 +191,11 @@ fn copilot_title_for_key(home: &Path, key: &str) -> Option<String> {
     let dir = home.join(".copilot").join("session-state").join(key);
     let workspace = dir.join("workspace.yaml");
     let yaml = fs::read_to_string(&workspace).ok()?;
-    parse_simple_yaml(&yaml, "summary").filter(|s| !s.is_empty())
-        .or_else(|| parse_simple_yaml(&yaml, "name").filter(|s| !s.is_empty()))
+    // Copilot writes the session title to `name`. `summary` is a removed
+    // legacy field kept only as a fallback for very old sessions that may
+    // still carry it; current workspace.yaml files have only `name`.
+    parse_simple_yaml(&yaml, "name").filter(|s| !s.is_empty())
+        .or_else(|| parse_simple_yaml(&yaml, "summary").filter(|s| !s.is_empty()))
 }
 
 fn claude_title_for_key(home: &Path, key: &str) -> Option<String> {
@@ -634,9 +637,12 @@ fn load_copilot_indexed(home: &Path, agent_pane_index: &HashSet<String>) -> Vec<
         let cwd = parse_simple_yaml(&yaml, "cwd")
             .map(PathBuf::from)
             .unwrap_or_default();
-        let title = parse_simple_yaml(&yaml, "summary")
+        // Copilot writes the session title to `name`; `summary` is a removed
+        // legacy field kept only as a fallback for very old sessions. Fall
+        // back to a short id when neither is present yet.
+        let title = parse_simple_yaml(&yaml, "name")
             .filter(|s| !s.is_empty())
-            .or_else(|| parse_simple_yaml(&yaml, "name").filter(|s| !s.is_empty()))
+            .or_else(|| parse_simple_yaml(&yaml, "summary").filter(|s| !s.is_empty()))
             .unwrap_or_else(|| short_id(&c.id, "copilot"));
 
         out.push(AgentSession {

--- a/tools/wta/src/history_loader.rs
+++ b/tools/wta/src/history_loader.rs
@@ -86,6 +86,14 @@ const TITLE_TAIL_BYTES: u64 = 64 * 1024;
 /// case (treated as phantom — conservative but safe).
 const CLASSIFY_SCAN_BYTES_CAP: u64 = 8 * 1024 * 1024;
 
+/// Cap the discovery-phase first-line read (`read_first_line`) so a corrupt
+/// / non-JSONL transcript that is one giant line with no newline can't pull
+/// an unbounded amount into memory during the *cheap* phase. A real header
+/// line is a single small JSON object; a read that hits this cap without a
+/// newline yields truncated text that fails the downstream JSON parse, so
+/// the candidate is skipped (treated as unparseable).
+const HEADER_LINE_BYTES_CAP: u64 = 64 * 1024;
+
 /// Decide which per-CLI loaders to run for a given filter.
 ///
 /// The session management view only ever shows the current agent's CLI, so
@@ -554,15 +562,18 @@ fn select_top_candidates(
 /// discovery phase to pull a session id / header out of Gemini and Codex
 /// transcripts without reading the whole (potentially multi-MB) file.
 fn read_first_line(path: &Path) -> Option<String> {
-    use std::io::{BufRead, BufReader};
+    use std::io::{BufRead, BufReader, Read};
     let file = fs::File::open(path).ok()?;
-    let mut reader = BufReader::new(file);
+    // Bound the read so a corrupt / non-JSONL file that is one giant line
+    // with no newline can't slurp unbounded bytes during the cheap
+    // discovery phase. See `HEADER_LINE_BYTES_CAP`.
+    let mut reader = BufReader::new(file.take(HEADER_LINE_BYTES_CAP));
     let mut line = String::new();
     loop {
         line.clear();
         let n = reader.read_line(&mut line).ok()?;
         if n == 0 {
-            return None; // EOF with no non-empty line
+            return None; // EOF (or cap reached) with no non-empty line
         }
         if !line.trim().is_empty() {
             return Some(line);
@@ -2577,6 +2588,25 @@ mod tests {
         let empty = home.join("empty.jsonl");
         write_file(&empty, "");
         assert!(read_first_line(&empty).is_none());
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn read_first_line_caps_oversize_unterminated_line() {
+        // A corrupt / non-JSONL file that is one giant line with no newline
+        // must not be slurped whole: the read is bounded at
+        // HEADER_LINE_BYTES_CAP, so we get back at most the cap (the
+        // truncated text then fails the downstream JSON header parse).
+        let home = tmp_root("first-line-cap");
+        let p = home.join("giant.jsonl");
+        let giant = "x".repeat(HEADER_LINE_BYTES_CAP as usize + 4096);
+        write_file(&p, &giant);
+        let got = read_first_line(&p).expect("returns the bounded prefix");
+        assert!(
+            got.len() <= HEADER_LINE_BYTES_CAP as usize,
+            "read_first_line must cap the read, got {} bytes",
+            got.len()
+        );
         let _ = fs::remove_dir_all(&home);
     }
 

--- a/tools/wta/src/history_loader.rs
+++ b/tools/wta/src/history_loader.rs
@@ -61,12 +61,12 @@
 //
 // Sort each list by last_activity desc; cap each CLI at MAX_PER_CLI.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-use crate::agent_sessions::{AgentSession, AgentStatus, CliSource, SessionOrigin};
+use crate::agent_sessions::{AgentSession, AgentStatus, CliSource};
 
 const MAX_PER_CLI: usize = 50;
 const TITLE_TAIL_BYTES: u64 = 64 * 1024;
@@ -82,26 +82,177 @@ const TITLE_TAIL_BYTES: u64 = 64 * 1024;
 /// case (treated as phantom — conservative but safe).
 const CLASSIFY_SCAN_BYTES_CAP: u64 = 8 * 1024 * 1024;
 
-pub fn load_all() -> Vec<AgentSession> {
-    let mut out = Vec::new();
-    let Some(home) = home_dir() else { return out };
-    out.extend(take_n(load_copilot(&home), MAX_PER_CLI));
-    out.extend(take_n(load_claude(&home),  MAX_PER_CLI));
-    out.extend(take_n(load_gemini(&home),  MAX_PER_CLI));
-    out.extend(take_n(load_codex(&home),  MAX_PER_CLI));
-    // Stamp `origin: AgentPane` on rows whose session id was recorded in
-    // the local agent-pane index. Loaded once and applied as a join so the
-    // per-CLI scanners stay agnostic of how the index is shaped or where
-    // it lives.
-    let agent_pane_keys = crate::agent_pane_origin::load_default_set();
-    if !agent_pane_keys.is_empty() {
-        for s in out.iter_mut() {
-            if agent_pane_keys.contains(&s.key) {
-                s.origin = SessionOrigin::AgentPane;
-            }
-        }
-    }
+// ─── Profiling instrumentation (diagnostic) ─────────────────────────────
+//
+// Temporary instrumentation to measure where `load_all` spends its time:
+// reading + parsing file *content* (the work a two-phase "filter by a
+// cheap time signal, then read only the survivors" optimization would
+// eliminate) versus directory traversal + `stat`. Every content-reading
+// call site is wrapped in `prof_content`; the per-thread accumulator is
+// sampled around each per-CLI loader in `load_all_profiled`.
+// "traversal/stat" is derived as `total - content`, so it also absorbs
+// the (negligible) sort/push cost.
+
+thread_local! {
+    static PROF_CONTENT_NS: std::cell::Cell<u128> = const { std::cell::Cell::new(0) };
+    static PROF_CONTENT_CALLS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// Time `f` (a file content read + parse) and add it to the per-thread
+/// content-IO accumulator. Returns `f`'s result unchanged.
+fn prof_content<T>(f: impl FnOnce() -> T) -> T {
+    let started = std::time::Instant::now();
+    let out = f();
+    let elapsed = started.elapsed().as_nanos();
+    PROF_CONTENT_NS.with(|c| c.set(c.get().saturating_add(elapsed)));
+    PROF_CONTENT_CALLS.with(|c| c.set(c.get() + 1));
     out
+}
+
+fn prof_content_snapshot() -> (u128, u64) {
+    (
+        PROF_CONTENT_NS.with(|c| c.get()),
+        PROF_CONTENT_CALLS.with(|c| c.get()),
+    )
+}
+
+/// Per-CLI timing slice produced by [`load_all_profiled`].
+#[derive(Default, Clone)]
+pub(crate) struct CliTiming {
+    pub total: std::time::Duration,
+    pub content: std::time::Duration,
+    pub content_calls: u64,
+    pub rows: usize,
+}
+
+impl CliTiming {
+    /// Time spent on directory traversal + `stat` (everything that is not
+    /// reading file content), derived so it also absorbs sort/push cost.
+    fn traversal_stat(&self) -> std::time::Duration {
+        self.total.saturating_sub(self.content)
+    }
+}
+
+impl std::fmt::Debug for CliTiming {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "rows={} total={:.1}ms content={:.1}ms({} reads) traversal_stat={:.1}ms",
+            self.rows,
+            self.total.as_secs_f64() * 1000.0,
+            self.content.as_secs_f64() * 1000.0,
+            self.content_calls,
+            self.traversal_stat().as_secs_f64() * 1000.0,
+        )
+    }
+}
+
+/// Whole-scan timing breakdown produced by [`load_all_profiled`].
+#[derive(Default)]
+pub(crate) struct LoadProfile {
+    pub total: std::time::Duration,
+    pub copilot: CliTiming,
+    pub claude: CliTiming,
+    pub gemini: CliTiming,
+    pub codex: CliTiming,
+}
+
+impl LoadProfile {
+    fn content(&self) -> std::time::Duration {
+        self.copilot.content + self.claude.content + self.gemini.content + self.codex.content
+    }
+
+    fn content_calls(&self) -> u64 {
+        self.copilot.content_calls
+            + self.claude.content_calls
+            + self.gemini.content_calls
+            + self.codex.content_calls
+    }
+
+    fn traversal_stat(&self) -> std::time::Duration {
+        self.total.saturating_sub(self.content())
+    }
+}
+
+/// Run one per-CLI loader, capturing its wall-clock total and the slice of
+/// that spent reading file content (via the `prof_content` accumulator).
+fn run_cli_profiled(
+    loader: impl FnOnce() -> Vec<AgentSession>,
+) -> (Vec<AgentSession>, CliTiming) {
+    let (content_ns_before, content_calls_before) = prof_content_snapshot();
+    let started = std::time::Instant::now();
+    let rows = loader();
+    let total = started.elapsed();
+    let (content_ns_after, content_calls_after) = prof_content_snapshot();
+    let content_ns = content_ns_after.saturating_sub(content_ns_before);
+    let timing = CliTiming {
+        total,
+        content: std::time::Duration::from_nanos(content_ns as u64),
+        content_calls: content_calls_after.saturating_sub(content_calls_before),
+        rows: rows.len(),
+    };
+    (rows, timing)
+}
+
+pub fn load_all() -> Vec<AgentSession> {
+    let (sessions, profile) = load_all_profiled();
+    tracing::info!(
+        target: "history_loader",
+        total_ms = profile.total.as_secs_f64() * 1000.0,
+        content_ms = profile.content().as_secs_f64() * 1000.0,
+        content_reads = profile.content_calls(),
+        traversal_stat_ms = profile.traversal_stat().as_secs_f64() * 1000.0,
+        copilot = ?profile.copilot,
+        claude = ?profile.claude,
+        gemini = ?profile.gemini,
+        codex = ?profile.codex,
+        "load_all timing distribution: content-read vs traversal/stat"
+    );
+    sessions
+}
+
+/// [`load_all`] plus a [`LoadProfile`] breaking down where the scan spent
+/// its time. Kept separate so the profiling test and the production
+/// `tracing` line share one measured code path.
+pub(crate) fn load_all_profiled() -> (Vec<AgentSession>, LoadProfile) {
+    let mut out = Vec::new();
+    let mut profile = LoadProfile::default();
+    let scan_started = std::time::Instant::now();
+    let Some(home) = home_dir() else {
+        profile.total = scan_started.elapsed();
+        return (out, profile);
+    };
+
+    // Load the agent-pane (Class A) index once. Each per-CLI loader uses it
+    // to skip WTA-created agent-pane sessions in its cheap discovery phase,
+    // *before* paying for any content read — these are hidden from the
+    // session picker (MVP `OriginFilter::ShellOnly`) and their live variants
+    // are tracked via `new_session`, not this disk scan, so dropping the
+    // historical ones here is safe. This is what keeps the expensive parse
+    // off Gemini's many seeded-prompt agent-pane phantoms.
+    let agent_pane_index = crate::agent_pane_origin::load_default_set();
+
+    let (copilot, copilot_timing) =
+        run_cli_profiled(|| load_copilot_indexed(&home, &agent_pane_index));
+    let (claude, claude_timing) =
+        run_cli_profiled(|| load_claude_indexed(&home, &agent_pane_index));
+    let (gemini, gemini_timing) =
+        run_cli_profiled(|| load_gemini_indexed(&home, &agent_pane_index));
+    let (codex, codex_timing) =
+        run_cli_profiled(|| load_codex_indexed(&home, &agent_pane_index));
+    profile.copilot = copilot_timing;
+    profile.claude = claude_timing;
+    profile.gemini = gemini_timing;
+    profile.codex = codex_timing;
+
+    // Each loader already caps at MAX_PER_CLI; take_n is a defensive no-op.
+    out.extend(take_n(copilot, MAX_PER_CLI));
+    out.extend(take_n(claude, MAX_PER_CLI));
+    out.extend(take_n(gemini, MAX_PER_CLI));
+    out.extend(take_n(codex, MAX_PER_CLI));
+
+    profile.total = scan_started.elapsed();
+    (out, profile)
 }
 
 /// Best-effort title lookup for a single live session. Reads the same
@@ -447,13 +598,96 @@ fn codex_key_has_definite_resumable_content_in(home: &Path, id: &str) -> bool {
     }
 }
 
+// ─── Two-phase scan helpers ─────────────────────────────────────────────
+//
+// Each per-CLI loader runs in two phases:
+//   1. cheap discovery — enumerate session artefacts with minimal IO,
+//      collecting a `Candidate` (id + sort signal + path). Class A
+//      (agent-pane) sessions are dropped here via the index, before any
+//      content is read.
+//   2. expensive parse — only for the newest `MAX_PER_CLI` survivors:
+//      phantom filtering, title, and cwd extraction.
+//
+// This bounds `load_all`'s content reads at ~`MAX_PER_CLI` per CLI instead
+// of "every file on disk", which on a populated machine is the difference
+// between ~50 reads and several hundred (the bulk being WTA's own
+// agent-pane phantoms — Gemini in particular writes a seeded-prompt
+// snapshot per pre-warm that costs an 8 KB read to classify).
+
+/// A lightweight session candidate from a loader's cheap discovery phase.
+/// Carries only what the Class A skip and the mtime top-N selection need;
+/// the expensive content parse runs later, for survivors only.
+struct Candidate {
+    /// Session key / id — used for the agent-pane (Class A) index lookup
+    /// and becomes the row key.
+    id: String,
+    /// Last-activity signal used to rank candidates newest-first.
+    sort_time: SystemTime,
+    /// Path to the session artefact: the session-state dir for Copilot,
+    /// the transcript file for Claude / Gemini / Codex.
+    path: PathBuf,
+    /// cwd already extracted by the cheap phase (Codex reads it from the
+    /// `session_meta` first line). `None` for CLIs that derive cwd during
+    /// the expensive phase.
+    cwd: Option<PathBuf>,
+}
+
+/// Drop Class A (agent-pane) candidates, rank the rest newest-first, and
+/// keep at most `n`. This is the cheap pre-filter that lets the expensive
+/// content parse touch only the most-recent `n` shell-pane sessions per
+/// CLI instead of every file on disk.
+fn select_top_candidates(
+    mut candidates: Vec<Candidate>,
+    agent_pane_index: &HashSet<String>,
+    n: usize,
+) -> Vec<Candidate> {
+    candidates.retain(|c| !agent_pane_index.contains(&c.id));
+    candidates.sort_by(|a, b| b.sort_time.cmp(&a.sort_time));
+    candidates.truncate(n);
+    candidates
+}
+
+/// Read only the first non-empty line of a file, stopping at the first
+/// newline instead of slurping a fixed-size prefix. Used by the cheap
+/// discovery phase to pull a session id / header out of Gemini and Codex
+/// transcripts without reading the whole (potentially multi-MB) file.
+fn read_first_line(path: &Path) -> Option<String> {
+    use std::io::{BufRead, BufReader};
+    let file = fs::File::open(path).ok()?;
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).ok()?;
+        if n == 0 {
+            return None; // EOF with no non-empty line
+        }
+        if !line.trim().is_empty() {
+            return Some(line);
+        }
+    }
+}
+
 // ─── Copilot ────────────────────────────────────────────────────────────
 
+#[cfg(test)]
 fn load_copilot(home: &Path) -> Vec<AgentSession> {
-    let base = home.join(".copilot").join("session-state");
-    let mut out = Vec::new();
-    let Ok(rd) = fs::read_dir(&base) else { return out };
+    load_copilot_indexed(home, &HashSet::new())
+}
 
+fn load_copilot_indexed(home: &Path, agent_pane_index: &HashSet<String>) -> Vec<AgentSession> {
+    let base = home.join(".copilot").join("session-state");
+    let Ok(rd) = fs::read_dir(&base) else { return Vec::new() };
+
+    // Phase 1 (cheap): one dir scan + stat per session. The phantom filter
+    // here is stat-only — a non-empty `events.jsonl` marks "the user did
+    // something" — so Copilot's many never-used pre-warm dirs (which only
+    // ever get a `workspace.yaml`) are dropped without reading any content.
+    // Whenever WT (or wta itself) spawns a Copilot CLI process — agent-pane
+    // back-end, `?prompt` delegate, coordinator — it eagerly creates
+    // `~/.copilot/session-state/<UUID>/workspace.yaml` before the user types
+    // anything; if the user never interacts, no `events.jsonl` is written.
+    let mut candidates = Vec::new();
     for entry in rd.flatten() {
         if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) { continue; }
         let dir = entry.path();
@@ -461,44 +695,39 @@ fn load_copilot(home: &Path) -> Vec<AgentSession> {
             Some(s) if !s.is_empty() => s.to_string(),
             _ => continue,
         };
-
-        let workspace = dir.join("workspace.yaml");
-        let events    = dir.join("events.jsonl");
-
-        // Skip ephemeral / never-used Copilot CLI sessions. Whenever WT (or
-        // wta itself) spawns a Copilot CLI process — e.g. as the back-end
-        // for an agent pane, a `?prompt` delegate, or a coordinator — that
-        // process eagerly creates `~/.copilot/session-state/<UUID>/workspace.yaml`
-        // even before the user types anything. If the user never interacts,
-        // no `events.jsonl` is ever written. These dirs would otherwise
-        // appear at the very top of session management view after each WT restart (most-recent
-        // last_activity), masking real historical sessions. Treat the
-        // existence of a non-empty `events.jsonl` as the marker for "user
-        // actually did something here".
+        let events = dir.join("events.jsonl");
         let has_real_activity = events.metadata()
             .map(|m| m.is_file() && m.len() > 0)
             .unwrap_or(false);
         if !has_real_activity { continue; }
-
         let last_activity = events.metadata()
             .and_then(|m| m.modified()).ok()
-            .or_else(|| workspace.metadata().and_then(|m| m.modified()).ok())
+            .or_else(|| dir.join("workspace.yaml").metadata().and_then(|m| m.modified()).ok())
             .unwrap_or(SystemTime::UNIX_EPOCH);
+        candidates.push(Candidate { id, sort_time: last_activity, path: dir, cwd: None });
+    }
+
+    // Phase 2 (expensive): read `workspace.yaml` for title + cwd, newest
+    // `MAX_PER_CLI` shell-pane sessions only.
+    let mut out = Vec::new();
+    for c in select_top_candidates(candidates, agent_pane_index, MAX_PER_CLI) {
+        let dir = c.path;
+        let workspace = dir.join("workspace.yaml");
+        let events = dir.join("events.jsonl");
         let started_at = workspace.metadata()
             .and_then(|m| m.modified()).ok()
-            .unwrap_or(last_activity);
-
-        let yaml = fs::read_to_string(&workspace).unwrap_or_default();
+            .unwrap_or(c.sort_time);
+        let yaml = prof_content(|| fs::read_to_string(&workspace)).unwrap_or_default();
         let cwd = parse_simple_yaml(&yaml, "cwd")
             .map(PathBuf::from)
             .unwrap_or_default();
         let title = parse_simple_yaml(&yaml, "summary")
             .filter(|s| !s.is_empty())
             .or_else(|| parse_simple_yaml(&yaml, "name").filter(|s| !s.is_empty()))
-            .unwrap_or_else(|| short_id(&id, "copilot"));
+            .unwrap_or_else(|| short_id(&c.id, "copilot"));
 
         out.push(AgentSession {
-            key:               id.clone(),
+            key:               c.id,
             cli_source:        CliSource::Copilot,
             pane_session_id:   None,
             window_id:         None,
@@ -506,7 +735,7 @@ fn load_copilot(home: &Path) -> Vec<AgentSession> {
             title,
             cwd,
             started_at,
-            last_activity_at:  last_activity,
+            last_activity_at:  c.sort_time,
             status:            AgentStatus::Historical,
             last_error:        None,
             current_tool:      None,
@@ -521,24 +750,27 @@ fn load_copilot(home: &Path) -> Vec<AgentSession> {
 
 // ─── Claude ─────────────────────────────────────────────────────────────
 
+#[cfg(test)]
 fn load_claude(home: &Path) -> Vec<AgentSession> {
-    let base = home.join(".claude").join("projects");
-    let mut out = Vec::new();
-    let Ok(rd) = fs::read_dir(&base) else { return out };
+    load_claude_indexed(home, &HashSet::new())
+}
 
+fn load_claude_indexed(home: &Path, agent_pane_index: &HashSet<String>) -> Vec<AgentSession> {
+    let base = home.join(".claude").join("projects");
+    let Ok(rd) = fs::read_dir(&base) else { return Vec::new() };
+
+    // Phase 1 (cheap): enumerate transcripts; id = filename stem, sort by
+    // mtime. No content is read here — Claude phantoms (e.g. `/model` then
+    // Ctrl+D) can only be told apart by content, so that filter is deferred
+    // to phase 2.
+    let mut candidates = Vec::new();
     for proj_entry in rd.flatten() {
         let proj_dir = proj_entry.path();
-        let proj_name = match proj_dir.file_name().and_then(|n| n.to_str()) {
-            Some(s) if s != "memory" => s.to_string(),
-            _ => continue,
-        };
-        // Claude's directory-name encoding (`\` -> `-`) is lossy: paths
-        // whose segments contain `-` (e.g. `agentic-terminal`) can't be
-        // recovered from the directory name alone. Use it only as a
-        // fallback — prefer the per-record `cwd` field embedded in the
-        // JSONL itself, which preserves the original path verbatim.
-        let cwd_fallback = decode_claude_cwd(&proj_name);
-
+        let is_project = proj_dir.file_name()
+            .and_then(|n| n.to_str())
+            .map(|s| s != "memory")
+            .unwrap_or(false);
+        if !is_project { continue; }
         let Ok(files) = fs::read_dir(&proj_dir) else { continue };
         for f in files.flatten() {
             let path = f.path();
@@ -548,38 +780,53 @@ fn load_claude(home: &Path) -> Vec<AgentSession> {
                 Some(s) if !s.is_empty() => s.to_string(),
                 _ => continue,
             };
-            // Reproduces the "ghost Claude session" bug: launching `claude`
-            // and exiting without typing a real prompt (e.g. just running
-            // `/model` then Ctrl+D) still leaves a JSONL on disk, but
-            // `claude --resume <id>` rejects it with
-            // `No conversation found with session ID: <id>`. Mirror the
-            // Copilot ghost-session filter so these rows never appear in
-            // the session management view, where Enter would dead-end with that error.
-            if !claude_session_has_real_content(&path) { continue; }
-            let last_activity = path.metadata().and_then(|m| m.modified()).ok()
+            let sort_time = path.metadata().and_then(|m| m.modified()).ok()
                 .unwrap_or(SystemTime::UNIX_EPOCH);
-            let title = first_user_text_jsonl(&path, ClaudeOrGemini::Claude)
-                .unwrap_or_else(|| short_id(&id, "claude"));
-            let cwd = read_cwd_from_claude_jsonl(&path).unwrap_or_else(|| cwd_fallback.clone());
-
-            out.push(AgentSession {
-                key:               id.clone(),
-                cli_source:        CliSource::Claude,
-                pane_session_id:   None,
-                window_id:         None,
-                tab_id:            None,
-                title,
-                cwd,
-                started_at:        last_activity,
-                last_activity_at:  last_activity,
-                status:            AgentStatus::Historical,
-                last_error:        None,
-                current_tool:      None,
-                attention_reason:  None,
-                log_path:          Some(path),
-                origin:            crate::agent_sessions::SessionOrigin::default(),
-            });
+            candidates.push(Candidate { id, sort_time, path, cwd: None });
         }
+    }
+
+    // Phase 2 (expensive): content read for the newest `MAX_PER_CLI` only.
+    let mut out = Vec::new();
+    for c in select_top_candidates(candidates, agent_pane_index, MAX_PER_CLI) {
+        let path = c.path;
+        // Reproduces the "ghost Claude session" bug: launching `claude` and
+        // exiting without typing a real prompt (e.g. just running `/model`
+        // then Ctrl+D) still leaves a JSONL on disk, but `claude --resume
+        // <id>` rejects it with `No conversation found with session ID:
+        // <id>`. Mirror the Copilot ghost-session filter so these rows never
+        // appear in the session management view, where Enter would dead-end.
+        if !prof_content(|| claude_session_has_real_content(&path)) { continue; }
+        // Claude's directory-name encoding (`\` -> `-`) is lossy: paths whose
+        // segments contain `-` can't be recovered from the directory name
+        // alone. Use it only as a fallback — prefer the per-record `cwd`
+        // embedded in the JSONL, which preserves the original path verbatim.
+        let cwd_fallback = path.parent()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .map(decode_claude_cwd)
+            .unwrap_or_default();
+        let title = prof_content(|| first_user_text_jsonl(&path, ClaudeOrGemini::Claude))
+            .unwrap_or_else(|| short_id(&c.id, "claude"));
+        let cwd = prof_content(|| read_cwd_from_claude_jsonl(&path)).unwrap_or(cwd_fallback);
+
+        out.push(AgentSession {
+            key:               c.id,
+            cli_source:        CliSource::Claude,
+            pane_session_id:   None,
+            window_id:         None,
+            tab_id:            None,
+            title,
+            cwd,
+            started_at:        c.sort_time,
+            last_activity_at:  c.sort_time,
+            status:            AgentStatus::Historical,
+            last_error:        None,
+            current_tool:      None,
+            attention_reason:  None,
+            log_path:          Some(path),
+            origin:            crate::agent_sessions::SessionOrigin::default(),
+        });
     }
     out.sort_by(|a, b| b.last_activity_at.cmp(&a.last_activity_at));
     out
@@ -587,73 +834,94 @@ fn load_claude(home: &Path) -> Vec<AgentSession> {
 
 // ─── Gemini ─────────────────────────────────────────────────────────────
 
+#[cfg(test)]
 fn load_gemini(home: &Path) -> Vec<AgentSession> {
+    load_gemini_indexed(home, &HashSet::new())
+}
+
+fn load_gemini_indexed(home: &Path, agent_pane_index: &HashSet<String>) -> Vec<AgentSession> {
     let tmp = home.join(".gemini").join("tmp");
-    let mut out = Vec::new();
-    let Ok(rd) = fs::read_dir(&tmp) else { return out };
+    let Ok(rd) = fs::read_dir(&tmp) else { return Vec::new() };
 
     let projects_json = home.join(".gemini").join("projects.json");
     let cwd_lookup    = parse_gemini_projects(&projects_json);
 
+    // Phase 1 (cheap): read only line 1 of each transcript to pull the
+    // sessionId (Gemini doesn't put it in the filename); sort by mtime.
+    // This is the key win — Gemini's seeded-prompt agent-pane phantoms are
+    // identified by id and skipped here in `select_top_candidates`, instead
+    // of each costing a full `gemini_jsonl_has_real_content` scan.
+    let mut candidates = Vec::new();
     for proj_entry in rd.flatten() {
         if !proj_entry.file_type().map(|t| t.is_dir()).unwrap_or(false) { continue; }
-        let proj_name = match proj_entry.file_name().to_str() {
-            Some(s) => s.to_string(),
-            None => continue,
-        };
         let chats = proj_entry.path().join("chats");
         let Ok(files) = fs::read_dir(&chats) else { continue };
-        let cwd = cwd_lookup.get(&proj_name).cloned().unwrap_or_default();
-
         for f in files.flatten() {
             let path = f.path();
             if !is_gemini_session_file(&path) { continue; }
-
-            // Drop phantom Gemini sessions: opening `gemini` and
-            // exiting without exchanging a turn leaves a JSONL on
-            // disk containing only the session header line(s) —
-            // pressing Enter on the row in session management view would launch
-            // `gemini --resume <id>` which Gemini rejects (and the
-            // synthetic title `gemini <8-char>` from `short_id`
-            // exposes the lack of content anyway). Mirrors the
-            // Claude and Copilot loader-side filters.
-            if !gemini_jsonl_has_real_content(&path) { continue; }
-
-            let (sid, last_updated) = parse_gemini_meta(&path);
-            // A JSONL with non-header content must also have a
-            // resolvable `sessionId` in its header — otherwise
-            // Gemini wouldn't have been able to write the rest. If
-            // we can't parse it here, skip the entry rather than
-            // synthesise an un-resumable `gemini:<filename>` key
-            // (Enter on such rows used to silently no-op).
-            let Some(key) = sid else { continue; };
-            let last_activity = last_updated
-                .or_else(|| path.metadata().and_then(|m| m.modified()).ok())
+            // A JSONL with content must have a resolvable `sessionId` in its
+            // header; if we can't parse it, skip rather than synthesise an
+            // un-resumable key (Enter on such rows used to silently no-op).
+            let Some(sid) = prof_content(|| gemini_session_id_from_header(&path)) else { continue; };
+            let sort_time = path.metadata().and_then(|m| m.modified()).ok()
                 .unwrap_or(SystemTime::UNIX_EPOCH);
-            let title = first_user_text_jsonl(&path, ClaudeOrGemini::Gemini)
-                .unwrap_or_else(|| short_id(&key, "gemini"));
-
-            out.push(AgentSession {
-                key:               key.clone(),
-                cli_source:        CliSource::Gemini,
-                pane_session_id:   None,
-                window_id:         None,
-                tab_id:            None,
-                title,
-                cwd:               cwd.clone(),
-                started_at:        last_activity,
-                last_activity_at:  last_activity,
-                status:            AgentStatus::Historical,
-                last_error:        None,
-                current_tool:      None,
-                attention_reason:  None,
-                log_path:          Some(path),
-                origin:            crate::agent_sessions::SessionOrigin::default(),
-            });
+            candidates.push(Candidate { id: sid, sort_time, path, cwd: None });
         }
+    }
+
+    // Phase 2 (expensive): phantom filter + title for the newest
+    // `MAX_PER_CLI` only.
+    let mut out = Vec::new();
+    for c in select_top_candidates(candidates, agent_pane_index, MAX_PER_CLI) {
+        let path = c.path;
+        // Drop phantom Gemini sessions: opening `gemini` and exiting without
+        // exchanging a turn leaves a JSONL containing only header line(s) —
+        // `gemini --resume <id>` would reject it. Mirrors the Claude and
+        // Copilot loader-side filters.
+        if !prof_content(|| gemini_jsonl_has_real_content(&path)) { continue; }
+        // cwd: `~/.gemini/tmp/<slug>/chats/session-*.jsonl` → look up <slug>.
+        let cwd = path.parent()
+            .and_then(|p| p.parent())
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .and_then(|slug| cwd_lookup.get(slug).cloned())
+            .unwrap_or_default();
+        let title = prof_content(|| first_user_text_jsonl(&path, ClaudeOrGemini::Gemini))
+            .unwrap_or_else(|| short_id(&c.id, "gemini"));
+
+        out.push(AgentSession {
+            key:               c.id,
+            cli_source:        CliSource::Gemini,
+            pane_session_id:   None,
+            window_id:         None,
+            tab_id:            None,
+            title,
+            cwd,
+            started_at:        c.sort_time,
+            last_activity_at:  c.sort_time,
+            status:            AgentStatus::Historical,
+            last_error:        None,
+            current_tool:      None,
+            attention_reason:  None,
+            log_path:          Some(path),
+            origin:            crate::agent_sessions::SessionOrigin::default(),
+        });
     }
     out.sort_by(|a, b| b.last_activity_at.cmp(&a.last_activity_at));
     out
+}
+
+/// Extract a Gemini session's `sessionId` from its header (first non-empty
+/// line) with a single cheap line read. A header line carries `sessionId`
+/// and no `type` field; a leading record that has a `type` field means the
+/// header is missing or not first, so we skip it (matches `parse_gemini_meta`).
+fn gemini_session_id_from_header(path: &Path) -> Option<String> {
+    let line = read_first_line(path)?;
+    let val: serde_json::Value = serde_json::from_str(line.trim()).ok()?;
+    if val.get("type").is_some() {
+        return None;
+    }
+    val.get("sessionId").and_then(|v| v.as_str()).map(String::from)
 }
 
 /// Top-level Gemini chat files are `~/.gemini/tmp/<slug>/chats/session-*.jsonl`.
@@ -668,10 +936,19 @@ fn is_gemini_session_file(p: &Path) -> bool {
 
 // ─── Codex ──────────────────────────────────────────────────────────────
 
+#[cfg(test)]
 fn load_codex(home: &Path) -> Vec<AgentSession> {
+    load_codex_indexed(home, &HashSet::new())
+}
+
+fn load_codex_indexed(home: &Path, agent_pane_index: &HashSet<String>) -> Vec<AgentSession> {
     let root = home.join(".codex").join("sessions");
-    let mut out: Vec<AgentSession> = Vec::new();
-    let Ok(years) = fs::read_dir(&root) else { return out };
+    let Ok(years) = fs::read_dir(&root) else { return Vec::new() };
+
+    // Phase 1 (cheap): read only the `session_meta` first line of each
+    // rollout to get id + cwd + timestamp + subagent flag. Subagent forks
+    // are dropped here; Class A is dropped in `select_top_candidates`.
+    let mut candidates = Vec::new();
     for y in years.flatten() {
         let Ok(months) = fs::read_dir(y.path()) else { continue };
         for m in months.flatten() {
@@ -682,37 +959,51 @@ fn load_codex(home: &Path) -> Vec<AgentSession> {
                     let path = f.path();
                     let Some(name) = path.file_name().and_then(|s| s.to_str()) else { continue };
                     if !name.starts_with("rollout-") || !name.ends_with(".jsonl") { continue; }
-                    if !codex_session_has_real_content(&path) { continue; }
-                    let Some(meta) = read_codex_session_meta(&path) else { continue; };
+                    let Some(meta) = prof_content(|| read_codex_session_meta(&path)) else { continue; };
                     // Skip Codex internal multi-agent subagent forks: they get
                     // their own rollout file but inherit the parent's history
                     // (same title) and are not user-facing sessions.
                     if meta.is_subagent { continue; }
-                    let title = codex_title_from_file(&path)
-                        .unwrap_or_else(|| short_id(&meta.id, "codex"));
-                    let last_activity_at = meta.timestamp
+                    let sort_time = meta.timestamp
                         .or_else(|| fs::metadata(&path).and_then(|m| m.modified()).ok())
                         .unwrap_or_else(SystemTime::now);
-                    out.push(AgentSession {
-                        key:               meta.id,
-                        cli_source:        CliSource::Codex,
-                        pane_session_id:   None,
-                        window_id:         None,
-                        tab_id:            None,
-                        title,
-                        cwd:               meta.cwd,
-                        started_at:        last_activity_at,
-                        last_activity_at,
-                        status:            AgentStatus::Historical,
-                        last_error:        None,
-                        current_tool:      None,
-                        attention_reason:  None,
-                        log_path:          Some(path),
-                        origin:            crate::agent_sessions::SessionOrigin::default(),
+                    candidates.push(Candidate {
+                        id: meta.id,
+                        sort_time,
+                        path,
+                        cwd: Some(meta.cwd),
                     });
                 }
             }
         }
+    }
+
+    // Phase 2 (expensive): full-content phantom filter + title for the
+    // newest `MAX_PER_CLI` only. cwd was already read in phase 1.
+    let mut out = Vec::new();
+    for c in select_top_candidates(candidates, agent_pane_index, MAX_PER_CLI) {
+        let path = c.path;
+        if !prof_content(|| codex_session_has_real_content(&path)) { continue; }
+        let title = prof_content(|| codex_title_from_file(&path))
+            .unwrap_or_else(|| short_id(&c.id, "codex"));
+        let cwd = c.cwd.unwrap_or_default();
+        out.push(AgentSession {
+            key:               c.id,
+            cli_source:        CliSource::Codex,
+            pane_session_id:   None,
+            window_id:         None,
+            tab_id:            None,
+            title,
+            cwd,
+            started_at:        c.sort_time,
+            last_activity_at:  c.sort_time,
+            status:            AgentStatus::Historical,
+            last_error:        None,
+            current_tool:      None,
+            attention_reason:  None,
+            log_path:          Some(path),
+            origin:            crate::agent_sessions::SessionOrigin::default(),
+        });
     }
     out.sort_by(|a, b| b.last_activity_at.cmp(&a.last_activity_at));
     out
@@ -1465,6 +1756,39 @@ mod tests {
     use super::*;
     use std::io::Write;
 
+    /// Diagnostic profiling (run manually): prints where `load_all` spends
+    /// its time against the *real* user home, so we can see the
+    /// content-read vs traversal/stat split before/after the two-phase
+    /// optimization.
+    ///
+    /// Ignored by default — it reads the real `~/.copilot`, `~/.claude`,
+    /// `~/.gemini`, `~/.codex`, and is meaningless on an empty CI home.
+    /// Run with:
+    ///   cargo test --manifest-path tools/wta/Cargo.toml \
+    ///       profile_load_all_distribution -- --ignored --nocapture
+    #[test]
+    #[ignore = "diagnostic: profiles load_all against the real home; run with --ignored --nocapture"]
+    fn profile_load_all_distribution() {
+        let (sessions, profile) = load_all_profiled();
+        eprintln!("\n=== load_all() timing distribution (real home) ===");
+        eprintln!("rows returned : {}", sessions.len());
+        eprintln!("TOTAL         : {:.1} ms", profile.total.as_secs_f64() * 1000.0);
+        eprintln!(
+            "  content read : {:.1} ms ({} reads)",
+            profile.content().as_secs_f64() * 1000.0,
+            profile.content_calls(),
+        );
+        eprintln!(
+            "  traversal/stat: {:.1} ms",
+            profile.traversal_stat().as_secs_f64() * 1000.0,
+        );
+        eprintln!("per-CLI (rows / total / content / traversal+stat):");
+        eprintln!("  copilot: {:?}", profile.copilot);
+        eprintln!("  claude : {:?}", profile.claude);
+        eprintln!("  gemini : {:?}", profile.gemini);
+        eprintln!("  codex  : {:?}", profile.codex);
+    }
+
     fn tmp_root(label: &str) -> PathBuf {
         let mut p = std::env::temp_dir();
         let id = format!("wta-history-test-{}-{:?}-{:?}",
@@ -1647,7 +1971,7 @@ mod tests {
         // join is layered on top by `load_all`. So scanner output should
         // always default to Unknown regardless of any index that may exist
         // in the host's real %LOCALAPPDATA%.
-        assert_eq!(s.origin, SessionOrigin::Unknown);
+        assert_eq!(s.origin, crate::agent_sessions::SessionOrigin::Unknown);
         let _ = fs::remove_dir_all(&home);
     }
 
@@ -2303,6 +2627,83 @@ mod tests {
         assert_eq!(v.len(), 3);
         assert!(v[0].last_activity_at >= v[1].last_activity_at);
         assert!(v[1].last_activity_at >= v[2].last_activity_at);
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn select_top_candidates_skips_class_a_sorts_and_truncates() {
+        use std::time::Duration;
+        let at = |secs: u64| SystemTime::UNIX_EPOCH + Duration::from_secs(secs);
+        let mk = |id: &str, secs: u64| Candidate {
+            id: id.to_string(),
+            sort_time: at(secs),
+            path: PathBuf::from(id),
+            cwd: None,
+        };
+        let mut index = HashSet::new();
+        index.insert("class-a".to_string());
+
+        let cands = vec![
+            mk("old", 100),
+            mk("class-a", 999), // newest, but Class A → must be dropped
+            mk("new", 300),
+            mk("mid", 200),
+        ];
+        let top = select_top_candidates(cands, &index, 2);
+        // Class A dropped, remaining sorted newest-first, truncated to 2.
+        assert_eq!(
+            top.iter().map(|c| c.id.as_str()).collect::<Vec<_>>(),
+            ["new", "mid"]
+        );
+    }
+
+    #[test]
+    fn load_copilot_indexed_skips_agent_pane_sessions() {
+        let home = tmp_root("copilot-classa");
+        let base = home.join(".copilot").join("session-state");
+        for sid in ["shell-1", "agent-pane-1"] {
+            let d = base.join(sid);
+            fs::create_dir_all(&d).unwrap();
+            write_file(&d.join("workspace.yaml"), &format!("id: {sid}\ncwd: C:\\proj\nsummary: t\n"));
+            write_file(&d.join("events.jsonl"), "{}\n");
+        }
+        let mut index = HashSet::new();
+        index.insert("agent-pane-1".to_string());
+
+        let v = load_copilot_indexed(&home, &index);
+        assert_eq!(v.len(), 1, "the agent-pane (Class A) session must be skipped");
+        assert_eq!(v[0].key, "shell-1");
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn read_first_line_returns_first_non_empty_line() {
+        let home = tmp_root("first-line");
+        let p = home.join("f.jsonl");
+        write_file(&p, "\n\n  \n{\"a\":1}\n{\"b\":2}\n");
+        assert_eq!(read_first_line(&p).as_deref().map(str::trim), Some("{\"a\":1}"));
+        let empty = home.join("empty.jsonl");
+        write_file(&empty, "");
+        assert!(read_first_line(&empty).is_none());
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn gemini_session_id_from_header_reads_header_only() {
+        let home = tmp_root("gem-header");
+        // Header (sessionId, no `type`) on line 1 → returns the id without
+        // reading the rest of the (potentially huge) transcript.
+        let p = home.join("session-x.jsonl");
+        write_file(
+            &p,
+            "{\"sessionId\":\"abc-123\",\"projectHash\":\"h\",\"kind\":\"main\"}\n\
+             {\"id\":\"m\",\"type\":\"user\",\"content\":\"hi\"}\n",
+        );
+        assert_eq!(gemini_session_id_from_header(&p).as_deref(), Some("abc-123"));
+        // First line is a `type` record (no header) → None (matches parse_gemini_meta).
+        let p2 = home.join("session-y.jsonl");
+        write_file(&p2, "{\"id\":\"m\",\"type\":\"user\",\"content\":\"hi\"}\n");
+        assert!(gemini_session_id_from_header(&p2).is_none());
         let _ = fs::remove_dir_all(&home);
     }
 

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2679,10 +2679,8 @@ async fn run_acp_app(
             // Apply --initial-view: if `sessions`, jump straight into the
             // agent session view (mirrors the Chat→Agents toggle). Wired to
             // WT's Ctrl+Shift+/ binding via `--initial-view sessions` on
-            // the wta cmdline. Must run after set_agent_event_tx so that
-            // ensure_history_loaded()'s event_tx clone is populated —
-            // otherwise the lazy scan would early-return and the Agents
-            // list would never populate.
+            // the wta cmdline. `open_agents_view_for_tab` fires the
+            // `session/list` refetch to master that populates the view.
             //
             // Skip in setup mode: --setup takes the FRE path and the user
             // shouldn't be dropped into an empty session list.
@@ -2693,7 +2691,6 @@ async fn run_acp_app(
                     .clone()
                     .unwrap_or_else(|| app::DEFAULT_TAB_ID.to_string());
                 app_state.open_agents_view_for_tab(tab_id);
-                app_state.ensure_history_loaded();
             }
 
             // Project the initial active-tab state to C++ once, after the
@@ -2713,18 +2710,10 @@ async fn run_acp_app(
                 app_state.project_active_tab_state();
             }
 
-            // NOTE: historical agent sessions used to be loaded here via
-            // `history_loader::load_all()` (later as a `spawn_blocking`).
-            // That work is now deferred — the registry is scanned lazily
-            // on the first Ctrl+Shift+/ press via `App::ensure_history_loaded()`.
-            //
-            // Why: load_all() is hundreds of file opens (one per Copilot
-            // session-state dir, reading events.jsonl for the autofix
-            // fingerprint). On a populated machine it's ~10s of disk I/O.
-            // Every wta spawn — including every model switch in the agent
-            // pane — paid that cost, even though the data is only ever
-            // consumed by the agent session view. Lazy-loading on Ctrl+Shift+/ keeps the
-            // model-switch path free of this overhead entirely.
+            // NOTE: the helper no longer scans on-disk history at all. The
+            // session view renders from master's `session/list` snapshot, and
+            // master performs the single CLI-filtered scan at its startup.
+            // See doc/specs/per-cli-history-filtering.md.
 
             // Enter setup mode if --setup <reason> was passed.
             tracing::info!("cli.setup = {:?}", cli.setup);
@@ -2764,17 +2753,10 @@ async fn run_acp_app(
 
             app_state.set_event_tx(event_tx.clone());
 
-            // Kick the historical-session scan immediately on agent-pane
-            // startup so the sessions view is populated by the time the
-            // user opens it. The scan runs on a `spawn_blocking` thread and
-            // posts `HistoricalSessionsLoaded` back, so it never blocks the
-            // LocalSet or the first frame. Subsequent `ensure_history_loaded`
-            // calls (from `/sessions`) short-circuit on `Loading`/`Loaded`.
-            //
-            // Only the ACP TUI path reaches here — `wta delegate`, `wta mcp`,
-            // and CLI subcommands never construct an App that wires
-            // `event_tx`, so they don't pay this cost.
-            app_state.ensure_history_loaded();
+            // The helper does not scan on-disk history: master performs the
+            // single (CLI-filtered) scan and the session view renders from
+            // its `session/list` snapshot. See
+            // doc/specs/per-cli-history-filtering.md.
 
             if let Some((pane_id, _tab_id, window_id)) = pane_identity {
                 app_state.pane_id = Some(pane_id);

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -1622,10 +1622,14 @@ async fn run_master_loop(cli: Cli, pipe_name: String) -> Result<()> {
     // up the historicals; helpers that open session management view later will see them on
     // the next `sessions/list` call.
     let inner_for_history = Arc::clone(&inner);
+    // The session view only shows the current agent's CLI, so seed the
+    // registry with just that CLI's history. `None` (custom / unrecognized
+    // agent) scans all four, matching the view's all-CLI behavior.
+    let history_cli = inner.cli_source.clone();
     tokio::task::spawn_local(async move {
         let scan_started = std::time::Instant::now();
-        let sessions = match tokio::task::spawn_blocking(|| {
-            crate::history_loader::load_all()
+        let sessions = match tokio::task::spawn_blocking(move || {
+            crate::history_loader::load_for_cli(history_cli.as_ref())
         })
         .await
         {

--- a/tools/wta/src/ui/agents_view.rs
+++ b/tools/wta/src/ui/agents_view.rs
@@ -11,7 +11,6 @@ use unicode_width::UnicodeWidthStr;
 use crate::agent_sessions::{
     AgentSession, AgentSessionRegistry, AgentStatus, CliSource, OriginFilter, SessionOrigin,
 };
-use crate::app::HistoryLoadState;
 use crate::session_registry::SessionInfo;
 use crate::ui::shimmer;
 
@@ -33,7 +32,6 @@ pub fn render(
     reg: &AgentSessionRegistry,
     snapshot: Option<&[SessionInfo]>,
     list_state: &mut ListState,
-    history_load_state: HistoryLoadState,
     activity_frame: usize,
     cli_filter: Option<&CliSource>,
     // MVP origin filter — `ShellOnly` by default, see
@@ -174,29 +172,19 @@ pub fn render(
         )).collect::<Vec<_>>(),
         area_w = area.width,
         area_h = area.height,
-        load_state = ?history_load_state,
         "rendering agents view"
     );
 
-    // While the lazy history scan is in flight, replace the whole list
-    // with a single shimmer-styled loading row. Showing live rows alongside
-    // a dim "loading…" hint led users to think the list was complete (only
-    // the 1 live session) and dismiss the view before the scan finished.
-    //
-    // Two distinct "we don't have any rows to show yet" sources trigger
-    // the shimmer:
-    //   * Legacy `!using_snapshot` path: registry-driven render with the
-    //     on-disk history scan still in progress (pre-PR-#73 behaviour,
-    //     kept for completeness — `using_snapshot` is now always true
-    //     when the view is open).
-    //   * Snapshot path: session management view was just opened, master hasn't yet replied
-    //     to our `session/list` refetch, and the placeholder snapshot
-    //     is still the empty Vec primed by `open_agents_view_for_tab`.
-    //     Without this branch the user sees a blank list (no shimmer,
-    //     no rows) and can't tell loading from "really empty".
+    // While the view is waiting on its first `session/list` snapshot from
+    // master, replace the whole list with a single shimmer-styled loading
+    // row. Showing live rows alongside a dim "loading…" hint led users to
+    // think the list was complete and dismiss the view before the snapshot
+    // arrived. The session view was just opened, master hasn't yet replied
+    // to our `session/list` refetch, and the placeholder snapshot is still
+    // the empty Vec primed by `open_agents_view_for_tab`; without this the
+    // user sees a blank list and can't tell loading from "really empty".
     let snapshot_loading = awaiting_first_snapshot && sorted.is_empty();
-    let legacy_loading = !using_snapshot && history_load_state == HistoryLoadState::Loading;
-    if snapshot_loading || legacy_loading {
+    if snapshot_loading {
         render_left_bar(f, area.x, list_area, None);
         let mut spans: Vec<Span<'static>> = vec![Span::raw("  ")];
         let loading_label = t!("agents.loading").into_owned();

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -47,7 +47,6 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     // the whole App and conflict with &app.agent_sessions).
     if app.current_tab().current_view == View::Agents {
         let tab_id = app.tab_id.as_deref().unwrap_or(DEFAULT_TAB_ID).to_string();
-        let load_state = app.history_load_state;
         let activity_frame = app.activity_frame as usize;
         let cli_filter = app.current_cli_filter();
         let origin_filter = app.sessions_origin_filter;
@@ -72,7 +71,6 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             &app.agent_sessions,
             tab.agents_view.snapshot.as_deref(),
             &mut tab.agents_list_state,
-            load_state,
             activity_frame,
             cli_filter.as_ref(),
             origin_filter,


### PR DESCRIPTION
## Summary

Speeds up agent session-view history loading in two complementary layers: a
**two-phase per-CLI scan** that avoids reading transcripts it will throw away,
and **per-CLI filtering** that scans only the current agent's CLI and drops the
helper's redundant local scan.

## Part 1 — Two-phase scan

`history_loader::load_all` opened and parsed **every** session transcript on
disk (~360 content reads, **~3.5 s** on a populated machine), then sorted and
truncated to 50/CLI. ~98% of that was content reading — most of it WTA's own
**agent-pane (Class A) phantoms**, which the session picker hides anyway.
Gemini alone had 50 seeded-prompt `header + $set` files, each costing an 8 KB
read ×3 just to classify and drop.

Each per-CLI loader is now two phases:

1. **Cheap discovery** — enumerate candidates (`id` + `mtime` + `path`) with
   minimal IO and skip **Class A** via the agent-pane index **before any
   content read**. Gemini/Codex read only line 1 to get the id.
2. **Expensive parse** — phantom filter + title + cwd for the newest
   `MAX_PER_CLI` (50) survivors only.

| | Before | After | |
|---|---:|---:|---:|
| **TOTAL** | 3461 ms | **943 ms** | **−73%** |
| Gemini | 1137 ms | 52 ms | −95% |
| Codex | 1207 ms | 85 ms | −93% |
| Copilot | 840 ms | 527 ms | −37% |
| Claude | 266 ms | 266 ms | (<50 real) |

## Part 2 — Per-CLI filtering

The session view only ever shows the **current** agent's CLI, yet master and
every per-tab helper scanned **all four**. This change:

- narrows master's scan to the current CLI (`load_for_cli`), and
- **removes the helper's local scan entirely** — the view renders from
  master's `session/list` snapshot; the helper's local registry was only a
  shadowed fallback.

So a WT process does **one** filtered scan (in master) instead of **N+1** full
scans (N helpers + master). Master's registry / broadcast / snapshot size
drops from up to ~200 rows to up to ~50 (one CLI). Switching the agent in
Settings restarts master, so the re-scan is automatic — no runtime switch
signal is added.

## Safety / behavior

- **Live Class A tracking is unaffected.** Live agent-pane rows come from
  `new_session`, not the disk scan (`apply_alive_session_join` is a no-op for
  unknown sids). The scan only ever produced *historical* rows.
- The picker already hides Class A (MVP `OriginFilter::ShellOnly`).
- Live / watcher cross-CLI rows stay filtered by the **view** filter, which
  this PR does not touch.
- **Behavior change:** `wta sessions list` now shows only the current CLI's
  history (master is filtered); dead agent-pane rows are no longer listed.

## Testing

`cargo test --manifest-path tools/wta/Cargo.toml` — full suite green. Adds
focused tests for `select_top_candidates`, `load_*_indexed` Class A skip,
`read_first_line` (incl. the oversize-line cap), `gemini_session_id_from_header`,
and `agents_view_awaiting_snapshot`.
