### PR TITLE
ci(spelling): match updated check-spelling secpoll advisory text

### DIFF
--- a/.github/workflows/spelling2.yml
+++ b/.github/workflows/spelling2.yml
@@ -78,19 +78,24 @@ permissions: {}
 
 # Workaround for the archival of check-spelling/check-spelling (archived 2026-06-16).
 # On archival the maintainer flipped the action's runtime security poll (secpoll)
-# to return the advisory 'Sorry' for v0.0.26 -- the final release -- which fatally
+# to return a security advisory for v0.0.26 -- the final release -- which fatally
 # cancels the workflow (exit 200) on every repo pinned to it. There is no fixed
 # version to upgrade to. The action exposes an `ignore_security_advisory` input,
 # but v0.0.26 never maps it into the secpoll step's environment, so passing it via
 # `with:` is silently dropped. secpoll reads the INPUT_IGNORE_SECURITY_ADVISORY env
 # var directly, so we set it here (composite action steps inherit workflow-level
-# env). The value must exactly match the advisory text 'Sorry'. This keeps the
-# (still-executable) archived action running. Caveat: if check-spelling.dev is ever
-# taken down, secpoll's lookup returns empty/NXDOMAIN and this var being set will
-# instead make secpoll fail ("...but there is no security advisory") -- at which
+# env). secpoll requires this value to EXACTLY equal the current advisory text
+# (the DNS TXT record at 26.0.0.security-status.secpoll.check-spelling.dev, minus
+# its leading "3 " status prefix); any mismatch re-triggers the fatal exit 200 with
+# "(ignore_security_advisory did not match)". The maintainer has already changed the
+# text once (from "Sorry" to the value below), so if spelling starts failing fast
+# (~6s) again, re-read that TXT record and update this string to match. This keeps
+# the (still-executable) archived action running. Caveat: if check-spelling.dev is
+# ever taken down, secpoll's lookup returns empty/NXDOMAIN and this var being set
+# will instead make secpoll fail ("...but there is no security advisory") -- at which
 # point this workflow must be reworked (remove the checker or pin a maintained fork).
 env:
-  INPUT_IGNORE_SECURITY_ADVISORY: Sorry
+  INPUT_IGNORE_SECURITY_ADVISORY: "Sorry. https://github.com/jsoref/2026-06-16-credential-leak/blob/main/README.md"
 
 jobs:
   spelling:


### PR DESCRIPTION
## Problem

The `Check Spelling` gate started failing fast (~6s, exit code 200) on every PR and on `main`, **not** because of any real spelling error:

```
##[error]Found security advisory for version 0.0.26:
  'Sorry. https://github.com/jsoref/2026-06-16-credential-leak/blob/main/README.md'
  (ignore_security_advisory did not match)
##[error]This is a fatal error ... asking Action Host to kill our workflow
```

`check-spelling/check-spelling` was archived 2026-06-16. Its runtime security poll (`secpoll`) returns a kill-switch advisory for the final `v0.0.26` release that fatally cancels any workflow pinned to it. Our existing workaround set `INPUT_IGNORE_SECURITY_ADVISORY: Sorry` to bypass it — but `secpoll` requires the value to **exactly** equal the advisory text, and the maintainer has since changed that text from `Sorry` to `Sorry. https://github.com/jsoref/2026-06-16-credential-leak/blob/main/README.md`. The stale `Sorry` no longer matches, so the bypass is defeated.

## Fix

Update `INPUT_IGNORE_SECURITY_ADVISORY` in `spelling2.yml` to the current advisory text (verified live against the DNS TXT record `26.0.0.security-status.secpoll.check-spelling.dev`, minus its leading `3 ` status prefix). Comment expanded to explain the exact-match requirement and what to do if the maintainer changes the text again.

Because `spelling2.yml` fires on `pull_request_target`, every open PR is evaluated against **main's** copy of this workflow — so the fix must land here on `main` to unblock all PRs (e.g. #298).

## Note

This keeps fighting a deliberate kill-switch. Longer-term we should either swap to a maintained fork or make the check non-required. Filing this as the quick unblock.