### PR TITLE
docs(wta): update architecture docs to helper+master model

### DIFF
--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -2,55 +2,87 @@
 
 ## What is WTA?
 
-WTA (Windows Terminal Agent) is a Rust binary that bridges AI agent protocols with Windows Terminal.
-It provides three interfaces:
+WTA (Windows Terminal Agent) is a Rust binary that bridges AI agent CLIs with
+Windows Terminal. It is built around a **helper + master** architecture (see
+`doc/specs/Multi-window-agent-pane.md`) and runs in one of three roles, selected
+at startup by flags / subcommands — **there is no standalone agent / TUI mode and
+no MCP server**; bare `wta` with neither `--master` nor `--connect-master` exits
+with an error.
 
-- **ACP client** (default) -- TUI that spawns an agent CLI (Copilot, Claude, Gemini, Codex, or a custom command) and communicates over ACP via stdio JSON-RPC.
-- **MCP server** (`wta mcp`) -- headless tool server that an external agent calls to interact with shells and Windows Terminal.
-- **CLI helpers** (`wta list-panes`, `wta capture-pane`, `wta new-tab`, etc.) -- thin commands for humans and agents that can shell out. Direct keystroke injection is not exposed by the CLI.
+- **`wta-master`** (`--master <pipe>`, spawned once by the C++ `SharedWta`
+  singleton) -- the ACP **multiplexer**. Owns the *single* `ACP/stdio`
+  connection to the agent CLI subprocess (Copilot, Claude, Gemini, Codex, or a
+  custom command), listens on a named pipe, and fans per-helper ACP sessions
+  onto that one agent CLI. Implementation: `src/master/mod.rs`.
+- **`wta-helper`** (`--connect-master <pipe>`, spawned once per agent pane by
+  Windows Terminal) -- the per-pane **TUI**. Drives the ratatui chat UI (`app.rs`)
+  but, instead of spawning its own agent CLI, speaks ACP/JSON-RPC to master over
+  the pipe. *From the helper's perspective, master is the agent.* Entry:
+  `src/helper/mod.rs` → `run_default_tui_over_pipe`.
+- **CLI helpers** (`wta list-panes`, `wta capture-pane`, `wta new-tab`,
+  `delegate`, `hooks`, `sessions`, …) -- one-shot WT-control commands for humans
+  and for agents that can shell out. Direct keystroke injection is not exposed by
+  the CLI. Dispatched in `src/main.rs`.
 
-ACP and MCP modes share `ShellManager`, which routes operations to either local subprocesses or Windows Terminal panes. WT pane operations use a `WtChannel` abstraction with a single implementation today:
+The helper side owns `ShellManager`, which services the agent CLI's ACP
+`create_terminal` / permission requests by routing to either a local subprocess
+or a Windows Terminal pane. WT pane operations use a `WtChannel` abstraction with
+a single implementation today:
 
-- `CliChannel` shells out to `wtcli.exe`, which calls WT's COM `IProtocolServer`. All WT operations — including `send_input` (via `wtcli send-keys`) — go through this path.
+- `CliChannel` shells out to `wtcli.exe`, which calls WT's COM `IProtocolServer`.
+  All WT operations — including `send_input` (via `wtcli send-keys`) — go through
+  this path.
 
 ## System Diagram
 
 ```
- Agent CLI (copilot/claude)     External agent       Human / AI shell-out
-       |  ACP/stdio                  |  MCP/stdio         |  CLI helpers
-       v                             v                    v
- +-----------+                +-----------+        +-------------+
- | ACP Mode  |                | MCP Mode  |        | CLI Mode    |
- | (TUI)     |                | (headless)|        | (one-shot)  |
- | client.rs |                | server.rs |        | main.rs     |
- +-----+-----+                +-----+-----+        +------+------+
-       |                             |                     |
-       +---------------+-------------+                     |
-                       |                                   |
-                 ShellManager                              |
-                       |                                   |
-                  CliChannel <-------------------------+---+
-                       |
-                       v
-              wtcli.exe -> COM IProtocolServer
-                       |
-                       v
-              TerminalProtocolComServer
-                       |
-                       v
-              Windows Terminal
+            Windows Terminal (WindowEmperor, one WT process)
+              |  spawns once (SharedWta)      |  spawns per agent pane
+              |  --master <pipe>              |  --connect-master <pipe>
+              v                               v
+        +--------------+   named pipe   +------------------+
+        | wta-master   |<-------------->| wta-helper       |  (one per pane)
+        | (singleton)  |  ACP/JSON-RPC  | TUI: app.rs +    |
+        | master/mod.rs|                | helper/mod.rs    |
+        +------+-------+                +--------+---------+
+               |  ACP/stdio                      |  ShellManager
+               v                                 |  (create_terminal /
+         Agent CLI                               |   permission)
+      (copilot/claude/                           v
+       gemini/codex)                        CliChannel
+                                                 |
+ Human / agent shell-out:                        v
+   wta <subcommand>  ----------------->  wtcli.exe -> COM IProtocolServer
+   (main.rs CLI helpers)                         |
+                                                 v
+                                    TerminalProtocolComServer
+                                                 |
+                                                 v
+                                         Windows Terminal
 ```
 
 ## Protocol Stack
 
 ### ACP (Agent Client Protocol)
 
-WTA acts as an ACP **client**. It spawns an agent CLI as a child process and speaks JSON-RPC 2.0 over stdin/stdout.
+ACP (`agent-client-protocol = "0.10"`, JSON-RPC 2.0) is spoken on **two hops**,
+because of the helper+master split:
 
-- Crate: `agent-client-protocol = "0.10"`
-- Implementation: `src/protocol/acp/client.rs`
-- The agent sends requests (`create_terminal`, `request_permission`, etc.) and WTA handles them.
-- Session notifications flow from agent to WTA: message chunks, tool calls, plans, and status changes.
+- **master ↔ agent CLI** (stdio): master is the ACP **client** of the agent CLI
+  subprocess — the same role legacy single-process wta used to play. It spawns
+  the agent CLI and owns its stdin/stdout.
+- **helper ↔ master** (named pipe): master is an ACP **agent** (server) to each
+  helper, and the helper is the ACP **client**. Master forwards helper requests
+  to the agent CLI and routes inbound `session_notification`s back to the helper
+  that owns the session (`session_to_helper` map in `src/master/mod.rs`).
+
+Implementations: agent-CLI client + helper-side `WtaClient` in
+`src/protocol/acp/client.rs`; the master multiplexer in `src/master/mod.rs`.
+
+The agent sends requests (`create_terminal`, `request_permission`, etc.) which
+ultimately land on the owning helper's `WtaClient`; session notifications
+(message chunks, tool calls, plans, status changes) flow agent CLI → master →
+helper.
 
 Key ACP message types handled:
 
@@ -58,33 +90,6 @@ Key ACP message types handled:
 - `request_permission` -- permission dialog with options (allow/reject)
 - `create_terminal` / `terminal_output` / `wait_for_terminal_exit` -- agent-managed shells
 - `release_terminal` / `kill_terminal` -- cleanup
-
-### MCP (Model Context Protocol)
-
-WTA acts as an MCP **server**. An external agent calls tools exposed by WTA over stdio.
-
-- Crate: `rmcp = "1.1"` with `#[tool_router]` / `#[tool_handler]` macros
-- Implementation: `src/protocol/mcp/server.rs`
-
-Tools exposed:
-
-| Category | Tool | Description |
-|----------|------|-------------|
-| Shell | `run_command` | Execute command, return stdout and exit code |
-| Shell | `create_terminal` | Spawn persistent terminal session |
-| Shell | `get_terminal_output` | Read buffered output |
-| Shell | `wait_for_terminal` | Block until exit |
-| Shell | `kill_terminal` | Terminate session |
-| WT Query | `wt_list_windows` | All WT windows |
-| WT Query | `wt_list_tabs` | Tabs in a window |
-| WT Query | `wt_list_panes` | Panes in a tab |
-| WT Query | `wt_get_active_pane` | Currently focused pane |
-| WT Query | `wt_read_pane_output` | Terminal buffer text |
-| WT Query | `wt_get_process_status` | Running/exit status |
-| WT Control | `wt_create_tab` | Create new tab |
-| WT Control | `wt_split_pane` | Split a pane |
-| WT Control | `wt_send_input` | Type text into a pane via `wtcli send-keys` / COM `SendInput` |
-| WT Control | `wt_close_pane` | Close a pane |
 
 ### WT COM Protocol
 
@@ -106,7 +111,10 @@ The COM surface exposes reads and mutations, including `list_*`, `read_pane_outp
 wta --agent "copilot --acp --stdio"
 ```
 
-WTA generates an MCP config file at startup pointing to `wta mcp` and injects it with Copilot's `--additional-mcp-config` option.
+Copilot speaks ACP directly (`--acp --stdio`). It is spawned by `wta-master`, not
+by the helper. The agent reaches Windows Terminal by shelling out to the `wta` /
+`wtcli` CLI helpers (which call WT's COM `IProtocolServer`); WTA no longer
+generates an MCP config or runs an MCP server for the agent.
 
 ### Claude and Codex
 
@@ -165,21 +173,34 @@ WTA discovers which WT pane it is running in by PID matching:
 
 ## Logging
 
-WTA writes structured logs under the Intelligent Terminal runtime directory:
+WTA writes structured logs under the package-private log dir, in a per-version
+subfolder keyed by the package version:
 
 ```
-%LOCALAPPDATA%\IntelligentTerminal\logs\
+…\Packages\<PFN>\LocalCache\Local\IntelligentTerminal\logs\<pkgver>\   (packaged)
+%LOCALAPPDATA%\IntelligentTerminal\logs\                                (unpackaged / dev)
 ```
 
-When running packaged, `%LOCALAPPDATA%` is redirected to the package sandbox.
+Per-process logs in the helper+master architecture:
 
-Current process logs include:
+- `wta-main_master.log` -- `wta-master`: agent CLI spawn, pipe accept loop,
+  per-helper routing, `session_to_helper` updates, agent CLI exit detection
+- `wta-main_helper-{pid}.log` -- each `wta-helper` (one file per PID): pipe
+  connect, ACP initialize, `session/new`, prompts, agent responses, TUI lifecycle
+- `wta-cli.log` -- short-lived CLI helpers (`list-*`, `capture-pane`, `listen`,
+  `sessions`, …); daily-rotated, 3-day retention
+- `wta-delegate.log` -- `wta delegate` (`?<prompt>` delegation)
+- `wta-probe.log` -- `probe-models`
+- `wta-install-hooks.log` -- `hooks install` / uninstall
+- `wta-ensure-host.log` -- WT-side background ensure-running / SharedWta lifecycle
+- `wta-acp-debug.log` -- low-level ACP JSON-RPC wire trace
 
-- `wta-main.log` -- default ACP TUI mode
-- `wta-delegate.log` -- `wta delegate`
-- `wta-install-hooks.log` -- hook installation and removal
+Two files in the same dir are written by **non-Rust** producers:
+`terminal-agent-pane.log` (C++ `AgentPaneLog`) and `hook-trace.log` (PowerShell
+hooks). See the repo-level architecture notes for the full storage layout.
 
-The log level is controlled by `WTA_LOG`; if unset, WTA defaults to a debug filter in `logging.rs`.
+The log level is controlled by `WTA_LOG` (or `RUST_LOG`); if unset, debug builds
+default to `debug` and release builds to `info` (`logging::default_filter_directive`).
 
 ## Build Rule
 
@@ -215,7 +236,6 @@ green build says nothing about the tests.
 | Crate | Version | Purpose |
 |-------|---------|---------|
 | `agent-client-protocol` | 0.10 | ACP client library |
-| `rmcp` | 1.1 | MCP server framework |
 | `tokio` | 1 | Async runtime |
 | `ratatui` | 0.30 | TUI rendering |
 | `crossterm` | 0.29 | Terminal I/O |

--- a/tools/wta/OVERVIEW.md
+++ b/tools/wta/OVERVIEW.md
@@ -189,7 +189,7 @@ cargo build
 # Output binary: tools/wta/target/debug/wta.exe
 
 # Run the WTA test suite (cargo build does NOT compile #[cfg(test)] code)
-cargo test --manifest-path tools/wta/Cargo.toml
+cargo test
 ```
 
 WTA is normally launched **by Windows Terminal** (master + helper), not run by

--- a/tools/wta/OVERVIEW.md
+++ b/tools/wta/OVERVIEW.md
@@ -2,48 +2,78 @@
 
 ## One-line summary
 
-WTA is a Rust command-line tool that **bridges AI agents and Windows Terminal**. It lets AI (e.g. GitHub Copilot, Claude) drive your terminal directly: create tabs, split panes, run commands, read output — like an AI-powered tmux.
+WTA is a Rust command-line tool that **bridges AI agent CLIs and Windows
+Terminal**. It lets AI (GitHub Copilot, Claude, Gemini, Codex, or a custom
+command) drive your terminal directly — create tabs, split panes, run commands,
+read output — and surfaces an in-terminal chat UI inside a Windows Terminal
+**agent pane**.
 
 ---
 
 ## What problem does it solve?
 
-Today's AI coding assistants can "talk about" code but can't "do" anything in the terminal. WTA fills that gap:
+Today's AI coding assistants can "talk about" code but can't "do" anything in the
+terminal. WTA fills that gap:
 
 - **AI wants to run a command?** → WTA opens a pane in Windows Terminal and runs it
 - **AI wants to read command output?** → WTA pulls the content from the terminal and returns it
-- **User wants to drive the terminal via natural-language chat?** → WTA provides a TUI chat surface; AI executes on your behalf
+- **User wants to drive the terminal via natural-language chat?** → WTA renders a TUI chat surface inside an agent pane; AI executes on your behalf
+- **A command just failed?** → WTA's autofix detects it and offers a fix via the agent
 
 ---
 
-## Three operating modes
+## Architecture in one sentence
 
-### 1. ACP TUI mode (default) — interactive chat UI
+WTA runs as a **helper + master** pair, never as a standalone process: Windows
+Terminal spawns one **`wta-master`** singleton that owns the single connection to
+the agent CLI, and one **`wta-helper`** per agent pane that renders the TUI and
+talks ACP to master over a named pipe. A third, stateless role is the **CLI
+helpers** (`wta list-panes`, `wta capture-pane`, …) used for one-shot WT control.
+
+> There is **no standalone agent / TUI mode and no MCP server** anymore. Bare
+> `wta` with neither `--master` nor `--connect-master` exits with an error
+> (`main.rs`). The earlier single-process "ACP TUI" and "`wta mcp`" modes were
+> removed.
+
+---
+
+## Three process roles
+
+### 1. `wta-master` — the ACP multiplexer (singleton)
 
 ```
-wta
-wta --agent "copilot --acp --stdio"
-wta "list all my git branches"
+wta --master \\.\pipe\wta-master-<GUID>
 ```
 
-Starts an in-terminal chat surface (rendered with ratatui). WTA acts as an **ACP client**, spawns an AI agent subprocess (Copilot by default), and talks to it over JSON-RPC on stdin/stdout. The user types in the chat box; the AI can request command execution, terminal creation, etc., which WTA dispatches and renders.
+Spawned **once** by the C++ `SharedWta` singleton (`WindowEmperor` side). It:
 
-When ACP mode is connected to Windows Terminal, the recommended agent control surface is the local `wta` CLI rather than MCP-in-the-same-session. That is, agents shell out to commands like `wta active-pane --json`, `wta list-panes --json`, `wta capture-pane --json`, and the CLI talks to WT over the protocol.
+1. Spawns the agent CLI subprocess (copilot / claude / gemini / codex) and wraps
+   its stdio in an `acp::ClientSideConnection` — master is the *client* of the
+   agent CLI.
+2. Listens on the named pipe; accepts one `wta-helper` per connect.
+3. For each helper, runs an `acp::AgentSideConnection` (master plays the *agent*
+   role), forwards helper requests to the agent CLI, and routes inbound
+   `session_notification`s back to the owning helper via the `session_to_helper`
+   map.
 
-### 2. MCP server mode — tool server for AI
+Implementation: `src/master/mod.rs`.
+
+### 2. `wta-helper` — the per-pane TUI
 
 ```
-wta mcp
+wta --connect-master \\.\pipe\wta-master-<GUID> [--owner-tab-id <GUID>] [--start-stashed] …
 ```
 
-Headless. WTA runs as an **MCP server** exposing 15 tools to an external AI agent. Through these tools the agent can:
-- Execute commands (`run_command`)
-- Create/manage terminal sessions (`create_terminal`, `get_terminal_output`, `kill_terminal`)
-- Query Windows Terminal state (`wt_list_windows`, `wt_list_tabs`, `wt_list_panes`)
-- Control Windows Terminal (`wt_create_tab`, `wt_split_pane`, `wt_send_input`, `wt_close_pane`)
-- Read terminal content (`wt_read_pane_output`, `wt_get_process_status`)
+Spawned **once per agent pane** by Windows Terminal (`TerminalPage`). It drives
+the ratatui chat UI (`app.rs`) but, instead of spawning its own agent CLI,
+connects to master over the pipe and speaks ACP JSON-RPC. *From the helper's
+perspective, master is the agent.* The helper owns the user-facing side effects:
+the TUI, permission prompts, `ShellManager` (for the agent's `create_terminal`),
+autofix, and the per-tab session model.
 
-### 3. CLI mode — tmux-style commands
+Entry: `src/helper/mod.rs` → `crate::run_default_tui_over_pipe` (in `main.rs`).
+
+### 3. CLI helpers — one-shot WT control
 
 ```
 wta list-windows                          # list all WT windows
@@ -51,33 +81,44 @@ wta list-tabs                             # list tabs
 wta capture-pane -t 3 -l 50               # read the last 50 lines from pane 3
 wta new-tab -c "pwsh.exe" -n "Build"      # create a new tab
 wta split-pane -h                         # split the current pane horizontally
+wta delegate "fix this build"             # open a delegate agent in a new tab
+wta sessions list                         # inspect sessions known to master
+wta hooks install                         # install the agent-hook bridge
 ```
 
-One-shot commands that talk directly to Windows Terminal. Useful for both humans and agents.
+Stateless, short-lived commands dispatched in `src/main.rs`. They talk directly
+to Windows Terminal via `CliChannel` → `wtcli.exe` → COM and exit. Used by humans
+debugging WTA and by agents that can shell out. (The agent CLI reaches WT this
+way too — by shelling out to `wta` / `wtcli`, **not** via an MCP server.)
 
 ---
 
 ## Architecture diagram
 
 ```
- AI Agent CLI (copilot/claude)     external AI agent     user / AI shell-out
-       |  ACP/stdio                  |  MCP/stdio              |  CLI subcommands
-       v                             v                          v
- +-----------+                +-----------+              +-------------+
- | ACP mode  |                | MCP mode  |              | CLI mode    |
- | (TUI)     |                | (headless)|              | (one-shot)  |
- | client.rs |                | server.rs |              | main.rs     |
- +-----+-----+                +-----+-----+              +------+------+
-       |                             |                          |
-       +-----------------+-----------+                          |
-                         |                                      |
-                   ShellManager                                 |
-                    |         |                                 |
-              local child   WtChannel (COM via wtcli) <---------+
-                                  |
-                                  v
-                         Windows Terminal
-                        (TerminalProtocolComServer)
+            Windows Terminal (WindowEmperor, one WT process)
+              |  spawns once (SharedWta)      |  spawns per agent pane
+              |  --master <pipe>              |  --connect-master <pipe>
+              v                               v
+        +--------------+   named pipe   +------------------+
+        | wta-master   |<-------------->| wta-helper       |  (one per pane)
+        | (singleton)  |  ACP/JSON-RPC  | TUI: app.rs +    |
+        | master/mod.rs|                | helper/mod.rs    |
+        +------+-------+                +--------+---------+
+               |  ACP/stdio                      |  ShellManager
+               v                                 |  (create_terminal /
+         Agent CLI                               |   permission)
+      (copilot/claude/                           v
+       gemini/codex)                        CliChannel (WtChannel)
+                                                 |
+ Human / agent shell-out:                        v
+   wta <subcommand>  ----------------->  wtcli.exe -> COM IProtocolServer
+   (main.rs CLI helpers)                         |
+                                                 v
+                                    TerminalProtocolComServer
+                                                 |
+                                                 v
+                                         Windows Terminal
 ```
 
 ---
@@ -86,26 +127,40 @@ One-shot commands that talk directly to Windows Terminal. Useful for both humans
 
 | Module | File | Responsibility |
 |------|------|------|
-| **main.rs** | `src/main.rs` | CLI parsing (clap), mode dispatch, protocol discovery |
-| **ACP Client** | `src/protocol/acp/client.rs` | ACP client; spawns the AI subprocess; handles JSON-RPC messages |
-| **MCP Server** | `src/protocol/mcp/server.rs` | MCP server; exposes 15 tools via rmcp |
+| **Entry / CLI** | `src/main.rs` | clap parsing, role/subcommand dispatch, protocol discovery, locale normalization |
+| **Master** | `src/master/mod.rs` | ACP multiplexer singleton: spawns the agent CLI, serves helpers over the pipe, routes per-session notifications |
+| **Helper** | `src/helper/mod.rs` | Thin per-pane entry; reuses `run_default_tui_over_pipe` with the pipe as ACP transport |
+| **App / TUI** | `src/app.rs` (+ `src/app/*.rs`) | TUI state machine and event loop; per-tab sessions, autofix, permission, session-management view |
+| **ACP client** | `src/protocol/acp/client.rs` | Agent-CLI client + helper-side `WtaClient`; prompt templating, model select, probe, failure handling |
+| **Coordinator** | `src/coordinator.rs` | `?<prompt>` delegate execution |
+| **Session tracking** | `src/agent_sessions.rs`, `src/session_registry.rs`, `src/session_watcher/*` | Session registry + CLI-log status classification (claude/copilot/codex/gemini) |
 | **ShellManager** | `src/shell/shell_manager.rs` | Terminal process manager: local child or WT pane |
-| **CliChannel** | `src/shell/wt_channel/cli_channel.rs` | Shells out to `wtcli.exe` to talk to WT's COM server (the only WT transport) |
-| **TUI** | `src/ui/*.rs` | ratatui chat UI: message rendering, input box, permission prompts, status bar |
-| **App** | `src/app.rs` | TUI state machine and event loop |
+| **CliChannel** | `src/shell/wt_channel/cli_channel.rs` | Shells out to `wtcli.exe` (the only WT transport) |
+| **TUI views** | `src/ui/*.rs` | ratatui rendering: chat, input, permission, popups, agents view, status bar |
+| **Hooks installer** | `src/agent_hooks_installer.rs` | Install / upgrade the `wt-agent-hooks` bridge per CLI |
 
 ---
 
 ## Communication protocols
 
-### WTA ↔ AI Agent
-- **ACP (Agent Client Protocol)**: JSON-RPC 2.0 over stdio; WTA is the client
-- **MCP (Model Context Protocol)**: JSON-RPC 2.0 over stdio; WTA is the server
+### WTA ↔ AI Agent (ACP, two hops)
 
-### WTA ↔ Windows Terminal
-- **Protocol**: COM (`IProtocolServer`) for all methods, including `SendInput` (direct shell input)
-- **Discovery**: `WT_COM_CLSID` environment variable, set by WT at startup and inherited by every conpty child (so wta and wtcli see it automatically)
-- **Authorization**: COM is gated by Windows packaged-COM / terminal activation policy
+ACP (`agent-client-protocol = "0.10"`, JSON-RPC 2.0) is spoken on two hops:
+
+- **master ↔ agent CLI** (stdio): master is the ACP **client**; it spawns and
+  owns the agent CLI.
+- **helper ↔ master** (named pipe): master is the ACP **agent** (server), the
+  helper is the **client**. Master forwards helper requests to the agent CLI and
+  fans notifications back to the owning helper.
+
+### WTA ↔ Windows Terminal (COM)
+
+- **Transport**: every WT operation shells out to `wtcli.exe`, which does
+  `CoCreateInstance(WT_COM_CLSID)` and calls WT's `IProtocolServer` — including
+  `send_input` (`wtcli send-keys`).
+- **Discovery**: the `WT_COM_CLSID` environment variable, set by WT at startup
+  and inherited by every conpty child (so `wta` and `wtcli` see it automatically).
+- **Authorization**: gated by Windows packaged-COM / terminal activation policy.
 
 ---
 
@@ -115,282 +170,108 @@ One-shot commands that talk directly to Windows Terminal. Useful for both humans
 |------|-----|
 | Async runtime | tokio |
 | CLI parsing | clap 4 |
-| TUI rendering | ratatui + crossterm |
+| TUI rendering | ratatui 0.30 + crossterm 0.29 |
 | ACP protocol | agent-client-protocol 0.10 |
-| MCP protocol | rmcp 1.1 |
 | Serialization | serde + serde_json |
 | Error handling | anyhow |
+| i18n | rust-i18n |
 
 ---
 
 ## Build & run
 
 ```bash
-# Prereq: install Rust (rustup)
 cd tools/wta
-cargo build
 
+# Kill any live wta.exe first (a running shared-host locks target/debug/wta.exe)
+#   PowerShell: Get-Process wta -ErrorAction SilentlyContinue | Stop-Process -Force
+cargo build
 # Output binary: tools/wta/target/debug/wta.exe
 
-# Run ACP chat mode
-wta
+# Run the WTA test suite (cargo build does NOT compile #[cfg(test)] code)
+cargo test --manifest-path tools/wta/Cargo.toml
+```
 
-# Run MCP server mode
-wta mcp
+WTA is normally launched **by Windows Terminal** (master + helper), not run by
+hand. For ad-hoc inspection, the CLI helpers work standalone inside a WT pane:
 
-# Test the WT protocol connection
-wta test-pipe
-
-# tmux-style operations
-wta list-windows
+```bash
+wta pipe-id            # show the inherited WT_COM_CLSID
+wta list-windows       # talk to WT over COM
 wta capture-pane -l 5
+wta sessions list      # ask master for the session registry
 ```
 
 ---
 
 ## Relationship to the Windows Terminal repo
 
-WTA lives under the `tools/wta/` subdirectory of the Windows Terminal source tree. It is an independent Rust project, but by design it is a **companion tool** to Windows Terminal:
+WTA lives under `tools/wta/` of the Windows Terminal (Intelligent Terminal) source
+tree. It is an independent Rust project but a **companion** to Windows Terminal:
 
-- The C++ side ships `TerminalProtocolComServer`, exposing `IProtocolServer` via local COM activation
-- The Rust side (WTA) talks to it indirectly by shelling out to `wtcli.exe`, which is the COM client
-- Current state: COM is the sole control plane for all WT operations, including direct shell input
-- Future plans: deeper in-pane integration may extend WT's VT parser or grow the protocol's method set
+- The C++ side ships `TerminalProtocolComServer`, exposing `IProtocolServer` via
+  local COM activation, and `SharedWta`, which spawns/owns the `wta-master`
+  singleton.
+- `TerminalPage` spawns one `wta-helper` per agent pane (pre-warmed per tab) and
+  hosts its `TermControl` inside `AgentPaneContent`.
+- The Rust side reaches WT only indirectly, by shelling out to `wtcli.exe`.
+
+See `doc/specs/Multi-window-agent-pane.md` for the full helper+master design, and
+`tools/wta/AGENTS.md` for the per-crate conventions (logging layout, session
+liveness model, hooks auto-upgrade, third-party notice generation).
 
 ---
 
 ## Process model in detail
 
-The system involves **4 kinds of processes** and a small number of IPC channels. Each scenario is broken down below.
-
----
-
 ### Process inventory
 
 | Process | Binary | Lifetime | Role |
 |------|-----------|---------|------|
-| **Windows Terminal** | `WindowsTerminal.exe` | User-launched, long-lived | Window manager + terminal renderer; hosts `TerminalProtocolComServer` |
-| **WTA** | `wta.exe` | User- or AI-launched | Bridge layer; plays different roles depending on mode |
-| **AI Agent** | `copilot`, `claude-agent-acp`, etc. | Spawned by WTA or running externally | The AI "brain"; makes decisions |
-| **wtcli** | `wtcli.exe` | Spawned per call (or long-running for `listen`) | COM client for `IProtocolServer`; bridges wta → WT |
-| **Shell commands** | `cargo`, `git`, `pwsh`, ... | Spawned by WTA or WT; exit when done | The actual tools doing the work |
+| **Windows Terminal** | `WindowsTerminal.exe` | User-launched, long-lived | Window manager + renderer; hosts `TerminalProtocolComServer`; spawns master + helpers |
+| **wta-master** | `wta.exe --master` | Spawned once by `SharedWta` | Owns the agent CLI; multiplexes ACP sessions for all helpers |
+| **wta-helper** | `wta.exe --connect-master` | One per agent pane | TUI + per-pane side effects; ACP client of master |
+| **Agent CLI** | `copilot`, `claude`, `gemini`, `codex` | Spawned once by master | The AI "brain"; shared across all helpers |
+| **wtcli** | `wtcli.exe` | Per call (or long-running for `listen`) | COM client for `IProtocolServer`; bridges wta → WT |
+| **Shell commands** | `pwsh`, `cargo`, `git`, … | Spawned by WT; exit when done | The actual tools doing the work |
 
----
+### Key lifetime points
 
-### Scenario 1: ACP TUI mode (default `wta`)
-
-User runs `wta` in a Windows Terminal pane; the chat UI comes up.
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                   Windows Terminal (process A)               │
-│                   PID: 1000                                  │
-│  ┌─────────────────────────────┐ ┌────────────────────────┐ │
-│  │ Pane 1: wta.exe (process B) │ │ Pane 2: cargo build    │ │
-│  │ PID: 2000                   │ │ PID: 4000              │ │
-│  │                             │ │ (created by AI via WTA)│ │
-│  │  ┌──────────────────────┐   │ │                        │ │
-│  │  │ copilot (process C)  │   │ │                        │ │
-│  │  │ PID: 3000            │   │ │                        │ │
-│  │  │ (WTA's child)        │   │ │                        │ │
-│  │  └──────────────────────┘   │ │                        │ │
-│  └─────────────────────────────┘ └────────────────────────┘ │
-└─────────────────────────────────────────────────────────────┘
-```
-
-**Process relationships and IPC:**
-
-```
-process A: Windows Terminal       process B: wta.exe            process C: copilot
-(WindowsTerminal.exe)             (chat TUI)                    (AI agent child)
-      │                                │                            │
-      │◄── COM (via wtcli) ───────────►│◄── stdio (ACP JSON-RPC) ──►│
-      │  (all methods, incl. SendInput)│    stdin/stdout             │
-      │                                │                            │
-      │                                │  B is C's parent           │
-      │                                │  B spawns C                │
-```
-
-**Information flow (user says "run cargo build"):**
-
-1. User types "run cargo build" in the WTA TUI
-2. **WTA → Agent** (ACP stdio): `prompt("run cargo build")`
-3. **Agent → WTA** (ACP stdio): `create_terminal({command: "cargo", args: ["build"]})`
-4. **WTA → WT** (COM via wtcli): `create_tab({commandline: "cargo build", background: true})`
-5. **WT** creates a new pane and spawns the `cargo build` process (process D, PID 4000)
-6. **WT → WTA** (COM): `{pane_id: "2"}`
-7. WTA maps pane_id to terminal_id and returns to the agent
-8. The agent later calls `terminal_output` → WTA invokes `read_pane_output` over COM
-9. The agent calls `wait_for_terminal_exit` → WTA polls `get_process_status`
-
-**Process count:** at minimum 3 (WT + WTA + agent); one extra shell process per command in WT.
-
----
-
-### Scenario 2: MCP server mode (`wta mcp`)
-
-WTA runs as a headless tool server, called by an external AI agent over MCP.
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                   Windows Terminal (process A)               │
-│  ┌─────────────────────────────┐ ┌────────────────────────┐ │
-│  │ Pane 1                      │ │ Pane 2: pwsh           │ │
-│  │ (some shell)                │ │ (created by wta)       │ │
-│  └─────────────────────────────┘ └────────────────────────┘ │
-└─────────────────────────────────────────────────────────────┘
-        ▲                          COM
-        │                             │
-┌───────┴───────────────────────────────┐
-│            wta.exe mcp (process B)     │  ← MCP server
-│            PID: 2000                    │
-└───────────────────┬────────────────────┘
-                    │ stdio (MCP JSON-RPC)
-                    │
-┌───────────────────▼────────────────────┐
-│        External AI agent (process C)   │  ← MCP client
-│        (VS Code Copilot, Claude Desktop│
-│         or any MCP client)              │
-│        C is B's parent!                 │
-└────────────────────────────────────────┘
-```
-
-**Key contrast:** in MCP mode, **the call direction is inverted**:
-
-| | ACP mode | MCP mode |
-|---|---|---|
-| Who spawns whom | WTA spawns Agent | Agent spawns WTA |
-| WTA's role | Client (sends requests) | Server (handles requests) |
-| Agent's role | Server (handles prompts) | Client (calls tools) |
-| stdio direction | WTA → Agent stdin | Agent → WTA stdin |
-
-**Information flow (AI wants to run `git status`):**
-
-1. **Agent → WTA** (MCP stdio): `tools/call run_command {command: "git", args: ["status"]}`
-2. WTA's ShellManager picks a route:
-   - **WT protocol available** → `create_tab` in WT, read output via COM
-   - **WT protocol unavailable** → local `tokio::process::Command` spawn
-3. **WTA → Agent** (MCP stdio): `{stdout: "On branch main\n...", exit_code: 0}`
-
----
-
-### Scenario 3: CLI mode (`wta list-windows`, etc.)
-
-Simplest case. WTA is a one-shot command-line tool that talks to WT and exits.
-
-```
-┌─────────────────────────────────────┐
-│    Windows Terminal (process A)      │
-└──────────────┬──────────────────────┘
-               │ COM (via wtcli)
-┌──────────────▼──────────────────────┐
-│    wta list-windows (process B)      │
-│    connect → send request → print → exit │
-└─────────────────────────────────────┘
-```
-
-**No AI agent, no ShellManager.** WTA just shells out to `wtcli` once, prints the result, and exits. Lifetime: a few hundred milliseconds.
-
----
+- One agent CLI is shared by **all** panes/tabs (master multiplexes). A helper's
+  `session/new` round-trips to the CLI; `initialize` is a cached replay.
+- Helpers are **pre-warmed per tab** at tab creation (`--start-stashed`), so the
+  ACP session connects in the background even before the user opens the pane —
+  this is what lets autofix work on a stashed pane.
+- Toggling an agent pane **stashes** it (helper + conpty + ACP session survive);
+  the pane is only destroyed on tab close or `Ctrl+C ×2` in the TUI.
+- If master dies, helpers see `TransportLost` and the only recovery is `/restart`
+  (routes via `wtcli publish` → C++ `SharedWta::Restart`, bypassing the dead pipe).
 
 ### Two paths for shell command execution
 
-When an AI agent needs to run a command, ShellManager picks one of two routes:
+When the agent's ACP `create_terminal` lands on a helper, `ShellManager` picks:
 
 ```
-                    ShellManager.create_terminal(config)
-                              │
-                    ┌─────────┴─────────┐
-                    │ has_wt_channel()?  │
-                    └─────────┬─────────┘
-                     Yes      │      No
-                  ┌───────────┴───────────┐
-                  ▼                       ▼
-         Path A: WT pane            Path B: local child
-         (via COM)                  (tokio::process::Command)
-                  │                       │
-     ┌────────────┴────────────┐   ┌──────┴──────────────────┐
-     │ 1. WTA → WT (COM):      │   │ 1. WTA spawns child       │
-     │    create_tab(cmd)      │   │    directly (kill_on_drop)│
-     │ 2. WT spawns in new pane│   │ 2. stdout/stderr piped    │
-     │ 3. Read: read_pane_output│  │    into a WTA buffer      │
-     │ 4. Status: get_process_status│ │ 3. Read buffer directly │
-     │                          │   │ 4. child.wait()           │
-     │ Pro: pane visible to user│   │                          │
-     │ Con: requires WT         │   │ Pro: no dependencies      │
-     └─────────────────────────┘   │ Con: invisible in TUI     │
-                                    └──────────────────────────┘
+                 ShellManager.create_terminal(config)
+                           │
+                 ┌─────────┴─────────┐
+                 │ has_wt_channel()? │
+                 └─────────┬─────────┘
+                  Yes      │      No
+               ┌───────────┴───────────┐
+               ▼                       ▼
+       Path A: WT pane            Path B: local child
+       (via wtcli/COM)            (tokio::process::Command)
+       visible to the user        invisible, dies with WTA
 ```
 
-**Fallback:** if WT pane creation fails, WTA automatically downgrades to the local-child path.
-
----
-
-### IPC channel summary
-
-| Channel | Transport | Protocol | Direction | Purpose |
-|------|--------|------|------|------|
-| **WTA ↔ Agent (ACP)** | stdio (stdin/stdout pipes) | JSON-RPC 2.0 (ACP) | bidirectional | WTA sends prompts; agent streams messages and requests command execution |
-| **WTA ↔ Agent (MCP)** | stdio (stdin/stdout pipes) | JSON-RPC 2.0 (MCP) | bidirectional | Agent calls tools; WTA returns results |
-| **WTA ↔ WT (COM)** | `wtcli.exe` subprocess → `CoCreateInstance(WT_COM_CLSID)` → `IProtocolServer` | WinRT IDL methods | bidirectional (push events via subscribed callback) | Tab/pane management, output reads, settings, events, direct shell input (`SendInput`) |
-
----
-
-### Process lifetimes
-
-```
-time ────────────────────────────────────────────────────────────────►
-
-Windows Terminal ════════════════════════════════════════════════════
-  (user-launched, long-running)
-
-  wta.exe ────────────────────────────────┐ (user Ctrl+C)
-    │                                      │
-    ├─ copilot (child) ───────────────────┤ (killed via kill_on_drop)
-    │                                      │
-    ├─[AI req] WT creates pane ────────────┼── cargo build ─── (done, exits)
-    │                                      │
-    ├─[AI req] WT creates pane ────────────┼── git status ──── (done, exits)
-    │                                      │
-    └──────────────────────────────────────┘
-
-  wta list-windows ─┐ (one-shot, exits immediately)
-                    └─
-```
-
-**Key points:**
-- When WTA exits, `kill_on_drop(true)` ensures the agent child is killed
-- Panes created by WT **outlive WTA** (they are WT's children, not WTA's)
-- Local children (the fallback path) **die with WTA** (`kill_on_drop`)
-- CLI-mode WTA processes are extremely short-lived: one request and out
-
----
-
-### Overall process tree
-
-```
-WindowsTerminal.exe (PID 1000)        ← OS-level process tree
-  ├── conhost / conpty
-  │   ├── pwsh.exe (Pane 1's shell)
-  │   │   └── wta.exe (PID 2000)      ← user runs wta in the pane
-  │   │       └── copilot (PID 3000)   ← AI agent spawned by WTA
-  │   │
-  │   ├── pwsh.exe (Pane 2's shell)    ← user's own pane
-  │   │
-  │   ├── cargo.exe (Pane 3)           ← AI asked WTA to ask WT to create it
-  │   └── git.exe   (Pane 4)           ← same
-  │
-  └── TerminalProtocolComServer        ← WT-internal component, not a separate process
-      (runs on WT's MTA thread pool, services COM requests)
-```
-
-> **Note:** `TerminalProtocolComServer` is not a standalone process — it is a component inside Windows Terminal, running on the MTA thread pool to service COM requests via metadata-based marshaling.
+Fallback: if WT pane creation fails, WTA downgrades to the local-child path.
 
 ---
 
 ## Current status
 
-- **Part 1** (dual-mode architecture, ACP + MCP): ✅ done
-- **Part 2** (Windows Terminal integration — COM protocol + CLI commands): ✅ done; this is the current primary path
-- **Part 3** (CLI subcommands): ✅ done
-- **Future**: deeper VT/OSC integration; `focus_pane`, `rename-window`, `resize-pane`, etc.
+- Helper+master architecture: ✅ current primary (and only) runtime model
+- COM/CLI control plane: ✅ done; sole WT transport
+- Autofix, delegate (`?<prompt>`), session-management view, hooks auto-upgrade: ✅ shipped
+- MCP server mode, standalone single-process TUI: ❌ removed

--- a/tools/wta/PLAN.md
+++ b/tools/wta/PLAN.md
@@ -1,8 +1,21 @@
 # WTA (Windows Terminal Agent) — Architecture Plan & Progress
 
+> **⚠️ Historical document.** This file is the original plan/progress log and
+> describes the *early* single-process design (standalone ACP TUI + `wta mcp`
+> server). The architecture has since moved to a **helper + master** model and
+> the MCP server mode was removed. For the current architecture see
+> [`OVERVIEW.md`](OVERVIEW.md) and [`AGENTS.md`](AGENTS.md). The sections below
+> are kept for history; treat their mode descriptions as outdated.
+
 ## Overview
 
-WTA is a Rust application that provides three modes of operation:
+WTA is a Rust application. **Current model (see OVERVIEW.md):** it runs as a
+`wta-master` singleton (owns the agent CLI) plus one `wta-helper` TUI per agent
+pane (ACP over a named pipe), with stateless **CLI helpers** (`wta list-panes`,
+`wta capture-pane`, …) for one-shot WT control. There is no standalone TUI and no
+MCP server.
+
+*The historical description below predates that change:*
 
 - **ACP mode** (default): TUI client that calls an agent subprocess via the Agent Client Protocol (ACP) over stdio
 - **MCP mode** (`wta mcp`): Headless MCP server exposing shell tools for an external agent to call

--- a/tools/wta/README.md
+++ b/tools/wta/README.md
@@ -198,7 +198,7 @@ cd tools/wta
 cargo build
 
 # Run the test suite (cargo build does NOT compile #[cfg(test)] code):
-cargo test --manifest-path tools/wta/Cargo.toml
+cargo test
 ```
 
 The TUI (master + helper) is launched by Windows Terminal as an agent pane — see

--- a/tools/wta/README.md
+++ b/tools/wta/README.md
@@ -16,25 +16,22 @@ cargo build
 
 The binary is output to `tools/wta/target/debug/wta.exe`.
 
-### Run (ACP TUI mode)
+### How WTA runs
 
-```bash
-# Default agent (Copilot)
-wta
+WTA is normally launched **by Windows Terminal**, not by hand. WT spawns one
+`wta-master` singleton (owns the agent CLI) and one `wta-helper` per agent pane
+(renders this TUI and speaks ACP to master over a named pipe). Bare `wta` with no
+subcommand and neither `--master` nor `--connect-master` exits with an error —
+there is no standalone agent / TUI mode.
 
-# With a specific agent
-wta --agent "copilot --acp --stdio"
+The default agent is Copilot; the agent and model come from Windows Terminal
+settings (`acpAgent` / `acpModel`) and are passed through to master via `--agent`
+/ `--agent-id` / `--acp-model`.
 
-# With an initial prompt
-wta "list all open tabs"
-
-# Claude via ACP adapter
-wta --agent "claude-agent-acp --stdio"
-```
-
-When ACP mode is connected to Windows Terminal, the current agent-facing contract is the local `wta` CLI.
-The agent is expected to shell out to commands like `wta active-pane --json`, `wta list-panes --json`, and `wta capture-pane --json`.
-The CLI then talks to Windows Terminal over the protocol.
+When the agent pane is connected to Windows Terminal, the agent-facing contract is
+the local `wta` CLI: the agent shells out to commands like `wta active-pane --json`,
+`wta list-panes --json`, and `wta capture-pane --json`, which talk to Windows
+Terminal over the COM protocol.
 
 ### tmux-like CLI
 
@@ -140,26 +137,35 @@ packaged (or bare `%LOCALAPPDATA%\IntelligentTerminal\logs\` unpackaged):
 
 | File | Contents |
 |------|----------|
-| `wta-main.log` | Main TUI runtime: lifecycle, agent events, protocol calls |
+| `wta-main_master.log` | `wta-master`: agent CLI spawn, pipe accept loop, per-helper routing |
+| `wta-main_helper-{pid}.log` | each `wta-helper`: pipe connect, ACP init, prompts, agent responses, TUI lifecycle |
+| `wta-cli.log` | short-lived CLI helpers (`list-*`, `capture-pane`, `listen`, `sessions`) |
 | `terminal-agent-pane.log` | Agent-pane chrome (C++ TerminalApp side) |
-| `wta-ensure-host.log` | Background host startup / COM connection |
+| `wta-ensure-host.log` | Background host startup / COM connection / SharedWta lifecycle |
 | `wta-acp-debug.log` | ACP protocol debug trace |
 | `wta-delegate.log` | `?<prompt>` delegation flow |
-| `wta-attach.log` | Agent pane TUI in attach mode |
 
-Set `WTA_LOG=debug` for verbose output (default: `info`). The F12 debug panel
-in the TUI shows protocol traffic live without tailing log files.
+Set `WTA_LOG=debug` for verbose output (debug builds default to `debug`, release
+to `info`). The F12 debug panel in the TUI shows protocol traffic live without
+tailing log files.
 
 ## Project Structure
 
 ```
 tools/wta/src/
-+-- main.rs                    Entry point, CLI subcommands, protocol discovery
-+-- app.rs                     TUI state machine, event loop, debug panel state
++-- main.rs                    Entry point, role/CLI dispatch, protocol discovery
++-- master/mod.rs             wta-master: owns the agent CLI, multiplexes helpers
++-- helper/mod.rs             wta-helper: per-pane entry (reuses the TUI over a pipe)
++-- app.rs                     TUI state machine, event loop, per-tab sessions
+|   +-- app/autofix.rs         Autofix detection + suggestion
+|   +-- app/turn_state.rs      Per-turn state machine
 +-- event.rs                   Crossterm event reader
++-- coordinator.rs             Delegate (?<prompt>) execution
++-- agent_sessions.rs          Session registry (status / liveness model)
++-- session_watcher/           CLI-log status classification per agent
 +-- theme.rs                   Color constants
 +-- protocol/
-|   +-- acp/client.rs          ACP client -- spawns agent, handles requests
+|   +-- acp/client.rs          ACP client (agent-CLI side) + helper-side WtaClient
 +-- shell/
 |   +-- shell_manager.rs       Terminal abstraction (local subprocess or WT pane)
 |   +-- wt_channel/
@@ -169,8 +175,8 @@ tools/wta/src/
     +-- layout.rs              Main layout (+ debug panel split)
     +-- chat.rs                Message rendering
     +-- input.rs               Input box with cursor
-    +-- status_bar.rs          Connection status, pane identity, debug hint
     +-- permission.rs          Permission modal dialog
+    +-- agents_view.rs         Session-management (/sessions) view
     +-- debug_panel.rs         Protocol traffic viewer (F12)
 ```
 
@@ -185,22 +191,26 @@ tools/wta/src/
 ### Build and run
 
 ```bash
-cd wta
+cd tools/wta
+
+# Kill any live wta.exe first (a running shared-host locks target/debug/wta.exe):
+#   Get-Process wta -ErrorAction SilentlyContinue | Stop-Process -Force
 cargo build
 
-# Option 1: Auto-discover pipe (run inside Windows Terminal)
-target/debug/wta.exe
-
-# Option 2: Set env vars for the session
-eval "$(target/debug/wta.exe set-env)"
-target/debug/wta.exe
+# Run the test suite (cargo build does NOT compile #[cfg(test)] code):
+cargo test --manifest-path tools/wta/Cargo.toml
 ```
+
+The TUI (master + helper) is launched by Windows Terminal as an agent pane — see
+the C++ F5 / `bcz` flow in the repo `AGENTS.md`. From a WT pane you can exercise
+the CLI helpers directly: `target/debug/wta.exe list-windows`, `… capture-pane`, etc.
 
 ### Development workflow
 
-1. Open Windows Terminal
+1. Open Windows Terminal (with the agent pane / protocol server enabled)
 2. Run `wta pipe-id` to verify `WT_COM_CLSID` is set
-3. Run `wta` to start the TUI
+3. Open the agent pane (`>Toggle AI assistant` / `Ctrl+Shift+.`) — WT spawns the
+   helper, which connects to master and renders this TUI
 4. Press F12 to open the debug panel and see all protocol traffic
 5. Interact with the agent -- watch requests/responses flow in real time
 6. Use `wta list-panes`, `wta capture-pane` etc. in another pane for debugging


### PR DESCRIPTION
## Summary

The WTA docs (`AGENTS.md`, `OVERVIEW.md`, `README.md`, `PLAN.md`) still described the **removed** single-process design — a standalone ACP TUI plus a `wta mcp` MCP server. This PR brings them in line with the current **helper + master** architecture. Docs-only; no code changes.

## What changed

- **Remove MCP everywhere it was described as current.** There is no `protocol/mcp` module, no `rmcp` in `Cargo.toml`, and no `wta mcp` subcommand or MCP-config generation in the tree. Dropped the MCP mode section, the 15-tool table, and the `rmcp` crate row.
- **Document the three real process roles:**
  - `wta-master` (`--master <pipe>`) — ACP multiplexer singleton that owns the single agent-CLI connection.
  - `wta-helper` (`--connect-master <pipe>`) — per-pane ratatui TUI that speaks ACP to master over a named pipe.
  - **CLI helpers** (`wta list-panes` / `capture-pane` / `delegate` / `sessions` / `hooks` …) — one-shot WT control.
  - Bare `wta` (no master/connect-master) now exits with an error — noted explicitly.
- **Rewrite the system/architecture diagrams** and describe the **two-hop ACP** flow (master ↔ agent CLI, helper ↔ master).
- **Logging tables** updated to the actual per-process files (`wta-main_master.log`, `wta-main_helper-{pid}.log`, `wta-cli.log` …) and the per-version package storage path.
- **README**: fixed Project Structure (added `master`/`helper`/`app`, dropped nonexistent `status_bar.rs`); reframed Run/Dev-workflow around WT-launched agent panes.
- **PLAN.md**: added a *historical document* banner pointing to OVERVIEW/AGENTS instead of rewriting its progress log.

## Verification

- Confirmed against source: `main.rs` default-mode dispatch errors without `--master`/`--connect-master`; `protocol/mod.rs` exposes only `acp`; no `rmcp` / `additional-mcp-config` references remain in `src/`.
- Remaining "MCP" mentions in the three current-state docs are intentional negations ("no MCP server", "removed").

Docs-only — no build/test impact.
