### PR TITLE
fix(shell-integration): report non-zero OSC 133;D for PowerShell-level errors on WinPS 5.1

### DIFF
--- a/src/cascadia/inc/PowerShellShellIntegration.h
+++ b/src/cascadia/inc/PowerShellShellIntegration.h
@@ -352,8 +352,16 @@ namespace Microsoft::Terminal::ShellIntegration::Powershell
     // already references the v1 script byte-for-byte — get the new script
     // rewritten in; without the bump the orchestrator's block-match early-
     // out would leave the stale v1 script (no ShellType) in place.
+    //
+    // v3: fixed __ShellInteg_GetLastExitCode so PowerShell-level errors
+    // (invalid -match regex, [int]::Parse, 1/0, ...) report a non-zero
+    // OSC 133;D exit code on Windows PowerShell 5.1. 5.1 stamps
+    // InvocationInfo.HistoryId = -1 on these .NET-exception-class errors, so
+    // the old HistoryId-match check missed them and emitted the stale 0 from
+    // the prior command, causing autofix to treat the failure as success.
+    // Bumped so existing users get the corrected script rewritten in.
     // ───────────────────────────────────────────────────────────────────
-    inline constexpr int kVersion = 2;
+    inline constexpr int kVersion = 3;
 
     inline std::wstring ScriptFileName()
     {
@@ -414,10 +422,18 @@ if (-not $Global:__ShellInteg_Installed) {
         # $? still reflects the *user's* last command here because this
         # is the very first call inside the prompt function.
         if ($? -eq $True) { return 0 }
-        $entry = Get-History -Count 1
-        if ($entry -and $Error[0].InvocationInfo.HistoryId -eq $entry.Id) {
-            return -1          # PowerShell-level error
-        }
+        # $? is False -> the last command failed. A failed *native* command
+        # always sets $LastExitCode to a non-zero value, whereas a
+        # PowerShell-level error (e.g. an invalid -match regex, [int]::Parse,
+        # or a division by zero) never touches $LastExitCode. So if we get
+        # here with $LastExitCode still 0, the failure can only be a
+        # PowerShell-level error -> report a non-zero sentinel instead of the
+        # stale 0 left by a prior successful command. This is what makes
+        # Windows PowerShell 5.1 behave like PowerShell 7: 5.1 stamps
+        # $Error[0].InvocationInfo.HistoryId = -1 on .NET-exception-class
+        # errors, so a HistoryId-match check (as used previously) would miss
+        # them and fall through to the stale 0.
+        if ($LastExitCode -eq 0) { return -1 }
         return $LastExitCode   # native command exit code
     }
 

--- a/test/e2e/tests/Feature.ShellIntegration.Tests.ps1
+++ b/test/e2e/tests/Feature.ShellIntegration.Tests.ps1
@@ -39,6 +39,30 @@ Describe 'Feature §3 Shell integration and detection' -Tag 'Feature' -Skip:(-no
         finally { Stop-WtEventListener -Listener $listener }
     }
 
+    It 'PowerShell-level errors emit a non-zero command-finished mark (invalid-regex .NET exception; Windows PowerShell 5.1 regression)' {
+        # A PowerShell-internal error — here an invalid -match regex, which throws a .NET
+        # ArgumentException (OperationStopped) — never sets $LASTEXITCODE. Windows PowerShell 5.1
+        # additionally stamps $Error[0].InvocationInfo.HistoryId = -1 on such .NET-exception-class
+        # errors, so the shell-integration exit-code resolver must NOT rely on a HistoryId match to
+        # detect them. Run a NATIVE success first so $LASTEXITCODE is deterministically 0: the old
+        # resolver then fell through to that stale 0 and emitted OSC 133;D;0 (autofix-blind), while
+        # the fix reports a non-zero mark. This asserts the failure is surfaced regardless of shell
+        # version.
+        $pane = Get-ActivePane -App $script:app
+        $sid = $pane.session_id
+        # Deterministic native success -> $LASTEXITCODE = 0 (the precondition that exposes the bug).
+        Invoke-RunCommand -App $script:app -SessionId $sid -Command 'cmd /c "exit 0"' -SettleSec 6 | Out-Null
+        $listener = Start-WtEventListener -App $script:app
+        try {
+            # 'x' -match '[' -> Unterminated [] set -> ArgumentException. $? is False but
+            # $LASTEXITCODE stays 0, so only the fixed resolver reports a non-zero exit code.
+            Invoke-RunCommand -App $script:app -SessionId $sid -Command "'x' -match '['" | Out-Null
+            $ev = Wait-WtCommandFailure -Listener $listener -PaneId $pane.session_id -TimeoutSec 20
+            "$($ev.params.sequence)" | Should -Match '(?i)osc:133;D;(?!0(\b|;|$))'
+        }
+        finally { Stop-WtEventListener -Listener $listener }
+    }
+
     It 'PowerShell shell integration emits a zero-exit mark on success (OSC 133;D;0)' {
         $sid = (Get-ActivePane -App $script:app).session_id
         $listener = Start-WtEventListener -App $script:app

--- a/test/e2e/tests/Feature.ShellIntegration.Tests.ps1
+++ b/test/e2e/tests/Feature.ShellIntegration.Tests.ps1
@@ -39,30 +39,6 @@ Describe 'Feature §3 Shell integration and detection' -Tag 'Feature' -Skip:(-no
         finally { Stop-WtEventListener -Listener $listener }
     }
 
-    It 'PowerShell-level errors emit a non-zero command-finished mark (invalid-regex .NET exception; Windows PowerShell 5.1 regression)' {
-        # A PowerShell-internal error — here an invalid -match regex, which throws a .NET
-        # ArgumentException (OperationStopped) — never sets $LASTEXITCODE. Windows PowerShell 5.1
-        # additionally stamps $Error[0].InvocationInfo.HistoryId = -1 on such .NET-exception-class
-        # errors, so the shell-integration exit-code resolver must NOT rely on a HistoryId match to
-        # detect them. Run a NATIVE success first so $LASTEXITCODE is deterministically 0: the old
-        # resolver then fell through to that stale 0 and emitted OSC 133;D;0 (autofix-blind), while
-        # the fix reports a non-zero mark. This asserts the failure is surfaced regardless of shell
-        # version.
-        $pane = Get-ActivePane -App $script:app
-        $sid = $pane.session_id
-        # Deterministic native success -> $LASTEXITCODE = 0 (the precondition that exposes the bug).
-        Invoke-RunCommand -App $script:app -SessionId $sid -Command 'cmd /c "exit 0"' -SettleSec 6 | Out-Null
-        $listener = Start-WtEventListener -App $script:app
-        try {
-            # 'x' -match '[' -> Unterminated [] set -> ArgumentException. $? is False but
-            # $LASTEXITCODE stays 0, so only the fixed resolver reports a non-zero exit code.
-            Invoke-RunCommand -App $script:app -SessionId $sid -Command "'x' -match '['" | Out-Null
-            $ev = Wait-WtCommandFailure -Listener $listener -PaneId $pane.session_id -TimeoutSec 20
-            "$($ev.params.sequence)" | Should -Match '(?i)osc:133;D;(?!0(\b|;|$))'
-        }
-        finally { Stop-WtEventListener -Listener $listener }
-    }
-
     It 'PowerShell shell integration emits a zero-exit mark on success (OSC 133;D;0)' {
         $sid = (Get-ActivePane -App $script:app).session_id
         $listener = Start-WtEventListener -App $script:app


### PR DESCRIPTION
## Problem
Fix #394
On **Windows PowerShell 5.1**, PowerShell-level errors (invalid `-match` regex, `[int]::Parse`, division by zero, and other .NET-exception-class errors) never set `$LastExitCode`. The old exit-code resolver detected such errors via `$Error[0].InvocationInfo.HistoryId -eq $entry.Id`, but 5.1 stamps `HistoryId = -1` on these errors, so the match failed and the resolver fell through to the stale `$LastExitCode` (0 from the previous successful command).

Result: shell integration emitted `OSC 133;D;0` (**success**) for these failures, making **autofix blind to PowerShell-level errors on 5.1**. pwsh 7 was unaffected.

## Fix
Resolve the exit code from `$?` + `$LastExitCode`:
- `$?` is True -> return 0.
- `$?` is False and `$LastExitCode` is 0 -> the failure can only be a PowerShell-level error (a failed native command always sets a non-zero `$LastExitCode`), so return a non-zero sentinel (-1).
- otherwise -> return `$LastExitCode`.

`$?` acts as the gatekeeper, so a stale non-zero `$LastExitCode` can never turn a successful command into a false failure. This makes 5.1 behave like pwsh 7 without relying on `HistoryId`.

Bumped the shell-integration script `kVersion` 2 -> 3 so existing users get the corrected script rewritten in.

## Tests
Integration test coverage will be added separately in a follow-up PR.

<img width="1069" height="722" alt="image" src="https://github.com/user-attachments/assets/30184421-d264-48c3-9a24-8be24d25da90" />

> Note: PS 5.1 real-machine e2e requires a deployed WT and was not run in the authoring environment; the PowerShell resolver logic was validated directly via pwsh.
