### PR TITLE
chore(upstream): sync remaining backlog to 66ac36e7a (17 commits)

### DIFF
--- a/.github/actions/spelling/allow/microsoft.txt
+++ b/.github/actions/spelling/allow/microsoft.txt
@@ -80,5 +80,6 @@ wtl
 wtt
 wttlog
 Xamarin
+XBOX
 xfgcheck
 IMEs

--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -1150,7 +1150,7 @@ nullopts
 NUMSCROLL
 NUnit
 nupkg
-NVIDIA
+nvidia
 NVT
 OACR
 ocolor

--- a/build/pipelines/templates-v2/pipeline-1espt-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-1espt-full-release-build.yml
@@ -130,6 +130,8 @@ extends:
                 - template: ./build/pipelines/templates-v2/steps-setup-versioning.yml@self
               beforeBuildSteps:
                 - template: ./build/pipelines/templates-v2/steps-install-terrapin.yml@self
+                  parameters:
+                    nugetFeed: "https://pkgs.dev.azure.com/microsoft/_packaging/WindowsTerminal/nuget/v3/index.json"
 
           - ${{ if eq(parameters.buildWPF, true) }}:
             # Add an Any CPU build flavor for the WPF control bits

--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -97,6 +97,10 @@ extends:
       asyncSdl:
         enabled: true
         tsaOptionsFile: 'build/config/tsa.json'
+      codeql:
+        enabledOnNonDefaultBranches: true
+        compiled:
+          enabled: true
       tsa:
         enabled: true
         configFile: '$(Build.SourcesDirectory)\build\config\tsa.json'

--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -146,6 +146,10 @@ extends:
               beforeRustBuildSteps:
                 - template: ./build/pipelines/templates-v2/steps-setup-versioning.yml@self
               beforeBuildSteps: # Right before we build, lay down the universal package and localizations
+                - template: ./build/pipelines/templates-v2/steps-install-terrapin.yml@self
+                  parameters:
+                    nugetFeed: "https://pkgs.dev.azure.com/microsoft/_packaging/WindowsTerminal/nuget/v3/index.json"
+
                 - task: UniversalPackages@0
                   displayName: Download terminal-internal Universal Package
                   inputs:

--- a/build/pipelines/templates-v2/steps-install-terrapin.yml
+++ b/build/pipelines/templates-v2/steps-install-terrapin.yml
@@ -1,6 +1,14 @@
+parameters:
+- name: nugetFeed
+  type: string
+  default: unspecified
+
 steps:
+- ${{ if eq(parameters.nugetFeed, 'unspecified') }}:
+  - "nugetFeed was not specified": error
+
 - pwsh: |-
-    nuget install -source "https://pkgs.dev.azure.com/microsoft/_packaging/WindowsTerminal/nuget/v3/index.json" TerrapinRetrievalTool -Prerelease -OutputDirectory _trt
+    nuget install -source "${{ parameters.nugetFeed }}" TerrapinRetrievalTool -Prerelease -OutputDirectory _trt
     $TerrapinRetrievalToolPath = (Get-Item _trt\TerrapinRetrievalTool.*\win-x64\TerrapinRetrievalTool.exe).FullName
     Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES]x-script,${TerrapinRetrievalToolPath} -b https://vcpkg.storage.devpackages.microsoft.io/artifacts/ -a true -u None -p {url} -s {sha512} -d {dst};x-block-origin"
-  displayName: Set up the Terrapin Retrieval Tool (vcpkg cache)
+  displayName: Install the Terrapin Retrieval Tool (vcpkg cache)

--- a/build/scripts/Create-AppxBundle.ps1
+++ b/build/scripts/Create-AppxBundle.ps1
@@ -22,8 +22,13 @@ Param(
     [Parameter(HelpMessage="Path to makeappx.exe")]
     [ValidateScript({Test-Path $_ -Type Leaf})]
     [string]
-    $MakeAppxPath = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x86\MakeAppx.exe"
+    $MakeAppxPath
 )
+
+If (-not $MakeAppxPath) {
+  $winSdk10Root = $(Get-ItemPropertyValue -Path "HKLM:\Software\Microsoft\Windows Kits\Installed Roots" -Name "KitsRoot10")
+  $MakeAppxPath = "$winSdk10Root\bin\10.0.26100.0\x86\MakeAppx.exe"
+}
 
 If ($null -Eq (Get-Item $MakeAppxPath -EA:SilentlyContinue)) {
     Write-Error "Could not find MakeAppx.exe at `"$MakeAppxPath`".`nMake sure that -MakeAppxPath points to a valid SDK."

--- a/build/scripts/Merge-PriFiles.ps1
+++ b/build/scripts/Merge-PriFiles.ps1
@@ -16,10 +16,20 @@ Param(
     [Parameter(HelpMessage="Path to makepri.exe")]
     [ValidateScript({Test-Path $_ -Type Leaf})]
     [string]
-    $MakePriPath = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\MakePri.exe"
+    $MakePriPath
 )
 
 $ErrorActionPreference = 'Stop'
+
+If (-not $MakePriPath) {
+  $winSdk10Root = $(Get-ItemPropertyValue -Path "HKLM:\Software\Microsoft\Windows Kits\Installed Roots" -Name "KitsRoot10")
+  $MakePriPath = "$winSdk10Root\bin\10.0.26100.0\x64\MakePri.exe"
+}
+
+If ($null -Eq (Get-Item $MakePriPath -EA:SilentlyContinue)) {
+    Write-Error "Could not find MakePriPath.exe at `"$MakePriPath`".`nMake sure that -MakePriPath points to a valid SDK."
+    Exit 1
+}
 
 $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "tmp$([Convert]::ToString((Get-Random 65535),16).PadLeft(4,'0')).tmp"
 New-Item -ItemType Directory -Path $tempDir | Out-Null

--- a/build/scripts/Merge-TerminalAndXamlResources.ps1
+++ b/build/scripts/Merge-TerminalAndXamlResources.ps1
@@ -17,10 +17,20 @@ Param(
     [Parameter(HelpMessage="Path to makepri.exe")]
     [ValidateScript({Test-Path $_ -Type Leaf})]
     [string]
-    $MakePriPath = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\MakePri.exe"
+    $MakePriPath
 )
 
 $ErrorActionPreference = 'Stop'
+
+If (-not $MakePriPath) {
+  $winSdk10Root = $(Get-ItemPropertyValue -Path "HKLM:\Software\Microsoft\Windows Kits\Installed Roots" -Name "KitsRoot10")
+  $MakePriPath = "$winSdk10Root\bin\10.0.26100.0\x64\MakePri.exe"
+}
+
+If ($null -Eq (Get-Item $MakePriPath -EA:SilentlyContinue)) {
+    Write-Error "Could not find MakePriPath.exe at `"$MakePriPath`".`nMake sure that -MakePriPath points to a valid SDK."
+    Exit 1
+}
 
 $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "tmp$([Convert]::ToString((Get-Random 65535),16).PadLeft(4,'0')).tmp"
 New-Item -ItemType Directory -Path $tempDir | Out-Null

--- a/build/scripts/New-UnpackagedTerminalDistribution.ps1
+++ b/build/scripts/New-UnpackagedTerminalDistribution.ps1
@@ -25,7 +25,7 @@ Param(
     [Parameter(HelpMessage="Path to makeappx.exe", ParameterSetName='Layout')]
     [ValidateScript({Test-Path $_ -Type Leaf})]
     [string]
-    $MakeAppxPath = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\MakeAppx.exe",
+    $MakeAppxPath,
 
     [Parameter(HelpMessage="Include the portable mode marker file by default", ParameterSetName='AppX')]
     [Parameter(HelpMessage="Include the portable mode marker file by default", ParameterSetName='Layout')]
@@ -38,6 +38,11 @@ $filesToKeep = @() # ... except for these
 $filesToCopyFromXaml = @("Microsoft.UI.Xaml.dll", "Microsoft.UI.Xaml") # We don't need the .winmd
 
 $ErrorActionPreference = 'Stop'
+
+If (-not $MakeAppxPath) {
+  $winSdk10Root = $(Get-ItemPropertyValue -Path "HKLM:\Software\Microsoft\Windows Kits\Installed Roots" -Name "KitsRoot10")
+  $MakeAppxPath = "$winSdk10Root\bin\10.0.26100.0\x64\MakeAppx.exe"
+}
 
 If ($null -Eq (Get-Item $MakeAppxPath -EA:SilentlyContinue)) {
     Write-Error "Could not find MakeAppx.exe at `"$MakeAppxPath`".`nMake sure that -MakeAppxPath points to a valid SDK."

--- a/build/scripts/Test-WindowsTerminalPackage.ps1
+++ b/build/scripts/Test-WindowsTerminalPackage.ps1
@@ -6,12 +6,17 @@ Param(
     $Path,
 
     [Parameter(HelpMessage="Path to Windows Kit")]
-    [ValidateScript({Test-Path $_ -Type Leaf})]
+    [ValidateScript({Test-Path $_})]
     [string]
-    $WindowsKitPath = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0"
+    $WindowsKitPath
 )
 
 $ErrorActionPreference = "Stop"
+
+If (-not $WindowsKitPath) {
+  $winSdk10Root = $(Get-ItemPropertyValue -Path "HKLM:\Software\Microsoft\Windows Kits\Installed Roots" -Name "KitsRoot10")
+  $WindowsKitPath = "$winSdk10Root\bin\10.0.26100.0"
+}
 
 If ($null -Eq (Get-Item $WindowsKitPath -EA:SilentlyContinue)) {
     Write-Error "Could not find a windows SDK at at `"$WindowsKitPath`".`nMake sure that WindowsKitPath points to a valid SDK."

--- a/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
@@ -746,6 +746,42 @@
     <value>Unbenanntes Fenster</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
+  <data name="NameThisWindowMenuItem" xml:space="preserve">
+    <value>Dieses Fenster benennen...</value>
+    <comment>Menu item text shown when the current window has no name assigned</comment>
+  </data>
+  <data name="RenameThisWindowMenuItem" xml:space="preserve">
+    <value>Dieses Fenster umbenennen...</value>
+    <comment>Menu item text shown when the current window already has a name</comment>
+  </data>
+  <data name="WindowListUnnamedEntry" xml:space="preserve">
+    <value>#{0} (unbenannt)</value>
+    <comment>{locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
+  </data>
+  <data name="DeleteWorkspaceMenuItem" xml:space="preserve">
+    <value>Arbeitsbereich löschen?</value>
+    <comment>Menu item text shown in the right-click context menu on a saved workspace</comment>
+  </data>
+  <data name="OpenWorkspaceMenuItem" xml:space="preserve">
+    <value>Arbeitsbereich öffnen</value>
+    <comment>Menu item text for opening a saved workspace</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceTitle" xml:space="preserve">
+    <value>„{0}“ löschen?</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceBody" xml:space="preserve">
+    <value>Möchten Sie "{0}" wirklich löschen? Diesem Arbeitsbereich zugeordnete Sitzungen werden ebenfalls gelöscht.</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceDelete" xml:space="preserve">
+    <value>Löschen</value>
+    <comment>Primary button text on the delete workspace confirmation dialog</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceCancel" xml:space="preserve">
+    <value>Abbrechen</value>
+    <comment>Cancel button text on the delete workspace confirmation dialog</comment>
+  </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
     <value>Geben Sie einen neuen Namen ein:</value>
   </data>
@@ -803,6 +839,9 @@
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Dieses Terminalfenster wird als Administrator ausgeführt.</value>
+  </data>
+  <data name="WorkspaceDropdown.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Arbeitsbereiche</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>Gefundene Vorschläge: {0}</value>

--- a/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
@@ -743,6 +743,42 @@
     <value>ventana sin nombre</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
+  <data name="NameThisWindowMenuItem" xml:space="preserve">
+    <value>Asigne un nombre a esta ventana...</value>
+    <comment>Menu item text shown when the current window has no name assigned</comment>
+  </data>
+  <data name="RenameThisWindowMenuItem" xml:space="preserve">
+    <value>Cambiar el nombre de esta ventana...</value>
+    <comment>Menu item text shown when the current window already has a name</comment>
+  </data>
+  <data name="WindowListUnnamedEntry" xml:space="preserve">
+    <value>#{0} (sin nombre)</value>
+    <comment>{locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
+  </data>
+  <data name="DeleteWorkspaceMenuItem" xml:space="preserve">
+    <value>¿Quiere eliminar el área de trabajo?</value>
+    <comment>Menu item text shown in the right-click context menu on a saved workspace</comment>
+  </data>
+  <data name="OpenWorkspaceMenuItem" xml:space="preserve">
+    <value>Abrir área de trabajo</value>
+    <comment>Menu item text for opening a saved workspace</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceTitle" xml:space="preserve">
+    <value>¿Eliminar "{0}"?</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceBody" xml:space="preserve">
+    <value>¿Está seguro de que desea eliminar "{0}"? También se eliminarán las sesiones asociadas a esta área de trabajo.</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceDelete" xml:space="preserve">
+    <value>Eliminar</value>
+    <comment>Primary button text on the delete workspace confirmation dialog</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceCancel" xml:space="preserve">
+    <value>Cancelar</value>
+    <comment>Cancel button text on the delete workspace confirmation dialog</comment>
+  </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
     <value>Escriba un nombre nuevo:</value>
   </data>
@@ -800,6 +836,9 @@
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Esta ventana de terminal se está ejecutando como administrador</value>
+  </data>
+  <data name="WorkspaceDropdown.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Áreas de trabajo</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>Sugerencias encontradas: {0}</value>

--- a/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
@@ -743,6 +743,42 @@
     <value>fenêtre sans nom</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
+  <data name="NameThisWindowMenuItem" xml:space="preserve">
+    <value>Nommer cette fenêtre...</value>
+    <comment>Menu item text shown when the current window has no name assigned</comment>
+  </data>
+  <data name="RenameThisWindowMenuItem" xml:space="preserve">
+    <value>Renommer cette fenêtre...</value>
+    <comment>Menu item text shown when the current window already has a name</comment>
+  </data>
+  <data name="WindowListUnnamedEntry" xml:space="preserve">
+    <value>#{0} (sans nom)</value>
+    <comment>{locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
+  </data>
+  <data name="DeleteWorkspaceMenuItem" xml:space="preserve">
+    <value>Supprimer l’espace de travail ?</value>
+    <comment>Menu item text shown in the right-click context menu on a saved workspace</comment>
+  </data>
+  <data name="OpenWorkspaceMenuItem" xml:space="preserve">
+    <value>Ouvrir un espace de travail</value>
+    <comment>Menu item text for opening a saved workspace</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceTitle" xml:space="preserve">
+    <value>Supprimer « {0} » ?</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceBody" xml:space="preserve">
+    <value>Voulez-vous vraiment supprimer "{0}" ? Les sessions associées à cet espace de travail seront également supprimées.</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceDelete" xml:space="preserve">
+    <value>Supprimer</value>
+    <comment>Primary button text on the delete workspace confirmation dialog</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceCancel" xml:space="preserve">
+    <value>Annuler</value>
+    <comment>Cancel button text on the delete workspace confirmation dialog</comment>
+  </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
     <value>Entrer un nouveau nom :</value>
   </data>
@@ -800,6 +836,9 @@
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Cette fenêtre de terminal s’exécute en tant qu’administrateur</value>
+  </data>
+  <data name="WorkspaceDropdown.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Espaces de travail</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>{0} suggestions trouvées</value>

--- a/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
@@ -743,6 +743,42 @@
     <value>finestra senza nome</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
+  <data name="NameThisWindowMenuItem" xml:space="preserve">
+    <value>Assegna un nome a questa finestra...</value>
+    <comment>Menu item text shown when the current window has no name assigned</comment>
+  </data>
+  <data name="RenameThisWindowMenuItem" xml:space="preserve">
+    <value>Rinomina questa finestra...</value>
+    <comment>Menu item text shown when the current window already has a name</comment>
+  </data>
+  <data name="WindowListUnnamedEntry" xml:space="preserve">
+    <value>#{0} (senza nome)</value>
+    <comment>{locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
+  </data>
+  <data name="DeleteWorkspaceMenuItem" xml:space="preserve">
+    <value>Eliminare l'area di lavoro?</value>
+    <comment>Menu item text shown in the right-click context menu on a saved workspace</comment>
+  </data>
+  <data name="OpenWorkspaceMenuItem" xml:space="preserve">
+    <value>Apri area di lavoro</value>
+    <comment>Menu item text for opening a saved workspace</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceTitle" xml:space="preserve">
+    <value>Eliminare "{0}"?</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceBody" xml:space="preserve">
+    <value>Eliminare "{0}"? Verranno eliminate anche le sessioni associate a questa area di lavoro.</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceDelete" xml:space="preserve">
+    <value>Elimina</value>
+    <comment>Primary button text on the delete workspace confirmation dialog</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceCancel" xml:space="preserve">
+    <value>Annulla</value>
+    <comment>Cancel button text on the delete workspace confirmation dialog</comment>
+  </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
     <value>Immetti un nuovo nome:</value>
   </data>
@@ -800,6 +836,9 @@
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Questa finestra del terminale è in esecuzione come amministratore</value>
+  </data>
+  <data name="WorkspaceDropdown.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Aree di lavoro</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>Suggerimenti trovati: {0}</value>

--- a/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
@@ -744,6 +744,42 @@
     <value>名前のないウィンドウ</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
+  <data name="NameThisWindowMenuItem" xml:space="preserve">
+    <value>このウィンドウに名前を付ける...</value>
+    <comment>Menu item text shown when the current window has no name assigned</comment>
+  </data>
+  <data name="RenameThisWindowMenuItem" xml:space="preserve">
+    <value>このウィンドウの名前を変更...</value>
+    <comment>Menu item text shown when the current window already has a name</comment>
+  </data>
+  <data name="WindowListUnnamedEntry" xml:space="preserve">
+    <value>#{0} (名前なし)</value>
+    <comment>{locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
+  </data>
+  <data name="DeleteWorkspaceMenuItem" xml:space="preserve">
+    <value>ワークスペースを削除しますか?</value>
+    <comment>Menu item text shown in the right-click context menu on a saved workspace</comment>
+  </data>
+  <data name="OpenWorkspaceMenuItem" xml:space="preserve">
+    <value>ワークスペースを開く</value>
+    <comment>Menu item text for opening a saved workspace</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceTitle" xml:space="preserve">
+    <value>"{0}" を削除しますか?</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceBody" xml:space="preserve">
+    <value>"{0}" を削除しますか?このワークスペースに関連付けられているセッションも削除されます。</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceDelete" xml:space="preserve">
+    <value>削除</value>
+    <comment>Primary button text on the delete workspace confirmation dialog</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceCancel" xml:space="preserve">
+    <value>キャンセル</value>
+    <comment>Cancel button text on the delete workspace confirmation dialog</comment>
+  </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
     <value>新しい名前を入力してください:</value>
   </data>
@@ -801,6 +837,9 @@
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>このターミナル ウィンドウは管理者として実行されています</value>
+  </data>
+  <data name="WorkspaceDropdown.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>ワークスペース</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>候補が見つかりました: {0} 件</value>

--- a/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
@@ -743,6 +743,42 @@
     <value>이름 없는 창</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
+  <data name="NameThisWindowMenuItem" xml:space="preserve">
+    <value>이 창의 이름 지정...</value>
+    <comment>Menu item text shown when the current window has no name assigned</comment>
+  </data>
+  <data name="RenameThisWindowMenuItem" xml:space="preserve">
+    <value>이 창의 이름 바꾸기...</value>
+    <comment>Menu item text shown when the current window already has a name</comment>
+  </data>
+  <data name="WindowListUnnamedEntry" xml:space="preserve">
+    <value>#{0}(이름 없음)</value>
+    <comment>{locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
+  </data>
+  <data name="DeleteWorkspaceMenuItem" xml:space="preserve">
+    <value>작업 영역을 삭제하시겠습니까?</value>
+    <comment>Menu item text shown in the right-click context menu on a saved workspace</comment>
+  </data>
+  <data name="OpenWorkspaceMenuItem" xml:space="preserve">
+    <value>작업 영역 열기</value>
+    <comment>Menu item text for opening a saved workspace</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceTitle" xml:space="preserve">
+    <value>“{0}”을(를) 삭제할까요?</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceBody" xml:space="preserve">
+    <value>"{0}" 삭제하시겠습니까? 이 작업 영역과 연결된 세션도 삭제됩니다.</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceDelete" xml:space="preserve">
+    <value>삭제</value>
+    <comment>Primary button text on the delete workspace confirmation dialog</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceCancel" xml:space="preserve">
+    <value>취소</value>
+    <comment>Cancel button text on the delete workspace confirmation dialog</comment>
+  </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
     <value>새 이름 입력:</value>
   </data>
@@ -800,6 +836,9 @@
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>이 터미널 창이 관리자 권한으로 실행되고 있습니다.</value>
+  </data>
+  <data name="WorkspaceDropdown.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>작업 영역</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>찾은 제안: {0}</value>

--- a/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
@@ -743,6 +743,42 @@
     <value>Janela sem nome</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
+  <data name="NameThisWindowMenuItem" xml:space="preserve">
+    <value>Nomear esta janela...</value>
+    <comment>Menu item text shown when the current window has no name assigned</comment>
+  </data>
+  <data name="RenameThisWindowMenuItem" xml:space="preserve">
+    <value>Renomear esta janela...</value>
+    <comment>Menu item text shown when the current window already has a name</comment>
+  </data>
+  <data name="WindowListUnnamedEntry" xml:space="preserve">
+    <value>#{0} (sem nome)</value>
+    <comment>{locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
+  </data>
+  <data name="DeleteWorkspaceMenuItem" xml:space="preserve">
+    <value>Excluir workspace?</value>
+    <comment>Menu item text shown in the right-click context menu on a saved workspace</comment>
+  </data>
+  <data name="OpenWorkspaceMenuItem" xml:space="preserve">
+    <value>Abrir workspace</value>
+    <comment>Menu item text for opening a saved workspace</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceTitle" xml:space="preserve">
+    <value>Excluir "{0}"?</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceBody" xml:space="preserve">
+    <value>Tem certeza de que deseja excluir "{0}"? As sessões associadas a este espaço de trabalho também serão excluídas.</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceDelete" xml:space="preserve">
+    <value>Excluir</value>
+    <comment>Primary button text on the delete workspace confirmation dialog</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceCancel" xml:space="preserve">
+    <value>Cancelar</value>
+    <comment>Cancel button text on the delete workspace confirmation dialog</comment>
+  </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
     <value>Insira um novo nome:</value>
   </data>
@@ -800,6 +836,9 @@
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Esta janela do Terminal está sendo executada como administrador</value>
+  </data>
+  <data name="WorkspaceDropdown.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Workspaces</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>Sugestões encontradas: {0}</value>

--- a/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
@@ -743,6 +743,42 @@
     <value>υŉňàмěđ ẅіπďōẅ !!! !</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
+  <data name="NameThisWindowMenuItem" xml:space="preserve">
+    <value>Ńªmè ťнĩš ώìńðőẃ... !!! !!!</value>
+    <comment>Menu item text shown when the current window has no name assigned</comment>
+  </data>
+  <data name="RenameThisWindowMenuItem" xml:space="preserve">
+    <value>Ŕеŋªмĕ тнįѕ шíŋďōщ... !!! !!!</value>
+    <comment>Menu item text shown when the current window already has a name</comment>
+  </data>
+  <data name="WindowListUnnamedEntry" xml:space="preserve">
+    <value>#{0} (цņŉàмėδ) !!! !</value>
+    <comment>{locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
+  </data>
+  <data name="DeleteWorkspaceMenuItem" xml:space="preserve">
+    <value>Ðеℓĕтэ ẁόŕķšφåςέ? !!! !!</value>
+    <comment>Menu item text shown in the right-click context menu on a saved workspace</comment>
+  </data>
+  <data name="OpenWorkspaceMenuItem" xml:space="preserve">
+    <value>Орεи ωоѓķšρдċè !!! !</value>
+    <comment>Menu item text for opening a saved workspace</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceTitle" xml:space="preserve">
+    <value>Ďĕℓéţę "{0}"? !!! </value>
+    <comment>{locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceBody" xml:space="preserve">
+    <value>Āŕę ÿоυ ŝűѓě ŷōū шąлŧ ŧό ðёłěŧё "{0}"? Ѕêşѕįŏпŝ άšѕǿĉіãťэδ ẁíτн тђíś шőґκѕρªĉэ щιłℓ ªĺśο ьэ ďэŀęтёδ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceDelete" xml:space="preserve">
+    <value>Ďėŀéтэ !</value>
+    <comment>Primary button text on the delete workspace confirmation dialog</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceCancel" xml:space="preserve">
+    <value>Сαńčēļ !</value>
+    <comment>Cancel button text on the delete workspace confirmation dialog</comment>
+  </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
     <value>Єиŧ℮ŗ ă ñéẁ йάmё: !!! !!</value>
   </data>
@@ -800,6 +836,9 @@
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ţђіś Тĕřмїηǻℓ шĩⁿðöŵ ïѕ ѓüñňĩñģ ãŝ áðmĭⁿîşŧŕãţθŕ !!! !!! !!! !!! !!</value>
+  </data>
+  <data name="WorkspaceDropdown.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Ẃǿřķşрǻсєš !!!</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>Ѕũğġεšтįóпş ƒōцŉđ: {0} !!! !!! </value>

--- a/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
@@ -743,6 +743,42 @@
     <value>υŉňàмěđ ẅіπďōẅ !!! !</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
+  <data name="NameThisWindowMenuItem" xml:space="preserve">
+    <value>Ńªmè ťнĩš ώìńðőẃ... !!! !!!</value>
+    <comment>Menu item text shown when the current window has no name assigned</comment>
+  </data>
+  <data name="RenameThisWindowMenuItem" xml:space="preserve">
+    <value>Ŕеŋªмĕ тнįѕ шíŋďōщ... !!! !!!</value>
+    <comment>Menu item text shown when the current window already has a name</comment>
+  </data>
+  <data name="WindowListUnnamedEntry" xml:space="preserve">
+    <value>#{0} (цņŉàмėδ) !!! !</value>
+    <comment>{locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
+  </data>
+  <data name="DeleteWorkspaceMenuItem" xml:space="preserve">
+    <value>Ðеℓĕтэ ẁόŕķšφåςέ? !!! !!</value>
+    <comment>Menu item text shown in the right-click context menu on a saved workspace</comment>
+  </data>
+  <data name="OpenWorkspaceMenuItem" xml:space="preserve">
+    <value>Орεи ωоѓķšρдċè !!! !</value>
+    <comment>Menu item text for opening a saved workspace</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceTitle" xml:space="preserve">
+    <value>Ďĕℓéţę "{0}"? !!! </value>
+    <comment>{locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceBody" xml:space="preserve">
+    <value>Āŕę ÿоυ ŝűѓě ŷōū шąлŧ ŧό ðёłěŧё "{0}"? Ѕêşѕįŏпŝ άšѕǿĉіãťэδ ẁíτн тђíś шőґκѕρªĉэ щιłℓ ªĺśο ьэ ďэŀęтёδ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceDelete" xml:space="preserve">
+    <value>Ďėŀéтэ !</value>
+    <comment>Primary button text on the delete workspace confirmation dialog</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceCancel" xml:space="preserve">
+    <value>Сαńčēļ !</value>
+    <comment>Cancel button text on the delete workspace confirmation dialog</comment>
+  </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
     <value>Єиŧ℮ŗ ă ñéẁ йάmё: !!! !!</value>
   </data>
@@ -800,6 +836,9 @@
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ţђіś Тĕřмїηǻℓ шĩⁿðöŵ ïѕ ѓüñňĩñģ ãŝ áðmĭⁿîşŧŕãţθŕ !!! !!! !!! !!! !!</value>
+  </data>
+  <data name="WorkspaceDropdown.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Ẃǿřķşрǻсєš !!!</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>Ѕũğġεšтįóпş ƒōцŉđ: {0} !!! !!! </value>

--- a/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
@@ -743,6 +743,42 @@
     <value>υŉňàмěđ ẅіπďōẅ !!! !</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
+  <data name="NameThisWindowMenuItem" xml:space="preserve">
+    <value>Ńªmè ťнĩš ώìńðőẃ... !!! !!!</value>
+    <comment>Menu item text shown when the current window has no name assigned</comment>
+  </data>
+  <data name="RenameThisWindowMenuItem" xml:space="preserve">
+    <value>Ŕеŋªмĕ тнįѕ шíŋďōщ... !!! !!!</value>
+    <comment>Menu item text shown when the current window already has a name</comment>
+  </data>
+  <data name="WindowListUnnamedEntry" xml:space="preserve">
+    <value>#{0} (цņŉàмėδ) !!! !</value>
+    <comment>{locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
+  </data>
+  <data name="DeleteWorkspaceMenuItem" xml:space="preserve">
+    <value>Ðеℓĕтэ ẁόŕķšφåςέ? !!! !!</value>
+    <comment>Menu item text shown in the right-click context menu on a saved workspace</comment>
+  </data>
+  <data name="OpenWorkspaceMenuItem" xml:space="preserve">
+    <value>Орεи ωоѓķšρдċè !!! !</value>
+    <comment>Menu item text for opening a saved workspace</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceTitle" xml:space="preserve">
+    <value>Ďĕℓéţę "{0}"? !!! </value>
+    <comment>{locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceBody" xml:space="preserve">
+    <value>Āŕę ÿоυ ŝűѓě ŷōū шąлŧ ŧό ðёłěŧё "{0}"? Ѕêşѕįŏпŝ άšѕǿĉіãťэδ ẁíτн тђíś шőґκѕρªĉэ щιłℓ ªĺśο ьэ ďэŀęтёδ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceDelete" xml:space="preserve">
+    <value>Ďėŀéтэ !</value>
+    <comment>Primary button text on the delete workspace confirmation dialog</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceCancel" xml:space="preserve">
+    <value>Сαńčēļ !</value>
+    <comment>Cancel button text on the delete workspace confirmation dialog</comment>
+  </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
     <value>Єиŧ℮ŗ ă ñéẁ йάmё: !!! !!</value>
   </data>
@@ -800,6 +836,9 @@
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ţђіś Тĕřмїηǻℓ шĩⁿðöŵ ïѕ ѓüñňĩñģ ãŝ áðmĭⁿîşŧŕãţθŕ !!! !!! !!! !!! !!</value>
+  </data>
+  <data name="WorkspaceDropdown.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Ẃǿřķşрǻсєš !!!</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>Ѕũğġεšтįóпş ƒōцŉđ: {0} !!! !!! </value>

--- a/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
@@ -743,6 +743,42 @@
     <value>окно без названия</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
+  <data name="NameThisWindowMenuItem" xml:space="preserve">
+    <value>Присвойте имя этому окну...</value>
+    <comment>Menu item text shown when the current window has no name assigned</comment>
+  </data>
+  <data name="RenameThisWindowMenuItem" xml:space="preserve">
+    <value>Переименуйте это окно...</value>
+    <comment>Menu item text shown when the current window already has a name</comment>
+  </data>
+  <data name="WindowListUnnamedEntry" xml:space="preserve">
+    <value>#{0} (без имени)</value>
+    <comment>{locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
+  </data>
+  <data name="DeleteWorkspaceMenuItem" xml:space="preserve">
+    <value>Удалить рабочую область?</value>
+    <comment>Menu item text shown in the right-click context menu on a saved workspace</comment>
+  </data>
+  <data name="OpenWorkspaceMenuItem" xml:space="preserve">
+    <value>Открыть рабочую область</value>
+    <comment>Menu item text for opening a saved workspace</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceTitle" xml:space="preserve">
+    <value>Удалить "{0}"?</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceBody" xml:space="preserve">
+    <value>Вы действительно хотите удалить "{0}"? Сеансы, связанные с этой рабочей областью, также будут удалены.</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceDelete" xml:space="preserve">
+    <value>Удалить</value>
+    <comment>Primary button text on the delete workspace confirmation dialog</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceCancel" xml:space="preserve">
+    <value>Отмена</value>
+    <comment>Cancel button text on the delete workspace confirmation dialog</comment>
+  </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
     <value>Введите новое имя:</value>
   </data>
@@ -800,6 +836,9 @@
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Это окно терминала запущено от имени администратора</value>
+  </data>
+  <data name="WorkspaceDropdown.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Рабочие области</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>Найдено рекомендаций: {0}</value>

--- a/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
@@ -746,6 +746,42 @@
     <value>未命名的窗口</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
+  <data name="NameThisWindowMenuItem" xml:space="preserve">
+    <value>命名此窗口...</value>
+    <comment>Menu item text shown when the current window has no name assigned</comment>
+  </data>
+  <data name="RenameThisWindowMenuItem" xml:space="preserve">
+    <value>重命名此窗口...</value>
+    <comment>Menu item text shown when the current window already has a name</comment>
+  </data>
+  <data name="WindowListUnnamedEntry" xml:space="preserve">
+    <value>#{0} (未命名)</value>
+    <comment>{locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
+  </data>
+  <data name="DeleteWorkspaceMenuItem" xml:space="preserve">
+    <value>是否删除工作区?</value>
+    <comment>Menu item text shown in the right-click context menu on a saved workspace</comment>
+  </data>
+  <data name="OpenWorkspaceMenuItem" xml:space="preserve">
+    <value>打开工作区</value>
+    <comment>Menu item text for opening a saved workspace</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceTitle" xml:space="preserve">
+    <value>是否删除“{0}”?</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceBody" xml:space="preserve">
+    <value>是否确实要删除 "{0}"？与此工作区关联的会话也将被删除。</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceDelete" xml:space="preserve">
+    <value>删除</value>
+    <comment>Primary button text on the delete workspace confirmation dialog</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceCancel" xml:space="preserve">
+    <value>取消</value>
+    <comment>Cancel button text on the delete workspace confirmation dialog</comment>
+  </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
     <value>输入新名称:</value>
   </data>
@@ -803,6 +839,9 @@
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>此终端窗口正在以管理员身份运行</value>
+  </data>
+  <data name="WorkspaceDropdown.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>工作区</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>找到的建议: {0}</value>

--- a/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
@@ -743,6 +743,42 @@
     <value>未命名的視窗</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
+  <data name="NameThisWindowMenuItem" xml:space="preserve">
+    <value>命名此視窗...</value>
+    <comment>Menu item text shown when the current window has no name assigned</comment>
+  </data>
+  <data name="RenameThisWindowMenuItem" xml:space="preserve">
+    <value>重新命名此視窗...</value>
+    <comment>Menu item text shown when the current window already has a name</comment>
+  </data>
+  <data name="WindowListUnnamedEntry" xml:space="preserve">
+    <value>#{0} (未命名)</value>
+    <comment>{locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
+  </data>
+  <data name="DeleteWorkspaceMenuItem" xml:space="preserve">
+    <value>是否要刪除工作區?</value>
+    <comment>Menu item text shown in the right-click context menu on a saved workspace</comment>
+  </data>
+  <data name="OpenWorkspaceMenuItem" xml:space="preserve">
+    <value>開啟工作區</value>
+    <comment>Menu item text for opening a saved workspace</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceTitle" xml:space="preserve">
+    <value>是否要刪除「{0}」?</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceBody" xml:space="preserve">
+    <value>確定要刪除 "{0}" 嗎？與此工作區相關聯的工作階段也會一併刪除。</value>
+    <comment>{locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceDelete" xml:space="preserve">
+    <value>刪除</value>
+    <comment>Primary button text on the delete workspace confirmation dialog</comment>
+  </data>
+  <data name="ConfirmDeleteWorkspaceCancel" xml:space="preserve">
+    <value>取消</value>
+    <comment>Cancel button text on the delete workspace confirmation dialog</comment>
+  </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
     <value>輸入新名稱：</value>
   </data>
@@ -800,6 +836,9 @@
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>此終端機視窗目前以系統管理員身分執行</value>
+  </data>
+  <data name="WorkspaceDropdown.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>工作區</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>找到的建議: {0}</value>

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -168,6 +168,40 @@ namespace winrt::TerminalApp::implementation
             }
         });
 
+        // BODGY: Work around a fail-fast crash in WinUI 2's TabView. When a
+        // game controller (e.g. an XBOX controller's d-pad/stick) moves focus
+        // Up or Down between two TabViewItems, MUX's TabView::OnListViewGettingFocus
+        // runs a GameController-only code path that calls
+        // DispatcherQueue.TryEnqueue, which fails with E_INVALIDARG. That
+        // unhandled error inside a GettingFocus callback makes XAML fail-fast,
+        // and the whole window vanishes. See
+        // microsoft-ui-xaml/blob/840c6cd4ac9d16d9aa99b24f0bd43997fe21bef8/dev/TabView/TabView.cpp#L246
+        //
+        // This GettingFocus handler is on the TabViewItem, which is closer to
+        // the focus source than the TabViewListView that MUX's handler lives
+        // on, so it runs first. Marking the event Handled - and cancelling the
+        // focus move, which is exactly what MUX itself does for the keyboard
+        // case - preempts MUX's broken handler. Keyboard navigation is left
+        // untouched; MUX handles that path safely.
+        TabViewItem().GettingFocus([](auto&&, const winrt::WUX::Input::GettingFocusEventArgs& args) {
+            const auto direction{ args.Direction() };
+            if (direction != winrt::WUX::Input::FocusNavigationDirection::Up &&
+                direction != winrt::WUX::Input::FocusNavigationDirection::Down)
+            {
+                return;
+            }
+            if (args.InputDevice() != winrt::WUX::Input::FocusInputDeviceKind::GameController)
+            {
+                return;
+            }
+            if (args.OldFocusedElement().try_as<winrt::MUX::Controls::TabViewItem>() &&
+                args.NewFocusedElement().try_as<winrt::MUX::Controls::TabViewItem>())
+            {
+                args.Cancel(true);
+                args.Handled(true);
+            }
+        });
+
         UpdateTitle();
         _RecalculateAndApplyTabColor();
     }

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -528,6 +528,10 @@ namespace winrt::TerminalApp::implementation
                     // shell32 file picker manually.
                     std::wstring filename{ tab.Title() };
                     filename = til::clean_filename(filename);
+
+                    // GH#20188: yield before the dialog so that the Enter from the Command Palette doesn't leak into the terminal.
+                    // Low priority, so the Command Palette's close paints first.
+                    co_await wil::resume_foreground(Dispatcher(), CoreDispatcherPriority::Low);
                     path = co_await SaveFilePicker(*_hostingHwnd, [filename = std::move(filename)](auto&& dialog) {
                         THROW_IF_FAILED(dialog->SetClientGuid(clientGuidExportFile));
                         try

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -812,41 +812,10 @@ namespace winrt::TerminalApp::implementation
             // 1. We want to customize this behavior (e.g., use MRU logic)
             // 2. In fullscreen (GH#5799) and focus (GH#7916) modes the _OnTabItemsChanged is not fired
             // 3. When rearranging tabs (GH#7916) _OnTabItemsChanged is suppressed
-            const auto tabSwitchMode = _settings.GlobalSettings().TabSwitcherMode();
 
-            winrt::TerminalApp::Tab newSelectedTab{ nullptr };
-            if (tabSwitchMode == TabSwitcherMode::MostRecentlyUsed)
-            {
-                newSelectedTab = _mruTabs.GetAt(0);
-                _UpdatedSelectedTab(newSelectedTab);
-                _tabView.SelectedItem(newSelectedTab.TabViewItem());
-            }
-            else
-            {
-                // We can't use
-                //   auto selectedIndex = _tabView.SelectedIndex();
-                // Because this will always return -1 in this scenario unfortunately.
-                //
-                // So, what we're going to try to do is move the focus to the tab
-                // to the right, within the bounds of how many tabs we have.
-                //
-                // EX: we have 4 tabs: [A, B, C, D]. If we close:
-                // * A (tabIndex=0): We'll want to focus tab B (now in index 0)
-                // * B (tabIndex=1): We'll want to focus tab C (now in index 1)
-                // * C (tabIndex=2): We'll want to focus tab D (now in index 2)
-                // * D (tabIndex=3): We'll want to focus tab C (now in index 2)
-                const auto newSelectedIndex = std::clamp<int32_t>(tabIndex, 0, _tabs.Size() - 1);
-                // _UpdatedSelectedTab will do the work of setting up the new tab as
-                // the focused one, and unfocusing all the others.
-                newSelectedTab = _tabs.GetAt(newSelectedIndex);
-                _UpdatedSelectedTab(newSelectedTab);
-
-                // Also, we need to _manually_ set the SelectedItem of the tabView
-                // here. If we don't, then the TabView will technically not have a
-                // selected item at all, which can make things like ClosePane not
-                // work correctly.
-                _tabView.SelectedItem(newSelectedTab.TabViewItem());
-            }
+            const auto newSelectedTab = _mruTabs.GetAt(0);
+            _UpdatedSelectedTab(newSelectedTab);
+            _tabView.SelectedItem(newSelectedTab.TabViewItem());
 
             // Flush any deferred agent settings rebuild now that a
             // terminal tab is active. Per-tab model — no shared pane

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -251,6 +251,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             [weakThis = get_weak()](const auto& update) {
                 if (auto core{ weakThis.get() }; core && !core->_IsClosing())
                 {
+                    // GH#20219: re-evaluate if we're hovering over a hyperlink after scrolling
+                    core->_refreshHoveredCell();
                     core->ScrollPositionChanged.raise(*core, update);
                 }
             });
@@ -753,6 +755,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             _terminal->UserScrollViewport(viewTop);
         }
 
+        // GH#20219: re-evaluate if we're hovering over a hyperlink after scrolling
+        _refreshHoveredCell();
+
         const auto shared = _shared.lock_shared();
         if (shared->outputIdle)
         {
@@ -839,9 +844,20 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         _updateHoveredCell(std::optional<til::point>{ pos });
     }
+
     void ControlCore::ClearHoveredCell()
     {
         _updateHoveredCell(std::nullopt);
+    }
+
+    void ControlCore::_refreshHoveredCell()
+    {
+        if (_lastHoveredCell)
+        {
+            const auto cell = *_lastHoveredCell;
+            _lastHoveredCell.reset();
+            _updateHoveredCell(cell);
+        }
     }
 
     void ControlCore::_updateHoveredCell(const std::optional<til::point> terminalPosition)

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -357,6 +357,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void _connectionOutputHandler(winrt::array_view<const char16_t> str);
         void _connectionStateChangedHandler(const TerminalConnection::ITerminalConnection&, const Windows::Foundation::IInspectable&);
         void _updateHoveredCell(const std::optional<til::point> terminalPosition);
+        void _refreshHoveredCell();
         void _setOpacity(const float opacity, const bool focused = true);
 
         bool _isBackgroundTransparent();

--- a/src/cascadia/TerminalSettingsEditor/Appearances.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.cpp
@@ -12,6 +12,7 @@
 #include "Appearances.g.cpp"
 
 using namespace winrt::Windows::UI::Text;
+using namespace winrt::Windows::UI::Core;
 using namespace winrt::Windows::UI::Xaml;
 using namespace winrt::Windows::UI::Xaml::Controls;
 using namespace winrt::Windows::UI::Xaml::Data;
@@ -1221,8 +1222,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             fontSpec = fontName;
         }
 
-        sender.Text(fontSpec);
-
         // Normally we'd just update the model property in LostFocus above, but because WinUI is the Ralph Wiggum
         // among the UI frameworks, it raises the LostFocus event _before_ the QuerySubmitted event.
         // So, when you press Save, the model will have the wrong font face string, because LostFocus was raised too early.
@@ -1233,11 +1232,20 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // You can't just do IsSuggestionListOpen(false) either, because you can show the list with that property but not hide it.
         // So, we update the model manually and assign focus to the parent container.
         //
-        // BUT you can't just focus the parent container, because of a weird interaction with AutoSuggestBox where it'll refuse to lose
-        // focus if you picked a suggestion that matches the current fontSpec. So, we unfocus it first and then focus the parent container.
-        _updateFontName(fontSpec);
-        sender.Focus(FocusState::Unfocused);
-        FontFaceContainer().Focus(FocusState::Programmatic);
+        // Queue the selected-suggestion commit so AutoSuggestBox can finish processing Enter before we change its text/model.
+        // Do not manually unfocus the AutoSuggestBox here. Its Focus(FocusState::Unfocused) path crashes during keyboard commits.
+        Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [weakThis{ get_weak() }, weakSender{ winrt::make_weak(sender) }, fontSpec{ std::move(fontSpec) }]() {
+            if (const auto self{ weakThis.get() })
+            {
+                if (const auto box{ weakSender.get() })
+                {
+                    box.Text(fontSpec);
+                }
+
+                self->_updateFontName(fontSpec);
+                self->FontFaceContainer().Focus(FocusState::Programmatic);
+            }
+        });
     }
 
     void Appearances::FontFaceBox_TextChanged(const AutoSuggestBox& sender, const AutoSuggestBoxTextChangedEventArgs& args)

--- a/src/cascadia/TerminalSettingsEditor/Appearances.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.cpp
@@ -1189,13 +1189,25 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void Appearances::FontFaceBox_GotFocus(const Windows::Foundation::IInspectable& sender, const RoutedEventArgs&)
     {
+        const auto box = sender.as<AutoSuggestBox>();
         _updateFontNameFilter({});
-        sender.as<AutoSuggestBox>().IsSuggestionListOpen(true);
+        box.IsSuggestionListOpen(true);
+        _fontFaceBoxHasUserInput = false;
     }
 
     void Appearances::FontFaceBox_LostFocus(const IInspectable& sender, const RoutedEventArgs&)
     {
-        _updateFontName(sender.as<AutoSuggestBox>().Text());
+        const auto box = sender.as<AutoSuggestBox>();
+        if (_fontFaceBoxHasUserInput)
+        {
+            _updateFontName(box.Text());
+        }
+        else
+        {
+            // AutoSuggestBox restores its cached user query when Tab closes the suggestion list.
+            // Programmatic Text updates don't synchronize that cache, so restore the committed value.
+            box.Text(Appearance().FontFace());
+        }
     }
 
     void Appearances::FontFaceBox_QuerySubmitted(const AutoSuggestBox& sender, const AutoSuggestBoxQuerySubmittedEventArgs& args)
@@ -1237,6 +1249,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [weakThis{ get_weak() }, weakSender{ winrt::make_weak(sender) }, fontSpec{ std::move(fontSpec) }]() {
             if (const auto self{ weakThis.get() })
             {
+                self->_fontFaceBoxHasUserInput = false;
+
                 if (const auto box{ weakSender.get() })
                 {
                     box.Text(fontSpec);
@@ -1254,6 +1268,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         {
             return;
         }
+
+        _fontFaceBoxHasUserInput = true;
 
         const auto fontSpec = sender.Text();
         std::wstring_view filter{ fontSpec };

--- a/src/cascadia/TerminalSettingsEditor/Appearances.h
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.h
@@ -237,6 +237,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Windows::Foundation::Collections::IObservableVector<winrt::hstring> _FontAxesNames;
         Windows::Foundation::Collections::IObservableVector<winrt::hstring> _FontFeaturesNames;
         std::wstring _fontNameFilter;
+        bool _fontFaceBoxHasUserInput = false;
         bool _ShowAllFonts = false;
 
         static void _ViewModelChanged(const Windows::UI::Xaml::DependencyObject& d, const Windows::UI::Xaml::DependencyPropertyChangedEventArgs& e);

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -401,7 +401,14 @@ void SettingsLoader::FindFragmentsAndMergeIntoUserSettings(bool generateExtensio
     try
     {
         const auto catalog = AppExtensionCatalog::Open(AppExtensionHostName);
-        extensions = extractValueFromTaskWithoutMainThreadAwait(catalog.FindAllAsync());
+        if (auto catalog2{ catalog.try_as<IAppExtensionCatalog2>() })
+        {
+            extensions = catalog2.FindAll();
+        }
+        else
+        {
+            extensions = extractValueFromTaskWithoutMainThreadAwait(catalog.FindAllAsync());
+        }
     }
     CATCH_LOG();
 
@@ -423,20 +430,37 @@ void SettingsLoader::FindFragmentsAndMergeIntoUserSettings(bool generateExtensio
             continue;
         }
 
-        // Likewise, getting the public folder from an extension is an async operation.
-        auto foundFolder = extractValueFromTaskWithoutMainThreadAwait(ext.GetPublicFolderAsync());
-        if (!foundFolder)
+        winrt::hstring publicFolderPath;
+        if (auto ext3{ ext.try_as<IAppExtension3>() })
         {
-            continue;
+            // Windows 11 24H2 and above support a much faster, much less
+            // Windows.Storage-y API.
+            publicFolderPath = ext3.GetPublicPath();
+            if (publicFolderPath.empty())
+            {
+                // No point in falling through to GetPublicFolderAsync;
+                // it won't work.
+                continue;
+            }
+        }
+        else
+        {
+            // Likewise, getting the public folder from an extension is an async operation.
+            auto foundFolder = extractValueFromTaskWithoutMainThreadAwait(ext.GetPublicFolderAsync());
+            if (!foundFolder)
+            {
+                continue;
+            }
+
+            // the StorageFolder class has its own methods for obtaining the files within the folder
+            // however, all those methods are Async methods
+            // you may have noticed that we need to resort to clunky implementations for async operations
+            // (they are in extractValueFromTaskWithoutMainThreadAwait)
+            // so for now we will just take the folder path and access the files that way
+            publicFolderPath = foundFolder.Path();
         }
 
-        // the StorageFolder class has its own methods for obtaining the files within the folder
-        // however, all those methods are Async methods
-        // you may have noticed that we need to resort to clunky implementations for async operations
-        // (they are in extractValueFromTaskWithoutMainThreadAwait)
-        // so for now we will just take the folder path and access the files that way
-        const auto path = buildPath(foundFolder.Path(), FragmentsSubDirectory);
-
+        const auto path = buildPath(publicFolderPath, FragmentsSubDirectory);
         if (std::filesystem::is_directory(path))
         {
             // MSIX does not support machine-wide scope

--- a/src/cascadia/TerminalSettingsModel/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/de-DE/Resources.resw
@@ -518,6 +518,13 @@
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
     <value>Fensternamen zurücksetzen</value>
   </data>
+  <data name="OpenWorkspaceCommandKey" xml:space="preserve">
+    <value>Arbeitsbereich „{0}“ öffnen</value>
+    <comment>{0} will be replaced with the workspace name</comment>
+  </data>
+  <data name="OpenWorkspaceDefaultCommandKey" xml:space="preserve">
+    <value>Arbeitsbereich öffnen</value>
+  </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
     <value>Fenster umbenennen...</value>
   </data>
@@ -739,6 +746,9 @@
   </data>
   <data name="OpenCWDCommandKey" xml:space="preserve">
     <value>Aktuelles Arbeitsverzeichnis öffnen</value>
+  </data>
+  <data name="WorkspacesCommandKey" xml:space="preserve">
+    <value>Arbeitsbereiche...</value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>Registerkarte schließen</value>

--- a/src/cascadia/TerminalSettingsModel/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/es-ES/Resources.resw
@@ -518,6 +518,13 @@
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
     <value>Restablecer el nombre de la ventana</value>
   </data>
+  <data name="OpenWorkspaceCommandKey" xml:space="preserve">
+    <value>Abrir área de trabajo "{0}"</value>
+    <comment>{0} will be replaced with the workspace name</comment>
+  </data>
+  <data name="OpenWorkspaceDefaultCommandKey" xml:space="preserve">
+    <value>Abrir área de trabajo</value>
+  </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
     <value>Cambiar el nombre de la ventana...</value>
   </data>
@@ -739,6 +746,9 @@
   </data>
   <data name="OpenCWDCommandKey" xml:space="preserve">
     <value>Abrir directorio de trabajo actual</value>
+  </data>
+  <data name="WorkspacesCommandKey" xml:space="preserve">
+    <value>Áreas de trabajo...</value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>Cerrar pestaña</value>

--- a/src/cascadia/TerminalSettingsModel/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/fr-FR/Resources.resw
@@ -518,6 +518,13 @@
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
     <value>Réinitialiser le nom de la fenêtre</value>
   </data>
+  <data name="OpenWorkspaceCommandKey" xml:space="preserve">
+    <value>Ouvrir un espace de travail « {0} »</value>
+    <comment>{0} will be replaced with the workspace name</comment>
+  </data>
+  <data name="OpenWorkspaceDefaultCommandKey" xml:space="preserve">
+    <value>Ouvrir un espace de travail</value>
+  </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
     <value>Renommer la fenêtre...</value>
   </data>
@@ -739,6 +746,9 @@
   </data>
   <data name="OpenCWDCommandKey" xml:space="preserve">
     <value>Ouvrir le répertoire de travail actif</value>
+  </data>
+  <data name="WorkspacesCommandKey" xml:space="preserve">
+    <value>Espaces de travail...</value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>Fermer l’onglet</value>

--- a/src/cascadia/TerminalSettingsModel/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/it-IT/Resources.resw
@@ -518,6 +518,13 @@
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
     <value>Reimposta nome finestra</value>
   </data>
+  <data name="OpenWorkspaceCommandKey" xml:space="preserve">
+    <value>Apri area di lavoro "{0}"</value>
+    <comment>{0} will be replaced with the workspace name</comment>
+  </data>
+  <data name="OpenWorkspaceDefaultCommandKey" xml:space="preserve">
+    <value>Apri area di lavoro</value>
+  </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
     <value>Rinomina finestra...</value>
   </data>
@@ -739,6 +746,9 @@
   </data>
   <data name="OpenCWDCommandKey" xml:space="preserve">
     <value>Apri directory di lavoro corrente</value>
+  </data>
+  <data name="WorkspacesCommandKey" xml:space="preserve">
+    <value>Aree di lavoro...</value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>Chiudi scheda</value>

--- a/src/cascadia/TerminalSettingsModel/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/ja-JP/Resources.resw
@@ -518,6 +518,13 @@
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
     <value>ウィンドウの名前をリセットする</value>
   </data>
+  <data name="OpenWorkspaceCommandKey" xml:space="preserve">
+    <value>ワークスペース "{0}" を開く</value>
+    <comment>{0} will be replaced with the workspace name</comment>
+  </data>
+  <data name="OpenWorkspaceDefaultCommandKey" xml:space="preserve">
+    <value>ワークスペースを開く</value>
+  </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
     <value>ウィンドウの名前を変更...</value>
   </data>
@@ -739,6 +746,9 @@
   </data>
   <data name="OpenCWDCommandKey" xml:space="preserve">
     <value>現在の作業ディレクトリを開く</value>
+  </data>
+  <data name="WorkspacesCommandKey" xml:space="preserve">
+    <value>ワークスペース...</value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>タブを閉じる</value>

--- a/src/cascadia/TerminalSettingsModel/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/ko-KR/Resources.resw
@@ -518,6 +518,13 @@
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
     <value>창 이름 다시 설정</value>
   </data>
+  <data name="OpenWorkspaceCommandKey" xml:space="preserve">
+    <value>작업 영역 "{0}" 열기</value>
+    <comment>{0} will be replaced with the workspace name</comment>
+  </data>
+  <data name="OpenWorkspaceDefaultCommandKey" xml:space="preserve">
+    <value>작업 영역 열기</value>
+  </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
     <value>창 이름 바꾸기...</value>
   </data>
@@ -739,6 +746,9 @@
   </data>
   <data name="OpenCWDCommandKey" xml:space="preserve">
     <value>현재 작업 디렉터리 열기</value>
+  </data>
+  <data name="WorkspacesCommandKey" xml:space="preserve">
+    <value>작업 영역...</value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>탭 닫기</value>

--- a/src/cascadia/TerminalSettingsModel/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/pt-BR/Resources.resw
@@ -518,6 +518,13 @@
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
     <value>Definir nome da janela</value>
   </data>
+  <data name="OpenWorkspaceCommandKey" xml:space="preserve">
+    <value>Abrir workspace "{0}"</value>
+    <comment>{0} will be replaced with the workspace name</comment>
+  </data>
+  <data name="OpenWorkspaceDefaultCommandKey" xml:space="preserve">
+    <value>Abrir workspace</value>
+  </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
     <value>Renomear janela...</value>
   </data>
@@ -739,6 +746,9 @@
   </data>
   <data name="OpenCWDCommandKey" xml:space="preserve">
     <value>Abrir o diretório de trabalho atual</value>
+  </data>
+  <data name="WorkspacesCommandKey" xml:space="preserve">
+    <value>Workspaces...</value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>Fechar guia</value>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-ploc/Resources.resw
@@ -521,6 +521,13 @@
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
     <value>Ŗεšзť ωĩйδōẁ ñâмé !!! !!</value>
   </data>
+  <data name="OpenWorkspaceCommandKey" xml:space="preserve">
+    <value>Θрėń ẅöгķśрáςε "{0}" !!! !!!</value>
+    <comment>{0} will be replaced with the workspace name</comment>
+  </data>
+  <data name="OpenWorkspaceDefaultCommandKey" xml:space="preserve">
+    <value>Ŏρєπ ẃõѓķŝρãĉë !!! !</value>
+  </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
     <value>Ґёŉάmë шϊйďθŵ... !!! !</value>
   </data>
@@ -742,6 +749,9 @@
   </data>
   <data name="OpenCWDCommandKey" xml:space="preserve">
     <value>Öφěп сùяŗĕŉŧ ώθяќìⁿġ ðїгéćţοŗу !!! !!! !!!</value>
+  </data>
+  <data name="WorkspacesCommandKey" xml:space="preserve">
+    <value>Ẁøґкśрªčèŝ... !!! </value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>Ċĺōşě ţав !!!</value>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-ploca/Resources.resw
@@ -521,6 +521,13 @@
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
     <value>Ŗεšзť ωĩйδōẁ ñâмé !!! !!</value>
   </data>
+  <data name="OpenWorkspaceCommandKey" xml:space="preserve">
+    <value>Θрėń ẅöгķśрáςε "{0}" !!! !!!</value>
+    <comment>{0} will be replaced with the workspace name</comment>
+  </data>
+  <data name="OpenWorkspaceDefaultCommandKey" xml:space="preserve">
+    <value>Ŏρєπ ẃõѓķŝρãĉë !!! !</value>
+  </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
     <value>Ґёŉάmë шϊйďθŵ... !!! !</value>
   </data>
@@ -742,6 +749,9 @@
   </data>
   <data name="OpenCWDCommandKey" xml:space="preserve">
     <value>Öφěп сùяŗĕŉŧ ώθяќìⁿġ ðїгéćţοŗу !!! !!! !!!</value>
+  </data>
+  <data name="WorkspacesCommandKey" xml:space="preserve">
+    <value>Ẁøґкśрªčèŝ... !!! </value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>Ċĺōşě ţав !!!</value>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-plocm/Resources.resw
@@ -521,6 +521,13 @@
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
     <value>Ŗεšзť ωĩйδōẁ ñâмé !!! !!</value>
   </data>
+  <data name="OpenWorkspaceCommandKey" xml:space="preserve">
+    <value>Θрėń ẅöгķśрáςε "{0}" !!! !!!</value>
+    <comment>{0} will be replaced with the workspace name</comment>
+  </data>
+  <data name="OpenWorkspaceDefaultCommandKey" xml:space="preserve">
+    <value>Ŏρєπ ẃõѓķŝρãĉë !!! !</value>
+  </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
     <value>Ґёŉάmë шϊйďθŵ... !!! !</value>
   </data>
@@ -742,6 +749,9 @@
   </data>
   <data name="OpenCWDCommandKey" xml:space="preserve">
     <value>Öφěп сùяŗĕŉŧ ώθяќìⁿġ ðїгéćţοŗу !!! !!! !!!</value>
+  </data>
+  <data name="WorkspacesCommandKey" xml:space="preserve">
+    <value>Ẁøґкśрªčèŝ... !!! </value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>Ċĺōşě ţав !!!</value>

--- a/src/cascadia/TerminalSettingsModel/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/ru-RU/Resources.resw
@@ -518,6 +518,13 @@
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
     <value>Сбросить имя окна</value>
   </data>
+  <data name="OpenWorkspaceCommandKey" xml:space="preserve">
+    <value>Открыть рабочую область "{0}"</value>
+    <comment>{0} will be replaced with the workspace name</comment>
+  </data>
+  <data name="OpenWorkspaceDefaultCommandKey" xml:space="preserve">
+    <value>Открыть рабочую область</value>
+  </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
     <value>Переименовать окно...</value>
   </data>
@@ -739,6 +746,9 @@
   </data>
   <data name="OpenCWDCommandKey" xml:space="preserve">
     <value>Открыть текущую рабочую папку</value>
+  </data>
+  <data name="WorkspacesCommandKey" xml:space="preserve">
+    <value>Рабочие области...</value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>Закрыть вкладку</value>

--- a/src/cascadia/TerminalSettingsModel/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/zh-CN/Resources.resw
@@ -518,6 +518,13 @@
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
     <value>重置窗口名称</value>
   </data>
+  <data name="OpenWorkspaceCommandKey" xml:space="preserve">
+    <value>打开工作区“{0}”</value>
+    <comment>{0} will be replaced with the workspace name</comment>
+  </data>
+  <data name="OpenWorkspaceDefaultCommandKey" xml:space="preserve">
+    <value>打开工作区</value>
+  </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
     <value>重命名窗口...</value>
   </data>
@@ -739,6 +746,9 @@
   </data>
   <data name="OpenCWDCommandKey" xml:space="preserve">
     <value>打开当前工作目录</value>
+  </data>
+  <data name="WorkspacesCommandKey" xml:space="preserve">
+    <value>工作区...</value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>关闭标签页</value>

--- a/src/cascadia/TerminalSettingsModel/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/zh-TW/Resources.resw
@@ -518,6 +518,13 @@
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
     <value>重設視窗名稱</value>
   </data>
+  <data name="OpenWorkspaceCommandKey" xml:space="preserve">
+    <value>開啟工作區「{0}」</value>
+    <comment>{0} will be replaced with the workspace name</comment>
+  </data>
+  <data name="OpenWorkspaceDefaultCommandKey" xml:space="preserve">
+    <value>開啟工作區</value>
+  </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
     <value>重新命名視窗...</value>
   </data>
@@ -739,6 +746,9 @@
   </data>
   <data name="OpenCWDCommandKey" xml:space="preserve">
     <value>開啟目前的工作目錄</value>
+  </data>
+  <data name="WorkspacesCommandKey" xml:space="preserve">
+    <value>工作區...</value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>關閉索引標籤</value>

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -564,6 +564,15 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
         __assume(false);
     }
 
+    // !! LOAD BEARING !!
+    // This prevents loader lock contention with some versions of the nvidia
+    // driver, which calls SHGetKnownFolderPath triggering a delay load while
+    // under lock during application startup. See GH#20348.
+    {
+        wil::unique_cotaskmem_string localAppDataFolder;
+        SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localAppDataFolder);
+    }
+
     _app = winrt::TerminalApp::App{};
     _app.Logic().ReloadSettings();
 

--- a/src/cascadia/WindowsTerminal/pch.h
+++ b/src/cascadia/WindowsTerminal/pch.h
@@ -32,6 +32,7 @@ Abstract:
 #include <shellscalingapi.h>
 #include <windowsx.h>
 #include <ShObjIdl.h>
+#include <shlobj_core.h>
 
 // Manually include til after we include Windows.Foundation to give it winrt superpowers
 #define BLOCK_TIL

--- a/src/host/ConsoleArguments.cpp
+++ b/src/host/ConsoleArguments.cpp
@@ -110,47 +110,11 @@ ConsoleArguments::ConsoleArguments(const std::wstring& commandline,
     _vtInHandle(hStdIn),
     _vtOutHandle(hStdOut)
 {
-    _clientCommandline = L"";
-    _headless = false;
-    _runAsComServer = false;
-    _createServerHandle = true;
-    _serverHandle = 0;
-    _signalHandle = 0;
-    _forceV1 = false;
-    _forceNoHandoff = false;
-    _width = 0;
-    _height = 0;
-    _inheritCursor = false;
 }
 
 ConsoleArguments::ConsoleArguments() :
     ConsoleArguments(L"", nullptr, nullptr)
 {
-}
-
-ConsoleArguments& ConsoleArguments::operator=(const ConsoleArguments& other)
-{
-    if (this != &other)
-    {
-        _commandline = other._commandline;
-        _clientCommandline = other._clientCommandline;
-        _vtInHandle = other._vtInHandle;
-        _vtOutHandle = other._vtOutHandle;
-        _headless = other._headless;
-        _textMeasurement = other._textMeasurement;
-        _ambiguousIsWide = other._ambiguousIsWide;
-        _createServerHandle = other._createServerHandle;
-        _serverHandle = other._serverHandle;
-        _signalHandle = other._signalHandle;
-        _forceV1 = other._forceV1;
-        _width = other._width;
-        _height = other._height;
-        _inheritCursor = other._inheritCursor;
-        _runAsComServer = other._runAsComServer;
-        _forceNoHandoff = other._forceNoHandoff;
-    }
-
-    return *this;
 }
 
 // Routine Description:

--- a/src/host/ConsoleArguments.hpp
+++ b/src/host/ConsoleArguments.hpp
@@ -27,7 +27,7 @@ public:
 
     ConsoleArguments();
 
-    ConsoleArguments& operator=(const ConsoleArguments& other);
+    ConsoleArguments& operator=(const ConsoleArguments& other) = default;
 
     [[nodiscard]] HRESULT ParseCommandline();
 
@@ -114,25 +114,25 @@ private:
 
     std::wstring _clientCommandline;
 
-    HANDLE _vtInHandle;
+    HANDLE _vtInHandle = nullptr;
 
-    HANDLE _vtOutHandle;
+    HANDLE _vtOutHandle = nullptr;
 
     std::wstring _textMeasurement;
     bool _ambiguousIsWide = false;
 
-    bool _forceNoHandoff;
-    bool _forceV1;
-    bool _headless;
+    bool _forceNoHandoff = false;
+    bool _forceV1 = false;
+    bool _headless = false;
 
-    short _width;
-    short _height;
+    short _width = 0;
+    short _height = 0;
 
-    bool _runAsComServer;
-    bool _createServerHandle;
-    DWORD _serverHandle;
-    DWORD _signalHandle;
-    bool _inheritCursor;
+    bool _runAsComServer = false;
+    bool _createServerHandle = true;
+    DWORD _serverHandle = 0;
+    DWORD _signalHandle = 0;
+    bool _inheritCursor = false;
 
     [[nodiscard]] HRESULT _GetClientCommandline(_Inout_ std::vector<std::wstring>& args,
                                                 const size_t index,

--- a/src/host/ft_host/testmd.definition
+++ b/src/host/ft_host/testmd.definition
@@ -30,7 +30,7 @@
   "Plugins": [
     {
         "Type": "Microsoft.TestInfrastructure.UniversalTest.TestMD.Plugins.Etw.EtwPlugin",
-        "Name": "Collecting conhost logs during FTs",
+        "Name": "Collecting conhost logs during feature tests",
         "Parameters": {
             "$schema": "Microsoft.TestInfrastructure.UniversalTest.TestMD.Plugins.Etw.EtwPlugin-1.json",
             "Profiles": [

--- a/src/host/ft_host/testmd.definition
+++ b/src/host/ft_host/testmd.definition
@@ -11,6 +11,10 @@
   "Dependencies": {
     "Files": [ 
       {
+        "SourcePath": "$(PROJECT_ROOT)\\core\\console\\open\\src\\Terminal.wprp",
+        "DestinationFolderPath": "$$(TEST_DEPLOY_BIN)"
+      },
+      {
         "SourcePath": "$(PROJECT_ROOT)\\core\\console\\open\\src\\ConsolePerf.wprp",
         "DestinationFolderPath": "$$(TEST_DEPLOY_BIN)"
       },
@@ -23,7 +27,22 @@
     "Packages": [ "Microsoft.Console.Tools.Nihilist" ]
   },
   "Logs": [ ],
-  "Plugins": [ ],
+  "Plugins": [
+    {
+        "Type": "Microsoft.TestInfrastructure.UniversalTest.TestMD.Plugins.Etw.EtwPlugin",
+        "Name": "Collecting conhost logs during FTs",
+        "Parameters": {
+            "$schema": "Microsoft.TestInfrastructure.UniversalTest.TestMD.Plugins.Etw.EtwPlugin-1.json",
+            "Profiles": [
+                {
+                    "ProfileFile": "Terminal.wprp",
+                    "Profile": "DefTerm"
+                }
+            ],
+            "InstanceName": "conhost_FeatureTests"
+        }
+    }
+  ],
   "Profiles": [
     {
       "Name": "Performance",

--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -2328,7 +2328,7 @@ void BackendD3D::_executeCustomShader(RenderingPayload& p)
     {
         // See the comment in _recreateCustomShader() which initializes the two members below and explains what they do.
         const auto now = queryPerfCount();
-        const auto time = static_cast<int>(now % _customShaderPerfTickMod) * _customShaderSecsPerPerfTick;
+        const auto time = (now % _customShaderPerfTickMod) * _customShaderSecsPerPerfTick;
 
         const CustomConstBuffer data{
             .time = time,

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -58,6 +58,17 @@ void Renderer::EnablePainting()
     // but once EnablePainting is called it should be safe to retrieve.
     _viewport = _pData->GetViewport();
 
+    // _viewport feeds the cursor coordinate (_updateCursorInfo), while the engine's
+    // backing buffer (e.g. AtlasEngine's _p.rows) is sized from viewportCellCount,
+    // which only UpdateViewport() writes. If the viewport grew while painting was
+    // disabled, assigning _viewport here without forcing a resync would let the next
+    // _CheckViewportAndScroll() early-return (srOldViewport == srNewViewport) and skip
+    // UpdateViewport(), leaving the engine viewport - and thus the row buffer - behind
+    // _viewport. The cursor could then be reported as in-viewport at a row past the end
+    // of the buffer (GH#20269). Force the resync so the backing buffer is resized to
+    // match before the next cursor move is painted.
+    _forceUpdateViewport = true;
+
     _enable.SetEvent();
 
     if (const auto guard = _threadMutex.lock_exclusive(); !_thread)

--- a/src/terminal/adapter/FontBuffer.cpp
+++ b/src/terminal/adapter/FontBuffer.cpp
@@ -335,6 +335,11 @@ void FontBuffer::_addSixelValue(const VTInt value) noexcept
 void FontBuffer::_endOfSixelLine()
 {
     // Move down six rows to the get to the next sixel position.
+    if (_currentCharBuffer >= _buffer.end() || _sixelRow >= MAX_HEIGHT) [[unlikely]]
+    {
+        // Advancing the cursor beyond the last row is not OK.
+        THROW_HR(E_OUTOFMEMORY);
+    }
     std::advance(_currentCharBuffer, 6);
     _sixelRow += 6;
 

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -3995,7 +3995,15 @@ ITermDispatch::StringHandler AdaptDispatch::DownloadDRCS(const VTInt fontNumber,
         // with the constructed bit pattern.
         if (ch != AsciiChars::ESC)
         {
-            _fontBuffer->AddSixelData(ch);
+            try
+            {
+                _fontBuffer->AddSixelData(ch);
+            }
+            catch (...)
+            {
+                // Ignore all further content.
+                return false;
+            }
         }
         else if (_fontBuffer->FinalizeSixelData())
         {


### PR DESCRIPTION
> [!WARNING]
> **DO NOT squash-merge.** Preserves per-commit upstream attribution + the
> `(cherry picked from commit <sha>)` watermark trailers. Rebase-merge only.

**Third in the upstream-sync stack — merge LAST, after #409 then #410.**
Base is the workspaces branch (`dev/yeelam/upstream-workspaces-1282d56a3`).

Syncs the remaining **17** upstream commits (indices 13–30 of the backlog),
completing the catch-up to `microsoft/terminal` `66ac36e7a`.

## Picked
Clean: `47253ef22`, `0732b483a`, `d288fa09d`, `05b613cf0`, `0c4881bc9`,
`d0263b86a`, `dc4ce1c09`, `e58bd4bda`, `27da3bce6`, `129025be5`, `014418434`,
`20f586118`, `3e6068a48`, `dd494ac79`, `66ac36e7a`.

Skipped-empty (fork-owned README, take-ours): `d21b58035` "Update README.md".

## Conflicts resolved (keep-both)
- `8824b02a7` **Always use MRU tab focus on tab close** — kept upstream's
  always-MRU close behavior alongside the fork's `_FlushPendingAgentRebuild`.
- `65345e075` **Use Terrapin for OneBranch build** — kept the fork's
  `beforeRustBuildSteps`, added upstream's Terrapin feed/install steps.

Includes notable upstream fixes: xbox-controller crash (`0c4881bc9`), font-face
crash (`d288fa09d`), shader integer overflow (`27da3bce6`), nvidia-driver
deadlock pre-warm (`05b613cf0`), Windows SDK path from registry (`dc4ce1c09`).

## Validation
Resolution independently sanity-checked (no markers, trailers/attribution
intact, XML/JSON valid, braces balanced). **Full build/tests still pending** —
draft until validated. CI must gate.