### PR TITLE
fix(agent-pane): don't persist agent panes into window layout (#275)

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -139,15 +139,36 @@ Pane::BuildStartupState Pane::BuildStartupActions(uint32_t currentId, uint32_t n
         return { .args = {}, .firstPane = shared_from_this(), .focusedPaneId = std::nullopt, .panesCreated = 0 };
     }
 
-    // Agent panes participate in cross-window move; their conpty + helper
-    // child survive via the ContentId reattach mechanism (see _MakePane), and
-    // the helper process is unchanged across the drag. Persistence (the
-    // BuildStartupKind::Persist path) is the SessionId rehydration mechanism
-    // — `TerminalPaneContent::GetNewTerminalArgs(BuildStartupKind::Persist)`
-    // emits the pane's persisted SessionId, and the terminal layer rebinds
-    // the saved session on restore. There is no longer a per-window agent
-    // singleton to special-case, so we let the agent pane serialize through
-    // the normal split-pane path.
+    // Agent panes participate in cross-window move (Content / MovePane); their
+    // conpty + helper child survive via the ContentId reattach mechanism (see
+    // _MakePane), and the helper process is unchanged across the drag.
+    //
+    // Persistence (BuildStartupKind::Persist, i.e. app restart) is different:
+    // an agent pane's command line is session-specific (it points at the
+    // previous run's wta-master named pipe and an owner-tab-id that no longer
+    // exist), and after a restart there is no live master / helper / conpty
+    // session left to rehydrate. Replaying that saved command line launches a
+    // broken `wta --connect-master <dead-pipe>` that fails its ACP transport
+    // and, combined with the per-tab pre-warmed agent pane each restored tab
+    // already re-creates, leaves the window littered with dead panes (#275).
+    //
+    // So we never persist agent panes into the saved window layout: when one
+    // child of this split is an agent-pane leaf, collapse the split and only
+    // serialize the other child. The user can re-open the agent pane after
+    // restore to get a fresh one.
+    if (kind == BuildStartupKind::Persist)
+    {
+        const auto firstIsAgentLeaf = _firstChild->_IsLeaf() && _firstChild->_isAgentPane;
+        const auto secondIsAgentLeaf = _secondChild->_IsLeaf() && _secondChild->_isAgentPane;
+        if (firstIsAgentLeaf && !secondIsAgentLeaf)
+        {
+            return _secondChild->BuildStartupActions(currentId, nextId, kind);
+        }
+        if (secondIsAgentLeaf && !firstIsAgentLeaf)
+        {
+            return _firstChild->BuildStartupActions(currentId, nextId, kind);
+        }
+    }
 
     auto buildSplitPane = [&](auto newPane) {
         ActionAndArgs actionAndArgs;


### PR DESCRIPTION
## Problem

Fixes #275. When `Restore window layout` / `Restore window layout and content` is enabled, opening the terminal after a restart fails the agent pane's ACP transport and litters the window with broken/duplicate `cmd` panes.

## Root cause

The agent pane was serialized into `state.json` like an ordinary terminal pane. Its command line embeds **session-specific** state:

```
wta.exe --connect-master "\\.\pipe\wta-master-DD3592BF-..." --owner-tab-id "{40550ecc-...}" ... --start-stashed
```

Both the `--connect-master` named pipe (the previous run's `wta-master`) and the `--owner-tab-id` are gone after a restart. On restore, WT replays the saved command line, so a fresh `wta-helper` tries to connect to the now-dead pipe:

```
WARN  helper: master pipe connect giving up ... attempts=21
ERROR helper: run_acp_client_over_pipe failed error=connect to master pipe '\\.\pipe\wta-master-DD3592BF-...': os error 2
INFO  failure: agent failure class="handshake_failed"
```

Combined with the per-tab pre-warmed agent pane each restored tab already re-creates (which connects to the *new* live master fine), the window ends up with broken + duplicate panes.

## Fix

Agent panes are ephemeral per-tab infrastructure and must not be persisted. In `Pane::BuildStartupActions`, on the `Persist` path only, when one child of a split is an agent-pane leaf we collapse the split and serialize just the other child — so no agent-pane command line is ever written to the layout.

Nothing is lost:
- Cross-window move (`Content` / `MovePane`) still reattaches via `ContentId` — unaffected.
- Each restored tab already re-warms a fresh stashed agent pane bound to the live master.
- The user can re-open the agent pane after restore to get a fresh one.

## Testing

- Built `TerminalAppLib` (contains `Pane.cpp`) — 0 errors.
- Manual repro confirmed via logs (dead-pipe `handshake_failed` vs live-pipe success). Suggested manual regression: enable layout restore, open several tabs, close & reopen, verify the shell layout restores cleanly with no leftover agent/cmd panes.
