### PR TITLE
Cancel orphaned sessions on helper disconnect so the shared agent CLI survives (#419)

### DIFF
--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -2501,12 +2501,37 @@ async fn serve_helper(
     // unboundedly across the master's lifetime, and so the agent
     // CLI's notifications for already-detached sessions don't keep
     // lighting up "unknown SessionId" warnings.
-    let dropped = drop_sessions_for_helper(&state, helper_id).await;
+    let victims = drop_sessions_for_helper(&state, helper_id).await;
+
+    // The agent CLI is shared across every pane in this window. If this helper
+    // disconnected mid-turn (e.g. the user closed the tab while the agent was
+    // still working), the agent would otherwise keep running an *orphaned*
+    // turn whose notifications have nowhere to route — and that orphaned state
+    // has been observed to make the shared CLI exit, taking down every OTHER
+    // tab's backend too. Send a best-effort `session/cancel` for each dropped
+    // session so the agent cleanly ends the turn instead of being orphaned.
+    if let Some(agent) = handler.agent.get() {
+        for sid in &victims {
+            if let Err(err) = agent
+                .conn
+                .cancel(acp::schema::v1::CancelNotification::new(sid.clone()))
+                .await
+            {
+                tracing::debug!(
+                    target: "master",
+                    helper_id = ?helper_id,
+                    session_id = ?sid,
+                    error = %err,
+                    "best-effort cancel of orphaned session on helper disconnect failed"
+                );
+            }
+        }
+    }
 
     tracing::info!(
         target: "master",
         helper_id = ?helper_id,
-        sessions_dropped = dropped,
+        sessions_dropped = victims.len(),
         "helper disconnected"
     );
 
@@ -2568,7 +2593,10 @@ fn build_restart_agent_pane_event(
 /// Returns the number of entries dropped. Factored out of
 /// `serve_helper` so the cleanup is unit-testable without a real
 /// named pipe.
-async fn drop_sessions_for_helper(state: &MasterStateInner, helper_id: HelperId) -> usize {
+async fn drop_sessions_for_helper(
+    state: &MasterStateInner,
+    helper_id: HelperId,
+) -> Vec<acp::schema::v1::SessionId> {
     // Collect the owned SessionIds first so we can drop them from the
     // live registry too. Single pass through `session_to_helper` while
     // we already hold its lock; the corresponding `registry.remove`
@@ -2602,7 +2630,7 @@ async fn drop_sessions_for_helper(state: &MasterStateInner, helper_id: HelperId)
         )
         .await;
     }
-    victims.len()
+    victims
 }
 
 /// Fan an ACP `ExtNotification` out to every currently-attached helper.
@@ -4610,7 +4638,9 @@ mod tests {
         }
 
         let dropped = drop_sessions_for_helper(&state, HelperId(1)).await;
-        assert_eq!(dropped, 2);
+        assert_eq!(dropped.len(), 2);
+        assert!(dropped.contains(&SessionId::new("a1")));
+        assert!(dropped.contains(&SessionId::new("a2")));
 
         let map = state.session_to_helper.lock().await;
         assert!(!map.contains_key(&SessionId::new("a1")));

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -2590,9 +2590,10 @@ fn build_restart_agent_pane_event(
 }
 
 /// Remove every `session_to_helper` entry owned by `helper_id`.
-/// Returns the number of entries dropped. Factored out of
-/// `serve_helper` so the cleanup is unit-testable without a real
-/// named pipe.
+/// Returns the `SessionId`s that were dropped so the caller can send a
+/// best-effort `session/cancel` to the shared agent CLI for each one.
+/// Factored out of `serve_helper` so the cleanup is unit-testable
+/// without a real named pipe.
 async fn drop_sessions_for_helper(
     state: &MasterStateInner,
     helper_id: HelperId,


### PR DESCRIPTION
## Summary

Fixes #419.

Closing an agent-pane tab **while its Copilot turn is still in progress** killed the *shared* agent CLI process, breaking the agent in **every other open tab** with `prompt error: Internal error: "send failed because receiver is gone"`.

All agent panes in one Windows Terminal window multiplex onto a single `copilot --acp --stdio` process owned by `wta-master`. When a helper disconnected, `drop_sessions_for_helper` removed the session from routing and broadcast `session_removed` **but never sent `session/cancel` to the agent CLI** — so Copilot was left running an orphaned turn whose `session/update`s had nowhere to route, and that orphaned state made the shared process exit, taking down every other tab's backend.

## Change

On helper disconnect, after dropping the helper's sessions, send a best-effort `session/cancel` to the shared agent CLI for each dropped session so the agent cleanly ends the turn instead of being orphaned.

- `drop_sessions_for_helper` now returns the dropped `SessionId`s (was a count) so `serve_helper` can cancel each one.
- The bound agent is read from the helper's handler (`handler.agent`); cancels are best-effort (logged at debug on failure) and never block teardown.

## Verification

- `cargo test --manifest-path tools/wta/Cargo.toml` — **1087 passed, 0 failed**.
- Updated `drop_sessions_for_helper_retains_only_other_helpers` to assert the returned victim ids.

## Not covered here (follow-up, see #419)

Defense-in-depth: making an existing session's prompt path recover a dead shared CLI (respawn + a "reconnecting" state) instead of surfacing the raw internal error. Tracked as the secondary item in #419.
