### PR TITLE
test(ci): verify spelling check passes after secpoll fix [dummy]

### DIFF
--- a/doc/spelling-ci-verify.md
+++ b/doc/spelling-ci-verify.md
@@ -1,0 +1,5 @@
+# Spelling CI Verification
+
+This file is a temporary marker used to verify that the spell checking
+workflow runs and passes after merging the secpoll workaround removal.
+It will be deleted once the verification is complete.

--- a/doc/spelling-ci-verify.md
+++ b/doc/spelling-ci-verify.md
@@ -1,5 +1,5 @@
-# Spelling CI Verification
+# Spelling Verification
 
 This file is a temporary marker used to verify that the spell checking
-workflow runs and passes after merging the secpoll workaround removal.
-It will be deleted once the verification is complete.
+workflow runs and reports correctly. It will be deleted once the check
+has been confirmed to pass.


### PR DESCRIPTION
Temporary dummy PR to confirm the `Check Spelling` workflow runs green after #358 removed the stale `INPUT_IGNORE_SECURITY_ADVISORY` env var. Will be closed/deleted once verified.