### PR TITLE
fix(wt): keep dragged tab's sessions Live across cross-window move

### DIFF
--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -698,7 +698,22 @@ namespace winrt::TerminalApp::implementation
         // wta demote agent-session rows bound to the tab's panes to
         // Ended on tab close (the `_HandleClosePaneRequested`
         // counterpart covers single-pane Ctrl+Shift+W).
-        _NotifyPanesClosing(rootPaneForClose);
+        //
+        // Skipped for `movingAway` — a cross-window tab drag is NOT a
+        // close: the tab's panes are reattached in the target window via
+        // ContentId, keeping the same connection `SessionId`. Emitting
+        // `connection_state:closed` here would send wta a `PaneClosed`
+        // for those (still-live) panes, flipping any agent session bound
+        // to them (e.g. a `copilot` CLI a user ran in a shell pane) to
+        // Ended/Historical even though the session is alive in the new
+        // window. The registry is shared master-side across every window
+        // in this WT process, so the moved session stays Live for both
+        // the old and new window when we don't fire this. Mirrors the
+        // `movingAway` guard on `_NotifyAgentTabClosed` below.
+        if (!movingAway)
+        {
+            _NotifyPanesClosing(rootPaneForClose);
+        }
 
         // Removing the tab from the collection should destroy its control and disconnect its connection,
         // but it doesn't always do so. The UI tree may still be holding the control and preventing its destruction.


### PR DESCRIPTION
## Summary

A session flipped from **Live** to **Ended/Historical** in sessions view after
the user dragged that session's tab out into a new window. The session is still
alive — only the liveness bookkeeping was wrong.

## Repro

1. In a tab, run `copilot` in a shell pane or resume a session; confirm it shows **Live** in `/sessions`.
2. Drag the tab out of the window to create a new window.
3. ❌ The session flips to **Ended/Historical**.
4. ✅ Expected: it stays **Live** (the process didn't die; the pane just moved).

## Root cause

Cross-window tab drag/move ends in `TerminalPage::_RemoveTab(tab, movingAway=true)`.
`_RemoveTab` calls `_NotifyPanesClosing(rootPaneForClose)` **unconditionally**,
*before* the `if (!movingAway)` guard. That emits `connection_state:closed`
(`pane_id = Connection().SessionId()` GUID) for every terminal pane in the tab.

## Fix

Guard `_NotifyPanesClosing` with `!movingAway`, mirroring the existing
`movingAway` guards on `_NotifyAgentTabClosed` and `SharedWta::ReleasePane` in
the same function (`movingAway` already means "the panes survive — they're being
reattached in another window, not closed"). The master session registry is
shared across every window in the one WT process, so once we stop firing the
bogus close the moved session stays **Live** in both the old and new window.

## Test plan

- [x] Run `copilot` in a shell pane in tab 2 → shows Live in `/sessions`.
- [x] Drag tab 2 out to a new window → session stays **Live** (both windows'
      `/sessions` agree, since the registry is master-shared).
- [x] Regular tab close (Ctrl+Shift+W) still demotes the session to **Ended**
      (the `movingAway=false` path is unchanged).

