### PR TITLE
Deliver delegate ?<prompt> context as inline base64 (#403, #404)

### DIFF
--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -184,15 +184,15 @@ pub fn lookup_profile(executable: &str) -> &'static AgentProfile {
         .rsplit(|ch: char| ch == '\\' || ch == '/')
         .next()
         .unwrap_or(executable);
-    let lower = basename
+    let lower = basename.to_ascii_lowercase();
+    let normalized = lower
         .strip_suffix(".exe")
-        .or_else(|| basename.strip_suffix(".cmd"))
-        .or_else(|| basename.strip_suffix(".bat"))
-        .unwrap_or(basename)
-        .to_ascii_lowercase();
+        .or_else(|| lower.strip_suffix(".cmd"))
+        .or_else(|| lower.strip_suffix(".bat"))
+        .unwrap_or(&lower);
     KNOWN_AGENTS
         .iter()
-        .find(|p| p.id == lower)
+        .find(|p| p.id == normalized)
         .unwrap_or(&DEFAULT_PROFILE)
 }
 
@@ -485,6 +485,20 @@ mod tests {
         assert_eq!(
             resolve_agent_id_from_cmd(r#""C:\npm tools\codex.cmd" --search"#),
             "codex",
+        );
+    }
+
+    #[test]
+    fn lookup_and_resolve_recognize_mixed_case_batch_extensions() {
+        assert_eq!(lookup_profile(r"C:\Tools\codex.CMD").id, "codex");
+        assert_eq!(lookup_profile(r"C:\Tools\copilot.BaT").id, "copilot");
+        assert_eq!(
+            resolve_agent_id_from_cmd(r#""C:\npm tools\codex.CMD" --search"#),
+            "codex",
+        );
+        assert_eq!(
+            resolve_agent_id_from_cmd(r"C:\npm\copilot.BaT --model gpt-5"),
+            "copilot",
         );
     }
 

--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -239,10 +239,14 @@ pub fn resolve_agent_id_from_cmd(agent_cmd: &str) -> &'static str {
         return profile.id;
     }
 
-    // Bare / path form: take the first whitespace-delimited token and let
-    // `lookup_profile` strip path and extension before matching.
-    let first = trimmed.split_whitespace().next().unwrap_or(trimmed);
-    lookup_profile(first).id
+    // Bare / path form: parse the first Windows commandline token so a quoted
+    // executable path containing spaces stays intact, then let `lookup_profile`
+    // strip path and extension before matching.
+    let tokens = crate::coordinator::split_windows_commandline(trimmed);
+    tokens
+        .first()
+        .map(|first| lookup_profile(first).id)
+        .unwrap_or(DEFAULT_PROFILE.id)
 }
 
 // ─── ACP Command Building ────────────────────────────────────────────────────
@@ -478,6 +482,10 @@ mod tests {
             "gemini",
         );
         assert_eq!(resolve_agent_id_from_cmd("copilot.cmd"), "copilot");
+        assert_eq!(
+            resolve_agent_id_from_cmd(r#""C:\npm tools\codex.cmd" --search"#),
+            "codex",
+        );
     }
 
     #[test]

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -798,12 +798,12 @@ fn is_direct_known_agent_command(commandline: &str) -> bool {
 /// PowerShell 7 with the prompt delivered as inline base64 (issue #403).
 ///
 /// The prompt is base64-encoded (an inert `[A-Za-z0-9+/=]` payload — no shell
-/// metacharacter, no `%`, so it survives WT's `ExpandEnvironmentStringsW` and the
-/// commandline transport untouched), decoded inside pwsh into `$p`, then handed to
-/// the agent via `& <agent> … $p` — the same PATH-resolved invocation a user would
-/// type. pwsh's native-argument passing delivers the multi-line `$p` to the CLI
-/// verbatim (unlike Windows PowerShell 5.1). Requires `pwsh` on PATH; callers gate
-/// on [`pwsh_available`].
+/// syntax characters and no `%`, so it survives WT's
+/// `ExpandEnvironmentStringsW` and the commandline transport untouched), decoded
+/// inside pwsh into `$p`, then handed to the agent via `& <agent> … $p` — the same
+/// PATH-resolved invocation a user would type. pwsh's native-argument passing
+/// delivers the multi-line `$p` to the CLI verbatim (unlike Windows PowerShell
+/// 5.1). Requires `pwsh` on PATH; callers gate on [`pwsh_available`].
 fn build_pwsh_base64_launch(
     commandline: &str,
     profile: &agent_registry::AgentProfile,
@@ -841,7 +841,7 @@ fn build_pwsh_base64_launch(
     call.push_str(" $p");
 
     let script = format!(
-        "$p = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('{b64}')); {call}"
+        "$p = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('{b64}')); {call}; exit $LASTEXITCODE"
     );
     format!(
         "pwsh -NoProfile -Command {}",
@@ -1136,10 +1136,10 @@ pub(crate) fn sh_quote(s: &str) -> String {
 
 /// Build the bash command that launches the delegate agent inside a WSL distro.
 ///
-/// The (possibly multi-line, metacharacter-laden) prompt is delivered as an
-/// **inline base64 payload**, decoded in-distro into `$prompt` and handed to the
-/// agent as a single `"$prompt"` argument. base64's alphabet
-/// (`[A-Za-z0-9+/=]`) has no shell metacharacter, no whitespace, and no `%`, so
+/// The (possibly multi-line) prompt may contain shell syntax characters and is
+/// delivered as an **inline base64 payload**, decoded in-distro into `$prompt`
+/// and handed to the agent as a single `"$prompt"` argument. base64's alphabet
+/// (`[A-Za-z0-9+/=]`) has no shell syntax characters, whitespace, or `%`, so
 /// the payload is immune to every re-parsing layer between here and the inner
 /// login bash:
 ///
@@ -2582,7 +2582,7 @@ mod tests {
 
         // The whole command is a single line — no raw newline rides the commandline.
         assert!(!cmd.contains('\n'), "commandline must be single-line: {cmd}");
-        // The raw prompt and its metacharacters never appear literally.
+        // The raw prompt and its shell syntax characters never appear literally.
         assert!(!cmd.contains("$(whoami)"));
         assert!(!cmd.contains("%TEMP%"));
         // The base64 of the prompt is present, decoded via a here-string.
@@ -2631,7 +2631,10 @@ mod tests {
         let b64 = crate::osc52::base64_encode(prompt.as_bytes());
         assert!(cmd.contains(&b64), "base64 payload missing: {cmd}");
         assert!(cmd.contains("FromBase64String"));
-        assert!(cmd.trim_end().ends_with("$p\""), "ends with the $p arg: {cmd}");
+        assert!(
+            cmd.trim_end().ends_with("$p; exit $LASTEXITCODE\""),
+            "propagates the agent exit code: {cmd}"
+        );
         assert!(!cmd.contains("l1\nl2"), "no raw multi-line prompt: {cmd:?}");
     }
 
@@ -2640,15 +2643,42 @@ mod tests {
         let profile = crate::agent_registry::lookup_profile_by_id("copilot"); // -i flag
         let cmd = build_pwsh_base64_launch("copilot", profile, None, None, "a\nb");
         assert!(
-            cmd.contains("& 'copilot' '-i' $p"),
+            cmd.contains("& 'copilot' '-i' $p; exit $LASTEXITCODE"),
             "flag prompt form: {cmd}"
         );
     }
 
     #[test]
+    fn pwsh_base64_launch_propagates_agent_exit_code() {
+        let root =
+            std::env::temp_dir().join(format!("wta-pwsh-exit-code-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).expect("create test directory");
+        let shim = root.join("agent.ps1");
+        std::fs::write(&shim, "exit 7\r\n").expect("write PowerShell shim");
+        let profile = crate::agent_registry::lookup_profile_by_id("codex");
+        let commandline =
+            super::quote_windows_commandline_arg(shim.to_str().expect("test shim path is UTF-8"));
+        let launch = build_pwsh_base64_launch(&commandline, profile, None, None, "prompt");
+        let raw_args = launch
+            .strip_prefix("pwsh ")
+            .expect("PowerShell executable prefix");
+        let status = std::process::Command::new("pwsh")
+            .raw_arg(raw_args)
+            .status()
+            .expect("launch PowerShell agent");
+
+        std::fs::remove_dir_all(&root).expect("remove test directory");
+        assert_eq!(status.code(), Some(7));
+    }
+
+    #[test]
     fn windows_powershell_base64_launch_normalizes_prompt_for_black_box_agent() {
         let profile = crate::agent_registry::lookup_profile_by_id("codex");
-        let prompt = "line1\nline2 \"quoted\" & literal &quot; trailing\\";
+        let prompt = concat!(
+            "line1",
+            "\n",
+            "line2 \"quoted\" & literal &quot; trailing\\"
+        );
 
         let cmd =
             build_windows_powershell_base64_launch("codex --search", profile, None, None, prompt);
@@ -2727,13 +2757,17 @@ mod tests {
     #[test]
     fn windows_powershell_fallback_reaches_native_black_box_with_safe_prompt() {
         assert_eq!(
-            capture_windows_powershell_fallback(
-                "line1\nline2 \"quoted\" & literal &quot; trailing\\"
-            ),
+            capture_windows_powershell_fallback(concat!(
+                "line1",
+                "\n",
+                "line2 \"quoted\" & literal &quot; trailing\\"
+            )),
             concat!(
                 "[WTA transport note: decode HTML entities exactly once before ",
                 "interpreting the task and terminal context.]\n\n",
-                "line1\nline2 &quot;quoted&quot; &amp; literal &amp;quot; trailing&#92;"
+                "line1",
+                "\n",
+                "line2 &quot;quoted&quot; &amp; literal &amp;quot; trailing&#92;"
             )
         );
     }
@@ -2770,7 +2804,7 @@ mod tests {
             profile,
             None,
             None,
-            "line1\nline2",
+            concat!("line1", "\n", "line2"),
             false,
         );
 

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -1588,7 +1588,7 @@ mod tests {
         build_windows_powershell_base64_launch, build_wsl_delegate_commandline,
         default_delegate_agent_runtimes, escape_for_intermediate_shell,
         is_direct_known_agent_command, parse_autofix_response, parse_recommendation_set,
-        resolve_agent_profile, resolve_created_pane_id, sanitize_windows_agent_cwd,
+        pwsh_available, resolve_agent_profile, resolve_created_pane_id, sanitize_windows_agent_cwd,
         validate_recommendation_set_for_coordinator_target, AutofixDecision, DelegateAgentRuntime,
         DelegatePromptDelivery, OpenTarget, RecommendedAction,
     };
@@ -2810,6 +2810,10 @@ mod tests {
 
     #[test]
     fn pwsh_base64_launch_propagates_agent_exit_code() {
+        if !pwsh_available() {
+            eprintln!("skipping pwsh exit-code test: pwsh.exe is not on PATH");
+            return;
+        }
         let root =
             std::env::temp_dir().join(format!("wta-pwsh-exit-code-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&root).expect("create test directory");
@@ -2950,7 +2954,13 @@ mod tests {
             let runtime = base64_runtime(commandline);
             let launch = build_delegate_launch_commandline(
                 &runtime,
-                Some("fix it\n\n## Terminal Context\ncommand output"),
+                Some(concat!(
+                    "fix it",
+                    "\n\n",
+                    "## Terminal Context",
+                    "\n",
+                    "command output"
+                )),
                 None,
             )
             .expect("delegate launch commandline");

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -750,13 +750,108 @@ fn build_delegate_launch_commandline(
             }
         },
     };
-    // .cmd/.bat shims (e.g. npm-installed CLIs) can't be launched directly
-    // via CreateProcess — wrap with cmd /c so the command interpreter finds them.
+    // .cmd/.bat shims (e.g. npm-installed CLIs) can't be launched directly via
+    // CreateProcess — normally we wrap with `cmd /c` so the interpreter resolves
+    // them. But `cmd /c` truncates a command-line argument at the first newline
+    // (#403), dropping the multi-line `## Terminal Context` block. For a
+    // multi-line prompt, launch the agent from PowerShell 7 (`pwsh`) the same way
+    // a user would (`& <agent> $p`, bare name resolved on PATH) with the prompt
+    // base64-decoded inside the shell: base64 rides the commandline unmangled (no
+    // metacharacter, no `%`), and pwsh's native-argument passing hands the decoded
+    // multi-line `$p` to the CLI intact. (Windows PowerShell 5.1's native-arg
+    // passing corrupts quotes/newlines, so this requires `pwsh`.) When `pwsh`
+    // isn't installed we fall back to the existing `cmd /c` path.
     if needs_shell_launch(&resolved) {
-        Ok(format!("cmd /c {}", raw))
-    } else {
-        Ok(raw)
+        if let Some(input) = input {
+            if input.contains('\n')
+                && matches!(
+                    runtime.prompt_delivery,
+                    DelegatePromptDelivery::LaunchWithStartupPrompt
+                )
+                && pwsh_available()
+            {
+                return Ok(build_pwsh_base64_launch(
+                    commandline,
+                    profile,
+                    runtime.model.as_deref(),
+                    session_id,
+                    input,
+                ));
+            }
+        }
+        return Ok(format!("cmd /c {}", raw));
     }
+    Ok(raw)
+}
+
+/// Build a delegate launch commandline that runs a `.cmd`/`.bat` shim agent from
+/// PowerShell 7 with the prompt delivered as inline base64 (issue #403).
+///
+/// The prompt is base64-encoded (an inert `[A-Za-z0-9+/=]` payload — no shell
+/// metacharacter, no `%`, so it survives WT's `ExpandEnvironmentStringsW` and the
+/// commandline transport untouched), decoded inside pwsh into `$p`, then handed to
+/// the agent via `& <agent> … $p` — the same PATH-resolved invocation a user would
+/// type. pwsh's native-argument passing delivers the multi-line `$p` to the CLI
+/// verbatim (unlike Windows PowerShell 5.1). Requires `pwsh` on PATH; callers gate
+/// on [`pwsh_available`].
+fn build_pwsh_base64_launch(
+    commandline: &str,
+    profile: &agent_registry::AgentProfile,
+    model: Option<&str>,
+    session_id: Option<&str>,
+    input: &str,
+) -> String {
+    let b64 = crate::osc52::base64_encode(input.as_bytes());
+
+    // `& <agent tokens> [flags] $p` — every literal token single-quoted for
+    // PowerShell; `$p` (the decoded prompt) stays a bare variable reference.
+    let mut call = String::from("& ");
+    for (i, tok) in split_windows_commandline(commandline).iter().enumerate() {
+        if i > 0 {
+            call.push(' ');
+        }
+        call.push_str(&ps_single_quote(tok));
+    }
+    if let (Some(model), Some(flag)) = (model, profile.model_flags.first()) {
+        call.push(' ');
+        call.push_str(&ps_single_quote(flag));
+        call.push(' ');
+        call.push_str(&ps_single_quote(model));
+    }
+    if let (Some(sid), Some(flag)) = (session_id, profile.new_session_id_flag) {
+        call.push(' ');
+        call.push_str(&ps_single_quote(flag));
+        call.push(' ');
+        call.push_str(&ps_single_quote(sid));
+    }
+    if let PromptFlag::Flag(flag) = profile.delegate_prompt_flag {
+        call.push(' ');
+        call.push_str(&ps_single_quote(flag));
+    }
+    call.push_str(" $p");
+
+    let script = format!(
+        "$p = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('{b64}')); {call}"
+    );
+    format!(
+        "pwsh -NoProfile -Command {}",
+        quote_windows_commandline_arg(&script)
+    )
+}
+
+/// Quote a string as a PowerShell single-quoted literal (only `'` is special,
+/// doubled).
+fn ps_single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "''"))
+}
+
+/// Whether PowerShell 7 (`pwsh.exe`) is available on `PATH`. The host base64
+/// delegate launch needs pwsh's correct native-argument passing; Windows
+/// PowerShell 5.1 (`powershell.exe`) corrupts multi-line/quoted arguments.
+fn pwsh_available() -> bool {
+    std::env::var_os("PATH")
+        .map(|path| std::env::split_paths(&path).any(|dir| dir.join("pwsh.exe").is_file()))
+        .unwrap_or(false)
 }
 
 /// Resolve the first token (executable) of a commandline using the agent CLI
@@ -966,16 +1061,31 @@ pub(crate) fn sh_quote(s: &str) -> String {
     out
 }
 
-/// Build the delegate agent commandline for execution inside a WSL distro.
+/// Build the bash command that launches the delegate agent inside a WSL distro.
 ///
-/// Unlike the Windows path which PATH-resolves and wraps with `cmd /c`, the
-/// WSL path uses the bare agent identity from `runtime.commandline` and
-/// applies `sh_quote` to the prompt so it survives `bash -lc "..."` without
-/// any shell expansion inside the distro.
+/// The (possibly multi-line, metacharacter-laden) prompt is delivered as an
+/// **inline base64 payload**, decoded in-distro into `$prompt` and handed to the
+/// agent as a single `"$prompt"` argument. base64's alphabet
+/// (`[A-Za-z0-9+/=]`) has no shell metacharacter, no whitespace, and no `%`, so
+/// the payload is immune to every re-parsing layer between here and the inner
+/// login bash:
 ///
-/// Callers wrap the result with `quote_windows_commandline_arg`,
-/// embed in `bash -lc <escaped>`, then
-/// `wsl -d <distro> --cd "<cwd>" -- <full>` before `CreateProcessW`.
+/// * WT `ConptyConnection` runs `ExpandEnvironmentStringsW` on the commandline
+///   before `CreateProcessW` (see `ConptyConnection.cpp`), so a raw `%VAR%` in
+///   the prompt would be Windows-expanded — base64 has no `%`.
+/// * the `wsl.exe` interop performs one round of double-quote-context expansion
+///   (`$(…)`, backtick, `$…`) — even inside single quotes — before the inner
+///   `bash -lc` runs. base64 triggers none of it.
+///
+/// The agent invocation and the fixed decode wrapper are escaped for that
+/// `wsl.exe` expansion pass via [`escape_for_intermediate_shell`], so the inner
+/// bash receives the command verbatim and performs the `$(base64 -d …)` /
+/// `$prompt` expansion exactly once. Validated md5-exact through an
+/// `ExpandEnvironmentStringsW` + `CreateProcessW` probe (issue #404).
+///
+/// Callers wrap the result with `quote_windows_commandline_arg`, embed in
+/// `bash -lc <escaped>`, then `wsl -d <distro> --cd "<cwd>" -- <full>` before
+/// `CreateProcessW`.
 pub(crate) fn build_wsl_delegate_commandline(
     runtime: &DelegateAgentRuntime,
     input: Option<&str>,
@@ -989,6 +1099,8 @@ pub(crate) fn build_wsl_delegate_commandline(
         agent_registry::resolve_agent_id_from_cmd(agent_cmd),
     );
 
+    // Agent invocation: the CLI tokens plus model / session-id flags, each
+    // single-quoted for the inner bash.
     let mut parts: Vec<String> = split_windows_commandline(agent_cmd)
         .into_iter()
         .map(|t| sh_quote(&t))
@@ -996,37 +1108,67 @@ pub(crate) fn build_wsl_delegate_commandline(
     if parts.is_empty() {
         bail!("delegate agent runtime commandline is empty");
     }
-
     if let Some(ref model) = runtime.model {
         if let Some(flag) = profile.model_flags.first() {
             parts.push(sh_quote(flag));
             parts.push(sh_quote(model));
         }
     }
-
     if let (Some(sid), Some(flag)) = (session_id, profile.new_session_id_flag) {
         parts.push(sh_quote(flag));
         parts.push(sh_quote(sid));
     }
+    let agent_invocation = parts.join(" ");
 
-    if let Some(input) = input {
-        match runtime.prompt_delivery {
-            DelegatePromptDelivery::LaunchWithStartupPrompt if !input.is_empty() => {
-                match profile.delegate_prompt_flag {
-                    PromptFlag::Flag(flag) => {
-                        parts.push(sh_quote(flag));
-                        parts.push(sh_quote(input));
-                    }
-                    PromptFlag::Positional => {
-                        parts.push(sh_quote(input));
-                    }
-                }
-            }
-            _ => {}
+    // Only bake a startup prompt when the delivery mode asks for one.
+    let startup_prompt = match input {
+        Some(input)
+            if matches!(
+                runtime.prompt_delivery,
+                DelegatePromptDelivery::LaunchWithStartupPrompt
+            ) && !input.is_empty() =>
+        {
+            Some(input)
+        }
+        _ => None,
+    };
+
+    // `exec` so the agent CLI replaces bash as the pane's process.
+    let bash_command = match startup_prompt {
+        Some(input) => {
+            let b64 = crate::osc52::base64_encode(input.as_bytes());
+            let prompt_arg = match profile.delegate_prompt_flag {
+                PromptFlag::Flag(flag) => format!("{} \"$prompt\"", sh_quote(flag)),
+                PromptFlag::Positional => "\"$prompt\"".to_string(),
+            };
+            format!("prompt=$(base64 -d <<< '{b64}'); exec {agent_invocation} {prompt_arg}")
+        }
+        None => format!("exec {agent_invocation}"),
+    };
+
+    Ok(escape_for_intermediate_shell(&bash_command))
+}
+
+/// Escape a bash command so it survives the single round of double-quote-context
+/// shell expansion the `wsl.exe` interop applies to `bash -lc "<cmd>"` before the
+/// inner login bash sees it.
+///
+/// That pass performs command substitution (`$(…)`, backtick) and parameter
+/// expansion (`$…`) — even inside single quotes — plus one level of backslash
+/// processing, but not full command parsing. Escaping every `$`, backtick, and
+/// `\` with a leading backslash makes the pass a no-op: it consumes exactly one
+/// backslash level and hands the inner bash the command verbatim.
+fn escape_for_intermediate_shell(cmd: &str) -> String {
+    let mut out = String::with_capacity(cmd.len() + 16);
+    for ch in cmd.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '$' => out.push_str("\\$"),
+            '`' => out.push_str("\\`"),
+            _ => out.push(ch),
         }
     }
-
-    Ok(parts.join(" "))
+    out
 }
 
 /// Returns true if the command cannot be launched directly via CreateProcess
@@ -1328,9 +1470,10 @@ fn extract_balanced_json_object(text: &str) -> Option<&str> {
 mod tests {
     use super::{
         build_delegate_launch_commandline,
-        build_delegate_launch_commandline_with_session, default_delegate_agent_runtimes,
-        parse_autofix_response, parse_recommendation_set, resolve_agent_profile,
-        resolve_created_pane_id, sanitize_windows_agent_cwd,
+        build_delegate_launch_commandline_with_session, build_pwsh_base64_launch,
+        build_wsl_delegate_commandline, default_delegate_agent_runtimes,
+        escape_for_intermediate_shell, parse_autofix_response, parse_recommendation_set,
+        resolve_agent_profile, resolve_created_pane_id, sanitize_windows_agent_cwd,
         validate_recommendation_set_for_coordinator_target, AutofixDecision, DelegateAgentRuntime,
         DelegatePromptDelivery, OpenTarget, RecommendedAction,
     };
@@ -2329,5 +2472,86 @@ mod tests {
             parse_autofix_response(text),
             AutofixDecision::Ignore
         ));
+    }
+
+    // ── #404: WSL delegate inline base64 ─────────────────────────────────
+
+    fn base64_runtime(commandline: &str) -> DelegateAgentRuntime {
+        DelegateAgentRuntime {
+            id: commandline.to_string(),
+            name: commandline.to_string(),
+            description: String::new(),
+            commandline: commandline.to_string(),
+            prompt_delivery: DelegatePromptDelivery::LaunchWithStartupPrompt,
+            model: None,
+        }
+    }
+
+    #[test]
+    fn wsl_delegate_delivers_prompt_as_inline_base64() {
+        let runtime = base64_runtime("claude"); // positional prompt flag
+        let prompt = "fix it\n\n## Terminal Context\n```\n$(whoami) `id` %TEMP% \"q\"\n```";
+        let cmd = build_wsl_delegate_commandline(&runtime, Some(prompt), None).expect("cmd");
+
+        // The whole command is a single line — no raw newline rides the commandline.
+        assert!(!cmd.contains('\n'), "commandline must be single-line: {cmd}");
+        // The raw prompt and its metacharacters never appear literally.
+        assert!(!cmd.contains("$(whoami)"));
+        assert!(!cmd.contains("%TEMP%"));
+        // The base64 of the prompt is present, decoded via a here-string.
+        let b64 = crate::osc52::base64_encode(prompt.as_bytes());
+        assert!(cmd.contains(&b64), "base64 payload missing: {cmd}");
+        assert!(cmd.contains("base64 -d <<<"));
+        // The decode wrapper is escaped for the wsl.exe expansion pass.
+        assert!(cmd.contains("\\$(base64 -d"), "escaped $() missing: {cmd}");
+        assert!(cmd.contains("exec 'claude' \"\\$prompt\""), "exec form: {cmd}");
+    }
+
+    #[test]
+    fn wsl_delegate_uses_prompt_flag_for_flag_agents() {
+        let runtime = base64_runtime("copilot"); // -i flag agent
+        let cmd = build_wsl_delegate_commandline(&runtime, Some("hi\nthere"), None).expect("cmd");
+        assert!(cmd.contains("'-i' \"\\$prompt\""), "flag prompt form: {cmd}");
+    }
+
+    #[test]
+    fn wsl_delegate_interactive_has_no_base64() {
+        let runtime = base64_runtime("claude");
+        let cmd = build_wsl_delegate_commandline(&runtime, None, None).expect("cmd");
+        assert_eq!(cmd, "exec 'claude'");
+    }
+
+    #[test]
+    fn escape_for_intermediate_shell_escapes_expansion_chars() {
+        assert_eq!(escape_for_intermediate_shell("a$b`c\\d"), "a\\$b\\`c\\\\d");
+        assert_eq!(escape_for_intermediate_shell("plain text"), "plain text");
+    }
+
+    // ── #403: host pwsh + inline base64 (avoids cmd /c truncation) ───────
+
+    #[test]
+    fn pwsh_base64_launch_uses_bare_name_and_base64() {
+        let profile = crate::agent_registry::lookup_profile_by_id("codex"); // positional
+        let prompt = "l1\nl2 \"q\" %TEMP%";
+        let cmd = build_pwsh_base64_launch("codex", profile, None, None, prompt);
+
+        assert!(cmd.starts_with("pwsh -NoProfile -Command "));
+        // launched like a user: bare name, no .cmd / underlying exe resolution.
+        assert!(cmd.contains("& 'codex'"));
+        assert!(!cmd.contains(".cmd"));
+        assert!(!cmd.contains("node "));
+        // prompt delivered as base64, decoded to $p inside pwsh (never raw).
+        let b64 = crate::osc52::base64_encode(prompt.as_bytes());
+        assert!(cmd.contains(&b64), "base64 payload missing: {cmd}");
+        assert!(cmd.contains("FromBase64String"));
+        assert!(cmd.trim_end().ends_with("$p\""), "ends with the $p arg: {cmd}");
+        assert!(!cmd.contains("l1\nl2"), "no raw multi-line prompt: {cmd:?}");
+    }
+
+    #[test]
+    fn pwsh_base64_launch_appends_prompt_flag_for_flag_agents() {
+        let profile = crate::agent_registry::lookup_profile_by_id("copilot"); // -i flag
+        let cmd = build_pwsh_base64_launch("copilot", profile, None, None, "a\nb");
+        assert!(cmd.contains("& 'copilot' '-i' $p"), "flag prompt form: {cmd}");
     }
 }

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -794,6 +794,41 @@ fn is_direct_known_agent_command(commandline: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Split an agent commandline into PowerShell invocation tokens, replacing a
+/// batch shim only with its adjacent `.ps1` companion or the known profile id.
+fn powershell_invocation_tokens(
+    commandline: &str,
+    profile: &agent_registry::AgentProfile,
+) -> Vec<String> {
+    let mut tokens = split_windows_commandline(commandline);
+    let Some(first) = tokens.first_mut() else {
+        return tokens;
+    };
+    let path = std::path::Path::new(first);
+    let is_batch = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| {
+            extension.eq_ignore_ascii_case("cmd") || extension.eq_ignore_ascii_case("bat")
+        })
+        .unwrap_or(false);
+    if !is_batch {
+        return tokens;
+    }
+
+    let is_explicit_path = first.contains('\\') || first.contains('/');
+    if is_explicit_path {
+        let companion = path.with_extension("ps1");
+        if companion.is_file() {
+            *first = companion.to_string_lossy().into_owned();
+            return tokens;
+        }
+    }
+
+    *first = profile.id.to_string();
+    tokens
+}
+
 /// Build a delegate launch commandline that runs a `.cmd`/`.bat` shim agent from
 /// PowerShell 7 with the prompt delivered as inline base64 (issue #403).
 ///
@@ -816,7 +851,10 @@ fn build_pwsh_base64_launch(
     // `& <agent tokens> [flags] $p` — every literal token single-quoted for
     // PowerShell; `$p` (the decoded prompt) stays a bare variable reference.
     let mut call = String::from("& ");
-    for (i, tok) in split_windows_commandline(commandline).iter().enumerate() {
+    for (i, tok) in powershell_invocation_tokens(commandline, profile)
+        .iter()
+        .enumerate()
+    {
         if i > 0 {
             call.push(' ');
         }
@@ -878,7 +916,10 @@ fn build_windows_powershell_base64_launch(
 ) -> String {
     let b64 = crate::osc52::base64_encode(input.as_bytes());
     let mut call = String::from("& ");
-    for (i, token) in split_windows_commandline(commandline).iter().enumerate() {
+    for (i, token) in powershell_invocation_tokens(commandline, profile)
+        .iter()
+        .enumerate()
+    {
         if i > 0 {
             call.push(' ');
         }
@@ -2648,6 +2689,125 @@ mod tests {
         );
     }
 
+    fn powershell_base64_launches(
+        commandline: &str,
+        profile: &crate::agent_registry::AgentProfile,
+    ) -> [String; 2] {
+        [
+            build_pwsh_base64_launch(commandline, profile, None, None, "prompt"),
+            build_windows_powershell_base64_launch(commandline, profile, None, None, "prompt"),
+        ]
+    }
+
+    #[test]
+    fn powershell_base64_launches_use_sibling_ps1_for_quoted_batch_path() {
+        let root =
+            std::env::temp_dir().join(format!("wta PowerShell companion {}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).expect("create test directory");
+        let cmd_path = root.join("codex.cmd");
+        let ps1_path = root.join("codex.ps1");
+        std::fs::write(&cmd_path, "@exit /b 0\r\n").expect("write batch shim");
+        std::fs::write(&ps1_path, "exit 0\r\n").expect("write PowerShell companion");
+        let commandline = format!(
+            "{} --search --full-auto",
+            super::quote_windows_commandline_arg(
+                cmd_path.to_str().expect("test shim path is UTF-8")
+            )
+        );
+        let profile = crate::agent_registry::lookup_profile_by_id("codex");
+
+        for launch in powershell_base64_launches(&commandline, profile) {
+            assert!(
+                launch.contains(&format!(
+                    "& {} '--search' '--full-auto' $p",
+                    super::ps_single_quote(
+                        ps1_path.to_str().expect("test companion path is UTF-8")
+                    )
+                )),
+                "PowerShell companion and flags missing: {launch}"
+            );
+            assert!(
+                !launch.contains(".cmd"),
+                "batch shim should not be invoked: {launch}"
+            );
+        }
+
+        std::fs::remove_dir_all(&root).expect("remove test directory");
+    }
+
+    #[test]
+    fn powershell_base64_launches_fall_back_to_profile_for_batch_without_companion() {
+        let root = std::env::temp_dir().join(format!(
+            "wta-missing-powershell-companion-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&root).expect("create test directory");
+        let cmd_path = root.join("codex.cmd");
+        std::fs::write(&cmd_path, "@exit /b 0\r\n").expect("write batch shim");
+        let commandline = format!(
+            "{} --search",
+            super::quote_windows_commandline_arg(
+                cmd_path.to_str().expect("test shim path is UTF-8")
+            )
+        );
+        let profile = crate::agent_registry::lookup_profile_by_id("codex");
+
+        for launch in powershell_base64_launches(&commandline, profile) {
+            assert!(
+                launch.contains("& 'codex' '--search' $p"),
+                "profile fallback and flags missing: {launch}"
+            );
+            assert!(
+                !launch.contains(".cmd"),
+                "missing companion path should not be invoked: {launch}"
+            );
+        }
+
+        std::fs::remove_dir_all(&root).expect("remove test directory");
+    }
+
+    #[test]
+    fn powershell_base64_launches_fall_back_to_profile_for_bare_batch_name() {
+        let profile = crate::agent_registry::lookup_profile_by_id("codex");
+
+        for commandline in [
+            "codex.cmd --search",
+            "codex.CMD --search",
+            "codex.BaT --search",
+        ] {
+            for launch in powershell_base64_launches(commandline, profile) {
+                assert!(
+                    launch.contains("& 'codex' '--search' $p"),
+                    "bare batch fallback and flags missing: {launch}"
+                );
+                assert!(
+                    !launch.contains("codex.cmd")
+                        && !launch.contains("codex.CMD")
+                        && !launch.contains("codex.BaT"),
+                    "bare batch shim should not be invoked: {launch}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn powershell_base64_launches_preserve_non_batch_first_tokens() {
+        let profile = crate::agent_registry::lookup_profile_by_id("codex");
+
+        for commandline in ["codex.ps1 --search", "codex.exe --search"] {
+            let first = super::split_windows_commandline(commandline)
+                .into_iter()
+                .next()
+                .expect("first commandline token");
+            for launch in powershell_base64_launches(commandline, profile) {
+                assert!(
+                    launch.contains(&format!("& '{}' '--search' $p", first)),
+                    "non-batch token or flags changed: {launch}"
+                );
+            }
+        }
+    }
+
     #[test]
     fn pwsh_base64_launch_propagates_agent_exit_code() {
         let root =
@@ -2782,6 +2942,28 @@ mod tests {
                 "line1\\\n"
             )
         );
+    }
+
+    #[test]
+    fn mixed_case_known_batch_delegate_with_multiline_prompt_uses_powershell() {
+        for commandline in ["codex.CMD", "codex.BaT"] {
+            let runtime = base64_runtime(commandline);
+            let launch = build_delegate_launch_commandline(
+                &runtime,
+                Some("fix it\n\n## Terminal Context\ncommand output"),
+                None,
+            )
+            .expect("delegate launch commandline");
+
+            assert!(
+                launch.starts_with("pwsh ") || launch.starts_with("powershell.exe "),
+                "mixed-case known batch command must use a PowerShell builder: {launch}"
+            );
+            assert!(
+                !launch.starts_with("cmd /c "),
+                "multiline prompt must not use cmd /c: {launch}"
+            );
+        }
     }
 
     #[test]

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -136,15 +136,17 @@ pub fn default_delegate_agent_runtimes(
 
 /// Derive a (id, display_name) pair from a delegate agent commandline.
 fn derive_agent_identity(commandline: &str) -> (String, String) {
-    let first_token = commandline
-        .split_whitespace()
-        .next()
-        .unwrap_or(commandline);
-    let unquoted = first_token.trim_matches('"');
-    let profile = agent_registry::lookup_profile(unquoted);
+    let profile = agent_registry::lookup_profile_by_id(agent_registry::resolve_agent_id_from_cmd(
+        commandline,
+    ));
     if profile.id != "unknown" {
         return (profile.id.to_string(), profile.display_name.to_string());
     }
+    let first_token = split_windows_commandline(commandline)
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| commandline.to_string());
+    let unquoted = first_token.trim_matches('"');
     // Unknown agent — use the basename as both id and name.
     let basename = unquoted
         .rsplit(|ch: char| ch == '\\' || ch == '/')
@@ -754,13 +756,11 @@ fn build_delegate_launch_commandline(
     // CreateProcess — normally we wrap with `cmd /c` so the interpreter resolves
     // them. But `cmd /c` truncates a command-line argument at the first newline
     // (#403), dropping the multi-line `## Terminal Context` block. For a
-    // multi-line prompt, launch the agent from PowerShell 7 (`pwsh`) the same way
-    // a user would (`& <agent> $p`, bare name resolved on PATH) with the prompt
-    // base64-decoded inside the shell: base64 rides the commandline unmangled (no
-    // metacharacter, no `%`), and pwsh's native-argument passing hands the decoded
-    // multi-line `$p` to the CLI intact. (Windows PowerShell 5.1's native-arg
-    // passing corrupts quotes/newlines, so this requires `pwsh`.) When `pwsh`
-    // isn't installed we fall back to the existing `cmd /c` path.
+    // multi-line prompt, prefer PowerShell 7 (`pwsh`) and otherwise invoke a
+    // known agent through Windows PowerShell just as a user would. Both paths
+    // keep the prompt base64-encoded until after the WT commandline transport.
+    // The Windows PowerShell fallback replaces its black-box-unsafe characters
+    // with ASCII HTML entities before handing the prompt to the agent.
     if needs_shell_launch(&resolved) {
         if let Some(input) = input {
             if input.contains('\n')
@@ -768,20 +768,30 @@ fn build_delegate_launch_commandline(
                     runtime.prompt_delivery,
                     DelegatePromptDelivery::LaunchWithStartupPrompt
                 )
-                && pwsh_available()
             {
-                return Ok(build_pwsh_base64_launch(
-                    commandline,
-                    profile,
-                    runtime.model.as_deref(),
-                    session_id,
-                    input,
-                ));
+                if is_direct_known_agent_command(commandline) {
+                    let commandline = build_shell_multiline_delegate_launch(
+                        commandline,
+                        profile,
+                        runtime.model.as_deref(),
+                        session_id,
+                        input,
+                        pwsh_available(),
+                    );
+                    return Ok(commandline);
+                }
             }
         }
         return Ok(format!("cmd /c {}", raw));
     }
     Ok(raw)
+}
+
+fn is_direct_known_agent_command(commandline: &str) -> bool {
+    split_windows_commandline(commandline)
+        .first()
+        .map(|command| agent_registry::lookup_profile(command).id != "unknown")
+        .unwrap_or(false)
 }
 
 /// Build a delegate launch commandline that runs a `.cmd`/`.bat` shim agent from
@@ -839,6 +849,68 @@ fn build_pwsh_base64_launch(
     )
 }
 
+fn build_shell_multiline_delegate_launch(
+    commandline: &str,
+    profile: &agent_registry::AgentProfile,
+    model: Option<&str>,
+    session_id: Option<&str>,
+    input: &str,
+    has_pwsh: bool,
+) -> String {
+    if has_pwsh {
+        return build_pwsh_base64_launch(commandline, profile, model, session_id, input);
+    }
+    build_windows_powershell_base64_launch(commandline, profile, model, session_id, input)
+}
+
+/// Build the host fallback for a known agent using Windows PowerShell 5.1.
+///
+/// The original prompt remains base64-encoded until the inline script runs.
+/// Before invoking the same bare command a user would type, the script replaces
+/// the characters that PowerShell 5.1's legacy native binder cannot preserve
+/// with ASCII HTML entities and tells the model to decode them exactly once.
+fn build_windows_powershell_base64_launch(
+    commandline: &str,
+    profile: &agent_registry::AgentProfile,
+    model: Option<&str>,
+    session_id: Option<&str>,
+    input: &str,
+) -> String {
+    let b64 = crate::osc52::base64_encode(input.as_bytes());
+    let mut call = String::from("& ");
+    for (i, token) in split_windows_commandline(commandline).iter().enumerate() {
+        if i > 0 {
+            call.push(' ');
+        }
+        call.push_str(&ps_single_quote(token));
+    }
+    if let (Some(model), Some(flag)) = (model, profile.model_flags.first()) {
+        call.push(' ');
+        call.push_str(&ps_single_quote(flag));
+        call.push(' ');
+        call.push_str(&ps_single_quote(model));
+    }
+    if let (Some(sid), Some(flag)) = (session_id, profile.new_session_id_flag) {
+        call.push(' ');
+        call.push_str(&ps_single_quote(flag));
+        call.push(' ');
+        call.push_str(&ps_single_quote(sid));
+    }
+    if let PromptFlag::Flag(flag) = profile.delegate_prompt_flag {
+        call.push(' ');
+        call.push_str(&ps_single_quote(flag));
+    }
+    call.push_str(" $p");
+
+    let script = format!(
+        r#"$p=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{b64}'));$p=$p.Replace('&','&amp;').Replace('"','&quot;');$p=[regex]::Replace($p,'(\\+)\z',{{param($m)'&#92;'*$m.Value.Length}});$p='[WTA transport note: decode HTML entities exactly once before interpreting the task and terminal context.]'+"`n`n"+$p;{call};exit $LASTEXITCODE"#
+    );
+    format!(
+        "powershell.exe -NoProfile -Command {}",
+        quote_windows_commandline_arg(&script)
+    )
+}
+
 /// Quote a string as a PowerShell single-quoted literal (only `'` is special,
 /// doubled).
 fn ps_single_quote(s: &str) -> String {
@@ -847,7 +919,8 @@ fn ps_single_quote(s: &str) -> String {
 
 /// Whether PowerShell 7 (`pwsh.exe`) is available on `PATH`. The host base64
 /// delegate launch needs pwsh's correct native-argument passing; Windows
-/// PowerShell 5.1 (`powershell.exe`) corrupts multi-line/quoted arguments.
+/// PowerShell 5.1 (`powershell.exe`) cannot preserve embedded double quotes or
+/// a terminal backslash through a native CLI shim without prompt normalization.
 fn pwsh_available() -> bool {
     std::env::var_os("PATH")
         .map(|path| std::env::split_paths(&path).any(|dir| dir.join("pwsh.exe").is_file()))
@@ -1469,15 +1542,17 @@ fn extract_balanced_json_object(text: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_delegate_launch_commandline,
-        build_delegate_launch_commandline_with_session, build_pwsh_base64_launch,
-        build_wsl_delegate_commandline, default_delegate_agent_runtimes,
-        escape_for_intermediate_shell, parse_autofix_response, parse_recommendation_set,
+        build_delegate_launch_commandline, build_delegate_launch_commandline_with_session,
+        build_pwsh_base64_launch, build_shell_multiline_delegate_launch,
+        build_windows_powershell_base64_launch, build_wsl_delegate_commandline,
+        default_delegate_agent_runtimes, escape_for_intermediate_shell,
+        is_direct_known_agent_command, parse_autofix_response, parse_recommendation_set,
         resolve_agent_profile, resolve_created_pane_id, sanitize_windows_agent_cwd,
         validate_recommendation_set_for_coordinator_target, AutofixDecision, DelegateAgentRuntime,
         DelegatePromptDelivery, OpenTarget, RecommendedAction,
     };
     use serde_json::json;
+    use std::os::windows::process::CommandExt;
 
     #[test]
     fn default_delegate_runtime_uses_cli_default_model() {
@@ -1537,6 +1612,18 @@ mod tests {
             runtime.commandline,
             "C:\\Users\\kaitao\\AppData\\Local\\Microsoft\\WinGet\\Links\\copilot.exe --model claude-haiku-4.5"
         );
+    }
+
+    #[test]
+    fn delegate_runtime_identifies_quoted_agent_path_with_spaces() {
+        let runtime =
+            default_delegate_agent_runtimes(Some(r#""C:\npm tools\codex.cmd""#), None, None)
+                .into_iter()
+                .next()
+                .expect("delegate runtime");
+
+        assert_eq!(runtime.id, "codex");
+        assert_eq!(runtime.name, "Codex");
     }
 
     #[test]
@@ -2552,6 +2639,144 @@ mod tests {
     fn pwsh_base64_launch_appends_prompt_flag_for_flag_agents() {
         let profile = crate::agent_registry::lookup_profile_by_id("copilot"); // -i flag
         let cmd = build_pwsh_base64_launch("copilot", profile, None, None, "a\nb");
-        assert!(cmd.contains("& 'copilot' '-i' $p"), "flag prompt form: {cmd}");
+        assert!(
+            cmd.contains("& 'copilot' '-i' $p"),
+            "flag prompt form: {cmd}"
+        );
+    }
+
+    #[test]
+    fn windows_powershell_base64_launch_normalizes_prompt_for_black_box_agent() {
+        let profile = crate::agent_registry::lookup_profile_by_id("codex");
+        let prompt = "line1\nline2 \"quoted\" & literal &quot; trailing\\";
+
+        let cmd =
+            build_windows_powershell_base64_launch("codex --search", profile, None, None, prompt);
+
+        assert!(cmd.starts_with("powershell.exe -NoProfile -Command "));
+        assert!(!cmd.contains(prompt), "raw prompt leaked: {cmd:?}");
+        assert!(
+            cmd.contains("& 'codex' '--search' $p"),
+            "bare call missing: {cmd}"
+        );
+        let prompt_b64 = crate::osc52::base64_encode(prompt.as_bytes());
+        assert!(cmd.contains(&prompt_b64), "prompt payload missing: {cmd}");
+        assert!(
+            cmd.contains(r#".Replace('&','&amp;').Replace('\"','&quot;')"#),
+            "HTML entity normalization missing: {cmd}"
+        );
+        assert!(
+            cmd.contains("'&#92;'*$m.Value.Length"),
+            "terminal slash normalization missing: {cmd}"
+        );
+        assert!(
+            cmd.contains("decode HTML entities exactly once"),
+            "transport note missing: {cmd}"
+        );
+    }
+
+    #[test]
+    fn windows_powershell_base64_launch_stays_below_windows_commandline_limit() {
+        let profile = crate::agent_registry::lookup_profile_by_id("codex");
+        let prompt = "\"".repeat(12 * 1024);
+
+        let cmd = build_windows_powershell_base64_launch("codex", profile, None, None, &prompt);
+
+        assert!(
+            cmd.encode_utf16().count() < 32_767,
+            "fallback commandline has {} UTF-16 code units",
+            cmd.encode_utf16().count()
+        );
+    }
+
+    fn capture_windows_powershell_fallback(prompt: &str) -> String {
+        let root =
+            std::env::temp_dir().join(format!("wta-powershell-black-box-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).expect("create test directory");
+        let capture = root.join("capture.js");
+        let shim = root.join("agent.ps1");
+        std::fs::write(&capture, "WScript.StdOut.Write(WScript.Arguments.Item(0));")
+            .expect("write native argument capture");
+        std::fs::write(
+            &shim,
+            "& cscript.exe //nologo \"$PSScriptRoot\\capture.js\" $args\r\nexit $LASTEXITCODE\r\n",
+        )
+        .expect("write PowerShell shim");
+        let profile = crate::agent_registry::lookup_profile_by_id("codex");
+        let commandline =
+            super::quote_windows_commandline_arg(shim.to_str().expect("test shim path is UTF-8"));
+        let launch =
+            build_windows_powershell_base64_launch(&commandline, profile, None, None, prompt);
+        let raw_args = launch
+            .strip_prefix("powershell.exe ")
+            .expect("fallback executable prefix");
+        let output = std::process::Command::new("powershell.exe")
+            .raw_arg(raw_args)
+            .output()
+            .expect("launch Windows PowerShell fallback");
+
+        std::fs::remove_dir_all(&root).expect("remove test directory");
+        assert!(
+            output.status.success(),
+            "fallback failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).expect("capture is UTF-8")
+    }
+
+    #[test]
+    fn windows_powershell_fallback_reaches_native_black_box_with_safe_prompt() {
+        assert_eq!(
+            capture_windows_powershell_fallback(
+                "line1\nline2 \"quoted\" & literal &quot; trailing\\"
+            ),
+            concat!(
+                "[WTA transport note: decode HTML entities exactly once before ",
+                "interpreting the task and terminal context.]\n\n",
+                "line1\nline2 &quot;quoted&quot; &amp; literal &amp;quot; trailing&#92;"
+            )
+        );
+    }
+
+    #[test]
+    fn windows_powershell_fallback_does_not_escape_slash_before_final_newline() {
+        assert_eq!(
+            capture_windows_powershell_fallback("line1\\\n"),
+            concat!(
+                "[WTA transport note: decode HTML entities exactly once before ",
+                "interpreting the task and terminal context.]\n\n",
+                "line1\\\n"
+            )
+        );
+    }
+
+    #[test]
+    fn windows_powershell_fallback_only_handles_direct_known_agents() {
+        assert!(is_direct_known_agent_command("codex"));
+        assert!(is_direct_known_agent_command(
+            r#""C:\npm tools\codex.cmd" --search"#
+        ));
+        assert!(!is_direct_known_agent_command(
+            "npx -y @zed-industries/codex-acp"
+        ));
+    }
+
+    #[test]
+    fn windows_powershell_is_used_when_pwsh_is_unavailable() {
+        let profile = crate::agent_registry::lookup_profile_by_id("codex");
+
+        let cmd = build_shell_multiline_delegate_launch(
+            "codex",
+            profile,
+            None,
+            None,
+            "line1\nline2",
+            false,
+        );
+
+        assert!(
+            cmd.starts_with("powershell.exe "),
+            "must not fall back to cmd: {cmd}"
+        );
     }
 }

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2087,18 +2087,25 @@ fn delegate_launchable_for_target(
 /// prompt itself is assumed small.
 const MAX_DELEGATE_CONTEXT_BYTES: usize = 12 * 1024;
 
-/// Trim captured terminal context to at most `max_bytes`, keeping the **tail**
-/// (most recent output) and prepending a truncation marker. Cuts on a UTF-8 char
-/// boundary so the result is always valid UTF-8.
+/// Trim captured terminal context to at most `max_bytes`, including the
+/// truncation marker, while keeping the **tail** (most recent output). Cuts on a
+/// UTF-8 char boundary. If the marker does not fit, returns only the valid tail.
 fn cap_delegate_context(context: &str, max_bytes: usize) -> String {
     if context.len() <= max_bytes {
         return context.to_string();
     }
-    let mut start = context.len() - max_bytes;
+    const TRUNCATION_MARKER: &str = "…(truncated)\n";
+    let marker = if TRUNCATION_MARKER.len() <= max_bytes {
+        TRUNCATION_MARKER
+    } else {
+        ""
+    };
+    let tail_bytes = max_bytes - marker.len();
+    let mut start = context.len() - tail_bytes;
     while start < context.len() && !context.is_char_boundary(start) {
         start += 1;
     }
-    format!("…(truncated)\n{}", &context[start..])
+    format!("{marker}{}", &context[start..])
 }
 
 /// Shared delegation logic: enrich the prompt with the active pane's recent
@@ -2243,7 +2250,7 @@ async fn delegate_with_context(
     //
     // Delivery (see `build_wsl_delegate_commandline`): the prompt rides as an
     // inline base64 payload decoded in-distro — base64's alphabet has no shell
-    // metacharacter and no `%`, so it survives WT's `ExpandEnvironmentStringsW`
+    // syntax characters and no `%`, so it survives WT's `ExpandEnvironmentStringsW`
     // and the `wsl.exe` interop's expansion pass. The bash command is escaped for
     // that pass, then wrapped once for Windows `CommandLineToArgvW`:
     //   1. build_wsl_delegate_commandline() → base64-inline bash command,
@@ -3516,8 +3523,7 @@ mod delegate_context_tests {
         assert!(out.starts_with("…(truncated)\n"));
         // keeps the tail (most recent output)
         assert!(out.ends_with(&ctx[ctx.len() - 100..]));
-        // trimmed to roughly the cap plus the marker
-        assert!(out.len() <= 1000 + "…(truncated)\n".len() + 4);
+        assert!(out.len() <= 1000);
     }
 
     #[test]
@@ -3525,8 +3531,15 @@ mod delegate_context_tests {
         // Each '⭐' is 3 bytes; cutting must land on a char boundary (no panic).
         let ctx: String = std::iter::repeat('⭐').take(500).collect();
         let out = cap_delegate_context(&ctx, 100);
+        assert!(out.len() <= 100);
+        assert!(out.ends_with('⭐'));
         assert!(out
             .chars()
             .all(|c| c == '⭐' || "…(truncated)\n".contains(c)));
+    }
+
+    #[test]
+    fn cap_omits_marker_when_limit_is_too_small() {
+        assert_eq!(cap_delegate_context("abcdef", 4), "cdef");
     }
 }

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -3540,6 +3540,6 @@ mod delegate_context_tests {
 
     #[test]
     fn cap_omits_marker_when_limit_is_too_small() {
-        assert_eq!(cap_delegate_context("abcdef", 4), "cdef");
+        assert_eq!(cap_delegate_context("prefix-tail", 4), "tail");
     }
 }

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -2077,6 +2077,30 @@ fn delegate_launchable_for_target(
     host_launchable || active_pane_is_wsl(active)
 }
 
+/// Max bytes of captured terminal context baked into a delegate prompt.
+///
+/// The enriched prompt rides the `wt_create_tab` commandline (base64-encoded).
+/// Windows caps a process commandline at ~32,767 chars, and base64 inflates by
+/// 4/3, so an unbounded 30-line capture from a very wide pane could overflow it
+/// and fail the launch with "filename or extension is too long". Capping the
+/// context keeps the encoded commandline comfortably under that limit; the user
+/// prompt itself is assumed small.
+const MAX_DELEGATE_CONTEXT_BYTES: usize = 12 * 1024;
+
+/// Trim captured terminal context to at most `max_bytes`, keeping the **tail**
+/// (most recent output) and prepending a truncation marker. Cuts on a UTF-8 char
+/// boundary so the result is always valid UTF-8.
+fn cap_delegate_context(context: &str, max_bytes: usize) -> String {
+    if context.len() <= max_bytes {
+        return context.to_string();
+    }
+    let mut start = context.len() - max_bytes;
+    while start < context.len() && !context.is_char_boundary(start) {
+        start += 1;
+    }
+    format!("…(truncated)\n{}", &context[start..])
+}
+
 /// Shared delegation logic: enrich the prompt with the active pane's recent
 /// output (when available), build the delegate-agent commandline, and create a
 /// new tab to launch it. WT's GetActivePane already resolves the agent pane to
@@ -2197,7 +2221,7 @@ async fn delegate_with_context(
                     prompt,
                     crate::session_registry::TERMINAL_CONTEXT_TITLE_MARKER,
                     pane_id,
-                    context
+                    cap_delegate_context(&context, MAX_DELEGATE_CONTEXT_BYTES)
                 ),
                 _ => prompt.to_string(),
             })
@@ -2217,15 +2241,16 @@ async fn delegate_with_context(
     // that runs the agent CLI inside the distro (using the Linux toolchain
     // and filesystem) instead of the Windows-host fallback.
     //
-    // Quoting strategy (two disjoint layers):
-    //   1. prompt → sh_quote() → bash '...' quoting (only ' is special)
-    //   2. wsl_agent_cmd → quote_windows_commandline_arg() → Windows
-    //      CommandLineToArgvW escaping (only " is special)
+    // Delivery (see `build_wsl_delegate_commandline`): the prompt rides as an
+    // inline base64 payload decoded in-distro — base64's alphabet has no shell
+    // metacharacter and no `%`, so it survives WT's `ExpandEnvironmentStringsW`
+    // and the `wsl.exe` interop's expansion pass. The bash command is escaped for
+    // that pass, then wrapped once for Windows `CommandLineToArgvW`:
+    //   1. build_wsl_delegate_commandline() → base64-inline bash command,
+    //      pre-escaped for the wsl.exe expansion pass (`\`, `$`, backtick)
+    //   2. quote_windows_commandline_arg() → Windows CommandLineToArgvW escaping
     //      → embed in format!("bash -lc {}")
     //   3. → wsl -d <distro> --cd "<cwd>" -- bash -lc <escaped>
-    //
-    // Composability works because the two layers have disjoint special
-    // characters: ' is special to bash, " is special to Windows.
     if let Some(ref active_pane) = active {
         if let Some(shell) = active_pane.get("shell").and_then(|v| v.as_str()) {
             // Require a non-empty distro name — shell integration only reports
@@ -3471,3 +3496,37 @@ async fn run_acp_app(
 
 #[cfg(test)]
 mod cli_tests;
+
+#[cfg(test)]
+mod delegate_context_tests {
+    use super::cap_delegate_context;
+
+    #[test]
+    fn cap_returns_short_context_unchanged() {
+        let ctx = "small output";
+        assert_eq!(cap_delegate_context(ctx, 1024), ctx);
+    }
+
+    #[test]
+    fn cap_keeps_tail_and_marks_truncation() {
+        let ctx: String = (0..5000u32)
+            .map(|i| char::from(b'a' + (i % 26) as u8))
+            .collect();
+        let out = cap_delegate_context(&ctx, 1000);
+        assert!(out.starts_with("…(truncated)\n"));
+        // keeps the tail (most recent output)
+        assert!(out.ends_with(&ctx[ctx.len() - 100..]));
+        // trimmed to roughly the cap plus the marker
+        assert!(out.len() <= 1000 + "…(truncated)\n".len() + 4);
+    }
+
+    #[test]
+    fn cap_is_char_boundary_safe() {
+        // Each '⭐' is 3 bytes; cutting must land on a char boundary (no panic).
+        let ctx: String = std::iter::repeat('⭐').take(500).collect();
+        let out = cap_delegate_context(&ctx, 100);
+        assert!(out
+            .chars()
+            .all(|c| c == '⭐' || "…(truncated)\n".contains(c)));
+    }
+}


### PR DESCRIPTION
## Summary

`?<prompt>` enriches the delegated prompt with a multi-line **`## Terminal Context (pane …)`** block. Delivering that block through a shell corrupted or dropped it:

- **#404 (WSL):** `wsl -- bash -lc "<agent> '<prompt>'"` split embedded newlines, re-evaluated `$()`/backticks in the captured output, and had `%VAR%` expanded by WT's `ExpandEnvironmentStringsW` (`ConptyConnection.cpp`) — the new tab flashed shell errors (`command not found`, `syntax error near '('`) and the context was lost.
- **#403 (host):** `cmd /c <agent>.cmd "<prompt>"` truncates the argument at the first newline for npm `.cmd` shims (claude, codex), silently dropping the context. `copilot` was unaffected only because it resolves to a direct `.exe`.

## Fix — deliver the prompt as inline base64

base64's alphabet (`[A-Za-z0-9+/=]`) has no shell syntax characters, whitespace, or **`%`**, so the payload is immune to every re-parsing layer (cmd truncation, `$()`/backtick re-evaluation, `%VAR%` expansion, and PowerShell quote handling). It is decoded at the destination and handed to the agent as a single argument.

- **WSL:** `bash -lc "prompt=$(base64 -d <<< '<b64>'); exec <agent> \"$prompt\""`, pre-escaped (`\ $ \``) for the one `wsl.exe` interop expansion pass. Validated md5-exact through an `ExpandEnvironmentStringsW` + `CreateProcessW` probe.
- **Host:** when a known agent resolves to a `.cmd`/`.bat` shim and the prompt is multi-line, prefer **PowerShell 7** and invoke the bare PATH-resolved command with the base64-decoded prompt. When `pwsh` is unavailable, use Windows PowerShell 5.1, replace the characters its native argument binder cannot preserve with ASCII HTML entities, prepend a decode-once transport note, and invoke the same bare command. Explicit `.cmd`/`.bat` tokens are normalized to an adjacent `.ps1` companion or the known agent id before either PowerShell launch. Unknown/custom batch commands retain the existing `cmd /c` fallback.

Direct-`.exe` agents (copilot) and single-line prompts keep their existing path.

A 12 KB cap, including the truncation marker, is applied to captured terminal context before base64 encoding. This keeps the generated commandline under the ~32,767-character Windows limit while retaining the most recent UTF-8-safe tail.

Both PowerShell launch paths propagate the agent process exit code so WT can preserve non-zero failures under `closeOnExit=automatic`.

## Notes

- Empirically validated the transport through faithful `ExpandEnvironmentStringsW` + `CreateProcessW` probes, including adversarial `%TEMP%`, `$()`, backtick, quote, and multi-line payloads.

## Test

- `cargo test --manifest-path tools/wta/Cargo.toml` → **1053 passed, 0 failed**.
- Unit tests cover the WSL base64 builder, the intermediate-shell escape, both PowerShell launch paths, non-zero exit-code propagation, the commandline-size bound, and UTF-8-safe context truncation.

Fixes #403
Fixes #404
