### PR TITLE
Add store-listing-localizer agent skill

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -281,3 +281,14 @@ zzzzz
 axum
 dispatchable
 slowloris
+appnames
+csvlib
+enu
+Intelligentes
+kok
+msstore
+NMQC
+quz
+SSJX
+subtag
+Weergawe

--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -142,3 +142,4 @@ Resources/(?!en)
 ^\Qsrc/tools/lnkd/lnkd.bat\E$
 ^\Qsrc/tools/pixels/pixels.bat\E$
 ^test/e2e/
+^\Q.github/skills/store-listing-localizer/references/intelligent-terminal-translations.md\E$

--- a/.github/skills/store-listing-localizer/LICENSE.txt
+++ b/.github/skills/store-listing-localizer/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Microsoft Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.github/skills/store-listing-localizer/SKILL.md
+++ b/.github/skills/store-listing-localizer/SKILL.md
@@ -48,18 +48,25 @@ Track progress with a TODO list; each step links to its reference.
 1. **Export** the listing CSV from Partner Center —
    [partner-center-mcp-workflow.md#export](./references/partner-center-mcp-workflow.md).
    Copy the downloaded `listingData-9NMQC2SSJX24-*.csv` into a clean working dir.
-2. **Build the work order**: `node scripts/extract.mjs --csv <export.csv>
-   [--enus <overrides.json>] --out work-order.json`. Lists every translatable
-   field with its en-US source and which locales are stale.
+2. **Build the work order** — lists every translatable field with its en-US
+   source and which locales are stale:
+
+   ```bash
+   node scripts/extract.mjs --csv <export.csv> [--enus <overrides.json>] --out work-order.json
+   ```
 3. **Translate** each changed field into every target locale, following
    [localization-rules.md](./references/localization-rules.md) (locked tokens,
    `.resw` terminology alignment, RTL handling). Use per-language sub-agents for
    breadth + a reviewer pass. Emit `translations.json` keyed
    `{ "<locale>": { "<Field>": "<text>" } }`.
-4. **Merge**: `node scripts/apply.mjs --csv <export.csv>
-   [--appnames <translations.md>] --translations translations.json
-   [--enus overrides.json] [--changed-fields ReleaseNotes] --out <stem>-localized.csv`.
-   (`--appnames` defaults to the bundled `references/intelligent-terminal-translations.md`.)
+4. **Merge** (`--appnames` defaults to the bundled
+   `references/intelligent-terminal-translations.md`):
+
+   ```bash
+   node scripts/apply.mjs --csv <export.csv> [--appnames <translations.md>] \
+     --translations translations.json [--enus overrides.json] \
+     [--changed-fields ReleaseNotes] --out <stem>-localized.csv
+   ```
 5. **Verify** the output (cols/rows unchanged, spot-check locales), then
    **import** `<stem>-localized.csv` —
    [partner-center-mcp-workflow.md#import](./references/partner-center-mcp-workflow.md).

--- a/.github/skills/store-listing-localizer/SKILL.md
+++ b/.github/skills/store-listing-localizer/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: store-listing-localizer
+description: 'Automate Microsoft Store (Partner Center) listing localization for Intelligent Terminal (Store ID 9NMQC2SSJX24). Use when asked to export/import Store listings, localize release notes / descriptions / captions / features into 80+ languages, update listingData CSV, or push Store listing translations without manually clicking through Partner Center. Drives Partner Center export/import via the Playwright MCP and merges per-locale translations into the listingData CSV.'
+license: Complete terms in LICENSE.txt
+---
+
+# Store Listing Localizer
+
+End-to-end automation for localizing the Intelligent Terminal Microsoft Store
+listing: **export** the `listingData` CSV from Partner Center, **localize** the
+changed fields (release notes, description, captions, features) into all 80+
+Store locales using the repo's terminology rules, then **import** the result —
+without manually logging into and clicking through the Partner Center web UI.
+
+- Store ID: `9NMQC2SSJX24` ·
+  Overview: `https://partner.microsoft.com/en-us/dashboard/products/9NMQC2SSJX24/overview`
+- The CSV has 89 locale columns × ~450 field rows. See
+  [listing-csv-format.md](./references/listing-csv-format.md).
+
+## When to Use This Skill
+
+- "Export the Store listings and localize the release notes to all languages."
+- "The en-US release note changed — update every locale and re-import."
+- Updating Store description / screenshot captions / features across locales.
+- Any Partner Center listing export → translate → import round trip.
+- The new en-US text may come **from the export CSV** *or* **be given in the
+  prompt** (handled via en-US overrides — see below).
+
+## Prerequisites
+
+- **Playwright MCP** registered as `playwright` in `~/.copilot/mcp-config.json`
+  (`@playwright/mcp`, `--browser msedge`, dedicated `--user-data-dir`,
+  `--output-dir <repo>\Generated Files\playwright-mcp`). Write browser outputs
+  to a per-run subfolder `store-listing-localizer/<YYYY-MM-DD>/…` (pass that as
+  the `filename` subpath). **Restart Copilot CLI** after enabling it, then sign
+  into Partner Center once in the launched Edge window. Full setup + gotchas:
+  [partner-center-mcp-workflow.md](./references/partner-center-mcp-workflow.md).
+- **Node.js** (uses only built-ins; `scripts/` has no npm dependencies).
+- **AppName table**: `intelligent-terminal-translations.md` (per-locale product
+  names). Pass its path to `apply.mjs --appnames`.
+
+## Workflow
+
+Track progress with a TODO list; each step links to its reference.
+
+1. **Export** the listing CSV from Partner Center —
+   [partner-center-mcp-workflow.md#export](./references/partner-center-mcp-workflow.md).
+   Copy the downloaded `listingData-9NMQC2SSJX24-*.csv` into a clean working dir.
+2. **Build the work order**: `node scripts/extract.mjs --csv <export.csv>
+   [--enus <overrides.json>] --out work-order.json`. Lists every translatable
+   field with its en-US source and which locales are stale.
+3. **Translate** each changed field into every target locale, following
+   [localization-rules.md](./references/localization-rules.md) (locked tokens,
+   `.resw` terminology alignment, RTL handling). Use per-language sub-agents for
+   breadth + a reviewer pass. Emit `translations.json` keyed
+   `{ "<locale>": { "<Field>": "<text>" } }`.
+4. **Merge**: `node scripts/apply.mjs --csv <export.csv>
+   --appnames <translations.md> --translations translations.json
+   [--enus overrides.json] [--changed-fields ReleaseNotes] --out <stem>-localized.csv`.
+5. **Verify** the output (cols/rows unchanged, spot-check locales), then
+   **import** `<stem>-localized.csv` —
+   [partner-center-mcp-workflow.md#import](./references/partner-center-mcp-workflow.md).
+6. Review in the UI and **publish the submission** separately (import only
+   stages the listing).
+
+### en-US supplied in the prompt (not from the CSV)
+
+When the new en-US text is given in the prompt, write it to an overrides file
+and pass it to both scripts:
+
+```json
+// enus.json
+{ "ReleaseNotes": "Version v0.1.1600\n\n- New: ...\n- Fixed: ..." }
+```
+
+`--enus` updates the en-US column *and* marks the field as **changed**, so stale
+per-locale values are never preserved (see Gotchas).
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| [`scripts/extract.mjs`](./scripts/extract.mjs) | Build a translation work order (what to translate, into which locales). |
+| [`scripts/apply.mjs`](./scripts/apply.mjs) | Merge translations + AppName table into the export → `*-localized.csv`. |
+| [`scripts/fields.mjs`](./scripts/fields.mjs) | Field classification (appname / translate / verbatim) + AppName-table parser. |
+| [`scripts/csvlib.mjs`](./scripts/csvlib.mjs) | Quote-aware CSV parse/serialize (UTF-8 BOM + CRLF, embedded newlines). |
+
+Run any script with `--help` for its options.
+
+## Gotchas
+
+- **Stale translations are the #1 risk.** When an en-US field changes, every
+  locale still holds the *previous version's* text. Always pass `--enus` (or
+  `--changed-fields`) for changed fields so `apply.mjs` re-translates them
+  instead of keeping stale content. Verified: without this, a German release
+  note kept `v0.1.1531` while en-US moved to `v0.1.1600`.
+- **The Playwright MCP needs a CLI restart** to load, and a **dedicated** Edge
+  profile dir (never the live `Edge\User Data`, which is locked while Edge runs).
+- **Import ≠ publish.** Importing stages the draft listing; the submission must
+  be published separately.
+- **Never edit the `Field`/`ID`/`Type` columns** or split the CSV on raw
+  newlines — ReleaseNotes/Description contain embedded newlines. Use `csvlib.mjs`.
+- **Locale codes are lowercase** in the CSV (`zh-cn`), mixed-case in `.resw`
+  (`zh-CN`). Match case-insensitively when borrowing terminology.
+- **Version string is locked** (`Version v0.1.1600`) — copy verbatim per locale;
+  only translate the bullet text. Keep brand/tech tokens (`Copilot`, `CLI`,
+  `Agent pane`, `PowerShell`) in English.
+- **Product name IS localized in body text.** `apply.mjs` replaces "Intelligent
+  Terminal" inside Description/ReleaseNotes/Features with the locale's AppName
+  (matching the Title), e.g. de-DE "Intelligentes Terminal", zh-CN "智能终端".
+  This is URL-safe (the `github.com/microsoft/intelligent-terminal` URL is
+  untouched). Don't hand-keep the English name in translated bullets.
+- **ReleaseNotes has a hard 1500-character limit PER LOCALE** (Description
+  10000, ShortDescription 1000). Translations expand vs. English by up to
+  ~1.3–1.4×, so a 1280-char en-US ReleaseNotes produced 1680-char translations
+  that **failed the whole import mid-run** ("Processing failed" → View errors →
+  "ReleaseNotes is too long"). Keep en-US ReleaseNotes ≤ ~1100 chars and tell
+  the translation sub-agents the ≤1400 target explicitly. `apply.mjs` now
+  runs a length guard and exits non-zero listing any over-limit locale — never
+  import a CSV that failed that check.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| `browser_*` MCP tools not available | The Playwright MCP didn't load — restart Copilot CLI; confirm the `playwright` entry in `~/.copilot/mcp-config.json`. |
+| Export lands on a login page | Corp SSO session expired — complete the interactive Microsoft login + MFA in the Edge window, then retry. |
+| Profile-lock / "browser in use" error | `--user-data-dir` points at the live Edge profile; use the dedicated `msstore-playwright-profile` dir. |
+| Import rejected / mojibake | Output must be UTF-8 **BOM** + CRLF with unchanged col/row counts — `apply.mjs` does this; don't re-save the CSV in another editor. |
+| A locale shows the old version number | The field wasn't marked changed — re-run `apply.mjs` with `--enus`/`--changed-fields`. |
+
+## References
+
+- [partner-center-mcp-workflow.md](./references/partner-center-mcp-workflow.md) — Playwright MCP export/import steps, auth, selectors.
+- [listing-csv-format.md](./references/listing-csv-format.md) — CSV schema and field handling.
+- [localization-rules.md](./references/localization-rules.md) — terminology, locked tokens, `.resw` alignment.

--- a/.github/skills/store-listing-localizer/SKILL.md
+++ b/.github/skills/store-listing-localizer/SKILL.md
@@ -36,8 +36,10 @@ without manually logging into and clicking through the Partner Center web UI.
   into Partner Center once in the launched Edge window. Full setup + gotchas:
   [partner-center-mcp-workflow.md](./references/partner-center-mcp-workflow.md).
 - **Node.js** (uses only built-ins; `scripts/` has no npm dependencies).
-- **AppName table**: `intelligent-terminal-translations.md` (per-locale product
-  names). Pass its path to `apply.mjs --appnames`.
+- **AppName table** — the per-locale product names ship with the skill at
+  [`references/intelligent-terminal-translations.md`](./references/intelligent-terminal-translations.md),
+  and `apply.mjs` defaults to it. Override with `--appnames <path>` only if you
+  maintain a newer copy elsewhere.
 
 ## Workflow
 
@@ -55,8 +57,9 @@ Track progress with a TODO list; each step links to its reference.
    breadth + a reviewer pass. Emit `translations.json` keyed
    `{ "<locale>": { "<Field>": "<text>" } }`.
 4. **Merge**: `node scripts/apply.mjs --csv <export.csv>
-   --appnames <translations.md> --translations translations.json
+   [--appnames <translations.md>] --translations translations.json
    [--enus overrides.json] [--changed-fields ReleaseNotes] --out <stem>-localized.csv`.
+   (`--appnames` defaults to the bundled `references/intelligent-terminal-translations.md`.)
 5. **Verify** the output (cols/rows unchanged, spot-check locales), then
    **import** `<stem>-localized.csv` —
    [partner-center-mcp-workflow.md#import](./references/partner-center-mcp-workflow.md).
@@ -90,10 +93,14 @@ Run any script with `--help` for its options.
 ## Gotchas
 
 - **Stale translations are the #1 risk.** When an en-US field changes, every
-  locale still holds the *previous version's* text. Always pass `--enus` (or
-  `--changed-fields`) for changed fields so `apply.mjs` re-translates them
-  instead of keeping stale content. Verified: without this, a German release
-  note kept `v0.1.1531` while en-US moved to `v0.1.1600`.
+  locale still holds the *previous version's* text. `apply.mjs` has an
+  **automatic version-drift safety net**: for any field whose en-US value
+  carries a `v<x.y.z>` token (e.g. ReleaseNotes), a locale whose existing text
+  has a *different* token is treated as stale and refreshed to the new en-US —
+  even if you forget `--changed-fields`. Still pass `--enus` (or
+  `--changed-fields`) for changed fields to be explicit; the guard is a backstop.
+  Verified: without any flag, a German release note that kept `v0.1.1531` while
+  en-US moved to `v0.1.1600` is now auto-refreshed.
 - **The Playwright MCP needs a CLI restart** to load, and a **dedicated** Edge
   profile dir (never the live `Edge\User Data`, which is locked while Edge runs).
 - **Import ≠ publish.** Importing stages the draft listing; the submission must

--- a/.github/skills/store-listing-localizer/references/intelligent-terminal-translations.md
+++ b/.github/skills/store-listing-localizer/references/intelligent-terminal-translations.md
@@ -1,0 +1,95 @@
+﻿# Intelligent Terminal — Localized Names by Locale
+
+| Locale | AppName |
+|--------|---------|
+| af-ZA | Intelligente Terminaal |
+| am-ET | ብልህ ተርሚናል |
+| ar-SA | الوحدة الطرفية الذكية |
+| as-IN | ইন্টেলিজেন্ট টাৰ্মিনেল |
+| az-Latn-AZ | Ağıllı Terminal |
+| bg-BG | Интелигентен Терминал |
+| bn-IN | ইন্টেলিজেন্ট টার্মিনাল |
+| bs-Latn-BA | Inteligentni Terminal |
+| ca-ES | Terminal Intel·ligent |
+| ca-Es-VALENCIA | Terminal Intel·ligent |
+| cs-CZ | Inteligentní Terminál |
+| cy-GB | Terfynell Ddeallus |
+| da-DK | Intelligent Terminal |
+| de-DE | Intelligentes Terminal |
+| el-GR | Έξυπνο Τερματικό |
+| en-GB | Intelligent Terminal |
+| en-US | Intelligent Terminal |
+| es-ES | Terminal Inteligente |
+| es-MX | Terminal Inteligente |
+| et-EE | Nutikas Terminal |
+| eu-ES | Terminal Adimenduna |
+| fa-IR | پایانه هوشمند |
+| fi-FI | Älykäs Pääte |
+| fil-PH | Matalinong Terminal |
+| fr-CA | Terminal Intelligent |
+| fr-FR | Terminal Intelligent |
+| ga-IE | Teirminéal Cliste |
+| gd-gb | Tèirmineal Glic |
+| gl-ES | Terminal Intelixente |
+| gu-IN | ઇન્ટેલિજન્ટ ટર્મિનલ |
+| he-IL | מסוף חכם |
+| hi-IN | इंटेलिजेंट टर्मिनल |
+| hr-HR | Inteligentni Terminal |
+| hu-HU | Intelligens Terminál |
+| hy-AM | Խելացի տերմինալ |
+| id-ID | Terminal Cerdas |
+| is-IS | Snjallútstöð |
+| it-IT | Terminale Intelligente |
+| ja-JP | インテリジェント ターミナル |
+| ka-GE | ჭკვიანი ტერმინალი |
+| kk-KZ | Зияткер терминал |
+| km-KH | ស្ថានីយឆ្លាតវៃ |
+| kn-IN | ಇಂಟೆಲಿಜೆಂಟ್ ಟರ್ಮಿನಲ್ |
+| ko-KR | 지능형 터미널 |
+| kok-IN | इंटेलिजंट टर्मिनल |
+| lb-LU | Intelligenten Terminal |
+| lo-LA | ເທອຮ໌ມິນັລອັດຊະລິຍະ |
+| lt-LT | Išmanusis Terminalas |
+| lv-LV | Viedais Terminālis |
+| mi-NZ | Iho Atamai |
+| mk-MK | Интелигентен Терминал |
+| ml-IN | ഇന്റലിജന്റ് ടെർമിനൽ |
+| mr-IN | इंटेलिजंट टर्मिनल |
+| ms-MY | Terminal Pintar |
+| mt-MT | Terminal Intelliġenti |
+| nb-NO | Intelligent Terminal |
+| ne-NP | इन्टेलिजेन्ट टर्मिनल |
+| nl-NL | Intelligente Terminal |
+| nn-NO | Intelligent Terminal |
+| or-IN | ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନାଲ |
+| pa-IN | ਇੰਟੈਲੀਜੈਂਟ ਟਰਮੀਨਲ |
+| pl-PL | Inteligentny Terminal |
+| pt-BR | Terminal Inteligente |
+| pt-PT | Terminal Inteligente |
+| qps-ploc | Terminal |
+| qps-ploca | Terminal |
+| qps-plocm | Terminal |
+| quz-PE | Yuyaysapa Terminal |
+| ro-RO | Terminal Inteligent |
+| ru-RU | Интеллектуальный Терминал |
+| sk-SK | Inteligentný Terminál |
+| sl-SI | Inteligentni Terminal |
+| sq-AL | Terminali inteligjent |
+| sr-Cyrl-BA | Интелигентни Терминал |
+| sr-Cyrl-RS | Интелигентни Терминал |
+| sr-Latn-RS | Inteligentni Terminal |
+| sv-SE | Intelligent Terminal |
+| ta-IN | அறிவாண் முனையம் |
+| te-IN | ఇంటెలిజెంట్ టెర్మినల్ |
+| th-TH | เทอร์มินัลอัจฉริยะ |
+| tr-TR | Akıllı Terminal |
+| tt-RU | Акыллы терминал |
+| ug-CN | ئەقلىي تېرمىنال |
+| uk-UA | Інтелектуальний Термінал |
+| ur-PK | ذہین ٹرمینل |
+| uz-Latn-UZ | Aqlli terminal |
+| vi-VN | Đầu cuối thông minh |
+| zh-CN | 智能终端 |
+| zh-TW | 智慧終端機 |
+
+_89 locales total (including 3 pseudo-locales: qps-ploc, qps-ploca, qps-plocm)_

--- a/.github/skills/store-listing-localizer/references/listing-csv-format.md
+++ b/.github/skills/store-listing-localizer/references/listing-csv-format.md
@@ -1,0 +1,70 @@
+# listingData CSV format (Partner Center export/import)
+
+The Partner Center **Export listings** button produces a UTF-8 (BOM),
+comma-delimited, CRLF CSV. Each **row** is one listing field; each **column** is
+one locale. Values legitimately contain embedded newlines (ReleaseNotes,
+Description), so always parse with a quote-aware parser — `scripts/csvlib.mjs`
+does this; never split on `\n` or use a naive CSV reader.
+
+## Shape (Intelligent Terminal, Store ID `9NMQC2SSJX24`)
+
+- **93 columns**: `Field`, `ID`, `Type (Type)`, `default`, then **89 locale
+  columns** starting at `en-us`, `en-gb`, … `zh-tw`.
+- **~450 field rows**: `Description`, `ReleaseNotes`, `Title`, screenshots,
+  captions, features, search terms, trailers, logos, hardware reqs, etc.
+- Locale codes are **lowercase** (`zh-cn`, not `zh-CN`). Look them up
+  case-insensitively (`findLocaleCol`).
+- **Never edit** the `Field`, `ID`, or `Type` columns — only locale columns.
+
+## Field handling (see `scripts/fields.mjs`)
+
+| Class | Fields | Behavior |
+|-------|--------|----------|
+| **appname** | `Title` | Filled from the per-locale AppName table (`intelligent-terminal-translations.md`). Falls back to en-US if a locale is missing. |
+| **translate** | `Description`, `ReleaseNotes`, `ShortTitle`/`SortTitle`/`VoiceTitle`, `ShortDescription`, `Feature1..20`, `*ScreenshotCaption*`, `SearchTerm*`, `MinimumHardwareReq*`, `RecommendedHardwareReq*`, `TrailerTitle*` | Localized per locale. Uses provided translation → else (if field unchanged) keeps existing → else falls back to en-US. |
+| **verbatim** | everything else: `*Screenshot\d+` (URLs), `*Logo*`, `*Promo*`, `Trailer\d+`/`TrailerThumbnail*`, `OverrideLogosForWin10`, `DevStudio`, `PublisherName`, `CopyrightTrademarkInformation`, `AdditionalLicenseTerms` | Copied from en-US into **empty** locale cells only; existing values left untouched. Never translated. |
+
+## Field character limits (hard Store rejects)
+
+Partner Center enforces per-locale maximum lengths and **fails the entire
+import** if any locale exceeds them (error surfaces as "Processing failed" →
+**View errors** → e.g. "ReleaseNotes is too long (must be 1500 characters or
+fewer)").
+
+| Field | Max chars (per locale) |
+|-------|------------------------|
+| ReleaseNotes | **1500** |
+| Description | 10000 |
+| ShortDescription | 1000 |
+
+> **Translations expand.** Observed expansion vs. en-US is up to ~1.3–1.4× for
+> verbose languages (Scottish Gaelic, French, Greek, German, Tamil). A 1280-char
+> en-US ReleaseNotes yielded 1680-char translations that failed import. **Keep
+> en-US ReleaseNotes ≤ ~1100 chars**, and instruct translation sub-agents to
+> cap output at ≤1400 (condensing wording, never dropping a bullet).
+> `apply.mjs` runs a length guard and exits non-zero listing any over-limit
+> locale — treat that as a hard stop before importing.
+
+## The stale-translation trap (most important)
+
+When an en-US field changes (e.g. a new `ReleaseNotes` version), the other
+locales still hold the **previous version's** translation. Blindly "keeping
+existing non-empty" would ship stale notes (wrong version number, missing new
+bullets). `apply.mjs` treats any field with an en-US override — or listed in
+`--changed-fields` — as **changed**: it never keeps the old per-locale value;
+it uses the supplied translation, or falls back to the new en-US text. Always
+mark changed fields so stale content can't survive.
+
+## ReleaseNotes specifics
+
+- Format: `Version v<x.y.zzzz>\n\n- bullet\n- bullet…`.
+- The **version string** (`Version v0.1.1600`) is **locked** — copy verbatim in
+  every locale; only translate the bullet text.
+- Product nouns inside bullets (`Agent pane`, `CLI`, `Copilot`, `PowerShell`)
+  follow the locked-token rules in `localization-rules.md`.
+
+## Output
+
+`apply.mjs` writes `<stem>-localized.csv` next to the source with **UTF-8 BOM +
+CRLF** (matching the export) so Partner Center accepts it on import. It preserves
+row/column counts exactly — verify `cols`/`rows` are unchanged before importing.

--- a/.github/skills/store-listing-localizer/references/localization-rules.md
+++ b/.github/skills/store-listing-localizer/references/localization-rules.md
@@ -1,0 +1,88 @@
+# Localization rules for Store listing text
+
+Store-listing localization reuses the **same terminology and locked-token
+discipline** as the repo's `.resw` UI localization. The CSV is a different file
+format, but the *word choices* must stay consistent with the shipped UI so the
+product reads the same in the Store and in the app.
+
+## Source of truth, in priority order
+
+When translating a term, resolve it using these sources **in order** (this
+mirrors `.github/instructions/localization.instructions.md`):
+
+1. **Existing `.resw` translations** in this repo — the authoritative term bank:
+   - `src/cascadia/TerminalApp/Resources/<locale>/Resources.resw`
+   - `src/cascadia/TerminalSettingsEditor/Resources/<locale>/Resources.resw`
+   - `src/cascadia/TerminalSettingsModel/Resources/<locale>/Resources.resw`
+2. **Rust WTA translations** — `tools/wta/locales/<locale>.yml`.
+3. **Microsoft Learn localized docs** — `learn.microsoft.com/<locale>/...` for
+   Microsoft-standard terms not yet in the repo.
+4. Community/established usage; if no native term fits, keep English or
+   transliterate.
+
+> **Locale code mapping.** The CSV uses lowercase hyphen codes (`zh-cn`,
+> `pt-br`); `.resw` folders use mixed case (`zh-CN`, `pt-BR`). Match them
+> case-insensitively when borrowing a term.
+
+## Locked tokens — copy verbatim in every locale
+
+Never translate these (same list as the `.resw` rules):
+
+| Token | Why |
+|-------|-----|
+| `Copilot`, `Claude`, `Gemini` | Brand names |
+| `CLI`, `ACP`, `PATH` | Technical acronyms / env var |
+| `PowerShell` | Product name |
+| `JSON`, `YAML`, `XML` | Formats |
+| `Hooks` / `Hook` | Technical term |
+| `Agent pane` | Product feature name — keep "Agent" as the AI-agent sense |
+| `Version v<x.y.zzzz>` | Release-notes version string |
+
+> **"Agent" means an AI agent**, not a proxy or human agent. Each locale may
+> differ — e.g. zh-CN uses 智能体 (per Azure AI Foundry docs), **not** 代理.
+> Always verify against the `.resw` term bank for that locale.
+
+## Product name
+
+The localized product name per locale comes from
+`intelligent-terminal-translations.md` (the AppName table). `apply.mjs` fills
+`Title` from it automatically, **and also localizes the product name inside
+translatable body text** (Description, ReleaseNotes, Features) so the body
+matches the Title — e.g. de-DE "Intelligentes Terminal", zh-CN "智能终端",
+fr-FR "Terminal Intelligent". Some locales keep the English "Intelligent
+Terminal" (e.g. `en-GB`, `da-DK`); that is intentional — the table value is used
+verbatim.
+
+> **URL-safe.** The replacement only touches the spaced, capitalized product
+> name "Intelligent Terminal". The GitHub URL form
+> `github.com/microsoft/intelligent-terminal` (hyphenated, lowercase) is never
+> altered. Disable the behavior with `apply.mjs --no-localize-product-name`.
+>
+> **Therefore: do NOT keep "Intelligent Terminal" English inside release-note
+> bullets when translating** — let `apply.mjs` substitute the localized AppName.
+> Translators should translate the surrounding sentence and may leave the
+> product name as the en-US "Intelligent Terminal" placeholder; the script
+> localizes it.
+
+## Per-language workflow (for the agent)
+
+For each target locale that needs a changed field translated:
+1. Read the new en-US source (from the work order or the prompt).
+2. Pull established terms from the `.resw` term bank for that locale (step 1
+   above) so wording matches the shipped UI.
+3. Translate the free text; keep every locked token in English; keep the
+   `Version v…` string verbatim.
+4. For RTL locales (`ar-SA`, `he-IL`, `fa-IR`, `ur-PK`), keep logical order;
+   don't reorder the version string or punctuation manually.
+5. Emit the result into the `translations.json` consumed by `apply.mjs`, keyed
+   `{ "<locale>": { "<Field>": "<text>" } }`.
+
+Use per-language sub-agents for breadth (80+ locales), then a reviewer pass that
+checks: locked tokens intact, version string verbatim, terminology aligned with
+`.resw`, no encoding mojibake.
+
+## What not to localize
+
+Screenshot/logo/trailer URLs, `OverrideLogosForWin10`, and other asset/boolean
+fields are `verbatim` — see `listing-csv-format.md`. Screenshot **captions**,
+however, *are* translatable text.

--- a/.github/skills/store-listing-localizer/references/partner-center-mcp-workflow.md
+++ b/.github/skills/store-listing-localizer/references/partner-center-mcp-workflow.md
@@ -1,0 +1,91 @@
+# Partner Center automation via the Playwright MCP
+
+The export/import steps drive `https://partner.microsoft.com` in a real Edge
+browser through the **Playwright MCP** (`@playwright/mcp`). Partner Center is
+gated by Microsoft corp SSO + MFA, so automation relies on a **persistent
+browser profile** that holds the signed-in session — you log in once, then every
+later run reuses the cookies. There is no password or secret in this skill.
+
+## One-time setup
+
+1. The MCP is registered in `~/.copilot/mcp-config.json` as `playwright` with:
+   - `--browser msedge`
+   - `--user-data-dir C:\Users\<you>\AppData\Local\msstore-playwright-profile`
+     (a **dedicated** profile dir — never your live Edge `User Data`, which is
+     locked while Edge runs).
+   - `--output-dir <repo>\Generated Files\playwright-mcp` (the gitignored
+     `**/Generated Files/` root). This is a **static root** shared by every
+     Playwright use — see **Output location** below for the per-run nesting.
+2. **Restart Copilot CLI** after the config changes — MCP servers load at
+   startup, so a newly-added server is not available mid-session.
+3. First run only: navigate to the dashboard and complete the interactive
+   Microsoft login + MFA in the launched Edge window. The session persists in
+   the profile dir for subsequent runs.
+
+## Output location
+
+`--output-dir` is a **single static root** set at MCP launch, so every Playwright
+purpose would otherwise dump files into the same flat folder. Keep runs isolated
+by passing a **relative subpath** in the `filename` argument of `browser_*` save
+tools (`browser_pdf_save`, `browser_take_screenshot`, …) — the MCP resolves it
+under the root and creates subdirectories as needed. Convention:
+
+```
+<output-dir>/<skill-name>/<YYYY-MM-DD>/<file>
+e.g. store-listing-localizer/2026-06-16/listingData.pdf
+```
+
+So a save call uses `filename: "store-listing-localizer/2026-06-16/<file>"`.
+This keeps each skill + execution-date in its own folder under the shared,
+gitignored `Generated Files\playwright-mcp` root.
+
+## Gotchas
+
+- **Restart required.** Adding/editing the MCP entry does nothing until Copilot
+  CLI restarts. If the `browser_*` tools aren't listed, the MCP isn't loaded.
+- **Dedicated profile dir.** Pointing `--user-data-dir` at the live Edge profile
+  (`...\Edge\User Data`) fails with a profile-lock error whenever Edge is open.
+- **Session expiry.** Corp SSO cookies expire (often daily). When a run lands on
+  the login page instead of the dashboard, just complete the interactive login
+  again — the automation can pause for it.
+- **Downloads location.** "Export listings" saves the `.csv` to the browser's
+  configured download folder. With `--output-dir` set (see **Output location**),
+  the MCP writes it under that root (`<repo>\Generated Files\playwright-mcp\…`),
+  **not** `~/Downloads`. Capture the download event or the newest
+  `listingData-9NMQC2SSJX24-*.csv` under the output root and copy it into a
+  clean working dir before processing, so re-runs don't pick up a stale file.
+- **The `Updated`/`Unchanged` pill** on the Store listings row reflects pending
+  edits; after a successful import it flips to `Updated`. Don't treat the pill
+  as a success signal for the *submission* — importing only stages the listing,
+  it does not publish.
+
+## Workflow (agent-driven, using `browser_*` MCP tools)
+
+### Export
+1. `browser_navigate` →
+   `https://partner.microsoft.com/en-us/dashboard/products/9NMQC2SSJX24/overview`
+   (Store ID `9NMQC2SSJX24`). If redirected to login, complete it interactively.
+2. Locate the **Store listings** section and click **Export listings**
+   (`browser_click` on the link with that text).
+3. Wait for the `.csv` to finish downloading (under the `--output-dir` root, e.g.
+   `<repo>\Generated Files\playwright-mcp\`).
+4. Copy the newest `listingData-9NMQC2SSJX24-*.csv` into a working dir for
+   processing (keep the original download untouched as a backup).
+
+### Import
+1. From the same overview page, click **Import listings**.
+2. In the file picker, choose the localized CSV
+   (`<stem>-localized.csv`) produced by `apply.mjs`.
+3. Confirm the upload. Verify the Store listings row shows **Updated** and spot
+   check a couple of locales in the UI before publishing the submission.
+
+> Importing **stages** the localized listings on the draft submission. Review
+> and **publish the submission** separately (in the UI or via StoreBroker /
+> msstore-cli) to push it live.
+
+## Selectors
+
+Partner Center markup changes over time, so prefer **role/text-based** locators
+(`getByRole('link', { name: 'Export listings' })`) over brittle CSS/XPath. The
+three controls on the Store listings row are the links **Add/remove languages**,
+**Export listings**, and **Import listings**.

--- a/.github/skills/store-listing-localizer/scripts/apply.mjs
+++ b/.github/skills/store-listing-localizer/scripts/apply.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+// apply.mjs — merge translations into a listingData export, producing the CSV
+// to re-import into Partner Center.
+//
+// Handling per field row (see fields.mjs / references/listing-csv-format.md):
+//   - appname  (Title)   : every locale column = localized AppName from the
+//                          translations.md table (falls back to en-US).
+//   - translate (text)   : locale = translations[locale][field] if provided,
+//                          else keep the existing non-empty locale value,
+//                          else fall back to the en-US value.
+//   - verbatim (assets)  : empty locale cells are filled from en-US; existing
+//                          values are left untouched (never clobbered).
+//
+// en-US overrides (--enus) are applied to the en-US column FIRST, so a new
+// ReleaseNotes supplied in the prompt becomes the source of truth for both the
+// en-US listing and the per-locale fallbacks.
+//
+// Usage:
+//   node apply.mjs --csv <export.csv> --appnames <translations.md> \
+//       [--translations <translations.json>] [--enus <overrides.json>] \
+//       [--changed-fields <Field1,Field2>] [--no-localize-product-name] \
+//       [--out <out.csv>]
+//
+// Output defaults to "<export-stem>-localized.csv" next to the source.
+// Exits non-zero if any ReleaseNotes/Description/ShortDescription exceeds the
+// Store's per-locale character limit (see the length guard at the end).
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { readCsv, writeCsv, indexListing } from './csvlib.mjs';
+import { classifyField, parseAppNames, appNameFor } from './fields.mjs';
+
+function arg(name, def) {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : def;
+}
+
+if (process.argv.includes('--help') || !arg('--csv') || !arg('--appnames')) {
+  console.log('Usage: node apply.mjs --csv <export.csv> --appnames <translations.md> ' +
+              '[--translations <translations.json>] [--enus <overrides.json>] ' +
+              '[--changed-fields <Field1,Field2>] [--no-localize-product-name] [--out <out.csv>]');
+  process.exit(process.argv.includes('--help') ? 0 : 1);
+}
+
+const csvPath = arg('--csv');
+const outPath = arg('--out') ||
+  path.join(path.dirname(csvPath), path.basename(csvPath, '.csv') + '-localized.csv');
+
+const records = readCsv(csvPath);
+const { localeCols, fieldRows } = indexListing(records);
+const appNames = parseAppNames(fs.readFileSync(arg('--appnames'), 'utf8'));
+const translations = arg('--translations') ? JSON.parse(fs.readFileSync(arg('--translations'), 'utf8')) : {};
+const enusOverrides = arg('--enus') ? JSON.parse(fs.readFileSync(arg('--enus'), 'utf8')) : {};
+
+// "Changed" fields: their en-US text was updated, so existing per-locale values
+// are stale and must NOT be preserved. Any field given an en-US override is
+// implicitly changed; --changed-fields adds more (comma-separated).
+const changedFields = new Set(Object.keys(enusOverrides));
+for (const f of (arg('--changed-fields', '').split(',').map(s => s.trim()).filter(Boolean))) changedFields.add(f);
+
+const enUsKey = Object.keys(localeCols).find(k => k.toLowerCase() === 'en-us');
+if (!enUsKey) throw new Error('export has no en-us column');
+const enCol = localeCols[enUsKey];
+const targetLocales = Object.keys(localeCols).filter(k => k.toLowerCase() !== 'en-us');
+
+// Case-insensitive lookup into translations.json by locale.
+function transFor(locale, field) {
+  if (translations[locale] && field in translations[locale]) return translations[locale][field];
+  const lc = locale.toLowerCase();
+  for (const [k, v] of Object.entries(translations)) {
+    if (k.toLowerCase() === lc && field in v) return v[field];
+  }
+  return undefined;
+}
+
+const stats = { appname: 0, translate: 0, verbatim: 0, enusOverridden: 0, cellsWritten: 0 };
+
+// Product-name localization: inside translatable text the product name should
+// read as the locale's AppName (matching the localized Title), e.g. de-DE
+// "Intelligentes Terminal", zh-CN "智能终端". We replace the en-US product name
+// (the en-US Title) with the locale's AppName. This is URL-safe: the en-US
+// Title is "Intelligent Terminal" (spaced, capitalized) while the GitHub URL
+// uses "intelligent-terminal" (hyphenated, lowercase), so the URL is never
+// touched. Disable with --no-localize-product-name.
+const localizeProductName = !process.argv.includes('--no-localize-product-name');
+const enUsProductName = (records[fieldRows['Title']] ? records[fieldRows['Title']][enCol] : '') || '';
+
+function applyProductName(text, loc) {
+  if (!localizeProductName || !enUsProductName) return text;
+  const localized = appNameFor(appNames, loc);
+  if (!localized || localized === enUsProductName) return text;
+  // Replace standalone product-name occurrences only (word boundaries around
+  // the spaced/capitalized form); the hyphenated URL form is unaffected.
+  const esc = enUsProductName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return text.replace(new RegExp(`(^|[^/\\w])${esc}(?![\\w-])`, 'g'), `$1${localized}`);
+}
+
+for (const [field, row] of Object.entries(fieldRows)) {
+  const kind = classifyField(field);
+
+  // 1) apply en-US override first (becomes source of truth + fallback)
+  if (field in enusOverrides) {
+    records[row][enCol] = enusOverrides[field];
+    stats.enusOverridden++;
+  }
+  const enUs = records[row][enCol] || '';
+
+  for (const loc of targetLocales) {
+    const col = localeCols[loc];
+    const before = records[row][col] || '';
+    let next = before;
+
+    if (kind === 'appname') {
+      next = appNameFor(appNames, loc) || enUs;
+    } else if (kind === 'translate') {
+      const t = transFor(loc, field);
+      if (t !== undefined) next = t;                 // use provided translation
+      else if (changedFields.has(field)) next = enUs; // changed: never keep stale → new en-US
+      else if (before.trim()) next = before;          // unchanged: keep existing translation
+      else next = enUs;                              // empty: fall back to en-US
+      next = applyProductName(next, loc);            // localize product name in body text
+    } else { // verbatim
+      if (!before.trim()) next = enUs;             // fill empty asset cells only
+    }
+
+    if (next !== before) { records[row][col] = next; stats.cellsWritten++; }
+  }
+  stats[kind]++;
+}
+
+writeCsv(outPath, records);
+console.log(`Wrote ${outPath}`);
+console.log(`Fields: ${stats.appname} appname, ${stats.translate} translate, ${stats.verbatim} verbatim`);
+console.log(`en-US overrides applied: ${stats.enusOverridden}; locale cells written: ${stats.cellsWritten}`);
+
+// Length guard: Microsoft Store hard-rejects ReleaseNotes/Description over
+// their per-locale character limits (ReleaseNotes: 1500, Description: 10000).
+// A too-long localized value fails the WHOLE import mid-run, so flag it here
+// BEFORE the operator uploads. Exit non-zero if any field is over its limit.
+const LIMITS = { ReleaseNotes: 1500, Description: 10000, ShortDescription: 1000 };
+const violations = [];
+for (const [field, limit] of Object.entries(LIMITS)) {
+  const row = fieldRows[field];
+  if (row == null) continue;
+  for (const [loc, col] of Object.entries(localeCols)) {
+    const len = (records[row][col] || '').length;
+    if (len > limit) violations.push({ field, loc, len, limit });
+  }
+}
+if (violations.length) {
+  console.error(`\n❌ LENGTH LIMIT EXCEEDED — these will fail Partner Center import:`);
+  for (const v of violations.sort((a, b) => b.len - a.len)) {
+    console.error(`   ${v.field} [${v.loc}]: ${v.len} > ${v.limit}`);
+  }
+  console.error(`Shorten these locales' translations (or the en-US source) and re-run before importing.`);
+  process.exitCode = 2;
+} else {
+  console.log(`Length check: all ReleaseNotes/Description/ShortDescription within Store limits.`);
+}

--- a/.github/skills/store-listing-localizer/scripts/apply.mjs
+++ b/.github/skills/store-listing-localizer/scripts/apply.mjs
@@ -63,12 +63,31 @@ if (!enUsKey) throw new Error('export has no en-us column');
 const enCol = localeCols[enUsKey];
 const targetLocales = Object.keys(localeCols).filter(k => k.toLowerCase() !== 'en-us');
 
-// Case-insensitive lookup into translations.json by locale.
+// Case-insensitive lookup into translations.json by locale. Validates that a
+// found value is a string: null/undefined are treated as "missing" (returns
+// undefined so the caller falls back), while any other non-string type
+// (object/number/array) is a malformed payload and throws with the offending
+// locale+field so the failure is explicit rather than crashing later in
+// applyProductName()'s .replace().
 function transFor(locale, field) {
-  if (translations[locale] && field in translations[locale]) return translations[locale][field];
+  const pick = (obj, srcLoc) => {
+    if (!obj || !(field in obj)) return undefined;
+    const v = obj[field];
+    if (v === null || v === undefined) return undefined;
+    if (typeof v !== 'string') {
+      throw new Error(`translations["${srcLoc}"]["${field}"] is ${typeof v}, expected string. ` +
+                      `Fix the malformed translation payload.`);
+    }
+    return v;
+  };
+  const direct = pick(translations[locale], locale);
+  if (direct !== undefined) return direct;
   const lc = locale.toLowerCase();
   for (const [k, v] of Object.entries(translations)) {
-    if (k.toLowerCase() === lc && field in v) return v[field];
+    if (k.toLowerCase() === lc) {
+      const hit = pick(v, k);
+      if (hit !== undefined) return hit;
+    }
   }
   return undefined;
 }

--- a/.github/skills/store-listing-localizer/scripts/apply.mjs
+++ b/.github/skills/store-listing-localizer/scripts/apply.mjs
@@ -133,15 +133,20 @@ const stats = { appname: 0, translate: 0, verbatim: 0, enusOverridden: 0, cellsW
 // touched. Disable with --no-localize-product-name.
 const localizeProductName = !process.argv.includes('--no-localize-product-name');
 const enUsProductName = (records[fieldRows['Title']] ? records[fieldRows['Title']][enCol] : '') || '';
+// Precompute the matcher once (it depends only on the constant en-US product
+// name): matches the standalone spaced/capitalized "Intelligent Terminal", not
+// the hyphenated URL form. null when there's no product name to localize.
+const productNameRe = enUsProductName
+  ? new RegExp(`(^|[^/\\w])${enUsProductName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![\\w-])`, 'g')
+  : null;
 
 function applyProductName(text, loc) {
-  if (!localizeProductName || !enUsProductName) return text;
+  if (!localizeProductName || !productNameRe) return text;
   const localized = appNameFor(appNames, loc);
   if (!localized || localized === enUsProductName) return text;
-  // Replace standalone product-name occurrences only (word boundaries around
-  // the spaced/capitalized form); the hyphenated URL form is unaffected.
-  const esc = enUsProductName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return text.replace(new RegExp(`(^|[^/\\w])${esc}(?![\\w-])`, 'g'), `$1${localized}`);
+  // Use a replace callback so any `$` in a localized name is inserted literally
+  // rather than interpreted as a special replacement pattern ($1, $&, …).
+  return text.replace(productNameRe, (_m, pre) => pre + localized);
 }
 
 for (const [field, row] of Object.entries(fieldRows)) {

--- a/.github/skills/store-listing-localizer/scripts/apply.mjs
+++ b/.github/skills/store-listing-localizer/scripts/apply.mjs
@@ -84,6 +84,15 @@ if (!enUsKey) throw new Error('export has no en-us column');
 const enCol = localeCols[enUsKey];
 const targetLocales = Object.keys(localeCols).filter(k => k.toLowerCase() !== 'en-us');
 
+// A valid listingData export always has a `Title` row (it drives both the
+// localized Title and product-name substitution in body text). Its absence
+// means the input isn't a real export — fail fast like the other structural
+// checks (missing `default`/`en-us`, column-count mismatch) instead of silently
+// skipping product-name localization and producing a quietly-wrong CSV.
+if (fieldRows['Title'] == null) {
+  throw new Error('export has no "Title" field row — not a valid listingData export?');
+}
+
 // Case-insensitive lookup into translations.json by locale. Validates that a
 // found value is a string: null/undefined are treated as "missing" (returns
 // undefined so the caller falls back), while any other non-string type

--- a/.github/skills/store-listing-localizer/scripts/apply.mjs
+++ b/.github/skills/store-listing-localizer/scripts/apply.mjs
@@ -27,6 +27,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { readCsv, writeCsv, indexListing } from './csvlib.mjs';
 import { classifyField, parseAppNames, appNameFor } from './fields.mjs';
 
@@ -35,10 +36,16 @@ function arg(name, def) {
   return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : def;
 }
 
-if (process.argv.includes('--help') || !arg('--csv') || !arg('--appnames')) {
-  console.log('Usage: node apply.mjs --csv <export.csv> --appnames <translations.md> ' +
+// The AppName table ships with the skill; default to the bundled copy so the
+// script is runnable without an external file. Override with --appnames.
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const defaultAppNames = path.join(scriptDir, '..', 'references', 'intelligent-terminal-translations.md');
+
+if (process.argv.includes('--help') || !arg('--csv')) {
+  console.log('Usage: node apply.mjs --csv <export.csv> [--appnames <translations.md>] ' +
               '[--translations <translations.json>] [--enus <overrides.json>] ' +
               '[--changed-fields <Field1,Field2>] [--no-localize-product-name] [--out <out.csv>]');
+  console.log('  --appnames defaults to the bundled references/intelligent-terminal-translations.md');
   process.exit(process.argv.includes('--help') ? 0 : 1);
 }
 
@@ -46,11 +53,25 @@ const csvPath = arg('--csv');
 const outPath = arg('--out') ||
   path.join(path.dirname(csvPath), path.basename(csvPath, '.csv') + '-localized.csv');
 
+const appNamesPath = arg('--appnames', defaultAppNames);
+if (!fs.existsSync(appNamesPath)) {
+  throw new Error(`AppName table not found: ${appNamesPath}. Pass --appnames <translations.md> ` +
+                  `or restore references/intelligent-terminal-translations.md.`);
+}
+
 const records = readCsv(csvPath);
 const { localeCols, fieldRows } = indexListing(records);
-const appNames = parseAppNames(fs.readFileSync(arg('--appnames'), 'utf8'));
+const appNames = parseAppNames(fs.readFileSync(appNamesPath, 'utf8'));
 const translations = arg('--translations') ? JSON.parse(fs.readFileSync(arg('--translations'), 'utf8')) : {};
 const enusOverrides = arg('--enus') ? JSON.parse(fs.readFileSync(arg('--enus'), 'utf8')) : {};
+
+// Extract a version token like "v0.1.1841" regardless of the (possibly
+// localized) leading word — "Version", "版本", "バージョン", etc. Used for the
+// automatic ReleaseNotes stale-version safety net below.
+function versionToken(s) {
+  const m = (s || '').match(/v\d+(?:\.\d+)+/i);
+  return m ? m[0].toLowerCase() : '';
+}
 
 // "Changed" fields: their en-US text was updated, so existing per-locale values
 // are stale and must NOT be preserved. Any field given an en-US override is
@@ -92,7 +113,7 @@ function transFor(locale, field) {
   return undefined;
 }
 
-const stats = { appname: 0, translate: 0, verbatim: 0, enusOverridden: 0, cellsWritten: 0 };
+const stats = { appname: 0, translate: 0, verbatim: 0, enusOverridden: 0, cellsWritten: 0, versionDrift: 0 };
 
 // Product-name localization: inside translatable text the product name should
 // read as the locale's AppName (matching the localized Title), e.g. de-DE
@@ -123,6 +144,10 @@ for (const [field, row] of Object.entries(fieldRows)) {
     stats.enusOverridden++;
   }
   const enUs = records[row][enCol] || '';
+  // Automatic stale-version safety net (ReleaseNotes and any versioned field):
+  // if en-US carries a version token, a locale whose existing value has a
+  // DIFFERENT token is stale even when the operator forgot --changed-fields.
+  const enVer = versionToken(enUs);
 
   for (const loc of targetLocales) {
     const col = localeCols[loc];
@@ -132,9 +157,11 @@ for (const [field, row] of Object.entries(fieldRows)) {
     if (kind === 'appname') {
       next = appNameFor(appNames, loc) || enUs;
     } else if (kind === 'translate') {
+      const versionDrift = enVer && versionToken(before) !== enVer;
       const t = transFor(loc, field);
       if (t !== undefined) next = t;                 // use provided translation
-      else if (changedFields.has(field)) next = enUs; // changed: never keep stale → new en-US
+      else if (changedFields.has(field)) next = enUs; // marked changed: never keep stale → new en-US
+      else if (versionDrift) { next = enUs; stats.versionDrift++; } // auto: stale version → new en-US
       else if (before.trim()) next = before;          // unchanged: keep existing translation
       else next = enUs;                              // empty: fall back to en-US
       next = applyProductName(next, loc);            // localize product name in body text
@@ -151,6 +178,9 @@ writeCsv(outPath, records);
 console.log(`Wrote ${outPath}`);
 console.log(`Fields: ${stats.appname} appname, ${stats.translate} translate, ${stats.verbatim} verbatim`);
 console.log(`en-US overrides applied: ${stats.enusOverridden}; locale cells written: ${stats.cellsWritten}`);
+if (stats.versionDrift) {
+  console.log(`Auto version-drift: ${stats.versionDrift} stale-version locale cell(s) refreshed to the new en-US text.`);
+}
 
 // Length guard: Microsoft Store hard-rejects ReleaseNotes/Description over
 // their per-locale character limits (ReleaseNotes: 1500, Description: 10000).

--- a/.github/skills/store-listing-localizer/scripts/csvlib.mjs
+++ b/.github/skills/store-listing-localizer/scripts/csvlib.mjs
@@ -1,0 +1,97 @@
+// Shared CSV helpers for Partner Center listingData CSV files.
+// The export is RFC-4180-ish: UTF-8 (with BOM), comma-delimited, CRLF line
+// endings, double-quote escaping, and values that legitimately contain
+// embedded newlines (ReleaseNotes, Description). We parse/serialize by hand so
+// we never depend on a CSV package and never corrupt the field structure.
+
+import fs from 'node:fs';
+
+/** Parse full CSV text into an array of records, each a string[] of fields. */
+export function parseCsv(text) {
+  const t = text.replace(/^\uFEFF/, '');
+  const records = [];
+  let field = '';
+  let record = [];
+  let inQuotes = false;
+  for (let i = 0; i < t.length; i++) {
+    const c = t[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (t[i + 1] === '"') { field += '"'; i++; }
+        else inQuotes = false;
+      } else {
+        field += c;
+      }
+    } else {
+      if (c === '"') inQuotes = true;
+      else if (c === ',') { record.push(field); field = ''; }
+      else if (c === '\r') { /* swallow, handled by \n */ }
+      else if (c === '\n') { record.push(field); records.push(record); record = []; field = ''; }
+      else field += c;
+    }
+  }
+  // trailing field / record (file may or may not end with newline)
+  if (field.length > 0 || record.length > 0) { record.push(field); records.push(record); }
+  return records;
+}
+
+/** Quote a single field the way Partner Center expects. */
+function quoteField(v) {
+  const s = v == null ? '' : String(v);
+  if (s === '') return '';
+  if (/[",\r\n]/.test(s)) return '"' + s.replace(/"/g, '""') + '"';
+  return s;
+}
+
+/**
+ * Serialize records back to CSV text.
+ * Defaults match the Partner Center export: UTF-8 BOM + CRLF line endings.
+ */
+export function serializeCsv(records, { bom = true, eol = '\r\n' } = {}) {
+  const body = records.map(r => r.map(quoteField).join(',')).join(eol);
+  // Partner Center exports end with a trailing newline; mirror that.
+  return (bom ? '\uFEFF' : '') + body + eol;
+}
+
+/** Read + parse a CSV file from disk. */
+export function readCsv(path) {
+  return parseCsv(fs.readFileSync(path, 'utf8'));
+}
+
+/** Write records to disk with BOM + CRLF (Partner Center compatible). */
+export function writeCsv(path, records, opts) {
+  fs.writeFileSync(path, serializeCsv(records, opts), 'utf8');
+}
+
+/**
+ * Build an index over a parsed listingData CSV.
+ * Returns { header, localeCols: {locale: colIndex}, fieldRows: {fieldName: rowIndex} }.
+ * Locale columns are every header column after the fixed `default` column.
+ */
+export function indexListing(records) {
+  const header = records[0];
+  const lower = header.map(h => h.trim().toLowerCase());
+  const defaultIdx = lower.indexOf('default');
+  if (defaultIdx < 0) throw new Error('CSV header missing "default" column — not a listingData export?');
+  const localeCols = {};
+  for (let c = defaultIdx + 1; c < header.length; c++) {
+    const name = header[c].trim();
+    if (name) localeCols[name] = c;
+  }
+  const fieldRows = {};
+  for (let r = 1; r < records.length; r++) {
+    const f = (records[r][0] || '').trim();
+    if (f) fieldRows[f] = r;
+  }
+  return { header, defaultIdx, localeCols, fieldRows };
+}
+
+/** Case-insensitive locale lookup (Partner Center uses lowercase like `zh-cn`). */
+export function findLocaleCol(localeCols, locale) {
+  if (locale in localeCols) return localeCols[locale];
+  const want = locale.toLowerCase();
+  for (const [k, v] of Object.entries(localeCols)) {
+    if (k.toLowerCase() === want) return v;
+  }
+  return undefined;
+}

--- a/.github/skills/store-listing-localizer/scripts/csvlib.mjs
+++ b/.github/skills/store-listing-localizer/scripts/csvlib.mjs
@@ -32,6 +32,13 @@ export function parseCsv(text) {
   }
   // trailing field / record (file may or may not end with newline)
   if (field.length > 0 || record.length > 0) { record.push(field); records.push(record); }
+  // Fail fast on an unterminated quoted field: if we reached EOF still inside a
+  // quote, the input is structurally broken and later rows have silently
+  // collapsed into one. Writing that back out would corrupt the CSV.
+  if (inQuotes) {
+    throw new Error('Malformed CSV: unterminated quoted field (reached end of input inside a quote). ' +
+                    'The source export is corrupt or was truncated.');
+  }
   return records;
 }
 
@@ -70,9 +77,26 @@ export function writeCsv(path, records, opts) {
  */
 export function indexListing(records) {
   const header = records[0];
+  if (!header || header.length === 0) throw new Error('CSV has no header row.');
   const lower = header.map(h => h.trim().toLowerCase());
   const defaultIdx = lower.indexOf('default');
   if (defaultIdx < 0) throw new Error('CSV header missing "default" column — not a listingData export?');
+
+  // Column-count sanity check: every data row must have exactly as many columns
+  // as the header. A mismatch means the parse went wrong (usually a stray quote
+  // or embedded newline), and reading/writing by column index from here would
+  // silently misalign locale values. Fail fast with the offending row numbers.
+  const width = header.length;
+  const badRows = [];
+  for (let r = 1; r < records.length; r++) {
+    if (records[r].length !== width) badRows.push(`${r + 1}(${records[r].length})`);
+  }
+  if (badRows.length) {
+    throw new Error(`Malformed CSV: ${badRows.length} row(s) have a column count != header (${width}). ` +
+                    `Offending rows [line(cols)]: ${badRows.slice(0, 10).join(', ')}` +
+                    (badRows.length > 10 ? ` …(+${badRows.length - 10} more)` : ''));
+  }
+
   const localeCols = {};
   for (let c = defaultIdx + 1; c < header.length; c++) {
     const name = header[c].trim();

--- a/.github/skills/store-listing-localizer/scripts/extract.mjs
+++ b/.github/skills/store-listing-localizer/scripts/extract.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// extract.mjs — build a translation "work order" from a listingData export.
+//
+// Reads the exported CSV and prints a JSON object describing exactly what needs
+// translating: the en-US source value for every translatable field, the full
+// target locale list, and (per field) which locales currently look stale
+// (their value equals the en-US value or is empty). The agent consumes this to
+// drive per-language translation, then feeds results to apply.mjs.
+//
+// Usage:
+//   node extract.mjs --csv <export.csv> [--enus <overrides.json>] \
+//       [--changed-fields <Field1,Field2>] [--out <work-order.json>]
+//
+//   --csv            Path to the Partner Center listingData export (required).
+//   --enus           Optional JSON { "<Field>": "<value>" } overriding the en-US
+//                    source for specific fields. Use this when the new en-US text
+//                    (e.g. a new ReleaseNotes) is supplied in the prompt rather
+//                    than already present in the export's en-US column.
+//   --changed-fields Comma-separated fields whose en-US text changed, so every
+//                    locale is flagged stale (ReleaseNotes version drift is also
+//                    auto-detected).
+//   --out            Where to write the work order JSON (default: stdout).
+
+import fs from 'node:fs';
+import { readCsv, indexListing } from './csvlib.mjs';
+import { classifyField } from './fields.mjs';
+
+function arg(name, def) {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : def;
+}
+
+if (process.argv.includes('--help') || !arg('--csv')) {
+  console.log('Usage: node extract.mjs --csv <export.csv> [--enus <overrides.json>] [--changed-fields <Field1,Field2>] [--out <work-order.json>]');
+  process.exit(arg('--csv') ? 0 : 1);
+}
+
+const csvPath = arg('--csv');
+const enusOverrides = arg('--enus') ? JSON.parse(fs.readFileSync(arg('--enus'), 'utf8')) : {};
+const changedFields = new Set(
+  (arg('--changed-fields', '').split(',').map(s => s.trim()).filter(Boolean))
+);
+
+// Extract a version token like "v0.1.1661" regardless of the (possibly
+// localized) leading word — "Version", "版本", "バージョン", "Weergawe", etc.
+function versionToken(s) {
+  const m = (s || '').match(/v\d+(?:\.\d+)+/i);
+  return m ? m[0].toLowerCase() : '';
+}
+
+const records = readCsv(csvPath);
+const { localeCols, fieldRows } = indexListing(records);
+
+const enUsKey = Object.keys(localeCols).find(k => k.toLowerCase() === 'en-us');
+if (!enUsKey) throw new Error('export has no en-us column');
+const enCol = localeCols[enUsKey];
+const targetLocales = Object.keys(localeCols).filter(k => k.toLowerCase() !== 'en-us');
+
+const fields = [];
+for (const [field, row] of Object.entries(fieldRows)) {
+  if (classifyField(field) !== 'translate') continue;
+  const enUs = (field in enusOverrides) ? enusOverrides[field] : (records[row][enCol] || '');
+  if (!enUs.trim()) continue; // nothing to translate
+
+  // A field is "changed" when its en-US text was overridden, when the caller
+  // lists it in --changed-fields, or (for ReleaseNotes) when the locale's
+  // embedded version token differs from en-US — the classic stale-translation
+  // case where a locale still holds a fully-translated *older* release note.
+  const isChanged = (field in enusOverrides) || changedFields.has(field);
+  const enVer = versionToken(enUs);
+
+  const staleLocales = [];
+  for (const loc of targetLocales) {
+    const cur = records[row][localeCols[loc]] || '';
+    let stale = !cur.trim() || cur === (records[row][enCol] || '');
+    if (!stale && isChanged) stale = true;                  // forced changed
+    if (!stale && enVer && versionToken(cur) !== enVer) stale = true; // version drift
+    if (stale) staleLocales.push(loc);
+  }
+  fields.push({ field, enUs, changed: isChanged || staleLocales.length > 0, staleLocales });
+}
+
+const workOrder = {
+  csv: csvPath,
+  enUsColumn: enUsKey,
+  targetLocales,
+  fieldsNeedingTranslation: fields,
+  note: 'Translate each field.enUs into every targetLocale (or at least staleLocales). ' +
+        'Follow references/localization-rules.md for locked tokens and terminology. ' +
+        'Return results to apply.mjs as { "<locale>": { "<Field>": "<translated>" } }.',
+};
+
+const json = JSON.stringify(workOrder, null, 2);
+if (arg('--out')) { fs.writeFileSync(arg('--out'), json, 'utf8'); console.error(`wrote ${arg('--out')}`); }
+else console.log(json);

--- a/.github/skills/store-listing-localizer/scripts/fields.mjs
+++ b/.github/skills/store-listing-localizer/scripts/fields.mjs
@@ -1,0 +1,61 @@
+// Field classification for the listingData CSV, plus the AppName table parser.
+//
+// Each field row in the CSV is classified into one of three handling modes:
+//   - 'appname'  : the localized product name (Title). Filled from the
+//                  intelligent-terminal-translations.md table.
+//   - 'translate': free user-visible text that must be localized per locale
+//                  (Description, ReleaseNotes, captions, features, ...).
+//   - 'verbatim' : non-translatable values copied from en-US to every locale
+//                  (screenshot/logo/trailer URLs, booleans, legal/IDs).
+//
+// The classification is intentionally conservative: anything not explicitly
+// recognized as translatable text is treated as 'verbatim' so we never garble
+// an asset URL or a boolean flag.
+
+// Only `Title` is auto-filled from the AppName table. ShortTitle/SortTitle/
+// VoiceTitle are usually empty; treat them as translatable text (skipped when
+// empty) rather than forcing the AppName into them.
+const APPNAME_FIELDS = new Set(['Title']);
+
+const TRANSLATE_PATTERNS = [
+  /^Description$/,
+  /^ReleaseNotes$/,
+  /^ShortTitle$/,
+  /^SortTitle$/,
+  /^VoiceTitle$/,
+  /^ShortDescription$/,
+  /^Feature\d+$/,
+  /^[A-Za-z]*ScreenshotCaption\d+$/,   // Desktop/Mobile/Xbox/Holographic/SurfaceHub caption
+  /^MinimumHardwareReq\d+$/,
+  /^RecommendedHardwareReq\d+$/,
+  /^SearchTerm\d+$/,
+  /^TrailerTitle\d+$/,
+];
+
+/** Return 'appname' | 'translate' | 'verbatim' for a field name. */
+export function classifyField(field) {
+  if (APPNAME_FIELDS.has(field)) return 'appname';
+  if (TRANSLATE_PATTERNS.some(re => re.test(field))) return 'translate';
+  return 'verbatim';
+}
+
+/**
+ * Parse the markdown AppName table (| Locale | AppName |) into a map.
+ * Keys are normalized to lowercase so `zh-CN` and `zh-cn` both resolve.
+ */
+export function parseAppNames(md) {
+  const out = {};
+  for (const line of md.split(/\r?\n/)) {
+    const m = line.match(/^\s*\|\s*([A-Za-z]{2}(?:-[A-Za-z0-9]+)*)\s*\|\s*(.+?)\s*\|\s*$/);
+    if (!m) continue;
+    const locale = m[1].trim();
+    const name = m[2].trim();
+    if (locale.toLowerCase() === 'locale' || /^-+$/.test(name)) continue; // header/separator
+    out[locale.toLowerCase()] = name;
+  }
+  return out;
+}
+
+export function appNameFor(appNames, locale) {
+  return appNames[locale.toLowerCase()];
+}

--- a/.github/skills/store-listing-localizer/scripts/fields.mjs
+++ b/.github/skills/store-listing-localizer/scripts/fields.mjs
@@ -46,7 +46,9 @@ export function classifyField(field) {
 export function parseAppNames(md) {
   const out = {};
   for (const line of md.split(/\r?\n/)) {
-    const m = line.match(/^\s*\|\s*([A-Za-z]{2}(?:-[A-Za-z0-9]+)*)\s*\|\s*(.+?)\s*\|\s*$/);
+    // Primary language subtag is 2–8 letters per BCP-47 (not just 2) — covers
+    // fil, kok, quz, and the qps-* pseudo-locales, not only 2-letter codes.
+    const m = line.match(/^\s*\|\s*([A-Za-z]{2,8}(?:-[A-Za-z0-9]+)*)\s*\|\s*(.+?)\s*\|\s*$/);
     if (!m) continue;
     const locale = m[1].trim();
     const name = m[2].trim();

--- a/.github/skills/store-listing-localizer/scripts/package.json
+++ b/.github/skills/store-listing-localizer/scripts/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "name": "store-listing-localizer-scripts",
+  "private": true,
+  "description": "Deterministic CSV helpers for the store-listing-localizer skill (no dependencies)."
+}


### PR DESCRIPTION
Adds the `store-listing-localizer` agent skill under `.github/skills/` — end-to-end automation for localizing the Intelligent Terminal Microsoft Store (Partner Center) listing.

## What it does
- Exports the `listingData` CSV from Partner Center via the Playwright MCP
- Localizes changed fields (release notes, descriptions, captions, features) into 80+ Store locales using the repo's `.resw` terminology rules
- Re-imports the localized CSV — no manual clicking through Partner Center

## Contents
- `SKILL.md` + `LICENSE.txt` (Apache 2.0)
- `scripts/` — zero-dependency Node modules: `extract.mjs`, `apply.mjs`, `fields.mjs`, `csvlib.mjs` (quote-aware CSV parser preserving UTF-8 BOM/CRLF/embedded newlines)
- `references/` — Partner Center MCP workflow, CSV format, localization rules, and the bundled per-locale AppName table (public Store display names)

## Safeguards (hardened over two live releases)
- Version-drift stale-translation detection (never ships an old release note under a new version) — now automatic
- Per-locale ReleaseNotes length guard (1500-char Store hard limit) that fails before a bad upload
- URL-safe product-name localization; fail-fast validation on malformed CSV / translation input

## Quality
Driven through the Copilot PR review loop to convergence on a fork-internal PR (5 rounds, 9 findings all fixed): yeelam-gordon/intelligent-terminal#4. Final hardened scripts verified to reproduce the exact CSV imported live to the Store.

## Privacy
No secrets, credentials, Azure AD app/tenant IDs, emails, or personal paths — auth relies on an on-machine persistent Edge SSO profile, never anything in the repo. Only the public Store ID and localized product names are included.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>