### PR TITLE
Add release-notes agent skill for generating user-facing changelogs

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -281,3 +281,4 @@ zzzzz
 axum
 dispatchable
 slowloris
+Verbed

--- a/.github/actions/spelling/allow/names.txt
+++ b/.github/actions/spelling/allow/names.txt
@@ -76,4 +76,7 @@ Figma
 gordon
 haonanttt
 Kinger
+Lucas
+ltrzesniewski
+Trzesniewski
 usmani

--- a/.github/actions/spelling/allow/names.txt
+++ b/.github/actions/spelling/allow/names.txt
@@ -76,7 +76,4 @@ Figma
 gordon
 haonanttt
 Kinger
-Lucas
-ltrzesniewski
-Trzesniewski
 usmani

--- a/.github/actions/spelling/allow/names.txt
+++ b/.github/actions/spelling/allow/names.txt
@@ -77,7 +77,3 @@ gordon
 haonanttt
 Kinger
 usmani
-gordon
-haonanttt
-Kinger
-usmani

--- a/.github/actions/spelling/allow/names.txt
+++ b/.github/actions/spelling/allow/names.txt
@@ -73,3 +73,7 @@ zljubisic
 Zoey
 zorio
 Figma
+gordon
+haonanttt
+Kinger
+usmani

--- a/.github/actions/spelling/allow/names.txt
+++ b/.github/actions/spelling/allow/names.txt
@@ -77,3 +77,7 @@ gordon
 haonanttt
 Kinger
 usmani
+gordon
+haonanttt
+Kinger
+usmani

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -62,7 +62,7 @@ Use the [release notes template](./templates/release-notes-template.md) and foll
 
 #### Formatting Rules
 
-1. **Use numbered lists** (`1.`, `2.`, `3.`) within every section — matches the house style of prior releases (e.g. `doc/release-notes/v0.1.2.md`), not bullet points.
+1. **Use numbered lists** (`1.`, `2.`, `3.`) within every section — matches the house style shown in [`references/example-release-notes.md`](./references/example-release-notes.md), not bullet points.
 
 2. **Every item uses "Verbed + Impact + Scenario"** — a human must understand what changed and why it matters to them
    - ✅ `**Press F5 to refresh the session list.** Re-scans history on demand so sessions that appeared after launch show up without restarting. #344`

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -18,16 +18,32 @@ Generate polished, user-facing release notes for Intelligent Terminal releases b
 
 ### Phase 1: Identify the Commit Range
 
-1. Determine the **last release point**. Ask the user or check:
-   - The latest git tag: `git tag --sort=-version:refname | head -5`
-     (PowerShell: `git tag --sort=-version:refname | Select-Object -First 5`)
-   - The last release notes file
-   - The user may specify a commit hash directly
-2. List all commits since that point:
+The base is the **previous release tag** (the `vX.Y.Z` sequence, e.g. `v0.1.2`) and the head is **`main`**. Do **not** anchor on `stable` (it is a cherry-picked subset that lags the release tag), on the legacy four-part `v0.1.NNNN.0` tags, or on upstream Windows Terminal `v1.x` tags — none of those are this fork's release line, and a plain `git tag --sort=-version:refname | head` surfaces exactly those wrong anchors.
+
+1. Determine the **last release point** (in order of preference):
+   - **From the release-notes files (source of truth).** The newest `doc/release-notes/vX.Y.Z.md` names the last shipped version; use its `vX.Y.Z` tag as the base.
+     ```bash
+     ls doc/release-notes/v*.md | sort -V | tail -1   # e.g. v0.1.2.md → base tag v0.1.2
+     ```
+     ```powershell
+     Get-ChildItem doc/release-notes/v*.md | Sort-Object { [version]($_.BaseName -replace '^v','') } | Select-Object -Last 1
+     ```
+   - **From tags (confirm before trusting).** A *candidate* base is the newest 3-part tag merged into `main` (the filter below drops upstream `v1.x` and the stale `v0.1.NNNN.0` tags). **Verify it is really the last release** — the `v0.1.x` line has out-of-band tags (e.g. `v0.1.18`) that outrank the true last release under version sort, so this is a hint, not an authority:
+     ```bash
+     git tag --list 'v*' --merged main | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1
+     ```
+     ```powershell
+     git tag --list 'v*' --merged main | Where-Object { $_ -match '^v\d+\.\d+\.\d+$' } | Sort-Object { [version]($_ -replace '^v','') } | Select-Object -Last 1
+     ```
+   - The user may specify the base commit/tag directly.
+   - If still unsure, **ask the user** — never guess from `git tag | head` in this repo.
+2. List all commits from the base to `main`:
    ```bash
-   git log --oneline --reverse <last-release>..HEAD
+   git log --oneline --reverse <last-release-tag>..main
    ```
-3. Extract PR numbers from commit messages (pattern: `(#NNN)`)
+3. Extract PR numbers from commit messages (pattern: `(#NNN)`).
+
+> The `0.1.xxxx.0` build number is injected by CI at release time; the human-facing version is the `vX.Y.Z` sequence.
 
 ### Phase 2: Enrich with PR Metadata
 
@@ -85,7 +101,7 @@ Use these sections in order:
 
 ### Phase 4: Output
 
-1. Save the release notes to `Generated Files/release-notes-v<version>.md` (this folder is gitignored — generated output only)
+1. Save the final release notes to `doc/release-notes/vX.Y.Z.md` (committed alongside prior releases, e.g. `doc/release-notes/v0.1.2.md`). Draft in `Generated Files/` first if you want a gitignored scratch copy.
 2. Present the full notes to the user
 3. Also list the top 5 elevator-pitch points separately
 

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -39,6 +39,8 @@ gh pr view <number> --repo <owner>/<repo> --json number,title,body,author,closin
 
 > `<owner>/<repo>` is `microsoft/intelligent-terminal` for this repo's own PRs, or `microsoft/terminal` for upstream `#20xxx` PRs.
 
+To batch this lookup across many PRs at once, run [`scripts/Get-PrMetadata.ps1`](./scripts/Get-PrMetadata.ps1) with a list of PR numbers — it reports linked issues and flags community contributors (authors not in `references/core-team.md`).
+
 Collect:
 - **PR → Issue mapping**: Which PRs fix/close GitHub issues
 - **Community contributors**: Authors NOT in the core team list

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -22,7 +22,7 @@ The base is the **latest release tag** (the `vX.Y.Z` sequence, e.g. `v0.1.18`) a
 
 1. Find the **latest release tag** — the newest 3-part `vX.Y.Z` tag that is merged into `main`. The filter is what keeps this reliable: it excludes upstream Windows Terminal `v1.x` tags (not on this fork's history) and the legacy four-part `v0.1.NNNN.0` tags (stale, some point at ancient upstream commits). Do **not** anchor on `stable` — it is a cherry-picked subset that lags the release tag.
    ```bash
-   git tag --list 'v*' --merged main | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1
+   git tag --list 'v*' --merged main --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1
    ```
    ```powershell
    git tag --list 'v*' --merged main | Where-Object { $_ -match '^v\d+\.\d+\.\d+$' } | Sort-Object { [version]($_ -replace '^v','') } | Select-Object -Last 1

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -28,9 +28,9 @@ The base is the **latest release tag** (the `vX.Y.Z` sequence, e.g. `v0.1.18`) a
    git tag --list 'v*' --merged main | Where-Object { $_ -match '^v\d+\.\d+\.\d+$' } | Sort-Object { [version]($_ -replace '^v','') } | Select-Object -Last 1
    ```
    (The user may override with a specific base commit/tag; if the plain `git tag` list looks nothing like the above — e.g. only `v1.x` shows up — the `--merged main` filter is being skipped.)
-2. List all commits from the base tag to `main`:
+2. List all commits from the base tag to `main` (replace `$BASE_TAG` with the tag from step 1):
    ```bash
-   git log --oneline --reverse <latest-release-tag>..main
+   git log --oneline --reverse "$BASE_TAG"..main
    ```
 3. Extract PR numbers from commit messages (pattern: `(#NNN)`).
 
@@ -38,13 +38,13 @@ The base is the **latest release tag** (the `vX.Y.Z` sequence, e.g. `v0.1.18`) a
 
 ### Phase 2: Enrich with PR Metadata
 
-For each PR number, look up linked issues and author info:
+For each PR number, look up linked issues and author info (replace `PR_NUMBER` and `OWNER/REPO`):
 
 ```bash
-gh pr view <number> --repo <owner>/<repo> --json number,title,body,author,closingIssuesReferences
+gh pr view PR_NUMBER --repo OWNER/REPO --json number,title,body,author,closingIssuesReferences
 ```
 
-> Use `microsoft/intelligent-terminal` for this repo's own PRs — they live on the canonical repo even when you're working from a fork/clone — or `microsoft/terminal` for upstream `#20xxx` PRs.
+> Use `OWNER/REPO` = `microsoft/intelligent-terminal` for this repo's own PRs — they live on the canonical repo even when you're working from a fork/clone — or `microsoft/terminal` for upstream `#20xxx` PRs.
 
 To batch this lookup across many PRs at once, run [`scripts/Get-PrMetadata.ps1`](./scripts/Get-PrMetadata.ps1) with a list of PR numbers — it reports linked issues and flags community contributors (authors not in `references/core-team.md`).
 

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -62,33 +62,41 @@ Use the [release notes template](./templates/release-notes-template.md) and foll
 
 #### Formatting Rules
 
-1. **Every bullet uses "Verbed + Impact + Scenario"** — a human must understand what changed and why it matters to them
-   - ✅ `**Fixed empty agent session views after first login** so the first tab's AI session reconnects and shows your conversation instead of appearing blank: #188`
-   - ❌ `Fixed bug #188` (no impact or scenario)
+1. **Use numbered lists** (`1.`, `2.`, `3.`) within every section — matches the house style of prior releases (e.g. `doc/release-notes/v0.1.2.md`), not bullet points.
+
+2. **Every item uses "Verbed + Impact + Scenario"** — a human must understand what changed and why it matters to them
+   - ✅ `**Press F5 to refresh the session list.** Re-scans history on demand so sessions that appeared after launch show up without restarting. #344`
+   - ❌ `Fixed bug #344` (no impact or scenario)
    - ❌ `emit connection_state:closed on UI-initiated pane/tab close` (developer jargon)
 
-2. **Every bullet has a PR or issue number** at the end (e.g., `: #195` or `: #188, #199`)
-   - If the PR has a linked issue, use the issue number
-   - If no linked issue, use the PR number
-   - Group related fixes that share user impact into one bullet with multiple numbers
+3. **Every item ends with its PR number(s)** — a space then `#PR` after the trailing period (e.g. `… without restarting. #344` or `… in strict-mode shells. #340`).
+   - Use the **PR number** as the primary reference (the shipped notes are PR-centric).
+   - In the 💜 Community section you may add the linked issue too, e.g. `(#366, closes #351)`.
+   - Group related items that share user impact into one entry with multiple numbers (e.g. `#305, #365`).
 
-3. **Omit purely internal changes** — CI fixes, code refactors, dev docs, test-only changes, localization bot updates — unless they have direct user-visible impact
+4. **Open with a metadata blockquote header**, mirroring `v0.1.2.md`: the base release tag + commit + build, the head `main` commit, the new-PR count, the CI-injects-build-number note, and the "base is the tag, not `stable`" note.
 
-4. **Avoid detailed security disclosures in public release notes** — fold security-related stability fixes into the Bug Fixes section rather than calling them out as security issues, and coordinate any security-sensitive wording with maintainers per [SECURITY.md](../../../SECURITY.md)
+5. **Frame the notes** with a one-paragraph plain-language intro (the release's headline theme) after the header, and a closing call-to-action inviting users to file issues.
 
-5. **Thank community contributors** in a 💜 Community section with GitHub profile links:
+6. **Omit purely internal changes** — CI fixes, code refactors, dev docs, test-only changes, localization bot updates — unless they have direct user-visible impact. (Prior releases sometimes collect these under a `## Development` section instead of omitting them; follow the maintainer's preference for the release at hand.)
+
+7. **Avoid detailed security disclosures in public release notes** — fold security-related stability fixes into the Bug Fixes section rather than calling them out as security issues, and coordinate any security-sensitive wording with maintainers per [SECURITY.md](../../../SECURITY.md)
+
+8. **Thank community contributors** in a 💜 Community section with GitHub profile links:
    ```markdown
-   - [@username](https://github.com/username) (Display Name) — what they contributed (#PR)
+   1. [@username](https://github.com/username) (Display Name) — what they contributed. (#PR, closes #issue)
    ```
 
 #### Section Structure
 
-Use these sections in order:
+Open with the metadata blockquote header and the intro paragraph, then use these sections in order:
 - `## ✨ New Features` — new capabilities users can use
 - `## 🔧 Improvements` — enhancements to existing features
 - `## 🐛 Bug Fixes` — things that were broken and are now fixed
 - `## 💜 Community` — external contributor thanks
 - `## 🚀 Top 5 Elevator-Pitch Points` — the most compelling highlights for social media / announcements
+
+Close with the call-to-action paragraph.
 
 ### Phase 4: Output
 

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -18,32 +18,23 @@ Generate polished, user-facing release notes for Intelligent Terminal releases b
 
 ### Phase 1: Identify the Commit Range
 
-The base is the **previous release tag** (the `vX.Y.Z` sequence, e.g. `v0.1.2`) and the head is **`main`**. Do **not** anchor on `stable` (it is a cherry-picked subset that lags the release tag), on the legacy four-part `v0.1.NNNN.0` tags, or on upstream Windows Terminal `v1.x` tags — none of those are this fork's release line, and blindly taking the newest tag by version sort surfaces exactly those wrong anchors.
+The base is the **latest release tag** (the `vX.Y.Z` sequence, e.g. `v0.1.18`) and the head is **`main`**. The range is everything between them.
 
-1. Determine the **last release point** (in order of preference):
-   - **From the release-notes files (source of truth).** If `doc/release-notes/` exists, the newest `doc/release-notes/vX.Y.Z.md` names the last shipped version; use its `vX.Y.Z` tag as the base. (This directory is a new convention — if it doesn't exist yet, skip to the tag method below.)
-     ```bash
-     ls doc/release-notes/v*.md | sort -V | tail -1   # e.g. v0.1.2.md → base tag v0.1.2
-     ```
-     ```powershell
-     Get-ChildItem doc/release-notes/v*.md | Sort-Object { [version]($_.BaseName -replace '^v','') } | Select-Object -Last 1
-     ```
-   - **From tags (confirm before trusting).** A *candidate* base is the newest 3-part tag merged into `main` (the filter below drops upstream `v1.x` and the stale `v0.1.NNNN.0` tags). **Verify it is really the last release** — the `v0.1.x` line has out-of-band tags (e.g. `v0.1.18`) that outrank the true last release under version sort, so this is a hint, not an authority:
-     ```bash
-     git tag --list 'v*' --merged main | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1
-     ```
-     ```powershell
-     git tag --list 'v*' --merged main | Where-Object { $_ -match '^v\d+\.\d+\.\d+$' } | Sort-Object { [version]($_ -replace '^v','') } | Select-Object -Last 1
-     ```
-   - The user may specify the base commit/tag directly.
-   - If still unsure, **ask the user** — never guess from a blind newest-tag sort in this repo.
-2. List all commits from the base to `main`:
+1. Find the **latest release tag** — the newest 3-part `vX.Y.Z` tag that is merged into `main`. The filter is what keeps this reliable: it excludes upstream Windows Terminal `v1.x` tags (not on this fork's history) and the legacy four-part `v0.1.NNNN.0` tags (stale, some point at ancient upstream commits). Do **not** anchor on `stable` — it is a cherry-picked subset that lags the release tag.
    ```bash
-   git log --oneline --reverse <last-release-tag>..main
+   git tag --list 'v*' --merged main | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1
+   ```
+   ```powershell
+   git tag --list 'v*' --merged main | Where-Object { $_ -match '^v\d+\.\d+\.\d+$' } | Sort-Object { [version]($_ -replace '^v','') } | Select-Object -Last 1
+   ```
+   (The user may override with a specific base commit/tag; if the plain `git tag` list looks nothing like the above — e.g. only `v1.x` shows up — the `--merged main` filter is being skipped.)
+2. List all commits from the base tag to `main`:
+   ```bash
+   git log --oneline --reverse <latest-release-tag>..main
    ```
 3. Extract PR numbers from commit messages (pattern: `(#NNN)`).
 
-> The `0.1.xxxx.0` build number is injected by CI at release time; the human-facing version is the `vX.Y.Z` sequence.
+> The `0.1.xxxx.0` build number is injected by CI at release time; the human-facing version is the `vX.Y.Z` tag sequence.
 
 ### Phase 2: Enrich with PR Metadata
 

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: release-notes
+description: 'Generate user-facing release notes for Intelligent Terminal. Use when asked to write release notes, changelog, what-is-new summary, or prepare a release. Compares git commits between releases, looks up PR-linked issues and community contributors, then outputs formatted notes with "Verbed + Impact + Scenario" style bullets, issue references, and contributor thanks.'
+---
+
+# Release Notes Generator
+
+Generate polished, user-facing release notes for Intelligent Terminal releases by analyzing git history, PR metadata, and issue links.
+
+## When to Use This Skill
+
+- User asks to write release notes or changelog
+- User asks "what's new since last release"
+- User asks to prepare a release
+- User asks to summarize recent commits for end-users
+
+## Step-by-Step Workflow
+
+### Phase 1: Identify the Commit Range
+
+1. Determine the **last release point**. Ask the user or check:
+   - The latest git tag: `git tag --sort=-version:refname | head -5`
+   - The last release notes file
+   - The user may specify a commit hash directly
+2. List all commits since that point:
+   ```bash
+   git log --oneline --reverse <last-release>..HEAD
+   ```
+3. Extract PR numbers from commit messages (pattern: `(#NNN)`)
+
+### Phase 2: Enrich with PR Metadata
+
+For each PR number, look up linked issues and author info:
+
+```bash
+gh pr view <number> --repo microsoft/intelligent-terminal --json number,title,body,author,closingIssuesReferences
+```
+
+Collect:
+- **PR → Issue mapping**: Which PRs fix/close GitHub issues
+- **Community contributors**: Authors NOT in the core team list
+
+#### Core Team (do NOT thank as community contributors)
+
+See [core-team.md](./references/core-team.md) for the current list.
+
+### Phase 3: Write Release Notes
+
+Use the [release notes template](./templates/release-notes-template.md) and follow these rules:
+
+#### Formatting Rules
+
+1. **Every bullet uses "Verbed + Impact + Scenario"** — a human must understand what changed and why it matters to them
+   - ✅ `**Fixed empty agent session views after first login** so the first tab's AI session reconnects and shows your conversation instead of appearing blank: #188`
+   - ❌ `Fixed bug #188` (no impact or scenario)
+   - ❌ `emit connection_state:closed on UI-initiated pane/tab close` (developer jargon)
+
+2. **Every bullet has a PR or issue number** at the end (e.g., `: #195` or `: #188, #199`)
+   - If the PR has a linked issue, use the issue number
+   - If no linked issue, use the PR number
+   - Group related fixes that share user impact into one bullet with multiple numbers
+
+3. **Omit purely internal changes** — CI fixes, code refactors, dev docs, test-only changes, localization bot updates — unless they have direct user-visible impact
+
+4. **Never mention security fixes publicly** — fold security-related stability fixes into the Bug Fixes section without calling them security issues
+
+5. **Thank community contributors** in a 💜 Community section with GitHub profile links:
+   ```markdown
+   - [@username](https://github.com/username) (Display Name) — what they contributed (#PR)
+   ```
+
+#### Section Structure
+
+Use these sections in order:
+- `## ✨ New Features` — new capabilities users can use
+- `## 🔧 Improvements` — enhancements to existing features
+- `## 🐛 Bug Fixes` — things that were broken and are now fixed
+- `## 💜 Community` — external contributor thanks
+- `## 🚀 Top 5 Elevator-Pitch Points` — the most compelling highlights for social media / announcements
+
+### Phase 4: Output
+
+1. Save the release notes to `Generated Files/release-notes-v<version>.md` (this folder is gitignored — generated output only)
+2. Present the full notes to the user
+3. Also list the top 5 elevator-pitch points separately
+
+## Gotchas
+
+- **Never include a 🔒 Security section** — the project policy is to not discuss security fixes publicly. Fold stability improvements into Bug Fixes.
+- **Upstream Windows Terminal PRs** (#20xxx numbers) should be looked up on `microsoft/terminal`, not `microsoft/intelligent-terminal`.
+- **The "Verbed + Impact + Scenario" format is non-negotiable** — every single bullet must follow it. "Fixed X" alone is not enough; you must explain the user impact.
+- **Some commits are cherry-picks from upstream** — check both repos when looking up PRs.
+- **Group related commits** — if 3 PRs all improve the FRE, combine into one bullet with multiple issue numbers rather than 3 separate bullets.
+
+## References
+
+- [Core team list](./references/core-team.md)
+- [Release notes template](./templates/release-notes-template.md)
+- [Previous release notes example](./references/example-release-notes.md)

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -92,9 +92,10 @@ Use these sections in order:
 
 ### Phase 4: Output
 
-1. Save the final release notes to `doc/release-notes/vX.Y.Z.md` (committed alongside prior releases, e.g. `doc/release-notes/v0.1.2.md`; create the `doc/release-notes/` folder if it doesn't exist yet). Draft in `Generated Files/` first if you want a gitignored scratch copy.
-2. Present the full notes to the user
-3. Also list the top 5 elevator-pitch points separately
+1. **Draft** into `Generated Files/release-notes-vX.Y.Z.md` — this folder is gitignored, so the working draft stays untracked while you iterate and get user sign-off.
+2. Present the full notes to the user for review.
+3. Also list the top 5 elevator-pitch points separately.
+4. **Publish (only once approved).** Copy the finalized notes to `doc/release-notes/vX.Y.Z.md` and commit them alongside prior releases (e.g. `doc/release-notes/v0.1.2.md`; create the folder if it doesn't exist yet). This committed file is the source of truth for the version — do **not** commit the `Generated Files/` draft.
 
 ## Gotchas
 

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -21,7 +21,7 @@ Generate polished, user-facing release notes for Intelligent Terminal releases b
 The base is the **previous release tag** (the `vX.Y.Z` sequence, e.g. `v0.1.2`) and the head is **`main`**. Do **not** anchor on `stable` (it is a cherry-picked subset that lags the release tag), on the legacy four-part `v0.1.NNNN.0` tags, or on upstream Windows Terminal `v1.x` tags — none of those are this fork's release line, and blindly taking the newest tag by version sort surfaces exactly those wrong anchors.
 
 1. Determine the **last release point** (in order of preference):
-   - **From the release-notes files (source of truth).** The newest `doc/release-notes/vX.Y.Z.md` names the last shipped version; use its `vX.Y.Z` tag as the base.
+   - **From the release-notes files (source of truth).** If `doc/release-notes/` exists, the newest `doc/release-notes/vX.Y.Z.md` names the last shipped version; use its `vX.Y.Z` tag as the base. (This directory is a new convention — if it doesn't exist yet, skip to the tag method below.)
      ```bash
      ls doc/release-notes/v*.md | sort -V | tail -1   # e.g. v0.1.2.md → base tag v0.1.2
      ```
@@ -101,7 +101,7 @@ Use these sections in order:
 
 ### Phase 4: Output
 
-1. Save the final release notes to `doc/release-notes/vX.Y.Z.md` (committed alongside prior releases, e.g. `doc/release-notes/v0.1.2.md`). Draft in `Generated Files/` first if you want a gitignored scratch copy.
+1. Save the final release notes to `doc/release-notes/vX.Y.Z.md` (committed alongside prior releases, e.g. `doc/release-notes/v0.1.2.md`; create the `doc/release-notes/` folder if it doesn't exist yet). Draft in `Generated Files/` first if you want a gitignored scratch copy.
 2. Present the full notes to the user
 3. Also list the top 5 elevator-pitch points separately
 

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -34,8 +34,10 @@ Generate polished, user-facing release notes for Intelligent Terminal releases b
 For each PR number, look up linked issues and author info:
 
 ```bash
-gh pr view <number> --repo microsoft/intelligent-terminal --json number,title,body,author,closingIssuesReferences
+gh pr view <number> --repo <owner>/<repo> --json number,title,body,author,closingIssuesReferences
 ```
+
+> `<owner>/<repo>` is `microsoft/intelligent-terminal` for this repo's own PRs, or `microsoft/terminal` for upstream `#20xxx` PRs.
 
 Collect:
 - **PR → Issue mapping**: Which PRs fix/close GitHub issues
@@ -63,7 +65,7 @@ Use the [release notes template](./templates/release-notes-template.md) and foll
 
 3. **Omit purely internal changes** — CI fixes, code refactors, dev docs, test-only changes, localization bot updates — unless they have direct user-visible impact
 
-4. **Never mention security fixes publicly** — fold security-related stability fixes into the Bug Fixes section without calling them security issues
+4. **Avoid detailed security disclosures in public release notes** — fold security-related stability fixes into the Bug Fixes section rather than calling them out as security issues, and coordinate any security-sensitive wording with maintainers per [SECURITY.md](../../../SECURITY.md)
 
 5. **Thank community contributors** in a 💜 Community section with GitHub profile links:
    ```markdown
@@ -87,7 +89,7 @@ Use these sections in order:
 
 ## Gotchas
 
-- **Never include a 🔒 Security section** — the project policy is to not discuss security fixes publicly. Fold stability improvements into Bug Fixes.
+- **Avoid a dedicated 🔒 Security section** — prefer folding security-related stability improvements into Bug Fixes rather than publicly detailing security issues; see [SECURITY.md](../../../SECURITY.md) for vulnerability handling and coordinate sensitive wording with maintainers.
 - **Upstream Windows Terminal PRs** (#20xxx numbers) should be looked up on `microsoft/terminal`, not `microsoft/intelligent-terminal`.
 - **The "Verbed + Impact + Scenario" format is non-negotiable** — every single bullet must follow it. "Fixed X" alone is not enough; you must explain the user impact.
 - **Some commits are cherry-picks from upstream** — check both repos when looking up PRs.

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -44,7 +44,7 @@ For each PR number, look up linked issues and author info:
 gh pr view <number> --repo <owner>/<repo> --json number,title,body,author,closingIssuesReferences
 ```
 
-> `<owner>/<repo>` is `microsoft/intelligent-terminal` for this repo's own PRs, or `microsoft/terminal` for upstream `#20xxx` PRs.
+> Use `microsoft/intelligent-terminal` for this repo's own PRs — they live on the canonical repo even when you're working from a fork/clone — or `microsoft/terminal` for upstream `#20xxx` PRs.
 
 To batch this lookup across many PRs at once, run [`scripts/Get-PrMetadata.ps1`](./scripts/Get-PrMetadata.ps1) with a list of PR numbers — it reports linked issues and flags community contributors (authors not in `references/core-team.md`).
 

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -18,7 +18,7 @@ Generate polished, user-facing release notes for Intelligent Terminal releases b
 
 ### Phase 1: Identify the Commit Range
 
-The base is the **previous release tag** (the `vX.Y.Z` sequence, e.g. `v0.1.2`) and the head is **`main`**. Do **not** anchor on `stable` (it is a cherry-picked subset that lags the release tag), on the legacy four-part `v0.1.NNNN.0` tags, or on upstream Windows Terminal `v1.x` tags — none of those are this fork's release line, and a plain `git tag --sort=-version:refname | head` surfaces exactly those wrong anchors.
+The base is the **previous release tag** (the `vX.Y.Z` sequence, e.g. `v0.1.2`) and the head is **`main`**. Do **not** anchor on `stable` (it is a cherry-picked subset that lags the release tag), on the legacy four-part `v0.1.NNNN.0` tags, or on upstream Windows Terminal `v1.x` tags — none of those are this fork's release line, and blindly taking the newest tag by version sort surfaces exactly those wrong anchors.
 
 1. Determine the **last release point** (in order of preference):
    - **From the release-notes files (source of truth).** The newest `doc/release-notes/vX.Y.Z.md` names the last shipped version; use its `vX.Y.Z` tag as the base.
@@ -36,7 +36,7 @@ The base is the **previous release tag** (the `vX.Y.Z` sequence, e.g. `v0.1.2`) 
      git tag --list 'v*' --merged main | Where-Object { $_ -match '^v\d+\.\d+\.\d+$' } | Sort-Object { [version]($_ -replace '^v','') } | Select-Object -Last 1
      ```
    - The user may specify the base commit/tag directly.
-   - If still unsure, **ask the user** — never guess from `git tag | head` in this repo.
+   - If still unsure, **ask the user** — never guess from a blind newest-tag sort in this repo.
 2. List all commits from the base to `main`:
    ```bash
    git log --oneline --reverse <last-release-tag>..main

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -20,6 +20,7 @@ Generate polished, user-facing release notes for Intelligent Terminal releases b
 
 1. Determine the **last release point**. Ask the user or check:
    - The latest git tag: `git tag --sort=-version:refname | head -5`
+     (PowerShell: `git tag --sort=-version:refname | Select-Object -First 5`)
    - The last release notes file
    - The user may specify a commit hash directly
 2. List all commits since that point:

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -74,7 +74,7 @@ Use the [release notes template](./templates/release-notes-template.md) and foll
    - In the 💜 Community section you may add the linked issue too, e.g. `(#366, closes #351)`.
    - Group related items that share user impact into one entry with multiple numbers (e.g. `#305, #365`).
 
-4. **Open with a metadata blockquote header**, mirroring `v0.1.2.md`: the base release tag + commit + build, the head `main` commit, the new-PR count, the CI-injects-build-number note, and the "base is the tag, not `stable`" note.
+4. **Open with a metadata blockquote header**, as shown in [`references/example-release-notes.md`](./references/example-release-notes.md): the base release tag + commit + build, the head `main` commit, the new-PR count, the CI-injects-build-number note, and the "base is the tag, not `stable`" note.
 
 5. **Frame the notes** with a one-paragraph plain-language intro (the release's headline theme) after the header, and a closing call-to-action inviting users to file issues.
 
@@ -103,7 +103,7 @@ Close with the call-to-action paragraph.
 1. **Draft** into `Generated Files/release-notes-vX.Y.Z.md` — this folder is gitignored, so the working draft stays untracked while you iterate and get user sign-off.
 2. Present the full notes to the user for review.
 3. Also list the top 5 elevator-pitch points separately.
-4. **Publish (only once approved).** Copy the finalized notes to `doc/release-notes/vX.Y.Z.md` and commit them alongside prior releases (e.g. `doc/release-notes/v0.1.2.md`; create the folder if it doesn't exist yet). This committed file is the source of truth for the version — do **not** commit the `Generated Files/` draft.
+4. **Publish (only once approved).** Copy the finalized notes to `doc/release-notes/vX.Y.Z.md` and commit them (create the `doc/release-notes/` folder if it doesn't exist yet — this is the intended home for published release notes). Follow the format in [`references/example-release-notes.md`](./references/example-release-notes.md). This committed file is the source of truth for the version — do **not** commit the `Generated Files/` draft.
 
 ## Gotchas
 

--- a/.github/skills/release-notes/references/core-team.md
+++ b/.github/skills/release-notes/references/core-team.md
@@ -1,0 +1,14 @@
+# Core Team Members
+
+These are the core Intelligent Terminal team members. Do NOT thank them as community contributors in release notes.
+
+| GitHub Username | Display Name | Role |
+|-----------------|-------------|------|
+| yeelam-gordon | Gordon Lam | Lead |
+| vanzue | Kai Tao | Developer |
+| DDKinger | DDKinger | Developer |
+| haonanttt | Nathan Tang | Developer |
+| hamza-usmani | Hamza Usmani | Developer |
+| pabhojwa | Pankaj Bhojwani | Developer |
+
+Anyone not on this list who authored a PR is a **community contributor** and should be thanked in the 💜 Community section.

--- a/.github/skills/release-notes/references/core-team.md
+++ b/.github/skills/release-notes/references/core-team.md
@@ -4,11 +4,11 @@ These are the core Intelligent Terminal team members. Do NOT thank them as commu
 
 | GitHub Username | Display Name | Role |
 |-----------------|-------------|------|
-| yeelam-gordon | Gordon Lam | Lead |
-| vanzue | Kai Tao | Developer |
 | DDKinger | DDKinger | Developer |
+| hamza-usmani | Hamza Usmani | PM |
 | haonanttt | Nathan Tang | Developer |
-| hamza-usmani | Hamza Usmani | Developer |
 | pabhojwa | Pankaj Bhojwani | Developer |
+| vanzue | Kai Tao | Developer |
+| yeelam-gordon | Gordon Lam | Lead |
 
 Anyone not on this list who authored a PR is a **community contributor** and should be thanked in the 💜 Community section.

--- a/.github/skills/release-notes/references/example-release-notes.md
+++ b/.github/skills/release-notes/references/example-release-notes.md
@@ -46,7 +46,7 @@ and a batch of important stability fixes.
 
 A huge thank you to the external contributors who helped make this release:
 
-1. [@arkthur](https://github.com/arkthur) (Ítalo Masserano) — added the Execution Policy setting command note for both PowerShell hosts. #213
+1. [@arkthur](https://github.com/arkthur) (Ítalo Masserano) — added the Execution Policy setting command note for both PowerShell hosts. (#213)
 2. [@ltrzesniewski](https://github.com/ltrzesniewski) (Lucas Trzesniewski) — added the `safeUriSchemes` setting. (#20207, closes #20191)
 
 ---

--- a/.github/skills/release-notes/references/example-release-notes.md
+++ b/.github/skills/release-notes/references/example-release-notes.md
@@ -46,8 +46,8 @@ and a batch of important stability fixes.
 
 A huge thank you to the external contributors who helped make this release:
 
-1. [@arkthur](https://github.com/arkthur) (Ítalo Masserano) — added the Execution Policy setting command note for both PowerShell hosts. (#213)
-2. [@ltrzesniewski](https://github.com/ltrzesniewski) (Lucas Trzesniewski) — added the `safeUriSchemes` setting. (#20207, closes #20191)
+1. [@contributor-handle](https://github.com/contributor-handle) (Contributor Name) — added the Execution Policy setting command note for both PowerShell hosts. (#213)
+2. [@another-contributor](https://github.com/another-contributor) (Another Contributor) — added the `safeUriSchemes` setting. (#20207, closes #20191)
 
 ---
 

--- a/.github/skills/release-notes/references/example-release-notes.md
+++ b/.github/skills/release-notes/references/example-release-notes.md
@@ -1,6 +1,6 @@
 # Intelligent Terminal v0.1.1
 
-> Base = **v0.1.0** release tag (`cfef0fa81`, build `0.1.1502.0`) → **latest `main`** (`008c4f645`).
+> Base = **v0.1.0** release tag (`<base-commit>`, build `0.1.1502.0`) → **latest `main`** (`<head-commit>`).
 > ~30 new PRs. The exact build number (`0.1.xxxx.0`) is injected by CI at release time.
 >
 > Note on the `stable` branch: `stable` is a cherry-picked subset of what already shipped in the

--- a/.github/skills/release-notes/references/example-release-notes.md
+++ b/.github/skills/release-notes/references/example-release-notes.md
@@ -1,51 +1,66 @@
-# Intelligent Terminal — Release Notes
+# Intelligent Terminal v0.1.1
 
-Smarter AI assistance, broader shell support, a smoother first-run experience, and important stability fixes.
+> Base = **v0.1.0** release tag (`cfef0fa81`, build `0.1.1502.0`) → **latest `main`** (`008c4f645`).
+> ~30 new PRs. The exact build number (`0.1.xxxx.0`) is injected by CI at release time.
+>
+> Note on the `stable` branch: `stable` is a cherry-picked subset of what already shipped in the
+> previous release, so it is *behind* the release tag. The clean "since last release" base is the
+> **v0.1.0 tag**, not `stable`.
+
+This release brings smarter AI assistance, broader shell support, a smoother first-run experience,
+and a batch of important stability fixes.
 
 ## ✨ New Features
 
-- **Added the `/fix` slash command** to diagnose and resolve a failed command on demand, so you get help even when autofix doesn't trigger automatically: #195
-- **Added a per-pane `/model` picker** so you can choose the best AI model for each task right in the agent pane, with your local choice overriding global settings: #227
-- **Extended autofix to Bash and WSL** so automatic error detection and fix suggestions now work beyond PowerShell, no matter which shell you use: #222
-- **Added the `safeUriSchemes` setting** to control which link types are clickable from the terminal, protecting you from opening risky links: #20191
-- **Redesigned the new-tab menu into a fast dropdown** so launching the profile you want is quicker than the old full-page menu: #20203
-- **Enabled winget installation** as `Microsoft.IntelligentTerminal` for simple command-line install and updates: #235
+1. **Added the `/fix` slash command** to diagnose and resolve a failed command on demand, so you get help even when autofix doesn't trigger automatically. #206
+2. **Added a per-pane `/model` picker** so you can choose the best AI model for each task right in the agent pane, with your local choice overriding global settings. #227
+3. **Extended autofix to Bash and WSL** so automatic error detection and fix suggestions now work beyond PowerShell, no matter which shell you use. #222
+4. **Added the `safeUriSchemes` setting** to control which link types are clickable from the terminal, protecting you from opening risky links. #20207
+5. **Redesigned the new-tab menu into a fast dropdown** so launching the profile you want is quicker than the old full-page menu. #20203
+6. **Enabled winget installation** as `Microsoft.IntelligentTerminal` for simple command-line install and updates. #235
 
 ## 🔧 Improvements
 
-- **Enabled live hot-reload of AI model and delegate settings** so changes apply instantly without restarting the agent pane: #187
-- **Made the agent pane follow your terminal color scheme** instead of a hardcoded dark palette, giving the AI panel a consistent themed look: #234
-- **Improved the first-run setup experience** with a clearer GitHub Copilot install flow, a modal progress overlay during save/install, and a faster, optimized hooks installation step: #201, #262, #281
-- **Hardened PowerShell setup guidance** so the wizard stops and explains the fix when an execution policy blocks installation, regardless of your profile setup: #292
-- **Repositioned the `/model` and autocomplete popups** directly above the input box where you'd expect to find them: #232
-- **Preserved your font size across settings reloads** so zoom adjustments no longer reset unexpectedly: #20230
-- **Added a live preview to tab search** so you can see the selected tab while searching, making the right one easier to find: #20233
-- **Switched profile bell sounds to a more dependable playback method** so custom bells play reliably: #17733
-- **Improved accessibility** by announcing navigation-pane open/close events to screen readers: #19687
-- **Expanded in-app help** with a new FAQ, the Alt+Shift+B shortcut, log-collection instructions for bug reports, and troubleshooting for known crashes: #185, #205
+1. **Enabled live hot-reload of AI model and delegate settings** so changes apply instantly without restarting the agent pane. #219
+2. **Made the agent pane follow your terminal color scheme** instead of a hardcoded dark palette, giving the AI panel a consistent themed look. #241
+3. **Improved the first-run setup experience** with a clearer GitHub Copilot install flow, a modal progress overlay during save/install, and a faster, optimized hooks installation step. #201, #262, #281
+4. **Hardened PowerShell setup guidance** so the wizard stops and explains the fix when an execution policy blocks installation, regardless of your profile setup. #292
+5. **Repositioned the `/model` and autocomplete popups** directly above the input box where you'd expect to find them. #232
+6. **Preserved your font size across settings reloads** so zoom adjustments no longer reset unexpectedly. #20230
+7. **Added a live preview to tab search** so you can see the selected tab while searching, making the right one easier to find. #20256
+8. **Switched profile bell sounds to a more dependable playback method** so custom bells play reliably. #20031
+9. **Improved accessibility** by announcing navigation-pane open/close events to screen readers. #20275
+10. **Expanded in-app help** with a new FAQ, the Alt+Shift+B shortcut, log-collection instructions for bug reports, and troubleshooting for known crashes. #185, #205
 
 ## 🐛 Bug Fixes
 
-- **Fixed empty agent session views after first login** so the first tab's AI session reconnects and shows your conversation instead of appearing blank: #188
-- **Fixed stale session/tab state on pane close** so closing a pane or tab from the UI correctly reports the connection as closed and keeps the AI's view accurate: #198
-- **Fixed crashes and agent pane initialization errors** — including the `0x80010105` and `0xc0000005` errors — by rebuilding the AI communication layer on a more robust foundation: #237, #199
-- **Fixed AI executable path resolution** so the correct agent is always found, preventing the agent pane and autofix from silently failing: #217
-- **Fixed odd window resizing and title behavior** so the terminal ignores redundant resize requests and handles cursor/title fallback like standard terminals: #19310, #19340, #20204, #19918
-- **Removed a duplicate Default Terminal policy** from the group-policy templates so administrators no longer see a conflicting entry: #212
-- **Trimmed unnecessary data from internal event reporting** so AI command-result monitoring runs lighter and faster: #216
+1. **Fixed empty agent session views after first login** so the first tab's AI session reconnects and shows your conversation instead of appearing blank. #186
+2. **Fixed stale session/tab state on pane close** so closing a pane or tab from the UI correctly reports the connection as closed and keeps the AI's view accurate. #208
+3. **Fixed crashes and agent pane initialization errors** — including the `0x80010105` and `0xc0000005` errors — by rebuilding the AI communication layer on a more robust foundation. #237, #268
+4. **Fixed AI executable path resolution** so the correct agent is always found, preventing the agent pane and autofix from silently failing. #217
+5. **Fixed odd window resizing and title behavior** so the terminal ignores redundant resize requests and handles cursor/title fallback like standard terminals. #20183, #20214
+6. **Removed a duplicate Default Terminal policy** from the group-policy templates so administrators no longer see a conflicting entry. #225
+7. **Trimmed unnecessary data from internal event reporting** so AI command-result monitoring runs lighter and faster. #216
 
 ## 💜 Community
 
 A huge thank you to the external contributors who helped make this release:
 
-- [@arkthur](https://github.com/arkthur) (Ítalo Masserano) — added the Execution Policy setting command note for both PowerShell hosts (#213)
+1. [@arkthur](https://github.com/arkthur) (Ítalo Masserano) — added the Execution Policy setting command note for both PowerShell hosts. #213
+2. [@ltrzesniewski](https://github.com/ltrzesniewski) (Lucas Trzesniewski) — added the `safeUriSchemes` setting. (#20207, closes #20191)
 
 ---
 
 ## 🚀 Top 5 Elevator-Pitch Points
 
-1. **Type `/fix` and let AI solve your failed command instantly** — on-demand error fixing right in your terminal: #195
-2. **Autofix now speaks Bash, PowerShell, and WSL** — automatic error help for every shell you use: #222
-3. **Pick the perfect AI model per pane with `/model`** — and hot-reload model settings live, with zero restarts: #187
-4. **Rebuilt AI engine squashes the startup crashes** — no more `0x80010105` / `0xc0000005` errors when the agent pane starts: #237
-5. **Install with one command** — `winget install Microsoft.IntelligentTerminal` and you're ready to go: #235
+1. **Type `/fix` and let AI solve your failed command instantly** — on-demand error fixing right in your terminal. #206
+2. **Autofix now speaks Bash, PowerShell, and WSL** — automatic error help for every shell you use. #222
+3. **Pick the perfect AI model per pane with `/model`** — and hot-reload model settings live, with zero restarts. #219
+4. **Rebuilt AI engine squashes the startup crashes** — no more `0x80010105` / `0xc0000005` errors when the agent pane starts. #237
+5. **Install with one command** — `winget install Microsoft.IntelligentTerminal` and you're ready to go. #235
+
+---
+
+We'll keep iterating on bugs and feature requests rapidly while Intelligent Terminal is in this
+experimental stage. Please [file issues](https://github.com/microsoft/intelligent-terminal/issues)
+to help us make this product better!

--- a/.github/skills/release-notes/references/example-release-notes.md
+++ b/.github/skills/release-notes/references/example-release-notes.md
@@ -1,0 +1,51 @@
+# Intelligent Terminal — Release Notes
+
+Smarter AI assistance, broader shell support, a smoother first-run experience, and important stability fixes.
+
+## ✨ New Features
+
+- **Added the `/fix` slash command** to diagnose and resolve a failed command on demand, so you get help even when autofix doesn't trigger automatically: #195
+- **Added a per-pane `/model` picker** so you can choose the best AI model for each task right in the agent pane, with your local choice overriding global settings: #227
+- **Extended autofix to Bash and WSL** so automatic error detection and fix suggestions now work beyond PowerShell, no matter which shell you use: #222
+- **Added the `safeUriSchemes` setting** to control which link types are clickable from the terminal, protecting you from opening risky links: #20191
+- **Redesigned the new-tab menu into a fast dropdown** so launching the profile you want is quicker than the old full-page menu: #20203
+- **Enabled winget installation** as `Microsoft.IntelligentTerminal` for simple command-line install and updates: #235
+
+## 🔧 Improvements
+
+- **Enabled live hot-reload of AI model and delegate settings** so changes apply instantly without restarting the agent pane: #187
+- **Made the agent pane follow your terminal color scheme** instead of a hardcoded dark palette, giving the AI panel a consistent themed look: #234
+- **Improved the first-run setup experience** with a clearer GitHub Copilot install flow, a modal progress overlay during save/install, and a faster, optimized hooks installation step: #201, #262, #281
+- **Hardened PowerShell setup guidance** so the wizard stops and explains the fix when an execution policy blocks installation, regardless of your profile setup: #292
+- **Repositioned the `/model` and autocomplete popups** directly above the input box where you'd expect to find them: #232
+- **Preserved your font size across settings reloads** so zoom adjustments no longer reset unexpectedly: #20230
+- **Added a live preview to tab search** so you can see the selected tab while searching, making the right one easier to find: #20233
+- **Switched profile bell sounds to a more dependable playback method** so custom bells play reliably: #17733
+- **Improved accessibility** by announcing navigation-pane open/close events to screen readers: #19687
+- **Expanded in-app help** with a new FAQ, the Alt+Shift+B shortcut, log-collection instructions for bug reports, and troubleshooting for known crashes: #185, #205
+
+## 🐛 Bug Fixes
+
+- **Fixed empty agent session views after first login** so the first tab's AI session reconnects and shows your conversation instead of appearing blank: #188
+- **Fixed stale session/tab state on pane close** so closing a pane or tab from the UI correctly reports the connection as closed and keeps the AI's view accurate: #198
+- **Fixed crashes and agent pane initialization errors** — including the `0x80010105` and `0xc0000005` errors — by rebuilding the AI communication layer on a more robust foundation: #237, #199
+- **Fixed AI executable path resolution** so the correct agent is always found, preventing the agent pane and autofix from silently failing: #217
+- **Fixed odd window resizing and title behavior** so the terminal ignores redundant resize requests and handles cursor/title fallback like standard terminals: #19310, #19340, #20204, #19918
+- **Removed a duplicate Default Terminal policy** from the group-policy templates so administrators no longer see a conflicting entry: #212
+- **Trimmed unnecessary data from internal event reporting** so AI command-result monitoring runs lighter and faster: #216
+
+## 💜 Community
+
+A huge thank you to the external contributors who helped make this release:
+
+- [@arkthur](https://github.com/arkthur) (Ítalo Masserano) — added the Execution Policy setting command note for both PowerShell hosts (#213)
+
+---
+
+## 🚀 Top 5 Elevator-Pitch Points
+
+1. **Type `/fix` and let AI solve your failed command instantly** — on-demand error fixing right in your terminal: #195
+2. **Autofix now speaks Bash, PowerShell, and WSL** — automatic error help for every shell you use: #222
+3. **Pick the perfect AI model per pane with `/model`** — and hot-reload model settings live, with zero restarts: #187
+4. **Rebuilt AI engine squashes the startup crashes** — no more `0x80010105` / `0xc0000005` errors when the agent pane starts: #237
+5. **Install with one command** — `winget install Microsoft.IntelligentTerminal` and you're ready to go: #235

--- a/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
+++ b/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
@@ -34,7 +34,7 @@ $ghCmd = Get-Command gh -ErrorAction SilentlyContinue
 if (-not $ghCmd) {
     throw "Prerequisite missing: 'gh' CLI is not on PATH. Install with: winget install GitHub.cli (Windows) or brew install gh (macOS). Then run: gh auth login"
 }
-$authStatus = gh auth status 2>&1
+gh auth status 2>&1 | Out-Null
 if ($LASTEXITCODE -ne 0) {
     throw "Prerequisite missing: 'gh' CLI is not authenticated. Run: gh auth login"
 }

--- a/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
+++ b/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
@@ -57,7 +57,7 @@ foreach ($pr in $PRNumbers) {
     }
     if (-not $json) { continue }
     try {
-        $data = $json | ConvertFrom-Json
+    $data = ($json -join "`n") | ConvertFrom-Json
 
         # Check for linked issues
         $issues = @()

--- a/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
+++ b/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
@@ -87,9 +87,9 @@ foreach ($pr in $PRNumbers) {
             $results.NoIssues += $pr
         }
 
-        # Check for community contributors
+        # Check for community contributors (exclude core team and bot accounts)
         $author = $data.author.login
-        if ($author -and $author -notin $CoreTeam) {
+        if ($author -and $author -notin $CoreTeam -and $author -notmatch '\[bot\]$') {
             $results.CommunityAuthors += [PSCustomObject]@{
                 PR          = $pr
                 Username    = $author

--- a/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
+++ b/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
@@ -28,6 +28,17 @@ param(
     [string]$Repo = 'microsoft/intelligent-terminal'
 )
 
+# ─── Prerequisite check ─────────────────────────────────────────────────────
+# Fail fast with an actionable message if gh is missing or unauthenticated.
+$ghCmd = Get-Command gh -ErrorAction SilentlyContinue
+if (-not $ghCmd) {
+    throw "Prerequisite missing: 'gh' CLI is not on PATH. Install with: winget install GitHub.cli (Windows) or brew install gh (macOS). Then run: gh auth login"
+}
+$authStatus = gh auth status 2>&1
+if ($LASTEXITCODE -ne 0) {
+    throw "Prerequisite missing: 'gh' CLI is not authenticated. Run: gh auth login"
+}
+
 # Core team members — do NOT thank as community contributors.
 # Source of truth is references/core-team.md, parsed at runtime so the
 # script and the docs can't drift. Falls back to a built-in list only
@@ -98,7 +109,7 @@ foreach ($pr in $PRNumbers) {
         }
     }
     catch {
-        Write-Warning "Failed to process PR #$pr`: $_"
+        Write-Warning "Failed to process PR #${pr}: $_"
     }
     finally {
         if (Test-Path -LiteralPath $errFile) {

--- a/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
+++ b/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
@@ -28,7 +28,7 @@ param(
 # Source of truth is references/core-team.md, parsed at runtime so the
 # script and the docs can't drift. Falls back to a built-in list only
 # if that reference file is missing or unparseable.
-$coreTeamRef = Join-Path $PSScriptRoot '..\references\core-team.md'
+$coreTeamRef = [IO.Path]::Combine($PSScriptRoot, '..', 'references', 'core-team.md')
 $CoreTeam = @()
 if (Test-Path $coreTeamRef) {
     $CoreTeam = Get-Content $coreTeamRef |

--- a/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
+++ b/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
@@ -59,6 +59,7 @@ foreach ($pr in $PRNumbers) {
         $json = & gh pr view $pr --repo $Repo --json number,title,author,closingIssuesReferences 2>$errFile
         if ($LASTEXITCODE -ne 0) {
             $err = (Get-Content -Raw -LiteralPath $errFile -ErrorAction SilentlyContinue)
+            if ($null -eq $err) { $err = '' }
             Write-Warning "Failed to look up PR #$pr (gh exited $LASTEXITCODE): $($err.Trim())"
             continue
         }

--- a/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
+++ b/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
@@ -24,11 +24,24 @@ param(
     [string]$Repo = 'microsoft/intelligent-terminal'
 )
 
-# Core team members — do NOT thank as community contributors
-$CoreTeam = @(
-    'yeelam-gordon', 'vanzue', 'DDKinger', 'haonanttt',
-    'hamza-usmani', 'pabhojwa'
-)
+# Core team members — do NOT thank as community contributors.
+# Source of truth is references/core-team.md, parsed at runtime so the
+# script and the docs can't drift. Falls back to a built-in list only
+# if that reference file is missing or unparseable.
+$coreTeamRef = Join-Path $PSScriptRoot '..\references\core-team.md'
+$CoreTeam = @()
+if (Test-Path $coreTeamRef) {
+    $CoreTeam = Get-Content $coreTeamRef |
+        Where-Object { $_ -match '^\s*\|' } |
+        ForEach-Object { ($_ -split '\|')[1].Trim() } |
+        Where-Object { $_ -and $_ -notmatch '^-+$' -and $_ -ne 'GitHub Username' }
+}
+if (-not $CoreTeam -or $CoreTeam.Count -eq 0) {
+    $CoreTeam = @(
+        'yeelam-gordon', 'vanzue', 'DDKinger', 'haonanttt',
+        'hamza-usmani', 'pabhojwa'
+    )
+}
 
 $results = @{
     WithIssues       = @()
@@ -37,9 +50,13 @@ $results = @{
 }
 
 foreach ($pr in $PRNumbers) {
+    $json = gh pr view $pr --repo $Repo --json number,title,author,closingIssuesReferences 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to look up PR #$pr (gh exited $LASTEXITCODE): $json"
+        continue
+    }
+    if (-not $json) { continue }
     try {
-        $json = gh pr view $pr --repo $Repo --json number,title,author,closingIssuesReferences 2>$null
-        if (-not $json) { continue }
         $data = $json | ConvertFrom-Json
 
         # Check for linked issues
@@ -52,7 +69,7 @@ foreach ($pr in $PRNumbers) {
             $results.WithIssues += [PSCustomObject]@{
                 PR     = $pr
                 Title  = $data.title
-                Issues = $issues -join ', '
+                Issues = ($issues | ForEach-Object { "#$_" }) -join ', '
             }
         }
         else {
@@ -70,7 +87,7 @@ foreach ($pr in $PRNumbers) {
         }
     }
     catch {
-        Write-Warning "Failed to look up PR #$pr`: $_"
+        Write-Warning "Failed to process PR #$pr`: $_"
     }
 }
 
@@ -79,7 +96,7 @@ Write-Host "`n## PRs with linked issues" -ForegroundColor Cyan
 if ($results.WithIssues.Count -eq 0) { Write-Host "  (none)" }
 else {
     $results.WithIssues | ForEach-Object {
-        Write-Host "  PR #$($_.PR) → fixes #$($_.Issues): $($_.Title)"
+        Write-Host "  PR #$($_.PR) → fixes $($_.Issues): $($_.Title)"
     }
 }
 

--- a/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
+++ b/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
@@ -120,7 +120,8 @@ else {
 }
 
 Write-Host "`n## PRs with no linked issues" -ForegroundColor Cyan
-Write-Host "  $($results.NoIssues -join ', ')"
+if ($results.NoIssues.Count -eq 0) { Write-Host "  (none)" }
+else { Write-Host "  $($results.NoIssues -join ', ')" }
 
 # Return structured data for programmatic use
 $results

--- a/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
+++ b/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
@@ -50,14 +50,20 @@ $results = @{
 }
 
 foreach ($pr in $PRNumbers) {
-    $json = gh pr view $pr --repo $Repo --json number,title,author,closingIssuesReferences 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        Write-Warning "Failed to look up PR #$pr (gh exited $LASTEXITCODE): $json"
-        continue
-    }
-    if (-not $json) { continue }
+    # Capture stdout and stderr separately (stderr -> temp file) so a
+    # 'gh' warning/progress line can never corrupt the JSON stream fed
+    # to ConvertFrom-Json. Mirrors the repo's Invoke-Gh pattern in
+    # .github/skills/copilot-pr-review-loop/scripts/_lib.ps1.
+    $errFile = [IO.Path]::GetTempFileName()
     try {
-    $data = ($json -join "`n") | ConvertFrom-Json
+        $json = & gh pr view $pr --repo $Repo --json number,title,author,closingIssuesReferences 2>$errFile
+        if ($LASTEXITCODE -ne 0) {
+            $err = (Get-Content -Raw -LiteralPath $errFile -ErrorAction SilentlyContinue)
+            Write-Warning "Failed to look up PR #$pr (gh exited $LASTEXITCODE): $($err.Trim())"
+            continue
+        }
+        if (-not $json) { continue }
+        $data = ($json | Out-String) | ConvertFrom-Json
 
         # Check for linked issues
         $issues = @()
@@ -88,6 +94,11 @@ foreach ($pr in $PRNumbers) {
     }
     catch {
         Write-Warning "Failed to process PR #$pr`: $_"
+    }
+    finally {
+        if (Test-Path -LiteralPath $errFile) {
+            Remove-Item -LiteralPath $errFile -ErrorAction SilentlyContinue
+        }
     }
 }
 

--- a/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
+++ b/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
@@ -21,6 +21,10 @@ param(
     [Parameter(Mandatory)]
     [int[]]$PRNumbers,
 
+    # Intelligent Terminal PRs live on the canonical repo, not on personal
+    # forks/clones, so this defaults to microsoft/intelligent-terminal on
+    # purpose (a fork wouldn't have the PRs). Override -Repo to microsoft/terminal
+    # for upstream #20xxx PRs, or to another repo if needed.
     [string]$Repo = 'microsoft/intelligent-terminal'
 )
 

--- a/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
+++ b/.github/skills/release-notes/scripts/Get-PrMetadata.ps1
@@ -1,0 +1,98 @@
+<#
+.SYNOPSIS
+    Look up GitHub PRs to find linked issues and community contributors.
+
+.DESCRIPTION
+    Given a list of PR numbers, queries the GitHub API via `gh` CLI to find:
+    1. Which PRs have linked/closing issues
+    2. Which PRs were authored by community members (not core team)
+
+.PARAMETER PRNumbers
+    Array of PR numbers to look up.
+
+.PARAMETER Repo
+    GitHub repository in owner/repo format. Default: microsoft/intelligent-terminal
+
+.EXAMPLE
+    .\Get-PrMetadata.ps1 -PRNumbers 206,208,219 -Repo microsoft/intelligent-terminal
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [int[]]$PRNumbers,
+
+    [string]$Repo = 'microsoft/intelligent-terminal'
+)
+
+# Core team members — do NOT thank as community contributors
+$CoreTeam = @(
+    'yeelam-gordon', 'vanzue', 'DDKinger', 'haonanttt',
+    'hamza-usmani', 'pabhojwa'
+)
+
+$results = @{
+    WithIssues       = @()
+    CommunityAuthors = @()
+    NoIssues         = @()
+}
+
+foreach ($pr in $PRNumbers) {
+    try {
+        $json = gh pr view $pr --repo $Repo --json number,title,author,closingIssuesReferences 2>$null
+        if (-not $json) { continue }
+        $data = $json | ConvertFrom-Json
+
+        # Check for linked issues
+        $issues = @()
+        if ($data.closingIssuesReferences) {
+            $issues = $data.closingIssuesReferences | ForEach-Object { $_.number }
+        }
+
+        if ($issues.Count -gt 0) {
+            $results.WithIssues += [PSCustomObject]@{
+                PR     = $pr
+                Title  = $data.title
+                Issues = $issues -join ', '
+            }
+        }
+        else {
+            $results.NoIssues += $pr
+        }
+
+        # Check for community contributors
+        $author = $data.author.login
+        if ($author -and $author -notin $CoreTeam) {
+            $results.CommunityAuthors += [PSCustomObject]@{
+                PR          = $pr
+                Username    = $author
+                DisplayName = $data.author.name
+            }
+        }
+    }
+    catch {
+        Write-Warning "Failed to look up PR #$pr`: $_"
+    }
+}
+
+# Output
+Write-Host "`n## PRs with linked issues" -ForegroundColor Cyan
+if ($results.WithIssues.Count -eq 0) { Write-Host "  (none)" }
+else {
+    $results.WithIssues | ForEach-Object {
+        Write-Host "  PR #$($_.PR) → fixes #$($_.Issues): $($_.Title)"
+    }
+}
+
+Write-Host "`n## Community contributors" -ForegroundColor Cyan
+if ($results.CommunityAuthors.Count -eq 0) { Write-Host "  (none)" }
+else {
+    $results.CommunityAuthors | ForEach-Object {
+        Write-Host "  PR #$($_.PR) by @$($_.Username) ($($_.DisplayName))"
+    }
+}
+
+Write-Host "`n## PRs with no linked issues" -ForegroundColor Cyan
+Write-Host "  $($results.NoIssues -join ', ')"
+
+# Return structured data for programmatic use
+$results

--- a/.github/skills/release-notes/templates/release-notes-template.md
+++ b/.github/skills/release-notes/templates/release-notes-template.md
@@ -1,35 +1,48 @@
-# Intelligent Terminal — Release Notes (vX.Y.Z)
+# Intelligent Terminal vX.Y.Z
 
-_One-line summary of what this release brings._
+> Base = **vX.Y.Z** release tag (`<base-commit>`, build `0.1.xxxx.0`) → **latest `main`** (`<head-commit>`).
+> N new PRs. The exact build number (`0.1.xxxx.0`) is injected by CI at release time.
+>
+> Note on the `stable` branch: `stable` is a cherry-picked subset of what already shipped in the
+> previous release, so it is *behind* the release tag. The clean "since last release" base is the
+> **vX.Y.Z tag**, not `stable`.
+
+_One-paragraph intro: what this release focuses on, in plain language — the headline theme(s) plus
+a nod to the batch of smaller fixes._
 
 ## ✨ New Features
 
-- **Verbed + new capability** so users can do something they couldn't before: #issue
-- ...
+1. **Verbed + new capability** so users can do something they couldn't before. #PR
+2. ...
 
 ## 🔧 Improvements
 
-- **Verbed + existing feature enhancement** so the experience is better in this scenario: #issue
-- ...
+1. **Verbed + existing feature enhancement** so the experience is better in this scenario. #PR
+2. ...
 
 ## 🐛 Bug Fixes
 
-- **Fixed specific problem** so the expected behavior now works correctly in this scenario: #issue, #issue
-- ...
+1. **Fixed specific problem** so the expected behavior now works correctly in this scenario. #PR, #PR
+2. ...
 
 ## 💜 Community
 
 A huge thank you to the external contributors who helped make this release:
 
-- [@username](https://github.com/username) (Display Name) — what they contributed (#PR)
-- ...
+1. [@username](https://github.com/username) (Display Name) — what they contributed. (#PR, closes #issue)
+2. ...
 
 ---
 
 ## 🚀 Top 5 Elevator-Pitch Points
 
-1. **Highlight 1** — one-line impact statement: #issue
-2. **Highlight 2** — one-line impact statement: #issue
-3. **Highlight 3** — one-line impact statement: #issue
-4. **Highlight 4** — one-line impact statement: #issue
-5. **Highlight 5** — one-line impact statement: #issue
+1. **Highlight 1** — one-line impact statement. #PR
+2. **Highlight 2** — one-line impact statement. #PR
+3. **Highlight 3** — one-line impact statement. #PR
+4. **Highlight 4** — one-line impact statement. #PR
+5. **Highlight 5** — one-line impact statement. #PR
+
+---
+
+_Closing call-to-action: invite users to [file issues](https://github.com/microsoft/intelligent-terminal/issues)
+while the product is in this experimental stage._

--- a/.github/skills/release-notes/templates/release-notes-template.md
+++ b/.github/skills/release-notes/templates/release-notes-template.md
@@ -30,6 +30,6 @@ A huge thank you to the external contributors who helped make this release:
 
 1. **Highlight 1** — one-line impact statement: #issue
 2. **Highlight 2** — one-line impact statement: #issue
-3. **Highlight 3** — one-line impact statement
-4. **Highlight 4** — one-line impact statement
-5. **Highlight 5** — one-line impact statement
+3. **Highlight 3** — one-line impact statement: #issue
+4. **Highlight 4** — one-line impact statement: #issue
+5. **Highlight 5** — one-line impact statement: #issue

--- a/.github/skills/release-notes/templates/release-notes-template.md
+++ b/.github/skills/release-notes/templates/release-notes-template.md
@@ -1,4 +1,4 @@
-# Intelligent Terminal — Release Notes (vX.X.X)
+# Intelligent Terminal — Release Notes (vX.Y.Z)
 
 _One-line summary of what this release brings._
 

--- a/.github/skills/release-notes/templates/release-notes-template.md
+++ b/.github/skills/release-notes/templates/release-notes-template.md
@@ -1,11 +1,11 @@
 # Intelligent Terminal vX.Y.Z
 
-> Base = **vX.Y.Z** release tag (`<base-commit>`, build `0.1.xxxx.0`) → **latest `main`** (`<head-commit>`).
+> Base = **`<previous-release-tag>`** release tag (`<base-commit>`, build `0.1.xxxx.0`) → **latest `main`** (`<head-commit>`).
 > N new PRs. The exact build number (`0.1.xxxx.0`) is injected by CI at release time.
 >
 > Note on the `stable` branch: `stable` is a cherry-picked subset of what already shipped in the
 > previous release, so it is *behind* the release tag. The clean "since last release" base is the
-> **vX.Y.Z tag**, not `stable`.
+> **`<previous-release-tag>`** tag, not `stable`.
 
 _One-paragraph intro: what this release focuses on, in plain language — the headline theme(s) plus
 a nod to the batch of smaller fixes._

--- a/.github/skills/release-notes/templates/release-notes-template.md
+++ b/.github/skills/release-notes/templates/release-notes-template.md
@@ -1,0 +1,35 @@
+# Intelligent Terminal — Release Notes (vX.X.X)
+
+<one-line summary of what this release brings>
+
+## ✨ New Features
+
+- **Verbed + new capability** so users can do something they couldn't before: #issue
+- ...
+
+## 🔧 Improvements
+
+- **Verbed + existing feature enhancement** so the experience is better in this scenario: #issue
+- ...
+
+## 🐛 Bug Fixes
+
+- **Fixed specific problem** so the expected behavior now works correctly in this scenario: #issue, #issue
+- ...
+
+## 💜 Community
+
+A huge thank you to the external contributors who helped make this release:
+
+- [@username](https://github.com/username) (Display Name) — what they contributed (#PR)
+- ...
+
+---
+
+## 🚀 Top 5 Elevator-Pitch Points
+
+1. **Highlight 1** — one-line impact statement: #issue
+2. **Highlight 2** — one-line impact statement: #issue
+3. **Highlight 3** — one-line impact statement
+4. **Highlight 4** — one-line impact statement
+5. **Highlight 5** — one-line impact statement

--- a/.github/skills/release-notes/templates/release-notes-template.md
+++ b/.github/skills/release-notes/templates/release-notes-template.md
@@ -1,6 +1,6 @@
 # Intelligent Terminal — Release Notes (vX.X.X)
 
-<one-line summary of what this release brings>
+_One-line summary of what this release brings._
 
 ## ✨ New Features
 


### PR DESCRIPTION
Adds a new agent skill at .github/skills/release-notes/ that automates generating user-facing release notes.

What it does:
- Compares git commits between releases
- Looks up PR-linked issues and community contributors via gh CLI
- Outputs formatted notes with Verbed + Impact + Scenario style bullets, issue references, and contributor thanks

Skill contents:
- SKILL.md: main instructions and workflow
- scripts/Get-PrMetadata.ps1: PR metadata lookup automation
- references/core-team.md: team list (to identify community contributors)
- references/example-release-notes.md: previous release as format reference
- templates/release-notes-template.md: output format template

Generated release notes are saved to Generated Files/ (gitignored).
