### PR TITLE
Fix wta x86 unit tests: PEB probes are x64-only

### DIFF
--- a/tools/wta/src/proc_bind.rs
+++ b/tools/wta/src/proc_bind.rs
@@ -616,9 +616,18 @@ mod tests {
         let missing = env_var_for_pid(pid, "WTA_NOT_SET_XYZ");
         let _ = child.kill();
         let _ = child.wait();
-        assert_eq!(got.as_deref(), Some("marker-value-42"));
-        assert_eq!(got_ci.as_deref(), Some("marker-value-42"));
-        assert_eq!(missing, None);
+        if cfg!(target_arch = "x86_64") {
+            assert_eq!(got.as_deref(), Some("marker-value-42"));
+            assert_eq!(got_ci.as_deref(), Some("marker-value-42"));
+            assert_eq!(missing, None);
+        } else {
+            // The PEB walk uses x64-specific offsets, so `read_process_env_block`
+            // bails to `None` on every other arch (e.g. i686/x86, aarch64) by
+            // design rather than read the wrong remote memory.
+            assert_eq!(got, None);
+            assert_eq!(got_ci, None);
+            assert_eq!(missing, None);
+        }
     }
 
     #[test]
@@ -681,6 +690,12 @@ mod tests {
         let got = cwd_for_pid(pid);
         let _ = child.kill();
         let _ = child.wait();
+        if !cfg!(target_arch = "x86_64") {
+            // `cwd_for_pid` uses x64-specific PEB offsets and returns `None` on
+            // every other arch (e.g. i686/x86, aarch64) by design.
+            assert_eq!(got, None);
+            return;
+        }
         let got = got.expect("cwd_for_pid returned None");
         // Compare case-insensitively on the final component to avoid
         // \\?\ prefix / drive-letter-case differences.


### PR DESCRIPTION
## Problem

The pipeline's **x86** Rust unit-test stage (`cargo test --manifest-path tools/wta/Cargo.toml --target i686-pc-windows-msvc`) was failing on two tests in `tools/wta/src/proc_bind.rs`:

- `proc_bind::tests::env_var_for_pid_reads_child_environment`
- `proc_bind::tests::cwd_for_pid_reads_child_working_dir`

Both tests asserted `Some(..)` unconditionally, but the production helpers `read_process_env_block` / `cwd_for_pid` **intentionally return `None` on any non-`x86_64` arch** — their PEB / `RTL_USER_PROCESS_PARAMETERS` offsets are hard-coded for x64 and guarded by `if !cfg!(target_arch = \"x86_64\")`. On the i686 (x86) target the functions correctly returned `None` and the tests panicked.

## Fix

Gate the test assertions by `target_arch`:
- on `x86_64`: expect the marker env value / child cwd (unchanged behavior),
- on other arches (x86/i686, aarch64): expect `None`, matching the documented x64-only contract.

No production code changed — this is a test-only correctness fix.

## Verification

- `cargo test --manifest-path tools/wta/Cargo.toml --target i686-pc-windows-msvc` → **991 passed; 0 failed** (previously 2 failed).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>