### PR TITLE
Improve Copilot auth flow after install

### DIFF
--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -1742,7 +1742,12 @@ namespace winrt::TerminalApp::implementation
             // if anything keeps the overlay alive a moment longer, it
             // doesn't appear stuck in the "saving" visual.
             _SetSavingState(false);
-            Completed.raise(*this, nullptr);
+            winrt::Windows::Foundation::IInspectable completedArgs{ nullptr };
+            if (needsCopilot)
+            {
+                completedArgs = winrt::box_value(winrt::hstring{ L"copilot" });
+            }
+            Completed.raise(*this, completedArgs);
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -962,7 +962,7 @@ namespace winrt::TerminalApp::implementation
     }
 
     void TerminalPage::_OnFreCompleted(const winrt::TerminalApp::FreOverlay& /*sender*/,
-                                       const winrt::Windows::Foundation::IInspectable& /*args*/)
+                                       const winrt::Windows::Foundation::IInspectable& args)
     {
         // Hide the FRE overlay
         if (auto overlay = FreOverlayElement())
@@ -1017,7 +1017,8 @@ namespace winrt::TerminalApp::implementation
         // Now create the agent pane on the freshly-created tab.
         if (const auto tab = _GetFocusedTabImpl())
         {
-            _OpenOrReuseAgentPane(false, L"FirstRunExperience");
+            const auto initialAuthAgent = winrt::unbox_value_or<winrt::hstring>(args, L"");
+            _OpenOrReuseAgentPane(false, L"FirstRunExperience", std::wstring_view{ initialAuthAgent });
             // Focus is set in the Initialized callback once the pane is ready.
         }
     }
@@ -1715,7 +1716,8 @@ namespace winrt::TerminalApp::implementation
                                                         bool intoSessionsView,
                                                         bool autoStash,
                                                         std::string_view initialLoadSessionId,
-                                                        std::string_view initialLoadCwd)
+                                                        std::string_view initialLoadCwd,
+                                                        std::wstring_view initialAuthAgent)
     {
         if (!tab || !tab->GetActiveTerminalControl())
         {
@@ -1851,6 +1853,18 @@ namespace winrt::TerminalApp::implementation
             // opened the pane" assumption), C++ receives the echo on a
             // stashed pane and restores it — defeating pre-warm.
             helperCmd.append(L" --start-stashed");
+        }
+        if (!initialAuthAgent.empty())
+        {
+            if (autoStash)
+            {
+                _agentPaneLog("_AutoCreateHiddenAgentPaneShared: ignoring initial auth hint for stashed helper");
+            }
+            else
+            {
+                _agentPaneLog("_AutoCreateHiddenAgentPaneShared: helper starts in auth mode for agent=" + winrt::to_string(winrt::hstring{ initialAuthAgent }));
+                appendHelperFlagValue(L"--initial-auth-agent", initialAuthAgent);
+            }
         }
 
         // Plan-C: bundle the resume request with helper spawn. Caller
@@ -2674,7 +2688,7 @@ namespace winrt::TerminalApp::implementation
         _RebuildAgentStack();
     }
 
-    void TerminalPage::_OpenOrReuseAgentPane(bool intoSessionsView, const wchar_t* triggerSource)
+    void TerminalPage::_OpenOrReuseAgentPane(bool intoSessionsView, const wchar_t* triggerSource, std::wstring_view initialAuthAgent)
     {
         _agentPaneLog(std::string{ "_OpenOrReuseAgentPane called, intoSessionsView=" } + (intoSessionsView ? "true" : "false"));
 
@@ -2800,7 +2814,7 @@ namespace winrt::TerminalApp::implementation
 
         _agentPaneLog("no agent pane on focused tab, creating new one");
 
-        if (!_AutoCreateHiddenAgentPaneShared(focusedTab, intoSessionsView))
+        if (!_AutoCreateHiddenAgentPaneShared(focusedTab, intoSessionsView, /*autoStash*/ false, std::string_view{}, std::string_view{}, initialAuthAgent))
         {
             _agentPaneLog("_OpenOrReuseAgentPane: _AutoCreateHiddenAgentPaneShared failed");
             return;

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -508,7 +508,8 @@ namespace winrt::TerminalApp::implementation
                                               bool intoSessionsView = false,
                                               bool autoStash = false,
                                               std::string_view initialLoadSessionId = {},
-                                              std::string_view initialLoadCwd = {});
+                                              std::string_view initialLoadCwd = {},
+                                              std::wstring_view initialAuthAgent = {});
         // Wraps the raw terminal pane's TerminalPaneContent in an
         // AgentPaneContent so the leaf renders the 36px XAML agent bar
         // above the wta TermControl + the bottom-bar below.
@@ -748,7 +749,7 @@ namespace winrt::TerminalApp::implementation
         // per-pane-wta architecture was deleted. Helper processes are now
         // ordinary conpty children of TermControl — TermControl /
         // ConptyConnection owns their lifetime.
-        void _OpenOrReuseAgentPane(bool intoSessionsView, const wchar_t* triggerSource);
+        void _OpenOrReuseAgentPane(bool intoSessionsView, const wchar_t* triggerSource, std::wstring_view initialAuthAgent = {});
         void _FocusAgentPane();
         void _RepositionAgentPanes();
         static winrt::Microsoft::Terminal::Settings::Model::SplitDirection _AgentPanePositionToSplitDirection(const winrt::hstring& position);

--- a/tools/wta/Cargo.toml
+++ b/tools/wta/Cargo.toml
@@ -27,7 +27,6 @@ serde = { version = "1", features = ["derive"] }
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Globalization",
-    "Win32_Security_Credentials",
     "Win32_Storage_Packaging_Appx",
     "Win32_System_Console",
     "Win32_System_DataExchange",

--- a/tools/wta/src/agent_check.rs
+++ b/tools/wta/src/agent_check.rs
@@ -2,28 +2,25 @@
 //!
 //! Basic functions (atomic, single-responsibility):
 //!   - `find_exe`          — find agent executable on PATH (registry-fresh)
-//!   - `has_credential`    — fast credential check (Credential Manager / config files)
-//!   - `run_auth_command`  — run auth_check_command from registry
 //!   - `build_login_cmd`   — build login command with full path
 //!   - `install`           — install agent via winget (async, streaming logs)
 //!   - `refresh_path`      — re-read PATH from Windows registry
 //!
 //! Composite functions (combine basics):
-//!   - `check_agent`       — find_exe + has_credential → AgentStatus
+//!   - `check_agent`       — find_exe → AgentStatus
 //!   - `ensure_installed`  — find_exe → install if missing → refresh_path → find_exe
 
 use crate::agent_registry;
 
 // ─── Data types ─────────────────────────────────────────────────────────────
 
-/// Status of a single agent, combining CLI detection + credential check.
+/// Status of a single agent, combining CLI detection and setup hints.
 #[derive(Debug, Clone)]
 pub struct AgentStatus {
     pub id: String,
     pub display_name: String,
     pub cli_found: bool,
     pub cli_path: Option<String>,
-    pub has_credential: bool,
     pub install_hint: String,
     pub auth_hint: String,
 }
@@ -69,74 +66,6 @@ pub fn find_exe(agent_id: &str) -> Option<String> {
     }
 
     None
-}
-
-/// Fast synchronous credential check. Returns true if a credential is
-/// likely present. Used to decide: connect directly vs show auth screen.
-///
-/// Strategy:
-///   1. If `auth_check_command` is defined → run it (exit 0 = true)
-///   2. Else → agent-specific fast check (Credential Manager / config files)
-pub fn has_credential(agent_id: &str) -> bool {
-    let profile = agent_registry::lookup_profile_by_id(agent_id);
-
-    // Strategy 1: auth_check_command
-    if let Some(result) = run_auth_command(profile.auth_check_command) {
-        return result;
-    }
-
-    // Strategy 2: agent-specific fast check
-    let home = std::env::var("USERPROFILE").unwrap_or_default();
-    let home = std::path::PathBuf::from(&home);
-
-    match agent_id {
-        "copilot" => {
-            let found = crate::win32::copilot_credential_present();
-            tracing::debug!(target: "agent_check", agent = "copilot", found, "copilot credential check (Credential Manager API)");
-            found
-        }
-        "claude" => {
-            let path = home.join(".claude").join(".credentials.json");
-            let exists = path.exists();
-            tracing::debug!(target: "agent_check", path = %path.display(), exists, "claude credential check");
-            exists
-        }
-        "codex" => {
-            std::env::var("OPENAI_API_KEY").is_ok() || home.join(".codex").exists()
-        }
-        "gemini" => {
-            // Check GEMINI_API_KEY or GOOGLE_API_KEY env var, or OAuth token in ~/.gemini/
-            std::env::var("GEMINI_API_KEY").is_ok()
-                || std::env::var("GOOGLE_API_KEY").is_ok()
-                || home.join(".gemini").exists()
-        }
-        _ => false,
-    }
-}
-
-/// Run an auth_check_command from the agent registry.
-/// Returns Some(true) if authenticated, Some(false) if not, None if command is empty.
-pub fn run_auth_command(command: &str) -> Option<bool> {
-    if command.is_empty() {
-        return None;
-    }
-
-    let parts: Vec<&str> = command.split_whitespace().collect();
-    let (program, args) = match parts.split_first() {
-        Some((prog, args)) => (*prog, args),
-        None => return None,
-    };
-
-    let result = std::process::Command::new(program)
-        .args(args)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status();
-
-    match result {
-        Ok(status) => Some(status.success()),
-        Err(_) => Some(false),
-    }
 }
 
 /// Build the login command for an agent, resolving the full executable path.
@@ -293,19 +222,17 @@ fn merge_paths(fresh: &str, current: &str) -> String {
 
 // ─── Composite functions ────────────────────────────────────────────────────
 
-/// Check a single agent: find executable + check credential.
+/// Check a single agent: find executable and surface setup hints.
 pub fn check_agent(agent_id: &str) -> AgentStatus {
     let profile = agent_registry::lookup_profile_by_id(agent_id);
     let cli_path = find_exe(agent_id);
     let cli_found = cli_path.is_some();
-    let cred = if cli_found { has_credential(agent_id) } else { false };
 
     AgentStatus {
         id: agent_id.to_string(),
         display_name: profile.display_name.to_string(),
         cli_found,
         cli_path,
-        has_credential: cred,
         install_hint: profile.install_hint.to_string(),
         auth_hint: profile.auth_hint.to_string(),
     }

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -3848,6 +3848,24 @@ impl App {
         }
     }
 
+    fn show_copilot_auth_screen(&mut self) {
+        let agent_id = "copilot";
+        let profile = crate::agent_registry::lookup_profile_by_id(agent_id);
+        let (enterprise_mode, enterprise_host) = copilot_enterprise_prefill(agent_id);
+        self.current_agent_id = agent_id.to_string();
+        self.mode = AppMode::Auth;
+        self.setup = None;
+        self.auth = Some(AuthState {
+            agent_id: agent_id.to_string(),
+            agent_name: profile.display_name.to_string(),
+            login_command: crate::agent_check::build_login_cmd(agent_id, None),
+            checking: false,
+            status_message: String::new(),
+            enterprise_mode,
+            enterprise_host,
+        });
+    }
+
     /// Diagnostic setup-mode key handler. Covers install, sign-in, and retry
     /// actions via the `SetupOption` variants.
     fn handle_setup_key(&mut self, key: KeyEvent) {
@@ -3953,19 +3971,17 @@ impl App {
             }
             SetupOption::SignIn {
                 agent_id,
-                display_name,
+                display_name: _,
             } => {
-                self.mode = AppMode::Auth;
-                let (enterprise_mode, enterprise_host) = copilot_enterprise_prefill(&agent_id);
-                self.auth = Some(AuthState {
-                    agent_id: agent_id.clone(),
-                    agent_name: display_name,
-                    login_command: crate::agent_check::build_login_cmd(&agent_id, None),
-                    checking: false,
-                    status_message: String::new(),
-                    enterprise_mode,
-                    enterprise_host,
-                });
+                if agent_id == "copilot" {
+                    self.show_copilot_auth_screen();
+                } else {
+                    tracing::warn!(
+                        target: "setup_key",
+                        agent_id = %agent_id,
+                        "ignoring SignIn option for non-Copilot agent"
+                    );
+                }
             }
             SetupOption::Retry => {
                 // Re-run preflight detection and try to reconnect
@@ -6001,19 +6017,7 @@ impl App {
                             // Copilot was just installed by IT. Route directly
                             // to sign-in instead of probing local credentials or
                             // paying for a doomed ACP auth roundtrip.
-                            self.mode = AppMode::Auth;
-                            self.setup = None;
-                            let (enterprise_mode, enterprise_host) =
-                                copilot_enterprise_prefill(&agent_id);
-                            self.auth = Some(AuthState {
-                                agent_id: agent_id.clone(),
-                                agent_name: status.display_name.clone(),
-                                login_command: crate::agent_check::build_login_cmd(&agent_id, None),
-                                checking: false,
-                                status_message: String::new(),
-                                enterprise_mode,
-                                enterprise_host,
-                            });
+                            self.show_copilot_auth_screen();
                         } else {
                             // Future-proofing: only Copilot has an in-app auth
                             // screen. If another agent ever becomes
@@ -14734,6 +14738,35 @@ mod tests {
             matches!(codex_options.as_slice(), [SetupOption::Retry]),
             "external-auth agents stay on the diagnostic Retry flow"
         );
+    }
+
+    #[test]
+    fn show_copilot_auth_screen_sets_expected_state() {
+        let mut app = test_app();
+        app.mode = AppMode::Setup;
+        app.setup = Some(SetupState {
+            reason: SetupReason::AgentError,
+            selected_index: 0,
+            preflight: PreflightResult::passed_for_custom_agent("copilot"),
+            install_in_progress: false,
+            install_log: Vec::new(),
+            install_error: None,
+            options: vec![SetupOption::Retry],
+            title: "setup".into(),
+            subtitle: "sub".into(),
+        });
+
+        app.show_copilot_auth_screen();
+
+        assert_eq!(app.mode, AppMode::Auth);
+        assert!(app.setup.is_none(), "auth screen should replace setup state");
+        assert_eq!(app.current_agent_id, "copilot");
+        let auth = app.auth.as_ref().expect("copilot auth state");
+        assert_eq!(auth.agent_id, "copilot");
+        assert_eq!(auth.agent_name, "GitHub Copilot");
+        assert!(auth.login_command.contains("copilot"));
+        assert!(!auth.checking);
+        assert!(auth.status_message.is_empty());
     }
 
     /// Render: a setup screen with a full options list while a winget install

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -323,7 +323,7 @@ pub fn build_setup_options(
                     display_name: status.display_name.clone(),
                 });
             }
-        } else if !status.has_credential || *reason == SetupReason::AgentError {
+        } else if *reason == SetupReason::AgentError {
             // CLI found but auth missing or known to have failed
             if status.id == "copilot" {
                 // Copilot: we can drive the device-flow sign-in
@@ -5997,32 +5997,10 @@ impl App {
                         // Install succeeded → proceed to connect or auth
                         let profile = crate::agent_registry::lookup_profile_by_id(&agent_id);
 
-                        if crate::agent_check::has_credential(&agent_id) {
-                            // Has credential → connect directly
-                            let new_cmd = self.build_agent_cmd(&agent_id);
-                            let _ = self.restart_tx.send(RestartRequest {
-                                agent_cmd: Some(new_cmd),
-                            });
-                            self.mode = AppMode::Chat;
-                            self.state =
-                                ConnectionState::Connecting(t!("connection.starting").into_owned());
-                            let tab = self.current_tab_mut();
-                            tab.messages.retain(|m| !matches!(m, ChatMessage::Error(_)));
-                            tab.chat_scroll.reset();
-                            self.setup = None;
-                            let (enterprise_mode, enterprise_host) =
-                                copilot_enterprise_prefill(&agent_id);
-                            self.auth = Some(AuthState {
-                                agent_id: agent_id.clone(),
-                                agent_name: status.display_name.clone(),
-                                login_command: crate::agent_check::build_login_cmd(&agent_id, None),
-                                checking: false,
-                                status_message: String::new(),
-                                enterprise_mode,
-                                enterprise_host,
-                            });
-                        } else if agent_id == "copilot" {
-                            // Copilot installed but not authenticated → auth screen.
+                        if agent_id == "copilot" {
+                            // Copilot was just installed by IT. Route directly
+                            // to sign-in instead of probing local credentials or
+                            // paying for a doomed ACP auth roundtrip.
                             self.mode = AppMode::Auth;
                             self.setup = None;
                             let (enterprise_mode, enterprise_host) =
@@ -14736,7 +14714,6 @@ mod tests {
             display_name: display.into(),
             cli_found,
             cli_path: None,
-            has_credential: false,
             install_hint: String::new(),
             auth_hint: String::new(),
         }
@@ -14744,16 +14721,14 @@ mod tests {
 
     #[test]
     fn diagnostic_setup_options_route_auth_by_agent() {
-        let mut copilot = agent_status_for_test("copilot", "GitHub Copilot", true);
-        copilot.has_credential = false;
+        let copilot = agent_status_for_test("copilot", "GitHub Copilot", true);
         let copilot_options = build_setup_options(&SetupReason::AgentError, Some(&copilot));
         assert!(
             matches!(copilot_options.as_slice(), [SetupOption::SignIn { agent_id, .. }] if agent_id == "copilot"),
             "Copilot auth failures must offer the in-app SignIn flow"
         );
 
-        let mut codex = agent_status_for_test("codex", "Codex", true);
-        codex.has_credential = false;
+        let codex = agent_status_for_test("codex", "Codex", true);
         let codex_options = build_setup_options(&SetupReason::AgentError, Some(&codex));
         assert!(
             matches!(codex_options.as_slice(), [SetupOption::Retry]),

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -306,6 +306,36 @@ fn is_post_login_auth_failure(failure: &crate::protocol::acp::failure::AgentFail
     )
 }
 
+/// True when a post-login reconnect could not even reach wta-master.
+///
+/// This is distinct from auth failure: after the IT setup flow installs Copilot,
+/// the old master may already be gone because it was spawned while `copilot`
+/// was missing. Login succeeds in the browser, but reconnecting to the saved
+/// pipe fails before initialize/authenticate/new_session can run. The right
+/// recovery is still the same fresh-master restart used for stale auth state.
+fn is_post_login_master_unavailable(
+    failure: &crate::protocol::acp::failure::AgentFailure,
+) -> bool {
+    use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
+    matches!(
+        failure,
+        AgentFailure::HandshakeFailed {
+            stage: HandshakeStage::PipeConnect,
+            ..
+        }
+    )
+}
+
+fn should_trigger_post_login_recovery(
+    post_login_auth: bool,
+    is_external_auth_agent: bool,
+    failure: &crate::protocol::acp::failure::AgentFailure,
+) -> bool {
+    post_login_auth
+        && ((is_external_auth_agent && is_post_login_auth_failure(failure))
+            || is_post_login_master_unavailable(failure))
+}
+
 /// Build the diagnostic setup options list based on the configured agent state:
 /// install when the CLI is missing and auto-installable, sign in for Copilot
 /// auth failures, or retry for external-auth / manually repaired cases.
@@ -2425,28 +2455,33 @@ impl App {
                                 &e,
                                 crate::protocol::acp::failure::HandshakeStage::Initialize,
                             );
-                            // A post-login reconnect for an External-auth agent
-                            // that STILL fails auth means the long-lived shared
-                            // master CLI is poisoned and `authenticate` won't
-                            // refresh it. Request a fresh master (auth recovery)
-                            // instead of looping back to the sign-in screen.
-                            // Match BOTH the plain AuthRequired and the post-
-                            // login HandshakeFailed{NewSession} the client
-                            // wraps a still-AuthRequired new_session into.
+                            // A post-login reconnect may fail because the old
+                            // shared master is stale/dead after login:
+                            //   * External-auth agent still AuthRequired after
+                            //     authenticate/new_session → the long-lived CLI
+                            //     cached unauthenticated state.
+                            //   * PipeConnect failure → the master died before
+                            //     login (e.g. Copilot was missing during IT
+                            //     install flow), so the saved pipe no longer
+                            //     exists.
+                            // Both need a fresh master rather than another
+                            // sign-in screen.
                             let is_external = matches!(
                                 crate::agent_registry::lookup_profile_by_id(&recovery_agent_id)
                                     .acp_auth_flow,
                                 crate::agent_registry::AcpAuthFlow::External
                             );
-                            if post_login_auth
-                                && is_external
-                                && is_post_login_auth_failure(&failure)
-                            {
+                            if should_trigger_post_login_recovery(
+                                post_login_auth,
+                                is_external,
+                                &failure,
+                            ) {
                                 tracing::warn!(
                                     target: "auth_recovery",
                                     agent_id = %recovery_agent_id,
                                     tab_id = ?recovery_tab_id,
-                                    "post-login reconnect still auth-failing on shared master CLI; requesting auth recovery"
+                                    failure_class = failure.class(),
+                                    "post-login reconnect needs fresh master; requesting auth recovery"
                                 );
                                 let _ = event_tx_for_pipe.send(AppEvent::PostLoginAuthRecovery {
                                     failure,
@@ -4709,8 +4744,7 @@ impl App {
                     failure_class = failure.class(),
                     tab_id = ?tab_id,
                     agent_id = %agent_id,
-                    "post-login auth recovery: shared master CLI still AuthRequired \
-                     after a successful login; reconnecting via a fresh master \
+                    "post-login recovery: reconnecting via a fresh master \
                      (restart_agent_stack)"
                 );
                 let resolved = if !agent_id.is_empty() {
@@ -12825,6 +12859,93 @@ mod tests {
             stage: HandshakeStage::Initialize,
             detail: "boom".to_string()
         }));
+    }
+
+    #[test]
+    fn post_login_master_unavailable_matches_only_pipe_connect() {
+        use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
+
+        assert!(is_post_login_master_unavailable(
+            &AgentFailure::HandshakeFailed {
+                stage: HandshakeStage::PipeConnect,
+                detail: "pipe missing".to_string()
+            }
+        ));
+        assert!(!is_post_login_master_unavailable(
+            &AgentFailure::HandshakeFailed {
+                stage: HandshakeStage::Initialize,
+                detail: "init failed".to_string()
+            }
+        ));
+        assert!(!is_post_login_master_unavailable(
+            &AgentFailure::HandshakeFailed {
+                stage: HandshakeStage::Authenticate,
+                detail: "auth failed".to_string()
+            }
+        ));
+        assert!(!is_post_login_master_unavailable(
+            &AgentFailure::HandshakeFailed {
+                stage: HandshakeStage::NewSession,
+                detail: "session failed".to_string()
+            }
+        ));
+    }
+
+    #[test]
+    fn typed_pipe_connect_failure_survives_classify_anyhow() {
+        use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
+
+        let err = anyhow::Error::new(AgentFailure::HandshakeFailed {
+            stage: HandshakeStage::PipeConnect,
+            detail: "connect to master pipe after 3 attempts: missing".into(),
+        });
+
+        assert_eq!(
+            crate::protocol::acp::failure::classify_anyhow(&err, HandshakeStage::Initialize),
+            AgentFailure::HandshakeFailed {
+                stage: HandshakeStage::PipeConnect,
+                detail: "connect to master pipe after 3 attempts: missing".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn post_login_recovery_route_covers_pipe_connect_without_external_auth_gate() {
+        use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
+
+        let pipe_connect = AgentFailure::HandshakeFailed {
+            stage: HandshakeStage::PipeConnect,
+            detail: "pipe missing".to_string(),
+        };
+        assert!(
+            should_trigger_post_login_recovery(
+                true,
+                false,
+                &pipe_connect
+            ),
+            "post-login master-unavailable recovery must not be gated on External auth flow"
+        );
+        assert!(
+            !should_trigger_post_login_recovery(
+                false,
+                false,
+                &pipe_connect
+            ),
+            "non-post-login pipe failures should surface normally"
+        );
+
+        let still_auth = AgentFailure::HandshakeFailed {
+            stage: HandshakeStage::NewSession,
+            detail: "still auth".to_string(),
+        };
+        assert!(
+            should_trigger_post_login_recovery(true, true, &still_auth),
+            "external post-login auth failures still recover via fresh master"
+        );
+        assert!(
+            !should_trigger_post_login_recovery(true, false, &still_auth),
+            "non-external auth failures should not use auth-stale recovery"
+        );
     }
 
     /// `PostLoginAuthRecovery` shows a transient "Reconnecting…" (NOT the

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -3848,7 +3848,7 @@ impl App {
         }
     }
 
-    fn show_copilot_auth_screen(&mut self) {
+    pub(crate) fn show_copilot_auth_screen(&mut self) {
         let agent_id = "copilot";
         let profile = crate::agent_registry::lookup_profile_by_id(agent_id);
         let (enterprise_mode, enterprise_host) = copilot_enterprise_prefill(agent_id);

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2495,6 +2495,28 @@ async fn run_info_mode() -> Result<()> {
     Ok(())
 }
 
+fn spawn_restart_agent_stack_forwarder(
+    mut restart_rx: tokio::sync::mpsc::UnboundedReceiver<
+        protocol::acp::client::RestartRequest,
+    >,
+) {
+    tokio::task::spawn_local(async move {
+        while let Some(req) = restart_rx.recv().await {
+            tracing::info!(
+                target: "helper",
+                new_agent = ?req.agent_cmd,
+                "restart requested before ACP task is running; asking WT to force-restart the agent stack"
+            );
+            let evt = serde_json::json!({
+                "type": "event",
+                "method": "restart_agent_stack",
+                "params": {},
+            });
+            crate::app::send_wt_protocol_event(evt.to_string());
+        }
+    });
+}
+
 async fn run_acp_app(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     cli: Cli,
@@ -2767,26 +2789,7 @@ async fn run_acp_app(
                 // The other receivers (prompt/new_session/…) genuinely have no
                 // master to reach, so they're dropped; they're re-created when
                 // /restart reopens this pane fresh.
-                {
-                    let mut restart_rx: tokio::sync::mpsc::UnboundedReceiver<
-                        protocol::acp::client::RestartRequest,
-                    > = restart_rx;
-                    tokio::task::spawn_local(async move {
-                        while let Some(req) = restart_rx.recv().await {
-                            tracing::info!(
-                                target: "helper",
-                                new_agent = ?req.agent_cmd,
-                                "restart requested while disconnected — asking WT to force-restart the agent stack"
-                            );
-                            let evt = serde_json::json!({
-                                "type": "event",
-                                "method": "restart_agent_stack",
-                                "params": {},
-                            });
-                            crate::app::send_wt_protocol_event(evt.to_string());
-                        }
-                    });
-                }
+                spawn_restart_agent_stack_forwarder(restart_rx);
                 // The remaining receivers have no master to forward to. They
                 // get re-created when /restart respawns the stack and reopens
                 // this pane fresh.
@@ -2812,6 +2815,12 @@ async fn run_acp_app(
                 // after login. Dropping the boot channels here avoids an
                 // explicit initial ACP race and makes the startup ordering
                 // independent from tokio task polling.
+                //
+                // Keep the /restart path alive even though no ACP task is
+                // running yet. The boot App holds the sole restart sender; when
+                // LoginComplete calls `try_start_acp`, it replaces that sender
+                // with a fresh channel and this forwarder exits.
+                spawn_restart_agent_stack_forwarder(restart_rx);
                 drop((
                     prompt_rx,
                     cancel_rx,
@@ -2819,7 +2828,6 @@ async fn run_acp_app(
                     load_session_rx,
                     drop_session_rx,
                     rename_session_rx,
-                    restart_rx,
                     session_hook_rx,
                     master_ext_rx,
                 ));

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -160,6 +160,13 @@ struct Cli {
     #[arg(long)]
     agent_id: Option<String>,
 
+    /// Boot-time hint from Windows Terminal: start directly on the auth screen
+    /// for the given agent instead of attempting the initial ACP session. Used
+    /// when FRE just installed Copilot, where the next expected action is
+    /// signing in. Hidden — only Windows Terminal should pass it.
+    #[arg(long, hide = true, value_name = "AGENT_ID")]
+    initial_auth_agent: Option<String>,
+
     /// Model override for the ACP agent. Sent via ACP setSessionModel after
     /// handshake. Used by adapter-style launches (claude, codex via npx)
     /// where the model can't be passed on the command line; native ACP
@@ -2648,12 +2655,95 @@ async fn run_acp_app(
             // events by the same StableId C++ routes per-tab events with.
             protocol::acp::client::set_helper_owner_tab_id(cli.owner_tab_id.as_deref());
 
+            let explicit_agent_id = cli
+                .agent_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty());
+            let canonical_agent_id: String = explicit_agent_id
+                .map(str::to_ascii_lowercase)
+                .unwrap_or_else(|| {
+                    agent_registry::resolve_agent_id_from_cmd(&agent_cmd).to_string()
+                });
+            let canonical_agent_source = if explicit_agent_id.is_some() {
+                "--agent-id"
+            } else {
+                "resolved-from-cmd"
+            };
+            let initial_load_requested = cli
+                .initial_load_session_id
+                .as_deref()
+                .map(str::trim)
+                .map(|s| !s.is_empty())
+                .unwrap_or(false);
+            let initial_auth_agent = match cli
+                .initial_auth_agent
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            {
+                Some(requested) if cli.assume_master_down => {
+                    tracing::warn!(
+                        target: "initial_auth",
+                        requested_agent = %requested,
+                        "--initial-auth-agent ignored because --assume-master-down is active"
+                    );
+                    None
+                }
+                Some(requested) if cli.start_stashed => {
+                    tracing::warn!(
+                        target: "initial_auth",
+                        requested_agent = %requested,
+                        "--initial-auth-agent ignored because --start-stashed is active"
+                    );
+                    None
+                }
+                Some(requested) if cli.setup.is_some() => {
+                    tracing::warn!(
+                        target: "initial_auth",
+                        requested_agent = %requested,
+                        "--initial-auth-agent ignored because --setup is active"
+                    );
+                    None
+                }
+                Some(requested) if initial_load_requested => {
+                    tracing::warn!(
+                        target: "initial_auth",
+                        requested_agent = %requested,
+                        "--initial-auth-agent ignored because --initial-load-session-id is active"
+                    );
+                    None
+                }
+                Some(requested) => {
+                    let requested_agent = requested.to_ascii_lowercase();
+                    if requested_agent != canonical_agent_id {
+                        tracing::warn!(
+                            target: "initial_auth",
+                            requested_agent = %requested_agent,
+                            current_agent = %canonical_agent_id,
+                            "--initial-auth-agent ignored because it does not match the effective agent"
+                        );
+                        None
+                    } else if requested_agent != "copilot" {
+                        tracing::warn!(
+                            target: "initial_auth",
+                            requested_agent = %requested_agent,
+                            "--initial-auth-agent ignored for unsupported agent"
+                        );
+                        None
+                    } else {
+                        Some(requested_agent)
+                    }
+                }
+                None => None,
+            };
+            let start_in_initial_auth = initial_auth_agent.as_deref() == Some("copilot");
+
             // Spawn the ACP client. In helper mode (`--connect-master <pipe>`)
-            // master owns the agent lifecycle, so we always spawn the
-            // pipe-attached variant immediately — there's no FRE flow to defer
-            // to. If the user is mid-FRE the initial handshake fails with
-            // `Authentication required` and `try_start_acp` re-spawns this task
-            // post-login.
+            // master owns the agent lifecycle, so normal panes spawn the
+            // pipe-attached variant immediately. FRE-installed Copilot is the
+            // exception: `--initial-auth-agent copilot` starts on Auth and lets
+            // `LoginComplete` spawn the first pipe client after sign-in.
             if cli.assume_master_down {
                 // Degraded open: master is known down, so don't even try the
                 // (dead) pipe — go straight to the disconnected view that an
@@ -2707,6 +2797,29 @@ async fn run_acp_app(
                     load_session_rx,
                     drop_session_rx,
                     rename_session_rx,
+                    session_hook_rx,
+                    master_ext_rx,
+                ));
+            } else if start_in_initial_auth {
+                tracing::info!(
+                    target: "initial_auth",
+                    agent_id = %canonical_agent_id,
+                    "starting helper on auth screen; initial ACP task skipped"
+                );
+                // The Auth screen's LoginComplete path uses
+                // `set_master_pipe_acp_params` below and `try_start_acp` to
+                // create fresh channels and reconnect through the master pipe
+                // after login. Dropping the boot channels here avoids an
+                // explicit initial ACP race and makes the startup ordering
+                // independent from tokio task polling.
+                drop((
+                    prompt_rx,
+                    cancel_rx,
+                    new_session_rx,
+                    load_session_rx,
+                    drop_session_rx,
+                    rename_session_rx,
+                    restart_rx,
                     session_hook_rx,
                     master_ext_rx,
                 ));
@@ -2825,43 +2938,36 @@ async fn run_acp_app(
                 wt_connected,
             );
 
+            if cli.setup.is_none() {
+                app_state.current_agent_id = canonical_agent_id.clone();
+                tracing::info!(
+                    target: "agents_view_filter",
+                    agent_id = %canonical_agent_id,
+                    agent_cmd = %agent_cmd,
+                    source = canonical_agent_source,
+                    "current_agent_id assigned",
+                );
+            }
+            if start_in_initial_auth {
+                app_state.show_copilot_auth_screen();
+            }
+
             // ── Preflight: check the agent CLI before connecting ──────────
             // Skip preflight when FRE is active — FRE has its own agent
             // selection + auth flow and doesn't need the preflight wizard.
-            if cli.setup.is_none() {
-                // Prefer the canonical id the host passed via `--agent-id`
-                // — that's the user's actual setting value (`acpAgent`).
-                // Fall back to reverse-parsing the `--agent` command line
-                // for manual runs / older hosts.
-                let canonical_id: String = cli
-                    .agent_id
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|s| !s.is_empty())
-                    .map(str::to_ascii_lowercase)
-                    .unwrap_or_else(|| {
-                        agent_registry::resolve_agent_id_from_cmd(&agent_cmd).to_string()
-                    });
-                app_state.current_agent_id = canonical_id.clone();
-                tracing::info!(
-                    target: "agents_view_filter",
-                    agent_id = %canonical_id,
-                    agent_cmd = %agent_cmd,
-                    source = if cli.agent_id.is_some() { "--agent-id" } else { "resolved-from-cmd" },
-                    "current_agent_id assigned",
-                );
-                let agent_id = canonical_id.as_str();
+            if cli.setup.is_none() && !start_in_initial_auth {
+                let agent_id = canonical_agent_id.as_str();
                 let preflight_result = if agent_id.starts_with("custom:")
                     || agent_registry::lookup_profile_by_id(agent_id).id == "unknown"
                 {
                     // Custom/unknown agents: command is opaque (`.cmd`, `node script.js`,
                     // shell function, …); a PATH probe would lie. The real spawn produces
                     // the authoritative error via `ConnectionFailed`, so skip preflight.
-                    app::PreflightResult::passed_for_custom_agent(&canonical_id)
+                    app::PreflightResult::passed_for_custom_agent(&canonical_agent_id)
                 } else {
                     let status = agent_check::check_agent(agent_id);
                     app::PreflightResult {
-                        agent_id: canonical_id.clone(),
+                        agent_id: canonical_agent_id.clone(),
                         display_name: status.display_name.clone(),
                         cli_status: if status.cli_found {
                             app::CheckStatus::Passed
@@ -3052,7 +3158,10 @@ async fn run_acp_app(
             //
             // Skip in setup mode: --setup takes the diagnostic path and the user
             // shouldn't be dropped into an empty session list.
-            if cli.setup.is_none() && cli.initial_view == InitialView::Sessions {
+            if cli.setup.is_none()
+                && !start_in_initial_auth
+                && cli.initial_view == InitialView::Sessions
+            {
                 tracing::info!(target: "initial_view", "starting in agent session view");
                 let tab_id = app_state
                     .tab_id

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2869,13 +2869,9 @@ async fn run_acp_app(
                             app::CheckStatus::Failed("Not found on PATH".to_string())
                         },
                         cli_path: status.cli_path.clone(),
-                        auth_status: if !status.cli_found {
-                            app::CheckStatus::Skipped
-                        } else if status.has_credential {
-                            app::CheckStatus::Passed
-                        } else {
-                            app::CheckStatus::Skipped
-                        },
+                        // Authentication is checked by the ACP handshake rather
+                        // than by a local credential-store preflight.
+                        auth_status: app::CheckStatus::Skipped,
                         install_hint: status.install_hint.clone(),
                         install_url: String::new(),
                         auth_hint: status.auth_hint.clone(),

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1,4 +1,4 @@
-use super::failure::AgentFailure;
+use super::failure::{AgentFailure, HandshakeStage};
 use super::prompt;
 use super::prompt_context::{self, ContextRequest};
 use super::soft_stop::SoftStopReason;
@@ -18,6 +18,20 @@ use crate::pane_context::PaneContext;
 use crate::shell::{ShellManager, TerminalConfig};
 
 const ACTIVE_PANE_CONTEXT_MAX_CHARS: usize = 4000;
+// Normal helper startup can race a slow wta-master cold start: master opens its
+// pipe only after spawning and initializing the agent CLI (up to 60s for npx
+// adapters), so keep a long budget there.
+const MASTER_PIPE_BACKOFF_MS: &[u64] = &[
+    50, 100, 100, 200, 200, 500, 500, 1000, 1000, 2000, 2000, 2000, 5000, 5000, 5000, 5000,
+    10000, 10000, 10000, 15000,
+];
+// Post-login reconnect is different: if the old master pipe is gone, the right
+// recovery is a fresh master restart. Keep a short bounded retry so brief
+// respawn/ERROR_PIPE_BUSY windows are tolerated without stranding the user for
+// the full cold-start budget.
+const POST_LOGIN_MASTER_PIPE_BACKOFF_MS: &[u64] = &[
+    50, 100, 100, 200, 200, 500, 500, 1000, 1000, 2000, 2000, 2000,
+];
 
 // Form A mock-ACP-agent harness + scenario tests (in-process, deterministic).
 // Lives as a sibling file so it stays out of this large module, but is a child
@@ -2107,12 +2121,11 @@ pub async fn run_acp_client_over_pipe(
     const ERROR_PIPE_BUSY: i32 = 231;
     let pipe = {
         let mut attempt: u32 = 0;
-        // Backoff schedule, summing to ~75s total. Most masters come
-        // up in 1-2s; the long tail is npx adapter cold starts.
-        let backoff_ms: &[u64] = &[
-            50, 100, 100, 200, 200, 500, 500, 1000, 1000, 2000, 2000, 2000, 5000, 5000, 5000, 5000,
-            10000, 10000, 10000, 15000,
-        ];
+        let backoff_ms = if post_login_reconnect {
+            POST_LOGIN_MASTER_PIPE_BACKOFF_MS
+        } else {
+            MASTER_PIPE_BACKOFF_MS
+        };
         loop {
             match tokio::net::windows::named_pipe::ClientOptions::new().open(&pipe_name) {
                 Ok(pipe) => {
@@ -2140,12 +2153,16 @@ pub async fn run_acp_client_over_pipe(
                             error = %e,
                             "master pipe connect giving up"
                         );
-                        return Err(anyhow::anyhow!(
+                        let detail = format!(
                             "connect to master pipe '{}' after {} attempt(s): {}",
                             pipe_name,
                             attempt + 1,
                             e
-                        ));
+                        );
+                        return Err(anyhow::Error::new(AgentFailure::HandshakeFailed {
+                            stage: HandshakeStage::PipeConnect,
+                            detail,
+                        }));
                     }
                     let wait = backoff_ms[attempt as usize];
                     tracing::debug!(

--- a/tools/wta/src/win32.rs
+++ b/tools/wta/src/win32.rs
@@ -4,77 +4,6 @@
 #[cfg(windows)]
 use std::io;
 
-/// Copilot CLI stores its OAuth credential in Windows Credential Manager under
-/// target names containing `copilot-cli`. This predicate is deliberately kept
-/// pure so the matching behavior is testable without touching a user's
-/// Credential Manager store.
-pub(crate) fn credential_target_matches_copilot(target: &str) -> bool {
-    target.to_ascii_lowercase().contains("copilot-cli")
-}
-
-#[cfg(windows)]
-unsafe fn wide_ptr_to_string(ptr: *const u16) -> String {
-    use std::ffi::OsString;
-    use std::os::windows::ffi::OsStringExt;
-
-    if ptr.is_null() {
-        return String::new();
-    }
-    let mut len = 0usize;
-    while unsafe { *ptr.add(len) } != 0 {
-        len += 1;
-    }
-    let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
-    OsString::from_wide(slice).to_string_lossy().into_owned()
-}
-
-#[cfg(windows)]
-struct CredentialArray(*mut *mut windows_sys::Win32::Security::Credentials::CREDENTIALW);
-
-#[cfg(windows)]
-impl Drop for CredentialArray {
-    fn drop(&mut self) {
-        unsafe {
-            windows_sys::Win32::Security::Credentials::CredFree(self.0 as _);
-        }
-    }
-}
-
-/// Read-only Copilot credential presence check using the native Credential
-/// Manager API. We inspect target names only; the credential secret/blob is
-/// never read.
-#[cfg(windows)]
-pub(crate) fn copilot_credential_present() -> bool {
-    use windows_sys::Win32::Security::Credentials::{CredEnumerateW, CREDENTIALW};
-
-    let mut count = 0u32;
-    let mut credentials: *mut *mut CREDENTIALW = std::ptr::null_mut();
-    // Enumerate all targets and apply our own substring predicate to preserve
-    // parity with the old shell-based substring probe. Copilot CLI has
-    // used both prefix (`copilot-cli/...`) and suffix (`... .copilot-cli`)
-    // target shapes; CredEnumerateW's filter is prefix-only and would miss the
-    // suffix form. We still inspect target names only — never credential blobs.
-    let ok = unsafe { CredEnumerateW(std::ptr::null(), 0, &mut count, &mut credentials) != 0 };
-    if !ok || credentials.is_null() || count == 0 {
-        return false;
-    }
-
-    let _guard = CredentialArray(credentials);
-    let entries = unsafe { std::slice::from_raw_parts(credentials, count as usize) };
-    entries.iter().any(|&cred| {
-        if cred.is_null() {
-            return false;
-        }
-        let target = unsafe { wide_ptr_to_string((*cred).TargetName) };
-        credential_target_matches_copilot(&target)
-    })
-}
-
-#[cfg(not(windows))]
-pub(crate) fn copilot_credential_present() -> bool {
-    false
-}
-
 #[cfg(windows)]
 struct ClipboardGuard;
 
@@ -195,23 +124,4 @@ pub(crate) fn open_url_in_default_browser(_url: &str) -> std::io::Result<()> {
         std::io::ErrorKind::Unsupported,
         "opening URLs is only supported on Windows",
     ))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::credential_target_matches_copilot;
-
-    #[test]
-    fn copilot_credential_match_accepts_known_target_shapes() {
-        assert!(credential_target_matches_copilot("copilot-cli/https://github.com:user"));
-        assert!(credential_target_matches_copilot("https://github.com:user.copilot-cli"));
-        assert!(credential_target_matches_copilot("COPILOT-CLI/https://example.ghe.com:user"));
-    }
-
-    #[test]
-    fn copilot_credential_match_rejects_unrelated_targets() {
-        assert!(!credential_target_matches_copilot(""));
-        assert!(!credential_target_matches_copilot("github.com:user"));
-        assert!(!credential_target_matches_copilot("other-agent-cli"));
-    }
 }


### PR DESCRIPTION
## Summary

This PR refines the Copilot auth flow by removing the local Credential Manager shortcut and relying on ACP as the source of truth for authentication state.

Changes:
- Remove the Copilot-specific `has_credential` / Credential Manager auth shortcut from WTA preflight.
- Keep Copilot-specific remediation UI by routing ACP auth failures to the Copilot Auth screen.
- Centralize Copilot Auth screen setup in `show_copilot_auth_screen()`.
- Route WTA-installed Copilot directly to Auth after install instead of credential-probing.
- Add `--initial-auth-agent copilot` so FRE-installed Copilot opens directly in sign-in mode.
- Recover the WTA install -> Auth -> login path when the original `wta-master` died before creating its pipe because Copilot was missing:
  - classify master pipe connect failures as `PipeConnect`
  - use a shorter post-login reconnect retry budget
  - route post-login missing-master failures through existing `PostLoginAuthRecovery`

## Validation

- `cargo test --target x86_64-pc-windows-msvc`
  - `983 passed`
- `src\cascadia\TerminalApp` incremental build (`bx`)
- Code-review/rubber-duck review found no substantive issues.
- Manual VM validation:
  - uninstall Copilot CLI
  - install Copilot through Intelligent Terminal setup/preflight
  - complete Copilot Auth in browser
  - verified the pane recovers via reconnect and enters Chat instead of failing on stale/dead master pipe

## Notes

The FRE install path and the WTA setup/install path now both preserve the expected UX: after Copilot is installed, the next user action is sign-in, and after sign-in the agent stack reconnects through a fresh working master when needed.

Non-Copilot agents, normal pane open, prewarm/stashed helpers, degraded/restart paths, and session resume paths are guarded from the `--initial-auth-agent` handoff.
