### PR TITLE
Fix delegate session title leaking injected terminal-context echo

### DIFF
--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2144,10 +2144,18 @@ async fn delegate_with_context(
                 None
             };
 
+            // The `## Terminal Context (pane …)` heading is built from
+            // `TERMINAL_CONTEXT_TITLE_MARKER` (the single source of truth) so the
+            // master-side title filter (`host_titles_via_acp`) can recognise —
+            // and skip — this injected block if an agent CLI echoes the first
+            // user message back as a `session/list` title.
             Some(match (pane_context, active_pane_id) {
                 (Some(context), Some(pane_id)) => format!(
-                    "{}\n\n## Terminal Context (pane {})\n```\n{}\n```",
-                    prompt, pane_id, context
+                    "{}\n\n{}{})\n```\n{}\n```",
+                    prompt,
+                    crate::session_registry::TERMINAL_CONTEXT_TITLE_MARKER,
+                    pane_id,
+                    context
                 ),
                 _ => prompt.to_string(),
             })

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -2253,7 +2253,18 @@ async fn host_titles_via_acp(
         .filter_map(|row| {
             row.title
                 .clone()
-                .filter(|title| !title.is_empty())
+                .filter(|title| {
+                    // Drop the delegate's injected first-message echo. An agent CLI
+                    // (e.g. Copilot) can briefly report the baked `?<prompt>` — which
+                    // embeds the `## Terminal Context (pane …)` block — as a session's
+                    // `session/list` title before it generates its real summary.
+                    // Adopting it would leak the injected context (pane GUID included)
+                    // and, being non-synthetic, lock the row out of the later upgrade
+                    // to the CLI's real name. Skipping it leaves the born-bound row
+                    // synthetic so a subsequent poll adopts the real summary instead.
+                    !title.is_empty()
+                        && !crate::session_registry::title_is_injected_context_echo(title)
+                })
                 .map(|title| (row.session_id.to_string(), title))
         })
         .collect()

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -1017,6 +1017,30 @@ pub(crate) fn title_is_synthetic(info: &SessionInfo) -> bool {
     }
 }
 
+/// The literal heading the delegate `?<prompt>` flow injects into the prompt it
+/// bakes into a freshly launched agent CLI: `"<prompt>\n\n## Terminal Context
+/// (pane <id>)\n```…```"` (built in `main.rs`, which references this same
+/// constant so the two can't drift).
+///
+/// Agent CLIs (e.g. Copilot) briefly surface a session's *first user message* as
+/// its `session/list` title before they generate their real chat summary. For a
+/// delegate session that first message is the baked prompt above, so the echoed
+/// title contains this marker; a genuine CLI-generated summary never does. That
+/// lets [`title_is_injected_context_echo`] tell the two apart.
+pub(crate) const TERMINAL_CONTEXT_TITLE_MARKER: &str = "## Terminal Context (pane ";
+
+/// Whether `title` is the delegate's injected first-message echo (contains
+/// [`TERMINAL_CONTEXT_TITLE_MARKER`]) rather than a real CLI-generated summary.
+///
+/// Such a title must not be adopted as a session's display title: it leaks the
+/// injected terminal context (pane GUID included), and adopting it would lock
+/// the row out of the later upgrade to the CLI's real summary name (an echoed
+/// title is non-synthetic, so `refresh_synthetic_titles_from` would skip it
+/// forever). Callers drop it so the row stays synthetic and keeps upgrading.
+pub(crate) fn title_is_injected_context_echo(title: &str) -> bool {
+    title.contains(TERMINAL_CONTEXT_TITLE_MARKER)
+}
+
 #[async_trait::async_trait]
 impl SessionRegistry for InMemoryRegistry {
     async fn upsert(&self, info: SessionInfo) {
@@ -1769,6 +1793,26 @@ mod tests {
         assert!(title_is_synthetic(&info_with("s-empty", "/repo/proj", Some(""))));
         assert!(title_is_synthetic(&info_with("s-leaf", "/repo/proj", Some("proj"))));
         assert!(!title_is_synthetic(&info_with("s-real", "/repo/proj", Some("Real Title"))));
+    }
+
+    #[test]
+    fn title_is_injected_context_echo_detects_delegate_marker_only() {
+        // Mirrors the `?<prompt>` prompt built in `main.rs` from
+        // `TERMINAL_CONTEXT_TITLE_MARKER`: an agent CLI can echo this whole first
+        // user message back as a `session/list` title before it generates a real
+        // summary. Such an echo must be dropped (see `host_titles_via_acp`) so the
+        // born-bound row stays synthetic and keeps upgrading — the counterpart
+        // behaviour is covered by `refresh_synthetic_titles_from_skips_when_id_absent`.
+        let echo = format!(
+            "hi test\n\n{}8A9B4ABA-BEB4-4F94-B0D3-55569420B902)\n```\nPowerShell 7.6.3\n```",
+            TERMINAL_CONTEXT_TITLE_MARKER
+        );
+        assert!(title_is_injected_context_echo(&echo));
+        // A real CLI-generated summary, the bare user prompt, and empty never
+        // contain the injected marker.
+        assert!(!title_is_injected_context_echo("PowerShell Terminal Session"));
+        assert!(!title_is_injected_context_echo("hi test"));
+        assert!(!title_is_injected_context_echo(""));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

A `?<prompt>` delegate session showed a title like
`hi test## Terminal Context (pane 8A9B4ABA-…)` (the raw prompt plus the
injected context/pane GUID) instead of the agent's real summary
(e.g. `PowerShell Terminal Session`), and never healed.

## Root cause (WTA-side title lock-in)

- The delegate bakes a `## Terminal Context (pane <id>)` block into the
  first message it sends to the agent CLI (`main.rs delegate_with_context`).
- Agent CLIs (Copilot) briefly report a session's **first user message**
  as its `session/list` title before generating a summary.
- WTA reads titles from `session/list` in `host_titles_via_acp`. The
  born-bound delegate row starts synthetic (empty), so
  `refresh_synthetic_titles_from` upgrades it to that echoed message.
  Since the echo is neither empty nor the cwd basename,
  `title_is_synthetic` treats it as a real title and the row is **locked**
  — it never heals to the CLI's later summary.
- Verified from `wta-main_master.log` for one session: the raw
  `session/list` title reached `PowerShell Terminal Session` (matching the
  CLI's `workspace.yaml` `name`) ~minutes later, but WTA's registry stayed
  frozen on the echoed prompt through the end of the log.

## Fix

Drop echoed titles in `host_titles_via_acp` — the single point where raw
`session/list` titles enter the registry — so a born-bound delegate row
stays synthetic and a later poll adopts the real summary. Detection keys
off a shared `TERMINAL_CONTEXT_TITLE_MARKER` constant that the delegate
prompt builder also references, so the injected string and the filter
can't drift (the `main.rs` change is byte-identical output, purely
single-sourcing the marker). The history sync path uses
`upsert_if_absent`, so it can't clobber the existing row — this single
choke point is sufficient.

Gap behaviour (agreed, minimal): while the CLI hasn't produced its summary
yet, the row shows its existing synthetic placeholder (cwd), then heals to
the real summary on a later poll.

## Tests

- New unit test `title_is_injected_context_echo_detects_delegate_marker_only`.
- `cargo test --manifest-path tools/wta/Cargo.toml`: **1025 passed, 0 failed**.
