### PR TITLE
Replace auth shell-outs with native Windows APIs

### DIFF
--- a/.github/actions/spelling/allow/apis.txt
+++ b/.github/actions/spelling/allow/apis.txt
@@ -21,6 +21,7 @@ colspan
 COMDLG
 commandlinetoargv
 COPYFROMRESOURCE
+CREDENTIALW
 cstdint
 CXICON
 CYICON

--- a/tools/wta/Cargo.toml
+++ b/tools/wta/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1", features = ["derive"] }
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Globalization",
+    "Win32_Security_Credentials",
     "Win32_Storage_Packaging_Appx",
     "Win32_System_DataExchange",
     "Win32_System_Environment",
@@ -34,6 +35,7 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Registry",
     "Win32_System_Threading",
     "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
 ] }
 # Image decode/encode for clipboard-paste (Alt+V). Minimal feature set: decode
 # the clipboard DIB (BMP) and re-encode to PNG for ACP `ContentBlock::Image`.

--- a/tools/wta/src/agent_check.rs
+++ b/tools/wta/src/agent_check.rs
@@ -2,7 +2,7 @@
 //!
 //! Basic functions (atomic, single-responsibility):
 //!   - `find_exe`          — find agent executable on PATH (registry-fresh)
-//!   - `has_credential`    — fast credential check (cmdkey / config files)
+//!   - `has_credential`    — fast credential check (Credential Manager / config files)
 //!   - `run_auth_command`  — run auth_check_command from registry
 //!   - `build_login_cmd`   — build login command with full path
 //!   - `install`           — install agent via winget (async, streaming logs)
@@ -90,7 +90,7 @@ pub fn find_exe(agent_id: &str) -> Option<String> {
 ///
 /// Strategy:
 ///   1. If `auth_check_command` is defined → run it (exit 0 = true)
-///   2. Else → agent-specific fast check (cmdkey / config files)
+///   2. Else → agent-specific fast check (Credential Manager / config files)
 pub fn has_credential(agent_id: &str) -> bool {
     let profile = agent_registry::lookup_profile_by_id(agent_id);
 
@@ -105,14 +105,8 @@ pub fn has_credential(agent_id: &str) -> bool {
 
     match agent_id {
         "copilot" => {
-            let found = std::process::Command::new("cmd")
-                .args(["/C", "cmdkey /list | findstr /i copilot-cli"])
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::null())
-                .output()
-                .map(|o| !o.stdout.is_empty())
-                .unwrap_or(false);
-            tracing::debug!(target: "agent_check", agent = "copilot", found, "copilot credential check (cmdkey)");
+            let found = crate::win32::copilot_credential_present();
+            tracing::debug!(target: "agent_check", agent = "copilot", found, "copilot credential check (Credential Manager API)");
             found
         }
         "claude" => {

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -557,10 +557,7 @@ impl WtNotification {
 /// Open a URL in the user's default browser. Used by Setup mode's
 /// "press O to open install URL" key handler.
 fn open_url_in_browser(url: &str) -> std::io::Result<()> {
-    std::process::Command::new("cmd")
-        .args(["/c", "start", "", url])
-        .spawn()?;
-    Ok(())
+    crate::win32::open_url_in_default_browser(url)
 }
 
 /// Route a parsed `agent_event` payload into the AgentSessionRegistry.
@@ -6436,11 +6433,12 @@ impl App {
                         )
                         .into_owned();
                         // Copy device code to clipboard
-                        #[cfg(windows)]
-                        {
-                            let _ = std::process::Command::new("cmd")
-                                .args(["/C", &format!("echo {}| clip", device_code)])
-                                .spawn();
+                        if let Err(e) = crate::win32::copy_text_to_clipboard(&device_code) {
+                            tracing::warn!(
+                                target: "clipboard",
+                                error = %e,
+                                "failed to copy Copilot device code to clipboard"
+                            );
                         }
                     }
                 }
@@ -6712,21 +6710,13 @@ impl App {
                             self.spawn_login(&agent_id, &login_cmd);
                         } else {
                             // Non-Copilot agents: copy command to clipboard, re-check credential
-                            #[cfg(windows)]
-                            {
-                                let _ = std::process::Command::new("powershell")
-                                    .args([
-                                        "-NoProfile",
-                                        "-Command",
-                                        &format!(
-                                            "Set-Clipboard '{}'",
-                                            login_cmd.replace('\'', "''")
-                                        ),
-                                    ])
-                                    .stdin(std::process::Stdio::null())
-                                    .stdout(std::process::Stdio::null())
-                                    .stderr(std::process::Stdio::null())
-                                    .spawn();
+                            if let Err(e) = crate::win32::copy_text_to_clipboard(&login_cmd) {
+                                tracing::warn!(
+                                    target: "clipboard",
+                                    agent = %agent_id,
+                                    error = %e,
+                                    "failed to copy login command to clipboard"
+                                );
                             }
 
                             self.begin_auth_checking();

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -6433,13 +6433,16 @@ impl App {
                         )
                         .into_owned();
                         // Copy device code to clipboard
-                        if let Err(e) = crate::win32::copy_text_to_clipboard(&device_code) {
-                            tracing::warn!(
-                                target: "clipboard",
-                                error = %e,
-                                "failed to copy Copilot device code to clipboard"
-                            );
-                        }
+                        let code_to_copy = device_code.clone();
+                        tokio::task::spawn_blocking(move || {
+                            if let Err(e) = crate::win32::copy_text_to_clipboard(&code_to_copy) {
+                                tracing::warn!(
+                                    target: "clipboard",
+                                    error = %e,
+                                    "failed to copy Copilot device code to clipboard"
+                                );
+                            }
+                        });
                     }
                 }
             }
@@ -6710,14 +6713,18 @@ impl App {
                             self.spawn_login(&agent_id, &login_cmd);
                         } else {
                             // Non-Copilot agents: copy command to clipboard, re-check credential
-                            if let Err(e) = crate::win32::copy_text_to_clipboard(&login_cmd) {
-                                tracing::warn!(
-                                    target: "clipboard",
-                                    agent = %agent_id,
-                                    error = %e,
-                                    "failed to copy login command to clipboard"
-                                );
-                            }
+                            let cmd_to_copy = login_cmd.clone();
+                            let agent_for_log = agent_id.clone();
+                            tokio::task::spawn_blocking(move || {
+                                if let Err(e) = crate::win32::copy_text_to_clipboard(&cmd_to_copy) {
+                                    tracing::warn!(
+                                        target: "clipboard",
+                                        agent = %agent_for_log,
+                                        error = %e,
+                                        "failed to copy login command to clipboard"
+                                    );
+                                }
+                            });
 
                             self.begin_auth_checking();
 

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -35,6 +35,7 @@ mod test_support;
 mod theme;
 mod ui;
 mod ui_trace;
+mod win32;
 mod wsl;
 
 use acp::Agent as _;

--- a/tools/wta/src/win32.rs
+++ b/tools/wta/src/win32.rs
@@ -123,7 +123,9 @@ pub(crate) fn copy_text_to_clipboard(text: &str) -> io::Result<()> {
     let bytes = wide.len() * std::mem::size_of::<u16>();
 
     unsafe {
-        EmptyClipboard();
+        if EmptyClipboard() == 0 {
+            return Err(io::Error::last_os_error());
+        }
         let handle = GlobalAlloc(GMEM_MOVEABLE, bytes);
         if handle.is_null() {
             return Err(io::Error::last_os_error());
@@ -176,8 +178,12 @@ pub(crate) fn open_url_in_default_browser(url: &str) -> io::Result<()> {
         )
     };
 
-    if (result as isize) <= 32 {
-        Err(io::Error::last_os_error())
+    let code = result as isize;
+    if code <= 32 {
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("ShellExecuteW failed with code {code}"),
+        ))
     } else {
         Ok(())
     }
@@ -197,25 +203,15 @@ mod tests {
 
     #[test]
     fn copilot_credential_match_accepts_known_target_shapes() {
-        assert!(credential_target_matches_copilot(
-            "LegacyGeneric:target=copilot-cli/https://github.com:haonanttt"
-        ));
-        assert!(credential_target_matches_copilot(
-            "LegacyGeneric:target=https://github.com:haonanttt.copilot-cli"
-        ));
-        assert!(credential_target_matches_copilot(
-            "legacygeneric:target=COPILOT-CLI/https://example.ghe.com:user"
-        ));
+        assert!(credential_target_matches_copilot("copilot-cli/https://github.com:user"));
+        assert!(credential_target_matches_copilot("https://github.com:user.copilot-cli"));
+        assert!(credential_target_matches_copilot("COPILOT-CLI/https://example.ghe.com:user"));
     }
 
     #[test]
     fn copilot_credential_match_rejects_unrelated_targets() {
         assert!(!credential_target_matches_copilot(""));
-        assert!(!credential_target_matches_copilot(
-            "LegacyGeneric:target=github.com:haonanttt"
-        ));
-        assert!(!credential_target_matches_copilot(
-            "LegacyGeneric:target=other-agent-cli"
-        ));
+        assert!(!credential_target_matches_copilot("github.com:user"));
+        assert!(!credential_target_matches_copilot("other-agent-cli"));
     }
 }

--- a/tools/wta/src/win32.rs
+++ b/tools/wta/src/win32.rs
@@ -1,0 +1,221 @@
+//! Small native Windows helpers used to call OS services directly instead of
+//! routing through external shell helpers.
+
+#[cfg(windows)]
+use std::io;
+
+/// Copilot CLI stores its OAuth credential in Windows Credential Manager under
+/// target names containing `copilot-cli`. This predicate is deliberately kept
+/// pure so the matching behavior is testable without touching a user's
+/// Credential Manager store.
+pub(crate) fn credential_target_matches_copilot(target: &str) -> bool {
+    target.to_ascii_lowercase().contains("copilot-cli")
+}
+
+#[cfg(windows)]
+unsafe fn wide_ptr_to_string(ptr: *const u16) -> String {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+
+    if ptr.is_null() {
+        return String::new();
+    }
+    let mut len = 0usize;
+    while unsafe { *ptr.add(len) } != 0 {
+        len += 1;
+    }
+    let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
+    OsString::from_wide(slice).to_string_lossy().into_owned()
+}
+
+#[cfg(windows)]
+struct CredentialArray(*mut *mut windows_sys::Win32::Security::Credentials::CREDENTIALW);
+
+#[cfg(windows)]
+impl Drop for CredentialArray {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Security::Credentials::CredFree(self.0 as _);
+        }
+    }
+}
+
+/// Read-only Copilot credential presence check using the native Credential
+/// Manager API. We inspect target names only; the credential secret/blob is
+/// never read.
+#[cfg(windows)]
+pub(crate) fn copilot_credential_present() -> bool {
+    use windows_sys::Win32::Security::Credentials::{CredEnumerateW, CREDENTIALW};
+
+    let mut count = 0u32;
+    let mut credentials: *mut *mut CREDENTIALW = std::ptr::null_mut();
+    // Enumerate all targets and apply our own substring predicate to preserve
+    // parity with the old shell-based substring probe. Copilot CLI has
+    // used both prefix (`copilot-cli/...`) and suffix (`... .copilot-cli`)
+    // target shapes; CredEnumerateW's filter is prefix-only and would miss the
+    // suffix form. We still inspect target names only — never credential blobs.
+    let ok = unsafe { CredEnumerateW(std::ptr::null(), 0, &mut count, &mut credentials) != 0 };
+    if !ok || credentials.is_null() || count == 0 {
+        return false;
+    }
+
+    let _guard = CredentialArray(credentials);
+    let entries = unsafe { std::slice::from_raw_parts(credentials, count as usize) };
+    entries.iter().any(|&cred| {
+        if cred.is_null() {
+            return false;
+        }
+        let target = unsafe { wide_ptr_to_string((*cred).TargetName) };
+        credential_target_matches_copilot(&target)
+    })
+}
+
+#[cfg(not(windows))]
+pub(crate) fn copilot_credential_present() -> bool {
+    false
+}
+
+#[cfg(windows)]
+struct ClipboardGuard;
+
+#[cfg(windows)]
+impl ClipboardGuard {
+    fn open() -> io::Result<Self> {
+        use windows_sys::Win32::System::DataExchange::OpenClipboard;
+
+        for _ in 0..10 {
+            if unsafe { OpenClipboard(std::ptr::null_mut()) } != 0 {
+                return Ok(Self);
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(windows)]
+impl Drop for ClipboardGuard {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::System::DataExchange::CloseClipboard();
+        }
+    }
+}
+
+/// Copy UTF-16 text to the Windows clipboard without spawning external helper
+/// processes or invoking a shell parser.
+#[cfg(windows)]
+pub(crate) fn copy_text_to_clipboard(text: &str) -> io::Result<()> {
+    use windows_sys::Win32::Foundation::GlobalFree;
+    use windows_sys::Win32::System::DataExchange::{EmptyClipboard, SetClipboardData};
+    use windows_sys::Win32::System::Memory::{
+        GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE,
+    };
+
+    // CF_UNICODETEXT. windows-sys exposes it under Win32_System_Ole, but the
+    // numeric clipboard format is stable and avoids pulling in Ole just for a
+    // constant.
+    const CF_UNICODETEXT: u32 = 13;
+
+    let _guard = ClipboardGuard::open()?;
+    let mut wide: Vec<u16> = text.encode_utf16().collect();
+    wide.push(0);
+    let bytes = wide.len() * std::mem::size_of::<u16>();
+
+    unsafe {
+        EmptyClipboard();
+        let handle = GlobalAlloc(GMEM_MOVEABLE, bytes);
+        if handle.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+
+        let ptr = GlobalLock(handle);
+        if ptr.is_null() {
+            GlobalFree(handle);
+            return Err(io::Error::last_os_error());
+        }
+
+        std::ptr::copy_nonoverlapping(wide.as_ptr(), ptr as *mut u16, wide.len());
+        GlobalUnlock(handle);
+
+        // On success, SetClipboardData transfers ownership of `handle` to the
+        // OS; on failure it remains ours and must be freed.
+        if SetClipboardData(CF_UNICODETEXT, handle as _).is_null() {
+            GlobalFree(handle);
+            return Err(io::Error::last_os_error());
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+pub(crate) fn copy_text_to_clipboard(_text: &str) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "clipboard is only supported on Windows",
+    ))
+}
+
+/// Open a URL with the user's default handler using ShellExecuteW instead of a
+/// shell wrapper.
+#[cfg(windows)]
+pub(crate) fn open_url_in_default_browser(url: &str) -> io::Result<()> {
+    use windows_sys::Win32::UI::Shell::ShellExecuteW;
+
+    let operation: Vec<u16> = "open".encode_utf16().chain(std::iter::once(0)).collect();
+    let file: Vec<u16> = url.encode_utf16().chain(std::iter::once(0)).collect();
+    let result = unsafe {
+        ShellExecuteW(
+            std::ptr::null_mut(),
+            operation.as_ptr(),
+            file.as_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            1, // SW_SHOWNORMAL
+        )
+    };
+
+    if (result as isize) <= 32 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(windows))]
+pub(crate) fn open_url_in_default_browser(_url: &str) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "opening URLs is only supported on Windows",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::credential_target_matches_copilot;
+
+    #[test]
+    fn copilot_credential_match_accepts_known_target_shapes() {
+        assert!(credential_target_matches_copilot(
+            "LegacyGeneric:target=copilot-cli/https://github.com:haonanttt"
+        ));
+        assert!(credential_target_matches_copilot(
+            "LegacyGeneric:target=https://github.com:haonanttt.copilot-cli"
+        ));
+        assert!(credential_target_matches_copilot(
+            "legacygeneric:target=COPILOT-CLI/https://example.ghe.com:user"
+        ));
+    }
+
+    #[test]
+    fn copilot_credential_match_rejects_unrelated_targets() {
+        assert!(!credential_target_matches_copilot(""));
+        assert!(!credential_target_matches_copilot(
+            "LegacyGeneric:target=github.com:haonanttt"
+        ));
+        assert!(!credential_target_matches_copilot(
+            "LegacyGeneric:target=other-agent-cli"
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Replaces auth/login-related shell-outs with native Win32 APIs.

This addresses a security review concern around using:

```text
cmd /C "cmdkey /list | findstr /i copilot-cli"
```

to detect GitHub Copilot CLI login state. The behavior is preserved, but the
implementation now uses in-process Windows APIs instead of cmd/PowerShell
wrappers.

## Changes

### Credential Manager probe

- Replaces the Copilot credential check shell-out with `CredEnumerateW`.
- Inspects Credential Manager target names only.
- Does **not** read credential blobs, OAuth tokens, or secrets.
- Preserves the old substring behavior by enumerating targets and matching
  `copilot-cli` case-insensitively, so both observed Copilot CLI target shapes
  continue to work:
  - `copilot-cli/https://github.com:<user>`
  - `https://github.com:<user>.copilot-cli`

### Clipboard copy

- Replaces `cmd /C "echo <code>| clip"` for Copilot device-code copy.
- Replaces PowerShell `Set-Clipboard` for non-Copilot login-command copy.
- Adds a shared native clipboard helper using:
  - `OpenClipboard`
  - `EmptyClipboard`
  - `GlobalAlloc` / `GlobalLock`
  - `SetClipboardData(CF_UNICODETEXT)`
- Clipboard failures are logged as warnings and do not block the login flow,
  matching the previous best-effort behavior.

### URL opening

- Replaces `cmd /c start "" <url>` with `ShellExecuteW("open", url)` for setup
  install-link opening.

### New helper module

Adds `tools/wta/src/win32.rs` for small native Windows helpers:
- `copilot_credential_present`
- `credential_target_matches_copilot`
- `copy_text_to_clipboard`
- `open_url_in_default_browser`

## Security notes

- Removes cmd/PowerShell wrappers from the auth/login path.
- Removes shell parsing, PATH lookup, and command-string interpolation for:
  - credential probing
  - device-code clipboard copy
  - login-command clipboard copy
  - setup URL opening
- Credential Manager access is read-only and limited to target-name inspection.

## Testing

- `cargo test --target x86_64-pc-windows-msvc`
  - **1019 passed, 0 failed**
- Manual VM validation:
  - Copilot logged-in detection still routes directly.
  - Copilot missing-login path still routes to sign-in.
  - Device code copy still works.
  - Non-Copilot login-command copy still works.
  - Setup install URL still opens.