### PR TITLE
Make workspace restore window-aware

### DIFF
--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
@@ -109,6 +109,7 @@
     <ClInclude Include="SharedWta.h" />
     <ClInclude Include="AgentPaneDragStash.h" />
     <ClInclude Include="AgentPaneLog.h" />
+    <ClInclude Include="WorkspaceRestoreDecision.h" />
     <ClInclude Include="Tab.h">
       <DependentUpon>Tab.idl</DependentUpon>
     </ClInclude>

--- a/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
@@ -13,6 +13,7 @@
 
 #include "pch.h"
 #include "TerminalPage.h"
+#include "WorkspaceRestoreDecision.h"
 #include "../../types/inc/utils.hpp"
 #include "../inc/IntelligentTerminalPaths.h"
 #include "../TerminalSettingsAppAdapterLib/TerminalSettings.h"
@@ -23,6 +24,8 @@
 #include <fstream>
 #include <json/json.h>
 #include <sddl.h>
+#include <sstream>
+#include <unordered_set>
 #include <wil/resource.h>
 #include <wil/stl.h>
 #include "../TerminalProtocol/ProtocolParsing.h"
@@ -41,6 +44,70 @@ namespace Model = winrt::Microsoft::Terminal::Settings::Model;
 
 namespace winrt::TerminalApp::implementation
 {
+    static Model::SavedWorkspaceSession _findSavedWorkspaceSession(const winrt::hstring& id)
+    {
+        if (const auto sessions = ApplicationState::SharedInstance().SavedWorkspaceSessions())
+        {
+            for (const auto& s : sessions)
+            {
+                if (s.Id() == id)
+                {
+                    return s;
+                }
+            }
+        }
+        return nullptr;
+    }
+
+    static std::vector<Model::SavedWorkspaceTab> _savedWorkspaceTabsInOrder(const Model::SavedWorkspaceSession& record)
+    {
+        std::vector<Model::SavedWorkspaceTab> tabsInOrder;
+        if (record)
+        {
+            if (const auto tabs = record.Tabs())
+            {
+                tabsInOrder.reserve(tabs.Size());
+                for (const auto& tab : tabs)
+                {
+                    tabsInOrder.push_back(tab);
+                }
+            }
+        }
+        return tabsInOrder;
+    }
+
+    static Json::Value _parseJsonString(const winrt::hstring& json)
+    {
+        Json::Value root;
+        Json::CharReaderBuilder rb;
+        std::string errs;
+        std::istringstream stream{ winrt::to_string(json) };
+        if (!Json::parseFromStream(rb, stream, &root, &errs))
+        {
+            return {};
+        }
+        return root;
+    }
+
+    static std::vector<std::wstring> _parseStringArrayJson(const winrt::hstring& json)
+    {
+        std::vector<std::wstring> strings;
+        const auto root = _parseJsonString(json);
+        if (!root.isArray())
+        {
+            return strings;
+        }
+        strings.reserve(root.size());
+        for (const auto& item : root)
+        {
+            if (item.isString())
+            {
+                strings.push_back(winrt::to_hstring(item.asString()).c_str());
+            }
+        }
+        return strings;
+    }
+
     // Helper to get PID from a pane's terminal control connection.
     static uint32_t _getPidFromPane(const std::shared_ptr<Pane>& pane)
     {
@@ -1017,6 +1084,91 @@ namespace winrt::TerminalApp::implementation
         _restoreWorkspaceIdOnInit = id;
     }
 
+    winrt::hstring TerminalPage::GetWorkspaceBindings(winrt::hstring workspaceId)
+    {
+        Json::Value arr{ Json::arrayValue };
+        const auto currentWindowId = _WindowProperties.WindowId();
+        for (const auto& t : _tabs)
+        {
+            if (const auto ti = _GetTabImpl(t); ti && ti->BoundWorkspaceId() == workspaceId)
+            {
+                Json::Value o{ Json::objectValue };
+                o["workspaceTabId"] = winrt::to_string(ti->BoundWorkspaceTabId());
+                o["currentWindowId"] = static_cast<Json::UInt64>(currentWindowId);
+                o["homeWindowId"] = static_cast<Json::UInt64>(ti->BoundHomeWindowId());
+                arr.append(o);
+            }
+        }
+
+        Json::StreamWriterBuilder wb;
+        return winrt::to_hstring(Json::writeString(wb, arr));
+    }
+
+    winrt::hstring TerminalPage::PlanWorkspaceRestore(winrt::hstring workspaceId, winrt::hstring allLiveBindingsJson)
+    {
+        std::vector<std::wstring> savedTabIds;
+        const auto record = _findSavedWorkspaceSession(workspaceId);
+        if (!record)
+        {
+            Json::Value out{ Json::objectValue };
+            out["target"] = "new";
+            Json::StreamWriterBuilder wb;
+            return winrt::to_hstring(Json::writeString(wb, out));
+        }
+
+        for (const auto& tab : _savedWorkspaceTabsInOrder(record))
+        {
+            savedTabIds.push_back(std::wstring{ std::wstring_view{ tab.WorkspaceTabId() } });
+        }
+
+        std::vector<WorkspaceLiveBinding> liveBindings;
+        const auto root = _parseJsonString(allLiveBindingsJson);
+        if (root.isArray())
+        {
+            liveBindings.reserve(root.size());
+            for (const auto& item : root)
+            {
+                if (!item.isObject() || !item["workspaceTabId"].isString())
+                {
+                    continue;
+                }
+
+                WorkspaceLiveBinding binding;
+                binding.workspaceTabId = winrt::to_hstring(item["workspaceTabId"].asString()).c_str();
+                binding.currentWindowId = item["currentWindowId"].isUInt64() ? item["currentWindowId"].asUInt64() : 0;
+                binding.homeWindowId = item["homeWindowId"].isUInt64() ? item["homeWindowId"].asUInt64() : 0;
+                liveBindings.push_back(std::move(binding));
+            }
+        }
+
+        const auto plan = DecideWorkspaceRestore(savedTabIds, liveBindings);
+
+        Json::Value out{ Json::objectValue };
+        if (plan.newWindow)
+        {
+            out["target"] = "new";
+        }
+        else
+        {
+            out["target"] = "existing";
+            out["windowId"] = static_cast<Json::UInt64>(plan.windowId);
+            Json::Value missing{ Json::arrayValue };
+            for (const auto& id : plan.missingTabIds)
+            {
+                missing.append(winrt::to_string(id));
+            }
+            out["missingTabIds"] = missing;
+        }
+
+        Json::StreamWriterBuilder wb;
+        return winrt::to_hstring(Json::writeString(wb, out));
+    }
+
+    void TerminalPage::RestoreMissingWorkspaceTabs(winrt::hstring workspaceId, winrt::hstring missingTabIdsJson)
+    {
+        _RestoreMissingWorkspaceTabs(std::move(workspaceId), std::move(missingTabIdsJson));
+    }
+
     // Bind restored tabs in the range [tabCountBefore + boundTabs, _tabs.Size())
     // to the workspace and register each tab's pending agent-pane load hint.
     //
@@ -1032,11 +1184,10 @@ namespace winrt::TerminalApp::implementation
     // bound exactly once. One record tab == one NewTab action, so the record
     // index tracks `boundTabs` (intra-tab SplitPane actions don't grow _tabs).
     void TerminalPage::_BindRestoredWorkspaceTabs(const winrt::hstring& id,
-                                                  const Model::SavedWorkspaceSession& record,
+                                                  const std::vector<Model::SavedWorkspaceTab>& restoredTabsInOrder,
                                                   uint32_t tabCountBefore,
                                                   uint32_t& boundTabs)
     {
-        const auto tabs = record.Tabs();
         while (tabCountBefore + boundTabs < _tabs.Size())
         {
             const auto ti = _GetTabImpl(_tabs.GetAt(tabCountBefore + boundTabs));
@@ -1048,11 +1199,11 @@ namespace winrt::TerminalApp::implementation
             }
             ti->BoundWorkspaceId(id);
 
-            if (!tabs || recIdx >= tabs.Size())
+            if (recIdx >= restoredTabsInOrder.size())
             {
                 continue;
             }
-            const auto savedTab = tabs.GetAt(recIdx);
+            const auto savedTab = restoredTabsInOrder.at(recIdx);
             ti->BoundWorkspaceTabId(savedTab.WorkspaceTabId());
             ti->BoundHomeWindowId(_WindowProperties.WindowId());
 
@@ -1089,30 +1240,19 @@ namespace winrt::TerminalApp::implementation
     // (with a default startup tab), it also closes those pre-existing default
     // tab(s) afterwards so the window shows exactly the restored workspace.
     // This is the sole restore path: the COM server always requests a brand-new
-    // window (WindowEmperor::RequestRestoreWorkspaceInNewWindow), so there is no
-    // "focus the already-open workspace" branch — a saved workspace can be
-    // restored repeatedly, template-style.
+    // window when WindowEmperor's workspace-aware restore routing decides that
+    // no existing window still anchors the workspace.
     safe_void_coroutine TerminalPage::_RestoreWorkspaceOnInit(winrt::hstring id)
     {
         auto strong = get_strong();
         co_await wil::resume_foreground(Dispatcher());
 
-        Model::SavedWorkspaceSession record{ nullptr };
-        if (const auto sessions = ApplicationState::SharedInstance().SavedWorkspaceSessions())
-        {
-            for (const auto& s : sessions)
-            {
-                if (s.Id() == id)
-                {
-                    record = s;
-                    break;
-                }
-            }
-        }
+        Model::SavedWorkspaceSession record = _findSavedWorkspaceSession(id);
         if (!record)
         {
             co_return;
         }
+        const auto restoredTabsInOrder = _savedWorkspaceTabsInOrder(record);
 
         // Capture the fresh window's default tab(s) to close after restoring.
         std::vector<winrt::com_ptr<Tab>> preexisting;
@@ -1128,27 +1268,24 @@ namespace winrt::TerminalApp::implementation
         const std::filesystem::path settingsRoot{ std::wstring_view{ CascadiaSettings::SettingsDirectory() } };
 
         std::vector<Model::ActionAndArgs> actions;
-        if (const auto tabs = record.Tabs())
+        using namespace std::string_view_literals;
+        const auto filenamePrefix = IsRunningElevated() ? L"elevated_"sv : L"buffer_"sv;
+        for (const auto& tab : restoredTabsInOrder)
         {
-            using namespace std::string_view_literals;
-            const auto filenamePrefix = IsRunningElevated() ? L"elevated_"sv : L"buffer_"sv;
-            for (const auto& tab : tabs)
+            if (const auto ids = tab.BufferSessionIds())
             {
-                if (const auto ids = tab.BufferSessionIds())
+                for (const auto& sid : ids)
                 {
-                    for (const auto& sid : ids)
-                    {
-                        const std::wstring storedName = std::wstring{ L"buffer_" } + std::wstring{ sid } + L".txt";
-                        const std::wstring stagedName = std::wstring{ filenamePrefix } + std::wstring{ sid } + L".txt";
-                        _copyBufferFileForRestore(dir / storedName, settingsRoot / stagedName, IsRunningElevated());
-                    }
+                    const std::wstring storedName = std::wstring{ L"buffer_" } + std::wstring{ sid } + L".txt";
+                    const std::wstring stagedName = std::wstring{ filenamePrefix } + std::wstring{ sid } + L".txt";
+                    _copyBufferFileForRestore(dir / storedName, settingsRoot / stagedName, IsRunningElevated());
                 }
-                if (const auto tabActions = tab.TabActions())
+            }
+            if (const auto tabActions = tab.TabActions())
+            {
+                for (const auto& a : tabActions)
                 {
-                    for (const auto& a : tabActions)
-                    {
-                        actions.push_back(a);
-                    }
+                    actions.push_back(a);
                 }
             }
         }
@@ -1166,16 +1303,88 @@ namespace winrt::TerminalApp::implementation
             suspend = true;
             // Bind whatever this action just created, synchronously, before the
             // next co_await can hand the thread to a tab's pre-warm tick.
-            _BindRestoredWorkspaceTabs(id, record, tabCountBefore, boundTabs);
+            _BindRestoredWorkspaceTabs(id, restoredTabsInOrder, tabCountBefore, boundTabs);
         }
         // Catch tabs created by the final action (no co_await follows it).
-        _BindRestoredWorkspaceTabs(id, record, tabCountBefore, boundTabs);
+        _BindRestoredWorkspaceTabs(id, restoredTabsInOrder, tabCountBefore, boundTabs);
 
         // Drop the fresh window's default startup tab(s).
         for (const auto& def : preexisting)
         {
             _RemoveTab(*def);
         }
+    }
+
+    safe_void_coroutine TerminalPage::_RestoreMissingWorkspaceTabs(winrt::hstring id, winrt::hstring missingTabIdsJson)
+    {
+        auto strong = get_strong();
+        co_await wil::resume_foreground(Dispatcher());
+
+        const auto record = _findSavedWorkspaceSession(id);
+        if (!record)
+        {
+            co_return;
+        }
+
+        const auto missingTabIds = _parseStringArrayJson(missingTabIdsJson);
+        std::unordered_set<std::wstring> missingSet{ missingTabIds.begin(), missingTabIds.end() };
+
+        std::vector<Model::SavedWorkspaceTab> restoredTabsInOrder;
+        for (const auto& tab : _savedWorkspaceTabsInOrder(record))
+        {
+            if (missingSet.contains(std::wstring{ std::wstring_view{ tab.WorkspaceTabId() } }))
+            {
+                restoredTabsInOrder.push_back(tab);
+            }
+        }
+
+        if (restoredTabsInOrder.empty())
+        {
+            _FocusCurrentTab(true);
+            co_return;
+        }
+
+        const auto dir = _SavedWorkspaceSessionDir(id);
+        const std::filesystem::path settingsRoot{ std::wstring_view{ CascadiaSettings::SettingsDirectory() } };
+
+        std::vector<Model::ActionAndArgs> actions;
+        using namespace std::string_view_literals;
+        const auto filenamePrefix = IsRunningElevated() ? L"elevated_"sv : L"buffer_"sv;
+        for (const auto& tab : restoredTabsInOrder)
+        {
+            if (const auto ids = tab.BufferSessionIds())
+            {
+                for (const auto& sid : ids)
+                {
+                    const std::wstring storedName = std::wstring{ L"buffer_" } + std::wstring{ sid } + L".txt";
+                    const std::wstring stagedName = std::wstring{ filenamePrefix } + std::wstring{ sid } + L".txt";
+                    _copyBufferFileForRestore(dir / storedName, settingsRoot / stagedName, IsRunningElevated());
+                }
+            }
+            if (const auto tabActions = tab.TabActions())
+            {
+                for (const auto& a : tabActions)
+                {
+                    actions.push_back(a);
+                }
+            }
+        }
+
+        const auto tabCountBefore = _tabs.Size();
+        uint32_t boundTabs = 0;
+        auto suspend = _tabs.Size() > 0;
+        for (auto&& a : actions)
+        {
+            if (suspend)
+            {
+                co_await wil::resume_foreground(Dispatcher(), winrt::Windows::UI::Core::CoreDispatcherPriority::Low);
+            }
+            _actionDispatch->DoAction(a);
+            suspend = true;
+            _BindRestoredWorkspaceTabs(id, restoredTabsInOrder, tabCountBefore, boundTabs);
+        }
+        _BindRestoredWorkspaceTabs(id, restoredTabsInOrder, tabCountBefore, boundTabs);
+        _FocusCurrentTab(true);
     }
 
     IAsyncOperation<bool> TerminalPage::DeleteSavedWorkspaceSessionProtocol(winrt::hstring id)

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -208,6 +208,9 @@ namespace winrt::TerminalApp::implementation
         Windows::Foundation::IAsyncOperation<Microsoft::Terminal::Protocol::TabCreationResult> CreateProtocolTab(Microsoft::Terminal::Settings::Model::NewTerminalArgs args, bool background);
         Windows::Foundation::IAsyncOperation<winrt::hstring> SaveWorkspaceSessionProtocol(winrt::hstring tabIds, winrt::hstring title, winrt::hstring mode);
         Windows::Foundation::IAsyncOperation<winrt::hstring> ListSavedWorkspaceSessionsProtocol();
+        winrt::hstring GetWorkspaceBindings(winrt::hstring workspaceId);
+        winrt::hstring PlanWorkspaceRestore(winrt::hstring workspaceId, winrt::hstring allLiveBindingsJson);
+        void RestoreMissingWorkspaceTabs(winrt::hstring workspaceId, winrt::hstring missingTabIdsJson);
         void SetRestoreWorkspaceOnInit(winrt::hstring id);
         Windows::Foundation::IAsyncOperation<bool> DeleteSavedWorkspaceSessionProtocol(winrt::hstring id);
         Windows::Foundation::IAsyncOperation<Microsoft::Terminal::Protocol::TabCreationResult> SplitProtocolPane(winrt::guid sessionId, Microsoft::Terminal::Settings::Model::SplitDirection direction, float size, Microsoft::Terminal::Settings::Model::NewTerminalArgs args, bool background);
@@ -457,12 +460,13 @@ namespace winrt::TerminalApp::implementation
         // self-restores that Eternal-Terminal workspace once it's Initialized.
         winrt::hstring _restoreWorkspaceIdOnInit{};
         safe_void_coroutine _RestoreWorkspaceOnInit(winrt::hstring id);
+        safe_void_coroutine _RestoreMissingWorkspaceTabs(winrt::hstring id, winrt::hstring missingTabIdsJson);
         // Bind newly created restored tabs (workspace id + pending agent-pane
         // load hint) synchronously as they appear, so the hint is registered
         // before each tab's deferred pre-warm tick can race ahead. `boundTabs`
         // is carried across calls so each restored tab is bound exactly once.
         void _BindRestoredWorkspaceTabs(const winrt::hstring& id,
-                                        const Microsoft::Terminal::Settings::Model::SavedWorkspaceSession& record,
+                                        const std::vector<Microsoft::Terminal::Settings::Model::SavedWorkspaceTab>& restoredTabsInOrder,
                                         uint32_t tabCountBefore,
                                         uint32_t& boundTabs);
         // Short-lived marks keyed by tab StableId: set whenever an agent

--- a/src/cascadia/TerminalApp/TerminalPage.idl
+++ b/src/cascadia/TerminalApp/TerminalPage.idl
@@ -119,6 +119,9 @@ namespace TerminalApp
         Windows.Foundation.IAsyncOperation<Microsoft.Terminal.Protocol.TabCreationResult> CreateProtocolTab(Microsoft.Terminal.Settings.Model.NewTerminalArgs args, Boolean background);
         Windows.Foundation.IAsyncOperation<String> SaveWorkspaceSessionProtocol(String tabIds, String title, String mode);
         Windows.Foundation.IAsyncOperation<String> ListSavedWorkspaceSessionsProtocol();
+        String GetWorkspaceBindings(String workspaceId);
+        String PlanWorkspaceRestore(String workspaceId, String allLiveBindingsJson);
+        void RestoreMissingWorkspaceTabs(String workspaceId, String missingTabIdsJson);
         // Stash a workspace id so this (freshly created) window self-restores
         // that workspace once its page finishes startup (Initialized).
         void SetRestoreWorkspaceOnInit(String id);

--- a/src/cascadia/TerminalApp/WorkspaceRestoreDecision.h
+++ b/src/cascadia/TerminalApp/WorkspaceRestoreDecision.h
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace winrt::TerminalApp::implementation
+{
+    struct WorkspaceLiveBinding
+    {
+        std::wstring workspaceTabId;
+        uint64_t currentWindowId;
+        uint64_t homeWindowId;
+    };
+
+    struct WorkspaceRestorePlan
+    {
+        bool newWindow{ false };
+        uint64_t windowId{ 0 };
+        std::vector<std::wstring> missingTabIds;
+    };
+
+    inline WorkspaceRestorePlan DecideWorkspaceRestore(const std::vector<std::wstring>& savedTabIds,
+                                                       const std::vector<WorkspaceLiveBinding>& live)
+    {
+        std::map<uint64_t, size_t> anchorCounts;
+        for (const auto& binding : live)
+        {
+            if (binding.homeWindowId != 0 && binding.currentWindowId == binding.homeWindowId)
+            {
+                ++anchorCounts[binding.homeWindowId];
+            }
+        }
+
+        if (anchorCounts.empty())
+        {
+            WorkspaceRestorePlan plan;
+            plan.newWindow = true;
+            return plan;
+        }
+
+        const auto targetWindow = std::max_element(anchorCounts.begin(), anchorCounts.end(), [](const auto& lhs, const auto& rhs) {
+            if (lhs.second == rhs.second)
+            {
+                return lhs.first > rhs.first;
+            }
+            return lhs.second < rhs.second;
+        })->first;
+
+        std::unordered_set<std::wstring> anchoredIds;
+        for (const auto& binding : live)
+        {
+            if (binding.homeWindowId == targetWindow && binding.currentWindowId == binding.homeWindowId)
+            {
+                anchoredIds.insert(binding.workspaceTabId);
+            }
+        }
+
+        WorkspaceRestorePlan plan;
+        plan.windowId = targetWindow;
+        for (const auto& savedTabId : savedTabIds)
+        {
+            if (!anchoredIds.contains(savedTabId))
+            {
+                plan.missingTabIds.push_back(savedTabId);
+            }
+        }
+        return plan;
+    }
+}

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
@@ -1033,10 +1033,9 @@ try
     *json = nullptr;
     RETURN_HR_IF(E_NOT_VALID_STATE, !s_emperor);
 
-    // Always restore into a BRAND-NEW window. Queue the id + post to the
-    // emperor's message window so window creation runs on the UI thread; the
-    // new window's page self-restores the workspace once it's Initialized.
-    s_emperor->RequestRestoreWorkspaceInNewWindow(_hstr(id));
+    // Queue the id + post to the emperor's message window so cross-window
+    // restore routing runs on the UI thread.
+    s_emperor->RequestRestoreWorkspace(_hstr(id));
 
     Json::Value out{ Json::objectValue };
     out["outcome"] = "opened";

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -23,6 +23,8 @@
 
 #include <bcrypt.h>
 #include <fstream>
+#include <json/json.h>
+#include <sstream>
 #pragma comment(lib, "bcrypt.lib")
 
 using namespace winrt;
@@ -316,7 +318,7 @@ void WindowEmperor::CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs args
 
 }
 
-void WindowEmperor::RequestRestoreWorkspaceInNewWindow(winrt::hstring id)
+void WindowEmperor::RequestRestoreWorkspace(winrt::hstring id)
 {
     if (id.empty())
     {
@@ -328,7 +330,7 @@ void WindowEmperor::RequestRestoreWorkspaceInNewWindow(winrt::hstring id)
     }
     if (_window)
     {
-        PostMessageW(_window.get(), WM_RESTORE_WORKSPACE_IN_NEW_WINDOW, 0, 0);
+        PostMessageW(_window.get(), WM_RESTORE_WORKSPACE, 0, 0);
     }
 }
 
@@ -1147,18 +1149,18 @@ LRESULT WindowEmperor::_messageHandler(HWND window, UINT const message, WPARAM c
             _messageBoxCount -= 1;
             _postQuitMessageIfNeeded();
             return 0;
-        case WM_RESTORE_WORKSPACE_IN_NEW_WINDOW:
+        case WM_RESTORE_WORKSPACE:
         {
-            // Eternal-Terminal /restore-ws: open a brand-new window per queued
-            // workspace id and let its page self-restore on Initialized. Runs
-            // on the UI thread (posted here from the COM MTA thread).
+            // Eternal-Terminal /restore-ws: route each queued workspace id to
+            // the window that still anchors it, or open a new window if none do.
+            // Runs on the UI thread (posted here from the COM MTA thread).
             std::deque<std::wstring> ids;
             {
                 std::lock_guard lock{ _pendingRestoreWsMutex };
                 ids.swap(_pendingRestoreWs);
             }
-            for (const auto& wsId : ids)
-            {
+
+            auto restoreInNewWindow = [this](const std::wstring& wsId) {
                 // Build a default new-window request (empty commandline ⇒ one
                 // default tab). We must NOT use the (window, content, bounds)
                 // ctor with empty content: AppHost::_HandleCommandlineArgs then
@@ -1172,6 +1174,106 @@ LRESULT WindowEmperor::_messageHandler(HWND window, UINT const message, WPARAM c
                     {
                         page.SetRestoreWorkspaceOnInit(winrt::hstring{ wsId });
                     }
+                }
+            };
+
+            auto summonWindow = [this](const uint64_t windowId) {
+                SummonWindowSelectionArgs args;
+                args.WindowID = windowId;
+                args.SummonBehavior.MoveToCurrentDesktop(false);
+                args.SummonBehavior.ToMonitor(winrt::TerminalApp::MonitorBehavior::InPlace);
+                args.SummonBehavior.ToggleVisibility(false);
+                std::ignore = _summonWindow(args);
+            };
+
+            for (const auto& wsId : ids)
+            {
+                if (_windows.empty())
+                {
+                    restoreInNewWindow(wsId);
+                    continue;
+                }
+
+                Json::Value mergedBindings{ Json::arrayValue };
+                winrt::TerminalApp::TerminalPage planningPage{ nullptr };
+                for (const auto& host : _windows)
+                {
+                    const auto page = host->Logic().GetRoot().try_as<winrt::TerminalApp::TerminalPage>();
+                    if (!page)
+                    {
+                        continue;
+                    }
+                    if (!planningPage)
+                    {
+                        planningPage = page;
+                    }
+
+                    const auto bindingsJson = page.GetWorkspaceBindings(winrt::hstring{ wsId });
+                    Json::Value windowBindings;
+                    Json::CharReaderBuilder rb;
+                    std::string errs;
+                    std::istringstream stream{ winrt::to_string(bindingsJson) };
+                    if (Json::parseFromStream(rb, stream, &windowBindings, &errs) && windowBindings.isArray())
+                    {
+                        for (const auto& binding : windowBindings)
+                        {
+                            mergedBindings.append(binding);
+                        }
+                    }
+                }
+
+                if (!planningPage)
+                {
+                    restoreInNewWindow(wsId);
+                    continue;
+                }
+
+                Json::StreamWriterBuilder wb;
+                const auto planJson = planningPage.PlanWorkspaceRestore(winrt::hstring{ wsId }, winrt::to_hstring(Json::writeString(wb, mergedBindings)));
+                Json::Value plan;
+                Json::CharReaderBuilder rb;
+                std::string errs;
+                std::istringstream stream{ winrt::to_string(planJson) };
+                if (!Json::parseFromStream(rb, stream, &plan, &errs) || !plan.isObject())
+                {
+                    restoreInNewWindow(wsId);
+                    continue;
+                }
+
+                if (plan["target"].asString() == "new")
+                {
+                    restoreInNewWindow(wsId);
+                    continue;
+                }
+
+                const auto windowId = plan["windowId"].isUInt64() ? plan["windowId"].asUInt64() : 0;
+                AppHost* targetHost = nullptr;
+                for (const auto& host : _windows)
+                {
+                    if (host->Logic().WindowProperties().WindowId() == windowId)
+                    {
+                        targetHost = host.get();
+                        break;
+                    }
+                }
+
+                if (!targetHost)
+                {
+                    restoreInNewWindow(wsId);
+                    continue;
+                }
+
+                summonWindow(windowId);
+                const auto targetPage = targetHost->Logic().GetRoot().try_as<winrt::TerminalApp::TerminalPage>();
+                if (!targetPage)
+                {
+                    continue;
+                }
+
+                const auto missing = plan["missingTabIds"].isArray() ? plan["missingTabIds"] : Json::Value{ Json::arrayValue };
+                if (!missing.empty())
+                {
+                    targetPage.RestoreMissingWorkspaceTabs(winrt::hstring{ wsId }, winrt::to_hstring(Json::writeString(wb, missing)));
                 }
             }
             return 0;

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -33,7 +33,7 @@ public:
         WM_MESSAGE_BOX_CLOSED,
         WM_IDENTIFY_ALL_WINDOWS,
         WM_NOTIFY_FROM_NOTIFICATION_AREA,
-        WM_RESTORE_WORKSPACE_IN_NEW_WINDOW,
+        WM_RESTORE_WORKSPACE,
     };
 
     WindowEmperor();
@@ -43,11 +43,10 @@ public:
     AppHost* GetWindowById(uint64_t id) const noexcept;
     AppHost* GetWindowByName(std::wstring_view name) const noexcept;
     void CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs args);
-    // Thread-safe (callable from the COM MTA thread): request that a brand-new
-    // window open and self-restore the given Eternal-Terminal workspace id.
-    // Queues the id and posts to the emperor's message window so the actual
-    // window creation runs on the main/UI thread.
-    void RequestRestoreWorkspaceInNewWindow(winrt::hstring id);
+    // Thread-safe (callable from the COM MTA thread): request that the given
+    // Eternal-Terminal workspace id be restored. Queues the id and posts to the
+    // emperor's message window so cross-window routing runs on the main/UI thread.
+    void RequestRestoreWorkspace(winrt::hstring id);
     void HandleCommandlineArgs(int nCmdShow);
     void FocusTabInAnyWindow(const winrt::TerminalApp::Tab& tab) const;
 
@@ -94,8 +93,8 @@ private:
     winrt::TerminalApp::App _app{ nullptr };
     std::vector<std::shared_ptr<::AppHost>> _windows;
 
-    // Workspace ids queued by RequestRestoreWorkspaceInNewWindow (COM thread),
-    // drained on the UI thread in the WM_RESTORE_WORKSPACE_IN_NEW_WINDOW handler.
+    // Workspace ids queued by RequestRestoreWorkspace (COM thread),
+    // drained on the UI thread in the WM_RESTORE_WORKSPACE handler.
     std::mutex _pendingRestoreWsMutex;
     std::deque<std::wstring> _pendingRestoreWs;
 

--- a/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
+++ b/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ClCompile Include="JsonUtilsTests.cpp" />
     <ClCompile Include="FzfTests.cpp" />
+    <ClCompile Include="WorkspaceRestoreDecisionTests.cpp" />
     <ClCompile Include="AgentHooksStatusTests.cpp" />
     <ClCompile Include="BoundedDispatchQueueTests.cpp" />
     <ClCompile Include="CustomAgentIdTests.cpp" />

--- a/src/cascadia/ut_app/WorkspaceRestoreDecisionTests.cpp
+++ b/src/cascadia/ut_app/WorkspaceRestoreDecisionTests.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "precomp.h"
+
+#include "../TerminalApp/WorkspaceRestoreDecision.h"
+
+using namespace WEX::Logging;
+using namespace WEX::TestExecution;
+using namespace WEX::Common;
+using namespace winrt::TerminalApp::implementation;
+
+namespace TerminalAppUnitTests
+{
+    class WorkspaceRestoreDecisionTests
+    {
+        TEST_CLASS(WorkspaceRestoreDecisionTests);
+
+        TEST_METHOD(AllClosedRestoresInNewWindow);
+        TEST_METHOD(OneAnchorRestoresOnlyMissingTabsIntoAnchorWindow);
+        TEST_METHOD(DraggedTabCountsAsMissing);
+        TEST_METHOD(EverythingPresentFocusesExistingWindow);
+    };
+
+    static void VerifyMissingIds(const std::vector<std::wstring>& expected, const std::vector<std::wstring>& actual)
+    {
+        VERIFY_ARE_EQUAL(expected.size(), actual.size());
+        for (size_t i = 0; i < expected.size() && i < actual.size(); ++i)
+        {
+            VERIFY_ARE_EQUAL(expected[i], actual[i]);
+        }
+    }
+
+    void WorkspaceRestoreDecisionTests::AllClosedRestoresInNewWindow()
+    {
+        const std::vector<std::wstring> saved{ L"A", L"B", L"C" };
+
+        const auto plan = DecideWorkspaceRestore(saved, {});
+
+        VERIFY_IS_TRUE(plan.newWindow);
+        VERIFY_ARE_EQUAL(uint64_t{ 0 }, plan.windowId);
+        VERIFY_IS_TRUE(plan.missingTabIds.empty());
+    }
+
+    void WorkspaceRestoreDecisionTests::OneAnchorRestoresOnlyMissingTabsIntoAnchorWindow()
+    {
+        const std::vector<std::wstring> saved{ L"A", L"B", L"C" };
+        const std::vector<WorkspaceLiveBinding> live{
+            { L"A", 42, 42 },
+        };
+
+        const auto plan = DecideWorkspaceRestore(saved, live);
+
+        VERIFY_IS_FALSE(plan.newWindow);
+        VERIFY_ARE_EQUAL(uint64_t{ 42 }, plan.windowId);
+        VerifyMissingIds({ L"B", L"C" }, plan.missingTabIds);
+    }
+
+    void WorkspaceRestoreDecisionTests::DraggedTabCountsAsMissing()
+    {
+        const std::vector<std::wstring> saved{ L"A", L"B", L"C" };
+        const std::vector<WorkspaceLiveBinding> live{
+            { L"A", 1, 1 },
+            { L"C", 2, 1 },
+        };
+
+        const auto plan = DecideWorkspaceRestore(saved, live);
+
+        VERIFY_IS_FALSE(plan.newWindow);
+        VERIFY_ARE_EQUAL(uint64_t{ 1 }, plan.windowId);
+        VerifyMissingIds({ L"B", L"C" }, plan.missingTabIds);
+    }
+
+    void WorkspaceRestoreDecisionTests::EverythingPresentFocusesExistingWindow()
+    {
+        const std::vector<std::wstring> saved{ L"A", L"B", L"C" };
+        const std::vector<WorkspaceLiveBinding> live{
+            { L"A", 7, 7 },
+            { L"B", 7, 7 },
+            { L"C", 7, 7 },
+        };
+
+        const auto plan = DecideWorkspaceRestore(saved, live);
+
+        VERIFY_IS_FALSE(plan.newWindow);
+        VERIFY_ARE_EQUAL(uint64_t{ 7 }, plan.windowId);
+        VERIFY_IS_TRUE(plan.missingTabIds.empty());
+    }
+}


### PR DESCRIPTION
## Summary
- Makes `/restore-ws` window-aware by gathering live workspace bindings across windows and routing through a pure `DecideWorkspaceRestore` plan.
- Restores only missing saved tabs into the existing anchor window when possible; falls back to the existing new-window restore path when no anchors remain.
- Adds `TerminalPage` binding/planning/partial-restore IDL methods and unit tests for the decision function.

## Reviewer F5 E2E scenarios
1. Save a 3-tab window, close 2 keep 1, `/restore-ws` → the 2 missing tabs reappear in the SAME window (no new window).
2. Close all 3, `/restore-ws` → a new window with all 3.
3. Drag 1 tab to another window, close 1, keep 1; `/restore-ws` → target = the window with the kept tab; the closed one AND a fresh copy of the dragged one are recreated there (the dragged original stays put).

## Verification
- TerminalApp `bx`: 0 errors.
- WindowsTerminal `bx`: 0 errors.
- ut_app `bx` + `/name:*WorkspaceRestoreDecision*`: 4/4 passed.
- Full `bcz no_clean`: 0 errors.