### PR TITLE
fix: keep a misconfigured delegate agent's tab open instead of flashing shut

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
@@ -566,6 +566,37 @@ namespace winrt::TerminalApp::implementation
 
         Protocol::TabCreationResult result{};
 
+        // A protocol create_tab that carries a commandline but no profile would
+        // otherwise resolve (via CascadiaSettings::GetProfileForArgs) to the
+        // "Defaults" profile, whose panes are auto-closed on *any* process exit
+        // — even a non-zero one. So a command that runs and exits (e.g. a
+        // misconfigured delegate agent that prints "'x' is not recognized" and
+        // exits with code 1) flashes the tab shut before the user can read the
+        // error. Pin a real profile instead so its closeOnExit (automatic/
+        // graceful) keeps a non-zero exit visible, exactly like a normally-
+        // opened tab.
+        //
+        // Prefer the profile of the pane the user is currently working in, so a
+        // delegate/agent tab opened from e.g. a WSL/Ubuntu session matches that
+        // session (same intent as PR #366); fall back to the user's global
+        // default profile when there is no focused terminal. Either way this is
+        // never left empty — that's what re-introduces the auto-closing
+        // "Defaults" profile. An explicitly-requested profile is left as-is; if
+        // the resolved GUID somehow can't be matched, GetProfileForArgs falls
+        // back to the same "Defaults" profile as before (no regression).
+        if (args && args.Profile().empty())
+        {
+            auto profileGuid = _settings.GlobalSettings().DefaultProfile();
+            if (const auto focusedTab = _GetFocusedTabImpl())
+            {
+                if (const auto focusedProfile = focusedTab->GetFocusedProfile())
+                {
+                    profileGuid = focusedProfile.Guid();
+                }
+            }
+            args.Profile(::Microsoft::Console::Utils::GuidToString(profileGuid));
+        }
+
         auto pane = _MakePane(args, nullptr);
         if (!pane)
             co_return result;

--- a/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
@@ -581,10 +581,16 @@ namespace winrt::TerminalApp::implementation
         // session (same intent as PR #366); fall back to the user's global
         // default profile when there is no focused terminal. Either way this is
         // never left empty — that's what re-introduces the auto-closing
-        // "Defaults" profile. An explicitly-requested profile is left as-is; if
-        // the resolved GUID somehow can't be matched, GetProfileForArgs falls
-        // back to the same "Defaults" profile as before (no regression).
-        if (args && args.Profile().empty())
+        // "Defaults" profile.
+        //
+        // Scope this narrowly to the case that actually hits the bug: a
+        // commandline with no explicit profile selection. A caller that omits
+        // the commandline already lands on the user's real default profile (not
+        // the auto-closing "Defaults"), and one that asked for a profile by name
+        // or index must keep it — so those are left untouched. If the resolved
+        // GUID somehow can't be matched, GetProfileForArgs falls back to the
+        // same "Defaults" profile as before (no regression).
+        if (args && !args.Commandline().empty() && args.Profile().empty() && !args.ProfileIndex())
         {
             auto profileGuid = _settings.GlobalSettings().DefaultProfile();
             if (const auto focusedTab = _GetFocusedTabImpl())

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -949,11 +949,14 @@ pub fn needs_shell_launch(commandline: &str) -> bool {
 /// Returns true if the first token of `commandline` can actually be launched —
 /// i.e. it resolves to a real program: a shell, an `.exe`/`.cmd`/`.bat`/`.com`
 /// found on PATH, or an existing file. Used to detect a misconfigured /
-/// nonexistent delegate agent *before* spawning the tab: without this, WT
-/// creates the tab, the not-found command exits instantly, and WT closes the
-/// pane before the user can see the error (the tab just flashes shut). Known
-/// built-in agents are covered because `resolve_commandline_executable` first
-/// resolves them to a concrete path.
+/// nonexistent delegate agent so the delegate can keep that doomed launch out
+/// of the prompt-baking path: a bare `cmd /c <agent>` fails cleanly with a
+/// non-zero exit and WT keeps the pane open (closeOnExit=automatic) showing the
+/// real "not recognized" error, whereas baking the active pane's output into
+/// `cmd /c <agent> -i "<context>"` can let a stray `"`/`&` in that text
+/// unbalance cmd's quoting so cmd exits 0 and the pane closes before the error
+/// is readable. Known built-in agents are covered because
+/// `resolve_commandline_executable` first resolves them to a concrete path.
 pub fn delegate_command_launchable(commandline: &str) -> bool {
     let resolved = resolve_commandline_executable(commandline);
     let token = match split_windows_commandline(&resolved).into_iter().next() {
@@ -1362,8 +1365,9 @@ mod tests {
     #[test]
     fn delegate_command_launchable_detects_missing_agent() {
         // A shell is always launchable; a real system exe resolves on PATH; a
-        // bogus bare name does not — this is the up-front check that lets the
-        // delegate open a persistent error tab instead of a tab that flashes shut.
+        // bogus bare name does not — this is the up-front check that keeps a
+        // doomed launch out of the fragile prompt-baking path, so it fails
+        // cleanly as a bare `cmd /c <agent>` and stays visible in its tab.
         assert!(super::delegate_command_launchable("cmd"));
         assert!(super::delegate_command_launchable("cmd.exe /c echo hi"));
         assert!(

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -950,12 +950,13 @@ pub fn needs_shell_launch(commandline: &str) -> bool {
 /// i.e. it resolves to a real program: a shell, an `.exe`/`.cmd`/`.bat`/`.com`
 /// found on PATH, or an existing file. Used to detect a misconfigured /
 /// nonexistent delegate agent so the delegate can keep that doomed launch out
-/// of the prompt-baking path: a bare `cmd /c <agent>` fails cleanly with a
-/// non-zero exit and WT keeps the pane open (closeOnExit=automatic) showing the
-/// real "not recognized" error, whereas baking the active pane's output into
-/// `cmd /c <agent> -i "<context>"` can let a stray `"`/`&` in that text
-/// unbalance cmd's quoting so cmd exits 0 and the pane closes before the error
-/// is readable. Known built-in agents are covered because
+/// of the prompt-baking path and instead launch it bare, where the failure is
+/// clean and stays visible (a shell-wrapped miss prints "not recognized" and
+/// exits non-zero; a direct `.exe` miss fails to start — either way WT keeps
+/// the pane open). Baking the active pane's output into the launch is fragile:
+/// once the command is shell-wrapped, a stray `"`/`&` in that arbitrary text
+/// can unbalance the shell's quoting so it exits 0 and the pane closes before
+/// the error is readable. Known built-in agents are covered because
 /// `resolve_commandline_executable` first resolves them to a concrete path.
 pub fn delegate_command_launchable(commandline: &str) -> bool {
     let resolved = resolve_commandline_executable(commandline);

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2065,7 +2065,7 @@ async fn delegate_with_context(
         .ok_or_else(|| anyhow::anyhow!("no delegate agent configured"))?;
 
     // Pre-flight: can the configured delegate agent actually be launched? A
-    // misconfigured / non-existent command still gets its own tab and stays
+    // misconfigured / nonexistent command still gets its own tab and stays
     // there showing the real failure — cmd's "'<agent>' is not recognized …",
     // then WT's "[process exited with code 1] … press Enter to restart" — just
     // like mistyping a command in any shell. WT keeps a non-zero-exit pane open
@@ -2081,9 +2081,16 @@ async fn delegate_with_context(
     // fails cleanly with a non-zero code and stays put.
     let launchable = crate::coordinator::delegate_command_launchable(&runtime.commandline);
     if !launchable {
+        // Log only the executable (first token), never the full commandline: a
+        // custom agent command can embed tokens/credentials that shouldn't land
+        // in the log. The full commandline stays trace-only (below).
+        let exe = crate::coordinator::split_windows_commandline(&runtime.commandline)
+            .into_iter()
+            .next()
+            .unwrap_or_default();
         tracing::warn!(
             target: "delegate",
-            commandline = %runtime.commandline,
+            agent = %exe,
             "delegate agent not launchable — opening its tab with the bare command so the real error stays visible",
         );
     }

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2064,48 +2064,28 @@ async fn delegate_with_context(
         .first()
         .ok_or_else(|| anyhow::anyhow!("no delegate agent configured"))?;
 
-    // Pre-flight: if the configured delegate agent can't actually be launched
-    // (a nonexistent / misconfigured command), don't spawn a doomed tab. WT
-    // would create it, the not-found command would exit instantly, and the pane
-    // would close before the user could see the error (the tab just flashes
-    // shut). Open a persistent single-line error tab instead so the failure is
-    // visible. Kept out of the prompt-baking path below so no multi-line prompt
-    // can truncate the command before the message renders.
-    if !crate::coordinator::delegate_command_launchable(&runtime.commandline) {
-        let exe = crate::coordinator::split_windows_commandline(&runtime.commandline)
-            .into_iter()
-            .next()
-            .unwrap_or_default();
-        // Sanitize for display: drop cmd-special characters so the echo can't be
-        // hijacked by a weird agent name (`&`, `|`, `>`, `%`, …).
-        let safe_exe: String = exe
-            .trim_matches('"')
-            .chars()
-            .map(|c| {
-                if c.is_alphanumeric() || matches!(c, '-' | '_' | '.' | '\\' | '/' | ':' | ' ') {
-                    c
-                } else {
-                    '?'
-                }
-            })
-            .collect();
-        // `cmd /k` keeps the pane open after echoing; a single-line message can't
-        // be truncated by a stray newline the way a baked-in prompt can.
-        let err_cmd = format!(
-            "cmd /k echo Delegate agent not found: {safe_exe} - check the delegate agent setting."
-        );
-        let windows_home = std::env::var("USERPROFILE").ok();
-        let sanitized_cwd =
-            crate::coordinator::sanitize_windows_agent_cwd(cwd, windows_home.as_deref());
-        shell_mgr
-            .wt_create_tab(Some(&err_cmd), sanitized_cwd.as_deref(), None, None)
-            .await?;
+    // Pre-flight: can the configured delegate agent actually be launched? A
+    // misconfigured / non-existent command still gets its own tab and stays
+    // there showing the real failure — cmd's "'<agent>' is not recognized …",
+    // then WT's "[process exited with code 1] … press Enter to restart" — just
+    // like mistyping a command in any shell. WT keeps a non-zero-exit pane open
+    // under closeOnExit=automatic, so there's nothing to "fix" for the common
+    // case; we do NOT open a second, canned-message tab.
+    //
+    // The flag is only used to keep a doomed launch OUT of the prompt-baking
+    // path below. Baking the active pane's output into `cmd /c <agent>
+    // -i "<context>"` is fragile: a stray `"`/`&` in that arbitrary text can
+    // unbalance cmd's quote tracking so cmd runs a trailing token and exits 0,
+    // which — under closeOnExit=automatic — closes the pane before the error is
+    // readable (the original "flash shut"). A bare `cmd /c <agent>` instead
+    // fails cleanly with a non-zero code and stays put.
+    let launchable = crate::coordinator::delegate_command_launchable(&runtime.commandline);
+    if !launchable {
         tracing::warn!(
             target: "delegate",
-            agent = %safe_exe,
-            "delegate agent not launchable — opened error tab instead of a doomed launch",
+            commandline = %runtime.commandline,
+            "delegate agent not launchable — opening its tab with the bare command so the real error stays visible",
         );
-        return Ok(());
     }
 
     // Pin a session id we choose, so the launched CLI writes its session under a
@@ -2115,17 +2095,25 @@ async fn delegate_with_context(
     // `split_whitespace`) so quoted/space-containing paths and adapter launches
     // resolve correctly -- and so this decision matches the one the command
     // builder makes when it appends the flag, keeping the pinned id and the
-    // actual launch flag in agreement.
-    let pinned_session_id: Option<String> = crate::agent_registry::lookup_profile_by_id(
-        crate::agent_registry::resolve_agent_id_from_cmd(&runtime.commandline),
-    )
-    .new_session_id_flag
-    .map(|_| uuid::Uuid::new_v4().to_string());
+    // actual launch flag in agreement. A non-launchable command will never
+    // produce a session, so skip pinning (and the born-bound registration below).
+    let pinned_session_id: Option<String> = if launchable {
+        crate::agent_registry::lookup_profile_by_id(
+            crate::agent_registry::resolve_agent_id_from_cmd(&runtime.commandline),
+        )
+        .new_session_id_flag
+        .map(|_| uuid::Uuid::new_v4().to_string())
+    } else {
+        None
+    };
 
     let commandline = match prompt {
-        // Prompt present → enrich it with the active pane's recent output and
-        // bake it into the new tab's agent CLI (the `?<prompt>` path).
-        Some(prompt) if !prompt.trim().is_empty() => {
+        // Prompt present AND the agent is launchable → enrich it with the
+        // active pane's recent output and bake it into the new tab's agent CLI
+        // (the `?<prompt>` path). A non-launchable agent deliberately skips this
+        // and falls through to the bare launch below, so it fails cleanly with a
+        // non-zero exit and the error stays visible in the tab.
+        Some(prompt) if !prompt.trim().is_empty() && launchable => {
             let active = shell_mgr.wt_get_active_pane().await.ok();
             let active_pane_id = active
                 .as_ref()
@@ -2162,7 +2150,11 @@ async fn delegate_with_context(
                 pinned_session_id.as_deref(),
             )?
         }
-        // No prompt → open the delegate agent interactively in the new tab.
+        // No prompt, or a non-launchable agent → open the delegate agent's bare
+        // command in the new tab. For a launchable agent this is the interactive
+        // CLI; for a misconfigured one it's the real `cmd /c <agent>`, whose
+        // "not recognized" error (exit code 1 → WT keeps the pane open) stays
+        // visible in the tab instead of flashing shut.
         _ => crate::coordinator::build_delegate_launch_commandline_with_session(
             runtime,
             None,


### PR DESCRIPTION
## Problem

Delegating (`?<prompt>`) to a non-existent / misconfigured agent opened a tab that **flashed shut** before the user could read the error. An earlier workaround opened a *separate* canned-message `cmd /k` tab; this PR restores the original behavior — the **real error stays visible in the tab that ran the command**, with no second tab.

Original (desired) behavior:

```
'wt-nonexistent-delegate-xyz' is not recognized as an internal or external command,
operable program or batch file.

[process exited with code 1 (0x00000001)]
You can now close this terminal with Ctrl+D, or press Enter to restart.
```

## Root cause

A protocol `create_tab` that carries a **commandline but no profile** resolves — via `CascadiaSettings::GetProfileForArgs` — to the **"Defaults" profile** (`ProfileDefaults()`), whose pane is auto-closed on **any** process exit, even a non-zero one. The delegate creates its tab with no profile (`wt_create_tab("cmd /c <agent>", ..., None)`), so the doomed command exited (code 1) and WT closed the pane before the "not recognized" error was readable.

Verified live via `wtcli` against a running instance:

- `wtcli new-tab -c "cmd /c exit 1"` (no profile) -> **flashed shut**
- `wtcli new-tab -p "{some-real-profile}" -c "cmd /c exit 1"` -> **stayed open**

Not an ACP-1.0-migration regression: PR #367 changed zero C++ files and did not change the delegate''s tab-creation command — the no-profile -> `ProfileDefaults` auto-close behavior predates it.

## Fix (two parts)

1. **C++ (`TerminalPage.Protocol.cpp`)** — `CreateProtocolTab` now pins a real profile when the caller specifies none: the profile of the pane the user is **currently working in** (so a delegate/agent tab opened from e.g. a WSL/Ubuntu session matches it — same intent as PR #366), falling back to the user''s **global default profile** when there is no focused terminal. Its `closeOnExit` (automatic/graceful) keeps a non-zero exit visible, exactly like a normally-opened tab. This is never left empty — that''s what re-introduces the auto-closing "Defaults" profile. It fixes every no-profile protocol tab, not just the delegate. An explicitly-requested profile is left untouched; if the resolved GUID can''t be matched, `GetProfileForArgs` falls back to the same "Defaults" profile as before (no regression).

2. **WTA (`delegate_with_context`)** — a non-launchable delegate agent is now launched as a bare `cmd /c <agent>` (no baked prompt) so it fails cleanly with a non-zero exit. This keeps the doomed launch out of the fragile prompt-baking path, where a stray `"`/`&` in the pane context could unbalance cmd''s quoting and make cmd exit `0` (which the profile would then close). Replaces the separate `cmd /k` error tab.

## Testing

- WTA unit suite: **1000 passed / 0 failed**.
- Verified live via `wtcli` (same COM path as the delegate) on a rebuilt + deployed build:
  - a no-profile `cmd /c exit 1` / `cmd /c wt-nonexistent-delegate-xyz` **stays open**;
  - with a **Command Prompt** tab focused, a no-profile `new-tab` is titled **Command Prompt** (inherits the focused profile), not the default — confirming the inheritance.
- Manual: `?<prompt>` to a misconfigured `custom:` delegate agent now opens a single tab that stays open showing the real not-recognized / process-exited error.
