### PR TITLE
Move GPOs out of category "Windows Components"

### DIFF
--- a/policies/IntelligentTerminal.admx
+++ b/policies/IntelligentTerminal.admx
@@ -14,7 +14,6 @@
   </supportedOn>
   <categories>
     <category name="IntelligentTerminal" displayName="$(string.IntelligentTerminal)">
-      <parentCategory ref="windows:WindowsComponents" />
     </category>
   </categories>
   <policies>

--- a/policies/en-US/IntelligentTerminal.adml
+++ b/policies/en-US/IntelligentTerminal.adml
@@ -5,7 +5,7 @@
   <description>Intelligent Terminal</description>
   <resources>
     <stringTable>
-      <string id="IntelligentTerminal">Intelligent Terminal</string>
+      <string id="IntelligentTerminal">Microsoft Intelligent Terminal</string>
       <string id="SUPPORTED_IntelligentTerminal_1_21">At least Intelligent Terminal 1.21</string>
       <string id="SUPPORTED_IntelligentTerminal_AgentPolicy">Intelligent Terminal with agent support</string>
       <string id="DisabledProfileSources">Disabled Profile Sources</string>


### PR DESCRIPTION
## Summary of the Pull Request

Intelligent Terminal isn't a Windows built-in component. So the correct place for the policy folder to be is outside of "Windows Components".

This PR
- moves the IntelligentTerminal category outside of "Windows Components".
- renames the category from "Intelligent Terminal" to "Microsoft Intelligent Terminal"

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
