### PR TITLE
ci: keep check-spelling running after upstream archival (secpoll 'Sorry')

### DIFF
--- a/.github/workflows/spelling2.yml
+++ b/.github/workflows/spelling2.yml
@@ -76,6 +76,22 @@ on:
 
 permissions: {}
 
+# Workaround for the archival of check-spelling/check-spelling (archived 2026-06-16).
+# On archival the maintainer flipped the action's runtime security poll (secpoll)
+# to return the advisory 'Sorry' for v0.0.26 -- the final release -- which fatally
+# cancels the workflow (exit 200) on every repo pinned to it. There is no fixed
+# version to upgrade to. The action exposes an `ignore_security_advisory` input,
+# but v0.0.26 never maps it into the secpoll step's environment, so passing it via
+# `with:` is silently dropped. secpoll reads the INPUT_IGNORE_SECURITY_ADVISORY env
+# var directly, so we set it here (composite action steps inherit workflow-level
+# env). The value must exactly match the advisory text 'Sorry'. This keeps the
+# (still-executable) archived action running. Caveat: if check-spelling.dev is ever
+# taken down, secpoll's lookup returns empty/NXDOMAIN and this var being set will
+# instead make secpoll fail ("...but there is no security advisory") -- at which
+# point this workflow must be reworked (remove the checker or pin a maintained fork).
+env:
+  INPUT_IGNORE_SECURITY_ADVISORY: Sorry
+
 jobs:
   spelling:
     name: Check Spelling


### PR DESCRIPTION
## Problem

PR CI fails on **check-spelling** — not because of a misspelling. `check-spelling/check-spelling` was **archived on 2026-06-16**, and on archival the maintainer flipped the action's runtime security poll (`secpoll`) to return the advisory text `Sorry` for `v0.0.26` (the final release). `secpoll` treats this as fatal and cancels the run:

```
Run secpoll
Error: Found security advisory for version 0.0.26: 'Sorry'
Error: This is a fatal error ... asking Action Host to kill our workflow
Error: Process completed with exit code 200.
```

This is a deliberate, effectively **permanent kill-switch** that breaks **every** repo pinned to `v0.0.26` — including upstream `microsoft/terminal` (same SHA). `v0.0.26` is the latest release and `main` is also `0.0.26`, so there is no fixed version to upgrade to. Another repo hit the identical error and responded by removing the checker entirely (eth-cscs/cscs-docs#422).

## Fix (this PR)

`secpoll` has an escape hatch: if the env var `INPUT_IGNORE_SECURITY_ADVISORY` exactly matches the advisory text, the fatal `die` becomes a non-fatal warning. The action's `ignore_security_advisory` **input** would normally feed that, but **v0.0.26 never maps the input into the secpoll step's environment** (the step only sets `GH_ACTION_REPOSITORY`/`GH_ACTION_REF`), so passing it via `with:` is silently dropped — which is why an earlier `with:`-based attempt still failed.

Instead, set the env var directly at the **workflow level** (composite-action steps inherit workflow/job `env`):

```yaml
env:
  INPUT_IGNORE_SECURITY_ADVISORY: Sorry
```

This keeps the still-executable archived action running, so spell-checking continues to work.

## Caveat / follow-up

This is a **stopgap on dead infrastructure**. If `check-spelling.dev` is ever taken down, `secpoll`'s DNS lookup returns empty/NXDOMAIN and — because the ignore var is set — it will then fail with *"...but there is no security advisory"*. At that point the workflow must be reworked. Longer-term options to decide:

- **Keep this bypass** (current) — minimal, green now.
- **Remove the spell checker** — like eth-cscs; no dependency on the dead action, but loses the gate.
- **Pin a maintained fork** of check-spelling with `secpoll` stripped — most robust, more maintenance.

Suggest matching whatever upstream `microsoft/terminal` settles on.