### PR TITLE
Address Copilot review comments from upstream-sync (#409/#410/#411)

### DIFF
--- a/build/scripts/Merge-PriFiles.ps1
+++ b/build/scripts/Merge-PriFiles.ps1
@@ -27,7 +27,7 @@ If (-not $MakePriPath) {
 }
 
 If ($null -Eq (Get-Item $MakePriPath -EA:SilentlyContinue)) {
-    Write-Error "Could not find MakePriPath.exe at `"$MakePriPath`".`nMake sure that -MakePriPath points to a valid SDK."
+    Write-Error "Could not find MakePri.exe at `"$MakePriPath`".`nMake sure that -MakePriPath points to a valid SDK."
     Exit 1
 }
 

--- a/build/scripts/Merge-TerminalAndXamlResources.ps1
+++ b/build/scripts/Merge-TerminalAndXamlResources.ps1
@@ -28,7 +28,7 @@ If (-not $MakePriPath) {
 }
 
 If ($null -Eq (Get-Item $MakePriPath -EA:SilentlyContinue)) {
-    Write-Error "Could not find MakePriPath.exe at `"$MakePriPath`".`nMake sure that -MakePriPath points to a valid SDK."
+    Write-Error "Could not find MakePri.exe at `"$MakePriPath`".`nMake sure that -MakePriPath points to a valid SDK."
     Exit 1
 }
 

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -773,7 +773,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="WindowListUnnamedEntry" xml:space="preserve">
     <value>#{0} (unnamed)</value>
-    <comment>{locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
+    <comment>{Locked="{0}"}{0} is the window ID number. Shown in the workspace flyout for windows that have no name assigned.</comment>
   </data>
   <data name="DeleteWorkspaceMenuItem" xml:space="preserve">
     <value>Delete workspace?</value>
@@ -785,11 +785,11 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="ConfirmDeleteWorkspaceTitle" xml:space="preserve">
     <value>Delete "{0}"?</value>
-    <comment>{locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
+    <comment>{Locked="{0}"}{0} is the workspace name. Shown as the title of a confirmation dialog when the user tries to delete a saved workspace.</comment>
   </data>
   <data name="ConfirmDeleteWorkspaceBody" xml:space="preserve">
     <value>Are you sure you want to delete "{0}"? Sessions associated with this workspace will also be deleted.</value>
-    <comment>{locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
+    <comment>{Locked="{0}"}{0} is the workspace name. Body text of the confirmation dialog shown when the user tries to delete a saved workspace.</comment>
   </data>
   <data name="ConfirmDeleteWorkspaceDelete" xml:space="preserve">
     <value>Delete</value>

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -1115,7 +1115,7 @@ namespace winrt::TerminalApp::implementation
     // Method Description:
     // - Provide a pre-built list of startup actions for this window. Used by
     //   the in-proc OpenNewWindow event (see TerminalPage::_OpenNewWindow ->
-    //   TerminalWindow -> AppHost -> WindowEmperor::OpenNewWindow)
+    //   TerminalWindow -> AppHost -> WindowEmperor::CreateNewWindow)
     void TerminalWindow::SetStartupActions(const IVector<ActionAndArgs>& actions)
     {
         _initialContentArgs = wil::to_vector(actions);

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -573,6 +573,14 @@
     <value>Дозволи OSC 52 (Manipulate Selection Data) за упис у клипборд</value>
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
+  <data name="Profile_AllowOscNotifications.Header" xml:space="preserve">
+    <value>Allow OSC 777 (Desktop Notification) to show toast notifications</value>
+    <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
+  </data>
+  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+    <value>When enabled, applications can send the OSC 777 escape sequence to trigger a desktop notification with a custom title and body.</value>
+    <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
+  </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
     <value>Дозволи да се Интелигентни Терминал извршава у позадини</value>
     <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
@@ -668,6 +676,14 @@
   <data name="Nav_Launch.Content" xml:space="preserve">
     <value>Покретање</value>
     <comment>Header for the "startup" menu item. This navigates to a page that lets you see and modify settings related to the app's launch experience (i.e. screen position, mode, etc.)</comment>
+  </data>
+  <data name="Nav_PaneOpenedAnnouncement" xml:space="preserve">
+    <value>Navigation pane opened</value>
+    <comment>Screen reader announcement made when the user activates the toggle button that opens the settings navigation pane.</comment>
+  </data>
+  <data name="Nav_PaneClosedAnnouncement" xml:space="preserve">
+    <value>Navigation pane closed</value>
+    <comment>Screen reader announcement made when the user activates the toggle button that closes the settings navigation pane.</comment>
   </data>
   <data name="Nav_OpenJSON.Content" xml:space="preserve">
     <value>Отвори JSON датотеку</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -574,11 +574,11 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Profile_AllowOscNotifications.Header" xml:space="preserve">
-    <value>Allow OSC 777 (Desktop Notification) to show toast notifications</value>
+    <value>Дозволи да OSC 777 (Desktop Notification) приказује искачућа обавештења</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
   <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
-    <value>When enabled, applications can send the OSC 777 escape sequence to trigger a desktop notification with a custom title and body.</value>
+    <value>Када је омогућено, апликације могу да пошаљу управљачку секвенцу OSC 777 да би покренуле обавештење на радној површини са прилагођеним насловом и телом.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
@@ -678,11 +678,11 @@
     <comment>Header for the "startup" menu item. This navigates to a page that lets you see and modify settings related to the app's launch experience (i.e. screen position, mode, etc.)</comment>
   </data>
   <data name="Nav_PaneOpenedAnnouncement" xml:space="preserve">
-    <value>Navigation pane opened</value>
+    <value>Навигационо окно је отворено</value>
     <comment>Screen reader announcement made when the user activates the toggle button that opens the settings navigation pane.</comment>
   </data>
   <data name="Nav_PaneClosedAnnouncement" xml:space="preserve">
-    <value>Navigation pane closed</value>
+    <value>Навигационо окно је затворено</value>
     <comment>Screen reader announcement made when the user activates the toggle button that closes the settings navigation pane.</comment>
   </data>
   <data name="Nav_OpenJSON.Content" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -580,6 +580,14 @@
     <value>Дозволити OSC 52 (Manipulate Selection Data) записувати в буфер обміну</value>
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
+  <data name="Profile_AllowOscNotifications.Header" xml:space="preserve">
+    <value>Allow OSC 777 (Desktop Notification) to show toast notifications</value>
+    <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
+  </data>
+  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+    <value>When enabled, applications can send the OSC 777 escape sequence to trigger a desktop notification with a custom title and body.</value>
+    <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
+  </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
     <value>Дозволити Інтелектуальному Терміналу працювати у фоновому режимі</value>
     <comment>Header for a control to toggle support for Intelligent Terminal to run in the background.</comment>
@@ -675,6 +683,14 @@
   <data name="Nav_Launch.Content" xml:space="preserve">
     <value>Запуск</value>
     <comment>Header for the "startup" menu item. This navigates to a page that lets you see and modify settings related to the app's launch experience (i.e. screen position, mode, etc.)</comment>
+  </data>
+  <data name="Nav_PaneOpenedAnnouncement" xml:space="preserve">
+    <value>Navigation pane opened</value>
+    <comment>Screen reader announcement made when the user activates the toggle button that opens the settings navigation pane.</comment>
+  </data>
+  <data name="Nav_PaneClosedAnnouncement" xml:space="preserve">
+    <value>Navigation pane closed</value>
+    <comment>Screen reader announcement made when the user activates the toggle button that closes the settings navigation pane.</comment>
   </data>
   <data name="Nav_OpenJSON.Content" xml:space="preserve">
     <value>Відкрити JSON файл</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -581,11 +581,11 @@
     <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
   </data>
   <data name="Profile_AllowOscNotifications.Header" xml:space="preserve">
-    <value>Allow OSC 777 (Desktop Notification) to show toast notifications</value>
+    <value>Дозволити OSC 777 (Desktop Notification) показувати спливаючі сповіщення</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
   <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
-    <value>When enabled, applications can send the OSC 777 escape sequence to trigger a desktop notification with a custom title and body.</value>
+    <value>Якщо ввімкнено, застосунки можуть надсилати керуючу послідовність OSC 777 для запуску сповіщення робочого стола з довільними заголовком і текстом.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
@@ -685,11 +685,11 @@
     <comment>Header for the "startup" menu item. This navigates to a page that lets you see and modify settings related to the app's launch experience (i.e. screen position, mode, etc.)</comment>
   </data>
   <data name="Nav_PaneOpenedAnnouncement" xml:space="preserve">
-    <value>Navigation pane opened</value>
+    <value>Панель навігації відкрито</value>
     <comment>Screen reader announcement made when the user activates the toggle button that opens the settings navigation pane.</comment>
   </data>
   <data name="Nav_PaneClosedAnnouncement" xml:space="preserve">
-    <value>Navigation pane closed</value>
+    <value>Панель навігації закрито</value>
     <comment>Screen reader announcement made when the user activates the toggle button that closes the settings navigation pane.</comment>
   </data>
   <data name="Nav_OpenJSON.Content" xml:space="preserve">

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -570,7 +570,7 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
     // under lock during application startup. See GH#20348.
     {
         wil::unique_cotaskmem_string localAppDataFolder;
-        SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localAppDataFolder);
+        LOG_IF_FAILED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localAppDataFolder));
     }
 
     _app = winrt::TerminalApp::App{};

--- a/src/terminal/adapter/FontBuffer.cpp
+++ b/src/terminal/adapter/FontBuffer.cpp
@@ -334,13 +334,22 @@ void FontBuffer::_addSixelValue(const VTInt value) noexcept
 
 void FontBuffer::_endOfSixelLine()
 {
-    // Move down six rows to the get to the next sixel position.
-    if (_currentCharBuffer >= _buffer.end() || _sixelRow >= MAX_HEIGHT) [[unlikely]]
+    // Move down six rows to get to the next sixel position. The buffer
+    // is packed at _fullHeight rows per glyph, so clamp partial final sixel
+    // rows instead of letting the cursor advance into the next glyph.
+    if (_currentChar >= MAX_CHARS) [[unlikely]]
     {
-        // Advancing the cursor beyond the last row is not OK.
         THROW_HR(E_OUTOFMEMORY);
     }
-    std::advance(_currentCharBuffer, 6);
+
+    const auto currentCharEnd = std::next(_buffer.begin(), gsl::narrow_cast<size_t>((_currentChar + 1) * _fullHeight));
+    if (_currentCharBuffer >= currentCharEnd) [[unlikely]]
+    {
+        THROW_HR(E_OUTOFMEMORY);
+    }
+
+    const auto rowsRemaining = gsl::narrow_cast<VTInt>(std::distance(_currentCharBuffer, currentCharEnd));
+    std::advance(_currentCharBuffer, std::min<VTInt>(6, rowsRemaining));
     _sixelRow += 6;
 
     // Keep track of the maximum width and height covered by the sixel data.

--- a/src/terminal/adapter/FontBuffer.cpp
+++ b/src/terminal/adapter/FontBuffer.cpp
@@ -348,7 +348,16 @@ void FontBuffer::_endOfSixelLine()
     const auto currentCharEnd = std::next(_buffer.begin(), gsl::narrow_cast<size_t>((_currentChar + 1) * _fullHeight));
     const auto rowsRemaining = gsl::narrow_cast<VTInt>(std::distance(_currentCharBuffer, currentCharEnd));
     std::advance(_currentCharBuffer, std::clamp<VTInt>(rowsRemaining, 0, 6));
-    _sixelRow += 6;
+
+    // Advance the row counter, but saturate it so a hostile DECDLD payload
+    // with an unbounded number of sixel line breaks can't overflow the signed
+    // counter (signed overflow is UB). Glyphs are at most MAX_HEIGHT rows and
+    // bands are six rows tall, so a legitimate glyph never needs more than
+    // MAX_HEIGHT rounded up to the next band; capping there leaves all valid
+    // rendering (and the _usedHeight it feeds) unchanged. The cursor advance
+    // above is already clamped to the current glyph.
+    static constexpr auto maxSixelRow = (MAX_HEIGHT + 5) / 6 * 6;
+    _sixelRow = std::min(_sixelRow + 6, maxSixelRow);
 
     // Keep track of the maximum width and height covered by the sixel data.
     _usedWidth = std::max(_usedWidth, _sixelColumn);

--- a/src/terminal/adapter/FontBuffer.cpp
+++ b/src/terminal/adapter/FontBuffer.cpp
@@ -334,22 +334,20 @@ void FontBuffer::_addSixelValue(const VTInt value) noexcept
 
 void FontBuffer::_endOfSixelLine()
 {
-    // Move down six rows to get to the next sixel position. The buffer
-    // is packed at _fullHeight rows per glyph, so clamp partial final sixel
-    // rows instead of letting the cursor advance into the next glyph.
+    // Move down six rows to get to the next sixel position. The buffer is
+    // packed at _fullHeight rows per glyph, so clamp the advance to the
+    // current glyph's remaining rows. This keeps the cursor from spilling
+    // into the next glyph on a partial final band, while still allowing a
+    // glyph that fills _fullHeight exactly (and any trailing empty band that
+    // _endOfCharacter appends) without falsely reporting E_OUTOFMEMORY.
     if (_currentChar >= MAX_CHARS) [[unlikely]]
     {
         THROW_HR(E_OUTOFMEMORY);
     }
 
     const auto currentCharEnd = std::next(_buffer.begin(), gsl::narrow_cast<size_t>((_currentChar + 1) * _fullHeight));
-    if (_currentCharBuffer >= currentCharEnd) [[unlikely]]
-    {
-        THROW_HR(E_OUTOFMEMORY);
-    }
-
     const auto rowsRemaining = gsl::narrow_cast<VTInt>(std::distance(_currentCharBuffer, currentCharEnd));
-    std::advance(_currentCharBuffer, std::min<VTInt>(6, rowsRemaining));
+    std::advance(_currentCharBuffer, std::clamp<VTInt>(rowsRemaining, 0, 6));
     _sixelRow += 6;
 
     // Keep track of the maximum width and height covered by the sixel data.

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -3560,6 +3560,74 @@ public:
         VERIFY_IS_TRUE(decdld(CellMatrix::Default, 0, FontSet::Size132x24, FontUsage::FullCell, bitmapOf6x18));
     }
 
+    TEST_METHOD(SoftFontBufferOverrun)
+    {
+        // Regression test for _endOfSixelLine bounds handling. Glyphs are packed
+        // into the font buffer at _fullHeight rows each, so a glyph whose sixel
+        // data supplies more bands than its stride must not let the write cursor
+        // advance into the next glyph's slot (previously it clamped only against
+        // the whole-buffer end / MAX_HEIGHT), and an unbounded number of sixel
+        // line breaks must not overflow the signed row counter.
+        using FontSet = DispatchTypes::DrcsFontSet;
+        using FontUsage = DispatchTypes::DrcsFontUsage;
+
+        FontBuffer fontBuffer;
+
+        const auto loadGlyph = [&](const auto cmw, const auto cmh, const std::wstring_view data) {
+            const auto cellMatrix = static_cast<DispatchTypes::DrcsCellMatrix>(cmw);
+            if (!fontBuffer.SetEraseControl(DispatchTypes::DrcsEraseControl::AllChars))
+            {
+                return false;
+            }
+            if (!fontBuffer.SetAttributes(cellMatrix, cmh, FontSet::Size80x24, FontUsage::FullCell))
+            {
+                return false;
+            }
+            if (!fontBuffer.SetStartChar(0, DispatchTypes::CharsetSize::Size94))
+            {
+                return false;
+            }
+            fontBuffer.AddSixelData(L'B'); // Charset identifier
+            for (const auto ch : data)
+            {
+                fontBuffer.AddSixelData(ch);
+            }
+            return fontBuffer.FinalizeSixelData();
+        };
+
+        // A short (8x8) glyph fed far more sixel bands than its eight-row stride.
+        // Each '/' is a line break that flushes a band; supplying 12 of them
+        // drives the cursor well past the glyph. This must be handled without
+        // running the write cursor past the current glyph or off the buffer,
+        // and the resulting cell size must stay within the hard storage max.
+        Log::Comment(L"Short glyph with many trailing sixel bands");
+        const std::wstring shortGlyphOverrun{ L"????????" + std::wstring(12, L'/') };
+        loadGlyph(8, 8, shortGlyphOverrun);
+        VERIFY_IS_LESS_THAN_OR_EQUAL(fontBuffer.GetCellSize().width, 16);
+        VERIFY_IS_LESS_THAN_OR_EQUAL(fontBuffer.GetCellSize().height, 32);
+
+        // A pathological payload consisting only of sixel line breaks. The
+        // cursor advance is clamped and the row counter is saturated, so this
+        // must complete without signed-overflow UB and stay in bounds.
+        Log::Comment(L"Payload of only sixel line breaks");
+        const std::wstring onlyLineBreaks(4096, L'/');
+        loadGlyph(8, 8, onlyLineBreaks);
+        VERIFY_IS_LESS_THAN_OR_EQUAL(fontBuffer.GetCellSize().height, 32);
+
+        // A tall (16x32) glyph that exactly fills its stride, followed by extra
+        // bands. The exactly-full case must still finalize successfully rather
+        // than reporting a spurious E_OUTOFMEMORY.
+        Log::Comment(L"Full-height glyph that exactly fills its stride");
+        std::wstring fullHeightGlyph;
+        for (auto row = 0; row < 32 / 6 + 2; ++row)
+        {
+            fullHeightGlyph.append(L"????????????????");
+            fullHeightGlyph.push_back(L'/');
+        }
+        VERIFY_IS_TRUE(loadGlyph(16, 32, fullHeightGlyph));
+        VERIFY_IS_LESS_THAN_OR_EQUAL(fontBuffer.GetCellSize().height, 32);
+    }
+
     TEST_METHOD(TogglingC1ParserMode)
     {
         _stateMachine->SetParserMode(StateMachine::Mode::AcceptC1, false);

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -3602,7 +3602,7 @@ public:
         // and the resulting cell size must stay within the hard storage max.
         Log::Comment(L"Short glyph with many trailing sixel bands");
         const std::wstring shortGlyphOverrun{ L"????????" + std::wstring(12, L'/') };
-        loadGlyph(8, 8, shortGlyphOverrun);
+        VERIFY_IS_TRUE(loadGlyph(8, 8, shortGlyphOverrun));
         VERIFY_IS_LESS_THAN_OR_EQUAL(fontBuffer.GetCellSize().width, 16);
         VERIFY_IS_LESS_THAN_OR_EQUAL(fontBuffer.GetCellSize().height, 32);
 
@@ -3611,7 +3611,7 @@ public:
         // must complete without signed-overflow UB and stay in bounds.
         Log::Comment(L"Payload of only sixel line breaks");
         const std::wstring onlyLineBreaks(4096, L'/');
-        loadGlyph(8, 8, onlyLineBreaks);
+        VERIFY_IS_TRUE(loadGlyph(8, 8, onlyLineBreaks));
         VERIFY_IS_LESS_THAN_OR_EQUAL(fontBuffer.GetCellSize().height, 32);
 
         // A tall (16x32) glyph that exactly fills its stride, followed by extra

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -3562,70 +3562,103 @@ public:
 
     TEST_METHOD(SoftFontBufferOverrun)
     {
-        // Regression test for _endOfSixelLine bounds handling. Glyphs are packed
-        // into the font buffer at _fullHeight rows each, so a glyph whose sixel
-        // data supplies more bands than its stride must not let the write cursor
-        // advance into the next glyph's slot (previously it clamped only against
-        // the whole-buffer end / MAX_HEIGHT), and an unbounded number of sixel
-        // line breaks must not overflow the signed row counter.
+        // Regression test for _endOfSixelLine bounds handling. During sixel
+        // loading every glyph is stored at the maximum stride (MAX_HEIGHT rows),
+        // and _endOfCharacter always flushes one final _endOfSixelLine. Before
+        // the fix, a glyph whose sixel bands filled the stride made that final
+        // flush trip an E_OUTOFMEMORY (the row counter had reached the cap),
+        // spuriously rejecting valid tall DRCS glyphs; an unbounded run of sixel
+        // line breaks could also overflow the signed row counter (UB). The fix
+        // clamps the cursor advance to the current glyph and saturates the row
+        // counter.
         using FontSet = DispatchTypes::DrcsFontSet;
         using FontUsage = DispatchTypes::DrcsFontUsage;
 
-        FontBuffer fontBuffer;
-
-        const auto loadGlyph = [&](const auto cmw, const auto cmh, const std::wstring_view data) {
+        // Loads a full-cell font from DECDLD sixel data: '/' is a sixel line
+        // break, ';' separates character definitions.
+        const auto load = [](FontBuffer& fb, const VTInt cmw, const VTInt cmh, const std::wstring_view data) {
             const auto cellMatrix = static_cast<DispatchTypes::DrcsCellMatrix>(cmw);
-            if (!fontBuffer.SetEraseControl(DispatchTypes::DrcsEraseControl::AllChars))
+            if (!fb.SetEraseControl(DispatchTypes::DrcsEraseControl::AllChars) ||
+                !fb.SetAttributes(cellMatrix, cmh, FontSet::Size80x24, FontUsage::FullCell) ||
+                !fb.SetStartChar(0, DispatchTypes::CharsetSize::Size94))
             {
                 return false;
             }
-            if (!fontBuffer.SetAttributes(cellMatrix, cmh, FontSet::Size80x24, FontUsage::FullCell))
-            {
-                return false;
-            }
-            if (!fontBuffer.SetStartChar(0, DispatchTypes::CharsetSize::Size94))
-            {
-                return false;
-            }
-            fontBuffer.AddSixelData(L'B'); // Charset identifier
+            fb.AddSixelData(L'B'); // Charset identifier
             for (const auto ch : data)
             {
-                fontBuffer.AddSixelData(ch);
+                fb.AddSixelData(ch);
             }
-            return fontBuffer.FinalizeSixelData();
+            return fb.FinalizeSixelData();
         };
 
-        // A short (8x8) glyph fed far more sixel bands than its eight-row stride.
-        // Each '/' is a line break that flushes a band; supplying 12 of them
-        // drives the cursor well past the glyph. This must be handled without
-        // running the write cursor past the current glyph or off the buffer,
-        // and the resulting cell size must stay within the hard storage max.
-        Log::Comment(L"Short glyph with many trailing sixel bands");
-        const std::wstring shortGlyphOverrun{ L"????????" + std::wstring(12, L'/') };
-        VERIFY_IS_TRUE(loadGlyph(8, 8, shortGlyphOverrun));
-        VERIFY_IS_LESS_THAN_OR_EQUAL(fontBuffer.GetCellSize().width, 16);
-        VERIFY_IS_LESS_THAN_OR_EQUAL(fontBuffer.GetCellSize().height, 32);
+        // A band of '~' sets all six pixels of every column; a 16-wide full-cell
+        // row of them packs to 0xFFFF. '?' is a blank sixel (0x0000).
+        const std::wstring fullBand(16, L'~');
+        const std::wstring blankBand(16, L'?');
+        const auto buildBands = [](const std::wstring_view band, const int count) {
+            std::wstring out;
+            for (auto i = 0; i < count; ++i)
+            {
+                if (i)
+                {
+                    out.push_back(L'/');
+                }
+                out.append(band);
+            }
+            return out;
+        };
 
-        // A pathological payload consisting only of sixel line breaks. The
-        // cursor advance is clamped and the row counter is saturated, so this
-        // must complete without signed-overflow UB and stay in bounds.
-        Log::Comment(L"Payload of only sixel line breaks");
-        const std::wstring onlyLineBreaks(4096, L'/');
-        VERIFY_IS_TRUE(loadGlyph(8, 8, onlyLineBreaks));
-        VERIFY_IS_LESS_THAN_OR_EQUAL(fontBuffer.GetCellSize().height, 32);
-
-        // A tall (16x32) glyph that exactly fills its stride, followed by extra
-        // bands. The exactly-full case must still finalize successfully rather
-        // than reporting a spurious E_OUTOFMEMORY.
-        Log::Comment(L"Full-height glyph that exactly fills its stride");
-        std::wstring fullHeightGlyph;
-        for (auto row = 0; row < 32 / 6 + 2; ++row)
+        // Case 1 — a full-height (16x32) glyph whose bands more than fill the
+        // 32-row stride (8 bands = 48 rows). It must load without a spurious
+        // E_OUTOFMEMORY and retain all 32 rows of set pixels.
+        Log::Comment(L"Full-height glyph over-filled past its stride");
         {
-            fullHeightGlyph.append(L"????????????????");
-            fullHeightGlyph.push_back(L'/');
+            FontBuffer fb;
+            VERIFY_IS_TRUE(load(fb, 16, 32, buildBands(fullBand, 8)));
+            VERIFY_ARE_EQUAL(fb.GetCellSize().height, 32);
+            const auto bits = fb.GetBitPattern();
+            // GetBitPattern spans MAX_CHARS (96) glyphs of _fullHeight (32) rows.
+            VERIFY_ARE_EQUAL(bits.size(), gsl::narrow_cast<size_t>(96 * 32));
+            for (auto row = 0; row < 32; ++row)
+            {
+                VERIFY_ARE_EQUAL(bits[row], gsl::narrow_cast<uint16_t>(0xFFFF));
+            }
         }
-        VERIFY_IS_TRUE(loadGlyph(16, 32, fullHeightGlyph));
-        VERIFY_IS_LESS_THAN_OR_EQUAL(fontBuffer.GetCellSize().height, 32);
+
+        // Case 2 — an over-filled char 0 must not bleed into char 1's slot.
+        // Char 1 is left blank, so its 32 packed rows must all stay zero.
+        Log::Comment(L"Over-filled glyph must not corrupt the next glyph");
+        {
+            FontBuffer fb;
+            const auto data = buildBands(fullBand, 8) + L";" + blankBand;
+            VERIFY_IS_TRUE(load(fb, 16, 32, data));
+            const auto bits = fb.GetBitPattern();
+            for (auto row = 0; row < 32; ++row)
+            {
+                VERIFY_ARE_EQUAL(bits[32 + row], gsl::narrow_cast<uint16_t>(0x0000));
+            }
+        }
+
+        // Case 3 — a pathological payload of only sixel line breaks must not
+        // overflow the signed row counter and must still finalize in bounds.
+        Log::Comment(L"Payload of only sixel line breaks");
+        {
+            FontBuffer fb;
+            VERIFY_IS_TRUE(load(fb, 16, 32, std::wstring(4096, L'/')));
+            VERIFY_IS_LESS_THAN_OR_EQUAL(fb.GetCellSize().height, 32);
+        }
+
+        // Case 4 — a short declared glyph (8x8) fed far more bands than eight
+        // rows. Exercises the same over-fill path at a non-maximal declared
+        // height; must load in bounds.
+        Log::Comment(L"Short declared glyph over-filled");
+        {
+            FontBuffer fb;
+            VERIFY_IS_TRUE(load(fb, 8, 8, buildBands(fullBand, 12)));
+            VERIFY_IS_LESS_THAN_OR_EQUAL(fb.GetCellSize().height, 32);
+            VERIFY_IS_LESS_THAN_OR_EQUAL(fb.GetCellSize().width, 16);
+        }
     }
 
     TEST_METHOD(TogglingC1ParserMode)


### PR DESCRIPTION
Follow-up to the upstream-sync PRs #409 / #410 / #411 — addresses the GitHub Copilot review comments left on those (now-merged) PRs.

## Changes (8 files)
- **Text / comment fixes:** correct `WindowEmperor::OpenNewWindow`→`CreateNewWindow` comment (`TerminalWindow.cpp`); fix `MakePriPath.exe`→`MakePri.exe` in two build-script error messages; fix three `{locked=...}`→`{Locked=...}` translator tokens (`TerminalApp/.../en-US/Resources.resw`).
- **`WindowEmperor.cpp`:** log the `SHGetKnownFolderPath` HRESULT in the LocalAppData warm-up via `LOG_IF_FAILED` (still non-fatal) instead of silently ignoring it.
- **`FontBuffer.cpp` (DRCS soft fonts):** bound `_endOfSixelLine`'s cursor advance to the current glyph's `_fullHeight` stride. The prior guard bounded only by the whole-buffer end / `MAX_HEIGHT`, so for a glyph shorter than the max the `+6` advance could step past the glyph (and form an iterator past `_buffer.end()` — UB). Safe for every DRCS glyph size (hard-capped 16×32); does not affect normal Unicode/CJK text, which renders via DirectWrite.
- **Localization:** add the new OSC 777 + navigation-pane screen-reader keys to `sr-Cyrl-RS` and `uk-UA` (the only two locales missing them) with proper Serbian-Cyrillic / Ukrainian translations.

## Stabilized via Copilot review loop
Run to convergence on a fork PR (`yeelam-gordon/intelligent-terminal#2`): the final Copilot review reported **no new comments** with all threads resolved.

Two Copilot suggestions were **intentionally reverted to upstream** after review discussion (not customer bugs, and unjustified divergence from `microsoft/terminal`): the OSC 777 double-split micro-opt (`adaptDispatch.cpp`) and the empty-name `openWorkspace` → show-UI behavior (`AppActionHandlers.cpp`). Those two files therefore match upstream exactly and are not in this diff.

Built locally (VS 2026 / v145): **0 errors**.