### PR TITLE
Render markdown in agent pane replies

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -698,6 +698,7 @@ if it were canonical for the whole group.
 - **portable-atomic** v1.13.1 -- [https://github.com/taiki-e/portable-atomic](https://github.com/taiki-e/portable-atomic) -- `Apache-2.0 OR MIT`
 - **powerfmt** v0.2.0 -- [https://github.com/jhpratt/powerfmt](https://github.com/jhpratt/powerfmt) -- `Apache-2.0 OR MIT`
 - **proc-macro2** v1.0.106 -- [https://github.com/dtolnay/proc-macro2](https://github.com/dtolnay/proc-macro2) -- `Apache-2.0 OR MIT`
+- **pulldown-cmark** v0.10.3 -- [https://github.com/raphlinus/pulldown-cmark](https://github.com/raphlinus/pulldown-cmark) -- `MIT`
 - **pxfm** v0.1.29 -- [https://github.com/awxkee/pxfm](https://github.com/awxkee/pxfm) -- `Apache-2.0 OR BSD-3-Clause`
 - **quote** v1.0.45 -- [https://github.com/dtolnay/quote](https://github.com/dtolnay/quote) -- `Apache-2.0 OR MIT`
 - **rand** v0.8.5 -- [https://github.com/rust-random/rand](https://github.com/rust-random/rand) -- `Apache-2.0 OR MIT`
@@ -777,6 +778,7 @@ if it were canonical for the whole group.
 - **triomphe** v0.1.15 -- [https://github.com/Manishearth/triomphe](https://github.com/Manishearth/triomphe) -- `Apache-2.0 OR MIT`
 - **typenum** v1.19.0 -- [https://github.com/paholg/typenum](https://github.com/paholg/typenum) -- `Apache-2.0 OR MIT`
 - **ucd-trie** v0.1.7 -- [https://github.com/BurntSushi/ucd-generate](https://github.com/BurntSushi/ucd-generate) -- `Apache-2.0 OR MIT`
+- **unicase** v2.9.0 -- [https://github.com/seanmonstar/unicase](https://github.com/seanmonstar/unicase) -- `Apache-2.0 OR MIT`
 - **unicode-ident** v1.0.24 -- [https://github.com/dtolnay/unicode-ident](https://github.com/dtolnay/unicode-ident) -- `(MIT OR Apache-2.0) AND Unicode-3.0`
 - **unicode-linebreak** v0.1.5 -- [https://github.com/axelf4/unicode-linebreak](https://github.com/axelf4/unicode-linebreak) -- `Apache-2.0`
 - **unicode-segmentation** v1.12.0 -- [https://github.com/unicode-rs/unicode-segmentation](https://github.com/unicode-rs/unicode-segmentation) -- `Apache-2.0 OR MIT`
@@ -829,7 +831,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 ### `Apache-2.0`
 
-Applies to 164 crate(s) (directly or via composite identifiers): adler2 v2.0.1, agent-client-protocol v0.10.0, agent-client-protocol-schema v0.11.0, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, anstyle-query v1.1.5, ... (+156 more)
+Applies to 165 crate(s) (directly or via composite identifiers): adler2 v2.0.1, agent-client-protocol v0.10.0, agent-client-protocol-schema v0.11.0, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, anstyle-query v1.1.5, ... (+157 more)
 
 _Canonical text reproduced from upstream `SPDX:Apache-2.0`:_
 
@@ -923,6 +925,7 @@ Copyright (c) 2014 Chris Morgan and the Teepee project developers
 Copyright (c) 2014 Paho Lurie-Gregg
 Copyright (c) 2014 The Rust Project Developers
 Copyright (c) 2014-2026 Alex Crichton
+Copyright (c) 2014-2026 Sean McArthur
 Copyright (c) 2015 Alice Maz
 Copyright (c) 2015 Andrew Gallant
 Copyright (c) 2015 nwin
@@ -1157,7 +1160,7 @@ express Statement of Purpose.
 
 ### `MIT`
 
-Applies to 240 crate(s) (directly or via composite identifiers): adler2 v2.0.1, aho-corasick v1.1.4, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, anstyle-query v1.1.5, anstyle-wincon v3.0.11, ... (+232 more)
+Applies to 242 crate(s) (directly or via composite identifiers): adler2 v2.0.1, aho-corasick v1.1.4, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, anstyle-query v1.1.5, anstyle-wincon v3.0.11, ... (+234 more)
 
 _Canonical text reproduced from upstream `SPDX:MIT`:_
 
@@ -1200,6 +1203,7 @@ Copyright (c) 2014 The Rust Project Developers
 Copyright (c) 2014-2019 Geoffroy Couprie
 Copyright (c) 2014-2022 Steven Fackler, Yuki Okushi
 Copyright (c) 2014-2026 Alex Crichton
+Copyright (c) 2014-2026 Sean McArthur
 Copyright (c) 2015 Alice Maz
 Copyright (c) 2015 Andrew Gallant
 Copyright (c) 2015 Bartłomiej Kamiński
@@ -1282,6 +1286,7 @@ Copyright 2010-2014 Rich Geldreich and Tenacious Software LLC
 Copyright 2012-2016 The Rust Project Developers.
 Copyright 2013-2014 RAD Game Tools and Valve Software
 Copyright 2014 Paho Lurie-Gregg
+Copyright 2015 Google Inc. All rights reserved.
 Copyright 2015 The Fancy Regex Authors.
 Copyright 2016-2026 Frank Denis.
 Copyright 2018 Developers of the Rand project

--- a/tools/wta/Cargo.lock
+++ b/tools/wta/Cargo.lock
@@ -1483,6 +1483,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
+dependencies = [
+ "bitflags 2.11.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2417,6 +2428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,6 +2943,7 @@ dependencies = [
  "futures",
  "image",
  "notify",
+ "pulldown-cmark",
  "ratatui",
  "rust-i18n",
  "serde",

--- a/tools/wta/Cargo.toml
+++ b/tools/wta/Cargo.toml
@@ -23,6 +23,9 @@ notify = "6"
 futures = "0.3"
 unicode-width = "0.2"
 textwrap = "0.16"
+# CommonMark parser used only at render time for agent-pane Markdown replies;
+# WTA owns the terminal layout/wrapping so markers and hanging indents stay stable.
+pulldown-cmark = { version = "0.10", default-features = false }
 serde = { version = "1", features = ["derive"] }
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",

--- a/tools/wta/cgmanifest.json
+++ b/tools/wta/cgmanifest.json
@@ -1283,6 +1283,15 @@
       "component": {
         "type": "cargo",
         "cargo": {
+          "name": "pulldown-cmark",
+          "version": "0.10.3"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
           "name": "pxfm",
           "version": "0.1.29"
         }
@@ -1987,6 +1996,15 @@
         "cargo": {
           "name": "ucd-trie",
           "version": "0.1.7"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "unicase",
+          "version": "2.9.0"
         }
       }
     },

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -360,6 +360,9 @@ pub enum ConnectionState {
 pub enum ChatMessage {
     User(String),
     Agent(String),
+    /// App-generated agent-style text that should stay literal (for example
+    /// parsed recommendation summaries containing command strings).
+    AgentLiteral(String),
     System(String),
     ToolCall {
         id: String,
@@ -8850,7 +8853,7 @@ impl App {
         let tab = self.session_tab_mut(session_id);
         let prompt = tab.turn.prompt().cloned().expect("prompt set");
         let mut details = tab.current_turn_details();
-        details.push(ChatMessage::Agent(summary));
+        details.push(ChatMessage::AgentLiteral(summary));
         tab.completed_turns.push(CompletedTurn {
             prompt: prompt.text.clone(),
             details,
@@ -8932,7 +8935,7 @@ impl App {
         let tab = self.session_tab_mut(session_id);
         let prompt = tab.turn.prompt().cloned().expect("prompt set");
         let mut details = tab.current_turn_details();
-        details.push(ChatMessage::Agent(summary));
+        details.push(ChatMessage::AgentLiteral(summary));
         tab.completed_turns.push(CompletedTurn {
             prompt: turn_prompt_label,
             details,

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -5,6 +5,7 @@ use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
 use crate::app::{App, ChatMessage, CompletedTurn, PlanEntryStatus};
 use crate::theme;
+use crate::ui::markdown;
 use crate::ui::shimmer;
 use crate::ui_trace;
 
@@ -52,8 +53,7 @@ fn pending_stream_height(tab: &crate::app::TabSession, wrap_width: usize) -> usi
     let Some(text) = pending_render_text(tab) else {
         return 0;
     };
-    let body_width = wrap_width.saturating_sub(2).max(1);
-    dot_wrap_count(&text, body_width)
+    markdown::agent_markdown_height(&text, wrap_width)
 }
 
 fn wrap_count(text: &str, width: usize) -> usize {
@@ -79,7 +79,9 @@ fn message_height(msg: &ChatMessage, wrap_width: usize) -> usize {
     // "> " for user) and a trailing blank line.
     let body_width = wrap_width.saturating_sub(2).max(1);
     match msg {
-        ChatMessage::Agent(t) | ChatMessage::Error(t) => dot_wrap_count(t, body_width) + 1,
+        ChatMessage::Agent(t) => markdown::agent_markdown_height(t, wrap_width) + 1,
+        ChatMessage::AgentLiteral(t) => dot_wrap_count(t, body_width) + 1,
+        ChatMessage::Error(t) => dot_wrap_count(t, body_width) + 1,
         ChatMessage::User(t) => wrap_count(t, body_width) + 1,
         ChatMessage::System(t) | ChatMessage::AgentEvent(t) => wrap_count(t, wrap_width) + 1,
         ChatMessage::ToolCall { .. } => 1,
@@ -459,15 +461,12 @@ fn build_pending_stream_lines<'a>(app: &App, wrap_width: usize) -> Vec<Line<'a>>
             Cow::Owned(text.chars().take(shown).collect())
         }
     };
-    let mut lines = Vec::new();
-    push_dot_prefixed_lines(
-        &mut lines,
+    markdown::render_agent_markdown_lines(
         &revealed,
         wrap_width,
         theme::DOT_AGENT,
         theme::AGENT_TEXT,
-    );
-    lines
+    )
 }
 
 fn build_message_lines<'a>(
@@ -486,6 +485,17 @@ fn build_message_lines<'a>(
             lines.push(Line::default());
         }
         ChatMessage::Agent(text) => {
+            lines.extend(markdown::render_agent_markdown_lines(
+                text,
+                wrap_width,
+                theme::DOT_AGENT,
+                theme::AGENT_TEXT,
+            ));
+            if !agent_streaming || !is_last_message {
+                lines.push(Line::default());
+            }
+        }
+        ChatMessage::AgentLiteral(text) => {
             push_dot_prefixed_lines(
                 &mut lines,
                 text,
@@ -842,6 +852,86 @@ mod tests {
         assert!(
             line_text(&lines[1]).starts_with("  "),
             "continuation rows get a 2-cell hanging indent"
+        );
+    }
+
+    #[test]
+    fn agent_message_uses_markdown_renderer() {
+        let msg = ChatMessage::Agent("hello **bold**".to_string());
+        let lines = build_message_lines(
+            &msg,
+            false,
+            false,
+            80,
+        );
+        assert_eq!(line_text(&lines[0]), "● hello bold");
+        assert!(lines[0].spans.iter().any(|s| {
+            s.content.as_ref() == "bold" && s.style.add_modifier.contains(Modifier::BOLD)
+        }));
+    }
+
+    #[test]
+    fn agent_markdown_bold_survives_paragraph_render() {
+        use ratatui::{backend::TestBackend, widgets::Paragraph, Terminal};
+
+        let msg = ChatMessage::Agent("hello **bold**".to_string());
+        let lines = build_message_lines(&msg, false, false, 80);
+        let backend = TestBackend::new(80, 4);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| frame.render_widget(Paragraph::new(lines), frame.area()))
+            .expect("render must not panic");
+        let buf = terminal.backend().buffer();
+        let width = buf.area.width as usize;
+        let first_row: String = buf.content[..width]
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        let start_byte = first_row.find("bold").expect("bold text rendered");
+        let start = unicode_width::UnicodeWidthStr::width(&first_row[..start_byte]);
+        let bold_cells = &buf.content[start..start + 4];
+        assert!(
+            bold_cells
+                .iter()
+                .all(|cell| cell.modifier.contains(Modifier::BOLD)),
+            "bold chars must stay bold in the final ratatui buffer"
+        );
+    }
+
+    #[test]
+    fn error_message_stays_literal_not_markdown() {
+        let msg = ChatMessage::Error("bad **thing**".to_string());
+        let lines = build_message_lines(
+            &msg,
+            false,
+            false,
+            80,
+        );
+        assert_eq!(line_text(&lines[0]), "● bad **thing**");
+        assert!(
+            !lines[0]
+                .spans
+                .iter()
+                .filter(|s| s.content.as_ref().contains("thing"))
+                .any(|s| s.style.add_modifier.contains(Modifier::BOLD)),
+            "error text must not be parsed as markdown"
+        );
+    }
+
+    #[test]
+    fn agent_literal_message_stays_literal_not_markdown() {
+        let msg = ChatMessage::AgentLiteral("Run: echo **literal**\n  ✓ 1. command".to_string());
+        let lines = build_message_lines(
+            &msg,
+            false,
+            false,
+            80,
+        );
+        let texts: Vec<String> = lines.iter().map(line_text).collect();
+        assert!(texts.iter().any(|line| line.contains("**literal**")));
+        assert!(
+            texts.iter().any(|line| line.contains("✓ 1. command")),
+            "recommendation summary lines must remain separate/literal: {texts:?}"
         );
     }
 }

--- a/tools/wta/src/ui/markdown.rs
+++ b/tools/wta/src/ui/markdown.rs
@@ -111,8 +111,14 @@ fn markdown_to_runs(text: &str, base_style: Style) -> Vec<StyledRun> {
                 _ => {}
             },
             Event::End(tag) => match tag {
-                TagEnd::Paragraph
-                | TagEnd::Item
+                TagEnd::Paragraph => {
+                    if lists.is_empty() {
+                        append_paragraph_break(&mut runs, *styles.last().unwrap());
+                    } else {
+                        append_newline(&mut runs, *styles.last().unwrap());
+                    }
+                }
+                TagEnd::Item
                 | TagEnd::FootnoteDefinition => append_newline(&mut runs, *styles.last().unwrap()),
                 TagEnd::Heading(_) | TagEnd::CodeBlock => {
                     append_newline(&mut runs, *styles.last().unwrap());
@@ -248,6 +254,11 @@ fn append_newline(runs: &mut Vec<StyledRun>, style: Style) {
 
 fn append_forced_newline(runs: &mut Vec<StyledRun>, style: Style) {
     append_text(runs, "\n", style);
+}
+
+fn append_paragraph_break(runs: &mut Vec<StyledRun>, style: Style) {
+    append_newline(runs, style);
+    append_forced_newline(runs, style);
 }
 
 fn ensure_line_start(runs: &mut Vec<StyledRun>, style: Style) {
@@ -533,6 +544,31 @@ code
         assert!(text.contains("> quote"));
         assert!(text.contains("---"));
         assert!(text.contains("code"));
+    }
+
+    #[test]
+    fn paragraph_break_preserves_blank_line() {
+        let lines = render_text("first\n\nsecond", 80);
+        let texts: Vec<String> = lines.iter().map(line_text).collect();
+        assert!(
+            texts.windows(3).any(|w| {
+                w[0].contains("first") && w[1].is_empty() && w[2].contains("second")
+            }),
+            "separate paragraphs must keep a blank line: {texts:?}"
+        );
+    }
+
+    #[test]
+    fn list_items_stay_compact_without_extra_blank_lines() {
+        let lines = render_text("- first\n- second", 80);
+        let texts: Vec<String> = lines.iter().map(line_text).collect();
+        let first = texts.iter().position(|line| line.contains("- first")).unwrap();
+        let second = texts.iter().position(|line| line.contains("- second")).unwrap();
+        assert_eq!(
+            second,
+            first + 1,
+            "adjacent list items should not get an inserted blank line: {texts:?}"
+        );
     }
 
     #[test]

--- a/tools/wta/src/ui/markdown.rs
+++ b/tools/wta/src/ui/markdown.rs
@@ -1,0 +1,633 @@
+use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
+use ratatui::prelude::*;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::theme;
+
+#[derive(Clone, Debug)]
+struct StyledRun {
+    text: String,
+    style: Style,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ListState {
+    next: Option<u64>,
+}
+
+#[derive(Clone, Debug)]
+struct StyledChar {
+    ch: char,
+    style: Style,
+}
+
+pub(crate) fn render_agent_markdown_lines(
+    text: &str,
+    wrap_width: usize,
+    dot_style: Style,
+    base_style: Style,
+) -> Vec<Line<'static>> {
+    let mut runs = markdown_to_runs(text, base_style);
+    trim_trailing_newlines(&mut runs);
+
+    if visible_text_is_empty(&runs) && !text.trim().is_empty() {
+        runs = vec![StyledRun {
+            text: text.to_string(),
+            style: base_style,
+        }];
+    }
+
+    dot_prefixed_wrapped_lines(&runs, wrap_width, dot_style)
+}
+
+pub(crate) fn agent_markdown_height(text: &str, wrap_width: usize) -> usize {
+    render_agent_markdown_lines(text, wrap_width, theme::DOT_AGENT, theme::AGENT_TEXT).len()
+}
+
+fn markdown_to_runs(text: &str, base_style: Style) -> Vec<StyledRun> {
+    let parser = Parser::new_ext(text, Options::empty());
+    let mut runs = Vec::new();
+    let mut styles = vec![base_style];
+    let mut lists: Vec<ListState> = Vec::new();
+    let mut quote_depth = 0usize;
+
+    for event in parser {
+        match event {
+            Event::Start(tag) => match tag {
+                Tag::Paragraph => ensure_quote_prefix(&mut runs, quote_depth),
+                Tag::Heading { .. } => {
+                    ensure_line_start(&mut runs, *styles.last().unwrap());
+                    ensure_quote_prefix(&mut runs, quote_depth);
+                    push_style(&mut styles, |s| s.add_modifier(Modifier::BOLD));
+                }
+                Tag::BlockQuote => {
+                    quote_depth += 1;
+                    ensure_line_start(&mut runs, *styles.last().unwrap());
+                }
+                Tag::CodeBlock(kind) => {
+                    ensure_line_start(&mut runs, *styles.last().unwrap());
+                    ensure_quote_prefix(&mut runs, quote_depth);
+                    if let CodeBlockKind::Fenced(lang) = kind {
+                        if !lang.is_empty() {
+                            append_text(&mut runs, "", code_style(*styles.last().unwrap()));
+                        }
+                    }
+                    push_style(&mut styles, code_style);
+                }
+                Tag::List(start) => {
+                    ensure_line_start(&mut runs, *styles.last().unwrap());
+                    ensure_quote_prefix(&mut runs, quote_depth);
+                    lists.push(ListState { next: start });
+                }
+                Tag::Item => {
+                    ensure_line_start(&mut runs, *styles.last().unwrap());
+                    ensure_quote_prefix(&mut runs, quote_depth);
+                    let indent = "  ".repeat(lists.len().saturating_sub(1));
+                    let marker = if let Some(list) = lists.last_mut() {
+                        if let Some(n) = list.next {
+                            list.next = Some(n + 1);
+                            format!("{indent}{n}. ")
+                        } else {
+                            format!("{indent}- ")
+                        }
+                    } else {
+                        format!("{indent}- ")
+                    };
+                    append_text(&mut runs, &marker, *styles.last().unwrap());
+                }
+                Tag::Emphasis => push_style(&mut styles, |s| s.add_modifier(Modifier::ITALIC)),
+                Tag::Strong => push_style(&mut styles, |s| s.add_modifier(Modifier::BOLD)),
+                Tag::Link { .. } | Tag::Image { .. } => push_style(&mut styles, link_style),
+                Tag::FootnoteDefinition(label) => {
+                    ensure_line_start(&mut runs, *styles.last().unwrap());
+                    ensure_quote_prefix(&mut runs, quote_depth);
+                    append_text(&mut runs, &format!("[^{label}]: "), theme::DIM);
+                }
+                _ => {}
+            },
+            Event::End(tag) => match tag {
+                TagEnd::Paragraph
+                | TagEnd::Item
+                | TagEnd::FootnoteDefinition => append_newline(&mut runs, *styles.last().unwrap()),
+                TagEnd::Heading(_) | TagEnd::CodeBlock => {
+                    append_newline(&mut runs, *styles.last().unwrap());
+                    pop_style(&mut styles);
+                }
+                TagEnd::List(_) => {
+                    lists.pop();
+                    append_newline(&mut runs, *styles.last().unwrap());
+                }
+                TagEnd::BlockQuote => {
+                    quote_depth = quote_depth.saturating_sub(1);
+                    append_newline(&mut runs, *styles.last().unwrap());
+                }
+                TagEnd::Emphasis | TagEnd::Strong | TagEnd::Link | TagEnd::Image => {
+                    pop_style(&mut styles);
+                }
+                _ => {}
+            },
+            Event::Text(text) => append_text_with_quote_prefix(
+                &mut runs,
+                &text,
+                *styles.last().unwrap(),
+                quote_depth,
+            ),
+            Event::Code(code) => append_text_with_quote_prefix(
+                &mut runs,
+                &code,
+                code_style(*styles.last().unwrap()),
+                quote_depth,
+            ),
+            Event::Html(html) | Event::InlineHtml(html) => {
+                append_text_with_quote_prefix(
+                    &mut runs,
+                    &html,
+                    *styles.last().unwrap(),
+                    quote_depth,
+                )
+            }
+            Event::FootnoteReference(label) => {
+                append_text(&mut runs, &format!("[^{label}]"), *styles.last().unwrap())
+            }
+            Event::SoftBreak => append_text(&mut runs, " ", *styles.last().unwrap()),
+            Event::HardBreak => {
+                append_newline(&mut runs, *styles.last().unwrap());
+                ensure_quote_prefix(&mut runs, quote_depth);
+            }
+            Event::Rule => {
+                ensure_line_start(&mut runs, *styles.last().unwrap());
+                ensure_quote_prefix(&mut runs, quote_depth);
+                append_text(&mut runs, "---", theme::DIM);
+                append_newline(&mut runs, *styles.last().unwrap());
+            }
+            Event::TaskListMarker(checked) => {
+                append_text(
+                    &mut runs,
+                    if checked { "[x] " } else { "[ ] " },
+                    *styles.last().unwrap(),
+                );
+            }
+        }
+    }
+
+    runs
+}
+
+fn push_style(styles: &mut Vec<Style>, f: impl FnOnce(Style) -> Style) {
+    let current = *styles.last().unwrap();
+    styles.push(f(current));
+}
+
+fn pop_style(styles: &mut Vec<Style>) {
+    if styles.len() > 1 {
+        styles.pop();
+    }
+}
+
+fn code_style(style: Style) -> Style {
+    style
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::REVERSED)
+}
+
+fn link_style(style: Style) -> Style {
+    style
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::UNDERLINED)
+}
+
+fn append_text(runs: &mut Vec<StyledRun>, text: &str, style: Style) {
+    if text.is_empty() {
+        return;
+    }
+    if let Some(last) = runs.last_mut() {
+        if last.style == style {
+            last.text.push_str(text);
+            return;
+        }
+    }
+    runs.push(StyledRun {
+        text: text.to_string(),
+        style,
+    });
+}
+
+fn append_text_with_quote_prefix(
+    runs: &mut Vec<StyledRun>,
+    text: &str,
+    style: Style,
+    quote_depth: usize,
+) {
+    for (idx, part) in text.split('\n').enumerate() {
+        if idx > 0 {
+            append_forced_newline(runs, style);
+            if !part.is_empty() {
+                ensure_quote_prefix(runs, quote_depth);
+            }
+        }
+        append_text(runs, part, style);
+    }
+}
+
+fn ensure_quote_prefix(runs: &mut Vec<StyledRun>, quote_depth: usize) {
+    if quote_depth > 0 && is_at_line_start(runs) {
+        append_text(runs, &"> ".repeat(quote_depth), theme::DIM);
+    }
+}
+
+fn append_newline(runs: &mut Vec<StyledRun>, style: Style) {
+    if !is_at_line_start(runs) {
+        append_text(runs, "\n", style);
+    }
+}
+
+fn append_forced_newline(runs: &mut Vec<StyledRun>, style: Style) {
+    append_text(runs, "\n", style);
+}
+
+fn ensure_line_start(runs: &mut Vec<StyledRun>, style: Style) {
+    if !is_at_line_start(runs) {
+        append_newline(runs, style);
+    }
+}
+
+fn is_at_line_start(runs: &[StyledRun]) -> bool {
+    runs
+        .last()
+        .map(|r| r.text.ends_with('\n'))
+        .unwrap_or(true)
+}
+
+fn visible_text_is_empty(runs: &[StyledRun]) -> bool {
+    runs.iter().all(|r| r.text.trim().is_empty())
+}
+
+fn trim_trailing_newlines(runs: &mut Vec<StyledRun>) {
+    while let Some(last) = runs.last_mut() {
+        let trimmed = last.text.trim_end_matches('\n');
+        if trimmed.len() == last.text.len() {
+            break;
+        }
+        last.text.truncate(trimmed.len());
+        if last.text.is_empty() {
+            runs.pop();
+        } else {
+            break;
+        }
+    }
+}
+
+fn dot_prefixed_wrapped_lines(
+    runs: &[StyledRun],
+    wrap_width: usize,
+    dot_style: Style,
+) -> Vec<Line<'static>> {
+    let body_width = wrap_width.saturating_sub(2).max(1);
+    let logical_lines = split_runs_on_newlines(runs);
+    let mut out = Vec::new();
+    let mut first_row = true;
+
+    for logical in logical_lines {
+        if runs_visible_width(&logical) == 0 {
+            if first_row {
+                continue;
+            }
+            out.push(Line::default());
+            continue;
+        }
+
+        for wrapped in wrap_runs_to_width(&logical, body_width) {
+            if first_row {
+                let mut spans = vec![Span::styled("● ", dot_style)];
+                spans.extend(runs_to_spans(wrapped));
+                out.push(Line::from(spans));
+                first_row = false;
+            } else {
+                let mut spans = vec![Span::raw("  ")];
+                spans.extend(runs_to_spans(wrapped));
+                out.push(Line::from(spans));
+            }
+        }
+    }
+
+    out
+}
+
+fn split_runs_on_newlines(runs: &[StyledRun]) -> Vec<Vec<StyledRun>> {
+    let mut lines: Vec<Vec<StyledRun>> = vec![Vec::new()];
+    for run in runs {
+        for (idx, part) in run.text.split('\n').enumerate() {
+            if idx > 0 {
+                lines.push(Vec::new());
+            }
+            if !part.is_empty() {
+                lines.last_mut().unwrap().push(StyledRun {
+                    text: part.to_string(),
+                    style: run.style,
+                });
+            }
+        }
+    }
+    lines
+}
+
+fn runs_visible_width(runs: &[StyledRun]) -> usize {
+    runs.iter().map(|r| UnicodeWidthStr::width(r.text.as_str())).sum()
+}
+
+fn wrap_runs_to_width(runs: &[StyledRun], width: usize) -> Vec<Vec<StyledRun>> {
+    let chars = styled_chars(runs);
+    if chars.is_empty() {
+        return vec![Vec::new()];
+    }
+
+    let mut lines = Vec::new();
+    let mut start = 0usize;
+    while start < chars.len() {
+        let mut row_width = 0usize;
+        let mut cursor = start;
+        let mut last_space = None;
+        let mut seen_non_whitespace = false;
+        while cursor < chars.len() {
+            let ch_width = char_width(chars[cursor].ch);
+            if row_width + ch_width > width && cursor > start {
+                break;
+            }
+            row_width += ch_width;
+            if chars[cursor].ch.is_whitespace() {
+                if seen_non_whitespace {
+                    last_space = Some(cursor);
+                }
+            } else {
+                seen_non_whitespace = true;
+            }
+            cursor += 1;
+            if row_width >= width {
+                break;
+            }
+        }
+
+        let (end, next) = if cursor >= chars.len() {
+            (chars.len(), chars.len())
+        } else if let Some(space) = last_space {
+            if space > start {
+                (space, space + 1)
+            } else {
+                (cursor.max(start + 1), cursor.max(start + 1))
+            }
+        } else {
+            (cursor.max(start + 1), cursor.max(start + 1))
+        };
+
+        let line = chars_to_runs(&chars[start..trim_trailing_space(&chars[start..end]) + start]);
+        if !line.is_empty() {
+            lines.push(line);
+        }
+        start = next;
+    }
+
+    if lines.is_empty() {
+        vec![Vec::new()]
+    } else {
+        lines
+    }
+}
+
+fn styled_chars(runs: &[StyledRun]) -> Vec<StyledChar> {
+    runs.iter()
+        .flat_map(|run| {
+            run.text.chars().map(|ch| StyledChar {
+                ch,
+                style: run.style,
+            })
+        })
+        .collect()
+}
+
+fn trim_trailing_space(chars: &[StyledChar]) -> usize {
+    let mut end = chars.len();
+    while end > 0 && chars[end - 1].ch.is_whitespace() {
+        end -= 1;
+    }
+    end
+}
+
+fn chars_to_runs(chars: &[StyledChar]) -> Vec<StyledRun> {
+    let mut runs = Vec::new();
+    for ch in chars {
+        append_text(&mut runs, &ch.ch.to_string(), ch.style);
+    }
+    runs
+}
+
+fn runs_to_spans(runs: Vec<StyledRun>) -> Vec<Span<'static>> {
+    runs.into_iter()
+        .map(|r| Span::styled(r.text, r.style))
+        .collect()
+}
+
+pub(crate) fn line_display_width(line: &Line<'_>) -> usize {
+    line.spans
+        .iter()
+        .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
+        .sum()
+}
+
+fn char_width(ch: char) -> usize {
+    UnicodeWidthChar::width(ch).unwrap_or(0).max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render_text(text: &str, width: usize) -> Vec<Line<'static>> {
+        render_agent_markdown_lines(text, width, theme::DOT_AGENT, theme::AGENT_TEXT)
+    }
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn bold_removes_markers_and_applies_style() {
+        let lines = render_text("hello **bold**", 80);
+        assert_eq!(line_text(&lines[0]), "● hello bold");
+        assert!(lines[0].spans.iter().any(|s| {
+            s.content.as_ref() == "bold" && s.style.add_modifier.contains(Modifier::BOLD)
+        }));
+    }
+
+    #[test]
+    fn italic_code_and_link_render_as_styled_visible_text() {
+        let lines = render_text("*it* `code` [site](https://example.com)", 80);
+        assert_eq!(line_text(&lines[0]), "● it code site");
+        assert!(lines[0].spans.iter().any(|s| {
+            s.content.as_ref() == "it" && s.style.add_modifier.contains(Modifier::ITALIC)
+        }));
+        assert!(lines[0].spans.iter().any(|s| {
+            s.content.as_ref() == "code" && s.style.add_modifier.contains(Modifier::REVERSED)
+        }));
+        assert!(lines[0].spans.iter().any(|s| {
+            s.content.as_ref() == "site" && s.style.add_modifier.contains(Modifier::UNDERLINED)
+        }));
+    }
+
+    #[test]
+    fn preserves_basic_block_markers_and_content() {
+        let lines = render_text("# Title\n\n- item\n> quote\n---\n```text\ncode\n```", 80);
+        let text = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+        assert!(text.contains("Title"));
+        assert!(text.contains("- item"));
+        assert!(text.contains("> quote"));
+        assert!(text.contains("---"));
+        assert!(text.contains("code"));
+    }
+
+    #[test]
+    fn code_block_preserves_leading_indentation() {
+        let lines = render_text("```text\n    indented\n```", 80);
+        let text = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+        assert!(
+            text.contains("    indented"),
+            "code block indentation must be preserved: {text:?}"
+        );
+    }
+
+    #[test]
+    fn code_block_preserves_blank_lines() {
+        let lines = render_text("```text\na\n\nb\n```", 80);
+        let texts: Vec<String> = lines.iter().map(line_text).collect();
+        assert!(
+            texts.windows(3).any(|w| w[0].contains('a') && w[1].is_empty() && w[2].contains('b')),
+            "code block blank line must be preserved: {texts:?}"
+        );
+    }
+
+    #[test]
+    fn wrapped_code_block_preserves_leading_indentation() {
+        let lines = render_text("```text\n    indented\n```", 12);
+        let texts: Vec<String> = lines.iter().map(line_text).collect();
+        assert!(
+            texts.iter().any(|line| line.contains("    ")),
+            "wrapped code must keep leading spaces: {texts:?}"
+        );
+        for line in lines {
+            assert!(
+                line_display_width(&line) <= 12,
+                "line exceeded width: {:?}",
+                line_text(&line)
+            );
+        }
+    }
+
+    #[test]
+    fn nested_list_preserves_child_indentation() {
+        let lines = render_text("- parent\n  - child", 80);
+        let text = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+        assert!(text.contains("- parent"));
+        assert!(
+            text.contains("    - child"),
+            "nested child marker must remain indented: {text:?}"
+        );
+    }
+
+    #[test]
+    fn blockquote_prefix_repeats_for_child_blocks() {
+        let lines = render_text("> first\n>\n> - item", 80);
+        let text = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+        assert!(text.contains("> first"));
+        assert!(
+            text.contains("> - item"),
+            "quoted list item must keep quote marker: {text:?}"
+        );
+    }
+
+    #[test]
+    fn long_agent_reply_is_not_globally_truncated() {
+        let long = format!("start {} end", "x ".repeat(2500));
+        let lines = render_text(&long, 40);
+        let text = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+        assert!(text.contains("start"));
+        assert!(text.contains("end"));
+        assert!(
+            !text.contains("chars omitted"),
+            "markdown renderer must not replace the middle of long replies"
+        );
+    }
+
+    #[test]
+    fn block_styles_do_not_leak_to_following_text() {
+        let lines = render_text("# Title\nplain\n\n`code` plain2", 80);
+        let plain_span = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .find(|s| s.content.as_ref().contains("plain"))
+            .expect("plain text span exists");
+        assert!(
+            !plain_span.style.add_modifier.contains(Modifier::BOLD),
+            "heading bold style must not leak into following paragraph"
+        );
+        let plain2_span = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .find(|s| s.content.as_ref() == " plain2")
+            .expect("post-code text span exists");
+        assert!(
+            !plain2_span.style.add_modifier.contains(Modifier::REVERSED),
+            "inline code style must not leak into following text"
+        );
+    }
+
+    #[test]
+    fn html_and_task_markers_stay_visible() {
+        let lines = render_text("<br>\n- [x] done", 80);
+        let text = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+        assert!(text.contains("<br>"));
+        assert!(text.contains("[x] done"));
+    }
+
+    #[test]
+    fn incomplete_markdown_remains_visible() {
+        let lines = render_text("hello **unterminated", 80);
+        let text = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+        assert!(text.contains("hello"));
+        assert!(text.contains("unterminated"));
+    }
+
+    #[test]
+    fn hard_wraps_long_unbreakable_text_and_preserves_width() {
+        let lines = render_text("`abcdefghijklmnopqrstuvwxyz`", 10);
+        assert!(lines.len() > 1);
+        for line in lines {
+            assert!(
+                line_display_width(&line) <= 10,
+                "line exceeded width: {:?}",
+                line_text(&line)
+            );
+        }
+    }
+
+    #[test]
+    fn wide_chars_do_not_exceed_width() {
+        let lines = render_text("**你好你好🙂🙂**", 8);
+        for line in lines {
+            assert!(
+                line_display_width(&line) <= 8,
+                "line exceeded width: {:?}",
+                line_text(&line)
+            );
+        }
+    }
+
+    #[test]
+    fn height_matches_rendered_line_count() {
+        let text = "hello **bold** and a veryveryverylongtoken";
+        let lines = render_text(text, 12);
+        assert_eq!(
+            agent_markdown_height(text, 12),
+            lines.len(),
+            "height must use the same wrapping as render"
+        );
+    }
+}

--- a/tools/wta/src/ui/markdown.rs
+++ b/tools/wta/src/ui/markdown.rs
@@ -196,9 +196,7 @@ fn pop_style(styles: &mut Vec<Style>) {
 }
 
 fn code_style(style: Style) -> Style {
-    style
-        .fg(Color::Yellow)
-        .add_modifier(Modifier::REVERSED)
+    style.add_modifier(Modifier::REVERSED)
 }
 
 fn link_style(style: Style) -> Style {

--- a/tools/wta/src/ui/markdown.rs
+++ b/tools/wta/src/ui/markdown.rs
@@ -1,4 +1,4 @@
-use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
 use ratatui::prelude::*;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -64,14 +64,9 @@ fn markdown_to_runs(text: &str, base_style: Style) -> Vec<StyledRun> {
                     quote_depth += 1;
                     ensure_line_start(&mut runs, *styles.last().unwrap());
                 }
-                Tag::CodeBlock(kind) => {
+                Tag::CodeBlock(_) => {
                     ensure_line_start(&mut runs, *styles.last().unwrap());
                     ensure_quote_prefix(&mut runs, quote_depth);
-                    if let CodeBlockKind::Fenced(lang) = kind {
-                        if !lang.is_empty() {
-                            append_text(&mut runs, "", code_style(*styles.last().unwrap()));
-                        }
-                    }
                     push_style(&mut styles, code_style);
                 }
                 Tag::List(start) => {
@@ -475,7 +470,15 @@ mod tests {
 
     #[test]
     fn preserves_basic_block_markers_and_content() {
-        let lines = render_text("# Title\n\n- item\n> quote\n---\n```text\ncode\n```", 80);
+        let source = r#"# Title
+
+- item
+> quote
+---
+```text
+code
+```"#;
+        let lines = render_text(source, 80);
         let text = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
         assert!(text.contains("Title"));
         assert!(text.contains("- item"));
@@ -486,7 +489,10 @@ mod tests {
 
     #[test]
     fn code_block_preserves_leading_indentation() {
-        let lines = render_text("```text\n    indented\n```", 80);
+        let source = r#"```text
+    indented
+```"#;
+        let lines = render_text(source, 80);
         let text = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
         assert!(
             text.contains("    indented"),
@@ -496,17 +502,27 @@ mod tests {
 
     #[test]
     fn code_block_preserves_blank_lines() {
-        let lines = render_text("```text\na\n\nb\n```", 80);
+        let source = r#"```text
+alpha
+
+beta
+```"#;
+        let lines = render_text(source, 80);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
         assert!(
-            texts.windows(3).any(|w| w[0].contains('a') && w[1].is_empty() && w[2].contains('b')),
+            texts.windows(3).any(|w| {
+                w[0].contains("alpha") && w[1].is_empty() && w[2].contains("beta")
+            }),
             "code block blank line must be preserved: {texts:?}"
         );
     }
 
     #[test]
     fn wrapped_code_block_preserves_leading_indentation() {
-        let lines = render_text("```text\n    indented\n```", 12);
+        let source = r#"```text
+    indented
+```"#;
+        let lines = render_text(source, 12);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
         assert!(
             texts.iter().any(|line| line.contains("    ")),
@@ -558,11 +574,15 @@ mod tests {
 
     #[test]
     fn block_styles_do_not_leak_to_following_text() {
-        let lines = render_text("# Title\nplain\n\n`code` plain2", 80);
+        let source = r#"# Title
+regular
+
+`code` regular2"#;
+        let lines = render_text(source, 80);
         let plain_span = lines
             .iter()
             .flat_map(|l| l.spans.iter())
-            .find(|s| s.content.as_ref().contains("plain"))
+            .find(|s| s.content.as_ref().contains("regular"))
             .expect("plain text span exists");
         assert!(
             !plain_span.style.add_modifier.contains(Modifier::BOLD),
@@ -571,7 +591,7 @@ mod tests {
         let plain2_span = lines
             .iter()
             .flat_map(|l| l.spans.iter())
-            .find(|s| s.content.as_ref() == " plain2")
+            .find(|s| s.content.as_ref() == " regular2")
             .expect("post-code text span exists");
         assert!(
             !plain2_span.style.add_modifier.contains(Modifier::REVERSED),
@@ -622,7 +642,7 @@ mod tests {
 
     #[test]
     fn height_matches_rendered_line_count() {
-        let text = "hello **bold** and a veryveryverylongtoken";
+        let text = "hello **bold** and a very long token";
         let lines = render_text(text, 12);
         assert_eq!(
             agent_markdown_height(text, 12),

--- a/tools/wta/src/ui/markdown.rs
+++ b/tools/wta/src/ui/markdown.rs
@@ -392,7 +392,7 @@ fn wrap_runs_to_width(runs: &[StyledRun], width: usize) -> Vec<Vec<StyledRun>> {
             }
             row_width += ch_width;
             if chars[cursor].ch.is_whitespace() {
-                if seen_non_whitespace {
+                if seen_non_whitespace && !is_code_style(chars[cursor].style) {
                     last_space = Some(cursor);
                 }
             } else {
@@ -447,10 +447,14 @@ fn trim_trailing_space(chars: &[StyledChar]) -> usize {
     }
 
     let mut end = chars.len();
-    while end > 0 && chars[end - 1].ch.is_whitespace() {
+    while end > 0 && chars[end - 1].ch.is_whitespace() && !is_code_style(chars[end - 1].style) {
         end -= 1;
     }
     end
+}
+
+fn is_code_style(style: Style) -> bool {
+    style.add_modifier.contains(Modifier::REVERSED)
 }
 
 fn chars_to_runs(chars: &[StyledChar]) -> Vec<StyledRun> {
@@ -644,6 +648,17 @@ beta
             1,
             "trailing separator whitespace after content should still be trimmed"
         );
+
+        let code = vec![
+            StyledChar { ch: 'a', style: code_style(theme::AGENT_TEXT) },
+            StyledChar { ch: ' ', style: code_style(theme::AGENT_TEXT) },
+            StyledChar { ch: ' ', style: code_style(theme::AGENT_TEXT) },
+        ];
+        assert_eq!(
+            trim_trailing_space(&code),
+            code.len(),
+            "trailing spaces are code content and must not be trimmed"
+        );
     }
 
     #[test]
@@ -741,6 +756,23 @@ regular
         for line in lines {
             assert!(
                 line_display_width(&line) <= 10,
+                "line exceeded width: {:?}",
+                line_text(&line)
+            );
+        }
+    }
+
+    #[test]
+    fn wrapped_inline_code_preserves_spaces() {
+        let lines = render_text("`a  b`", 5);
+        let text = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+        assert!(
+            text.contains("a  \n  b"),
+            "inline code spaces must survive wrapping: {text:?}"
+        );
+        for line in lines {
+            assert!(
+                line_display_width(&line) <= 5,
                 "line exceeded width: {:?}",
                 line_text(&line)
             );

--- a/tools/wta/src/ui/markdown.rs
+++ b/tools/wta/src/ui/markdown.rs
@@ -546,7 +546,10 @@ code
 
     #[test]
     fn paragraph_break_preserves_blank_line() {
-        let lines = render_text("first\n\nsecond", 80);
+        let source = r#"first
+
+second"#;
+        let lines = render_text(source, 80);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
         assert!(
             texts.windows(3).any(|w| {

--- a/tools/wta/src/ui/markdown.rs
+++ b/tools/wta/src/ui/markdown.rs
@@ -200,9 +200,7 @@ fn code_style(style: Style) -> Style {
 }
 
 fn link_style(style: Style) -> Style {
-    style
-        .fg(Color::Cyan)
-        .add_modifier(Modifier::UNDERLINED)
+    style.add_modifier(Modifier::UNDERLINED)
 }
 
 fn append_text(runs: &mut Vec<StyledRun>, text: &str, style: Style) {

--- a/tools/wta/src/ui/markdown.rs
+++ b/tools/wta/src/ui/markdown.rs
@@ -41,7 +41,17 @@ pub(crate) fn render_agent_markdown_lines(
 }
 
 pub(crate) fn agent_markdown_height(text: &str, wrap_width: usize) -> usize {
-    render_agent_markdown_lines(text, wrap_width, theme::DOT_AGENT, theme::AGENT_TEXT).len()
+    let mut runs = markdown_to_runs(text, theme::AGENT_TEXT);
+    trim_trailing_newlines(&mut runs);
+
+    if visible_text_is_empty(&runs) && !text.trim().is_empty() {
+        runs = vec![StyledRun {
+            text: text.to_string(),
+            style: theme::AGENT_TEXT,
+        }];
+    }
+
+    dot_prefixed_wrapped_line_count(&runs, wrap_width)
 }
 
 fn markdown_to_runs(text: &str, base_style: Style) -> Vec<StyledRun> {
@@ -308,6 +318,31 @@ fn dot_prefixed_wrapped_lines(
     out
 }
 
+fn dot_prefixed_wrapped_line_count(runs: &[StyledRun], wrap_width: usize) -> usize {
+    let body_width = wrap_width.saturating_sub(2).max(1);
+    let logical_lines = split_runs_on_newlines(runs);
+    let mut count = 0usize;
+    let mut first_row = true;
+
+    for logical in logical_lines {
+        if runs_visible_width(&logical) == 0 {
+            if first_row {
+                continue;
+            }
+            count += 1;
+            continue;
+        }
+
+        let wrapped = wrap_runs_to_width(&logical, body_width);
+        if !wrapped.is_empty() {
+            first_row = false;
+            count += wrapped.len();
+        }
+    }
+
+    count
+}
+
 fn split_runs_on_newlines(runs: &[StyledRun]) -> Vec<Vec<StyledRun>> {
     let mut lines: Vec<Vec<StyledRun>> = vec![Vec::new()];
     for run in runs {
@@ -408,9 +443,18 @@ fn trim_trailing_space(chars: &[StyledChar]) -> usize {
 }
 
 fn chars_to_runs(chars: &[StyledChar]) -> Vec<StyledRun> {
-    let mut runs = Vec::new();
+    let mut runs: Vec<StyledRun> = Vec::new();
     for ch in chars {
-        append_text(&mut runs, &ch.ch.to_string(), ch.style);
+        if let Some(last) = runs.last_mut() {
+            if last.style == ch.style {
+                last.text.push(ch.ch);
+                continue;
+            }
+        }
+        runs.push(StyledRun {
+            text: ch.ch.to_string(),
+            style: ch.style,
+        });
     }
     runs
 }

--- a/tools/wta/src/ui/markdown.rs
+++ b/tools/wta/src/ui/markdown.rs
@@ -90,7 +90,7 @@ fn markdown_to_runs(text: &str, base_style: Style) -> Vec<StyledRun> {
                     let indent = "  ".repeat(lists.len().saturating_sub(1));
                     let marker = if let Some(list) = lists.last_mut() {
                         if let Some(n) = list.next {
-                            list.next = Some(n + 1);
+                            list.next = Some(n.saturating_add(1));
                             format!("{indent}{n}. ")
                         } else {
                             format!("{indent}- ")
@@ -435,6 +435,10 @@ fn styled_chars(runs: &[StyledRun]) -> Vec<StyledChar> {
 }
 
 fn trim_trailing_space(chars: &[StyledChar]) -> usize {
+    if chars.iter().all(|ch| ch.ch.is_whitespace()) {
+        return chars.len();
+    }
+
     let mut end = chars.len();
     while end > 0 && chars[end - 1].ch.is_whitespace() {
         end -= 1;
@@ -579,6 +583,42 @@ beta
                 line_text(&line)
             );
         }
+    }
+
+    #[test]
+    fn trim_trailing_space_preserves_whitespace_only_slices() {
+        let spaces = vec![
+            StyledChar { ch: ' ', style: theme::AGENT_TEXT },
+            StyledChar { ch: ' ', style: theme::AGENT_TEXT },
+            StyledChar { ch: ' ', style: theme::AGENT_TEXT },
+            StyledChar { ch: ' ', style: theme::AGENT_TEXT },
+        ];
+        assert_eq!(
+            trim_trailing_space(&spaces),
+            spaces.len(),
+            "pure indentation is content in code/list blocks and must not be dropped"
+        );
+
+        let mixed = vec![
+            StyledChar { ch: 'a', style: theme::AGENT_TEXT },
+            StyledChar { ch: ' ', style: theme::AGENT_TEXT },
+            StyledChar { ch: ' ', style: theme::AGENT_TEXT },
+        ];
+        assert_eq!(
+            trim_trailing_space(&mixed),
+            1,
+            "trailing separator whitespace after content should still be trimmed"
+        );
+    }
+
+    #[test]
+    fn huge_ordered_list_start_does_not_overflow() {
+        let lines = render_text("18446744073709551615. item", 80);
+        let text = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+        assert!(
+            text.contains("18446744073709551615. item"),
+            "huge ordered-list marker should render without overflow: {text:?}"
+        );
     }
 
     #[test]

--- a/tools/wta/src/ui/mod.rs
+++ b/tools/wta/src/ui/mod.rs
@@ -5,6 +5,7 @@ mod command_popup;
 mod debug_panel;
 mod input;
 mod layout;
+pub(crate) mod markdown;
 mod model_popup;
 mod permission;
 mod popup;


### PR DESCRIPTION
## Summary

Closes #387.

This PR adds Markdown rendering for agent replies in the WTA agent pane. Copilot and other ACP agents can return Markdown-formatted text such as `**bold**`, inline code, links, lists, blockquotes, and code fences; the agent pane now renders those as styled terminal output instead of showing raw Markdown markers.

Changes:
- Add `pulldown-cmark` for Markdown parsing in WTA.
- Add an agent-reply Markdown renderer that converts Markdown events into ratatui styled lines.
- Apply Markdown rendering only to agent replies:
  - pending streaming agent text
  - finalized `ChatMessage::Agent`
  - completed-turn agent details
- Preserve current agent pane layout:
  - `● ` prefix on the first visual row
  - hanging indent on continuation rows
  - display-width-aware wrapping to avoid ratatui double-wrap
- Preserve basic block content and structure for headings, lists, blockquotes, rules, HTML, task markers, and code fences without trying to show every raw Markdown delimiter.
- Keep app-generated recommendation summaries literal via `ChatMessage::AgentLiteral`, so command strings are not parsed as Markdown.
- Keep User/System/Error/ToolCall/Plan rendering unchanged.

## Validation

- `cargo test --target x86_64-pc-windows-msvc markdown`
  - 19 Markdown-focused tests passed
- `cargo test --target x86_64-pc-windows-msvc`
  - full WTA suite passed during implementation
- Manual VM validation:
  - Copilot replies no longer show literal `**...**`
  - Markdown bold renders through the agent reply path
  - Agent Pane profile/settings remain respected
