### PR TITLE
fix(shell-integration): bash PROMPT_COMMAND set -u safety + Agent Pane profile-count UTs

### DIFF
--- a/src/cascadia/UnitTests_SettingsModel/DeserializationTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/DeserializationTests.cpp
@@ -542,7 +542,7 @@ namespace SettingsModelUnitTests
         const auto settings = winrt::make_self<implementation::CascadiaSettings>(settings0String, implementation::LoadStringResource(IDR_DEFAULTS));
 
         VERIFY_ARE_EQUAL(0u, settings->Warnings().Size());
-        VERIFY_ARE_EQUAL(4u, settings->AllProfiles().Size());
+        VERIFY_ARE_EQUAL(5u, settings->AllProfiles().Size());
         VERIFY_IS_TRUE(settings->AllProfiles().GetAt(0).HasGuid());
         VERIFY_IS_TRUE(settings->AllProfiles().GetAt(1).HasGuid());
         VERIFY_IS_TRUE(settings->AllProfiles().GetAt(2).HasGuid());
@@ -550,7 +550,10 @@ namespace SettingsModelUnitTests
         VERIFY_ARE_EQUAL(L"profile0", settings->AllProfiles().GetAt(0).Name());
         VERIFY_ARE_EQUAL(L"profile1", settings->AllProfiles().GetAt(1).Name());
         VERIFY_ARE_EQUAL(L"cmdFromUserSettings", settings->AllProfiles().GetAt(2).Name());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->AllProfiles().GetAt(3).Name());
+        // The hidden "Agent Pane" profile from defaults.json (fork addition) is
+        // emitted in defaults.json order, ahead of the other inbox profiles.
+        VERIFY_ARE_EQUAL(L"Agent Pane", settings->AllProfiles().GetAt(3).Name());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->AllProfiles().GetAt(4).Name());
     }
 
     void DeserializationTests::TestReorderingWithoutGuid()
@@ -620,7 +623,7 @@ namespace SettingsModelUnitTests
         const auto settings = winrt::make_self<implementation::CascadiaSettings>(settings0String, implementation::LoadStringResource(IDR_DEFAULTS));
 
         VERIFY_ARE_EQUAL(0u, settings->Warnings().Size());
-        VERIFY_ARE_EQUAL(4u, settings->AllProfiles().Size());
+        VERIFY_ARE_EQUAL(5u, settings->AllProfiles().Size());
         VERIFY_IS_TRUE(settings->AllProfiles().GetAt(0).HasGuid());
         VERIFY_IS_TRUE(settings->AllProfiles().GetAt(1).HasGuid());
         VERIFY_IS_TRUE(settings->AllProfiles().GetAt(2).HasGuid());
@@ -628,7 +631,10 @@ namespace SettingsModelUnitTests
         VERIFY_ARE_EQUAL(L"Command Prompt", settings->AllProfiles().GetAt(0).Name());
         VERIFY_ARE_EQUAL(L"ThisProfileShouldNotCrash", settings->AllProfiles().GetAt(1).Name());
         VERIFY_ARE_EQUAL(L"Ubuntu", settings->AllProfiles().GetAt(2).Name());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->AllProfiles().GetAt(3).Name());
+        // The hidden "Agent Pane" profile from defaults.json (fork addition) is
+        // emitted in defaults.json order, ahead of the other inbox profiles.
+        VERIFY_ARE_EQUAL(L"Agent Pane", settings->AllProfiles().GetAt(3).Name());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->AllProfiles().GetAt(4).Name());
     }
 
     void DeserializationTests::TestLayeringNameOnlyProfiles()
@@ -656,12 +662,15 @@ namespace SettingsModelUnitTests
 
         const auto settings = winrt::make_self<implementation::CascadiaSettings>(settings0String, implementation::LoadStringResource(IDR_DEFAULTS));
         const auto profiles = settings->AllProfiles();
-        VERIFY_ARE_EQUAL(5u, profiles.Size());
+        VERIFY_ARE_EQUAL(6u, profiles.Size());
         VERIFY_ARE_EQUAL(L"ThisProfileIsGood", profiles.GetAt(0).Name());
         VERIFY_ARE_EQUAL(L"ThisProfileShouldNotLayer", profiles.GetAt(1).Name());
         VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", profiles.GetAt(2).Name());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", profiles.GetAt(3).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", profiles.GetAt(4).Name());
+        // The hidden "Agent Pane" profile from defaults.json (fork addition) is
+        // emitted in defaults.json order, ahead of the other inbox profiles.
+        VERIFY_ARE_EQUAL(L"Agent Pane", profiles.GetAt(3).Name());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", profiles.GetAt(4).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", profiles.GetAt(5).Name());
     }
 
     void DeserializationTests::TestHideAllProfiles()
@@ -1028,7 +1037,9 @@ namespace SettingsModelUnitTests
         const auto settings = winrt::make_self<implementation::CascadiaSettings>(settings0String, implementation::LoadStringResource(IDR_DEFAULTS));
 
         VERIFY_ARE_EQUAL(guid1String, settings->GlobalSettings().UnparsedDefaultProfile());
-        VERIFY_ARE_EQUAL(4u, settings->AllProfiles().Size());
+        // 5u = profile0 + auto-guid profile1 + Windows PowerShell + Command Prompt
+        //      + the hidden "Agent Pane" profile from defaults.json (fork addition).
+        VERIFY_ARE_EQUAL(5u, settings->AllProfiles().Size());
         VERIFY_ARE_EQUAL(guid1, settings->AllProfiles().GetAt(0).Guid());
         VERIFY_ARE_NOT_EQUAL(guid1, settings->AllProfiles().GetAt(1).Guid());
     }
@@ -1909,8 +1920,10 @@ namespace SettingsModelUnitTests
         // GH#8146: A LoadDefaults call should populate the list of active profiles
 
         const auto settings{ CascadiaSettings::LoadDefaults() };
-        VERIFY_ARE_EQUAL(settings.ActiveProfiles().Size(), settings.AllProfiles().Size());
-        VERIFY_ARE_EQUAL(settings.AllProfiles().Size(), 2u);
+        // The fork's defaults.json adds a hidden "Agent Pane" profile, so the
+        // defaults now contain 3 profiles total (2 active + 1 hidden).
+        VERIFY_ARE_EQUAL(2u, settings.ActiveProfiles().Size());
+        VERIFY_ARE_EQUAL(3u, settings.AllProfiles().Size());
     }
 
     void DeserializationTests::TestInheritedCommand()
@@ -2111,9 +2124,13 @@ namespace SettingsModelUnitTests
         loader.FinalizeLayering();
 
         VERIFY_IS_FALSE(loader.duplicateProfile);
-        VERIFY_ARE_EQUAL(3u, loader.userSettings.profiles.size());
+        // 4u = Windows PowerShell + Command Prompt + the new "{6239...}" fragment
+        //      profile + the hidden "Agent Pane" profile from defaults.json (fork addition).
+        VERIFY_ARE_EQUAL(4u, loader.userSettings.profiles.size());
         // GH#12520: Fragments should be able to override the name of builtin profiles.
-        VERIFY_ARE_EQUAL(L"NewName", loader.userSettings.profiles[0]->Name());
+        // profiles[0] is the hidden "Agent Pane" profile from defaults.json (fork
+        // addition); Windows PowerShell (renamed by the fragment) follows it.
+        VERIFY_ARE_EQUAL(L"NewName", loader.userSettings.profiles[1]->Name());
     }
 
     void DeserializationTests::FragmentActionSimple()

--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -1096,7 +1096,11 @@ void ShellIntegrationTests::Bash_ScriptContent_HasIdempotencyGuardAndOscSequence
     VERIFY_IS_TRUE(_Contains(script, "${BASH_VERSION:-}"));
     VERIFY_IS_TRUE(_Contains(script, "${-:-}"));
     VERIFY_IS_TRUE(_Contains(script, "${__IT_SHELLINTEG_INSTALLED:-}"));
-    VERIFY_IS_TRUE(_Contains(script, "${PROMPT_COMMAND:-}"));
+    // PROMPT_COMMAND can be an array (bash 5.1+) so scalar ${VAR:-}
+    // defaulting is wrong for it — it would only see element [0]. The
+    // set -u-safe form for the array read is the ${ARR[@]+...}
+    // alternate-value guard, which collapses to nothing when unset.
+    VERIFY_IS_TRUE(_Contains(script, "${PROMPT_COMMAND[@]+\"${PROMPT_COMMAND[@]}\"}"));
     VERIFY_IS_TRUE(_Contains(script, "${PS1:-}"));
     // PWD too — printf reads it for the OSC 9;9 CWD report.
     VERIFY_IS_TRUE(_Contains(script, "${PWD:-}"));

--- a/src/cascadia/inc/BashShellIntegration.h
+++ b/src/cascadia/inc/BashShellIntegration.h
@@ -113,9 +113,15 @@ __IT_SHELLINTEG_INSTALLED=1
 #
 # "${PROMPT_COMMAND[@]}" expands to one element on a scalar var, zero
 # elements when unset, and N elements on an array -- the same loop
-# handles bash 3.2+ scalar and bash 5.1+ array uniformly.
+# handles bash 3.2+ scalar and bash 5.1+ array uniformly. The
+# ${PROMPT_COMMAND[@]+...} alternate-value guard keeps it `set -u`
+# safe: when PROMPT_COMMAND is unset the whole expansion collapses to
+# nothing instead of tripping "unbound variable" on bash 3.2 (a plain
+# "${PROMPT_COMMAND[@]}" errors there). ${PROMPT_COMMAND:-} can't be
+# used: scalar ${VAR:-} defaulting only sees element [0] of an array,
+# which is exactly the empty-slot case this loop exists to handle.
 __IT_SHELLINTEG_USER_PC=""
-for __it_pc_entry in "${PROMPT_COMMAND[@]}"; do
+for __it_pc_entry in ${PROMPT_COMMAND[@]+"${PROMPT_COMMAND[@]}"}; do
     [ -z "$__it_pc_entry" ] && continue
     if [ -z "$__IT_SHELLINTEG_USER_PC" ]; then
         __IT_SHELLINTEG_USER_PC="$__it_pc_entry"


### PR DESCRIPTION
## What

Fixes two fork-caused unit-test failures (Debug builds).

### 1. bash shell-integration `PROMPT_COMMAND` not `set -u` safe (real product bug)
`ScriptContent()` promised `${VAR:-}` defaulting for every variable read, but read `PROMPT_COMMAND` via the unguarded `"${PROMPT_COMMAND[@]}"`, which errors with `unbound variable` on bash 3.2 under `set -u` when `PROMPT_COMMAND` is unset. Switched to the `set -u`-safe `${PROMPT_COMMAND[@]+"${PROMPT_COMMAND[@]}"}` idiom (verified across unset / scalar / empty-slot-array / multi-element). Updated `Bash_ScriptContent_HasIdempotencyGuardAndOscSequences` to assert the correct contract.

### 2. SettingsModel `DeserializationTests` profile counts (fork product change)
The fork adds a hidden "Agent Pane" profile (`{fd19208a-...}`) to `defaults.json`. Six upstream profile-counting tests hard-coded the old count/order and weren't updated. Bumped counts (+1) and added Agent Pane index/name checks. Upstream will never fix these (the profile is fork-only).

## Scope note
Two other upstream tests (`ScreenBufferTests::ResizeCursorUnchanged`, `UiaTextRangeTests::FindAttribute`) also fail in Debug, but those are **upstream-caused** (PR #19535 lock assert; an upstream test's own iterator-invalidation) and were intentionally left untouched to wait for upstream.

## Test
- ShellIntegrationTests: 93/93
- SettingsModel: 177/177
- Full console/core UT suites + WTA: green
