### PR TITLE
test(e2e): deterministic FRE execution-policy coverage via registry

### DIFF
--- a/test/e2e/ItE2E/ItE2E.psm1
+++ b/test/e2e/ItE2E/ItE2E.psm1
@@ -27,6 +27,7 @@ $publicFns = @(
     'Set-WtAutofix', 'Set-WtPanePosition', 'Set-WtSettings', 'ConvertFrom-JsonC',
     'Get-WtStateObject', 'Set-WtState', 'Invoke-FrePass', 'Reset-Fre', 'Get-FreCompleted',
     'Invoke-FrePassViaUi', 'Test-FreShowing',
+    'Get-WtExecutionPolicyState', 'Set-WtExecutionPolicy', 'Restore-WtExecutionPolicy',
     # Ui
     'Get-UiTree', 'Find-UiElement', 'Invoke-UiElement', 'Invoke-UiClick', 'Set-UiValue', 'Get-UiValue',
     'Wait-UiElement', 'Test-UiElementExists', 'Save-UiScreenshot', 'Get-WtWindowHwnds',

--- a/test/e2e/ItE2E/ItE2E.psm1
+++ b/test/e2e/ItE2E/ItE2E.psm1
@@ -28,6 +28,7 @@ $publicFns = @(
     'Get-WtStateObject', 'Set-WtState', 'Invoke-FrePass', 'Reset-Fre', 'Get-FreCompleted',
     'Invoke-FrePassViaUi', 'Test-FreShowing',
     'Get-WtExecutionPolicyState', 'Set-WtExecutionPolicy', 'Restore-WtExecutionPolicy',
+    'Test-WtExecutionPolicyControllable', 'Test-WtPwshBlocksShellIntegration',
     # Ui
     'Get-UiTree', 'Find-UiElement', 'Invoke-UiElement', 'Invoke-UiClick', 'Set-UiValue', 'Get-UiValue',
     'Wait-UiElement', 'Test-UiElementExists', 'Save-UiScreenshot', 'Get-WtWindowHwnds',

--- a/test/e2e/ItE2E/Private/Paths.ps1
+++ b/test/e2e/ItE2E/Private/Paths.ps1
@@ -79,9 +79,11 @@ function Resolve-ItApp {
     $localState = Join-Path $env:LOCALAPPDATA "Packages\$pfn\LocalState"
     $logRoot = Join-Path $env:LOCALAPPDATA "Packages\$pfn\LocalCache\Local\IntelligentTerminal\logs"
 
-    # Launch entry point: the package's `wtai` AppExecutionAlias is the canonical,
-    # package-identity entry point for Intelligent Terminal (and matches how users start it).
-    # Prefer it; fall back to AUMID shell activation only if the alias isn't on PATH.
+    # Launch entry point: tests activate via AUMID (shell:AppsFolder\<PFN>!App),
+    # which is package-specific and therefore reliably hits THIS package even when
+    # both the Store and a Dev build are installed (see Start-Terminal). The global
+    # `wtai` AppExecutionAlias is owned by a single package, so it is ambiguous in
+    # that scenario — it is kept here only as a last-resort fallback.
     $launchAlias = (Get-Command 'wtai' -ErrorAction SilentlyContinue | Select-Object -First 1).Source
 
     [pscustomobject]@{

--- a/test/e2e/ItE2E/Public/Fre.ps1
+++ b/test/e2e/ItE2E/Public/Fre.ps1
@@ -71,3 +71,48 @@ function Test-FreShowing {
     [CmdletBinding()] param([Parameter(Mandatory, ValueFromPipeline)]$App)
     process { Test-UiElementExists -App $App -Selector 'WelcomePage' -TimeoutSec 3 }
 }
+
+# ── Execution-policy control (deterministic FRE EP-block coverage) ────────────
+# The FRE Save probes each PowerShell host's execution policy and blocks shell
+# integration when it refuses unsigned local scripts (Restricted/AllSigned). These
+# helpers force the *Windows PowerShell* effective policy via the CurrentUser
+# registry scope — which outranks LocalMachine and needs NO admin — so a test can
+# deterministically exercise BOTH the blocked and the not-blocked verdict, then
+# restore the machine. (pwsh 7 keeps its policy in powershell.config.json, not the
+# registry; the FRE blocks if EITHER host is blocked, so forcing WinPS is enough.)
+
+$script:WtWinPSExecutionPolicyKey = 'HKCU:\SOFTWARE\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell'
+
+function Get-WtExecutionPolicyState {
+    <# Snapshot the WinPS CurrentUser execution-policy registry value for restore. #>
+    [CmdletBinding()] param()
+    $val = (Get-ItemProperty -Path $script:WtWinPSExecutionPolicyKey -Name ExecutionPolicy -ErrorAction SilentlyContinue).ExecutionPolicy
+    [pscustomobject]@{ Key = $script:WtWinPSExecutionPolicyKey; HadValue = ($null -ne $val); Value = $val }
+}
+
+function Set-WtExecutionPolicy {
+    <#
+    .SYNOPSIS
+        Force the Windows PowerShell CurrentUser execution policy (HKCU, no admin) so the FRE
+        EP probe deterministically returns it. Pass 'Undefined' to clear the scope. Returns the
+        prior state object — pass it to Restore-WtExecutionPolicy (always restore in a finally).
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][ValidateSet('Restricted', 'AllSigned', 'RemoteSigned', 'Unrestricted', 'Bypass', 'Undefined')][string]$Value)
+    $state = Get-WtExecutionPolicyState
+    if (-not (Test-Path $state.Key)) { New-Item -Path $state.Key -Force | Out-Null }
+    if ($Value -eq 'Undefined') { Remove-ItemProperty -Path $state.Key -Name ExecutionPolicy -ErrorAction SilentlyContinue }
+    else { Set-ItemProperty -Path $state.Key -Name ExecutionPolicy -Value $Value -Type String }
+    Write-ItLog -Level INFO -Message "Set WinPS CurrentUser ExecutionPolicy = $Value (was '$($state.Value)')"
+    $state
+}
+
+function Restore-WtExecutionPolicy {
+    <# Restore the snapshot returned by Set-WtExecutionPolicy / Get-WtExecutionPolicyState. #>
+    [CmdletBinding()] param([Parameter(Mandatory, ValueFromPipeline)]$State)
+    process {
+        if ($State.HadValue) { Set-ItemProperty -Path $State.Key -Name ExecutionPolicy -Value $State.Value -Type String }
+        else { Remove-ItemProperty -Path $State.Key -Name ExecutionPolicy -ErrorAction SilentlyContinue }
+        Write-ItLog -Level INFO -Message "Restored WinPS CurrentUser ExecutionPolicy to '$($State.Value)'"
+    }
+}

--- a/test/e2e/ItE2E/Public/Fre.ps1
+++ b/test/e2e/ItE2E/Public/Fre.ps1
@@ -102,7 +102,7 @@ function Set-WtExecutionPolicy {
     $state = Get-WtExecutionPolicyState
     if (-not (Test-Path $state.Key)) { New-Item -Path $state.Key -Force | Out-Null }
     if ($Value -eq 'Undefined') { Remove-ItemProperty -Path $state.Key -Name ExecutionPolicy -ErrorAction SilentlyContinue }
-    else { Set-ItemProperty -Path $state.Key -Name ExecutionPolicy -Value $Value -Type String }
+    else { Set-ItemProperty -Path $state.Key -Name ExecutionPolicy -Value $Value -Type String -ErrorAction Stop }
     Write-ItLog -Level INFO -Message "Set WinPS CurrentUser ExecutionPolicy = $Value (was '$($state.Value)')"
     $state
 }
@@ -111,8 +111,48 @@ function Restore-WtExecutionPolicy {
     <# Restore the snapshot returned by Set-WtExecutionPolicy / Get-WtExecutionPolicyState. #>
     [CmdletBinding()] param([Parameter(Mandatory, ValueFromPipeline)]$State)
     process {
-        if ($State.HadValue) { Set-ItemProperty -Path $State.Key -Name ExecutionPolicy -Value $State.Value -Type String }
+        if ($State.HadValue) { Set-ItemProperty -Path $State.Key -Name ExecutionPolicy -Value $State.Value -Type String -ErrorAction Stop }
         else { Remove-ItemProperty -Path $State.Key -Name ExecutionPolicy -ErrorAction SilentlyContinue }
         Write-ItLog -Level INFO -Message "Restored WinPS CurrentUser ExecutionPolicy to '$($State.Value)'"
     }
+}
+
+function Test-WtExecutionPolicyControllable {
+    <#
+    .SYNOPSIS
+        Returns $true when the Windows PowerShell effective execution policy can be forced
+        via the HKCU CurrentUser scope — i.e. no Group Policy override is in effect.
+    .DESCRIPTION
+        Group Policy scopes (MachinePolicy / UserPolicy) outrank CurrentUser, so when one is
+        set the registry value these tests write is NOT the effective policy and the FRE
+        verdict becomes non-deterministic. The EP suite must skip in that environment. GPO
+        scopes are host-independent (HKLM/HKCU ...\Policies\...\PowerShell), so probing them
+        from whatever host runs the test is valid for the WinPS the FRE will probe.
+    #>
+    [CmdletBinding()] param()
+    $gpo = Get-ExecutionPolicy -List |
+        Where-Object { $_.Scope -in 'MachinePolicy', 'UserPolicy' -and $_.ExecutionPolicy -ne 'Undefined' }
+    -not [bool]$gpo
+}
+
+function Test-WtPwshBlocksShellIntegration {
+    <#
+    .SYNOPSIS
+        Returns $true when pwsh 7 is installed AND its effective execution policy refuses
+        unsigned local scripts (Restricted / AllSigned).
+    .DESCRIPTION
+        The FRE blocks shell integration if EITHER PowerShell host blocks, but these helpers
+        only control Windows PowerShell via HKCU (pwsh keeps its policy in
+        powershell.config.json, not the registry). So the not-blocked case must skip when a
+        present pwsh would independently block — otherwise the FRE blocks regardless of the
+        RemoteSigned WinPS policy under test.
+    #>
+    [CmdletBinding()] param()
+    $pwsh = Get-Command pwsh.exe -ErrorAction SilentlyContinue
+    if (-not $pwsh) { return $false }
+    try {
+        $policy = & $pwsh.Source -NoProfile -NonInteractive -Command 'Get-ExecutionPolicy' 2>$null
+        return ([string]$policy -in 'Restricted', 'AllSigned')
+    }
+    catch { return $false }
 }

--- a/test/e2e/ItE2E/Public/Harness.ps1
+++ b/test/e2e/ItE2E/Public/Harness.ps1
@@ -129,15 +129,20 @@ function Start-Terminal {
     if ($Settings) { Set-WtSettings -App $app -Settings $Settings | Out-Null }
 
     $existing = @(Get-WtProcessesForApp -App $app | Select-Object -ExpandProperty Id)
-    # Launch via the `wtai` AppExecutionAlias (correct package-identity entry point).
-    # Fall back to AUMID shell activation only if the alias isn't available.
-    if ($app.LaunchAlias -and (Test-Path $app.LaunchAlias)) {
-        Write-ItLog -Level INFO -Message "Launching via wtai alias: $($app.LaunchAlias)"
-        Start-Process -FilePath $app.LaunchAlias | Out-Null
-    }
-    else {
-        Write-ItLog -Level WARN -Message "wtai alias not found; falling back to AUMID activation ($($app.AppUserModelId))."
+    # Launch via AUMID shell activation — this is package-specific by construction
+    # (shell:AppsFolder\<PackageFamilyName>!App) and therefore launches EXACTLY the
+    # target package. The global `wtai` AppExecutionAlias is owned by only one package,
+    # so when both the store and a dev/sideloaded IT build are installed it is ambiguous
+    # and would launch the wrong one (silently timing out the dev-targeted tests). The
+    # earlier crash-on-AUMID-activation was the state.json corruption bug (now fixed via
+    # the unary-comma ConvertFrom-ItJsonElement change), not the activation method.
+    if ($app.AppUserModelId) {
+        Write-ItLog -Level INFO -Message "Launching via AUMID: $($app.AppUserModelId)"
         Start-Process -FilePath 'explorer.exe' -ArgumentList "shell:AppsFolder\$($app.AppUserModelId)" | Out-Null
+    }
+    elseif ($app.LaunchAlias -and (Test-Path $app.LaunchAlias)) {
+        Write-ItLog -Level WARN -Message "No AUMID; falling back to wtai alias ($($app.LaunchAlias)) — may be ambiguous across packages."
+        Start-Process -FilePath $app.LaunchAlias | Out-Null
     }
 
     # Find our WindowsTerminal.exe process (prefer a newly-spawned pid).

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -15,6 +15,7 @@ environment. Current status (run on the Store package):
 | `Feature.Packaging.Tests.ps1` | §9 packaging/protocol + §10 logging | 16 |
 | `Feature.Settings.Tests.ps1` | §1 Settings>AI Agents + §0 FRE settings/positions/auto-error/session-mgmt | 18 |
 | `Feature.FreFlow.Tests.ps1` | §0 FRE overlay click-through (Next→Save, privacy link, close-safety) | 5 |
+| `Feature.FreExecutionPolicy.Tests.ps1` | §0 FRE execution-policy verdict (deterministic via registry; **Dev**, auto-skips) | 2 |
 | `Feature.AgentPaneInteraction.Tests.ps1` | open/hide/focus, input/rendering, slash, Copilot chat | 13 |
 | `Feature.AutofixPane.Tests.ps1` | autofix card render/insert/run/reject/target/stashed + across layout | 10 |
 | `Feature.SessionList.Tests.ps1` | session view, session states, view switching, focus/restore | 11 (+1 skip) |
@@ -59,6 +60,40 @@ One-shot setup + verify:
 pwsh -File test/e2e/bootstrap.ps1          # install deps, import module
 pwsh -File test/e2e/bootstrap.ps1 -Check   # verify only
 ```
+
+## Choosing the build: Dev vs Store
+
+Every harness entry point takes a **`-Package`** selector, so a test can target
+either the production build or the build you're developing:
+
+| `-Package` | Resolves to | When to use |
+|---|---|---|
+| `Store` | `Microsoft.IntelligentTerminal_8wekyb3d8bbwe` | The shipped/production package — real user environment. |
+| `Dev` | `IntelligentTerminal_rd9vj3e6a2mbr` | A locally **sideloaded** build (e.g. your F5 / `bx` output). Use this to validate a change before it ships. |
+| `Auto` *(default)* | First fully-resolvable of Store → Dev | Most feature suites; picks whatever is installed. |
+| *(explicit PFN)* | the family name you pass | Any other package. |
+
+```powershell
+$app = Start-Terminal       -Package Dev    # control/UI tests against the dev build
+$app = Start-TerminalFre    -Package Store  # drive the FRE overlay on the store build
+```
+
+**Both builds can be installed at once and targeted independently.** The harness
+launches via **AUMID** (`shell:AppsFolder\<PackageFamilyName>!App`), which is
+package-specific, so `-Package Dev` always hits the dev build even while the
+store build is also installed. (The global `wtai` AppExecutionAlias is owned by a
+single package and is therefore ambiguous in that scenario — it is kept only as a
+last-resort fallback.)
+
+To make a build selectable:
+- **Dev**: build + deploy it once, e.g. `cd src/cascadia/CascadiaPackage; bx` then
+  `DeployAppRecipe.exe bin\x64\Debug\CascadiaPackage.build.appxrecipe`.
+- **Store**: install the shipped MSIX.
+
+A suite that asserts on diagnostics only present in a particular build should pin
+its `-Package` and **`-Skip`** itself when that package isn't installed (see
+`Feature.FreExecutionPolicy.Tests.ps1`, which targets `Dev` and skips when the
+dev package is absent — keeping CI green on machines that only have the store build).
 
 ## Running the self-tests
 
@@ -123,6 +158,11 @@ Describe 'Agent pane' -Tag 'Live' {
 FRE complete, applies your settings, launches the app, brings COM online (probes the
 per-brand `WT_COM_CLSID`), and resolves the window HWND. `Stop-Terminal` closes it and
 restores the backup.
+
+> **Picking the build**: pass `-Package Dev` / `-Package Store` (default `Auto`) — see
+> [Choosing the build](#choosing-the-build-dev-vs-store). Launch is package-specific
+> (AUMID), so both builds can be installed and targeted independently.
+
 
 ## How it works (key facts)
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -15,7 +15,7 @@ environment. Current status (run on the Store package):
 | `Feature.Packaging.Tests.ps1` | §9 packaging/protocol + §10 logging | 16 |
 | `Feature.Settings.Tests.ps1` | §1 Settings>AI Agents + §0 FRE settings/positions/auto-error/session-mgmt | 18 |
 | `Feature.FreFlow.Tests.ps1` | §0 FRE overlay click-through (Next→Save, privacy link, close-safety) | 5 |
-| `Feature.FreExecutionPolicy.Tests.ps1` | §0 FRE execution-policy verdict (deterministic via registry; **Dev**, auto-skips) | 2 |
+| `Feature.FreExecutionPolicy.Tests.ps1` | §0 FRE execution-policy verdict (deterministic via registry; **Dev**, auto-skips) | 3 (1 conditional skip) |
 | `Feature.AgentPaneInteraction.Tests.ps1` | open/hide/focus, input/rendering, slash, Copilot chat | 13 |
 | `Feature.AutofixPane.Tests.ps1` | autofix card render/insert/run/reject/target/stashed + across layout | 10 |
 | `Feature.SessionList.Tests.ps1` | session view, session states, view switching, focus/restore | 11 (+1 skip) |

--- a/test/e2e/tests/Feature.FreExecutionPolicy.Tests.ps1
+++ b/test/e2e/tests/Feature.FreExecutionPolicy.Tests.ps1
@@ -6,8 +6,20 @@
 # tests only ever exercise the happy path against whatever policy the machine
 # happens to have; these force the *real* policy via the Windows PowerShell
 # CurrentUser registry scope (HKCU — no admin; outranks LocalMachine, so it is the
-# effective policy) and assert the FRE's verdict from terminal-agent-pane.log, for
-# BOTH the blocked and not-blocked cases. The registry is always restored.
+# effective policy) and assert the FRE's verdict from terminal-agent-pane.log.
+#
+# Cases (one per outcome class the deny-list in PolicyNameBlocksUnsignedScripts has):
+#   * Restricted  -> BLOCKED      (blocking policy #1; FRE surfaces problem, never completes)
+#   * AllSigned   -> BLOCKED      (blocking policy #2 — the other refuse-unsigned policy)
+#   * RemoteSigned-> not-blocked  (permissive; FRE installs SI and COMPLETES)
+# The registry is always restored.
+#
+# NOT covered here, by design: the empty/"undefined"/probe-timeout fail-open path
+# (the core #336 regression — an EP probe that times out must NOT block). It can't be
+# triggered deterministically from a test: clearing the HKCU value only exposes the
+# machine-dependent LocalMachine fallback, and forcing a >20s probe timeout would mean
+# hanging powershell.exe. That behavior is pinned by the C++ unit tests instead
+# (ShellIntegrationTests::PolicyName_EmptyOrUnknown_NotBlocking + QueryExecutionPolicy_*).
 #
 # Targets the DEV package: the build under development carries the probe-timeout
 # fix + the per-host "[FRE] EP probe …" diagnostics these tests assert on; the
@@ -76,6 +88,34 @@ Describe 'Feature §0 FRE execution-policy verdict (deterministic, via registry)
         finally { Restore-WtExecutionPolicy -State $st }
     }
 
+    It 'AllSigned policy -> FRE probe reads it and BLOCKS; FRE does not complete' {
+        # AllSigned is the *other* blocking policy (it refuses unsigned local scripts
+        # just like Restricted). Forcing it via HKCU outranks LocalMachine, so the
+        # winPs probe deterministically reads 'allsigned' regardless of the machine's
+        # baseline. pwsh's policy is irrelevant here — the assertion keys on the winPs
+        # probe line, and FRE blocks if WinPS blocks no matter what pwsh reports.
+        $st = Set-WtExecutionPolicy -Value AllSigned
+        try {
+            $app = Start-TerminalFre -Package Dev
+            try {
+                & $script:DriveFreSave $app
+                $blocked = Test-Until -TimeoutSec 60 -IntervalSec 2 -Condition {
+                    (Get-ItLogText -App $app -Name 'terminal-agent-pane.log' -SinceStart) -match "EP probe winPs policy='allsigned'.*BLOCKED"
+                }
+                $blocked | Should -BeTrue -Because "the probe must read the real AllSigned policy and block"
+                $surfaced = Test-Until -TimeoutSec 60 -IntervalSec 2 -Condition {
+                    (Get-ItLogText -App $app -Name 'terminal-agent-pane.log' -SinceStart) -match 'Showing problem: ShellIntegration'
+                }
+                $surfaced | Should -BeTrue -Because "a real EP block must surface the shell-integration problem"
+                $log = Get-ItLogText -App $app -Name 'terminal-agent-pane.log' -SinceStart
+                $log | Should -Not -Match 'Completed — raising Completed event'
+                Get-FreCompleted -App $app | Should -BeFalse
+            }
+            finally { Stop-Terminal -App $app }
+        }
+        finally { Restore-WtExecutionPolicy -State $st }
+    }
+
     It 'RemoteSigned policy -> FRE probe reads it and does NOT block (winPs=ok)' -Skip:($script:PwshBlocks) {
         # RemoteSigned permits *local* unsigned scripts, so our $PROFILE block runs
         # and the probe must NOT block shell integration.
@@ -88,9 +128,15 @@ Describe 'Feature §0 FRE execution-policy verdict (deterministic, via registry)
                     (Get-ItLogText -App $app -Name 'terminal-agent-pane.log' -SinceStart) -match "EP probe winPs policy='remotesigned'.*not-blocked"
                 }
                 $notBlocked | Should -BeTrue -Because "the probe must read the real RemoteSigned policy and not block"
-                # The not-blocked path must never surface the shell-integration EP problem.
-                # (Asserted after a short settle so a late-arriving problem would be caught.)
-                Start-Sleep -Seconds 3
+                # The symmetric POSITIVE of the blocked cases: a not-blocked verdict must let
+                # shell integration install and the FRE actually finish (Completed raised,
+                # agentFreCompleted flag set). Asserting only "no problem shown" would pass even
+                # if the FRE silently stalled for an unrelated reason — this catches that.
+                $completed = Test-Until -TimeoutSec 60 -IntervalSec 2 -Condition {
+                    Get-FreCompleted -App $app
+                }
+                $completed | Should -BeTrue -Because "a not-blocked EP verdict must let the FRE complete"
+                # ...and the not-blocked path must never surface the shell-integration EP problem.
                 (Get-ItLogText -App $app -Name 'terminal-agent-pane.log' -SinceStart) | Should -Not -Match 'Showing problem: ShellIntegration'
             }
             finally { Stop-Terminal -App $app }

--- a/test/e2e/tests/Feature.FreExecutionPolicy.Tests.ps1
+++ b/test/e2e/tests/Feature.FreExecutionPolicy.Tests.ps1
@@ -15,10 +15,18 @@
 #   Invoke-Pester test/e2e/tests/Feature.FreExecutionPolicy.Tests.ps1 -Tag Feature
 
 BeforeDiscovery {
+    Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
     $script:DevReady = [bool](Get-AppxPackage | Where-Object { $_.Name -eq 'IntelligentTerminal' })
+    # A Group Policy execution-policy override (MachinePolicy/UserPolicy) outranks the HKCU
+    # CurrentUser scope these tests force, making the FRE verdict non-deterministic — skip the
+    # whole suite when one is in effect rather than assert against an uncontrollable policy.
+    $script:EpControllable = Test-WtExecutionPolicyControllable
+    # The not-blocked case additionally needs pwsh (if present) to not independently block,
+    # since the FRE blocks when EITHER host blocks and we only control WinPS via the registry.
+    $script:PwshBlocks = Test-WtPwshBlocksShellIntegration
 }
 
-Describe 'Feature §0 FRE execution-policy verdict (deterministic, via registry)' -Tag 'Feature' -Skip:(-not $script:DevReady) {
+Describe 'Feature §0 FRE execution-policy verdict (deterministic, via registry)' -Tag 'Feature' -Skip:(-not ($script:DevReady -and $script:EpControllable)) {
     BeforeAll {
         Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
         # Safety-net snapshot so the machine's policy is restored even if a test
@@ -68,7 +76,7 @@ Describe 'Feature §0 FRE execution-policy verdict (deterministic, via registry)
         finally { Restore-WtExecutionPolicy -State $st }
     }
 
-    It 'RemoteSigned policy -> FRE probe reads it and does NOT block (winPs=ok)' {
+    It 'RemoteSigned policy -> FRE probe reads it and does NOT block (winPs=ok)' -Skip:($script:PwshBlocks) {
         # RemoteSigned permits *local* unsigned scripts, so our $PROFILE block runs
         # and the probe must NOT block shell integration.
         $st = Set-WtExecutionPolicy -Value RemoteSigned

--- a/test/e2e/tests/Feature.FreExecutionPolicy.Tests.ps1
+++ b/test/e2e/tests/Feature.FreExecutionPolicy.Tests.ps1
@@ -28,7 +28,12 @@
 
 BeforeDiscovery {
     Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
-    $script:DevReady = [bool](Get-AppxPackage | Where-Object { $_.Name -eq 'IntelligentTerminal' })
+    # Gate on the SAME resolution the harness uses (Resolve-ItApp -Package Dev resolves by
+    # PackageFamilyName), not a raw Name match — otherwise a same-Name-but-different-PFN
+    # sideload could pass the gate and then make Start-TerminalFre -Package Dev throw instead
+    # of the suite cleanly skipping.
+    $script:DevReady = $false
+    try { $null = Resolve-ItApp -Package Dev -ErrorAction Stop; $script:DevReady = $true } catch { $script:DevReady = $false }
     # A Group Policy execution-policy override (MachinePolicy/UserPolicy) outranks the HKCU
     # CurrentUser scope these tests force, making the FRE verdict non-deterministic — skip the
     # whole suite when one is in effect rather than assert against an uncontrollable policy.

--- a/test/e2e/tests/Feature.FreExecutionPolicy.Tests.ps1
+++ b/test/e2e/tests/Feature.FreExecutionPolicy.Tests.ps1
@@ -1,0 +1,92 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+# Release checklist §0 FRE — DETERMINISTIC execution-policy coverage.
+#
+# The FRE "Install"/Save probes each PowerShell host's execution policy and blocks
+# shell integration when it refuses unsigned local scripts. The other FreFlow
+# tests only ever exercise the happy path against whatever policy the machine
+# happens to have; these force the *real* policy via the Windows PowerShell
+# CurrentUser registry scope (HKCU — no admin; outranks LocalMachine, so it is the
+# effective policy) and assert the FRE's verdict from terminal-agent-pane.log, for
+# BOTH the blocked and not-blocked cases. The registry is always restored.
+#
+# Targets the DEV package: the build under development carries the probe-timeout
+# fix + the per-host "[FRE] EP probe …" diagnostics these tests assert on; the
+# store build (0.1.1681.0) has neither.
+#   Invoke-Pester test/e2e/tests/Feature.FreExecutionPolicy.Tests.ps1 -Tag Feature
+
+BeforeDiscovery {
+    $script:DevReady = [bool](Get-AppxPackage | Where-Object { $_.Name -eq 'IntelligentTerminal' })
+}
+
+Describe 'Feature §0 FRE execution-policy verdict (deterministic, via registry)' -Tag 'Feature' -Skip:(-not $script:DevReady) {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
+        # Safety-net snapshot so the machine's policy is restored even if a test
+        # throws before its own finally runs.
+        $script:epSnapshot = Get-WtExecutionPolicyState
+
+        # Drive the FRE wizard to Save. Defined in BeforeAll (not the Describe body)
+        # so Pester v5 exposes the $script: scriptblock to the It blocks.
+        $script:DriveFreSave = {
+            param($App)
+            Invoke-UiElement -App $App -Selector 'NextButton' -TimeoutSec 15 | Out-Null
+            Wait-UiElement -App $App -Selector 'SaveButton' -TimeoutSec 15 | Out-Null
+            Invoke-UiElement -App $App -Selector 'SaveButton' -TimeoutSec 15 | Out-Null
+        }
+    }
+    AfterAll {
+        if ($script:epSnapshot) { Restore-WtExecutionPolicy -State $script:epSnapshot }
+    }
+
+    It 'Restricted policy -> FRE probe reads it and BLOCKS; FRE does not complete' {
+        $st = Set-WtExecutionPolicy -Value Restricted
+        try {
+            $app = Start-TerminalFre -Package Dev
+            try {
+                & $script:DriveFreSave $app
+                # The probe must read the real policy ('restricted') for Windows
+                # PowerShell and return the BLOCKED verdict — this is the correct,
+                # actionable case (Restricted genuinely refuses unsigned scripts).
+                $blocked = Test-Until -TimeoutSec 60 -IntervalSec 2 -Condition {
+                    (Get-ItLogText -App $app -Name 'terminal-agent-pane.log' -SinceStart) -match "EP probe winPs policy='restricted'.*BLOCKED"
+                }
+                $blocked | Should -BeTrue -Because "the probe must read the real Restricted policy and block"
+                # The blocked verdict drives FreOverlay::_SaveAndInstallAsync to surface
+                # the shell-integration problem (FreProblemKind::ShellIntegrationExecutionPolicy)
+                # and co_return *without* raising Completed — so the FRE does not finish.
+                $surfaced = Test-Until -TimeoutSec 60 -IntervalSec 2 -Condition {
+                    (Get-ItLogText -App $app -Name 'terminal-agent-pane.log' -SinceStart) -match 'Showing problem: ShellIntegration'
+                }
+                $surfaced | Should -BeTrue -Because "a real EP block must surface the shell-integration problem"
+                # ...and the FRE must NOT have completed.
+                $log = Get-ItLogText -App $app -Name 'terminal-agent-pane.log' -SinceStart
+                $log | Should -Not -Match 'Completed — raising Completed event'
+                Get-FreCompleted -App $app | Should -BeFalse
+            }
+            finally { Stop-Terminal -App $app }
+        }
+        finally { Restore-WtExecutionPolicy -State $st }
+    }
+
+    It 'RemoteSigned policy -> FRE probe reads it and does NOT block (winPs=ok)' {
+        # RemoteSigned permits *local* unsigned scripts, so our $PROFILE block runs
+        # and the probe must NOT block shell integration.
+        $st = Set-WtExecutionPolicy -Value RemoteSigned
+        try {
+            $app = Start-TerminalFre -Package Dev
+            try {
+                & $script:DriveFreSave $app
+                $notBlocked = Test-Until -TimeoutSec 60 -IntervalSec 2 -Condition {
+                    (Get-ItLogText -App $app -Name 'terminal-agent-pane.log' -SinceStart) -match "EP probe winPs policy='remotesigned'.*not-blocked"
+                }
+                $notBlocked | Should -BeTrue -Because "the probe must read the real RemoteSigned policy and not block"
+                # The not-blocked path must never surface the shell-integration EP problem.
+                # (Asserted after a short settle so a late-arriving problem would be caught.)
+                Start-Sleep -Seconds 3
+                (Get-ItLogText -App $app -Name 'terminal-agent-pane.log' -SinceStart) | Should -Not -Match 'Showing problem: ShellIntegration'
+            }
+            finally { Stop-Terminal -App $app }
+        }
+        finally { Restore-WtExecutionPolicy -State $st }
+    }
+}


### PR DESCRIPTION
## What

Adds **deterministic** execution-policy coverage for the FRE Save flow, plus the framework plumbing it needs. This is the E2E counterpart to the product fix in #336 (FRE false-blocking on a load-induced execution-policy probe timeout).

### New test — `test/e2e/tests/Feature.FreExecutionPolicy.Tests.ps1`
The existing `FreFlow` tests only exercise whatever execution policy the machine happens to have. These two force the **real** Windows PowerShell effective policy through the **HKCU CurrentUser scope** (no admin; outranks LocalMachine) and assert the FRE Save verdict straight from `terminal-agent-pane.log`:

| Policy | Probe verdict | FRE outcome asserted |
|---|---|---|
| `Restricted` | `EP probe winPs policy='restricted' … -> BLOCKED` | `Showing problem: ShellIntegration`, **no** `Completed`, `agentFreCompleted=false` |
| `RemoteSigned` | `EP probe winPs policy='remotesigned' … -> not-blocked` | **no** shell-integration problem surfaced |

The registry scope is **always restored** (per-test `finally` + `AfterAll` safety net). Verified before/after: effective policy returns to its original value and the HKCU value is cleared.

Targets the **dev** package — only that build carries the probe-timeout fix (#336) and the per-host `[FRE] EP probe …` diagnostics these tests assert on. The Describe is `-Skip`ped when the dev package isn't deployed (CI-safe).

### Framework changes
- **`Fre.ps1`** — `Get-/Set-/Restore-WtExecutionPolicy` helpers (exported in `ItE2E.psm1`).
- **`Harness.ps1`** — launch via **AUMID** (`shell:AppsFolder\<PFN>!App`) instead of the global `wtai` AppExecutionAlias. The alias is owned by a single package, so with both the store and a dev build installed it's ambiguous and launched the *wrong* package (silently timing out dev-targeted tests). AUMID is package-specific. The old AUMID "crash" was the already-fixed `state.json` corruption bug, not the activation method.

## Verification
```
Tests Passed: 2, Failed: 0, Skipped: 0
EP before: Unrestricted  ->  EP after: Unrestricted  (HKCU value cleared)
```
Smoke-checked the AUMID launch change against the default/store package: launches, COM CLSID resolves — no regression.