### PR TITLE
fix(fre): stop FRE false-blocking on a load-induced execution-policy probe timeout

### DIFF
--- a/src/cascadia/TerminalApp/AgentPaneLog.h
+++ b/src/cascadia/TerminalApp/AgentPaneLog.h
@@ -22,10 +22,9 @@
 #include <windows.h>
 
 #include <chrono>
+#include <cstdio>
 #include <ctime>
 #include <filesystem>
-#include <fstream>
-#include <iomanip>
 #include <string>
 #include <system_error>
 
@@ -62,13 +61,6 @@ namespace winrt::TerminalApp::implementation
             return;
         }
 
-        const auto logPath = logDir / L"terminal-agent-pane.log";
-        std::ofstream f{ logPath, std::ios::app };
-        if (!f)
-        {
-            return;
-        }
-
         const auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
                                std::chrono::system_clock::now().time_since_epoch())
                                .count();
@@ -76,9 +68,37 @@ namespace winrt::TerminalApp::implementation
         const int ms = static_cast<int>(nowMs % 1000);
         std::tm tmUtc{};
         ::gmtime_s(&tmUtc, &secs);
-        char ts[32];
+        char ts[24]{};
         std::strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%S", &tmUtc);
-        f << '[' << ts << '.' << std::setw(3) << std::setfill('0') << ms
-          << "Z] " << msg << '\n';
+
+        // Format the whole line up front, then emit it with a SINGLE
+        // FILE_APPEND_DATA WriteFile. Appends < 4 KB are atomic, so concurrent
+        // writers (multiple WT threads, and the per-version log is shared) never
+        // interleave a half-written line — which matters precisely for the
+        // concurrent FRE activity this log is used to debug. (A buffered
+        // std::ofstream `<<` chain can emit several writes per line and tear.)
+        std::string line(72 + msg.size(), '\0');
+        const int n = _snprintf_s(line.data(), line.size(), _TRUNCATE,
+                                  "[%s.%03dZ] %s\n", ts, ms, msg.c_str());
+        if (n <= 0)
+        {
+            return;
+        }
+
+        const auto logPath = (logDir / L"terminal-agent-pane.log").wstring();
+        const HANDLE h = CreateFileW(logPath.c_str(),
+                                     FILE_APPEND_DATA,
+                                     FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                     nullptr,
+                                     OPEN_ALWAYS,
+                                     FILE_ATTRIBUTE_NORMAL,
+                                     nullptr);
+        if (h == INVALID_HANDLE_VALUE)
+        {
+            return;
+        }
+        DWORD written = 0;
+        WriteFile(h, line.data(), static_cast<DWORD>(n), &written, nullptr);
+        CloseHandle(h);
     }
 }

--- a/src/cascadia/TerminalApp/ShellIntegrationSweep.h
+++ b/src/cascadia/TerminalApp/ShellIntegrationSweep.h
@@ -43,6 +43,7 @@
 
 #include "../inc/ShellIntegration.h"
 #include "../inc/ShellIntegrationProfileGate.h"
+#include "AgentPaneLog.h"
 
 #include <winrt/Microsoft.Terminal.Settings.Model.h>
 
@@ -194,13 +195,29 @@ namespace winrt::TerminalApp::implementation::ShellIntegrationSweep
             }
             return SI::Install(profilePath);
         };
+        // Probe each PowerShell host's execution policy, and log the raw outcome
+        // (policy + whether the probe timed out + verdict) so a future FRE
+        // false-block is diagnosable straight from terminal-agent-pane.log. The
+        // probe itself is a pure query (ExecutionPolicyBlocksShellIntegration does
+        // no I/O); the logging lives here, at the app layer, next to the existing
+        // [FRE] shell-integration logging — not buried in the shared inc/ header.
+        const auto probeExecutionPolicyBlocked = [](SI::Target t, const char* label) {
+            std::wstring policy;
+            bool timedOut = false;
+            const bool blocked = SI::ExecutionPolicyBlocksShellIntegration(t, &policy, &timedOut);
+            _agentPaneLog(std::string{ "[FRE] EP probe " } + label +
+                          " policy='" + winrt::to_string(winrt::hstring{ policy }) + "'" +
+                          " timedOut=" + (timedOut ? "1" : "0") +
+                          " -> " + (blocked ? "BLOCKED" : "not-blocked"));
+            return blocked;
+        };
         r.pwsh = SI::ResolvePowerShellHostInstall(
             shellPresence.pwsh,
-            SI::ExecutionPolicyBlocksShellIntegration(SI::Target::Pwsh),
+            probeExecutionPolicyBlocked(SI::Target::Pwsh, "pwsh"),
             [&] { return installSkippingPolicyProbe(SI::Target::Pwsh); });
         r.windowsPowerShell = SI::ResolvePowerShellHostInstall(
             shellPresence.windowsPowerShell,
-            SI::ExecutionPolicyBlocksShellIntegration(SI::Target::WindowsPowerShell),
+            probeExecutionPolicyBlocked(SI::Target::WindowsPowerShell, "winPs"),
             [&] { return installSkippingPolicyProbe(SI::Target::WindowsPowerShell); });
         if (shellPresence.bash)
         {

--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -852,7 +852,7 @@ void ShellIntegrationTests::QueryExecutionPolicy_ParsesStdoutAndLowercases()
     // Smoke test against real powershell.exe (always present on Windows).
     // We don't care WHICH policy the runner returns — we care that the
     // QueryExecutionPolicy contract holds:
-    //   * the call completes within the 5s timeout (no hang on the pipe),
+    //   * the call completes within the 20s timeout (no hang on the pipe),
     //   * stdout is captured (non-empty), and
     //   * the result is lowercase ASCII letters only — the parser strips
     //     newlines / spaces / tabs, lowercases A-Z, but a stray BOM byte or

--- a/src/cascadia/inc/PowerShellShellIntegration.h
+++ b/src/cascadia/inc/PowerShellShellIntegration.h
@@ -20,18 +20,33 @@ namespace Microsoft::Terminal::ShellIntegration::Powershell
     namespace details
     {
         // Runs `<exe> -NoProfile -NonInteractive -Command Get-ExecutionPolicy`
-        // synchronously and returns the lowercased policy name from stdout
-        // (e.g. "restricted"). Returns an empty string if the executable can't
-        // be launched (typical for pwsh.exe when PowerShell 7 isn't installed)
-        // or if the call doesn't finish within the timeout.
+        // synchronously and returns the lowercased effective policy name from
+        // stdout (e.g. "restricted"), or an EMPTY string if it could not be
+        // determined — CreateProcess failed, the host isn't installed, or the
+        // child didn't finish within the timeout. Empty therefore means "unknown
+        // / probe failed", NOT "blocked" (the caller fails open on empty).
         //
-        // `-Command <expr>` runs an inline expression that is NOT subject to
-        // the .ps1 execution policy, so this works even when the answer is
-        // Restricted / AllSigned. We deliberately do NOT pass
-        // `-ExecutionPolicy` because that would set the Process scope and
-        // override the value we're trying to read.
-        inline std::wstring QueryExecutionPolicy(LPCWSTR exe) noexcept
+        // `outTimedOut`, when provided, is set to true iff the wait hit the
+        // timeout (vs. a CreateProcess/pipe failure) — for diagnostic logging.
+        //
+        // Timeout = 20s: the probe spawns a PowerShell host, and its COLD START
+        // can take many seconds when the machine is busy — which is exactly the
+        // FRE Save case (concurrent winget pre-warm + agent-hook install + the
+        // other host's probe). The previous 5s budget was hit under that load,
+        // the killed probe returned empty, and an empty result used to be misread
+        // as "blocked", false-stopping FRE completion. 20s comfortably covers a
+        // loaded cold start while still bounding the FRE Save so it can't hang.
+        //
+        // `-Command <expr>` runs an inline expression that is NOT subject to the
+        // .ps1 execution policy, so this works even when the answer is Restricted
+        // / AllSigned. We deliberately do NOT pass `-ExecutionPolicy` because that
+        // would set the Process scope and override the value we're trying to read.
+        inline std::wstring QueryExecutionPolicy(LPCWSTR exe, bool* outTimedOut = nullptr) noexcept
         {
+            if (outTimedOut)
+            {
+                *outTimedOut = false;
+            }
             // This is a best-effort helper: any failure (CreateProcess, pipe,
             // read hang, OOM, …) must fail-open by returning an empty string
             // so the caller treats the policy as "not blocking" rather than
@@ -83,8 +98,21 @@ namespace Microsoft::Terminal::ShellIntegration::Powershell
 
                 writeEnd.reset();
 
-                if (WaitForSingleObject(process.get(), 5000) != WAIT_OBJECT_0)
+                constexpr DWORD timeoutMs = 20000;
+                const DWORD waitResult = WaitForSingleObject(process.get(), timeoutMs);
+                if (waitResult != WAIT_OBJECT_0)
                 {
+                    // The child didn't exit on its own — either it timed out, or the
+                    // wait itself failed (WAIT_FAILED / unexpected). In BOTH cases the
+                    // child may still be running and still holds the pipe's write end,
+                    // so the ReadFile below would block forever waiting for EOF — kill
+                    // it first so the read returns promptly and we fail open. Only a
+                    // real WAIT_TIMEOUT is reported as a timeout; a wait failure is an
+                    // inconclusive probe (empty result), not a timeout.
+                    if (waitResult == WAIT_TIMEOUT && outTimedOut)
+                    {
+                        *outTimedOut = true;
+                    }
                     TerminateProcess(process.get(), 1);
                     WaitForSingleObject(process.get(), 1000);
                 }
@@ -129,13 +157,18 @@ namespace Microsoft::Terminal::ShellIntegration::Powershell
 
         inline bool PolicyNameBlocksUnsignedScripts(std::wstring_view name) noexcept
         {
-            // Allow-list: only these three policies permit unsigned local
-            // scripts (like our shell-integration profile) to execute.
-            // Everything else — including the empty string returned when
-            // QueryExecutionPolicy fails in packaged-app context — is
-            // treated as blocking so FRE surfaces the actionable EP error
-            // instead of silently writing a profile that will never load.
-            return !(name == L"remotesigned" || name == L"unrestricted" || name == L"bypass");
+            // Block only the two effective policies that actually refuse to run
+            // unsigned local scripts — Restricted and AllSigned. Everything else
+            // permits our (unsigned) shell-integration $PROFILE block to load:
+            // RemoteSigned / Unrestricted / Bypass, the "undefined" no-restriction
+            // marker, AND an empty/unknown result from an inconclusive probe (a
+            // probe failure is NOT a restrictive policy, so it must not block).
+            //
+            // This is the contract the ShellIntegrationTests PolicyName_* unit
+            // tests assert — the earlier allow-list form ("block unless
+            // RemoteSigned/Unrestricted/Bypass") contradicted them by treating "",
+            // "undefined" and unknown values as blocking.
+            return name == L"restricted" || name == L"allsigned";
         }
 
         // Body-line recognizer for orphan-marker recovery — matches the
@@ -211,22 +244,82 @@ namespace Microsoft::Terminal::ShellIntegration::Powershell
     // Re-queried on every call so that after the user fixes the policy outside
     // (e.g. `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`) and clicks
     // Save again, the Terminal picks up the new policy.
-    inline bool ExecutionPolicyBlocksShellIntegration(Target target) noexcept
+    //
+    // Pure query — no logging / no I/O side effects. The optional out-params let
+    // the caller (the FRE shell-integration sweep) record diagnostics:
+    //   * `outPolicy`   — the raw effective policy we read ("" when the probe was
+    //                     inconclusive, e.g. it timed out).
+    //   * `outTimedOut` — true iff the probe was killed at its timeout (so an
+    //                     empty `outPolicy` is a probe failure, NOT a restrictive
+    //                     policy).
+    inline bool ExecutionPolicyBlocksShellIntegration(Target target,
+                                                      std::wstring* outPolicy = nullptr,
+                                                      bool* outTimedOut = nullptr) noexcept
     {
-        const auto exe = target == Target::Pwsh ? L"pwsh.exe" : L"powershell.exe";
-        // If the host binary isn't on PATH, we can't (and shouldn't) probe
-        // its policy. Return false so a missing optional host (e.g. pwsh.exe
-        // on machines without PowerShell 7) doesn't false-positive as
-        // "EP blocked". QueryExecutionPolicy would return "" for a missing
-        // host, and the allow-list predicate treats "" as blocking — correct
-        // for a PRESENT host whose policy probe failed in packaged-app
-        // context, but wrong for a genuinely absent host.
-        wchar_t buf[MAX_PATH]{};
-        if (SearchPathW(nullptr, exe, nullptr, MAX_PATH, buf, nullptr) == 0)
+        if (outPolicy)
         {
-            return false;
+            outPolicy->clear();
         }
-        return details::PolicyNameBlocksUnsignedScripts(details::QueryExecutionPolicy(exe));
+        if (outTimedOut)
+        {
+            *outTimedOut = false;
+        }
+        // Resolve the host to a FULL path and probe THAT exact binary (not the bare
+        // name), so a PATH change between resolution and the probe can't make us run a
+        // different executable, and so the probe isn't susceptible to PATH-order
+        // hijacking. If the host can't be resolved to a trustworthy path we fail open
+        // (return false): a missing/unresolvable host — e.g. pwsh.exe on machines
+        // without PowerShell 7 — must not false-positive as "EP blocked". A PRESENT
+        // host whose probe comes back empty/inconclusive (which can happen in the
+        // packaged-app context) ALSO does not block: only a definitively restrictive
+        // policy (Restricted/AllSigned) does — see PolicyNameBlocksUnsignedScripts.
+        std::wstring resolved;
+        if (target == Target::WindowsPowerShell)
+        {
+            // Windows PowerShell ships in the OS at a FIXED system location, so pin it
+            // to %SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe instead of
+            // trusting PATH — exactly as WslDistroGenerator pins wsl.exe to System32
+            // (GH#11096) to defeat path hijacking of a system binary.
+            wchar_t system32[MAX_PATH]{};
+            const UINT system32Len = GetSystemDirectoryW(system32, MAX_PATH);
+            if (system32Len == 0 || system32Len >= MAX_PATH)
+            {
+                return false;
+            }
+            resolved.assign(system32, system32Len);
+            resolved += L"\\WindowsPowerShell\\v1.0\\powershell.exe";
+            // A genuinely absent system powershell.exe (extremely unusual) fails open.
+            if (GetFileAttributesW(resolved.c_str()) == INVALID_FILE_ATTRIBUTES)
+            {
+                return false;
+            }
+        }
+        else
+        {
+            // PowerShell 7 (pwsh.exe) is an optional third-party install with no fixed
+            // location, so it must be resolved via PATH.
+            wchar_t buffer[MAX_PATH]{};
+            const DWORD resolvedLen = SearchPathW(nullptr, L"pwsh.exe", nullptr, MAX_PATH, buffer, nullptr);
+            if (resolvedLen == 0 || resolvedLen >= MAX_PATH)
+            {
+                // Not on PATH (resolvedLen == 0), or path too long for the buffer
+                // (resolvedLen >= MAX_PATH leaves `buffer` unfilled/truncated).
+                return false;
+            }
+            resolved.assign(buffer, resolvedLen);
+        }
+        bool timedOut = false;
+        auto policy = details::QueryExecutionPolicy(resolved.c_str(), &timedOut);
+        const bool blocked = details::PolicyNameBlocksUnsignedScripts(policy);
+        if (outTimedOut)
+        {
+            *outTimedOut = timedOut;
+        }
+        if (outPolicy)
+        {
+            *outPolicy = std::move(policy);
+        }
+        return blocked;
     }
 
     // Discover the PowerShell $PROFILE path.

--- a/src/cascadia/inc/ShellIntegration.h
+++ b/src/cascadia/inc/ShellIntegration.h
@@ -73,7 +73,9 @@ namespace Microsoft::Terminal::ShellIntegration
     inline InstallResult Install(const std::wstring& profilePathW) { return Powershell::Install(profilePathW); }
     inline InstallResult Uninstall(const std::wstring& profilePathW) { return Powershell::Uninstall(profilePathW); }
     inline std::wstring DiscoverProfilePath(Target target) { return Powershell::DiscoverProfilePath(target); }
-    inline bool ExecutionPolicyBlocksShellIntegration(Target target) noexcept { return Powershell::ExecutionPolicyBlocksShellIntegration(target); }
+    inline bool ExecutionPolicyBlocksShellIntegration(Target target,
+                                                      std::wstring* outPolicy = nullptr,
+                                                      bool* outTimedOut = nullptr) noexcept { return Powershell::ExecutionPolicyBlocksShellIntegration(target, outPolicy, outTimedOut); }
     inline constexpr int kShellIntegrationVersion = Powershell::kVersion;
     inline std::wstring ShellIntegrationScriptFileName() { return Powershell::ScriptFileName(); }
     inline std::string ShellIntegrationScriptContent() { return Powershell::ScriptContent(); }


### PR DESCRIPTION
## Summary

The FRE "Install" / Save probes each PowerShell host's execution policy by spawning the host (`Get-ExecutionPolicy`) with a **5s timeout**. Under the concurrent FRE Save load (winget pre-warm + agent-hook install + the other host's probe) the host's cold start can exceed 5s; the probe is killed, returns **empty**, and empty was read as *"execution policy blocks scripts"* — **false-stopping FRE completion on a machine whose policy is actually fine**. Proven by instrumenting the probe in a deployed build and reproducing under load (`timedOut=1 -> empty -> BLOCKED`); on a calm machine the same probe returns the real policy in <1s and the FRE completes.

## Changes

- **Probe timeout 5s → 20s** (single attempt — an immediate retry hits the same sustained load, so it's no better than one longer wait).
- **Terminate the child on any non-`WAIT_OBJECT_0`** (timeout *or* `WAIT_FAILED`) so the following `ReadFile` can't hang on a still-running child; only a real `WAIT_TIMEOUT` is flagged as a timeout.
- **Probe the SearchPath-resolved full path** (resists PATH change / hijack); fail open if missing or `>= MAX_PATH`.
- **Log each probe** (host, policy, timedOut, verdict) from the app layer; make `_agentPaneLog` write atomically (`FILE_APPEND_DATA` + one `WriteFile`) so concurrent lines can't interleave. The `inc/` predicate stays a pure, side-effect-free query.
- **Align the verdict with its own unit tests** (TDD): `PolicyNameBlocksUnsignedScripts` was an allow-list, but `ShellIntegrationTests::PolicyName_*` assert a deny-list (only `Restricted`/`AllSigned` block; empty/`undefined`/unknown fail open). The code contradicted those tests — 2 were failing locally (not gated in PR CI). Code aligned to the tests; **tests unchanged**.

## Validation

`ShellIntegrationTests::PolicyName_*` + `QueryExecutionPolicy_*` pass; TerminalApp builds. Reproduced + fixed **under load** on a deployed dev build: the 24-process hammer that gave `timedOut=1 -> BLOCKED` at 5s now gives `timedOut=0 -> not-blocked`; calm run reaches `[FRE] Completed`.

Likely also fixes #328 (Unrestricted-via-GPO false-block) — same empty/inconclusive-probe family; couldn't reproduce the exact GPO setup locally.