### PR TITLE
fix(spelling): clear check-spelling unrecognized words and forbidden pattern

### DIFF
--- a/.github/actions/spelling/allow/apis.txt
+++ b/.github/actions/spelling/allow/apis.txt
@@ -9,6 +9,7 @@ APPLYTOSUBMENUS
 appxrecipe
 bitfield
 bitfields
+BITMAPFILEHEADER
 BUILDBRANCH
 BUILDMSG
 BUILDNUMBER
@@ -125,6 +126,7 @@ overridable
 PAGESCROLL
 PALLOC
 PATINVERT
+Pels
 PICKFOLDERS
 PINPUT
 pmr
@@ -194,6 +196,7 @@ virtualalloc
 wcsnicmp
 wcsnlen
 WDJ
+wingdi
 winhttp
 wininet
 winmain
@@ -230,5 +233,6 @@ xtree
 xutility
 YIcon
 YMax
+YPels
 zstring
 zwstring

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2181,7 +2181,7 @@ pub struct AgentsViewState {
     /// Set by F5 in the session view to request a master-side disk re-scan
     /// (`load_for_cli`) on the next dispatched `sessions/list`. Sticky across
     /// in-flight coalescing: only cleared when a request is actually built, so
-    /// an F5 pressed while a poll is in flight still rescans on the trailing
+    /// an F5 pressed while a poll is in flight still re-scans on the trailing
     /// refetch. Reset on view close.
     pub pending_rescan: bool,
     /// True while an F5 rescan request is in flight (set when dispatched,

--- a/tools/wta/src/clipboard_image.rs
+++ b/tools/wta/src/clipboard_image.rs
@@ -49,7 +49,7 @@ const BI_BITFIELDS: u32 = 3;
 /// corrupted or hostile `GlobalSize` could otherwise drive an unbounded
 /// allocation (OOM) in the helper just from an Alt+V keypress. 256 MiB is far
 /// above any realistic screenshot DIB (a 4K 32-bpp frame is ~33 MiB) yet bounds
-/// the worst case. Oversized payloads are treated as non-pastable.
+/// the worst case. Oversized payloads are rejected (too large to paste).
 #[cfg(windows)]
 const MAX_CLIPBOARD_BYTES: usize = 256 * 1024 * 1024;
 
@@ -354,27 +354,27 @@ pub(crate) unsafe fn set_clipboard_dib(dib: &[u8]) -> bool {
     if OpenClipboard(std::ptr::null_mut()) == 0 {
         return false;
     }
-    // Wipe any pre-existing content so the read is deterministic (only our DIB).
+    // Wipe any preexisting content so the read is deterministic (only our DIB).
     EmptyClipboard();
-    let hmem = GlobalAlloc(GMEM_MOVEABLE, dib.len());
-    if hmem.is_null() {
+    let handle = GlobalAlloc(GMEM_MOVEABLE, dib.len());
+    if handle.is_null() {
         CloseClipboard();
         return false;
     }
-    let ptr = GlobalLock(hmem);
+    let ptr = GlobalLock(handle);
     if ptr.is_null() {
         // Ownership was not handed to the clipboard — free our allocation.
-        GlobalFree(hmem);
+        GlobalFree(handle);
         CloseClipboard();
         return false;
     }
     std::ptr::copy_nonoverlapping(dib.as_ptr(), ptr as *mut u8, dib.len());
-    GlobalUnlock(hmem);
-    // On success the system takes ownership of `hmem`; on failure it does not,
+    GlobalUnlock(handle);
+    // On success the system takes ownership of `handle`; on failure it does not,
     // so we must free it ourselves to avoid leaking the allocation.
-    let placed = !SetClipboardData(CF_DIB, hmem as _).is_null();
+    let placed = !SetClipboardData(CF_DIB, handle as _).is_null();
     if !placed {
-        GlobalFree(hmem);
+        GlobalFree(handle);
     }
     CloseClipboard();
     placed
@@ -421,7 +421,7 @@ mod tests {
     }
 
     #[test]
-    fn dib_offbits_accounts_for_palette() {
+    fn dib_off_bits_accounts_for_palette() {
         // 8-bpp indexed bitmap with a full 256-entry palette.
         let mut dib = Vec::new();
         dib.extend_from_slice(&40u32.to_le_bytes()); // biSize

--- a/tools/wta/src/history_loader.rs
+++ b/tools/wta/src/history_loader.rs
@@ -2945,11 +2945,11 @@ mod tests {
     fn codex_user_text_is_synthetic_recognizes_bare_and_dir_headings() {
         // Project AGENTS.md (directory=Some) -> "# AGENTS.md instructions for <dir>".
         assert!(codex_user_text_is_synthetic(
-            "# AGENTS.md instructions for C:/proj\n\n<INSTRUCTIONS>\nbody\n</INSTRUCTIONS>"
+            "# AGENTS.md instructions for C:/proj\n\n<INSTRUCTIONS>\n be concise \n</INSTRUCTIONS>"
         ));
         // Global ~/.codex/AGENTS.md (directory=None) -> bare "# AGENTS.md instructions".
         assert!(codex_user_text_is_synthetic(
-            "# AGENTS.md instructions\n\n<INSTRUCTIONS>\nbody\n</INSTRUCTIONS>"
+            "# AGENTS.md instructions\n\n<INSTRUCTIONS>\n be concise \n</INSTRUCTIONS>"
         ));
         // Bare heading with nothing after it, and with tolerated leading space.
         assert!(codex_user_text_is_synthetic("# AGENTS.md instructions"));
@@ -3002,7 +3002,7 @@ mod tests {
 \"content\":[{{\"text\":\"<environment_context>cwd=C:/proj</environment_context>\"}}]}}}}\n");
         let agents = format!(
             "{{\"type\":\"response_item\",\"payload\":{{\"role\":\"user\",\
-\"content\":[{{\"text\":\"# AGENTS.md instructions\\n\\n<INSTRUCTIONS>\\nbody\\n</INSTRUCTIONS>\"}}]}}}}\n");
+\"content\":[{{\"text\":\"# AGENTS.md instructions\\n\\n<INSTRUCTIONS>\\n be concise \\n</INSTRUCTIONS>\"}}]}}}}\n");
         write_file(&path, &(codex_meta_line(id, "2026-05-28T17:00:00Z", "C:/proj") + &env + &agents));
         assert_eq!(load_codex(&home).len(), 0,
                    "meta + env_context + bare AGENTS.md injection alone must be phantom");

--- a/tools/wta/src/ui/command_popup.rs
+++ b/tools/wta/src/ui/command_popup.rs
@@ -150,16 +150,16 @@ mod tests {
 
     #[test]
     fn highlight_follows_cursor() {
-        let cands = vec![spec("help"), spec("new"), spec("restart")];
-        assert_eq!(popup_highlight(&cands, 1), Some(1));
+        let candidates = vec![spec("help"), spec("new"), spec("restart")];
+        assert_eq!(popup_highlight(&candidates, 1), Some(1));
     }
 
     #[test]
     fn highlight_clamps_out_of_range_cursor() {
         // The App collapses the list to a single command (/restart) when the
         // transport is lost; a stale larger `selected` must clamp onto it.
-        let cands = vec![spec("restart")];
-        assert_eq!(popup_highlight(&cands, 9), Some(0));
+        let candidates = vec![spec("restart")];
+        assert_eq!(popup_highlight(&candidates, 9), Some(0));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Now that the `Check Spelling` workflow runs again (after #358 removed the
fatal secpoll workaround), it surfaces **11 pre-existing** code-scanning
alerts — 10 unrecognized words plus 1 `line_forbidden.patterns` hit.

## Fix (per the maintainer guidance: fix what's ours, allow-list what we can't rename)

**Reworded / renamed (our comments, variables, test fixtures):**

| Alert | Where | Change |
|-------|-------|--------|
| `cands` | command_popup test | -> `candidates` |
| `hmem` | `set_clipboard_dib` local | -> `handle` |
| `offbits` | test fn name | `dib_offbits_*` -> `dib_off_bits_*` |
| `pastable` | doc comment | "non-pastable" -> "too large to paste" |
| `rescans` | doc comment | -> "re-scans" |
| `nbody` | test fixture string | `\nbody` -> `\n be concise` (kills the `\n`+`body` token) |
| `pre-existing` | comment (forbidden pattern) | -> `preexisting` |

**Allow-listed (genuine Win32 identifiers in comments documenting the DIB binary layout — cannot be renamed):** `BITMAPFILEHEADER`, `wingdi` (wingdi.h), `Pels` / `YPels` (biX/biYPelsPerMeter fields) -> `allow/apis.txt`.

## Validation

- `cargo check` (wta) passes — only pre-existing warnings.
- The 6 affected unit tests pass (clipboard_image, command_popup, history_loader codex tests).
- The full repo-wide check-spelling alert list (11 items) is each addressed; no new unrecognized words introduced by the rewordings.

No behavior change: `hmem`->`handle` is a local rename; the `nbody` fixture keeps identical compiled bytes' intent (only the placeholder body text changes); all other edits are comments / test identifiers.