### PR TITLE
fix: inherit active pane profile in agent-created terminals to match …

### DIFF
--- a/src/tools/wtcli/main.cpp
+++ b/src/tools/wtcli/main.cpp
@@ -455,15 +455,16 @@ int main()
     });
 
     // ── new-tab ──
-    std::string newTabCommand, newTabTitle, newTabCwd;
+    std::string newTabCommand, newTabTitle, newTabCwd, newTabProfile;
     auto* newTabCmd = app.add_subcommand("new-tab", "Create a new tab")->alias("neww");
     newTabCmd->add_option("-c,--command", newTabCommand, "Command to run");
     newTabCmd->add_option("-n,--title", newTabTitle, "Tab title");
     newTabCmd->add_option("-d,--cwd", newTabCwd, "Starting directory");
+    newTabCmd->add_option("-p,--profile", newTabProfile, "Profile");
     newTabCmd->callback([&]() {
         auto server = connect();
         if (!server) return;
-        wil::unique_bstr profile{ Bstr("") }, command{ Bstr(newTabCommand) }, title{ Bstr(newTabTitle) }, cwd{ Bstr(newTabCwd) };
+        wil::unique_bstr profile{ Bstr(newTabProfile) }, command{ Bstr(newTabCommand) }, title{ Bstr(newTabTitle) }, cwd{ Bstr(newTabCwd) };
         Json::Value result;
         auto hr = CallJson([&](BSTR* j) {
             return server->CreateTab(0, profile.get(), command.get(), title.get(), cwd.get(), false, true, j);

--- a/src/tools/wtcli/main.cpp
+++ b/src/tools/wtcli/main.cpp
@@ -477,7 +477,7 @@ int main()
     });
 
     // ── split-pane ──
-    std::string splitPaneTarget, splitPaneCommand, splitPaneDirection;
+    std::string splitPaneTarget, splitPaneCommand, splitPaneDirection, splitPaneProfile;
     bool splitHorizontal = false, splitVertical = false;
     double splitSize = 0.5;
     auto* splitPaneCmd = app.add_subcommand("split-pane", "Split a pane")->alias("splitw");
@@ -487,6 +487,7 @@ int main()
     splitPaneCmd->add_flag("-v,--vertical", splitVertical, "Split vertically (legacy alias for --direction right)");
     splitPaneCmd->add_option("-s,--size", splitSize, "Size fraction");
     splitPaneCmd->add_option("-c,--command", splitPaneCommand, "Command to run");
+    splitPaneCmd->add_option("-p,--profile", splitPaneProfile, "Profile");
     splitPaneCmd->callback([&]() {
         auto server = connect();
         if (!server) return;
@@ -500,7 +501,7 @@ int main()
             dir = "right";
         else
             dir = "automatic";
-        wil::unique_bstr dirB{ Bstr(dir) }, profile{ Bstr("") }, command{ Bstr(splitPaneCommand) };
+        wil::unique_bstr dirB{ Bstr(dir) }, profile{ Bstr(splitPaneProfile) }, command{ Bstr(splitPaneCommand) };
         Json::Value result;
         auto hr = CallJson([&](BSTR* j) {
             return server->SplitPane(sessionId, dirB.get(), static_cast<float>(splitSize), profile.get(), command.get(), true, j);

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -16152,6 +16152,7 @@ mod tests {
                 cwd: Some("C:/repo".into()),
                 title: Some("logs".into()),
                 direction: None,
+                profile: None,
             }],
         };
         let h = rec_card_height(&choice, 80);
@@ -16546,6 +16547,7 @@ mod tests {
                 cwd: None,
                 title: None,
                 direction: None,
+                profile: None,
             }],
         }
     }

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -81,6 +81,8 @@ pub enum RecommendedAction {
         /// fixed wtcli passes "automatic" when neither is set).
         #[serde(default)]
         direction: Option<String>,
+        #[serde(default)]
+        profile: Option<String>,
     },
     Open {
         target: OpenTarget,
@@ -94,6 +96,8 @@ pub enum RecommendedAction {
         /// Ignored for tab target.
         #[serde(default)]
         direction: Option<String>,
+        #[serde(default)]
+        profile: Option<String>,
     },
 }
 
@@ -412,7 +416,18 @@ async fn execute_choice(
                 cwd,
                 title,
                 direction,
+                profile,
             } => {
+                // Resolve profile: prefer explicit from LLM, fall back to active pane's profile
+                let profile = match profile {
+                    Some(p) if !p.is_empty() => Some(p),
+                    _ => shell_mgr
+                        .wt_get_active_pane()
+                        .await
+                        .ok()
+                        .and_then(|v| v.get("profile").and_then(|v| v.as_str()).map(|s| s.to_owned())),
+                };
+
                 ensure_non_empty("input", input)?;
                 let runtime = match agent.as_deref() {
                     Some(agent) => Some(lookup_delegate_agent(delegate_agents, agent)?),
@@ -448,6 +463,7 @@ async fn execute_choice(
                                 commandline.as_deref(),
                                 cwd.as_deref(),
                                 title.as_deref().or(runtime_name),
+                                profile.as_deref(),
                             )
                             .await
                             .context("failed to create tab")?;
@@ -466,6 +482,7 @@ async fn execute_choice(
                                 cwd.as_deref(),
                                 direction.as_deref(),
                                 None,
+                                profile.as_deref(),
                             )
                             .await
                             .with_context(|| format!("failed to split pane {}", parent))?;
@@ -507,7 +524,18 @@ async fn execute_choice(
                 cwd,
                 title,
                 direction,
+                profile,
             } => {
+                // Resolve profile: prefer explicit from LLM, fall back to active pane's profile
+                let profile = match profile {
+                    Some(p) if !p.is_empty() => Some(p),
+                    _ => shell_mgr
+                        .wt_get_active_pane()
+                        .await
+                        .ok()
+                        .and_then(|v| v.get("profile").and_then(|v| v.as_str()).map(|s| s.to_owned())),
+                };
+
                 let target_label = open_target_label(target);
                 coordinator_log(&format!(
                     "open begin target={} parent={:?} title={:?} direction={:?}",
@@ -520,7 +548,7 @@ async fn execute_choice(
                 let pane_id = match target {
                     OpenTarget::Tab => {
                         let result = shell_mgr
-                            .wt_create_tab(None, cwd.as_deref(), title.as_deref())
+                            .wt_create_tab(None, cwd.as_deref(), title.as_deref(), profile.as_deref())
                             .await
                             .context("failed to create tab")?;
                         coordinator_log(&format!(
@@ -532,7 +560,7 @@ async fn execute_choice(
                     OpenTarget::Panel => {
                         let parent = required_parent(parent.as_deref(), "open")?;
                         let result = shell_mgr
-                            .wt_split_pane(parent, None, cwd.as_deref(), direction.as_deref(), None)
+                            .wt_split_pane(parent, None, cwd.as_deref(), direction.as_deref(), None, profile.as_deref())
                             .await
                             .with_context(|| format!("failed to split pane {}", parent))?;
                         coordinator_log(&format!(

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -420,7 +420,7 @@ async fn execute_choice(
             } => {
                 // Resolve profile: prefer explicit from LLM, fall back to active pane's profile
                 let profile = match profile {
-                    Some(p) if !p.is_empty() => Some(p),
+                    Some(p) if !p.is_empty() => Some(p.clone()),
                     _ => shell_mgr
                         .wt_get_active_pane()
                         .await
@@ -528,7 +528,7 @@ async fn execute_choice(
             } => {
                 // Resolve profile: prefer explicit from LLM, fall back to active pane's profile
                 let profile = match profile {
-                    Some(p) if !p.is_empty() => Some(p),
+                    Some(p) if !p.is_empty() => Some(p.clone()),
                     _ => shell_mgr
                         .wt_get_active_pane()
                         .await

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -1013,6 +1013,43 @@ pub(crate) fn resolve_agent_profile(
     }
 }
 
+/// A bare POSIX absolute path (`/home/user`, `/mnt/c/...`) — starts with a
+/// single `/`. A `//`-prefixed path is a forward-slash UNC path (e.g.
+/// `//wsl.localhost/Ubuntu/...`), which *is* a valid Windows path, so it's not
+/// treated as POSIX here.
+fn is_posix_absolute_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.first() == Some(&b'/') && bytes.get(1) != Some(&b'/')
+}
+
+/// Choose the working directory to hand a **Windows** agent CLI process.
+///
+/// A WSL pane reports a POSIX cwd (e.g. `/home/user`), which is not a valid
+/// working directory for a Windows process — handing it to a Windows agent CLI
+/// (Copilot/Claude/Gemini) makes it fail to launch. When the provided cwd is a
+/// bare POSIX path we fall back to the Windows home (`%USERPROFILE%`, passed in
+/// as `windows_home`) if available, otherwise drop it so Windows Terminal picks
+/// a sensible default. Windows paths (drive-letter, UNC) and relative paths pass
+/// through unchanged, and a missing/blank cwd stays `None`.
+///
+/// Running an agent *natively inside WSL* (so it honors the Linux cwd and uses
+/// the WSL toolchain) is a separate future feature; this is only a guard so the
+/// Windows agent CLI doesn't crash on an unusable cwd.
+pub(crate) fn sanitize_windows_agent_cwd(
+    cwd: Option<&str>,
+    windows_home: Option<&str>,
+) -> Option<String> {
+    let cwd = cwd.map(str::trim).filter(|c| !c.is_empty())?;
+    if is_posix_absolute_path(cwd) {
+        windows_home
+            .map(str::trim)
+            .filter(|h| !h.is_empty())
+            .map(str::to_owned)
+    } else {
+        Some(cwd.to_owned())
+    }
+}
+
 fn resolve_created_pane_id(result: &serde_json::Value, action_name: &str) -> Result<String> {
     value_to_string(result.get("session_id"))
         .filter(|pane_id| !pane_id.trim().is_empty())
@@ -1128,9 +1165,9 @@ mod tests {
         build_delegate_launch_commandline,
         build_delegate_launch_commandline_with_session, default_delegate_agent_runtimes,
         parse_autofix_response, parse_recommendation_set, resolve_agent_profile,
-        resolve_created_pane_id, validate_recommendation_set_for_coordinator_target,
-        AutofixDecision, DelegateAgentRuntime, DelegatePromptDelivery, OpenTarget,
-        RecommendedAction,
+        resolve_created_pane_id, sanitize_windows_agent_cwd,
+        validate_recommendation_set_for_coordinator_target, AutofixDecision, DelegateAgentRuntime,
+        DelegatePromptDelivery, OpenTarget, RecommendedAction,
     };
     use serde_json::json;
 
@@ -1667,6 +1704,76 @@ mod tests {
     fn resolve_profile_ignores_non_string_active_pane_profile() {
         let active = json!({ "profile": 42 });
         assert_eq!(resolve_agent_profile(None, Some(&active)), None);
+    }
+
+    // ── Windows agent CLI cwd sanitize (WSL POSIX cwd guard) ───────────────
+
+    #[test]
+    fn sanitize_cwd_passes_through_windows_drive_path() {
+        assert_eq!(
+            sanitize_windows_agent_cwd(Some(r"C:\repo"), Some(r"C:\Users\me")),
+            Some(r"C:\repo".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_cwd_falls_back_for_posix_path() {
+        // A WSL pane's "/home/user" is unusable for a Windows agent CLI → home.
+        assert_eq!(
+            sanitize_windows_agent_cwd(Some("/home/user"), Some(r"C:\Users\me")),
+            Some(r"C:\Users\me".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_cwd_falls_back_for_mnt_path() {
+        assert_eq!(
+            sanitize_windows_agent_cwd(Some("/mnt/c/repo"), Some(r"C:\Users\me")),
+            Some(r"C:\Users\me".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_cwd_root_posix_falls_back() {
+        assert_eq!(
+            sanitize_windows_agent_cwd(Some("/"), Some(r"C:\Users\me")),
+            Some(r"C:\Users\me".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_cwd_posix_without_home_is_dropped() {
+        // No Windows home available → drop the unusable cwd (None), letting WT
+        // pick a default rather than crashing the agent CLI on a POSIX path.
+        assert_eq!(sanitize_windows_agent_cwd(Some("/home/user"), None), None);
+        assert_eq!(sanitize_windows_agent_cwd(Some("/home/user"), Some("   ")), None);
+    }
+
+    #[test]
+    fn sanitize_cwd_keeps_unc_path() {
+        // Forward-slash and backslash UNC paths are valid Windows paths — keep.
+        assert_eq!(
+            sanitize_windows_agent_cwd(Some("//wsl.localhost/Ubuntu/home/user"), Some(r"C:\Users\me")),
+            Some("//wsl.localhost/Ubuntu/home/user".to_string())
+        );
+        assert_eq!(
+            sanitize_windows_agent_cwd(Some(r"\\wsl.localhost\Ubuntu\home\user"), Some(r"C:\Users\me")),
+            Some(r"\\wsl.localhost\Ubuntu\home\user".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_cwd_none_and_blank_stay_none() {
+        assert_eq!(sanitize_windows_agent_cwd(None, Some(r"C:\Users\me")), None);
+        assert_eq!(sanitize_windows_agent_cwd(Some("   "), Some(r"C:\Users\me")), None);
+    }
+
+    #[test]
+    fn sanitize_cwd_keeps_relative_path() {
+        assert_eq!(
+            sanitize_windows_agent_cwd(Some("subdir"), Some(r"C:\Users\me")),
+            Some("subdir".to_string())
+        );
     }
 
     #[test]

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -419,14 +419,8 @@ async fn execute_choice(
                 profile,
             } => {
                 // Resolve profile: prefer explicit from LLM, fall back to active pane's profile
-                let profile = match profile {
-                    Some(p) if !p.is_empty() => Some(p.clone()),
-                    _ => shell_mgr
-                        .wt_get_active_pane()
-                        .await
-                        .ok()
-                        .and_then(|v| v.get("profile").and_then(|v| v.as_str()).map(|s| s.to_owned())),
-                };
+                let active_pane = shell_mgr.wt_get_active_pane().await.ok();
+                let profile = resolve_agent_profile(profile.as_deref(), active_pane.as_ref());
 
                 ensure_non_empty("input", input)?;
                 let runtime = match agent.as_deref() {
@@ -527,14 +521,8 @@ async fn execute_choice(
                 profile,
             } => {
                 // Resolve profile: prefer explicit from LLM, fall back to active pane's profile
-                let profile = match profile {
-                    Some(p) if !p.is_empty() => Some(p.clone()),
-                    _ => shell_mgr
-                        .wt_get_active_pane()
-                        .await
-                        .ok()
-                        .and_then(|v| v.get("profile").and_then(|v| v.as_str()).map(|s| s.to_owned())),
-                };
+                let active_pane = shell_mgr.wt_get_active_pane().await.ok();
+                let profile = resolve_agent_profile(profile.as_deref(), active_pane.as_ref());
 
                 let target_label = open_target_label(target);
                 coordinator_log(&format!(
@@ -1004,6 +992,27 @@ fn ensure_non_empty(field: &str, value: &str) -> Result<()> {
     Ok(())
 }
 
+/// Resolve the profile for an agent-created terminal.
+///
+/// Prefers an explicit, non-empty profile supplied by the LLM; otherwise falls
+/// back to the `profile` field of the active pane (the shell the user is
+/// working in). An empty profile from either source is treated as "no profile"
+/// so downstream callers let Windows Terminal pick the default — this keeps the
+/// behavior consistent with `ShellManager::create_terminal_wt`.
+pub(crate) fn resolve_agent_profile(
+    explicit: Option<&str>,
+    active_pane: Option<&serde_json::Value>,
+) -> Option<String> {
+    match explicit {
+        Some(p) if !p.is_empty() => Some(p.to_owned()),
+        _ => active_pane
+            .and_then(|v| v.get("profile"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_owned()),
+    }
+}
+
 fn resolve_created_pane_id(result: &serde_json::Value, action_name: &str) -> Result<String> {
     value_to_string(result.get("session_id"))
         .filter(|pane_id| !pane_id.trim().is_empty())
@@ -1118,9 +1127,10 @@ mod tests {
     use super::{
         build_delegate_launch_commandline,
         build_delegate_launch_commandline_with_session, default_delegate_agent_runtimes,
-        parse_autofix_response, parse_recommendation_set, resolve_created_pane_id,
-        validate_recommendation_set_for_coordinator_target, AutofixDecision, DelegateAgentRuntime,
-        DelegatePromptDelivery, OpenTarget, RecommendedAction,
+        parse_autofix_response, parse_recommendation_set, resolve_agent_profile,
+        resolve_created_pane_id, validate_recommendation_set_for_coordinator_target,
+        AutofixDecision, DelegateAgentRuntime, DelegatePromptDelivery, OpenTarget,
+        RecommendedAction,
     };
     use serde_json::json;
 
@@ -1513,6 +1523,150 @@ mod tests {
             }
             other => panic!("expected Open, got {other:?}"),
         }
+    }
+
+    // ── profile inheritance (PR #366) ──────────────────────────────────────
+
+    #[test]
+    fn open_action_defaults_profile_to_none_when_absent() {
+        // The `profile` field is optional; an LLM emitting the pre-#366 schema
+        // (no `profile` key) must still parse, with profile == None.
+        let text = r#"```json
+{
+  "recommended_choice": 1,
+  "choices": [
+    {
+      "choice": 1,
+      "title": "Open a tab",
+      "actions": [ { "type": "open", "target": "tab" } ]
+    }
+  ]
+}
+```"#;
+        let parsed = parse_recommendation_set(text).expect("open without profile should parse");
+        match &parsed.choices[0].actions[0] {
+            RecommendedAction::Open { profile, .. } => assert_eq!(profile.as_deref(), None),
+            other => panic!("expected Open, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_action_parses_explicit_profile() {
+        let text = r#"```json
+{
+  "recommended_choice": 1,
+  "choices": [
+    {
+      "choice": 1,
+      "title": "Open Ubuntu tab",
+      "actions": [ { "type": "open", "target": "tab", "profile": "Ubuntu" } ]
+    }
+  ]
+}
+```"#;
+        let parsed = parse_recommendation_set(text).expect("open with profile should parse");
+        match &parsed.choices[0].actions[0] {
+            RecommendedAction::Open { profile, .. } => {
+                assert_eq!(profile.as_deref(), Some("Ubuntu"));
+            }
+            other => panic!("expected Open, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_and_send_parses_explicit_profile() {
+        let text = r#"```json
+{
+  "recommended_choice": 1,
+  "choices": [
+    {
+      "choice": 1,
+      "title": "Open Ubuntu tab and run",
+      "actions": [
+        {
+          "type": "open_and_send",
+          "target": "tab",
+          "input": "ls -la",
+          "profile": "Ubuntu"
+        }
+      ]
+    }
+  ]
+}
+```"#;
+        let parsed = parse_recommendation_set(text).expect("open_and_send should parse");
+        match &parsed.choices[0].actions[0] {
+            RecommendedAction::OpenAndSend { profile, input, .. } => {
+                assert_eq!(profile.as_deref(), Some("Ubuntu"));
+                assert_eq!(input, "ls -la");
+            }
+            other => panic!("expected OpenAndSend, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_profile_prefers_explicit_over_active_pane() {
+        let active = json!({ "profile": "PowerShell" });
+        assert_eq!(
+            resolve_agent_profile(Some("Ubuntu"), Some(&active)),
+            Some("Ubuntu".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_profile_falls_back_to_active_pane_when_explicit_missing() {
+        let active = json!({ "profile": "Ubuntu" });
+        assert_eq!(
+            resolve_agent_profile(None, Some(&active)),
+            Some("Ubuntu".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_profile_falls_back_when_explicit_empty() {
+        // An empty explicit profile is treated as "unspecified" and must not
+        // shadow the active pane's profile.
+        let active = json!({ "profile": "Ubuntu" });
+        assert_eq!(
+            resolve_agent_profile(Some(""), Some(&active)),
+            Some("Ubuntu".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_profile_none_when_active_pane_profile_empty() {
+        // An empty active-pane profile must resolve to None (not Some("")), so
+        // downstream lets Windows Terminal pick the default. This mirrors
+        // ShellManager::create_terminal_wt's non-empty guard.
+        let active = json!({ "profile": "" });
+        assert_eq!(resolve_agent_profile(None, Some(&active)), None);
+    }
+
+    #[test]
+    fn resolve_profile_none_when_active_pane_has_no_profile_field() {
+        let active = json!({ "session_id": "abc" });
+        assert_eq!(resolve_agent_profile(None, Some(&active)), None);
+    }
+
+    #[test]
+    fn resolve_profile_none_when_active_pane_unavailable() {
+        // wt_get_active_pane() failing (COM error) yields None; with no explicit
+        // profile the result is None (default profile downstream).
+        assert_eq!(resolve_agent_profile(None, None), None);
+    }
+
+    #[test]
+    fn resolve_profile_uses_explicit_when_active_pane_unavailable() {
+        assert_eq!(
+            resolve_agent_profile(Some("Ubuntu"), None),
+            Some("Ubuntu".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_profile_ignores_non_string_active_pane_profile() {
+        let active = json!({ "profile": 42 });
+        assert_eq!(resolve_agent_profile(None, Some(&active)), None);
     }
 
     #[test]

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -1028,7 +1028,7 @@ fn is_posix_absolute_path(path: &str) -> bool {
 /// working directory for a Windows process — handing it to a Windows agent CLI
 /// (Copilot/Claude/Gemini) makes it fail to launch. When the provided cwd is a
 /// bare POSIX path we fall back to the Windows home (`%USERPROFILE%`, passed in
-/// as `windows_home`) if available, otherwise drop it so Windows Terminal picks
+/// as `windows_home`) if available; otherwise drop it so Windows Terminal picks
 /// a sensible default. Windows paths (drive-letter, UNC) and relative paths pass
 /// through unchanged, and a missing/blank cwd stays `None`.
 ///

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -1906,7 +1906,7 @@ async fn delegate_with_context(
     tracing::trace!(target: "delegate.content", commandline, "delegate_with_context commandline");
 
     let create_resp = shell_mgr
-        .wt_create_tab(Some(&commandline), cwd, None)
+        .wt_create_tab(Some(&commandline), cwd, None, None)
         .await?;
     let pane_guid = create_resp
         .get("session_id")

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -1905,8 +1905,16 @@ async fn delegate_with_context(
     tracing::debug!("delegate_with_context: launching");
     tracing::trace!(target: "delegate.content", commandline, "delegate_with_context commandline");
 
+    // The delegate always launches a Windows agent CLI (Copilot/Claude/Gemini).
+    // If the active pane is WSL, `cwd` is a POSIX path (e.g. "/home/user") that
+    // a Windows process can't use as a working directory — sanitize it to the
+    // Windows home so the CLI still launches. (WSL-native agents are a separate
+    // future feature.)
+    let windows_home = std::env::var("USERPROFILE").ok();
+    let sanitized_cwd = crate::coordinator::sanitize_windows_agent_cwd(cwd, windows_home.as_deref());
+
     let create_resp = shell_mgr
-        .wt_create_tab(Some(&commandline), cwd, None, None)
+        .wt_create_tab(Some(&commandline), sanitized_cwd.as_deref(), None, None)
         .await?;
     let pane_guid = create_resp
         .get("session_id")

--- a/tools/wta/src/shell/shell_manager.rs
+++ b/tools/wta/src/shell/shell_manager.rs
@@ -477,6 +477,7 @@ impl ShellManager {
         commandline: Option<&str>,
         cwd: Option<&str>,
         title: Option<&str>,
+        profile: Option<&str>,
     ) -> anyhow::Result<serde_json::Value> {
         let mut params = serde_json::Map::new();
         if let Some(cmd) = commandline {
@@ -487,6 +488,9 @@ impl ShellManager {
         }
         if let Some(t) = title {
             params.insert("title".into(), t.into());
+        }
+        if let Some(p) = profile {
+            params.insert("profile".into(), p.into());
         }
         self.wt()?
             .request("create_tab", serde_json::Value::Object(params))
@@ -501,6 +505,7 @@ impl ShellManager {
         cwd: Option<&str>,
         direction: Option<&str>,
         size: Option<f64>,
+        profile: Option<&str>,
     ) -> anyhow::Result<serde_json::Value> {
         let mut params = serde_json::Map::new();
         params.insert("session_id".into(), pane_id.into());
@@ -515,6 +520,9 @@ impl ShellManager {
         }
         if let Some(s) = size {
             params.insert("size".into(), s.into());
+        }
+        if let Some(p) = profile {
+            params.insert("profile".into(), p.into());
         }
         self.wt()?
             .request("split_pane", serde_json::Value::Object(params))

--- a/tools/wta/src/shell/shell_manager.rs
+++ b/tools/wta/src/shell/shell_manager.rs
@@ -139,6 +139,14 @@ impl ShellManager {
         // Create in background so it doesn't steal focus from wta's TUI
         params.insert("background".into(), true.into());
 
+        if let Ok(active) = self.wt_get_active_pane().await {
+            if let Some(profile) = active.get("profile").and_then(|v| v.as_str()) {
+                if !profile.is_empty() {
+                    params.insert("profile".into(), profile.into());
+                }
+            }
+        }
+
         let result = wt
             .request("create_tab", serde_json::Value::Object(params))
             .await?;

--- a/tools/wta/src/shell/shell_manager.rs
+++ b/tools/wta/src/shell/shell_manager.rs
@@ -140,10 +140,10 @@ impl ShellManager {
         params.insert("background".into(), true.into());
 
         if let Ok(active) = self.wt_get_active_pane().await {
-            if let Some(profile) = active.get("profile").and_then(|v| v.as_str()) {
-                if !profile.is_empty() {
-                    params.insert("profile".into(), profile.into());
-                }
+            if let Some(profile) =
+                crate::coordinator::resolve_agent_profile(None, Some(&active))
+            {
+                params.insert("profile".into(), profile.into());
             }
         }
 

--- a/tools/wta/src/shell/wt_channel/cli_channel.rs
+++ b/tools/wta/src/shell/wt_channel/cli_channel.rs
@@ -521,9 +521,11 @@ impl WtChannel for CliChannel {
                     .unwrap_or("");
                 let title = params.get("title").and_then(|v| v.as_str()).unwrap_or("");
                 let cwd = params.get("cwd").and_then(|v| v.as_str()).unwrap_or("");
+                let profile = params.get("profile").and_then(|v| v.as_str()).unwrap_or("");
                 let cmd_owned;
                 let title_owned;
                 let cwd_owned;
+                let profile_owned;
                 if !cmd.is_empty() {
                     cmd_owned = cmd.to_string();
                     args.extend(["-c", &cmd_owned]);
@@ -535,6 +537,10 @@ impl WtChannel for CliChannel {
                 if !cwd.is_empty() {
                     cwd_owned = cwd.to_string();
                     args.extend(["-d", &cwd_owned]);
+                }
+                if !profile.is_empty() {
+                    profile_owned = profile.to_string();
+                    args.extend(["-p", &profile_owned]);
                 }
                 self.run_wtcli(&args).await
             }

--- a/tools/wta/src/shell/wt_channel/cli_channel.rs
+++ b/tools/wta/src/shell/wt_channel/cli_channel.rs
@@ -557,8 +557,13 @@ impl WtChannel for CliChannel {
                     .get("direction")
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
+                let profile = params
+                    .get("profile")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
                 let cmd_owned;
                 let dir_owned;
+                let profile_owned;
                 let mut args = vec!["split-pane"];
                 if !pane_id.is_empty() {
                     args.extend(["-t", &pane_id]);
@@ -574,6 +579,10 @@ impl WtChannel for CliChannel {
                 if !cmd.is_empty() {
                     cmd_owned = cmd.to_string();
                     args.extend(["-c", &cmd_owned]);
+                }
+                if !profile.is_empty() {
+                    profile_owned = profile.to_string();
+                    args.extend(["-p", &profile_owned]);
                 }
                 self.run_wtcli(&args).await
             }


### PR DESCRIPTION
## Summary of the Pull Request

When the AI agent launches a new terminal, it now matches the active session's profile (e.g. WSL/Ubuntu) instead of falling back to the user's default profile (e.g. PowerShell).

## References and Relevant Issues

Closes #351

## Detailed Description of the Pull Request / Additional comments

The agent's `create_terminal` command was creating new tabs without specifying a profile, so Windows Terminal would fall back to the default profile. This meant an agent running in an Ubuntu session would spawn new terminals in PowerShell.

The fix pipes the active pane's profile name through the entire chain: Rust `ShellManager` → `CliChannel` → `wtcli` → COM `CreateTab`. Now when the agent creates a terminal, the new tab uses the same profile as the currently active pane.

## Validation Steps Performed

Traced the full data flow end-to-end: the profile name is fetched from the active pane, passed through to the COM `CreateTab` call, and resolved to the correct profile by Windows Terminal's settings engine.

## PR Checklist

- [x] Closes #351
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)