### PR TITLE
TerminalApp: foreground target window in FocusProtocolPane

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
@@ -728,6 +728,21 @@ namespace winrt::TerminalApp::implementation
             if (!paneId)
                 co_return false;
 
+            // Bring this window to the foreground. `focus_pane` can target a
+            // pane that lives in a *different* window than the one driving the
+            // request (e.g. Enter on a session in window B whose pane lives in
+            // window A). The `_SetFocusedTab` / `FocusPane` calls below only
+            // move XAML focus *within* this window — they don't activate the OS
+            // window, and when the target pane is already the focused pane here
+            // they no-op entirely. Without an explicit summon the window would
+            // then stay in the background whenever it happened to already have
+            // the target pane focused, while working only when focus actually
+            // transitioned (an accidental side effect). Raising
+            // `SummonWindowRequested` mirrors the desktop-notification
+            // activation path (TabManagement.cpp) and makes `focus_pane`
+            // reliably surface the window regardless of its prior focus state.
+            SummonWindowRequested.raise(nullptr, nullptr);
+
             _SetFocusedTab(tab);
 
             // The pane may be a currently-stashed agent pane (Ctrl+Shift+. /


### PR DESCRIPTION
## Summary

Cross-window `focus_pane` (Enter on a **Live** session in the session-management view) could fail to bring the target window to the foreground when that window already had the target pane focused.

## Repro

1. Two windows: window1 and window2.
2. window1 hosts session1 (in one of its panes); window2 hosts session2.
3. From window2's session-management view, press **Enter** on session1.

- ❌ When window1 was already focused on session1's own pane (e.g. the top shell pane), window1 did **not** come forward.
- ✅ When window1 was focused on a *different* pane (e.g. the agent pane), it worked.

## Root cause

`TerminalPage::FocusProtocolPane` only moved XAML focus *within* the target window via `_SetFocusedTab` / `FocusPane`. Those no-op when the pane is already focused, and the OS window previously only came forward as an accidental side effect of the focus actually transitioning. When the target pane was already focused, no transition happened → no activation → the window stayed in the background.

## Fix

Raise `SummonWindowRequested` once the target pane is found, mirroring the desktop-notification activation path in `TabManagement.cpp`. The window is then reliably brought to the foreground regardless of its prior focus state. `SummonWindow(toggleVisibility=false)` → `_globalActivateWindow` performs the activation; it is intra-process (the COM server runs inside `WindowsTerminal.exe`), so no `AllowSetForegroundWindow` is required.

## Test plan

- [x] Full solution build (Debug/x64): `0 Error(s)`; `WindowsTerminal.exe` + `CascadiaPackage` link and pack cleanly.
- [x] Runtime: two windows; Enter on a session whose pane is already focused in its window → window surfaces and the pane is focused.
