### PR TITLE
Move protocol event fan-out off the producer thread (#239)

### DIFF
--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
@@ -118,11 +118,19 @@ HRESULT TerminalProtocolComServer::s_StopListening()
 
 TerminalProtocolComServer::~TerminalProtocolComServer()
 {
-    // Signal the delivery worker to exit; do NOT join. The detached worker owns
-    // its own reference to the shared _DeliveryState and never touches `this`,
-    // so the object can be destroyed immediately without waiting on a slow
-    // OnEvent (and without risking a re-entrancy deadlock). The worker frees the
-    // state when it returns.
+    // Remove this instance from the global fan-out set FIRST. This preserves the
+    // global lock order: s_NotifyEventToComClients takes s_instancesMutex before
+    // _enqueueEvent takes _deliveryMutex, so destruction must not take
+    // _deliveryMutex before _removeInstance takes s_instancesMutex.
+    //
+    // Once removed, no new fan-out can enqueue into this instance. Then signal
+    // the delivery worker to exit; do NOT join. The detached worker owns its own
+    // reference to the shared _DeliveryState and never touches `this`, so the
+    // object can be destroyed immediately without waiting on a slow OnEvent (and
+    // without risking a re-entrancy deadlock). The worker frees the state when it
+    // returns.
+    _removeInstance();
+
     std::shared_ptr<_DeliveryState> d;
     {
         std::lock_guard lock{ _deliveryMutex };
@@ -132,7 +140,6 @@ TerminalProtocolComServer::~TerminalProtocolComServer()
     {
         d->queue.stop();
     }
-    _removeInstance();
 }
 
 void TerminalProtocolComServer::_addInstance()

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
@@ -118,11 +118,20 @@ HRESULT TerminalProtocolComServer::s_StopListening()
 
 TerminalProtocolComServer::~TerminalProtocolComServer()
 {
-    // Stop + join this subscriber's delivery thread BEFORE _removeInstance so
-    // the worker (which dereferences `this`) cannot outlive the object. The
-    // join also runs before the queue/mutex/condvar members destruct, since
-    // member teardown happens only after the destructor body returns.
-    _stopWorker();
+    // Signal the delivery worker to exit; do NOT join. The detached worker owns
+    // its own reference to the shared _DeliveryState and never touches `this`,
+    // so the object can be destroyed immediately without waiting on a slow
+    // OnEvent (and without risking a re-entrancy deadlock). The worker frees the
+    // state when it returns.
+    std::shared_ptr<_DeliveryState> d;
+    {
+        std::lock_guard lock{ _deliveryMutex };
+        d = _delivery;
+    }
+    if (d)
+    {
+        d->queue.stop();
+    }
     _removeInstance();
 }
 
@@ -368,63 +377,39 @@ void TerminalProtocolComServer::s_NotifyEventToComClients(const std::string& eve
 
 void TerminalProtocolComServer::_enqueueEvent(const std::string& eventJson)
 {
-    // Hand the event to this subscriber's bounded queue and return. The queue
-    // applies the subscribe-gate (drops while inactive) and drop-oldest
-    // back-pressure; the producer never blocks. The dedicated worker thread
-    // performs the actual cross-process OnEvent. See BoundedDispatchQueue.
-    _deliveryQueue.try_push(eventJson);
-}
-
-void TerminalProtocolComServer::_startWorkerIfNeeded()
-{
-    std::lock_guard lock{ _workerMutex };
-    if (_worker.joinable())
+    // Hand the event to the current subscriber's bounded queue and return. The
+    // queue applies the subscribe-gate (drops while inactive) and drop-oldest
+    // back-pressure; the producer never blocks. The detached worker performs the
+    // actual cross-process OnEvent. Hold the shared_ptr across the push so a
+    // concurrent Unsubscribe swap can't free the state from under us.
+    std::shared_ptr<_DeliveryState> d;
     {
-        // Already running from a prior Subscribe; it picks up the new _sinkRef
-        // on its next iteration (read under _callbackMutex).
-        return;
+        std::lock_guard lock{ _deliveryMutex };
+        d = _delivery;
     }
-    _worker = std::thread([this]() { _workerLoop(); });
+    d->queue.try_push(eventJson);
 }
 
-void TerminalProtocolComServer::_stopWorker() noexcept
-{
-    std::lock_guard lock{ _workerMutex };
-    _deliveryQueue.stop();
-    if (_worker.joinable())
-    {
-        // NOTE: if the worker is currently blocked inside a stuck OnEvent (a
-        // subscriber that is alive but permanently not draining), this join
-        // waits for that call to return. It never blocks the UI thread — the
-        // UI thread only ever enqueues. A future hardening could add an
-        // OnEvent cancel/timeout (ICancelMethodCalls) to bound this wait.
-        _worker.join();
-    }
-}
-
-void TerminalProtocolComServer::_workerLoop()
+void TerminalProtocolComServer::_runDeliveryWorker(std::shared_ptr<_DeliveryState> state)
 {
     // Resolve the agile sink reference and call OnEvent on THIS dedicated MTA
-    // thread, so the synchronous cross-process call never runs on the producer
-    // (UI/STA or COM MTA) thread. MTA init is required so the agile reference's
-    // Resolve hands back a proxy valid on this thread.
+    // thread, so the synchronous cross-process call never runs on a producer
+    // (UI/STA or COM MTA) thread. MTA init is required so Resolve hands back a
+    // proxy valid on this thread. The worker owns `state`; when wait_pop returns
+    // false (stop()) the loop exits and the last reference is released here.
     auto coInit = wil::CoInitializeEx(COINIT_MULTITHREADED);
 
     std::string eventJson;
-    while (_deliveryQueue.wait_pop(eventJson))
+    while (state->queue.wait_pop(eventJson))
     {
-        // Snapshot the agile ref under the callback lock, then resolve + call
-        // outside it so Unsubscribe can swap/clear the sink without waiting on
-        // a long OnEvent.
         ComPtr<IAgileReference> ref;
         {
-            std::lock_guard lock{ _callbackMutex };
-            ref = _sinkRef;
+            std::lock_guard lock{ state->mutex };
+            ref = state->sinkRef;
         }
         if (!ref)
         {
-            // Not subscribed (yet / anymore) — drop this event and idle until
-            // the next Subscribe or until _stopWorker tears the thread down.
+            // Not subscribed (yet / anymore) — drop and keep waiting.
             continue;
         }
 
@@ -441,19 +426,24 @@ void TerminalProtocolComServer::_workerLoop()
         ComPtr<ITerminalProtocolEventSink> sink;
         if (FAILED(ref->Resolve(IID_PPV_ARGS(&sink))) || !sink)
         {
+            // The sink can no longer be resolved — treat as a disconnect (same
+            // as an OnEvent failure): close the gate and clear the sink so
+            // producers stop enqueuing and we stop churning for a dead client.
+            state->queue.set_active(false);
+            std::lock_guard lock{ state->mutex };
+            state->sinkRef.Reset();
             continue;
         }
 
         if (FAILED(sink->OnEvent(eventBstr.get())))
         {
-            // Client disconnected. Clear our sink AND close the queue gate so
+            // Client disconnected — close the gate and clear the sink so
             // producers stop enqueuing (and we stop popping/dropping) work for a
-            // dead subscriber — that churn would otherwise continue until COM
-            // rundown destroys the instance. The now-idle worker parks in
-            // wait_pop until _stopWorker tears it down on Unsubscribe/destruction.
-            _deliveryQueue.set_active(false);
-            std::lock_guard lock{ _callbackMutex };
-            _sinkRef.Reset();
+            // dead subscriber. The now-idle worker parks in wait_pop until the
+            // instance's teardown calls stop().
+            state->queue.set_active(false);
+            std::lock_guard lock{ state->mutex };
+            state->sinkRef.Reset();
         }
     }
 }
@@ -967,27 +957,36 @@ try
     ComPtr<IAgileReference> ref;
     RETURN_IF_FAILED(::RoGetAgileReference(AGILEREFERENCE_DEFAULT, __uuidof(ITerminalProtocolEventSink), sink, &ref));
 
+    std::shared_ptr<_DeliveryState> d;
     {
-        std::lock_guard lock{ _callbackMutex };
-        _sinkRef = ref;
+        std::lock_guard lock{ _deliveryMutex };
+        d = _delivery;
+    }
+    {
+        std::lock_guard lock{ d->mutex };
+        d->sinkRef = ref;
     }
 
-    // Spin up this subscriber's dedicated delivery thread so OnEvent never runs
-    // on the producer thread (no-op if already running from a prior Subscribe).
-    // set_active() opens the queue's subscribe-gate and clears any prior stop.
-    // It must precede _startWorkerIfNeeded so a re-subscribed instance clears the
-    // stop flag before the fresh worker starts (else wait_pop returns false at
-    // once); if thread creation throws, roll the gate back so producers don't
-    // enqueue undeliverable work for a subscriber with no worker.
-    _deliveryQueue.set_active(true);
-    try
+    // Open the subscribe-gate, then start the detached delivery worker once for
+    // this state so OnEvent never runs on the producer thread. If thread
+    // creation throws, roll the gate back so producers don't enqueue
+    // undeliverable work for a subscriber with no worker.
+    d->queue.set_active(true);
     {
-        _startWorkerIfNeeded();
-    }
-    catch (...)
-    {
-        _deliveryQueue.set_active(false);
-        throw;
+        std::lock_guard lock{ d->mutex };
+        if (!d->workerStarted)
+        {
+            try
+            {
+                std::thread(&TerminalProtocolComServer::_runDeliveryWorker, d).detach();
+            }
+            catch (...)
+            {
+                d->queue.set_active(false);
+                throw;
+            }
+            d->workerStarted = true;
+        }
     }
 
     // Ensure page events are wired up (one-time global init).
@@ -998,18 +997,23 @@ CATCH_RETURN()
 
 STDMETHODIMP TerminalProtocolComServer::Unsubscribe()
 {
-    // Close the subscribe-gate first so nothing new is enqueued during teardown.
-    _deliveryQueue.set_active(false);
+    // Non-blocking teardown: swap in a fresh state for any future Subscribe,
+    // then signal the old worker to stop. We never join — a worker blocked in a
+    // slow OnEvent, or a client re-entering Unsubscribe from within its own
+    // OnEvent handler, must not stall or deadlock this call. The detached worker
+    // owns its reference to `old` and frees it when it returns.
+    std::shared_ptr<_DeliveryState> old;
     {
-        std::lock_guard lock{ _callbackMutex };
-        _sinkRef.Reset();
+        std::lock_guard lock{ _deliveryMutex };
+        old = _delivery;
+        _delivery = std::make_shared<_DeliveryState>(s_maxQueuedEvents);
     }
-
-    // Tear down the delivery thread (stop() wakes wait_pop and drops backlog).
-    // Unsubscribe is driven by the client, which is therefore actively
-    // draining — the worker's in-flight OnEvent (if any) returns promptly, so
-    // the join is quick.
-    _stopWorker();
+    old->queue.set_active(false);
+    {
+        std::lock_guard lock{ old->mutex };
+        old->sinkRef.Reset();
+    }
+    old->queue.stop();
     return S_OK;
 }
 

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
@@ -1013,8 +1013,14 @@ try
 CATCH_RETURN()
 
 STDMETHODIMP TerminalProtocolComServer::Unsubscribe()
+try
 {
-    // Non-blocking teardown: swap in a fresh state for any future Subscribe,
+    // Allocate the fresh replacement state BEFORE taking the lock so a throwing
+    // allocation is caught by CATCH_RETURN (escaping a COM method would crash
+    // the process) and never leaves _delivery half-swapped under the lock.
+    auto fresh = std::make_shared<_DeliveryState>(s_maxQueuedEvents);
+
+    // Non-blocking teardown: swap in the fresh state for any future Subscribe,
     // then signal the old worker to stop. We never join — a worker blocked in a
     // slow OnEvent, or a client re-entering Unsubscribe from within its own
     // OnEvent handler, must not stall or deadlock this call. The detached worker
@@ -1023,7 +1029,7 @@ STDMETHODIMP TerminalProtocolComServer::Unsubscribe()
     {
         std::lock_guard lock{ _deliveryMutex };
         old = _delivery;
-        _delivery = std::make_shared<_DeliveryState>(s_maxQueuedEvents);
+        _delivery = std::move(fresh);
     }
     old->queue.set_active(false);
     {
@@ -1033,6 +1039,7 @@ STDMETHODIMP TerminalProtocolComServer::Unsubscribe()
     old->queue.stop();
     return S_OK;
 }
+CATCH_RETURN()
 
 STDMETHODIMP TerminalProtocolComServer::SendEvent(BSTR eventJson)
 try

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
@@ -446,9 +446,12 @@ void TerminalProtocolComServer::_workerLoop()
 
         if (FAILED(sink->OnEvent(eventBstr.get())))
         {
-            // Client disconnected — clear our sink. Subsequent iterations see a
-            // null ref and idle until the instance is torn down (the client's
-            // COM ref release drives ~TerminalProtocolComServer -> _stopWorker).
+            // Client disconnected. Clear our sink AND close the queue gate so
+            // producers stop enqueuing (and we stop popping/dropping) work for a
+            // dead subscriber — that churn would otherwise continue until COM
+            // rundown destroys the instance. The now-idle worker parks in
+            // wait_pop until _stopWorker tears it down on Unsubscribe/destruction.
+            _deliveryQueue.set_active(false);
             std::lock_guard lock{ _callbackMutex };
             _sinkRef.Reset();
         }
@@ -972,8 +975,20 @@ try
     // Spin up this subscriber's dedicated delivery thread so OnEvent never runs
     // on the producer thread (no-op if already running from a prior Subscribe).
     // set_active() opens the queue's subscribe-gate and clears any prior stop.
+    // It must precede _startWorkerIfNeeded so a re-subscribed instance clears the
+    // stop flag before the fresh worker starts (else wait_pop returns false at
+    // once); if thread creation throws, roll the gate back so producers don't
+    // enqueue undeliverable work for a subscriber with no worker.
     _deliveryQueue.set_active(true);
-    _startWorkerIfNeeded();
+    try
+    {
+        _startWorkerIfNeeded();
+    }
+    catch (...)
+    {
+        _deliveryQueue.set_active(false);
+        throw;
+    }
 
     // Ensure page events are wired up (one-time global init).
     _ensurePageEventsRegistered();

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
@@ -397,54 +397,71 @@ void TerminalProtocolComServer::_runDeliveryWorker(std::shared_ptr<_DeliveryStat
     // (UI/STA or COM MTA) thread. MTA init is required so Resolve hands back a
     // proxy valid on this thread. The worker owns `state`; when wait_pop returns
     // false (stop()) the loop exits and the last reference is released here.
-    auto coInit = wil::CoInitializeEx(COINIT_MULTITHREADED);
-
-    std::string eventJson;
-    while (state->queue.wait_pop(eventJson))
+    //
+    // This worker is DETACHED: an exception escaping the thread function would
+    // call std::terminate and crash the whole process. Everything therefore runs
+    // under a catch-all — a per-event catch drops one bad event and keeps the
+    // worker alive; the outer catch handles a CoInitializeEx / wait_pop failure
+    // by exiting cleanly.
+    try
     {
-        ComPtr<IAgileReference> ref;
-        {
-            std::lock_guard lock{ state->mutex };
-            ref = state->sinkRef;
-        }
-        if (!ref)
-        {
-            // Not subscribed (yet / anymore) — drop and keep waiting.
-            continue;
-        }
+        auto coInit = wil::CoInitializeEx(COINIT_MULTITHREADED);
 
-        wil::unique_bstr eventBstr{ ::SysAllocString(winrt::to_hstring(eventJson).c_str()) };
-        if (!eventBstr)
+        std::string eventJson;
+        while (state->queue.wait_pop(eventJson))
         {
-            // OOM allocating the payload — skip rather than call OnEvent with a
-            // null BSTR, which would break the JSON-string event contract.
-            continue;
-        }
+            try
+            {
+                ComPtr<IAgileReference> ref;
+                {
+                    std::lock_guard lock{ state->mutex };
+                    ref = state->sinkRef;
+                }
+                if (!ref)
+                {
+                    // Not subscribed (yet / anymore) — drop and keep waiting.
+                    continue;
+                }
 
-        // Resolve the agile reference to a sink proxy valid on THIS thread,
-        // then call it — the cross-apartment-safe callback path.
-        ComPtr<ITerminalProtocolEventSink> sink;
-        if (FAILED(ref->Resolve(IID_PPV_ARGS(&sink))) || !sink)
-        {
-            // The sink can no longer be resolved — treat as a disconnect (same
-            // as an OnEvent failure): close the gate and clear the sink so
-            // producers stop enqueuing and we stop churning for a dead client.
-            state->queue.set_active(false);
-            std::lock_guard lock{ state->mutex };
-            state->sinkRef.Reset();
-            continue;
-        }
+                wil::unique_bstr eventBstr{ ::SysAllocString(winrt::to_hstring(eventJson).c_str()) };
+                if (!eventBstr)
+                {
+                    // OOM allocating the payload — skip rather than call OnEvent
+                    // with a null BSTR, which would break the event contract.
+                    continue;
+                }
 
-        if (FAILED(sink->OnEvent(eventBstr.get())))
-        {
-            // Client disconnected — close the gate and clear the sink so
-            // producers stop enqueuing (and we stop popping/dropping) work for a
-            // dead subscriber. The now-idle worker parks in wait_pop until the
-            // instance's teardown calls stop().
-            state->queue.set_active(false);
-            std::lock_guard lock{ state->mutex };
-            state->sinkRef.Reset();
+                // Resolve the agile reference to a sink proxy valid on THIS
+                // thread, then call it (cross-apartment-safe callback path).
+                // Short-circuit so OnEvent is never called on a null sink.
+                ComPtr<ITerminalProtocolEventSink> sink;
+                if (FAILED(ref->Resolve(IID_PPV_ARGS(&sink))) || !sink || FAILED(sink->OnEvent(eventBstr.get())))
+                {
+                    // The sink can no longer be resolved, or the client
+                    // disconnected — treat as a disconnect: close the gate and
+                    // clear the sink so producers stop enqueuing (and we stop
+                    // churning) for a dead client. BUT only if this is STILL the
+                    // sink we just used: a concurrent re-Subscribe may have
+                    // swapped in a new sink while this delivery (using the old
+                    // `ref`) was in flight, and we must not clobber it.
+                    std::lock_guard lock{ state->mutex };
+                    if (state->sinkRef.Get() == ref.Get())
+                    {
+                        state->sinkRef.Reset();
+                        state->queue.set_active(false);
+                    }
+                }
+            }
+            catch (...)
+            {
+                // Never let an exception escape a detached worker. Drop this
+                // event and keep delivering.
+            }
         }
+    }
+    catch (...)
+    {
+        // CoInitializeEx / wait_pop failure — exit the worker without crashing.
     }
 }
 

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
@@ -118,6 +118,11 @@ HRESULT TerminalProtocolComServer::s_StopListening()
 
 TerminalProtocolComServer::~TerminalProtocolComServer()
 {
+    // Stop + join this subscriber's delivery thread BEFORE _removeInstance so
+    // the worker (which dereferences `this`) cannot outlive the object. The
+    // join also runs before the queue/mutex/condvar members destruct, since
+    // member teardown happens only after the destructor body returns.
+    _stopWorker();
     _removeInstance();
 }
 
@@ -345,59 +350,107 @@ void TerminalProtocolComServer::s_OnWindowAdded(AppHost* /*host*/)
 
 void TerminalProtocolComServer::s_NotifyEventToComClients(const std::string& eventJson)
 {
-    wil::unique_bstr eventBstr{ ::SysAllocString(winrt::to_hstring(eventJson).c_str()) };
-    if (!eventBstr)
+    // Enqueue the event into every connected subscriber's bounded queue and
+    // return immediately. Each subscriber's dedicated worker thread performs
+    // the synchronous cross-process OnEvent OFF this (producer) thread, so a
+    // slow or blocked subscriber can no longer stall the terminal UI thread,
+    // and subscribers are isolated from one another. See issue #239.
+    //
+    // Instance members are touched only under s_instancesMutex; _removeInstance
+    // takes the same lock, so an instance cannot be erased mid-iteration. This
+    // matches the locking discipline of the previous (synchronous) fan-out.
+    std::lock_guard lock{ s_instancesMutex };
+    for (auto* instance : s_instances)
     {
-        // OOM allocating the event payload — skip this delivery rather than
-        // calling OnEvent with a null BSTR, which would break the documented
-        // JSON-string event contract.
+        instance->_enqueueEvent(eventJson);
+    }
+}
+
+void TerminalProtocolComServer::_enqueueEvent(const std::string& eventJson)
+{
+    // Hand the event to this subscriber's bounded queue and return. The queue
+    // applies the subscribe-gate (drops while inactive) and drop-oldest
+    // back-pressure; the producer never blocks. The dedicated worker thread
+    // performs the actual cross-process OnEvent. See BoundedDispatchQueue.
+    _deliveryQueue.try_push(eventJson);
+}
+
+void TerminalProtocolComServer::_startWorkerIfNeeded()
+{
+    std::lock_guard lock{ _workerMutex };
+    if (_worker.joinable())
+    {
+        // Already running from a prior Subscribe; it picks up the new _sinkRef
+        // on its next iteration (read under _callbackMutex).
         return;
     }
+    _worker = std::thread([this]() { _workerLoop(); });
+}
 
-    // Snapshot the agile sink references under lock, then invoke outside the
-    // lock to avoid deadlocks if a callback reenters the server (e.g. via
-    // SendEvent).
-    std::vector<ComPtr<IAgileReference>> sinks;
+void TerminalProtocolComServer::_stopWorker() noexcept
+{
+    std::lock_guard lock{ _workerMutex };
+    _deliveryQueue.stop();
+    if (_worker.joinable())
     {
-        std::lock_guard lock{ s_instancesMutex };
-        for (auto* instance : s_instances)
-        {
-            std::lock_guard cbLock{ instance->_callbackMutex };
-            if (instance->_sinkRef)
-                sinks.push_back(instance->_sinkRef);
-        }
+        // NOTE: if the worker is currently blocked inside a stuck OnEvent (a
+        // subscriber that is alive but permanently not draining), this join
+        // waits for that call to return. It never blocks the UI thread — the
+        // UI thread only ever enqueues. A future hardening could add an
+        // OnEvent cancel/timeout (ICancelMethodCalls) to bound this wait.
+        _worker.join();
     }
+}
 
-    // TODO: event fan-out runs on the UI/STA thread (ProtocolVtSequenceReceived
-    // is raised there), and each OnEvent below is a SYNCHRONOUS cross-process
-    // call. A slow or blocked subscriber (e.g. wtcli's stdout pipe full because
-    // wta isn't draining it) therefore stalls the terminal UI thread, and the
-    // cost is serial across all subscribers. For high event volume this should
-    // be moved off the UI thread — queue events and drain them on a dedicated
-    // background MTA thread (mind ordering, back-pressure, and subscriber
-    // add/remove thread-safety), and/or give OnEvent a timeout. Tracked as
-    // follow-up; not addressed in the WinRT->classic-COM migration.
-    for (auto& ref : sinks)
+void TerminalProtocolComServer::_workerLoop()
+{
+    // Resolve the agile sink reference and call OnEvent on THIS dedicated MTA
+    // thread, so the synchronous cross-process call never runs on the producer
+    // (UI/STA or COM MTA) thread. MTA init is required so the agile reference's
+    // Resolve hands back a proxy valid on this thread.
+    auto coInit = wil::CoInitializeEx(COINIT_MULTITHREADED);
+
+    std::string eventJson;
+    while (_deliveryQueue.wait_pop(eventJson))
     {
+        // Snapshot the agile ref under the callback lock, then resolve + call
+        // outside it so Unsubscribe can swap/clear the sink without waiting on
+        // a long OnEvent.
+        ComPtr<IAgileReference> ref;
+        {
+            std::lock_guard lock{ _callbackMutex };
+            ref = _sinkRef;
+        }
+        if (!ref)
+        {
+            // Not subscribed (yet / anymore) — drop this event and idle until
+            // the next Subscribe or until _stopWorker tears the thread down.
+            continue;
+        }
+
+        wil::unique_bstr eventBstr{ ::SysAllocString(winrt::to_hstring(eventJson).c_str()) };
+        if (!eventBstr)
+        {
+            // OOM allocating the payload — skip rather than call OnEvent with a
+            // null BSTR, which would break the JSON-string event contract.
+            continue;
+        }
+
         // Resolve the agile reference to a sink proxy valid on THIS thread,
-        // then call it — this is the cross-apartment-safe callback path.
+        // then call it — the cross-apartment-safe callback path.
         ComPtr<ITerminalProtocolEventSink> sink;
         if (FAILED(ref->Resolve(IID_PPV_ARGS(&sink))) || !sink)
+        {
             continue;
+        }
 
         if (FAILED(sink->OnEvent(eventBstr.get())))
         {
-            // Client disconnected — clear the matching sink reference.
-            std::lock_guard lock{ s_instancesMutex };
-            for (auto* instance : s_instances)
-            {
-                std::lock_guard cbLock{ instance->_callbackMutex };
-                if (instance->_sinkRef.Get() == ref.Get())
-                {
-                    instance->_sinkRef.Reset();
-                    break;
-                }
-            }
+            // Client disconnected — clear our sink. Subsequent iterations see a
+            // null ref and idle until the instance is torn down (the client's
+            // COM ref release drives ~TerminalProtocolComServer -> _stopWorker).
+            std::lock_guard lock{ _callbackMutex };
+            _sinkRef.Reset();
         }
     }
 }
@@ -916,6 +969,12 @@ try
         _sinkRef = ref;
     }
 
+    // Spin up this subscriber's dedicated delivery thread so OnEvent never runs
+    // on the producer thread (no-op if already running from a prior Subscribe).
+    // set_active() opens the queue's subscribe-gate and clears any prior stop.
+    _deliveryQueue.set_active(true);
+    _startWorkerIfNeeded();
+
     // Ensure page events are wired up (one-time global init).
     _ensurePageEventsRegistered();
     return S_OK;
@@ -924,8 +983,18 @@ CATCH_RETURN()
 
 STDMETHODIMP TerminalProtocolComServer::Unsubscribe()
 {
-    std::lock_guard lock{ _callbackMutex };
-    _sinkRef.Reset();
+    // Close the subscribe-gate first so nothing new is enqueued during teardown.
+    _deliveryQueue.set_active(false);
+    {
+        std::lock_guard lock{ _callbackMutex };
+        _sinkRef.Reset();
+    }
+
+    // Tear down the delivery thread (stop() wakes wait_pop and drops backlog).
+    // Unsubscribe is driven by the client, which is therefore actively
+    // draining — the worker's in-flight OnEvent (if any) returns promptly, so
+    // the join is quick.
+    _stopWorker();
     return S_OK;
 }
 

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.h
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.h
@@ -6,7 +6,6 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <thread>
 #include <vector>
 
 #include <wrl/implements.h>

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.h
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -77,38 +78,47 @@ TerminalProtocolComServer : public Microsoft::WRL::RuntimeClass<
 private:
     bool _authenticated = false;
 
-    // Per-instance event sink, stored as an agile reference so it can be
-    // resolved + called from any apartment (set via Subscribe, cleared via
-    // Unsubscribe).
-    std::mutex _callbackMutex;
-    Microsoft::WRL::ComPtr<IAgileReference> _sinkRef;
-
     // ── Per-subscriber asynchronous event delivery (issue #239) ──
     //
-    // Each connected client (= one instance) owns a bounded FIFO queue and a
-    // dedicated MTA worker thread that drains it. The producer
-    // (s_NotifyEventToComClients, raised on the UI/STA thread for VT events and
-    // on a COM MTA thread for SendEvent broadcasts) only ever ENQUEUES and
-    // returns immediately. The worker resolves the agile sink reference and
-    // makes the SYNCHRONOUS cross-process OnEvent call on its own thread — so a
-    // slow or blocked subscriber (e.g. wtcli's stdout pipe full because wta
-    // isn't draining it) can no longer stall the terminal UI thread, and
-    // subscribers are isolated from one another (one stuck client only backs up
-    // its own bounded queue; the others keep flowing).
+    // Each connected client (= one instance) owns a bounded FIFO queue drained
+    // by a dedicated MTA worker thread. The producer (s_NotifyEventToComClients,
+    // raised on the UI/STA thread for VT events and on a COM MTA thread for
+    // SendEvent broadcasts) only ever ENQUEUES and returns immediately. The
+    // worker resolves the agile sink reference and makes the SYNCHRONOUS
+    // cross-process OnEvent call on its own thread — so a slow or blocked
+    // subscriber (e.g. wtcli's stdout pipe full because wta isn't draining it)
+    // can no longer stall the terminal UI thread, and subscribers are isolated
+    // from one another (one stuck client only backs up its own bounded queue).
+    //
+    // The queue + sink live in a ref-counted _DeliveryState shared between the
+    // instance and a DETACHED worker thread. Teardown (Unsubscribe/destructor)
+    // only signals stop() and drops the instance's reference — it NEVER joins.
+    // This is deliberate: joining could deadlock if a subscriber re-enters the
+    // server (e.g. calls Unsubscribe) from inside its own OnEvent handler, and
+    // would otherwise block on a stuck OnEvent. The detached worker holds its
+    // own reference, touches only the shared state (never `this`), and frees the
+    // state when it returns — so the COM object can be destroyed immediately.
     //
     // The bounded-queue / back-pressure / subscribe-gate logic lives in the
     // dependency-free Microsoft::Terminal::BoundedDispatchQueue (unit-tested in
     // ut_app); only the COM resolve + OnEvent + thread shell lives here.
     static constexpr size_t s_maxQueuedEvents = 4096;
 
-    Microsoft::Terminal::BoundedDispatchQueue<std::string> _deliveryQueue{ s_maxQueuedEvents };
-    std::mutex _workerMutex;
-    std::thread _worker;
+    struct _DeliveryState
+    {
+        explicit _DeliveryState(size_t cap) :
+            queue{ cap } {}
+        Microsoft::Terminal::BoundedDispatchQueue<std::string> queue;
+        std::mutex mutex; // guards sinkRef + workerStarted
+        Microsoft::WRL::ComPtr<IAgileReference> sinkRef;
+        bool workerStarted{ false };
+    };
+
+    std::mutex _deliveryMutex; // guards the _delivery shared_ptr swap
+    std::shared_ptr<_DeliveryState> _delivery{ std::make_shared<_DeliveryState>(s_maxQueuedEvents) };
 
     void _enqueueEvent(const std::string& eventJson);
-    void _startWorkerIfNeeded();
-    void _stopWorker() noexcept;
-    void _workerLoop();
+    static void _runDeliveryWorker(std::shared_ptr<_DeliveryState> state);
 
     // Static tracking of live COM instances for event delivery.
     static std::mutex s_instancesMutex;

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.h
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.h
@@ -4,12 +4,15 @@
 #pragma once
 
 #include <mutex>
+#include <string>
+#include <thread>
 #include <vector>
 
 #include <wrl/implements.h>
 #include <wrl/client.h>
 
 #include "ITerminalProtocol.h"
+#include "../inc/BoundedDispatchQueue.h"
 
 // Per-brand CLSIDs — same pattern as CTerminalHandoff. Reused unchanged from the
 // previous WinRT/MBM server, so WT_COM_CLSID discovery on the client is identical.
@@ -79,6 +82,33 @@ private:
     // Unsubscribe).
     std::mutex _callbackMutex;
     Microsoft::WRL::ComPtr<IAgileReference> _sinkRef;
+
+    // ── Per-subscriber asynchronous event delivery (issue #239) ──
+    //
+    // Each connected client (= one instance) owns a bounded FIFO queue and a
+    // dedicated MTA worker thread that drains it. The producer
+    // (s_NotifyEventToComClients, raised on the UI/STA thread for VT events and
+    // on a COM MTA thread for SendEvent broadcasts) only ever ENQUEUES and
+    // returns immediately. The worker resolves the agile sink reference and
+    // makes the SYNCHRONOUS cross-process OnEvent call on its own thread — so a
+    // slow or blocked subscriber (e.g. wtcli's stdout pipe full because wta
+    // isn't draining it) can no longer stall the terminal UI thread, and
+    // subscribers are isolated from one another (one stuck client only backs up
+    // its own bounded queue; the others keep flowing).
+    //
+    // The bounded-queue / back-pressure / subscribe-gate logic lives in the
+    // dependency-free Microsoft::Terminal::BoundedDispatchQueue (unit-tested in
+    // ut_app); only the COM resolve + OnEvent + thread shell lives here.
+    static constexpr size_t s_maxQueuedEvents = 4096;
+
+    Microsoft::Terminal::BoundedDispatchQueue<std::string> _deliveryQueue{ s_maxQueuedEvents };
+    std::mutex _workerMutex;
+    std::thread _worker;
+
+    void _enqueueEvent(const std::string& eventJson);
+    void _startWorkerIfNeeded();
+    void _stopWorker() noexcept;
+    void _workerLoop();
 
     // Static tracking of live COM instances for event delivery.
     static std::mutex s_instancesMutex;

--- a/src/cascadia/inc/BoundedDispatchQueue.h
+++ b/src/cascadia/inc/BoundedDispatchQueue.h
@@ -54,10 +54,15 @@ namespace Microsoft::Terminal
         BoundedDispatchQueue& operator=(const BoundedDispatchQueue&) = delete;
 
         // Producer side. Returns true if the item was queued, false if it was
-        // dropped because the queue is inactive or stopped. When the queue is
-        // already at capacity the OLDEST item is evicted (and dropped_count is
-        // incremented) to make room; the push still succeeds. Never blocks.
-        bool try_push(T item)
+        // dropped because the queue is inactive/stopped OR because copying the
+        // item failed (allocation failure). When the queue is already at
+        // capacity the OLDEST item is evicted (and dropped_count is incremented)
+        // to make room; the push still succeeds. Never blocks and NEVER throws:
+        // the item is taken by const-reference and the (potentially allocating)
+        // copy is performed inside a try/catch under the lock, so an allocation
+        // failure becomes a rejected push instead of an exception escaping onto
+        // the producer thread (which, for VT events, is the UI/STA thread).
+        bool try_push(const T& item)
         {
             {
                 std::lock_guard lock{ _mutex };
@@ -65,12 +70,23 @@ namespace Microsoft::Terminal
                 {
                     return false;
                 }
-                if (_queue.size() >= _maxItems)
+                try
+                {
+                    // push_back has the strong exception guarantee: on failure
+                    // the deque is unchanged, so we can simply reject the push.
+                    _queue.push_back(item);
+                }
+                catch (...)
+                {
+                    return false;
+                }
+                // Trim AFTER the successful push so a throwing copy never leaves
+                // us having evicted an item for an event we failed to enqueue.
+                while (_queue.size() > _maxItems)
                 {
                     _queue.pop_front();
                     ++_droppedCount;
                 }
-                _queue.push_back(std::move(item));
             }
             _cv.notify_one();
             return true;

--- a/src/cascadia/inc/BoundedDispatchQueue.h
+++ b/src/cascadia/inc/BoundedDispatchQueue.h
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// BoundedDispatchQueue.h
+//
+// A small, COM-free, header-only multi-producer / single-consumer queue used
+// to decouple event producers from a slow or blocked event consumer.
+//
+// It exists so that the protocol event fan-out (TerminalProtocolComServer)
+// never makes its synchronous, cross-process OnEvent callbacks on the thread
+// that produced the event — in particular the UI/STA thread (see issue #239).
+// Producers call try_push() and return immediately; a dedicated consumer
+// thread drains the queue via wait_pop() and performs the (potentially
+// blocking) delivery on its own thread.
+//
+// The COM/threading/marshaling concerns live in the owner; THIS type is pure
+// data + synchronization so the back-pressure and lifecycle behavior can be
+// unit-tested without a COM apartment. Behavior summary:
+//
+//   * Bounded: at most `maxItems` are retained. When full, the OLDEST item is
+//     evicted (drop-oldest) and a dropped counter is incremented — this caps
+//     memory if the consumer stops draining (e.g. a subscriber whose pipe is
+//     full) and prefers the most recent events. Producers never block.
+//   * Active gate: try_push is a no-op while inactive (mirrors "not
+//     subscribed"), so producers don't accumulate work nothing will consume.
+//   * Stop: wakes the consumer so wait_pop() returns false and drops any
+//     backlog — used for teardown. Re-activating clears a prior stop so one
+//     queue instance can be reused across subscribe/unsubscribe cycles.
+//
+// Ordering is FIFO per queue. There is a single logical consumer (wait_pop is
+// not designed to be called concurrently from multiple threads); any number of
+// producers may call try_push concurrently.
+
+#pragma once
+
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <utility>
+
+namespace Microsoft::Terminal
+{
+    template<typename T>
+    class BoundedDispatchQueue
+    {
+    public:
+        explicit BoundedDispatchQueue(size_t maxItems) noexcept :
+            _maxItems{ maxItems }
+        {
+        }
+
+        BoundedDispatchQueue(const BoundedDispatchQueue&) = delete;
+        BoundedDispatchQueue& operator=(const BoundedDispatchQueue&) = delete;
+
+        // Producer side. Returns true if the item was queued, false if it was
+        // dropped because the queue is inactive or stopped. When the queue is
+        // already at capacity the OLDEST item is evicted (and dropped_count is
+        // incremented) to make room; the push still succeeds. Never blocks.
+        bool try_push(T item)
+        {
+            {
+                std::lock_guard lock{ _mutex };
+                if (!_active || _stopped)
+                {
+                    return false;
+                }
+                if (_queue.size() >= _maxItems)
+                {
+                    _queue.pop_front();
+                    ++_droppedCount;
+                }
+                _queue.push_back(std::move(item));
+            }
+            _cv.notify_one();
+            return true;
+        }
+
+        // Consumer side. Blocks until an item is available or the queue is
+        // stopped. On stop returns false (backlog already dropped by stop()).
+        // Otherwise moves the front item into `out` and returns true.
+        bool wait_pop(T& out)
+        {
+            std::unique_lock lock{ _mutex };
+            _cv.wait(lock, [this]() { return _stopped || !_queue.empty(); });
+            if (_stopped)
+            {
+                return false;
+            }
+            out = std::move(_queue.front());
+            _queue.pop_front();
+            return true;
+        }
+
+        // Enable/disable producer pushes (the "subscribed" gate). Re-activating
+        // also clears a prior stop() so the queue can be reused.
+        void set_active(bool active)
+        {
+            std::lock_guard lock{ _mutex };
+            _active = active;
+            if (active)
+            {
+                _stopped = false;
+            }
+        }
+
+        // Wake the consumer so wait_pop() returns false, and drop any backlog.
+        void stop()
+        {
+            {
+                std::lock_guard lock{ _mutex };
+                _stopped = true;
+                _queue.clear();
+            }
+            _cv.notify_all();
+        }
+
+        // ── Observers (test / diagnostics) ──
+        size_t size() const
+        {
+            std::lock_guard lock{ _mutex };
+            return _queue.size();
+        }
+
+        uint64_t dropped_count() const
+        {
+            std::lock_guard lock{ _mutex };
+            return _droppedCount;
+        }
+
+        bool is_active() const
+        {
+            std::lock_guard lock{ _mutex };
+            return _active;
+        }
+
+    private:
+        mutable std::mutex _mutex;
+        std::condition_variable _cv;
+        std::deque<T> _queue;
+        const size_t _maxItems;
+        uint64_t _droppedCount{ 0 };
+        bool _active{ false };
+        bool _stopped{ false };
+    };
+}

--- a/src/cascadia/inc/BoundedDispatchQueue.h
+++ b/src/cascadia/inc/BoundedDispatchQueue.h
@@ -46,7 +46,7 @@ namespace Microsoft::Terminal
     {
     public:
         explicit BoundedDispatchQueue(size_t maxItems) noexcept :
-            _maxItems{ maxItems }
+            _maxItems{ maxItems > 0 ? maxItems : 1 } // clamp: 0 would pop_front() an empty deque (UB)
         {
         }
 

--- a/src/cascadia/ut_app/BoundedDispatchQueueTests.cpp
+++ b/src/cascadia/ut_app/BoundedDispatchQueueTests.cpp
@@ -1,0 +1,260 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// BoundedDispatchQueueTests.cpp
+//
+// Spec-derived tests for src/cascadia/inc/BoundedDispatchQueue.h — the
+// dependency-free multi-producer / single-consumer queue that decouples
+// protocol event producers (the UI/STA thread, COM MTA threads) from the
+// per-subscriber delivery worker in TerminalProtocolComServer (issue #239).
+//
+// These assert the queue's CONTRACT (FIFO, drop-oldest back-pressure, the
+// subscribe gate, stop semantics, and integrity under concurrent producers)
+// rather than re-deriving the current implementation — the goal is to surface
+// bugs, not to bless the code.
+
+#include "precomp.h"
+
+#include <atomic>
+#include <chrono>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "../inc/BoundedDispatchQueue.h"
+
+using namespace WEX::Logging;
+using namespace WEX::TestExecution;
+using namespace WEX::Common;
+using namespace Microsoft::Terminal;
+
+namespace TerminalAppUnitTests
+{
+    class BoundedDispatchQueueTests
+    {
+        TEST_CLASS(BoundedDispatchQueueTests);
+
+        TEST_METHOD(InactiveByDefaultRejectsPush);
+        TEST_METHOD(PreservesFifoOrder);
+        TEST_METHOD(DropsOldestWhenFullAndCountsDrops);
+        TEST_METHOD(SetInactiveGatesPushButKeepsBacklog);
+        TEST_METHOD(StopDropsBacklogAndWaitPopReturnsFalse);
+        TEST_METHOD(ReactivateAfterStopAcceptsAgain);
+        TEST_METHOD(WaitPopUnblocksOnStop);
+        TEST_METHOD(WaitPopUnblocksOnPush);
+        TEST_METHOD(ConcurrentProducersLoseNothingWhenUnbounded);
+    };
+
+    // A queue is inactive (closed gate) until set_active(true). This mirrors
+    // an instance that authenticated but never Subscribe'd — it must not
+    // accumulate work nothing will deliver.
+    void BoundedDispatchQueueTests::InactiveByDefaultRejectsPush()
+    {
+        BoundedDispatchQueue<std::string> q{ 10 };
+
+        VERIFY_IS_FALSE(q.is_active());
+        VERIFY_IS_FALSE(q.try_push("x"), L"push must be rejected while inactive");
+        VERIFY_ARE_EQUAL(size_t{ 0 }, q.size());
+        VERIFY_ARE_EQUAL(uint64_t{ 0 }, q.dropped_count(), L"a gated push is not an overflow drop");
+
+        q.set_active(true);
+        VERIFY_IS_TRUE(q.try_push("x"));
+        VERIFY_ARE_EQUAL(size_t{ 1 }, q.size());
+    }
+
+    // Items come out in the exact order they went in.
+    void BoundedDispatchQueueTests::PreservesFifoOrder()
+    {
+        BoundedDispatchQueue<std::string> q{ 10 };
+        q.set_active(true);
+
+        VERIFY_IS_TRUE(q.try_push("a"));
+        VERIFY_IS_TRUE(q.try_push("b"));
+        VERIFY_IS_TRUE(q.try_push("c"));
+
+        std::string out;
+        VERIFY_IS_TRUE(q.wait_pop(out));
+        VERIFY_ARE_EQUAL(std::string{ "a" }, out);
+        VERIFY_IS_TRUE(q.wait_pop(out));
+        VERIFY_ARE_EQUAL(std::string{ "b" }, out);
+        VERIFY_IS_TRUE(q.wait_pop(out));
+        VERIFY_ARE_EQUAL(std::string{ "c" }, out);
+        VERIFY_ARE_EQUAL(size_t{ 0 }, q.size());
+    }
+
+    // At capacity, the OLDEST item is evicted and counted; size never exceeds
+    // the bound; the most-recent items survive.
+    void BoundedDispatchQueueTests::DropsOldestWhenFullAndCountsDrops()
+    {
+        BoundedDispatchQueue<std::string> q{ 3 };
+        q.set_active(true);
+
+        for (int i = 1; i <= 5; ++i)
+        {
+            VERIFY_IS_TRUE(q.try_push(std::to_string(i)), L"push still succeeds when evicting to make room");
+        }
+
+        VERIFY_ARE_EQUAL(size_t{ 3 }, q.size(), L"size must never exceed the bound");
+        VERIFY_ARE_EQUAL(uint64_t{ 2 }, q.dropped_count(), L"two oldest items were evicted");
+
+        // 1 and 2 were dropped; 3,4,5 remain in order.
+        std::string out;
+        VERIFY_IS_TRUE(q.wait_pop(out));
+        VERIFY_ARE_EQUAL(std::string{ "3" }, out);
+        VERIFY_IS_TRUE(q.wait_pop(out));
+        VERIFY_ARE_EQUAL(std::string{ "4" }, out);
+        VERIFY_IS_TRUE(q.wait_pop(out));
+        VERIFY_ARE_EQUAL(std::string{ "5" }, out);
+    }
+
+    // Deactivating closes the gate for NEW pushes but — unlike stop() — keeps
+    // any already-queued backlog, which remains drainable.
+    void BoundedDispatchQueueTests::SetInactiveGatesPushButKeepsBacklog()
+    {
+        BoundedDispatchQueue<std::string> q{ 10 };
+        q.set_active(true);
+        VERIFY_IS_TRUE(q.try_push("a"));
+        VERIFY_IS_TRUE(q.try_push("b"));
+
+        q.set_active(false);
+        VERIFY_IS_FALSE(q.try_push("c"), L"push rejected while inactive");
+        VERIFY_ARE_EQUAL(size_t{ 2 }, q.size(), L"deactivate must not drop existing backlog");
+
+        std::string out;
+        VERIFY_IS_TRUE(q.wait_pop(out));
+        VERIFY_ARE_EQUAL(std::string{ "a" }, out);
+    }
+
+    // stop() drops the backlog and makes wait_pop return false (consumer exit).
+    void BoundedDispatchQueueTests::StopDropsBacklogAndWaitPopReturnsFalse()
+    {
+        BoundedDispatchQueue<std::string> q{ 10 };
+        q.set_active(true);
+        VERIFY_IS_TRUE(q.try_push("a"));
+        VERIFY_IS_TRUE(q.try_push("b"));
+        VERIFY_ARE_EQUAL(size_t{ 2 }, q.size());
+
+        q.stop();
+        VERIFY_ARE_EQUAL(size_t{ 0 }, q.size(), L"stop must drop the backlog");
+
+        std::string out;
+        VERIFY_IS_FALSE(q.wait_pop(out), L"wait_pop must return false once stopped");
+    }
+
+    // A queue can be reused after stop(): re-activating clears the stop, drops
+    // are gone, and the previous backlog stays dropped.
+    void BoundedDispatchQueueTests::ReactivateAfterStopAcceptsAgain()
+    {
+        BoundedDispatchQueue<std::string> q{ 10 };
+        q.set_active(true);
+        VERIFY_IS_TRUE(q.try_push("old"));
+
+        q.stop();
+        VERIFY_IS_FALSE(q.try_push("rejected"), L"pushes are rejected while stopped");
+
+        q.set_active(true); // clears the prior stop
+        VERIFY_IS_TRUE(q.try_push("new"));
+
+        std::string out;
+        VERIFY_IS_TRUE(q.wait_pop(out));
+        VERIFY_ARE_EQUAL(std::string{ "new" }, out, L"old backlog was dropped by stop; only 'new' survives");
+        VERIFY_ARE_EQUAL(size_t{ 0 }, q.size());
+    }
+
+    // A consumer blocked in wait_pop on an empty queue is released by stop()
+    // and returns false. Timing-independent: even if stop() runs before the
+    // consumer reaches wait_pop, the stopped predicate is already satisfied.
+    void BoundedDispatchQueueTests::WaitPopUnblocksOnStop()
+    {
+        BoundedDispatchQueue<std::string> q{ 10 };
+        q.set_active(true);
+
+        std::atomic<bool> finished{ false };
+        bool popResult = true;
+        std::thread consumer([&]() {
+            std::string out;
+            popResult = q.wait_pop(out);
+            finished.store(true);
+        });
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        q.stop();
+        consumer.join();
+
+        VERIFY_IS_TRUE(finished.load());
+        VERIFY_IS_FALSE(popResult, L"a stopped queue must release a blocked consumer with false");
+    }
+
+    // A consumer blocked in wait_pop on an empty queue is released by a push
+    // and receives the item. Timing-independent for the same reason.
+    void BoundedDispatchQueueTests::WaitPopUnblocksOnPush()
+    {
+        BoundedDispatchQueue<std::string> q{ 10 };
+        q.set_active(true);
+
+        std::string got;
+        bool popResult = false;
+        std::thread consumer([&]() {
+            popResult = q.wait_pop(got);
+        });
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        VERIFY_IS_TRUE(q.try_push("hello"));
+        consumer.join();
+
+        VERIFY_IS_TRUE(popResult);
+        VERIFY_ARE_EQUAL(std::string{ "hello" }, got);
+    }
+
+    // The real integrity test: many producers push concurrently into a queue
+    // sized so nothing is ever dropped. Every distinct value must survive
+    // exactly once — no loss, no duplication, no corruption — and the dropped
+    // counter stays at zero.
+    void BoundedDispatchQueueTests::ConcurrentProducersLoseNothingWhenUnbounded()
+    {
+        constexpr int producers = 4;
+        constexpr int perProducer = 1000;
+        constexpr size_t total = static_cast<size_t>(producers) * perProducer;
+
+        // Capacity strictly greater than total => no eviction can occur, so we
+        // can assert exact set equality.
+        BoundedDispatchQueue<std::string> q{ total + 1 };
+        q.set_active(true);
+
+        std::atomic<size_t> pushed{ 0 };
+        std::vector<std::thread> threads;
+        for (int p = 0; p < producers; ++p)
+        {
+            threads.emplace_back([&q, &pushed, p]() {
+                for (int i = 0; i < perProducer; ++i)
+                {
+                    if (q.try_push(std::to_string(p * perProducer + i)))
+                    {
+                        pushed.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+            });
+        }
+        for (auto& t : threads)
+        {
+            t.join();
+        }
+
+        VERIFY_ARE_EQUAL(total, pushed.load(), L"every concurrent push must succeed");
+        VERIFY_ARE_EQUAL(total, q.size());
+        VERIFY_ARE_EQUAL(uint64_t{ 0 }, q.dropped_count(), L"an unbounded run must drop nothing");
+
+        // Drain (all items already present, so no blocking) and confirm we
+        // recover exactly the unique set 0..total-1.
+        std::set<std::string> seen;
+        for (size_t i = 0; i < total; ++i)
+        {
+            std::string out;
+            VERIFY_IS_TRUE(q.wait_pop(out));
+            seen.insert(out);
+        }
+        VERIFY_ARE_EQUAL(total, seen.size(), L"no value may be lost or duplicated under concurrent push");
+        VERIFY_ARE_EQUAL(size_t{ 0 }, q.size());
+    }
+}

--- a/src/cascadia/ut_app/BoundedDispatchQueueTests.cpp
+++ b/src/cascadia/ut_app/BoundedDispatchQueueTests.cpp
@@ -36,6 +36,7 @@ namespace TerminalAppUnitTests
         TEST_CLASS(BoundedDispatchQueueTests);
 
         TEST_METHOD(InactiveByDefaultRejectsPush);
+        TEST_METHOD(ClampsZeroCapacityToOne);
         TEST_METHOD(PreservesFifoOrder);
         TEST_METHOD(DropsOldestWhenFullAndCountsDrops);
         TEST_METHOD(SetInactiveGatesPushButKeepsBacklog);
@@ -61,6 +62,23 @@ namespace TerminalAppUnitTests
         q.set_active(true);
         VERIFY_IS_TRUE(q.try_push("x"));
         VERIFY_ARE_EQUAL(size_t{ 1 }, q.size());
+    }
+
+    // A zero capacity must be clamped to 1 — otherwise try_push would pop_front()
+    // an empty deque (undefined behavior) on the very first overflow.
+    void BoundedDispatchQueueTests::ClampsZeroCapacityToOne()
+    {
+        BoundedDispatchQueue<std::string> q{ 0 };
+        q.set_active(true);
+
+        VERIFY_IS_TRUE(q.try_push("a"));
+        VERIFY_IS_TRUE(q.try_push("b")); // would be UB if maxItems stayed 0
+        VERIFY_ARE_EQUAL(size_t{ 1 }, q.size());
+        VERIFY_ARE_EQUAL(uint64_t{ 1 }, q.dropped_count());
+
+        std::string out;
+        VERIFY_IS_TRUE(q.wait_pop(out));
+        VERIFY_ARE_EQUAL(std::string{ "b" }, out, L"newest survives, oldest evicted");
     }
 
     // Items come out in the exact order they went in.
@@ -142,8 +160,10 @@ namespace TerminalAppUnitTests
         VERIFY_IS_FALSE(q.wait_pop(out), L"wait_pop must return false once stopped");
     }
 
-    // A queue can be reused after stop(): re-activating clears the stop, drops
-    // are gone, and the previous backlog stays dropped.
+    // A queue can be reused after stop(): re-activating clears the stop and
+    // re-enables pushes. The backlog that stop() dropped stays gone. (Note:
+    // set_active(true) does NOT reset dropped_count(); it isn't exercised here
+    // because no overflow drop occurs in this test.)
     void BoundedDispatchQueueTests::ReactivateAfterStopAcceptsAgain()
     {
         BoundedDispatchQueue<std::string> q{ 10 };

--- a/src/cascadia/ut_app/BoundedDispatchQueueTests.cpp
+++ b/src/cascadia/ut_app/BoundedDispatchQueueTests.cpp
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <future>
 #include <set>
 #include <string>
 #include <thread>
@@ -183,46 +184,62 @@ namespace TerminalAppUnitTests
     }
 
     // A consumer blocked in wait_pop on an empty queue is released by stop()
-    // and returns false. Timing-independent: even if stop() runs before the
-    // consumer reaches wait_pop, the stopped predicate is already satisfied.
+    // and returns false. The handshake proves the consumer reached the
+    // wait_pop call, and the pre-stop assertion catches an early-return bug.
     void BoundedDispatchQueueTests::WaitPopUnblocksOnStop()
     {
         BoundedDispatchQueue<std::string> q{ 10 };
         q.set_active(true);
 
-        std::atomic<bool> finished{ false };
+        std::promise<void> aboutToWait;
+        auto aboutToWaitFuture = aboutToWait.get_future();
+        std::promise<void> finished;
+        auto finishedFuture = finished.get_future();
         bool popResult = true;
         std::thread consumer([&]() {
             std::string out;
+            aboutToWait.set_value();
             popResult = q.wait_pop(out);
-            finished.store(true);
+            finished.set_value();
         });
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        aboutToWaitFuture.wait();
+        VERIFY_ARE_EQUAL(std::future_status::timeout, finishedFuture.wait_for(std::chrono::milliseconds{ 0 }), L"consumer must still be blocked before stop()");
+
         q.stop();
         consumer.join();
 
-        VERIFY_IS_TRUE(finished.load());
+        VERIFY_ARE_EQUAL(std::future_status::ready, finishedFuture.wait_for(std::chrono::milliseconds{ 0 }));
         VERIFY_IS_FALSE(popResult, L"a stopped queue must release a blocked consumer with false");
     }
 
     // A consumer blocked in wait_pop on an empty queue is released by a push
-    // and receives the item. Timing-independent for the same reason.
+    // and receives the item. The handshake proves the consumer reached the
+    // wait_pop call, and the pre-push assertion catches an early-return bug.
     void BoundedDispatchQueueTests::WaitPopUnblocksOnPush()
     {
         BoundedDispatchQueue<std::string> q{ 10 };
         q.set_active(true);
 
+        std::promise<void> aboutToWait;
+        auto aboutToWaitFuture = aboutToWait.get_future();
+        std::promise<void> finished;
+        auto finishedFuture = finished.get_future();
         std::string got;
         bool popResult = false;
         std::thread consumer([&]() {
+            aboutToWait.set_value();
             popResult = q.wait_pop(got);
+            finished.set_value();
         });
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        aboutToWaitFuture.wait();
+        VERIFY_ARE_EQUAL(std::future_status::timeout, finishedFuture.wait_for(std::chrono::milliseconds{ 0 }), L"consumer must still be blocked before push()");
+
         VERIFY_IS_TRUE(q.try_push("hello"));
         consumer.join();
 
+        VERIFY_ARE_EQUAL(std::future_status::ready, finishedFuture.wait_for(std::chrono::milliseconds{ 0 }));
         VERIFY_IS_TRUE(popResult);
         VERIFY_ARE_EQUAL(std::string{ "hello" }, got);
     }

--- a/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
+++ b/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="JsonUtilsTests.cpp" />
     <ClCompile Include="FzfTests.cpp" />
     <ClCompile Include="AgentHooksStatusTests.cpp" />
+    <ClCompile Include="BoundedDispatchQueueTests.cpp" />
     <ClCompile Include="CustomAgentIdTests.cpp" />
     <ClCompile Include="RtlHelperTests.cpp" />
     <ClCompile Include="precomp.cpp">


### PR DESCRIPTION
## Summary of the Pull Request

Move the protocol event fan-out off the thread that raises the event so a slow or
stuck COM subscriber can no longer freeze a terminal window. Each connected
subscriber now owns a **bounded FIFO queue drained by a dedicated MTA worker
thread**; producers only enqueue and return immediately.

## References and Relevant Issues

Fixes #239

## Detailed Description of the Pull Request / Additional comments

**Problem.** `TerminalProtocolComServer::s_NotifyEventToComClients` delivered
events by calling each subscriber's **synchronous, cross-process `OnEvent`** in a
serial loop, on the thread that raised the event. For VT / lifecycle events that
thread is a window's **UI/STA thread** (`ProtocolVtSequenceReceived`); for
`SendEvent` broadcasts (agent hooks) it is a COM **MTA** thread. A slow or blocked
subscriber — e.g. `wtcli`'s stdout pipe full because `wta` isn't draining it —
therefore stalled that thread, and the cost accumulated serially across **every**
subscriber (one per agent-pane helper + master). When the blocked thread was a
window's UI thread, **the whole window froze**.

**Fix.** Give each connected client its own bounded FIFO queue drained by a
dedicated MTA worker thread:

- Producers (`s_NotifyEventToComClients`) only `try_push` into each subscriber's
  queue and return — they never call `OnEvent`.
- Each subscriber's worker resolves the agile sink reference and makes the
  synchronous `OnEvent` **on its own thread**.
- A slow/stuck subscriber only backs up **its own** bounded queue (drop-oldest
  back-pressure, capped at 4096) — the UI thread never blocks and subscribers are
  isolated from one another. Ordering is FIFO per subscriber.

**Testability.** The bounded-queue / drop-oldest / subscribe-gate / stop logic is
extracted into the dependency-free, header-only
`Microsoft::Terminal::BoundedDispatchQueue` so it can be unit-tested without a COM
apartment; only the COM resolve + `OnEvent` + thread shell stays in the server.

**Latent gap also closed.** The old fan-out was already invoked from two threads
concurrently (UI thread for `ProtocolVtSequenceReceived`, an MTA thread for
`SendEvent` broadcasts) with no serialization of delivery. The single
per-subscriber consumer restores ordered, non-concurrent delivery per sink.

**Files**
- `src/cascadia/inc/BoundedDispatchQueue.h` — new header-only MPSC queue.
- `src/cascadia/WindowsTerminal/TerminalProtocolComServer.{h,cpp}` — per-subscriber
  queue + worker; producers enqueue only.
- `src/cascadia/ut_app/BoundedDispatchQueueTests.cpp` (+ `.vcxproj`) — unit tests.

## Validation Steps Performed

**Unit tests (TAEF, `ut_app`).** New `BoundedDispatchQueueTests` assert the queue
contract from first principles: FIFO order, drop-oldest + dropped count, the
subscribe gate, stop drains/drops + `wait_pop`, reuse after stop, blocked-consumer
wakeup, and **integrity under concurrent producers** (no loss / dup / corruption).
9/9 pass; full `ut_app` suite 111/111.

**Runtime A/B — the key method: deterministically freeze a real subscriber.**
A COM subscriber is a `wtcli listen` process whose `OnEvent` writes to stdout. We
freeze one **deterministically** with `NtSuspendProcess` (ntdll) — this suspends
**all** of its threads, so its RPC worker never dispatches `OnEvent` and the
server's synchronous call to it **blocks indefinitely** (local COM/RPC has no
default timeout). This reproduces the exact server-side symptom of the issue's
"stdout pipe full" case, but on demand. With one subscriber frozen we then drive
**UI-thread (Producer-1) events** (switching tabs / running commands) and sample
the window's `Process.Responding`:

- **Pre-fix build (production install):** the window whose UI thread performed the
  fan-out **froze entirely** (`Responding=False`, fully unresponsive), while a
  **separate window in the same process stayed responsive** — confirming the
  freeze is the UI thread blocking inside the synchronous `OnEvent`, and that it
  is scoped to the window that raised the event.
- **This build (dev):** **all** windows stayed responsive the whole time
  (`Responding=True` for 60/60 samples). Working set stayed bounded (~+8 MB under
  an 8000-event flood at the frozen subscriber), healthy subscribers kept
  receiving while the victim was frozen, and on resume the victim drained a
  bounded backlog (≤ queue cap) with no crash.

**Multi-subscriber integrity + churn.** With several subscribers and a high event
rate: no loss / duplication / corruption. Subscribe/unsubscribe churn shows no
leak — thread/handle counts return to baseline. (Force-killed clients reclaim
asynchronously once COM rundown detects the dead client, ~minutes; a graceful
`Unsubscribe` reclaims immediately.)

## PR Checklist
- [x] Closes #239
- [x] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)
