### PR TITLE
fix(wta): remove split-pane -h short flag colliding with clap help

### DIFF
--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -371,7 +371,7 @@ enum Command {
         target: Option<String>,
 
         /// Split horizontally (panes side by side)
-        #[arg(short = 'h', long)]
+        #[arg(long)]
         horizontal: bool,
 
         /// Split vertically (panes stacked)


### PR DESCRIPTION
## Problem

Opening the agent pane in a **debug** build does nothing — the pane flashes open and immediately closes. `terminal-agent-pane.log` shows `wta-master` spawning and dying instantly on every attempt:

```
_AutoCreateHiddenAgentPaneShared: done — helper conpty child spawned
wta-master exited unexpectedly pid=… (crash/OOM/external kill …)
agent pane closed
```

## Root cause

The `split-pane` subcommand declared `#[arg(short = 'h', long)]` on `horizontal`, colliding with clap's auto-generated `-h`/`--help`. clap validates the entire command tree in `Command::debug_assert()`, which `Cli::parse()` runs at the very top of `main()` — **before** the master/helper dispatch. Running the deployed debug binary directly reproduces it:

```
$ wta.exe --version
thread 'main' panicked at clap_builder-4.5.60/src/builder/debug_asserts.rs:112:
Command split-pane: Short option names must be unique for each argument,
but '-h' is in use by both 'horizontal' and 'help'
```

`debug_assert` is compiled out in release builds, so this was invisible in CI and release deployments but panics **every** debug (dev) build at startup — which is exactly what `wta-master` is, so it crashes before it can serve the agent pane.

## Fix

Drop the `-h` short from `horizontal` (keep `--horizontal`); `-h` stays the standard help alias. `--vertical` keeps its non-colliding `-v`.

## Verification

Debug `wta.exe` built from this branch:
- `wta --version` — no longer panics (command-tree validation passes)
- `wta split-pane --help` — `--horizontal` present, `-h` = help, `-v/--vertical` unchanged
