### PR TITLE
?<prompt>: route WSL delegates through wsl -d <distro> (host-absent prompt fix + tests)

### DIFF
--- a/tools/wta/src/cli_tests.rs
+++ b/tools/wta/src/cli_tests.rs
@@ -348,7 +348,7 @@ fn json_str_or_num_reads_strings_and_numbers_else_dash() {
     assert_eq!(json_str_or_num(&v, "missing"), "-");
 }
 
-// ── Delegate: WSL panes bypass the Windows-host launchability pre-flight ─────
+// ── Delegate: WSL panes bypass the Windows-host launchable check ─────────────
 //
 // `delegate_command_launchable` only checks the Windows PATH, which is
 // meaningless for a WSL pane (the agent runs inside the distro). These lock in
@@ -376,7 +376,7 @@ fn active_pane_is_wsl_rejects_non_wsl_shells() {
     assert!(!active_pane_is_wsl(Some(&pane_with_shell("pwsh"))));
     assert!(!active_pane_is_wsl(Some(&pane_with_shell("cmd"))));
     // A pane name that merely contains "wsl" is not the `wsl:` prefix.
-    assert!(!active_pane_is_wsl(Some(&pane_with_shell("mywsl"))));
+    assert!(!active_pane_is_wsl(Some(&pane_with_shell("my-wsl"))));
     // `shell` field absent.
     let no_shell = serde_json::json!({ "cwd": "/home/u" });
     assert!(!active_pane_is_wsl(Some(&no_shell)));

--- a/tools/wta/src/cli_tests.rs
+++ b/tools/wta/src/cli_tests.rs
@@ -347,3 +347,61 @@ fn json_str_or_num_reads_strings_and_numbers_else_dash() {
     assert_eq!(json_str_or_num(&v, "nl"), "-");
     assert_eq!(json_str_or_num(&v, "missing"), "-");
 }
+
+// ── Delegate: WSL panes bypass the Windows-host launchability pre-flight ─────
+//
+// `delegate_command_launchable` only checks the Windows PATH, which is
+// meaningless for a WSL pane (the agent runs inside the distro). These lock in
+// that a WSL pane is treated as launchable regardless of the host check, so a
+// `?<prompt>` from a WSL pane still gets its prompt enriched/delivered when the
+// agent (e.g. Copilot) is installed only inside the distro. Regression guard
+// for the "prompt silently dropped" bug.
+
+/// Build a minimal active-pane JSON value with the given `shell` field, as
+/// reported by WT's `get_active_pane` / `OSC 9001;ShellType`.
+fn pane_with_shell(shell: &str) -> serde_json::Value {
+    serde_json::json!({ "shell": shell })
+}
+
+#[test]
+fn active_pane_is_wsl_detects_wsl_shell() {
+    assert!(active_pane_is_wsl(Some(&pane_with_shell("wsl:Ubuntu"))));
+    assert!(active_pane_is_wsl(Some(&pane_with_shell("wsl:Debian"))));
+    // Bare `wsl:` prefix (no distro name) still counts as WSL.
+    assert!(active_pane_is_wsl(Some(&pane_with_shell("wsl:"))));
+}
+
+#[test]
+fn active_pane_is_wsl_rejects_non_wsl_shells() {
+    assert!(!active_pane_is_wsl(Some(&pane_with_shell("pwsh"))));
+    assert!(!active_pane_is_wsl(Some(&pane_with_shell("cmd"))));
+    // A pane name that merely contains "wsl" is not the `wsl:` prefix.
+    assert!(!active_pane_is_wsl(Some(&pane_with_shell("mywsl"))));
+    // `shell` field absent.
+    let no_shell = serde_json::json!({ "cwd": "/home/u" });
+    assert!(!active_pane_is_wsl(Some(&no_shell)));
+    // `shell` present but not a string.
+    let numeric_shell = serde_json::json!({ "shell": 42 });
+    assert!(!active_pane_is_wsl(Some(&numeric_shell)));
+    // No active pane at all.
+    assert!(!active_pane_is_wsl(None));
+}
+
+#[test]
+fn delegate_launchable_for_target_bypasses_host_check_for_wsl() {
+    let wsl = pane_with_shell("wsl:Ubuntu");
+    let pwsh = pane_with_shell("pwsh");
+
+    // The regression: agent not launchable on the Windows host, but the active
+    // pane is WSL → still launchable, so the prompt is enriched, not dropped.
+    assert!(delegate_launchable_for_target(false, Some(&wsl)));
+
+    // Not launchable on host AND not a WSL pane → stays non-launchable (the
+    // bare-command path, where the prompt is intentionally not baked in).
+    assert!(!delegate_launchable_for_target(false, Some(&pwsh)));
+    assert!(!delegate_launchable_for_target(false, None));
+
+    // Launchable on the host is always launchable, WSL pane or not.
+    assert!(delegate_launchable_for_target(true, Some(&pwsh)));
+    assert!(delegate_launchable_for_target(true, Some(&wsl)));
+}

--- a/tools/wta/src/cli_tests.rs
+++ b/tools/wta/src/cli_tests.rs
@@ -367,8 +367,6 @@ fn pane_with_shell(shell: &str) -> serde_json::Value {
 fn active_pane_is_wsl_detects_wsl_shell() {
     assert!(active_pane_is_wsl(Some(&pane_with_shell("wsl:Ubuntu"))));
     assert!(active_pane_is_wsl(Some(&pane_with_shell("wsl:Debian"))));
-    // Bare `wsl:` prefix (no distro name) still counts as WSL.
-    assert!(active_pane_is_wsl(Some(&pane_with_shell("wsl:"))));
 }
 
 #[test]
@@ -377,6 +375,9 @@ fn active_pane_is_wsl_rejects_non_wsl_shells() {
     assert!(!active_pane_is_wsl(Some(&pane_with_shell("cmd"))));
     // A pane name that merely contains "wsl" is not the `wsl:` prefix.
     assert!(!active_pane_is_wsl(Some(&pane_with_shell("my-wsl"))));
+    // Bare `wsl:` with an empty distro name is not a valid WSL pane — shell
+    // integration only emits `wsl:<distro>` when `$WSL_DISTRO_NAME` is set.
+    assert!(!active_pane_is_wsl(Some(&pane_with_shell("wsl:"))));
     // `shell` field absent.
     let no_shell = serde_json::json!({ "cwd": "/home/u" });
     assert!(!active_pane_is_wsl(Some(&no_shell)));

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -1014,7 +1014,7 @@ pub(crate) fn build_wsl_delegate_commandline(
             DelegatePromptDelivery::LaunchWithStartupPrompt if !input.is_empty() => {
                 match profile.delegate_prompt_flag {
                     PromptFlag::Flag(flag) => {
-                        parts.push(flag.to_string());
+                        parts.push(sh_quote(flag));
                         parts.push(sh_quote(input));
                     }
                     PromptFlag::Positional => {

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2111,7 +2111,7 @@ async fn delegate_with_context(
     let launchable = crate::coordinator::delegate_command_launchable(&runtime.commandline);
 
     // A WSL pane runs the agent *inside the distro* (`wsl -d <distro> -- …`), so
-    // the Windows-host launchability pre-flight does not apply to it. Fetch the
+    // the Windows-host launchable check does not apply to it. Fetch the
     // active pane up front so both the gate below and the WSL branch further
     // down can see it. See `delegate_launchable_for_target`.
     let active = shell_mgr.wt_get_active_pane().await.ok();

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2043,6 +2043,35 @@ async fn run_delegate(
     }
 }
 
+/// True when the delegate's active pane runs inside a WSL distro — i.e. its
+/// shell, reported via `OSC 9001;ShellType`, is `wsl:<distro>` (e.g.
+/// `wsl:Ubuntu`). Returns `false` when the pane is missing, has no `shell`
+/// field, or the shell is anything else (PowerShell, cmd, …).
+fn active_pane_is_wsl(active: Option<&serde_json::Value>) -> bool {
+    active
+        .and_then(|p| p.get("shell"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.starts_with("wsl:"))
+        .unwrap_or(false)
+}
+
+/// Whether the delegate agent should be treated as launchable for the active
+/// pane's *target* environment.
+///
+/// `host_launchable` comes from [`crate::coordinator::delegate_command_launchable`],
+/// which only inspects the Windows PATH. That check is meaningless for a WSL
+/// pane, whose agent runs *inside* the distro (`wsl -d <distro> -- …`), so a
+/// WSL pane is always launchable here. Without this bypass a Copilot/Claude
+/// installed only in the distro would be treated as non-launchable and
+/// silently drop its `?<prompt>` text — the prompt-enrichment and session-pin
+/// gates in `delegate_with_context` both key off this value.
+fn delegate_launchable_for_target(
+    host_launchable: bool,
+    active: Option<&serde_json::Value>,
+) -> bool {
+    host_launchable || active_pane_is_wsl(active)
+}
+
 /// Shared delegation logic: enrich the prompt with the active pane's recent
 /// output (when available), build the delegate-agent commandline, and create a
 /// new tab to launch it. WT's GetActivePane already resolves the agent pane to
@@ -2080,7 +2109,15 @@ async fn delegate_with_context(
     // readable (the original "flash shut"). A bare `cmd /c <agent>` instead
     // fails cleanly with a non-zero code and stays put.
     let launchable = crate::coordinator::delegate_command_launchable(&runtime.commandline);
-    if !launchable {
+
+    // A WSL pane runs the agent *inside the distro* (`wsl -d <distro> -- …`), so
+    // the Windows-host launchability pre-flight does not apply to it. Fetch the
+    // active pane up front so both the gate below and the WSL branch further
+    // down can see it. See `delegate_launchable_for_target`.
+    let active = shell_mgr.wt_get_active_pane().await.ok();
+    let launchable_for_target = delegate_launchable_for_target(launchable, active.as_ref());
+
+    if !launchable_for_target {
         // Log only the executable (first token), never the full commandline: a
         // custom agent command can embed tokens/credentials that shouldn't land
         // in the log. The full commandline stays trace-only (below).
@@ -2103,8 +2140,10 @@ async fn delegate_with_context(
     // resolve correctly -- and so this decision matches the one the command
     // builder makes when it appends the flag, keeping the pinned id and the
     // actual launch flag in agreement. A non-launchable command will never
-    // produce a session, so skip pinning (and the born-bound registration below).
-    let pinned_session_id: Option<String> = if launchable {
+    // produce a session, so skip pinning (and the born-bound registration
+    // below). A WSL pane is launchable via the distro, so it pins like any
+    // other supported agent.
+    let pinned_session_id: Option<String> = if launchable_for_target {
         crate::agent_registry::lookup_profile_by_id(
             crate::agent_registry::resolve_agent_id_from_cmd(&runtime.commandline),
         )
@@ -2114,15 +2153,13 @@ async fn delegate_with_context(
         None
     };
 
-    // ── Active pane (hoisted for enrichment + WSL detection) ──────────────
-    let active = shell_mgr.wt_get_active_pane().await.ok();
-
     // ── Enriched prompt ──────────────────────────────────────────────────
-    // Only bake the active pane's output into the prompt when the agent is
-    // launchable (upstream pre-flight). A non-launchable agent stays in the
-    // bare-command path so its failure is clean and visible.
+    // Bake the active pane's output into the prompt when the agent is
+    // launchable for the target environment — the Windows pre-flight, or a WSL
+    // pane that will run the agent inside the distro. A non-launchable agent
+    // stays in the bare-command path so its failure is clean and visible.
     let enriched_prompt: Option<String> = match prompt {
-        Some(prompt) if !prompt.trim().is_empty() && launchable => {
+        Some(prompt) if !prompt.trim().is_empty() && launchable_for_target => {
             let active_pane_id = active
                 .as_ref()
                 .and_then(|v| v.get("session_id"))
@@ -2229,10 +2266,8 @@ async fn delegate_with_context(
                 if let (Some(sid), Some(pane)) =
                     (pinned_session_id.as_deref(), pane_guid.as_deref())
                 {
-register_launched_session_with_master(
-    sid, pane, &runtime.id, wsl_cwd.or(cwd),
-)
-.await;
+                    register_launched_session_with_master(sid, pane, &runtime.id, wsl_cwd.or(cwd))
+                        .await;
                 }
                 return Ok(());
             }

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2044,14 +2044,19 @@ async fn run_delegate(
 }
 
 /// True when the delegate's active pane runs inside a WSL distro — i.e. its
-/// shell, reported via `OSC 9001;ShellType`, is `wsl:<distro>` (e.g.
-/// `wsl:Ubuntu`). Returns `false` when the pane is missing, has no `shell`
-/// field, or the shell is anything else (PowerShell, cmd, …).
+/// shell, reported via `OSC 9001;ShellType`, is `wsl:<distro>` with a
+/// **non-empty** distro name (e.g. `wsl:Ubuntu`). The shipped Bash shell
+/// integration only emits `wsl:<distro>` when `$WSL_DISTRO_NAME` is set
+/// (otherwise it reports `bash`), so a bare `wsl:` never occurs in practice;
+/// rejecting it defensively keeps us from ever building a `wsl -d "" …`
+/// command. Returns `false` when the pane is missing, has no `shell` field, or
+/// the shell is anything else (PowerShell, cmd, …).
 fn active_pane_is_wsl(active: Option<&serde_json::Value>) -> bool {
     active
         .and_then(|p| p.get("shell"))
         .and_then(|v| v.as_str())
-        .map(|s| s.starts_with("wsl:"))
+        .and_then(|s| s.strip_prefix("wsl:"))
+        .map(|distro| !distro.is_empty())
         .unwrap_or(false)
 }
 
@@ -2215,7 +2220,10 @@ async fn delegate_with_context(
     // characters: ' is special to bash, " is special to Windows.
     if let Some(ref active_pane) = active {
         if let Some(shell) = active_pane.get("shell").and_then(|v| v.as_str()) {
-            if let Some(distro) = shell.strip_prefix("wsl:") {
+            // Require a non-empty distro name — shell integration only reports
+            // `wsl:<distro>` when `$WSL_DISTRO_NAME` is set, so a bare `wsl:`
+            // would otherwise build an invalid `wsl -d "" …` command.
+            if let Some(distro) = shell.strip_prefix("wsl:").filter(|d| !d.is_empty()) {
                 let wsl_agent_cmd =
                     crate::coordinator::build_wsl_delegate_commandline(
                         runtime,


### PR DESCRIPTION
## Summary

Builds on #375 (community PR by @adityabagchi24) — routes `?<prompt>` from a
WSL pane to run the agent CLI **inside** the active WSL distro
(`wsl -d <distro> -- bash -lc "..."`) instead of on the Windows host, so it
starts in the pane's Linux working directory and uses the distro's
toolchain / `PATH`. This branch is #375's work plus two follow-up fixes and
unit tests.

## Follow-up fixes on top of #375

1. **WSL delegate silently dropped the prompt when the agent is host-absent.**
   `delegate_command_launchable` only checks the *Windows* PATH. For the exact
   users this feature targets — Copilot/Claude installed **only inside** the
   distro — that returns `false`, so prompt enrichment and session pinning were
   skipped and the WSL branch launched a **bare** CLI with the user's
   `?<prompt>` text dropped. Added `delegate_launchable_for_target`, which
   treats a WSL pane as launchable regardless of the Windows-host check (the
   agent runs inside the distro).
2. **`cargo fmt` violation** — fixed a mis-indented
   `register_launched_session_with_master` call introduced in #375.

## Tests

Added unit tests for `active_pane_is_wsl` and `delegate_launchable_for_target`
(a WSL pane bypasses the host launchability gate; non-WSL panes do not). Full
suite: `cargo test` → 1027 passed, 0 failed.

## Known limitation (separate follow-up)

A "pure WSL" user still cannot *select* a WSL-only agent as the delegate agent
in Settings, because the picker is host-gated (`_IsAgentInstalled` via
`SearchPathW`). This PR fixes the Rust delegate path; surfacing WSL-installed
agents in the Settings UI is separate follow-up work.

## References and Relevant Issues

- Fixes #372
- Supersedes / builds on #375 (credit: @adityabagchi24)

## PR Checklist

- [x] Fixes #372
- [x] Tests added/passed
