### PR TITLE
chore(upstream): workspaces based on window names (redux) (#20314)

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -441,6 +441,7 @@
         "openTabColorPicker",
         "openTabRenamer",
         "openWindowRenamer",
+        "openWorkspace",
         "paste",
         "prevTab",
         "quakeMode",
@@ -479,6 +480,7 @@
         "toggleReadOnlyMode",
         "toggleShaderEffects",
         "toggleSplitOrientation",
+        "workspaces",
         "wt",
         "unbound"
       ],
@@ -1721,6 +1723,28 @@
         }
       ]
     },
+    "OpenWorkspaceAction": {
+      "description": "Arguments corresponding to an openWorkspace Action",
+      "allOf": [
+        {
+          "$ref": "#/$defs/ShortcutAction"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "const": "openWorkspace"
+            },
+            "name": {
+              "type": "string",
+              "default": "",
+              "description": "The name of the workspace to open. If omitted, the workspaces UI will be shown so the user can pick one."
+            }
+          }
+        }
+      ]
+    },
     "FocusPaneAction": {
       "description": "Arguments corresponding to a focusPane Action",
       "allOf": [
@@ -2040,6 +2064,11 @@
         "unfocusedFrame": {
           "description": "The color of the window frame when the window is inactive. This only works on Windows 11",
           "$ref": "#/$defs/ThemeColor"
+        },
+        "showWorkspacesButton": {
+          "description": "When set to true, the workspaces button will be shown in the tab row.",
+          "type": "boolean",
+          "default": true
         }
       }
     },
@@ -2207,6 +2236,9 @@
             },
             {
               "$ref": "#/$defs/RenameWindowAction"
+            },
+            {
+              "$ref": "#/$defs/OpenWorkspaceAction"
             },
             {
               "$ref": "#/$defs/FocusPaneAction"

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -923,6 +923,16 @@ namespace winrt::TerminalApp::implementation
         RequestNewWindow.raise(*this, request);
     }
 
+    // Ask the WindowEmperor (in-process) to open or summon a named window,
+    // restoring its persisted workspace if one exists. The event bubbles up
+    // through TerminalWindow to AppHost, which calls into the WindowEmperor
+    // directly — no second wt.exe process is launched.
+    void TerminalPage::_OpenWorkspaceWindow(const winrt::hstring name)
+    {
+        const auto args = winrt::make<implementation::OpenWindowRequestedArgs>(name);
+        RequestOpenWindow.raise(*this, args);
+    }
+
     void TerminalPage::_HandleNewWindow(const IInspectable& /*sender*/,
                                         const ActionEventArgs& actionArgs)
     {
@@ -944,7 +954,10 @@ namespace winrt::TerminalApp::implementation
             newContentArgs = NewTerminalArgs{};
         }
 
-        // Manually fill in the evaluated profile
+        // If this is a NewTerminalArgs, resolve its profile up-front so the
+        // spawned window doesn't need to re-resolve it. Other content types
+        // (e.g. scratchpad) don't have profiles to evaluate — they get passed
+        // through as-is.
         if (const auto terminalArgs{ newContentArgs.try_as<NewTerminalArgs>() })
         {
             const auto profile{ _settings.GetProfileForArgs(terminalArgs) };
@@ -1043,6 +1056,7 @@ namespace winrt::TerminalApp::implementation
         // Fun!
         // WindowRenamerTextBox().Focus(FocusState::Programmatic);
         _renamerLayoutUpdatedRevoker.revoke();
+        _renamerLayoutCount = 0;
         _renamerLayoutUpdatedRevoker = WindowRenamerTextBox().LayoutUpdated(winrt::auto_revoke, [weakThis = get_weak()](auto&&, auto&&) {
             if (auto self{ weakThis.get() })
             {
@@ -2188,4 +2202,35 @@ namespace winrt::TerminalApp::implementation
             presenter.ShowDialog(dialog);
         }
     }
+
+    void TerminalPage::_HandleOpenWorkspace(const IInspectable& /*sender*/,
+                                            const ActionEventArgs& args)
+    {
+        // Open (or summon) a named window.  We launch a new `wt -w <name>`
+        // process which the monarch will route to the correct live window or
+        // restore from a persisted workspace.
+        if (args)
+        {
+            if (const auto& realArgs = args.ActionArgs().try_as<OpenWorkspaceArgs>())
+            {
+                const auto name = realArgs.Name();
+                if (!name.empty())
+                {
+                    _OpenWorkspaceWindow(name);
+                }
+                args.Handled(true);
+            }
+        }
+    }
+
+    void TerminalPage::_HandleWorkspaces(const IInspectable& /*sender*/,
+                                         const ActionEventArgs& args)
+    {
+        if (_workspaceFlyout && _workspaceDropdown)
+        {
+            _workspaceFlyout.ShowAt(_workspaceDropdown);
+        }
+        args.Handled(true);
+    }
+
 }

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -99,6 +99,10 @@ INewContentArgs Pane::GetTerminalArgsForPane(BuildStartupKind kind) const
 {
     // Leaves are the only things that have controls
     assert(_IsLeaf());
+    if (!_content)
+    {
+        return nullptr;
+    }
     return _content.GetNewTerminalArgs(kind);
 }
 

--- a/src/cascadia/TerminalApp/Remoting.h
+++ b/src/cascadia/TerminalApp/Remoting.h
@@ -85,6 +85,7 @@ namespace winrt::TerminalApp::implementation
         WINRT_PROPERTY(TerminalApp::CommandlineArgs, Command, nullptr);
         WINRT_PROPERTY(winrt::hstring, Content);
         WINRT_PROPERTY(Windows::Foundation::IReference<Windows::Foundation::Rect>, InitialBounds);
+        WINRT_PROPERTY(winrt::Microsoft::Terminal::Settings::Model::WindowLayout, PersistedLayout, nullptr);
         WINRT_PROPERTY(Windows::Foundation::Collections::IVector<winrt::Microsoft::Terminal::Settings::Model::ActionAndArgs>, StartupActions, nullptr);
     };
 }

--- a/src/cascadia/TerminalApp/Remoting.idl
+++ b/src/cascadia/TerminalApp/Remoting.idl
@@ -51,6 +51,7 @@ namespace TerminalApp
         CommandlineArgs Command { get; };
         String Content { get; };
         Windows.Foundation.IReference<Windows.Foundation.Rect> InitialBounds { get; };
+        Microsoft.Terminal.Settings.Model.WindowLayout PersistedLayout;
         Windows.Foundation.Collections.IVector<Microsoft.Terminal.Settings.Model.ActionAndArgs> StartupActions;
     };
 }

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -763,6 +763,42 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>unnamed window</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
+  <data name="NameThisWindowMenuItem" xml:space="preserve">
+    <value>Name this window...</value>
+    <comment>Menu item text shown when the current window has no name assigned</comment>
+  </data>
+  <data name="RenameThisWindowMenuItem" xml:space="preserve">
+    <value>Rename this window...</value>
+    <comment>Menu item text shown when the current window already has a name</comment>
+  </data>
+  <data name="WindowListUnnamedEntry" xml:space="preserve">
+    <value>#{0} (unnamed)</value>
+    <comment>{locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
+  </data>
+  <data name="DeleteWorkspaceMenuItem" xml:space="preserve">
+    <value>Delete workspace?</value>
+    <comment>Menu item text shown in the right-click context menu on a saved workspace</comment>
+  </data>
+  <data name="OpenWorkspaceMenuItem" xml:space="preserve">
+    <value>Open workspace</value>
+    <comment>Menu item text for opening a saved workspace</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceTitle" xml:space="preserve">
+    <value>Delete "{0}"?</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceBody" xml:space="preserve">
+    <value>Are you sure you want to delete "{0}"? Sessions associated with this workspace will also be deleted.</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceDelete" xml:space="preserve">
+    <value>Delete</value>
+    <comment>Primary button text on the delete workspace confirmation dialog</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceCancel" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>Cancel button text on the delete workspace confirmation dialog</comment>
+  </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
     <value>Enter a new name:</value>
   </data>
@@ -821,6 +857,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>This Terminal window is running as administrator</value>
+  </data>
+  <data name="WorkspaceDropdown.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Workspaces</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>Suggestions found: {0}</value>

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -585,6 +585,22 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Method Description:
+    // - If this window has a name, persist its current workspace layout to
+    //   ApplicationState. Intended to be called from the close-pane / close-tab
+    //   paths while tab/pane content is still alive (before it gets torn down).
+    void TerminalPage::_SaveWorkspaceIfNeeded()
+    {
+        const auto& windowName = _WindowProperties.WindowName();
+        if (!windowName.empty())
+        {
+            if (const auto layout = GetWindowLayout())
+            {
+                ApplicationState::SharedInstance().SaveWorkspace(windowName, layout);
+            }
+        }
+    }
+
+    // Method Description:
     // - Removes the tab (both TerminalControl and XAML) after prompting for approval
     // Arguments:
     // - tab: the tab to remove
@@ -633,6 +649,14 @@ namespace winrt::TerminalApp::implementation
 
         // Per-tab model: each tab owns its own agent pane. Closing a tab
         // takes its agent pane with it — no rescue needed.
+
+        // If this is the last tab in a named window, persist the workspace
+        // layout now while tab content is still alive. After tab.Close()
+        // the pane content will be torn down by the time _RemoveTab runs.
+        if (_tabs.Size() == 1)
+        {
+            _SaveWorkspaceIfNeeded();
+        }
 
         tab.Close();
     }
@@ -714,6 +738,13 @@ namespace winrt::TerminalApp::implementation
         {
             _NotifyPanesClosing(rootPaneForClose);
         }
+
+        // NOTE: Workspace persistence for named windows used to live here,
+        // but by the time _RemoveTab runs the pane content may already be
+        // torn down (e.g. from the close-pane path). Instead, workspace
+        // saves are handled earlier:
+        //  - Close-pane (last pane): in _HandleClosePaneRequested
+        //  - Close-tab: in _HandleCloseTabRequested
 
         // Removing the tab from the collection should destroy its control and disconnect its connection,
         // but it doesn't always do so. The UI tree may still be holding the control and preventing its destruction.
@@ -1081,6 +1112,21 @@ namespace winrt::TerminalApp::implementation
         // happen before `pane->Close()` since Close destroys the
         // TermControl and the SessionId becomes unresolvable.
         _NotifyPanesClosing(pane);
+
+        // If this is the last pane on the last tab of a named window, persist
+        // the workspace layout now while the pane content is still alive.
+        // We can't wait until _RemoveTab, because pane->Close() below will
+        // destroy the content before _RemoveTab is reached.
+        if (_tabs.Size() == 1)
+        {
+            if (const auto activeTab{ _GetFocusedTabImpl() })
+            {
+                if (activeTab->GetLeafPaneCount() == 1)
+                {
+                    _SaveWorkspaceIfNeeded();
+                }
+            }
+        }
 
         // If specified, detach before closing to directly update the pane structure
         pane->Close();

--- a/src/cascadia/TerminalApp/TabRowControl.h
+++ b/src/cascadia/TerminalApp/TabRowControl.h
@@ -19,6 +19,8 @@ namespace winrt::TerminalApp::implementation
 
         til::property_changed_event PropertyChanged;
         WINRT_OBSERVABLE_PROPERTY(bool, ShowElevationShield, PropertyChanged.raise, false);
+        WINRT_OBSERVABLE_PROPERTY(bool, ShowWorkspacesButton, PropertyChanged.raise, true);
+        WINRT_OBSERVABLE_PROPERTY(winrt::hstring, WorkspaceName, PropertyChanged.raise, L"");
     };
 }
 

--- a/src/cascadia/TerminalApp/TabRowControl.idl
+++ b/src/cascadia/TerminalApp/TabRowControl.idl
@@ -9,5 +9,7 @@ namespace TerminalApp
         TabRowControl();
         Microsoft.UI.Xaml.Controls.TabView TabView { get; };
         Boolean ShowElevationShield;
+        Boolean ShowWorkspacesButton;
+        String WorkspaceName;
     }
 }

--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -8,6 +8,7 @@
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                   xmlns:local="using:TerminalApp"
                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                  xmlns:mtu="using:Microsoft.Terminal.UI"
                   xmlns:mux="using:Microsoft.UI.Xaml.Controls"
                   Background="{ThemeResource TabViewBackground}"
                   mc:Ignorable="d">
@@ -35,14 +36,45 @@
                  TabWidthMode="Equal">
 
         <mux:TabView.TabStripHeader>
-            <!--  EA18 is the "Shield" glyph  -->
-            <FontIcon x:Uid="ElevationShield"
-                      Margin="9,4,0,4"
-                      FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                      FontSize="16"
-                      Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
-                      Glyph="&#xEA18;"
-                      Visibility="{x:Bind ShowElevationShield, Mode=OneWay}" />
+            <StackPanel Orientation="Horizontal">
+                <!--  EA18 is the "Shield" glyph  -->
+                <FontIcon x:Uid="ElevationShield"
+                          Margin="9,4,0,4"
+                          FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                          FontSize="16"
+                          Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
+                          Glyph="&#xEA18;"
+                          Visibility="{x:Bind ShowElevationShield, Mode=OneWay}" />
+
+                <!--  Workspace/windows button  -->
+                <Button x:Name="WorkspaceDropdown"
+                        x:Uid="WorkspaceDropdown"
+                        Margin="4,0,0,4"
+                        Padding="8,0,0,0"
+                        VerticalAlignment="Stretch"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Visibility="{x:Bind ShowWorkspacesButton, Mode=OneWay}">
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="8">
+                            <!--  EE40 is the "TaskViewSettings" glyph  -->
+                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                      FontSize="12"
+                                      Glyph="&#xEE40;" />
+                            <TextBlock x:Name="WorkspaceNameText"
+                                       Padding="0,0,8,0"
+                                       VerticalAlignment="Center"
+                                       FontSize="12"
+                                       Text="{x:Bind WorkspaceName, Mode=OneWay}"
+                                       Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(WorkspaceName), Mode=OneWay}" />
+                        </StackPanel>
+                    </Button.Content>
+                    <Button.Flyout>
+                        <MenuFlyout x:Name="WorkspaceFlyout" />
+                    </Button.Flyout>
+                </Button>
+            </StackPanel>
         </mux:TabView.TabStripHeader>
 
         <mux:TabView.TabStripFooter>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -36,7 +36,10 @@
 #include "TerminalSettingsCache.h"
 
 #include "LaunchPositionRequest.g.cpp"
+#include "WindowListEntry.g.cpp"
+#include "WindowListRequest.g.cpp"
 #include "RenameWindowRequestedArgs.g.cpp"
+#include "OpenWindowRequestedArgs.g.cpp"
 #include "RequestMoveContentArgs.g.cpp"
 #include "TerminalPage.g.cpp"
 
@@ -428,6 +431,21 @@ namespace winrt::TerminalApp::implementation
 
         auto tabRowImpl = winrt::get_self<implementation::TabRowControl>(_tabRow);
         _newTabButton = tabRowImpl->NewTabButton();
+        _workspaceFlyout = tabRowImpl->WorkspaceFlyout();
+        _workspaceDropdown = tabRowImpl->WorkspaceDropdown();
+
+        // Set the initial workspace name from the window name.
+        // Use raw WindowName() so unnamed windows show no text.
+        _tabRow.WorkspaceName(_WindowProperties.WindowName());
+
+        // Rebuild the workspace flyout each time it opens so it always
+        // reflects the latest set of persisted workspaces.
+        _workspaceFlyout.Opening([weakThis{ get_weak() }](auto&&, auto&&) {
+            if (auto page{ weakThis.get() })
+            {
+                page->_PopulateWorkspaceFlyout();
+            }
+        });
 
         if (_settings.GlobalSettings().ShowTabsInTitlebar())
         {
@@ -536,6 +554,12 @@ namespace winrt::TerminalApp::implementation
         // them.
 
         _tabRow.ShowElevationShield(IsRunningElevated() && _settings.GlobalSettings().ShowAdminShield());
+
+        // Apply the ShowWorkspacesButton theme setting.
+        if (const auto theme = _settings.GlobalSettings().CurrentTheme())
+        {
+            _tabRow.ShowWorkspacesButton(theme.Window() ? theme.Window().ShowWorkspacesButton() : true);
+        }
 
         _adjustProcessPriorityThrottled = std::make_shared<ThrottledFunc<>>(
             DispatcherQueue::GetForCurrentThread(),
@@ -5636,14 +5660,14 @@ namespace winrt::TerminalApp::implementation
         QuitRequested.raise(nullptr, nullptr);
     }
 
-    void TerminalPage::PersistState()
+    WindowLayout TerminalPage::GetWindowLayout()
     {
         // This method may be called for a window even if it hasn't had a tab yet or lost all of them.
         // We shouldn't persist such windows.
         const auto tabCount = _tabs.Size();
         if (_startupState != StartupState::Initialized || tabCount == 0)
         {
-            return;
+            return nullptr;
         }
 
         std::vector<ActionAndArgs> actions;
@@ -5658,7 +5682,7 @@ namespace winrt::TerminalApp::implementation
         // Avoid persisting a window with zero tabs, because `BuildStartupActions` happened to return an empty vector.
         if (actions.empty())
         {
-            return;
+            return nullptr;
         }
 
         // if the focused tab was not the last tab, restore that
@@ -5707,7 +5731,49 @@ namespace winrt::TerminalApp::implementation
         RequestLaunchPosition.raise(*this, launchPosRequest);
         layout.InitialPosition(launchPosRequest.Position());
 
-        ApplicationState::SharedInstance().AppendPersistedWindowLayout(layout);
+        return layout;
+    }
+
+    void TerminalPage::PersistState()
+    {
+        // There are two persistence mechanisms in play here:
+        //   * PersistedWindowLayouts (vector) — consumed on next startup to
+        //     re-open a matching set of windows. Cleared after restore.
+        //   * PersistedWorkspaces (name-keyed map) — the full tab/buffer
+        //     state of a named window, claimed by name on demand via
+        //     ApplicationState::TakeWorkspace.
+        //
+        // For named windows we save the full layout into the workspace map
+        // and drop a lightweight `openWorkspace` stub into the generic vector,
+        // so the generic restore path re-opens the named window which in
+        // turn claims its own workspace. Unnamed windows don't have a stable
+        // key, so their full layout is stored directly in the vector.
+        if (const auto layout = GetWindowLayout())
+        {
+            const auto& windowName = _WindowProperties.WindowName();
+            if (!windowName.empty())
+            {
+                // Persist the full layout into the workspace collection.
+                ApplicationState::SharedInstance().SaveWorkspace(windowName, layout);
+
+                // Build a minimal layout with just an openWorkspace action
+                // so the generic restore path re-opens this workspace by name.
+                std::vector<ActionAndArgs> actions;
+                ActionAndArgs action;
+                action.Action(ShortcutAction::OpenWorkspace);
+                OpenWorkspaceArgs args{ windowName };
+                action.Args(args);
+                actions.emplace_back(std::move(action));
+
+                WindowLayout stub;
+                stub.TabLayout(winrt::single_threaded_vector<ActionAndArgs>(std::move(actions)));
+                ApplicationState::SharedInstance().AppendPersistedWindowLayout(stub);
+            }
+            else
+            {
+                ApplicationState::SharedInstance().AppendPersistedWindowLayout(layout);
+            }
+        }
     }
 
     // Method Description:
@@ -7594,6 +7660,12 @@ namespace winrt::TerminalApp::implementation
 
         _tabRow.ShowElevationShield(IsRunningElevated() && _settings.GlobalSettings().ShowAdminShield());
 
+        // Apply the ShowWorkspacesButton theme setting.
+        if (const auto theme = _settings.GlobalSettings().CurrentTheme())
+        {
+            _tabRow.ShowWorkspacesButton(theme.Window() ? theme.Window().ShowWorkspacesButton() : true);
+        }
+
         Media::SolidColorBrush transparent{ Windows::UI::Colors::Transparent() };
         _tabView.Background(transparent);
 
@@ -9264,6 +9336,196 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
+    // Rebuild the workspace flyout contents. Called every time the flyout opens
+    // so it reflects the current set of persisted workspaces.
+    void TerminalPage::_PopulateWorkspaceFlyout()
+    {
+        if (!_workspaceFlyout)
+        {
+            return;
+        }
+
+        _workspaceFlyout.Items().Clear();
+
+        // --- "Name / Rename this window" ---
+        {
+            MenuFlyoutItem item{};
+            item.Text(_WindowProperties.WindowName().empty() ? RS_(L"NameThisWindowMenuItem") : RS_(L"RenameThisWindowMenuItem"));
+
+            auto iconElement = UI::IconPathConverter::IconWUX(L"\uE8AC"); // Rename glyph
+            Automation::AutomationProperties::SetAccessibilityView(iconElement, Automation::Peers::AccessibilityView::Raw);
+            item.Icon(iconElement);
+
+            item.Click([weakThis{ get_weak() }](auto&&, auto&&) {
+                if (auto page{ weakThis.get() })
+                {
+                    page->_actionDispatch->DoAction(ActionAndArgs{ ShortcutAction::OpenWindowRenamer, nullptr });
+                }
+            });
+            _workspaceFlyout.Items().Append(item);
+        }
+
+        // --- Gather open window info first so we can filter workspaces ---
+        const auto windowListReq{ winrt::make<WindowListRequest>() };
+        RequestWindowList.raise(*this, windowListReq);
+        const auto windowEntries = windowListReq.Entries();
+
+        std::set<winrt::hstring> openWindowNames;
+        if (windowEntries)
+        {
+            for (const auto& entry : windowEntries)
+            {
+                const auto& name = entry.Name();
+                if (!name.empty())
+                {
+                    openWindowNames.emplace(name);
+                }
+            }
+        }
+
+        // --- Saved workspaces section (only those not currently open) ---
+        // Collect workspace names that aren't currently open so we can show
+        // them both as top-level "open" items and inside the delete sub-menu.
+        const auto workspaces = ApplicationState::SharedInstance().AllPersistedWorkspaces();
+        if (workspaces && workspaces.Size() > 0)
+        {
+            bool addedSeparator = false;
+
+            for (const auto& pair : workspaces)
+            {
+                const auto name = pair.Key();
+
+                // Skip workspaces that correspond to a currently-open window.
+                if (openWindowNames.contains(name))
+                {
+                    continue;
+                }
+
+                if (!addedSeparator)
+                {
+                    _workspaceFlyout.Items().Append(MenuFlyoutSeparator{});
+                    addedSeparator = true;
+                }
+
+                MenuFlyoutItem item{};
+                item.Text(name);
+
+                auto iconElement = UI::IconPathConverter::IconWUX(L"\uE8F1"); // SwitchApps glyph
+                Automation::AutomationProperties::SetAccessibilityView(iconElement, Automation::Peers::AccessibilityView::Raw);
+                item.Icon(iconElement);
+
+                item.Click([weakThis{ get_weak() }, name](auto&&, auto&&) {
+                    if (auto page{ weakThis.get() })
+                    {
+                        page->_OpenWorkspaceWindow(name);
+                    }
+                });
+
+                // Right-click to delete: attach a context flyout with a
+                // "Delete workspace?" item that opens a confirmation dialog.
+                {
+                    WUX::Controls::MenuFlyout deleteFlyout{};
+                    deleteFlyout.Placement(WUX::Controls::Primitives::FlyoutPlacementMode::BottomEdgeAlignedRight);
+
+                    WUX::Controls::MenuFlyoutItem deleteItem{};
+                    deleteItem.Text(RS_(L"DeleteWorkspaceMenuItem"));
+
+                    auto trashIcon = UI::IconPathConverter::IconWUX(L"\xE74D"); // Delete  glyph
+
+                    deleteItem.Click([weakThis{ get_weak() }, name](auto&&, auto&&) -> safe_void_coroutine {
+                        auto page{ weakThis.get() };
+                        if (!page)
+                        {
+                            co_return;
+                        }
+
+                        // Build and show a confirmation ContentDialog.
+                        ContentDialog dialog{};
+                        dialog.Title(winrt::box_value(winrt::hstring{ RS_fmt(L"ConfirmDeleteWorkspaceTitle", name) }));
+                        dialog.Content(winrt::box_value(winrt::hstring{ RS_fmt(L"ConfirmDeleteWorkspaceBody", name) }));
+                        dialog.PrimaryButtonText(RS_(L"ConfirmDeleteWorkspaceDelete"));
+                        dialog.CloseButtonText(RS_(L"ConfirmDeleteWorkspaceCancel"));
+                        dialog.DefaultButton(ContentDialogButton::Close);
+
+                        if (auto presenter{ page->_dialogPresenter.get() })
+                        {
+                            const auto result = co_await presenter.ShowDialog(dialog);
+                            // Re-check after co_await
+                            page = weakThis.get();
+                            if (!page)
+                            {
+                                co_return;
+                            }
+                            if (result == ContentDialogResult::Primary)
+                            {
+                                ApplicationState::SharedInstance().RemoveWorkspace(name);
+                                page->_PopulateWorkspaceFlyout();
+                            }
+                        }
+                    });
+
+                    deleteFlyout.Items().Append(deleteItem);
+                    WUX::Controls::Primitives::FlyoutBase::SetAttachedFlyout(item, deleteFlyout);
+                    item.ContextRequested([item](auto&&, auto&&) {
+                        WUX::Controls::Primitives::FlyoutBase::ShowAttachedFlyout(item);
+                    });
+                }
+
+                _workspaceFlyout.Items().Append(item);
+            }
+        }
+
+        // --- Open windows section ---
+        if (windowEntries && windowEntries.Size() > 0)
+        {
+            _workspaceFlyout.Items().Append(MenuFlyoutSeparator{});
+
+            const auto thisWindowId = _WindowProperties.WindowId();
+
+            for (const auto& entry : windowEntries)
+            {
+                const auto id = entry.Id();
+                const auto& name = entry.Name();
+
+                winrt::hstring displayText;
+                if (name.empty())
+                {
+                    displayText = winrt::hstring{ RS_fmt(L"WindowListUnnamedEntry", id) };
+                }
+                else
+                {
+                    displayText = winrt::hstring{ fmt::format(FMT_COMPILE(L"#{}: {}"), id, name) };
+                }
+
+                MenuFlyoutItem item{};
+                item.Text(displayText);
+
+                if (id == thisWindowId)
+                {
+                    auto iconElement = UI::IconPathConverter::IconWUX(L"\uE73E"); // CheckMark glyph
+                    Automation::AutomationProperties::SetAccessibilityView(iconElement, Automation::Peers::AccessibilityView::Raw);
+                    item.Icon(iconElement);
+                    item.IsEnabled(false);
+                }
+                else
+                {
+                    auto iconElement = UI::IconPathConverter::IconWUX(L"\uE737"); // ChromeRestore glyph
+                    Automation::AutomationProperties::SetAccessibilityView(iconElement, Automation::Peers::AccessibilityView::Raw);
+                    item.Icon(iconElement);
+
+                    item.Click([weakThis{ get_weak() }, id](auto&&, auto&&) {
+                        if (auto page{ weakThis.get() })
+                        {
+                            page->SummonWindowByIdRequested.raise(*page, winrt::make<SummonWindowByIdRequestedArgs>(id));
+                        }
+                    });
+                }
+
+                _workspaceFlyout.Items().Append(item);
+            }
+        }
+    }
+
     // Handler for our WindowProperties's PropertyChanged event. We'll use this
     // to pop the "Identify Window" toast when the user renames our window.
     void TerminalPage::_windowPropertyChanged(const IInspectable& /*sender*/, const WUX::Data::PropertyChangedEventArgs& args)
@@ -9272,6 +9534,10 @@ namespace winrt::TerminalApp::implementation
         {
             return;
         }
+
+        // Keep the workspace dropdown label in sync with the window name.
+        // Use raw WindowName() so clearing the name hides the text.
+        _tabRow.WorkspaceName(_WindowProperties.WindowName());
 
         // DON'T display the confirmation if this is the name we were
         // given on startup!

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -10,8 +10,12 @@
 #include "AppKeyBindings.h"
 #include "AppCommandlineArgs.h"
 #include "RenameWindowRequestedArgs.g.h"
+#include "OpenWindowRequestedArgs.g.h"
+#include "SummonWindowByIdRequestedArgs.g.h"
 #include "RequestMoveContentArgs.g.h"
 #include "LaunchPositionRequest.g.h"
+#include "WindowListEntry.g.h"
+#include "WindowListRequest.g.h"
 #include "Toast.h"
 
 #include "WindowsPackageManagerFactory.h"
@@ -78,6 +82,24 @@ namespace winrt::TerminalApp::implementation
             _ProposedName{ name } {};
     };
 
+    struct OpenWindowRequestedArgs : OpenWindowRequestedArgsT<OpenWindowRequestedArgs>
+    {
+        WINRT_PROPERTY(winrt::hstring, Name);
+
+    public:
+        OpenWindowRequestedArgs(const winrt::hstring& name) :
+            _Name{ name } {};
+    };
+
+    struct SummonWindowByIdRequestedArgs : SummonWindowByIdRequestedArgsT<SummonWindowByIdRequestedArgs>
+    {
+        WINRT_PROPERTY(uint64_t, WindowId);
+
+    public:
+        SummonWindowByIdRequestedArgs(uint64_t id) :
+            _WindowId{ id } {};
+    };
+
     struct RequestMoveContentArgs : RequestMoveContentArgsT<RequestMoveContentArgs>
     {
         WINRT_PROPERTY(winrt::hstring, Window);
@@ -97,6 +119,25 @@ namespace winrt::TerminalApp::implementation
         LaunchPositionRequest() = default;
 
         til::property<winrt::Microsoft::Terminal::Settings::Model::LaunchPosition> Position;
+    };
+
+    struct WindowListEntry : WindowListEntryT<WindowListEntry>
+    {
+        WindowListEntry() = default;
+
+        til::property<uint64_t> Id;
+        til::property<winrt::hstring> Name;
+    };
+
+    struct WindowListRequest : WindowListRequestT<WindowListRequest>
+    {
+        WindowListRequest() :
+            _Entries{ winrt::single_threaded_vector<winrt::TerminalApp::WindowListEntry>() } {}
+
+        winrt::Windows::Foundation::Collections::IVector<winrt::TerminalApp::WindowListEntry> Entries() const { return _Entries; }
+
+    private:
+        winrt::Windows::Foundation::Collections::IVector<winrt::TerminalApp::WindowListEntry> _Entries;
     };
 
     struct WinGetSearchParams
@@ -138,6 +179,7 @@ namespace winrt::TerminalApp::implementation
 
         safe_void_coroutine RequestQuit();
         safe_void_coroutine CloseWindow();
+        winrt::Microsoft::Terminal::Settings::Model::WindowLayout GetWindowLayout();
         void PersistState();
         std::vector<IPaneContent> Panes() const;
 
@@ -234,6 +276,7 @@ namespace winrt::TerminalApp::implementation
         til::typed_event<IInspectable, IInspectable> IdentifyWindowsRequested;
         til::typed_event<IInspectable, winrt::TerminalApp::RenameWindowRequestedArgs> RenameWindowRequested;
         til::typed_event<IInspectable, IInspectable> SummonWindowRequested;
+        til::typed_event<IInspectable, winrt::TerminalApp::SummonWindowByIdRequestedArgs> SummonWindowByIdRequested;
         til::typed_event<IInspectable, winrt::TerminalApp::Tab> FocusTabRequested;
         til::typed_event<IInspectable, winrt::Microsoft::Terminal::Control::WindowSizeChangedEventArgs> WindowSizeChanged;
 
@@ -246,6 +289,8 @@ namespace winrt::TerminalApp::implementation
         til::typed_event<Windows::Foundation::IInspectable, winrt::TerminalApp::RequestReceiveContentArgs> RequestReceiveContent;
 
         til::typed_event<IInspectable, winrt::TerminalApp::LaunchPositionRequest> RequestLaunchPosition;
+        til::typed_event<IInspectable, winrt::TerminalApp::WindowListRequest> RequestWindowList;
+        til::typed_event<IInspectable, winrt::TerminalApp::OpenWindowRequestedArgs> RequestOpenWindow;
         til::typed_event<IInspectable, winrt::TerminalApp::WindowRequestedArgs> RequestNewWindow;
 
         WINRT_OBSERVABLE_PROPERTY(winrt::Windows::UI::Xaml::Media::Brush, TitlebarBrush, PropertyChanged.raise, nullptr);
@@ -269,6 +314,8 @@ namespace winrt::TerminalApp::implementation
         TerminalApp::TabRowControl _tabRow{ nullptr };
         Windows::UI::Xaml::Controls::Grid _tabContent{ nullptr };
         Microsoft::UI::Xaml::Controls::SplitButton _newTabButton{ nullptr };
+        Windows::UI::Xaml::Controls::MenuFlyout _workspaceFlyout{ nullptr };
+        Windows::UI::Xaml::Controls::Button _workspaceDropdown{ nullptr };
         winrt::TerminalApp::ColorPickupFlyout _tabColorPicker{ nullptr };
 
         Microsoft::Terminal::Settings::Model::CascadiaSettings _settings{ nullptr };
@@ -586,6 +633,7 @@ namespace winrt::TerminalApp::implementation
         void _restartPaneConnection(const TerminalApp::TerminalPaneContent&, const winrt::Windows::Foundation::IInspectable&);
 
         void _OpenNewWindow(const Microsoft::Terminal::Settings::Model::INewContentArgs& contentArgs);
+        void _OpenWorkspaceWindow(const winrt::hstring name);
 
         void _OpenNewTerminalViaDropdown(const Microsoft::Terminal::Settings::Model::NewTerminalArgs newTerminalArgs);
 
@@ -615,6 +663,7 @@ namespace winrt::TerminalApp::implementation
         void _CloseTabAtIndex(uint32_t index);
         void _RemoveTab(const winrt::TerminalApp::Tab& tab, bool movingAway = false);
         safe_void_coroutine _RemoveTabs(const std::vector<winrt::TerminalApp::Tab> tabs);
+        void _SaveWorkspaceIfNeeded();
 
         void _InitializeTab(winrt::com_ptr<Tab> newTabImpl, uint32_t insertPosition = -1, bool openInBackground = false);
         void _RegisterTerminalEvents(Microsoft::Terminal::Control::TermControl term);
@@ -857,6 +906,7 @@ namespace winrt::TerminalApp::implementation
 
         void _PopulateContextMenu(const Microsoft::Terminal::Control::TermControl& control, const Microsoft::UI::Xaml::Controls::CommandBarFlyout& sender, const bool withSelection);
         void _PopulateQuickFixMenu(const Microsoft::Terminal::Control::TermControl& control, const Windows::UI::Xaml::Controls::MenuFlyout& sender);
+        void _PopulateWorkspaceFlyout();
         winrt::Windows::UI::Xaml::Controls::MenuFlyout _CreateRunAsAdminFlyout(int profileIndex);
 
         winrt::Microsoft::Terminal::Control::TermControl _senderOrActiveControl(const winrt::Windows::Foundation::IInspectable& sender);
@@ -883,4 +933,5 @@ namespace winrt::TerminalApp::implementation
 namespace winrt::TerminalApp::factory_implementation
 {
     BASIC_FACTORY(TerminalPage);
+    BASIC_FACTORY(WindowListEntry);
 }

--- a/src/cascadia/TerminalApp/TerminalPage.idl
+++ b/src/cascadia/TerminalApp/TerminalPage.idl
@@ -20,6 +20,14 @@ namespace TerminalApp
     {
         String ProposedName { get; };
     };
+    [default_interface] runtimeclass OpenWindowRequestedArgs
+    {
+        String Name { get; };
+    };
+    [default_interface] runtimeclass SummonWindowByIdRequestedArgs
+    {
+        UInt64 WindowId { get; };
+    };
     [default_interface] runtimeclass RequestMoveContentArgs
     {
         String Window { get; };
@@ -51,6 +59,20 @@ namespace TerminalApp
     }
 
     // ── Protocol structs moved to Microsoft.Terminal.Protocol.TerminalProtocol.idl ──
+
+    [default_interface] runtimeclass WindowListEntry
+    {
+        WindowListEntry();
+        UInt64 Id;
+        String Name;
+    }
+
+    // Raised by TerminalPage when it needs the list of open windows.
+    // The handler (AppHost) fills Entries synchronously.
+    [default_interface] runtimeclass WindowListRequest
+    {
+        Windows.Foundation.Collections.IVector<WindowListEntry> Entries { get; };
+    }
 
     [default_interface] runtimeclass TerminalPage : Windows.UI.Xaml.Controls.Page, Windows.UI.Xaml.Data.INotifyPropertyChanged, Microsoft.Terminal.UI.IDirectKeyListener
     {
@@ -95,6 +117,7 @@ namespace TerminalApp
         event Windows.Foundation.TypedEventHandler<Object, Object> IdentifyWindowsRequested;
         event Windows.Foundation.TypedEventHandler<Object, RenameWindowRequestedArgs> RenameWindowRequested;
         event Windows.Foundation.TypedEventHandler<Object, Object> SummonWindowRequested;
+        event Windows.Foundation.TypedEventHandler<Object, SummonWindowByIdRequestedArgs> SummonWindowByIdRequested;
         event Windows.Foundation.TypedEventHandler<Object, Microsoft.Terminal.Control.WindowSizeChangedEventArgs> WindowSizeChanged;
 
         event Windows.Foundation.TypedEventHandler<Object, Object> OpenSystemMenu;
@@ -105,6 +128,12 @@ namespace TerminalApp
         event Windows.Foundation.TypedEventHandler<Object, RequestReceiveContentArgs> RequestReceiveContent;
 
         event Windows.Foundation.TypedEventHandler<Object, LaunchPositionRequest> RequestLaunchPosition;
+        event Windows.Foundation.TypedEventHandler<Object, WindowListRequest> RequestWindowList;
+
+        // Raised when the page wants the monarch to open (or summon) a
+        // named window in-process, restoring its persisted workspace if
+        // one exists. No new wt.exe process is spawned.
+        event Windows.Foundation.TypedEventHandler<Object, OpenWindowRequestedArgs> RequestOpenWindow;
 
         event Windows.Foundation.TypedEventHandler<Object, WindowRequestedArgs> RequestNewWindow;
 

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -258,6 +258,15 @@ namespace winrt::TerminalApp::implementation
         AppLogic::Current()->NotifyRootInitialized();
     }
 
+    WindowLayout TerminalWindow::GetWindowLayout() const
+    {
+        if (_root)
+        {
+            return _root->GetWindowLayout();
+        }
+        return nullptr;
+    }
+
     void TerminalWindow::PersistState()
     {
         if (_root)
@@ -1112,6 +1121,11 @@ namespace winrt::TerminalApp::implementation
         _initialContentArgs = wil::to_vector(actions);
     }
 
+    void TerminalWindow::SetPersistedLayout(const winrt::Microsoft::Terminal::Settings::Model::WindowLayout& layout)
+    {
+        _cachedLayout = layout;
+    }
+
     // Method Description:
     // - Parse the provided commandline arguments into actions, and try to
     //   perform them immediately.
@@ -1232,7 +1246,14 @@ namespace winrt::TerminalApp::implementation
     void TerminalWindow::WindowName(const winrt::hstring& name)
     {
         const auto oldIsQuakeMode = _WindowProperties->IsQuakeWindow();
+        const auto oldName = _WindowProperties->WindowName();
         _WindowProperties->WindowName(name);
+        // If this window had a persisted workspace under the old name, rename
+        // that entry too so we don't leave a stale copy behind.
+        if (!oldName.empty() && !name.empty() && oldName != name)
+        {
+            ApplicationState::SharedInstance().RenameWorkspace(oldName, name);
+        }
         if (!_root)
         {
             return;

--- a/src/cascadia/TerminalApp/TerminalWindow.h
+++ b/src/cascadia/TerminalApp/TerminalWindow.h
@@ -70,6 +70,7 @@ namespace winrt::TerminalApp::implementation
 
         void Create();
 
+        winrt::Microsoft::Terminal::Settings::Model::WindowLayout GetWindowLayout() const;
         void PersistState();
 
         void UpdateSettings(winrt::TerminalApp::SettingsLoadEventArgs args);
@@ -79,6 +80,7 @@ namespace winrt::TerminalApp::implementation
         int32_t SetStartupCommandline(TerminalApp::CommandlineArgs args);
         void SetStartupContent(const winrt::hstring& content, const Windows::Foundation::IReference<Windows::Foundation::Rect>& contentBounds);
         void SetStartupActions(const Windows::Foundation::Collections::IVector<winrt::Microsoft::Terminal::Settings::Model::ActionAndArgs>& actions);
+        void SetPersistedLayout(const winrt::Microsoft::Terminal::Settings::Model::WindowLayout& layout);
         int32_t ExecuteCommandline(TerminalApp::CommandlineArgs args);
         void SetSettingsStartupArgs(const std::vector<winrt::Microsoft::Terminal::Settings::Model::ActionAndArgs>& actions);
 
@@ -225,6 +227,7 @@ namespace winrt::TerminalApp::implementation
         FORWARDED_TYPED_EVENT(SetTaskbarProgress, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable, _root, SetTaskbarProgress);
         FORWARDED_TYPED_EVENT(IdentifyWindowsRequested, Windows::Foundation::IInspectable, Windows::Foundation::IInspectable, _root, IdentifyWindowsRequested);
         FORWARDED_TYPED_EVENT(SummonWindowRequested, Windows::Foundation::IInspectable, Windows::Foundation::IInspectable, _root, SummonWindowRequested);
+        FORWARDED_TYPED_EVENT(SummonWindowByIdRequested, Windows::Foundation::IInspectable, winrt::TerminalApp::SummonWindowByIdRequestedArgs, _root, SummonWindowByIdRequested);
         FORWARDED_TYPED_EVENT(FocusTabRequested, Windows::Foundation::IInspectable, winrt::TerminalApp::Tab, _root, FocusTabRequested);
         FORWARDED_TYPED_EVENT(OpenSystemMenu, Windows::Foundation::IInspectable, Windows::Foundation::IInspectable, _root, OpenSystemMenu);
         FORWARDED_TYPED_EVENT(QuitRequested, Windows::Foundation::IInspectable, Windows::Foundation::IInspectable, _root, QuitRequested);
@@ -234,6 +237,8 @@ namespace winrt::TerminalApp::implementation
         FORWARDED_TYPED_EVENT(RequestReceiveContent, Windows::Foundation::IInspectable, winrt::TerminalApp::RequestReceiveContentArgs, _root, RequestReceiveContent);
 
         FORWARDED_TYPED_EVENT(RequestLaunchPosition, Windows::Foundation::IInspectable, winrt::TerminalApp::LaunchPositionRequest, _root, RequestLaunchPosition);
+        FORWARDED_TYPED_EVENT(RequestWindowList, Windows::Foundation::IInspectable, winrt::TerminalApp::WindowListRequest, _root, RequestWindowList);
+        FORWARDED_TYPED_EVENT(RequestOpenWindow, Windows::Foundation::IInspectable, winrt::TerminalApp::OpenWindowRequestedArgs, _root, RequestOpenWindow);
         FORWARDED_TYPED_EVENT(RequestNewWindow, Windows::Foundation::IInspectable, winrt::TerminalApp::WindowRequestedArgs, _root, RequestNewWindow);
 
 #ifdef UNIT_TESTING

--- a/src/cascadia/TerminalApp/TerminalWindow.idl
+++ b/src/cascadia/TerminalApp/TerminalWindow.idl
@@ -57,11 +57,13 @@ namespace TerminalApp
         Int32 SetStartupCommandline(CommandlineArgs args);
         void SetStartupContent(String json, Windows.Foundation.IReference<Windows.Foundation.Rect> bounds);
         void SetStartupActions(Windows.Foundation.Collections.IVector<Microsoft.Terminal.Settings.Model.ActionAndArgs> actions);
+        void SetPersistedLayout(Microsoft.Terminal.Settings.Model.WindowLayout layout);
         Int32 ExecuteCommandline(CommandlineArgs args);
 
         Boolean ShouldImmediatelyHandoffToElevated();
         void HandoffToElevated();
 
+        Microsoft.Terminal.Settings.Model.WindowLayout GetWindowLayout();
         void PersistState();
 
         Windows.UI.Xaml.UIElement GetRoot();
@@ -129,6 +131,7 @@ namespace TerminalApp
         event Windows.Foundation.TypedEventHandler<Object, Object> IdentifyWindowsRequested;
         event Windows.Foundation.TypedEventHandler<Object, Object> IsQuakeWindowChanged;
         event Windows.Foundation.TypedEventHandler<Object, Object> SummonWindowRequested;
+        event Windows.Foundation.TypedEventHandler<Object, SummonWindowByIdRequestedArgs> SummonWindowByIdRequested;
         event Windows.Foundation.TypedEventHandler<Object, TerminalApp.Tab> FocusTabRequested;
         event Windows.Foundation.TypedEventHandler<Object, Object> OpenSystemMenu;
         event Windows.Foundation.TypedEventHandler<Object, Object> QuitRequested;
@@ -141,6 +144,8 @@ namespace TerminalApp
         event Windows.Foundation.TypedEventHandler<Object, RequestMoveContentArgs> RequestMoveContent;
         event Windows.Foundation.TypedEventHandler<Object, RequestReceiveContentArgs> RequestReceiveContent;
         event Windows.Foundation.TypedEventHandler<Object, LaunchPositionRequest> RequestLaunchPosition;
+        event Windows.Foundation.TypedEventHandler<Object, WindowListRequest> RequestWindowList;
+        event Windows.Foundation.TypedEventHandler<Object, OpenWindowRequestedArgs> RequestOpenWindow;
         event Windows.Foundation.TypedEventHandler<Object, WindowRequestedArgs> RequestNewWindow;
 
         void AttachContent(String content, UInt32 tabIndex);

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -74,6 +74,8 @@ static constexpr std::string_view NewWindowKey{ "newWindow" };
 static constexpr std::string_view IdentifyWindowKey{ "identifyWindow" };
 static constexpr std::string_view IdentifyWindowsKey{ "identifyWindows" };
 static constexpr std::string_view RenameWindowKey{ "renameWindow" };
+static constexpr std::string_view OpenWorkspaceKey{ "openWorkspace" };
+
 static constexpr std::string_view OpenWindowRenamerKey{ "openWindowRenamer" };
 static constexpr std::string_view DisplayWorkingDirectoryKey{ "debugTerminalCwd" };
 static constexpr std::string_view SearchForTextKey{ "searchWeb" };
@@ -109,6 +111,7 @@ static constexpr std::string_view TriggerAutofixKey{ "triggerAutofix" };
 static constexpr std::string_view OpenBackgroundAgentKey{ "openBackgroundAgent" };
 static constexpr std::string_view ShowProtocolInfoKey{ "showProtocolInfo" };
 static constexpr std::string_view BugReportKey{ "bugReport" };
+static constexpr std::string_view WorkspacesKey{ "workspaces" };
 
 static constexpr std::string_view ActionKey{ "action" };
 

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -40,6 +40,7 @@
 #include "PrevTabArgs.g.cpp"
 #include "NextTabArgs.g.cpp"
 #include "RenameWindowArgs.g.cpp"
+#include "OpenWorkspaceArgs.g.cpp"
 #include "SearchForTextArgs.g.cpp"
 #include "GlobalSummonArgs.g.cpp"
 #include "FocusPaneArgs.g.cpp"
@@ -797,6 +798,15 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             return winrt::hstring{ RS_switchable_fmt(L"RenameWindowCommandKey", Name()) };
         }
         return RS_switchable_(L"ResetWindowNameCommandKey");
+    }
+
+    winrt::hstring OpenWorkspaceArgs::GenerateName(const winrt::WARC::ResourceContext& context) const
+    {
+        if (!Name().empty())
+        {
+            return winrt::hstring{ RS_switchable_fmt(L"OpenWorkspaceCommandKey", Name()) };
+        }
+        return RS_switchable_(L"OpenWorkspaceDefaultCommandKey");
     }
 
     winrt::hstring SearchForTextArgs::GenerateName(const winrt::WARC::ResourceContext& context) const

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -42,6 +42,7 @@
 #include "PrevTabArgs.g.h"
 #include "NextTabArgs.g.h"
 #include "RenameWindowArgs.g.h"
+#include "OpenWorkspaceArgs.g.h"
 #include "SearchForTextArgs.g.h"
 #include "GlobalSummonArgs.g.h"
 #include "FocusPaneArgs.g.h"
@@ -244,6 +245,10 @@ protected:                                                                  \
 
 ////////////////////////////////////////////////////////////////////////////////
 #define RENAME_WINDOW_ARGS(X) \
+    X(winrt::hstring, Name, "name", false, ArgTypeHint::None, L"")
+
+////////////////////////////////////////////////////////////////////////////////
+#define OPEN_WORKSPACE_ARGS(X) \
     X(winrt::hstring, Name, "name", false, ArgTypeHint::None, L"")
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -940,6 +945,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
     ACTION_ARGS_STRUCT(RenameWindowArgs, RENAME_WINDOW_ARGS);
 
+    ACTION_ARGS_STRUCT(OpenWorkspaceArgs, OPEN_WORKSPACE_ARGS);
+
     ACTION_ARGS_STRUCT(SearchForTextArgs, SEARCH_FOR_TEXT_ARGS);
 
     struct GlobalSummonArgs : public GlobalSummonArgsT<GlobalSummonArgs>
@@ -1059,6 +1066,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::factory_implementation
     BASIC_FACTORY(SetMaximizedArgs);
     BASIC_FACTORY(SetColorSchemeArgs);
     BASIC_FACTORY(RenameWindowArgs);
+    BASIC_FACTORY(OpenWorkspaceArgs);
     BASIC_FACTORY(ExecuteCommandlineArgs);
     BASIC_FACTORY(CloseOtherTabsArgs);
     BASIC_FACTORY(CloseTabsAfterArgs);

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -421,6 +421,12 @@ namespace Microsoft.Terminal.Settings.Model
         String Name { get; };
     };
 
+    [default_interface] runtimeclass OpenWorkspaceArgs : IActionArgs, IActionArgsDescriptorAccess
+    {
+        OpenWorkspaceArgs(String name);
+        String Name { get; };
+    };
+
     [default_interface] runtimeclass SearchForTextArgs : IActionArgs, IActionArgsDescriptorAccess
     {
         String QueryUrl { get; };

--- a/src/cascadia/TerminalSettingsModel/ActionMap.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.cpp
@@ -122,6 +122,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 { ShortcutAction::OpenTabColorPicker, USES_RESOURCE(L"OpenTabColorPickerCommandKey") },
                 { ShortcutAction::OpenTabRenamer, USES_RESOURCE(L"OpenTabRenamerCommandKey") },
                 { ShortcutAction::OpenWindowRenamer, USES_RESOURCE(L"OpenWindowRenamerCommandKey") },
+                { ShortcutAction::OpenWorkspace, USES_RESOURCE(L"OpenWorkspaceDefaultCommandKey") },
                 { ShortcutAction::PasteText, USES_RESOURCE(L"PasteTextCommandKey") },
                 { ShortcutAction::PrevTab, USES_RESOURCE(L"PrevTabCommandKey") },
                 { ShortcutAction::QuickFix, USES_RESOURCE(L"QuickFixCommandKey") },
@@ -170,6 +171,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 { ShortcutAction::TogglePaneZoom, USES_RESOURCE(L"TogglePaneZoomCommandKey") },
                 { ShortcutAction::ToggleShaderEffects, USES_RESOURCE(L"ToggleShaderEffectsCommandKey") },
                 { ShortcutAction::ToggleSplitOrientation, USES_RESOURCE(L"ToggleSplitOrientationCommandKey") },
+                { ShortcutAction::Workspaces, USES_RESOURCE(L"WorkspacesCommandKey") },
             };
         }();
 
@@ -233,6 +235,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             return winrt::make<NextTabArgs>();
         case Model::ShortcutAction::OpenSettings:
             return winrt::make<OpenSettingsArgs>();
+        case Model::ShortcutAction::OpenWorkspace:
+            return winrt::make<OpenWorkspaceArgs>();
         case Model::ShortcutAction::SetFocusMode:
             return winrt::make<SetFocusModeArgs>();
         case Model::ShortcutAction::SetFullScreen:

--- a/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
+++ b/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
@@ -121,7 +121,9 @@
     ON_ALL_ACTIONS(TriggerAutofix)          \
     ON_ALL_ACTIONS(OpenBackgroundAgent)     \
     ON_ALL_ACTIONS(ShowProtocolInfo)        \
-    ON_ALL_ACTIONS(BugReport)
+    ON_ALL_ACTIONS(BugReport)               \
+    ON_ALL_ACTIONS(OpenWorkspace)           \
+    ON_ALL_ACTIONS(Workspaces)
 
 #define ALL_SHORTCUT_ACTIONS_WITH_ARGS             \
     ON_ALL_ACTIONS_WITH_ARGS(AdjustFontSize)       \
@@ -166,7 +168,8 @@
     ON_ALL_ACTIONS_WITH_ARGS(Suggestions)          \
     ON_ALL_ACTIONS_WITH_ARGS(SelectCommand)        \
     ON_ALL_ACTIONS_WITH_ARGS(SelectOutput)         \
-    ON_ALL_ACTIONS_WITH_ARGS(ColorSelection)
+    ON_ALL_ACTIONS_WITH_ARGS(ColorSelection)       \
+    ON_ALL_ACTIONS_WITH_ARGS(OpenWorkspace)
 
 // These two macros here are for actions that we only use as internal currency.
 // They don't need to be parsed by the settings model, or saved as actions to

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.cpp
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.cpp
@@ -253,6 +253,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         return *state;
     }
 
+// Need the COMMA macro hack for IMap template arguments in the macros
+#define COMMA ,
+
     // Method Description:
     // - Loads data from the given json blob. Will only read the data that's in
     //   the specified parseSource - so if we're reading the Local state file,
@@ -302,6 +305,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         return root;
     }
 
+#undef COMMA
+
     void ApplicationState::AppendPersistedWindowLayout(Model::WindowLayout layout)
     {
         {
@@ -341,6 +346,120 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         return false;
     }
 
+    void ApplicationState::SaveWorkspace(const hstring& name, const Model::WindowLayout& layout)
+    {
+        {
+            const auto state = _state.lock();
+            if (!state->PersistedWorkspaces || !*state->PersistedWorkspaces)
+            {
+                state->PersistedWorkspaces = winrt::single_threaded_map<hstring, Model::WindowLayout>();
+            }
+            (*state->PersistedWorkspaces).Insert(name, layout);
+        }
+        _throttler();
+    }
+
+    bool ApplicationState::RemoveWorkspace(const hstring& name)
+    {
+        bool removed{ false };
+        {
+            const auto state = _state.lock();
+            if (state->PersistedWorkspaces && *state->PersistedWorkspaces)
+            {
+                auto map = *state->PersistedWorkspaces;
+                if (map.HasKey(name))
+                {
+                    map.Remove(name);
+                    removed = true;
+                }
+            }
+        }
+        if (removed)
+        {
+            _throttler();
+        }
+        return removed;
+    }
+
+    // Method Description:
+    // - Rename a persisted workspace entry from oldName to newName. If there
+    //   was no entry for oldName, this is a no-op. If an entry for newName
+    //   already exists, it will be overwritten with the layout from oldName.
+    // - If newName is empty, the entry under oldName is simply removed (the
+    //   old name no longer points at a valid window, so the persisted layout
+    //   would otherwise be left stranded).
+    // Return Value:
+    // - true if the persisted state was modified, false otherwise.
+    bool ApplicationState::RenameWorkspace(const hstring& oldName, const hstring& newName)
+    {
+        if (oldName == newName || oldName.empty())
+        {
+            return false;
+        }
+
+        bool changed{ false };
+        {
+            const auto state = _state.lock();
+            if (state->PersistedWorkspaces && *state->PersistedWorkspaces)
+            {
+                auto map = *state->PersistedWorkspaces;
+                if (map.HasKey(oldName))
+                {
+                    if (!newName.empty())
+                    {
+                        const auto layout = map.Lookup(oldName);
+                        map.Insert(newName, layout);
+                    }
+                    map.Remove(oldName);
+                    changed = true;
+                }
+            }
+        }
+        if (changed)
+        {
+            _throttler();
+        }
+        return changed;
+    }
+
+    // Method Description:
+    // - Atomically remove and return a persisted workspace entry. This is the
+    //   intended API for the startup path that restores a named workspace,
+    //   because it guarantees only one caller can claim a given workspace.
+    // Return Value:
+    // - The layout that was stored under `name`, or nullptr if there was none.
+    Model::WindowLayout ApplicationState::TakeWorkspace(const hstring& name)
+    {
+        Model::WindowLayout result{ nullptr };
+        {
+            const auto state = _state.lock();
+            if (state->PersistedWorkspaces && *state->PersistedWorkspaces)
+            {
+                auto map = *state->PersistedWorkspaces;
+                if (map.HasKey(name))
+                {
+                    result = map.Lookup(name);
+                    map.Remove(name);
+                }
+            }
+        }
+        if (result)
+        {
+            _throttler();
+        }
+        return result;
+    }
+
+    Windows::Foundation::Collections::IMapView<hstring, Model::WindowLayout> ApplicationState::AllPersistedWorkspaces()
+    {
+        const auto state = _state.lock_shared();
+        if (state->PersistedWorkspaces && *state->PersistedWorkspaces)
+        {
+            return (*state->PersistedWorkspaces).GetView();
+        }
+        return nullptr;
+    }
+
     // Generate all getter/setters
 #define MTSM_APPLICATION_STATE_GEN(source, type, name, key, ...) \
     type ApplicationState::name() const noexcept                 \
@@ -359,7 +478,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                                                                  \
         _throttler();                                            \
     }
+#define COMMA ,
     MTSM_APPLICATION_STATE_FIELDS(MTSM_APPLICATION_STATE_GEN)
+#undef COMMA
 #undef MTSM_APPLICATION_STATE_GEN
 
     // Method Description:

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.h
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.h
@@ -16,7 +16,7 @@ Abstract:
 #include "WindowLayout.g.h"
 
 #include <inc/cppwinrt_utils.h>
-#include <JsonUtils.h>
+#include "JsonUtils.h"
 
 namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 {
@@ -34,6 +34,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 // This macro generates all getters and setters for ApplicationState.
 // It provides X with the following arguments:
 //   (source, type, function name, JSON key, ...variadic construction arguments)
+// Note: we're using the COMMA macro hack for the template arguments as used elsewhere.
 #define MTSM_APPLICATION_STATE_FIELDS(X)                                                                                                                                  \
     X(FileSource::Shared, winrt::hstring, SettingsHash, "settingsHash")                                                                                                   \
     X(FileSource::Shared, std::unordered_set<winrt::guid>, GeneratedProfiles, "generatedProfiles")                                                                        \
@@ -42,8 +43,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     X(FileSource::Shared, Windows::Foundation::Collections::IVector<winrt::Microsoft::Terminal::Settings::Model::InfoBarMessage>, DismissedMessages, "dismissedMessages") \
     X(FileSource::Local, Windows::Foundation::Collections::IVector<hstring>, AllowedCommandlines, "allowedCommandlines")                                                  \
     X(FileSource::Local, std::unordered_set<hstring>, DismissedBadges, "dismissedBadges")                                                                                 \
-    X(FileSource::Shared, bool, SSHFolderGenerated, "sshFolderGenerated", false)                                                                                  \
-    X(FileSource::Shared, bool, AgentFreCompleted, "agentFreCompleted", false)                                                                                  \
+    X(FileSource::Local, Windows::Foundation::Collections::IMap<hstring COMMA Model::WindowLayout>, PersistedWorkspaces, "persistedWorkspaces")                           \
+    X(FileSource::Shared, bool, SSHFolderGenerated, "sshFolderGenerated", false)                                                                                          \
+    X(FileSource::Shared, bool, AgentFreCompleted, "agentFreCompleted", false)                                                                                           \
     X(FileSource::Shared, bool, AgentWelcomeShown, "agentWelcomeShown", false)
 
     struct WindowLayout : WindowLayoutT<WindowLayout>
@@ -58,6 +60,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         friend ::Microsoft::Terminal::Settings::Model::JsonUtils::ConversionTrait<Model::WindowLayout>;
     };
+
+#define COMMA ,
 
     struct ApplicationState : public ApplicationStateT<ApplicationState>
     {
@@ -76,6 +80,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void AppendPersistedWindowLayout(Model::WindowLayout layout);
         bool DismissBadge(const hstring& badgeId);
         bool BadgeDismissed(const hstring& badgeId) const;
+
+        void SaveWorkspace(const hstring& name, const Model::WindowLayout& layout);
+        bool RemoveWorkspace(const hstring& name);
+        bool RenameWorkspace(const hstring& oldName, const hstring& newName);
+        Model::WindowLayout TakeWorkspace(const hstring& name);
+        Windows::Foundation::Collections::IMapView<hstring, Model::WindowLayout> AllPersistedWorkspaces();
 
         // State getters/setters
 #define MTSM_APPLICATION_STATE_GEN(source, type, name, key, ...) \
@@ -106,6 +116,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         std::string _readLocalContents() const;
         void _writeLocalContents(const std::string_view content) const;
     };
+#undef COMMA
 }
 
 namespace winrt::Microsoft::Terminal::Settings::Model::factory_implementation

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.idl
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.idl
@@ -36,6 +36,12 @@ namespace Microsoft.Terminal.Settings.Model
         Boolean DismissBadge(String badgeId);
         Boolean BadgeDismissed(String badgeId);
 
+        void SaveWorkspace(String name, WindowLayout layout);
+        Boolean RemoveWorkspace(String name);
+        Boolean RenameWorkspace(String oldName, String newName);
+        WindowLayout TakeWorkspace(String name);
+        Windows.Foundation.Collections.IMapView<String, WindowLayout> AllPersistedWorkspaces();
+
         String SettingsHash;
         Windows.Foundation.Collections.IVector<WindowLayout> PersistedWindowLayouts;
         Windows.Foundation.Collections.IVector<String> RecentCommands;

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -177,7 +177,8 @@ Author(s):
     X(winrt::Microsoft::Terminal::Settings::Model::ThemeColor, Frame, "frame", nullptr)                                            \
     X(winrt::Microsoft::Terminal::Settings::Model::ThemeColor, UnfocusedFrame, "unfocusedFrame", nullptr)                          \
     X(bool, RainbowFrame, "experimental.rainbowFrame", false)                                                                      \
-    X(bool, UseMica, "useMica", false)
+    X(bool, UseMica, "useMica", false)                                                                                             \
+    X(bool, ShowWorkspacesButton, "showWorkspacesButton", true)
 
 #define MTSM_THEME_SETTINGS_SETTINGS(X) \
     X(winrt::Windows::UI::Xaml::ElementTheme, RequestedTheme, "theme", winrt::Windows::UI::Xaml::ElementTheme::Default)

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -528,6 +528,13 @@
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
     <value>Reset window name</value>
   </data>
+  <data name="OpenWorkspaceCommandKey" xml:space="preserve">
+    <value>Open workspace "{0}"</value>
+    <comment>{0} will be replaced with the workspace name</comment>
+  </data>
+  <data name="OpenWorkspaceDefaultCommandKey" xml:space="preserve">
+    <value>Open workspace</value>
+  </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
     <value>Rename window...</value>
   </data>
@@ -766,6 +773,9 @@
   <data name="TriggerAutofixCommandKey" xml:space="preserve">
     <value>Trigger autofix</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
+  <data name="WorkspacesCommandKey" xml:space="preserve">
+    <value>Workspaces...</value>
+  </data>
   <data name="CloseTab" xml:space="preserve">
     <value>Close tab</value>
   </data>

--- a/src/cascadia/TerminalSettingsModel/Theme.idl
+++ b/src/cascadia/TerminalSettingsModel/Theme.idl
@@ -62,6 +62,7 @@ namespace Microsoft.Terminal.Settings.Model
         Windows.UI.Xaml.ElementTheme RequestedTheme { get; };
         Boolean UseMica { get; };
         Boolean RainbowFrame { get; };
+        Boolean ShowWorkspacesButton { get; };
         ThemeColor Frame { get; };
         ThemeColor UnfocusedFrame { get; };
     }

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -562,6 +562,8 @@
         { "command": "triggerAutofix", "id": "Terminal.TriggerAutofix" },
         { "command": "openBackgroundAgent", "id": "Terminal.OpenBackgroundAgent" },
         { "command": "bugReport", "id": "Terminal.BugReport" },
+        { "command": "workspaces", "id": "Terminal.Workspaces" },
+
         // Tab Management
         // "command": "closeTab" is unbound by default.
         //   The closeTab command closes a tab without confirmation, even if it has multiple panes.

--- a/src/cascadia/UnitTests_SettingsModel/ApplicationStateTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/ApplicationStateTests.cpp
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+
+#include "../TerminalSettingsModel/ApplicationState.h"
+
+using namespace Microsoft::Console;
+using namespace WEX::Logging;
+using namespace WEX::TestExecution;
+using namespace WEX::Common;
+using namespace winrt::Microsoft::Terminal::Settings::Model;
+
+namespace SettingsModelUnitTests
+{
+    // Covers the workspace-persistence APIs added to ApplicationState:
+    //   SaveWorkspace / RemoveWorkspace / RenameWorkspace / TakeWorkspace /
+    //   AllPersistedWorkspaces.
+    // All tests operate on a throw-away ApplicationState instance pointed at
+    // a temp directory, so they don't touch the real user state.
+    class ApplicationStateTests
+    {
+        TEST_CLASS(ApplicationStateTests);
+
+        TEST_METHOD(SaveAndLookupWorkspace);
+        TEST_METHOD(RemoveWorkspaceReturnsFalseWhenMissing);
+        TEST_METHOD(RenameWorkspaceMigratesEntry);
+        TEST_METHOD(RenameWorkspaceNoOpForEmptyOrEqualNames);
+        TEST_METHOD(RenameWorkspaceNoOpForMissingEntry);
+        TEST_METHOD(TakeWorkspaceRemovesAndReturns);
+        TEST_METHOD(TakeWorkspaceReturnsNullWhenMissing);
+
+    private:
+        static std::filesystem::path _tempRoot()
+        {
+            auto root = std::filesystem::temp_directory_path() / L"WT_ApplicationStateTests";
+            std::error_code ec;
+            std::filesystem::create_directories(root, ec);
+            // Best-effort clean of any leftover state.json from a prior run so
+            // tests see an empty starting point.
+            std::filesystem::remove(root / L"state.json", ec);
+            std::filesystem::remove(root / L"elevated-state.json", ec);
+            return root;
+        }
+
+        static winrt::com_ptr<implementation::ApplicationState> _make()
+        {
+            return winrt::make_self<implementation::ApplicationState>(_tempRoot());
+        }
+
+        static WindowLayout _makeLayout()
+        {
+            WindowLayout layout;
+            layout.TabLayout(winrt::single_threaded_vector<ActionAndArgs>());
+            return layout;
+        }
+    };
+
+    void ApplicationStateTests::SaveAndLookupWorkspace()
+    {
+        auto state = _make();
+        const auto layout = _makeLayout();
+        state->SaveWorkspace(L"win1", layout);
+
+        const auto all = state->AllPersistedWorkspaces();
+        VERIFY_IS_NOT_NULL(all);
+        VERIFY_IS_TRUE(all.HasKey(L"win1"));
+    }
+
+    void ApplicationStateTests::RemoveWorkspaceReturnsFalseWhenMissing()
+    {
+        auto state = _make();
+        VERIFY_IS_FALSE(state->RemoveWorkspace(L"does-not-exist"));
+
+        state->SaveWorkspace(L"win1", _makeLayout());
+        VERIFY_IS_TRUE(state->RemoveWorkspace(L"win1"));
+        VERIFY_IS_FALSE(state->RemoveWorkspace(L"win1"));
+    }
+
+    void ApplicationStateTests::RenameWorkspaceMigratesEntry()
+    {
+        auto state = _make();
+        state->SaveWorkspace(L"oldName", _makeLayout());
+
+        VERIFY_IS_TRUE(state->RenameWorkspace(L"oldName", L"newName"));
+
+        const auto all = state->AllPersistedWorkspaces();
+        VERIFY_IS_NOT_NULL(all);
+        VERIFY_IS_FALSE(all.HasKey(L"oldName"));
+        VERIFY_IS_TRUE(all.HasKey(L"newName"));
+    }
+
+    void ApplicationStateTests::RenameWorkspaceNoOpForEmptyOrEqualNames()
+    {
+        auto state = _make();
+        state->SaveWorkspace(L"win1", _makeLayout());
+
+        VERIFY_IS_FALSE(state->RenameWorkspace(L"win1", L"win1"));
+        VERIFY_IS_FALSE(state->RenameWorkspace(L"", L"win2"));
+
+        // Renaming to an empty name removes the stale entry under the old name.
+        VERIFY_IS_TRUE(state->RenameWorkspace(L"win1", L""));
+        const auto all = state->AllPersistedWorkspaces();
+        if (all)
+        {
+            VERIFY_IS_FALSE(all.HasKey(L"win1"));
+            VERIFY_IS_FALSE(all.HasKey(L""));
+        }
+
+        // Calling again is now a no-op because the entry is gone.
+        VERIFY_IS_FALSE(state->RenameWorkspace(L"win1", L""));
+    }
+
+    void ApplicationStateTests::RenameWorkspaceNoOpForMissingEntry()
+    {
+        auto state = _make();
+        VERIFY_IS_FALSE(state->RenameWorkspace(L"missing", L"newName"));
+    }
+
+    void ApplicationStateTests::TakeWorkspaceRemovesAndReturns()
+    {
+        auto state = _make();
+        state->SaveWorkspace(L"win1", _makeLayout());
+
+        const auto taken = state->TakeWorkspace(L"win1");
+        VERIFY_IS_NOT_NULL(taken);
+
+        // Subsequent Take for the same name must return null — this is the
+        // atomicity guarantee the startup path relies on.
+        VERIFY_IS_NULL(state->TakeWorkspace(L"win1"));
+    }
+
+    void ApplicationStateTests::TakeWorkspaceReturnsNullWhenMissing()
+    {
+        auto state = _make();
+        VERIFY_IS_NULL(state->TakeWorkspace(L"missing"));
+    }
+}

--- a/src/cascadia/UnitTests_SettingsModel/SettingsModel.UnitTests.vcxproj
+++ b/src/cascadia/UnitTests_SettingsModel/SettingsModel.UnitTests.vcxproj
@@ -46,6 +46,7 @@
     <ClCompile Include="ThemeTests.cpp" />
     <ClCompile Include="MediaResourceTests.cpp" />
     <ClCompile Include="CustomAgentAndPolicyTests.cpp" />
+    <ClCompile Include="ApplicationStateTests.cpp" />
     <ClCompile Include="../TerminalSettingsAppAdapterLib/TerminalSettings.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>

--- a/src/cascadia/UnitTests_SettingsModel/pch.h
+++ b/src/cascadia/UnitTests_SettingsModel/pch.h
@@ -66,6 +66,8 @@ Author(s):
 // Manually include til after we include Windows.Foundation to give it winrt superpowers
 #include "til.h"
 #include <til/winrt.h>
+#include <til/mutex.h>
+#include <til/throttled_func.h>
 
 // Common includes for most tests:
 #include "../../inc/conattrs.hpp"

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -133,7 +133,12 @@ void AppHost::_HandleCommandlineArgs(const winrt::TerminalApp::WindowRequestedAr
     // We don't have XAML yet, but we do have other stuff.
     _windowLogic = _appLogic.CreateNewWindow();
 
-    if (const auto content = windowArgs.Content(); !content.empty())
+    if (const auto layout = windowArgs.PersistedLayout())
+    {
+        _windowLogic.SetPersistedLayout(layout);
+        _launchShowWindowCommand = SW_NORMAL;
+    }
+    else if (const auto content = windowArgs.Content(); !content.empty())
     {
         _windowLogic.SetStartupContent(content, windowArgs.InitialBounds());
         _launchShowWindowCommand = SW_NORMAL;
@@ -271,12 +276,15 @@ void AppHost::Initialize()
 
     _revokers.IsQuakeWindowChanged = _windowLogic.IsQuakeWindowChanged(winrt::auto_revoke, { this, &AppHost::_IsQuakeWindowChanged });
     _revokers.SummonWindowRequested = _windowLogic.SummonWindowRequested(winrt::auto_revoke, { this, &AppHost::_SummonWindowRequested });
+    _revokers.SummonWindowByIdRequested = _windowLogic.SummonWindowByIdRequested(winrt::auto_revoke, { this, &AppHost::_SummonWindowByIdRequested });
     _revokers.FocusTabRequested = _windowLogic.FocusTabRequested(winrt::auto_revoke, { this, &AppHost::_FocusTabRequested });
     _revokers.OpenSystemMenu = _windowLogic.OpenSystemMenu(winrt::auto_revoke, { this, &AppHost::_OpenSystemMenu });
     _revokers.QuitRequested = _windowLogic.QuitRequested(winrt::auto_revoke, { this, &AppHost::_RequestQuitAll });
     _revokers.ShowWindowChanged = _windowLogic.ShowWindowChanged(winrt::auto_revoke, { this, &AppHost::_ShowWindowChanged });
     _revokers.RequestMoveContent = _windowLogic.RequestMoveContent(winrt::auto_revoke, { this, &AppHost::_handleMoveContent });
     _revokers.RequestReceiveContent = _windowLogic.RequestReceiveContent(winrt::auto_revoke, { this, &AppHost::_handleReceiveContent });
+    _revokers.RequestWindowList = _windowLogic.RequestWindowList(winrt::auto_revoke, { this, &AppHost::_HandleRequestWindowList });
+    _revokers.RequestOpenWindow = _windowLogic.RequestOpenWindow(winrt::auto_revoke, { this, &AppHost::_HandleOpenWindowRequested });
     _revokers.RequestNewWindow = _windowLogic.RequestNewWindow(winrt::auto_revoke, { this, &AppHost::_HandleNewWindowRequested });
 
     // BODGY
@@ -415,6 +423,40 @@ void AppHost::_HandleRequestLaunchPosition(const winrt::Windows::Foundation::IIn
                                            winrt::TerminalApp::LaunchPositionRequest args)
 {
     args.Position(_GetWindowLaunchPosition());
+}
+
+void AppHost::_HandleRequestWindowList(const winrt::Windows::Foundation::IInspectable& /*sender*/,
+                                       winrt::TerminalApp::WindowListRequest args)
+{
+    // Ask the Emperor (on the main thread) for the current window list.
+    // SendMessage blocks until the message is processed, so this is
+    // synchronous and the results vector is filled in-place.
+    std::vector<WindowEmperor::WindowListEntry> entries;
+    SendMessage(_windowManager->GetMainWindow(),
+                WindowEmperor::WM_GET_WINDOW_LIST,
+                0,
+                reinterpret_cast<LPARAM>(&entries));
+
+    auto windowEntries = args.Entries();
+    for (const auto& entry : entries)
+    {
+        winrt::TerminalApp::WindowListEntry w;
+        w.Id(entry.Id);
+        w.Name(winrt::hstring{ entry.Name });
+        windowEntries.Append(w);
+    }
+}
+
+// In-process replacement for the old `ShellExecute("wt -w ...")` dance.
+// Asks the WindowEmperor to summon a named window or restore its persisted
+// workspace, without launching a second wt.exe.
+void AppHost::_HandleOpenWindowRequested(const winrt::Windows::Foundation::IInspectable&,
+                                         const winrt::TerminalApp::OpenWindowRequestedArgs& args)
+{
+    if (_windowManager && args)
+    {
+        _windowManager->OpenWindow(args.Name());
+    }
 }
 
 // In-process replacement for the old `ShellExecute("wt -w -1 new-tab ...")`
@@ -1082,6 +1124,23 @@ void AppHost::_SummonWindowRequested(const winrt::Windows::Foundation::IInspecta
     summonArgs.ToMonitor(winrt::TerminalApp::MonitorBehavior::InPlace);
     summonArgs.ToggleVisibility(false); // Do not toggle, just make visible.
     HandleSummon(std::move(summonArgs));
+}
+
+void AppHost::_SummonWindowByIdRequested(const winrt::Windows::Foundation::IInspectable&,
+                                         const winrt::TerminalApp::SummonWindowByIdRequestedArgs& args)
+{
+    // Summon the window by its ID without creating a new tab.
+    // We look up the target window in WindowEmperor and call HandleSummon directly.
+    const auto targetId = args.WindowId();
+    if (auto* targetWindow = _windowManager->GetWindowById(targetId))
+    {
+        winrt::TerminalApp::SummonWindowBehavior summonBehavior;
+        summonBehavior.MoveToCurrentDesktop(false);
+        summonBehavior.DropdownDuration(0);
+        summonBehavior.ToMonitor(winrt::TerminalApp::MonitorBehavior::InPlace);
+        summonBehavior.ToggleVisibility(false); // Do not toggle, just make visible.
+        targetWindow->HandleSummon(std::move(summonBehavior));
+    }
 }
 
 void AppHost::_FocusTabRequested(const winrt::Windows::Foundation::IInspectable&,

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -91,11 +91,17 @@ private:
     void _SummonWindowRequested(const winrt::Windows::Foundation::IInspectable& sender,
                                 const winrt::Windows::Foundation::IInspectable& args);
 
+    void _SummonWindowByIdRequested(const winrt::Windows::Foundation::IInspectable& sender,
+                                    const winrt::TerminalApp::SummonWindowByIdRequestedArgs& args);
+
     void _FocusTabRequested(const winrt::Windows::Foundation::IInspectable& sender,
                             const winrt::TerminalApp::Tab& tab);
 
     void _OpenSystemMenu(const winrt::Windows::Foundation::IInspectable& sender,
                          const winrt::Windows::Foundation::IInspectable& args);
+
+    void _HandleOpenWindowRequested(const winrt::Windows::Foundation::IInspectable& sender,
+                                    const winrt::TerminalApp::OpenWindowRequestedArgs& args);
 
     void _HandleNewWindowRequested(const winrt::Windows::Foundation::IInspectable& sender,
                                    const winrt::TerminalApp::WindowRequestedArgs& args);
@@ -136,6 +142,8 @@ private:
     void _AppTitleChanged(const winrt::Windows::Foundation::IInspectable&, const winrt::Windows::Foundation::IInspectable&);
     void _HandleRequestLaunchPosition(const winrt::Windows::Foundation::IInspectable& sender,
                                       winrt::TerminalApp::LaunchPositionRequest args);
+    void _HandleRequestWindowList(const winrt::Windows::Foundation::IInspectable& sender,
+                                  winrt::TerminalApp::WindowListRequest args);
 
     // Helper struct. By putting these all into one struct, we can revoke them
     // all at once, by assigning _revokers to a fresh Revokers instance. That'll
@@ -157,6 +165,7 @@ private:
         winrt::TerminalApp::TerminalWindow::IdentifyWindowsRequested_revoker IdentifyWindowsRequested;
         winrt::TerminalApp::TerminalWindow::IsQuakeWindowChanged_revoker IsQuakeWindowChanged;
         winrt::TerminalApp::TerminalWindow::SummonWindowRequested_revoker SummonWindowRequested;
+        winrt::TerminalApp::TerminalWindow::SummonWindowByIdRequested_revoker SummonWindowByIdRequested;
         winrt::TerminalApp::TerminalWindow::FocusTabRequested_revoker FocusTabRequested;
         winrt::TerminalApp::TerminalWindow::OpenSystemMenu_revoker OpenSystemMenu;
         winrt::TerminalApp::TerminalWindow::QuitRequested_revoker QuitRequested;
@@ -165,6 +174,8 @@ private:
         winrt::TerminalApp::TerminalWindow::RequestReceiveContent_revoker RequestReceiveContent;
         winrt::TerminalApp::TerminalWindow::RequestLaunchPosition_revoker RequestLaunchPosition;
         winrt::TerminalApp::TerminalWindow::RequestNewWindow_revoker RequestNewWindow;
+        winrt::TerminalApp::TerminalWindow::RequestWindowList_revoker RequestWindowList;
+        winrt::TerminalApp::TerminalWindow::RequestOpenWindow_revoker RequestOpenWindow;
         winrt::TerminalApp::TerminalWindow::PropertyChanged_revoker PropertyChanged;
         winrt::TerminalApp::TerminalWindow::SettingsChanged_revoker SettingsChanged;
         winrt::TerminalApp::TerminalWindow::WindowSizeChanged_revoker WindowSizeChanged;

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -316,6 +316,60 @@ void WindowEmperor::CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs args
 
 }
 
+// Public entry point used by in-process callers (e.g. AppHost reacting to a
+// TerminalPage RequestOpenWindow event) to open or summon a named window -
+// restoring its persisted workspace if one exists - without spawning a second
+// wt.exe. Bypasses the commandline parser entirely.
+void WindowEmperor::OpenWindow(const winrt::hstring& name)
+{
+    _assertIsMainThread();
+
+    if (name.empty())
+    {
+        return;
+    }
+
+    // If a window with this name is already live, just summon it.
+    // This mirrors the summon behavior in AppHost::DispatchCommandline (which is
+    // what the old `wt -w <name>` ShellExecute path effectively triggered).
+    if (const auto window = GetWindowByName(name))
+    {
+        winrt::TerminalApp::SummonWindowBehavior summon{};
+        summon.MoveToCurrentDesktop(false);
+        summon.DropdownDuration(0);
+        summon.ToMonitor(winrt::TerminalApp::MonitorBehavior::InPlace);
+        summon.ToggleVisibility(false);
+        window->HandleSummon(std::move(summon));
+        return;
+    }
+
+    // Otherwise, create a new window under that name. A default-constructed
+    // CommandlineArgs is supplied as the launch fallback for the case where
+    // no persisted workspace exists; AppHost ignores it when PersistedLayout
+    // is set.
+    _createWindowMaybeRestoringWorkspace(0, name, winrt::TerminalApp::CommandlineArgs{});
+}
+
+// Shared tail used by both the commandline dispatch path and OpenWindow():
+// build a WindowRequestedArgs for a new window and, if the request carries a
+// name, atomically claim any persisted workspace stored under that name so
+// it's restored here and no subsequent caller can pick up the same entry.
+void WindowEmperor::_createWindowMaybeRestoringWorkspace(uint64_t windowId, const winrt::hstring& windowName, winrt::TerminalApp::CommandlineArgs args)
+{
+    winrt::TerminalApp::WindowRequestedArgs request{ windowId, std::move(args) };
+    request.WindowName(windowName);
+
+    if (!windowName.empty())
+    {
+        if (const auto layout = ApplicationState::SharedInstance().TakeWorkspace(windowName))
+        {
+            request.PersistedLayout(layout);
+        }
+    }
+
+    CreateNewWindow(std::move(request));
+}
+
 AppHost* WindowEmperor::_mostRecentWindow() const noexcept
 {
     int64_t max = INT64_MIN;
@@ -824,9 +878,7 @@ void WindowEmperor::_dispatchCommandline(winrt::TerminalApp::CommandlineArgs arg
     }
     else
     {
-        winrt::TerminalApp::WindowRequestedArgs request{ windowId, std::move(args) };
-        request.WindowName(std::move(windowName));
-        CreateNewWindow(std::move(request));
+        _createWindowMaybeRestoringWorkspace(windowId, windowName, std::move(args));
     }
 }
 
@@ -1110,6 +1162,22 @@ LRESULT WindowEmperor::_messageHandler(HWND window, UINT const message, WPARAM c
                         // anyway (since we threw and exited this message handler) so this at least gives back our
                         // deterministic window count management.
                         const auto strong = *it;
+
+                        // Before destroying a named window, persist its full
+                        // tab/buffer state as a workspace so it can be restored later.
+                        try
+                        {
+                            const auto windowName = strong->Logic().WindowProperties().WindowName();
+                            if (!windowName.empty())
+                            {
+                                if (const auto layout = strong->Logic().GetWindowLayout())
+                                {
+                                    ApplicationState::SharedInstance().SaveWorkspace(windowName, layout);
+                                }
+                            }
+                        }
+                        CATCH_LOG();
+
                         _windows.erase(it);
                         try
                         {
@@ -1137,6 +1205,19 @@ LRESULT WindowEmperor::_messageHandler(HWND window, UINT const message, WPARAM c
                 host->Logic().IdentifyWindow();
             }
             return 0;
+        case WM_GET_WINDOW_LIST:
+        {
+            auto* result = reinterpret_cast<std::vector<WindowListEntry>*>(lParam);
+            if (result)
+            {
+                for (const auto& host : _windows)
+                {
+                    const auto props = host->Logic().WindowProperties();
+                    result->emplace_back(WindowListEntry{ props.WindowId(), std::wstring{ props.WindowName() } });
+                }
+            }
+            return 0;
+        }
         case WM_NOTIFY_FROM_NOTIFICATION_AREA:
             switch (LOWORD(lParam))
             {

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -30,6 +30,16 @@ public:
         WM_MESSAGE_BOX_CLOSED,
         WM_IDENTIFY_ALL_WINDOWS,
         WM_NOTIFY_FROM_NOTIFICATION_AREA,
+        WM_GET_WINDOW_LIST,
+    };
+
+    // Used by WM_GET_WINDOW_LIST.  Callers allocate a vector on their
+    // stack and pass a pointer through LPARAM; the emperor fills it in
+    // synchronously via SendMessage.
+    struct WindowListEntry
+    {
+        uint64_t Id;
+        std::wstring Name;
     };
 
     WindowEmperor();
@@ -42,6 +52,8 @@ public:
     void CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs args);
     void HandleCommandlineArgs(int nCmdShow);
     void FocusTabInAnyWindow(const winrt::TerminalApp::Tab& tab) const;
+    // OpenWindow is used for opening a new window or summoning an existing window by name.
+    void OpenWindow(const winrt::hstring& name);
 
     // Protocol server access
     const std::wstring& GetComClsid() const noexcept { return _comClsid; }
@@ -60,6 +72,7 @@ private:
     [[nodiscard]] static LRESULT __stdcall _wndProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept;
 
     AppHost* _mostRecentWindow() const noexcept;
+    void _createWindowMaybeRestoringWorkspace(uint64_t windowId, const winrt::hstring& windowName, winrt::TerminalApp::CommandlineArgs args);
     bool _summonWindow(const SummonWindowSelectionArgs& args) const;
     void _summonAllWindows() const;
     void _dispatchSpecialKey(const MSG& msg) const;

--- a/src/inc/til/mutex.h
+++ b/src/inc/til/mutex.h
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+#pragma once
+
 namespace til
 {
     namespace details


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked PR: this targets `upstream-sync/2026-07-14-133227-224c` and must merge **after** #409.
>
> Do **not** squash-merge. This commit must retain its upstream author and `(cherry picked from commit 1282d56a33bb15206fcb3a09d3bea0a33036f2cd)` trailer for future upstream-sync watermarking.

Cherry-picks upstream microsoft/terminal commit `1282d56a33bb15206fcb3a09d3bea0a33036f2cd`:

- Add support for "workspaces" based on window names (redux) (#20314)

Conflict resolution summary (keep-both):

- `src/cascadia/TerminalApp/AppActionHandlers.cpp`: preserved the fork's AI-agent action handlers (`openAgentPane`, `focusAgentPane`, agent sessions, autofix, bug report, protocol info) and added upstream workspace action handlers (`openWorkspace`, `workspaces`).
- `src/cascadia/TerminalApp/TabManagement.cpp`: preserved fork WTA/agent-pane close notifications and per-tab agent behavior, while adding upstream workspace persistence before last-tab/last-pane teardown.
- `src/cascadia/TerminalApp/TerminalPage.idl`: preserved the fork's protocol-struct migration note and added upstream window-list request/entry types used by workspaces.
- `src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp`: kept fork agent action string mappings and added upstream `workspaces` mapping.
- `src/cascadia/TerminalSettingsModel/AllShortcutActions.h`: kept fork agent actions and added upstream `OpenWorkspace` / `Workspaces` actions.
- `src/cascadia/TerminalSettingsModel/ApplicationState.h`: kept fork agent FRE/welcome state and added upstream persisted workspace state.
- `src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw`: kept fork AI-agent command resources and added upstream workspace command resources.
- `src/cascadia/TerminalSettingsModel/defaults.json`: kept fork AI-agent default commands and added upstream `Terminal.Workspaces` default command.
- `src/cascadia/UnitTests_SettingsModel/SettingsModel.UnitTests.vcxproj`: kept fork custom agent/policy tests and added upstream `ApplicationStateTests.cpp`.

Validation performed:

- Cherry-pick continued successfully with trailer intact.
- No conflict markers remain.
- Brace counts balanced in the two resolved C++ files.
- `defaults.json` parses as JSONC.
- `Resources.resw` and `SettingsModel.UnitTests.vcxproj` parse as XML.
- No duplicate `.resw` resource keys found.

Full build/tests have **not** run yet because another build is in progress. This PR is draft pending full validation.
