### PR TITLE
build: rename main exe to IntelligentTerminal.exe

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,7 +35,7 @@ Three configurations exist: **Debug**, **Release**, and **AuditMode** (enables e
 
 **OpenConsole (console host):** From a razzle environment, run `opencon` to launch `OpenConsole.exe` from the build output.
 
-**Windows Terminal:** You cannot launch `WindowsTerminal.exe` directly — it is a packaged app. The easiest way is F5 in Visual Studio with `CascadiaPackage` as the startup project (set Debug > Application/Background process to "Native Only"). From the command line in a razzle environment:
+**Windows Terminal:** You cannot launch `IntelligentTerminal.exe` directly — it is a packaged app. The easiest way is F5 in Visual Studio with `CascadiaPackage` as the startup project (set Debug > Application/Background process to "Native Only"). From the command line in a razzle environment:
 
 ```cmd
 cd src\cascadia\CascadiaPackage
@@ -87,7 +87,7 @@ The codebase has two main products sharing foundational components:
 - **TerminalConnection** — Abstraction for backends (ConPTY, Azure Cloud Shell, SSH, etc.).
 - **TerminalSettingsModel** — Settings parsing, serialization, and schema. Uses a macro-driven `MTSM_SETTINGS` pattern and an `IInheritable` parent-chain for settings layering.
 - **TerminalSettingsEditor** — XAML-based Settings UI.
-- **CascadiaPackage** — MSIX packaging project. **This is the startup project for debugging** (not WindowsTerminal.exe directly).
+- **CascadiaPackage** — MSIX packaging project. **This is the startup project for debugging** (not IntelligentTerminal.exe directly).
 - **Remoting** — Cross-process communication for single-instance / quake-mode window management.
 
 ### Console Host (`src/host/`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,7 +183,7 @@ same bare path when the process has no package identity):
 
 ```
 # Packaged (every production wta process — helper is a conpty child of the
-# packaged WindowsTerminal.exe, master is spawned in-package by SharedWta):
+# packaged IntelligentTerminal.exe, master is spawned in-package by SharedWta):
 
   …\Packages\<PackageFamilyName>\LocalState\IntelligentTerminal\   <- STATE root
       prompts\                      (prompt overrides)             intelligent_terminal_root()
@@ -352,7 +352,7 @@ cmd.exe //c "tools\razzle.cmd && bcz no_clean"
 - Set `CascadiaPackage` as startup project → F5
 - MSBuild copies `wta.exe` from Cargo output into the package layout
   (via Content items in `CascadiaPackage.wapproj`)
-- The deployed `wta.exe` sits next to `WindowsTerminal.exe` in the
+- The deployed `wta.exe` sits next to `IntelligentTerminal.exe` in the
   package directory, inheriting package identity for COM access
 
 ### Full rebuild flow (typical dev cycle)
@@ -374,7 +374,7 @@ The COM server (`TerminalProtocolComServer`) is registered under the
 Terminal's package identity. `wtcli.exe` and `wta.exe` must also have
 package identity to activate it via `CoCreateInstance`. This is why:
 
-- `wta.exe` is deployed **inside the package** (next to `WindowsTerminal.exe`)
+- `wta.exe` is deployed **inside the package** (next to `IntelligentTerminal.exe`)
 - `_DetectWtaPath()` prefers the co-located `wta.exe` over dev-build paths
 - Running `wta.exe` from `tools/wta/target/debug/` directly will fail with
   `0x80073D54` (APPMODEL_ERROR_NO_PACKAGE) when calling COM methods

--- a/build/config/esrp.build.batch.terminal_constituents.json
+++ b/build/config/esrp.build.batch.terminal_constituents.json
@@ -18,7 +18,7 @@
 
             // The rest
             "PackageContents/wt.exe",
-            "PackageContents/WindowsTerminal.exe",
+            "PackageContents/IntelligentTerminal.exe",
             "PackageContents/elevate-shim.exe"
         ],
         "SigningInfo": {

--- a/build/scripts/Test-WindowsTerminalPackage.ps1
+++ b/build/scripts/Test-WindowsTerminalPackage.ps1
@@ -100,8 +100,8 @@ Try {
     If (($null -eq (Get-Item "$AppxPackageRootPath\wtd.exe" -EA:Ignore)) -And
         ($null -eq (Get-Item "$AppxPackageRootPath\wt.exe" -EA:Ignore)) -And
         ($null -eq (Get-Item "$AppxPackageRootPath\wtai.exe" -EA:Ignore)) -And
-        ($null -eq (Get-Item "$AppxPackageRootPath\WindowsTerminal.exe" -EA:Ignore))) {
-        Throw "Failed to find wt.exe/wtd.exe/wtai.exe/WindowsTerminal.exe -- check the WAP packaging project"
+        ($null -eq (Get-Item "$AppxPackageRootPath\IntelligentTerminal.exe" -EA:Ignore))) {
+        Throw "Failed to find wt.exe/wtd.exe/wtai.exe/IntelligentTerminal.exe -- check the WAP packaging project"
     }
 
     If ($null -eq (Get-Item "$AppxPackageRootPath\OpenConsole.exe" -EA:Ignore)) {

--- a/doc/building-installer.md
+++ b/doc/building-installer.md
@@ -192,7 +192,7 @@ To repeat-test the FRE, run [`fre-test-reset.ps1`](../tools/fre-test-reset.ps1) 
 
 ## 2. Self-Extracting EXE Installer (Unpackaged / Portable)
 
-Built by [`build\scripts\New-WtaLocalInstaller.ps1`](../build/scripts/New-WtaLocalInstaller.ps1). Creates a portable distribution with `WindowsTerminal.exe`, `wta.exe`, `wtcli.exe`, and prompt templates — no MSIX, no package identity.
+Built by [`build\scripts\New-WtaLocalInstaller.ps1`](../build/scripts/New-WtaLocalInstaller.ps1). Creates a portable distribution with `IntelligentTerminal.exe`, `wta.exe`, `wtcli.exe`, and prompt templates — no MSIX, no package identity.
 
 ### Prerequisites
 

--- a/doc/building.md
+++ b/doc/building.md
@@ -52,7 +52,7 @@ To debug the Windows Terminal in VS, right click on `CascadiaPackage` (in the So
 
 You should then be able to build & debug the Terminal project by hitting <kbd>F5</kbd>.
 
-> 👉 You will _not_ be able to launch the Terminal directly by running the WindowsTerminal.exe. For more details on why, see [#926](https://github.com/microsoft/terminal/issues/926), [#4043](https://github.com/microsoft/terminal/issues/4043)
+> 👉 You will _not_ be able to launch the Terminal directly by running the IntelligentTerminal.exe. For more details on why, see [#926](https://github.com/microsoft/terminal/issues/926), [#4043](https://github.com/microsoft/terminal/issues/4043)
 
 ## Configuration Types
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -75,7 +75,7 @@ In this release, **agent session management only tracks sessions for the agent C
 
 **Symptom:** One of two related failures:
 
-- The app launches, the agent pane starts, and then **`WindowsTerminal.exe` crashes a few seconds later**. Windows Event Viewer records an *Application Error* faulting in **`combase.dll`** with exception code **`0xc0000005`**.
+- The app launches, the agent pane starts, and then **`IntelligentTerminal.exe` crashes a few seconds later**. Windows Event Viewer records an *Application Error* faulting in **`combase.dll`** with exception code **`0xc0000005`**.
 - Or the app stays open, but agent-driven actions (for example, inserting a command into a pane) fail with **`Connection failed: 0x80010105 — The server threw an exception`** (`RPC_E_SERVERFAULT`) reported by `wtcli`.
 
 **Cause:** This appears to be an **operating-system-level issue in the Windows COM/WinRT cross-process activation path** (the `combase.dll` activation/marshaling path) that is **triggered by Intelligent Terminal's use of Metadata-Based Marshaling** when activating its out-of-proc COM/WinRT service. The same underlying fault can surface either as the `combase.dll` crash or as the `0x80010105` "server threw an exception" error.

--- a/doc/security-model.md
+++ b/doc/security-model.md
@@ -50,7 +50,7 @@ Key security claim post-revert: shell input is **not** held behind a separate ca
 
 | Component | Process | Identity / boundary notes |
 |---|---|---|
-| **WT** (`WindowsTerminal.exe`) | Long-lived UI host | Packaged desktop app running at medium integrity in the current configuration. Package-local paths are storage layout, not a low-privilege isolation boundary. |
+| **WT** (`IntelligentTerminal.exe`) | Long-lived UI host | Packaged desktop app running at medium integrity in the current configuration. Package-local paths are storage layout, not a low-privilege isolation boundary. |
 | **WT-launched WTA** (`wta.exe`) | Agent-pane TUI or hidden delegate helper | Production intent is packaged and co-located with WT, but development / PATH fallbacks exist. Agent-pane WTA performs all WT operations (including `send_input`) by shelling out to `wtcli.exe`, which speaks COM. Hidden delegate WTA uses COM `CreateTab(commandline)` to start the delegate Agent CLI in a new tab. Binary resolution and identity are part of the trust boundary. |
 | **WTA helper CLI** (`wta.exe`) | One-shot helper commands | Invoked by panes, agents, users, Settings UI, or support scripts. It routes through COM / filesystem / third-party plugin managers depending on the subcommand. |
 | **Agent-pane ACP Agent CLI / adapter** | `copilot`, `claude`, `gemini`, `codex`, custom; adapter packages launched through tools such as `npx` | Third-party child process spawned by agent-pane WTA and connected over ACP stdio. Treated as semi-trusted. It inherits normal process environment unless scrubbed, including `WT_COM_CLSID`, so a compromised Agent CLI or adapter can also attempt COM access. Claude/Codex ACP paths currently launch `npx -y` adapter packages, which adds package-manager supply-chain risk beyond local binary resolution. |
@@ -73,7 +73,7 @@ Key security claim post-revert: shell input is **not** held behind a separate ca
 ### 2.3 Typical process tree
 
 ```text
-WindowsTerminal.exe
+IntelligentTerminal.exe
 +-- ConPTY -> user shell(s)
 +-- ConPTY -> wta.exe agent pane
 |   +-- Agent CLI (ACP stdio child)
@@ -91,7 +91,7 @@ flowchart TB
     LLM[/LLM provider/]
 
     subgraph WTZone["WT full-trust packaged process (not AppContainer)"]
-        WT(("WindowsTerminal.exe<br/>TerminalPage / AppHost"))
+        WT(("IntelligentTerminal.exe<br/>TerminalPage / AppHost"))
         Scroll[("Pane scrollback<br/>in WT memory")]
         SettingsModel("Settings model<br/>(loaded in WT)")
         EventBus(("Protocol event bus<br/>ProtocolVtSequenceReceived"))

--- a/doc/specs/Multi-window-agent-pane.md
+++ b/doc/specs/Multi-window-agent-pane.md
@@ -222,7 +222,7 @@ makes Z's "helper as conpty child" structurally important.
 ### 1. Process topology
 
 ```
-WindowsTerminal.exe (one process)
+IntelligentTerminal.exe (one process)
  ├─ Window A, Window B, Window C  (each a TerminalPage / AppHost)
  │   └─ Per agent pane: TerminalControl with a ConptyConnection
  │                                          │

--- a/installer/install-local-terminal.ps1
+++ b/installer/install-local-terminal.ps1
@@ -186,7 +186,7 @@ function Get-ExecutablePathWithinInstallDir {
 function Get-RunningInstalledProcesses {
     param([string]$InstallRoot)
 
-    $candidates = Get-CimInstance Win32_Process -Filter "Name = 'WindowsTerminal.exe' OR Name = 'wta.exe'" -ErrorAction SilentlyContinue
+    $candidates = Get-CimInstance Win32_Process -Filter "Name = 'IntelligentTerminal.exe' OR Name = 'wta.exe'" -ErrorAction SilentlyContinue
     $running = @()
 
     foreach ($candidate in $candidates) {
@@ -340,7 +340,7 @@ try {
         Write-Status "Restored user settings"
     }
 
-    $terminalExe = Join-Path $InstallDir 'WindowsTerminal.exe'
+    $terminalExe = Join-Path $InstallDir 'IntelligentTerminal.exe'
     $wtaExe = Join-Path $InstallDir 'wta.exe'
 
     if (-not $NoShortcuts) {

--- a/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
@@ -122,7 +122,7 @@
                 <com:ExeServer DisplayName="OpenConsole" Executable="OpenConsole.exe">
                     <com:Class Id="A854D02A-F2FE-44A5-BB24-D03F4CF830D4"/>
                 </com:ExeServer>
-                <com:ExeServer DisplayName="WindowsTerminal" Executable="WindowsTerminal.exe">
+                <com:ExeServer DisplayName="WindowsTerminal" Executable="IntelligentTerminal.exe">
                     <com:Class Id="1706609C-A4CE-4C0D-B7D2-C19BF66398A5"/>
                     <com:Class Id="C4A6B8D0-3E5F-4A7B-C8D9-E0F1A2B3C4D5"/> <!-- TerminalProtocolComServer (Canary) -->
                 </com:ExeServer>

--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -210,7 +210,7 @@
                 <com:ExeServer DisplayName="OpenConsole" Executable="OpenConsole.exe">
                     <com:Class Id="1F9F2BF5-5BC3-4F17-B0E6-912413F1F451"/>
                 </com:ExeServer>
-                <com:ExeServer DisplayName="WindowsTerminal" Executable="WindowsTerminal.exe">
+                <com:ExeServer DisplayName="WindowsTerminal" Executable="IntelligentTerminal.exe">
                     <com:Class Id="051F34EE-C1FD-4B19-AF75-9BA54648434C"/>
                     <com:Class Id="D5B7C9E1-4F6A-4B8C-D9E0-F1A2B3C4D5E6"/> <!-- TerminalProtocolComServer (Dev) -->
                 </com:ExeServer>

--- a/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
@@ -211,7 +211,7 @@
                 <com:ExeServer DisplayName="OpenConsole" Executable="OpenConsole.exe">
                     <com:Class Id="06EC847C-C0A5-46B8-92CB-7C92F6E35CD5"/>
                 </com:ExeServer>
-                <com:ExeServer DisplayName="WindowsTerminal" Executable="WindowsTerminal.exe">
+                <com:ExeServer DisplayName="WindowsTerminal" Executable="IntelligentTerminal.exe">
                     <com:Class Id="86633F1F-6454-40EC-89CE-DA4EBA977EE2"/>
                     <com:Class Id="B3F5A7C9-2D4E-4F6A-B7C8-D9E0F1A2B3C4"/> <!-- TerminalProtocolComServer (Preview) -->
                 </com:ExeServer>

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -211,7 +211,7 @@
                 <com:ExeServer DisplayName="OpenConsole" Executable="OpenConsole.exe">
                     <com:Class Id="7ABAC0AD-3AEF-4556-ABE7-C1812594E071"/>
                 </com:ExeServer>
-                <com:ExeServer DisplayName="IntelligentTerminal" Executable="WindowsTerminal.exe">
+                <com:ExeServer DisplayName="IntelligentTerminal" Executable="IntelligentTerminal.exe">
                     <com:Class Id="ECC17785-94ED-4359-B545-0472B7D0275F"/>
                     <com:Class Id="A2E4F6B8-1C3D-4E5F-A6B7-C8D9E0F1A2B3"/> <!-- TerminalProtocolComServer (Release) -->
                 </com:ExeServer>

--- a/src/cascadia/ElevateShim/elevate-shim.cpp
+++ b/src/cascadia/ElevateShim/elevate-shim.cpp
@@ -38,8 +38,8 @@ int __stdcall wWinMain(HINSTANCE, HINSTANCE, LPWSTR cmdline, int)
     //    cmd:    shell:AppsFolder\WindowsTerminalDev_8wekyb3d8bbwe!App
     //    params: new-tab -p {guid}
     //
-    // #2 find and execute WindowsTerminal.exe
-    //    cmd:    {same path as this binary}\WindowsTerminal.exe
+    // #2 find and execute IntelligentTerminal.exe
+    //    cmd:    {same path as this binary}\IntelligentTerminal.exe
     //    params: new-tab -p {guid}
 
     std::wstring cmd;
@@ -64,12 +64,12 @@ int __stdcall wWinMain(HINSTANCE, HINSTANCE, LPWSTR cmdline, int)
     if (cmd.empty())
     {
         // scenario #2
-        // Get the path to WindowsTerminal.exe, which should live next to us.
+        // Get the path to IntelligentTerminal.exe, which should live next to us.
         std::filesystem::path module{
             wil::GetModuleFileNameW<std::wstring>(nullptr)
         };
-        // Swap elevate-shim.exe for WindowsTerminal.exe
-        module.replace_filename(L"WindowsTerminal.exe");
+        // Swap elevate-shim.exe for IntelligentTerminal.exe
+        module.replace_filename(L"IntelligentTerminal.exe");
         cmd = module;
     }
 
@@ -81,7 +81,7 @@ int __stdcall wWinMain(HINSTANCE, HINSTANCE, LPWSTR cmdline, int)
     seInfo.cbSize = sizeof(seInfo);
     seInfo.fMask = SEE_MASK_DEFAULT;
     seInfo.lpVerb = L"runas"; // This asks the shell to elevate the process
-    seInfo.lpFile = cmd.c_str(); // This is `shell:AppsFolder\...` or `...\WindowsTerminal.exe`
+    seInfo.lpFile = cmd.c_str(); // This is `shell:AppsFolder\...` or `...\IntelligentTerminal.exe`
     seInfo.lpParameters = cmdline; // This is `new-tab -p {guid}`
     seInfo.nShow = SW_SHOWNORMAL;
     LOG_IF_WIN32_BOOL_FALSE(ShellExecuteExW(&seInfo));

--- a/src/cascadia/ShellExtension/OpenTerminalHere.cpp
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.cpp
@@ -49,7 +49,7 @@ try
         siEx.StartupInfo.wShowWindow = SW_SHOWNORMAL;
 
         std::filesystem::path modulePath{ wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle()) };
-        modulePath.replace_filename(runElevated ? ElevateShimExe : WindowsTerminalExe);
+        modulePath.replace_filename(runElevated ? ElevateShimExe : IntelligentTerminalExe);
 
         std::wstring cmdline;
         cmdline.reserve(256); // The IntelligentTerminal.exe path is ~110 characters long

--- a/src/cascadia/ShellExtension/OpenTerminalHere.cpp
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.cpp
@@ -52,7 +52,7 @@ try
         modulePath.replace_filename(runElevated ? ElevateShimExe : WindowsTerminalExe);
 
         std::wstring cmdline;
-        cmdline.reserve(256); // The WindowsTerminal.exe path is ~110 characters long
+        cmdline.reserve(256); // The IntelligentTerminal.exe path is ~110 characters long
         cmdline.push_back(L'"');
         cmdline.append(modulePath.native());
         cmdline.append(LR"(" -d )");
@@ -132,10 +132,10 @@ HRESULT OpenTerminalHere::GetIcon(IShellItemArray* /*psiItemArray*/,
 try
 {
     std::filesystem::path modulePath{ wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle()) };
-    // WindowsTerminal.exe,-101 will be the first icon group in WT
-    // We're using WindowsTerminal here explicitly, and not wt (from GetWtExePath), because
-    // WindowsTerminal is the only one built with the right icons.
-    modulePath.replace_filename(L"WindowsTerminal.exe,-101");
+    // IntelligentTerminal.exe,-101 will be the first icon group in WT
+    // We're using IntelligentTerminal here explicitly, and not wt (from GetWtExePath), because
+    // IntelligentTerminal is the only one built with the right icons.
+    modulePath.replace_filename(L"IntelligentTerminal.exe,-101");
     return SHStrDupW(modulePath.c_str(), ppszIcon);
 }
 CATCH_RETURN();

--- a/src/cascadia/TerminalApp/AgentPaneDragStash.h
+++ b/src/cascadia/TerminalApp/AgentPaneDragStash.h
@@ -46,10 +46,10 @@ namespace winrt::TerminalApp::implementation
     // fails to run we leak one std::pair until process exit, which is
     // acceptable for a drag-drop edge case.
     //
-    // This lives in TerminalApp (and not WindowEmperor in WindowsTerminal.exe)
+    // This lives in TerminalApp (and not WindowEmperor in IntelligentTerminal.exe)
     // because both producer and consumer (Tab.cpp + TerminalPage.cpp) link
     // against TerminalApp; TerminalApp.dll is loaded exactly once into
-    // WindowsTerminal.exe, so a static inside it is process-wide.
+    // IntelligentTerminal.exe, so a static inside it is process-wide.
     struct AgentPaneDragStash
     {
         static void Stash(uint64_t contentId, const winrt::hstring& originalTabId) noexcept

--- a/src/cascadia/TerminalProtocol/TerminalProtocol.idl
+++ b/src/cascadia/TerminalProtocol/TerminalProtocol.idl
@@ -96,7 +96,7 @@ namespace Microsoft.Terminal.Protocol
         void OnEvent(String eventJson);
     }
 
-    // Server interface — implemented by WindowsTerminal.exe, consumed by wtcli.exe.
+    // Server interface — implemented by IntelligentTerminal.exe, consumed by wtcli.exe.
     // Activated via CoCreateInstance (CLSCTX_LOCAL_SERVER) with a custom class factory.
     // Marshaled cross-process via MBM (no proxy/stub DLL needed).
     interface IProtocolServer

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -1141,7 +1141,7 @@ winrt::hstring CascadiaSettings::ApplicationVersion()
         {
             WORD language, codepage;
         };
-        // Use the current module instance handle for TerminalApp.dll, nullptr for WindowsTerminal.exe
+        // Use the current module instance handle for TerminalApp.dll, nullptr for IntelligentTerminal.exe
         auto filename{ wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle()) };
         auto size{ GetFileVersionInfoSizeExW(0, filename.c_str(), nullptr) };
         THROW_LAST_ERROR_IF(size == 0);

--- a/src/cascadia/WinRTUtils/inc/WtExeUtils.h
+++ b/src/cascadia/WinRTUtils/inc/WtExeUtils.h
@@ -10,7 +10,7 @@
 // dev/preview/release flavor.
 constexpr std::wstring_view WtExe{ L"wtai.exe" };
 constexpr std::wstring_view WtdExe{ L"wtai.exe" };
-constexpr std::wstring_view WindowsTerminalExe{ L"IntelligentTerminal.exe" };
+constexpr std::wstring_view IntelligentTerminalExe{ L"IntelligentTerminal.exe" };
 constexpr std::wstring_view LocalAppDataAppsPath{ L"%LOCALAPPDATA%\\Microsoft\\WindowsApps\\" };
 constexpr std::wstring_view ElevateShimExe{ L"elevate-shim.exe" };
 
@@ -106,7 +106,7 @@ _TIL_INLINEPREFIX const std::wstring& GetWtExePath()
         try
         {
             std::filesystem::path module = wil::GetModuleFileNameW<std::wstring>(nullptr);
-            module.replace_filename(WindowsTerminalExe);
+            module.replace_filename(IntelligentTerminalExe);
             return module;
         }
         CATCH_LOG();

--- a/src/cascadia/WinRTUtils/inc/WtExeUtils.h
+++ b/src/cascadia/WinRTUtils/inc/WtExeUtils.h
@@ -10,7 +10,7 @@
 // dev/preview/release flavor.
 constexpr std::wstring_view WtExe{ L"wtai.exe" };
 constexpr std::wstring_view WtdExe{ L"wtai.exe" };
-constexpr std::wstring_view WindowsTerminalExe{ L"WindowsTerminal.exe" };
+constexpr std::wstring_view WindowsTerminalExe{ L"IntelligentTerminal.exe" };
 constexpr std::wstring_view LocalAppDataAppsPath{ L"%LOCALAPPDATA%\\Microsoft\\WindowsApps\\" };
 constexpr std::wstring_view ElevateShimExe{ L"elevate-shim.exe" };
 
@@ -66,12 +66,12 @@ _TIL_INLINEPREFIX bool IsDevBuild()
 //   for this instance of the shell extension. If we're running the dev build,
 //   it should be a `wtd.exe`, but if we're preview or release, we want to make
 //   sure to get the correct `wt.exe` that corresponds to _us_.
-// - If we're unpackaged, this needs to get us `WindowsTerminal.exe`, because
+// - If we're unpackaged, this needs to get us `IntelligentTerminal.exe`, because
 //   the `wt*exe` alias won't have been installed for this install.
 // Arguments:
 // - <none>
 // Return Value:
-// - the full path to the exe, one of `wt.exe`, `wtd.exe`, or `WindowsTerminal.exe`.
+// - the full path to the exe, one of `wt.exe`, `wtd.exe`, or `IntelligentTerminal.exe`.
 _TIL_INLINEPREFIX const std::wstring& GetWtExePath()
 {
     static const auto exePath = []() -> std::wstring {
@@ -102,7 +102,7 @@ _TIL_INLINEPREFIX const std::wstring& GetWtExePath()
 
         // If we're here, then we couldn't resolve our exe from the package. This
         // means we're running unpackaged. We should just use the
-        // WindowsTerminal.exe that's sitting in the directory next to us.
+        // IntelligentTerminal.exe that's sitting in the directory next to us.
         try
         {
             std::filesystem::path module = wil::GetModuleFileNameW<std::wstring>(nullptr);

--- a/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
@@ -6,7 +6,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WindowsTerminal</RootNamespace>
     <ProjectName>WindowsTerminal</ProjectName>
-    <TargetName>WindowsTerminal</TargetName>
+    <TargetName>IntelligentTerminal</TargetName>
     <ConfigurationType>Application</ConfigurationType>
     <OpenConsoleUniversalApp>false</OpenConsoleUniversalApp>
     <ApplicationType>Windows Store</ApplicationType>

--- a/src/cascadia/WindowsTerminal/main.cpp
+++ b/src/cascadia/WindowsTerminal/main.cpp
@@ -26,7 +26,7 @@ TRACELOGGING_DEFINE_PROVIDER(
 // Manually use the resources from TerminalApp as our resources.
 // The WindowsTerminal project doesn't actually build a Resources.resw file, but
 // we still need to be able to localize strings for the notification icon menu. Anything
-// you want localized for WindowsTerminal.exe should be stuck in
+// you want localized for IntelligentTerminal.exe should be stuck in
 // ...\TerminalApp\Resources\en-US\Resources.resw
 UTILS_DEFINE_LIBRARY_RESOURCE_SCOPE(L"TerminalApp/Resources");
 

--- a/src/cascadia/WindowsTerminal_UIATests/Common/Globals.cs
+++ b/src/cascadia/WindowsTerminal_UIATests/Common/Globals.cs
@@ -28,7 +28,7 @@ namespace WindowsTerminal.UIA.Tests.Common
 
         static string[] modules =
         {
-            "WindowsTerminal.exe",
+            "IntelligentTerminal.exe",
             "OpenConsole.exe",
             "Microsoft.Terminal.Control.dll",
             "Microsoft.Terminal.Settings.Editor.dll",

--- a/src/cascadia/WindowsTerminal_UIATests/Elements/TerminalApp.cs
+++ b/src/cascadia/WindowsTerminal_UIATests/Elements/TerminalApp.cs
@@ -54,12 +54,12 @@ namespace WindowsTerminal.UIA.Tests.Elements
             // the Terminal appx, then use
             // New-UnpackagedTerminalDistribution.ps1 to build an unpackaged
             // layout that can successfully launch. Then, point the tests at
-            // that WindowsTerminal.exe like so:
+            // that IntelligentTerminal.exe like so:
             //
-            //   te.exe WindowsTerminal.UIA.Tests.dll /p:WTPath=C:\the\path\to\the\unpackaged\layout\WindowsTerminal.exe
+            //   te.exe WindowsTerminal.UIA.Tests.dll /p:WTPath=C:\the\path\to\the\unpackaged\layout\IntelligentTerminal.exe
             //
             // On the build machines, the scripts lay it out at the terminal-0.0.1.0\ subfolder of the test deployment directory
-            string path = Path.GetFullPath(Path.Combine(context.TestDeploymentDir, @"terminal-0.0.1.0\WindowsTerminal.exe"));
+            string path = Path.GetFullPath(Path.Combine(context.TestDeploymentDir, @"terminal-0.0.1.0\IntelligentTerminal.exe"));
             if (context.Properties.Contains("WTPath"))
             {
                 path = (string)context.Properties["WTPath"];

--- a/src/cascadia/wt/shim.cpp
+++ b/src/cascadia/wt/shim.cpp
@@ -15,8 +15,8 @@ int __stdcall wWinMain(HINSTANCE, HINSTANCE, LPWSTR pCmdLine, int)
     // Cache our name (wt, wtd)
     std::wstring ourFilename{ module.filename() };
 
-    // Swap wt[d].exe for WindowsTerminal.exe
-    module.replace_filename(L"WindowsTerminal.exe");
+    // Swap wt[d].exe for IntelligentTerminal.exe
+    module.replace_filename(L"IntelligentTerminal.exe");
 
     // Append the rest of the commandline to the saved name
     std::wstring cmdline;

--- a/src/host/proxy/ITerminalProtocol.idl
+++ b/src/host/proxy/ITerminalProtocol.idl
@@ -28,7 +28,7 @@ import "unknwn.idl";
     HRESULT OnEvent([in] BSTR eventJson);
 };
 
-// Terminal protocol — implemented by WindowsTerminal.exe, activated by the
+// Terminal protocol — implemented by IntelligentTerminal.exe, activated by the
 // client via CoCreateInstance(CLSCTX_LOCAL_SERVER) under the existing
 // per-branding CLSID (discovered through the WT_COM_CLSID env var).
 [

--- a/test/e2e/ItE2E/Private/Paths.ps1
+++ b/test/e2e/ItE2E/Private/Paths.ps1
@@ -72,7 +72,7 @@ function Resolve-ItApp {
     # Binaries: prefer co-located (have package identity, readable for Store).
     $wtcli = if ($install -and (Test-Path (Join-Path $install 'wtcli.exe'))) { Join-Path $install 'wtcli.exe' }
     else { (Get-Command wtcli -ErrorAction SilentlyContinue).Source }
-    $wt = if ($install -and (Test-Path (Join-Path $install 'WindowsTerminal.exe'))) { Join-Path $install 'WindowsTerminal.exe' } else { $null }
+    $wt = if ($install -and (Test-Path (Join-Path $install 'IntelligentTerminal.exe'))) { Join-Path $install 'IntelligentTerminal.exe' } else { $null }
 
     $wta = $null
     if ($install -and (Test-Path (Join-Path $install 'wta.exe'))) { $wta = Join-Path $install 'wta.exe' }

--- a/test/e2e/ItE2E/Public/Harness.ps1
+++ b/test/e2e/ItE2E/Public/Harness.ps1
@@ -50,7 +50,7 @@ function Restore-WtConfig {
 function Get-WtProcessesForApp {
     [CmdletBinding()] param([Parameter(Mandatory)]$App)
     $loc = $App.InstallLocation
-    Get-Process -Name WindowsTerminal -ErrorAction SilentlyContinue | Where-Object {
+    Get-Process -Name IntelligentTerminal -ErrorAction SilentlyContinue | Where-Object {
         try { $loc -and $_.Path -and $_.Path.StartsWith($loc, [StringComparison]::OrdinalIgnoreCase) } catch { $false }
     }
 }
@@ -117,7 +117,7 @@ function Stop-StaleItInstances {
             ForEach-Object { $_.InstallLocation } | Where-Object { $_ })
     if (-not $locs) { return }
     $find = {
-        Get-Process -Name WindowsTerminal -ErrorAction SilentlyContinue | Where-Object {
+        Get-Process -Name IntelligentTerminal -ErrorAction SilentlyContinue | Where-Object {
             $path = $null; try { $path = $_.Path } catch {}
             $path -and ($locs | Where-Object { $path.StartsWith($_, [StringComparison]::OrdinalIgnoreCase) })
         }
@@ -209,7 +209,7 @@ function Start-Terminal {
         Start-Process -FilePath $app.LaunchAlias | Out-Null
     }
 
-    # Find our WindowsTerminal.exe process (prefer a newly-spawned pid).
+    # Find our IntelligentTerminal.exe process (prefer a newly-spawned pid).
     $proc = Wait-Until -TimeoutSec $TimeoutSec -IntervalSec 1 -Because "WindowsTerminal process for $($app.Package)" -Condition {
         $ps = Get-WtProcessesForApp -App $app
         $new = $ps | Where-Object { $_.Id -notin $existing } | Select-Object -First 1

--- a/test/e2e/ItE2E/Public/Ui.ps1
+++ b/test/e2e/ItE2E/Public/Ui.ps1
@@ -49,7 +49,7 @@ function Invoke-WinAppUi {
 function Get-WtWindowHwnds {
     <# Return normalized @{ hwnd; pid; title } for WT windows (via winapp list-windows). #>
     [CmdletBinding()] param([Parameter(Mandatory)]$App)
-    $r = Invoke-WinAppUi -App $App -NoTarget -UiArgs @('list-windows', '-a', 'WindowsTerminal', '--json') -TimeoutSec 15
+    $r = Invoke-WinAppUi -App $App -NoTarget -UiArgs @('list-windows', '-a', 'IntelligentTerminal', '--json') -TimeoutSec 15
     $j = $r.StdOut | ConvertFrom-JsonSafe
     if ($null -ne $j) {
         $rows = if ($j -is [System.Array]) { $j } elseif ($j.windows) { $j.windows } else { @($j) }

--- a/test/e2e/ItE2E/Public/Ui.ps1
+++ b/test/e2e/ItE2E/Public/Ui.ps1
@@ -58,9 +58,9 @@ function Get-WtWindowHwnds {
             [pscustomobject]@{ hwnd = [int]$_.hwnd; pid = [int]$wpid; title = [string]$_.title }
         }
     }
-    # Fallback: parse the text form "HWND 985238: "title" ... (WindowsTerminal, PID 21228)".
+    # Fallback: parse the text form "HWND 985238: "title" ... (IntelligentTerminal, PID 21228)".
     @($r.StdOut -split "`n" | ForEach-Object {
-            if ($_ -match 'HWND\s+(\d+):\s+"?(.*?)"?\s+.*\(WindowsTerminal,\s*PID\s+(\d+)\)') {
+            if ($_ -match 'HWND\s+(\d+):\s+"?(.*?)"?\s+.*\(IntelligentTerminal,\s*PID\s+(\d+)\)') {
                 [pscustomobject]@{ hwnd = [int]$Matches[1]; title = $Matches[2]; pid = [int]$Matches[3] }
             }
         })

--- a/tools/wta/OVERVIEW.md
+++ b/tools/wta/OVERVIEW.md
@@ -228,7 +228,7 @@ liveness model, hooks auto-upgrade, third-party notice generation).
 
 | Process | Binary | Lifetime | Role |
 |------|-----------|---------|------|
-| **Windows Terminal** | `WindowsTerminal.exe` | User-launched, long-lived | Window manager + renderer; hosts `TerminalProtocolComServer`; spawns master + helpers |
+| **Windows Terminal** | `IntelligentTerminal.exe` | User-launched, long-lived | Window manager + renderer; hosts `TerminalProtocolComServer`; spawns master + helpers |
 | **wta-master** | `wta.exe --master` | Spawned once by `SharedWta` | Owns the agent CLI; multiplexes ACP sessions for all helpers |
 | **wta-helper** | `wta.exe --connect-master` | One per agent pane | TUI + per-pane side effects; ACP client of master |
 | **Agent CLI** | `copilot`, `claude`, `gemini`, `codex` | Spawned once by master | The AI "brain"; shared across all helpers |


### PR DESCRIPTION
## What

Renames the IT fork's main binary (and therefore the running process) from `WindowsTerminal.exe` to **`IntelligentTerminal.exe`**.

The exe name has a single source of truth — `WindowsTerminal.vcxproj` `<TargetName>` — and the package manifest's `<Application Executable>` uses the `$targetnametoken$` token that auto-follows it. `<ProjectName>`, `<RootNamespace>` and the `.vcxproj` file path are deliberately left as `WindowsTerminal` so the `.slnx` and all `ProjectReference`s stay stable (no `.wapproj` change needed).

## Why

- **Distinct process identity.** Before this, our process was named identically to Microsoft's shipping Windows Terminal, so Task Manager / `Get-Process` / scripts / WER + Event Viewer crash attribution couldn't tell them apart. The package family name and AUMID were already distinct — the exe name was the last place still colliding.
- **Removes a footgun.** A blanket process-name kill of `WindowsTerminal` (e.g. from an agent cleaning up stale instances) no longer matches — and can no longer kill — our own host terminal.

This is an operational-clarity / foolproofing change, not a new capability. It does **not** change package identity and does **not** address the separate Store-vs-Dev COM CLSID conflict (that's keyed on package/CLSID, not exe name).

## Changed (functional)

| Area | Files |
|---|---|
| Binary name source | `WindowsTerminal.vcxproj` (`TargetName`) |
| COM ExeServer (hardcoded) | `Package{,-Pre,-Dev,-Can}.appxmanifest` |
| Exe resolution / shims | `wt/shim.cpp`, `ElevateShim/elevate-shim.cpp`, `WinRTUtils/inc/WtExeUtils.h`, `ShellExtension/OpenTerminalHere.cpp` (icon) |
| e2e + UIA | `Harness.ps1`, `Paths.ps1`, `Ui.ps1`, `Globals.cs`, `TerminalApp.cs` |
| Installer / packaging | `install-local-terminal.ps1`, `Test-WindowsTerminalPackage.ps1`, ESRP constituents JSON |
| Docs + code comments | `AGENTS.md`, `copilot-instructions.md`, `doc/*`, `tools/wta/OVERVIEW.md`, inline comments |

## Intentionally left as-is

Upstream historical design specs (`#492 - Default Terminal`, `portable-mode-spec`), the `scratch/` project, package-family-name prefixes (`WindowsTerminalDev`), the toast notification group string, and C# test namespaces (`WindowsTerminal.UIA.Tests`) — none of these are the main exe/process name.

## Verification

- Clean build of `WindowsTerminal` + `CascadiaPackage` (0 errors); produced binary is `IntelligentTerminal.exe`.
- `DeployAppRecipe` deploy of the Dev package; launched it and confirmed the live process is **`IntelligentTerminal`** at `...\AppX\IntelligentTerminal.exe`, cleanly distinct from the Microsoft Store `WindowsTerminal` process.
