### PR TITLE
Revert "Cancel orphaned sessions on helper disconnect (#420)"

### DIFF
--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -2501,37 +2501,12 @@ async fn serve_helper(
     // unboundedly across the master's lifetime, and so the agent
     // CLI's notifications for already-detached sessions don't keep
     // lighting up "unknown SessionId" warnings.
-    let victims = drop_sessions_for_helper(&state, helper_id).await;
-
-    // The agent CLI is shared across every pane in this window. If this helper
-    // disconnected mid-turn (e.g. the user closed the tab while the agent was
-    // still working), the agent would otherwise keep running an *orphaned*
-    // turn whose notifications have nowhere to route — and that orphaned state
-    // has been observed to make the shared CLI exit, taking down every OTHER
-    // tab's backend too. Send a best-effort `session/cancel` for each dropped
-    // session so the agent cleanly ends the turn instead of being orphaned.
-    if let Some(agent) = handler.agent.get() {
-        for sid in &victims {
-            if let Err(err) = agent
-                .conn
-                .cancel(acp::schema::v1::CancelNotification::new(sid.clone()))
-                .await
-            {
-                tracing::debug!(
-                    target: "master",
-                    helper_id = ?helper_id,
-                    session_id = ?sid,
-                    error = %err,
-                    "best-effort cancel of orphaned session on helper disconnect failed"
-                );
-            }
-        }
-    }
+    let dropped = drop_sessions_for_helper(&state, helper_id).await;
 
     tracing::info!(
         target: "master",
         helper_id = ?helper_id,
-        sessions_dropped = victims.len(),
+        sessions_dropped = dropped,
         "helper disconnected"
     );
 
@@ -2590,14 +2565,10 @@ fn build_restart_agent_pane_event(
 }
 
 /// Remove every `session_to_helper` entry owned by `helper_id`.
-/// Returns the `SessionId`s that were dropped so the caller can send a
-/// best-effort `session/cancel` to the shared agent CLI for each one.
-/// Factored out of `serve_helper` so the cleanup is unit-testable
-/// without a real named pipe.
-async fn drop_sessions_for_helper(
-    state: &MasterStateInner,
-    helper_id: HelperId,
-) -> Vec<acp::schema::v1::SessionId> {
+/// Returns the number of entries dropped. Factored out of
+/// `serve_helper` so the cleanup is unit-testable without a real
+/// named pipe.
+async fn drop_sessions_for_helper(state: &MasterStateInner, helper_id: HelperId) -> usize {
     // Collect the owned SessionIds first so we can drop them from the
     // live registry too. Single pass through `session_to_helper` while
     // we already hold its lock; the corresponding `registry.remove`
@@ -2631,7 +2602,7 @@ async fn drop_sessions_for_helper(
         )
         .await;
     }
-    victims
+    victims.len()
 }
 
 /// Fan an ACP `ExtNotification` out to every currently-attached helper.
@@ -4639,9 +4610,7 @@ mod tests {
         }
 
         let dropped = drop_sessions_for_helper(&state, HelperId(1)).await;
-        assert_eq!(dropped.len(), 2);
-        assert!(dropped.contains(&SessionId::new("a1")));
-        assert!(dropped.contains(&SessionId::new("a2")));
+        assert_eq!(dropped, 2);
 
         let map = state.session_to_helper.lock().await;
         assert!(!map.contains_key(&SessionId::new("a1")));


### PR DESCRIPTION
Reverts #420.

The `session/cancel`-on-disconnect approach in #420 does **not** fix #419. Live traces showed it neither aborts the orphaned mid-turn (the shared agent CLI runs it to a natural `EndTurn`) nor prevents the CLI from exiting, so closing one tab mid-turn still crashes the agent in every other tab with `send failed because receiver is gone`.

Reverting to keep `main` clean. The **real** root cause and fix land in a follow-up PR:
- Root cause: master delivered an orphaned turn''s result to the disconnected helper''s responder; that delivery error propagated out of the prompt-forwarding callback (which runs on the shared master↔CLI dispatch loop) and tore the shared connection down, exiting the CLI.
- Fix: swallow the "helper gone" delivery error; answer orphan-session `request_permission` with a graceful `Cancelled`; track orphaned-but-loaded sessions and re-bind them directly on resume; make resume silent.
