### PR TITLE
wta: hide WSL sessions from the session view by default

### DIFF
--- a/doc/specs/wsl-session-management.md
+++ b/doc/specs/wsl-session-management.md
@@ -255,24 +255,26 @@ Resume routing already exists: `decide_enter_action` (`session_mgmt.rs`) →
    (ACP `session/load`) is suppressed for `Wsl` location (helper/agent are
    host-side); both Enter and Shift+Enter route to the CLI-flag resume above.
 
-## Gating: `wta`-side choke point + env kill-switch (real setting deferred)
+## Gating: `wta`-side choke point + env opt-in (real setting deferred)
 
 Following the repo's own MVP-gate convention
 (`app.rs:62-78` — `MVP_SESSIONS_ORIGIN_FILTER` const + `WTA_SESSIONS_SHOW_AGENT_PANE`
-env override), the WSL scan is gated at a **single choke point** in `load_all`:
+env override), the WSL scan is gated at a **single choke point**:
 
 - A function `wsl_sessions_enabled() -> bool` reads `WTA_WSL_SESSIONS`
-  (`0`/`false` disables) and otherwise returns the build default (**enabled**).
-- `load_all` only enumerates/scans distros when `wsl_sessions_enabled()` is true.
+  (`1`/`true`/`yes`/`on` enables) and otherwise returns the build default
+  (**disabled** — WSL rows are hidden until the mixed host/WSL TUI is designed).
+- The WSL seed (`spawn_wsl_seed`) only enumerates/scans distros when
+  `wsl_sessions_enabled()` is true.
 
 Rationale:
 
-- **Gate at the scan, not the display.** Disabling means WSL rows never enter the
-  registry → never rendered → and **no** `wsl.exe` spawn cost is paid. (Trade-off:
-  re-enabling needs a re-scan to repopulate — acceptable for a kill-switch.)
-- **Immediate safety, zero C++/settings-model/XAML work.** If WSL scanning
-  misbehaves on a user's machine (slow distro, odd `wsl` build), they can set
-  `WTA_WSL_SESSIONS=0` without a new build.
+- **Gate at the scan, not the display.** Keeping WSL off means WSL rows never
+  enter the registry → never rendered → and **no** `wsl.exe` spawn cost is paid.
+  (Trade-off: enabling needs a re-scan to repopulate — acceptable for a toggle.)
+- **Immediate control, zero C++/settings-model/XAML work.** Users who want the
+  mixed host/WSL view early (or need to debug the scan) can set
+  `WTA_WSL_SESSIONS=1` without a new build; if it misbehaves they simply unset it.
 - **Future-proofed wiring.** When a real `wslSessions` setting is added later
   (`MTSMSettings.h` X-macro → `GlobalAppSettings` → C++ passes a `--wsl-sessions`
   flag to `wta`, same as `acpAgent`/`language`), it overrides the env default at
@@ -281,7 +283,8 @@ Rationale:
   is needed.
 
 This is a deferred follow-up, not MVP work; the spec only commits to the
-choke point + env override now.
+choke point + env override now. **The build default ships disabled** so the
+session view stays host-only until the WSL TUI is designed.
 
 ## Where this plugs into the existing pipeline
 
@@ -315,8 +318,8 @@ async reactor / UI thread).
   existing `DispatchedCommand` test seam), and the host-disk phantom guard is
   bypassed for WSL keys.
 - **Gate:** `wsl_sessions_enabled()` honors `WTA_WSL_SESSIONS=0/1` and the build
-  default (guard env mutation with the existing serialization mutex pattern used
-  by the `WTA_SESSIONS_SHOW_AGENT_PANE` tests).
+  default (**disabled**) (guard env mutation with the existing serialization mutex
+  pattern used by the `WTA_SESSIONS_SHOW_AGENT_PANE` tests).
 - **No real `wsl.exe` in unit tests** — the spawn boundary is injected/mocked;
   `running_distros()` and the spawn helper take their raw bytes from a seam so
   CI (no WSL) stays deterministic.

--- a/tools/wta/src/history_loader.rs
+++ b/tools/wta/src/history_loader.rs
@@ -50,19 +50,22 @@ const TITLE_TAIL_BYTES: u64 = 64 * 1024;
 const CLASSIFY_SCAN_BYTES_CAP: u64 = 8 * 1024 * 1024;
 
 /// Whether to scan WSL distros for historical sessions. Single
-/// choke point + env kill-switch (`WTA_WSL_SESSIONS=0|false|no|off`).
-/// Defaults to **enabled**. A future `wslSessions` setting will pass a
-/// flag that overrides this same function — no other call site changes.
+/// choke point + env opt-in (`WTA_WSL_SESSIONS=1|true|yes|on`).
+/// Defaults to **disabled**: WSL sessions are intentionally hidden from
+/// the session view until the mixed host/WSL TUI is designed. Flip the
+/// `Err(_)` default back to `true` (or wire up the future `wslSessions`
+/// setting through this same function) to re-enable — no other call site
+/// changes.
 pub(crate) fn wsl_sessions_enabled() -> bool {
-    // Trim + case-fold so the kill-switch is forgiving in scripts / CI
-    // (` False `, `NO`, `off`, …), mirroring the env-bool parsing in
+    // Trim + case-fold so the opt-in is forgiving in scripts / CI
+    // (` True `, `YES`, `on`, …), mirroring the env-bool parsing in
     // `resolve_sessions_origin_filter`.
     match std::env::var("WTA_WSL_SESSIONS") {
-        Ok(v) => !matches!(
+        Ok(v) => matches!(
             v.trim().to_ascii_lowercase().as_str(),
-            "0" | "false" | "no" | "off"
+            "1" | "true" | "yes" | "on"
         ),
-        Err(_) => true,
+        Err(_) => false,
     }
 }
 
@@ -825,23 +828,26 @@ mod tests {
     static WSL_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
-    fn wsl_gate_defaults_on_and_honors_env() {
+    fn wsl_gate_defaults_off_and_honors_env() {
         let _g = WSL_ENV_LOCK.lock().unwrap();
         std::env::remove_var("WTA_WSL_SESSIONS");
-        assert!(wsl_sessions_enabled(), "default must be enabled");
+        assert!(!wsl_sessions_enabled(), "default must be disabled");
+        std::env::set_var("WTA_WSL_SESSIONS", "1");
+        assert!(wsl_sessions_enabled());
+        std::env::set_var("WTA_WSL_SESSIONS", "true");
+        assert!(wsl_sessions_enabled());
+        // Forgiving parsing: trimmed, case-insensitive, extra truthy spellings.
+        std::env::set_var("WTA_WSL_SESSIONS", "  True ");
+        assert!(wsl_sessions_enabled(), "trimmed + case-insensitive True");
+        std::env::set_var("WTA_WSL_SESSIONS", "YES");
+        assert!(wsl_sessions_enabled());
+        std::env::set_var("WTA_WSL_SESSIONS", "on");
+        assert!(wsl_sessions_enabled());
+        // Anything else (incl. the old falsey spellings) stays disabled.
         std::env::set_var("WTA_WSL_SESSIONS", "0");
         assert!(!wsl_sessions_enabled());
         std::env::set_var("WTA_WSL_SESSIONS", "false");
         assert!(!wsl_sessions_enabled());
-        // Forgiving parsing: trimmed, case-insensitive, extra falsey spellings.
-        std::env::set_var("WTA_WSL_SESSIONS", "  False ");
-        assert!(!wsl_sessions_enabled(), "trimmed + case-insensitive False");
-        std::env::set_var("WTA_WSL_SESSIONS", "NO");
-        assert!(!wsl_sessions_enabled());
-        std::env::set_var("WTA_WSL_SESSIONS", "off");
-        assert!(!wsl_sessions_enabled());
-        std::env::set_var("WTA_WSL_SESSIONS", "1");
-        assert!(wsl_sessions_enabled());
         std::env::remove_var("WTA_WSL_SESSIONS");
     }
 }


### PR DESCRIPTION
## Summary

PR #323 / #365 surfaced WSL agent sessions in the `/sessions` view, mixed in with host sessions. Per the decision to **defer the mixed host/WSL TUI**, this hides WSL sessions from the session view **by default** until that UI is designed.

## Change

Flip `wsl_sessions_enabled()` (the single WSL-scan choke point) from a default-**on** env kill-switch to a default-**off** env opt-in:

| | Before | After |
|---|---|---|
| Default (no env) | enabled | **disabled** |
| Env semantics | `WTA_WSL_SESSIONS=0\|false\|no\|off` disables | `WTA_WSL_SESSIONS=1\|true\|yes\|on` enables |

- The choke point itself (`spawn_wsl_seed` → `wsl_sessions_enabled()`) is unchanged, so **no WSL rows enter the registry** → never rendered → no `wsl.exe` spawn cost. Host sessions are completely unaffected.
- `SessionLocation::Wsl` has a single production producer (the gated scan), so there is no bypass.
- `wta probe-wsl-sessions` (diagnostic) still scans on demand, independent of the gate.

## Re-enabling later

When the WSL TUI is ready, flip the `Err(_)` default back to `true` (or wire the future `wslSessions` setting through the same function). No other call site changes.

## Files

- `tools/wta/src/history_loader.rs` — default flip + inverted env semantics + updated gate unit test (`wsl_gate_defaults_off_and_honors_env`).
- `doc/specs/wsl-session-management.md` — spec wording updated (kill-switch/default-enabled → opt-in/default-disabled).

## Test

`cargo test --manifest-path tools/wta/Cargo.toml` → **1010 passed, 0 failed**.