### PR TITLE
test(wta): cover WSL-session hide gate end to end (#407)

### DIFF
--- a/tools/wta/src/history_loader.rs
+++ b/tools/wta/src/history_loader.rs
@@ -671,11 +671,12 @@ mod tests {
         assert!(parse_iso_to_system_time("2023-02-29T00:00:00Z").is_none());
     }
 
-    static WSL_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     #[test]
     fn wsl_gate_defaults_off_and_honors_env() {
-        let _g = WSL_ENV_LOCK.lock().unwrap();
+        // Share the crate-wide env lock so this and the master-side gate tests
+        // (`spawn_wsl_seed_is_noop_when_wsl_sessions_disabled` et al.) can't race
+        // on the process-global `WTA_WSL_SESSIONS` var.
+        let _g = crate::test_support::lock_env();
         std::env::remove_var("WTA_WSL_SESSIONS");
         assert!(!wsl_sessions_enabled(), "default must be disabled");
         std::env::set_var("WTA_WSL_SESSIONS", "1");

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -5756,6 +5756,64 @@ mod tests {
         );
     }
 
+    /// PR #407 (master-side gate): with `WTA_WSL_SESSIONS` unset (the default),
+    /// `spawn_wsl_seed` must be a no-op — it dispatches no distro scan, claims no
+    /// scan slot, and surfaces no WSL row into the registry. This is the master
+    /// half of "hide WSL delegate sessions when the flag is off": even with a
+    /// running distro, the whole WSL surface stays dark.
+    #[tokio::test]
+    async fn spawn_wsl_seed_is_noop_when_wsl_sessions_disabled() {
+        let _env = crate::test_support::lock_env();
+        std::env::remove_var("WTA_WSL_SESSIONS");
+
+        let state = make_state();
+        let dispatched = spawn_wsl_seed(&state);
+
+        assert!(
+            !dispatched,
+            "no WSL scan may be dispatched while WTA_WSL_SESSIONS is disabled"
+        );
+        assert!(
+            !state
+                .wsl_seed_in_flight
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "the scan slot must stay free — a disabled seed claims nothing"
+        );
+        assert!(
+            state.registry.snapshot().await.is_empty(),
+            "no WSL session may be surfaced into the registry when disabled"
+        );
+    }
+
+    /// PR #407: the poll-path `maybe_spawn_wsl_title_seed` must short-circuit on
+    /// the disabled flag *before* it touches a distro or arms its throttle — even
+    /// when a genuinely seed-warranting born-bound WSL row is present (live,
+    /// synthetic, pane-bound, WSL-located, not host-listed). Otherwise a hidden
+    /// WSL delegate could still drive `wsl.exe` scans from behind the flag.
+    #[tokio::test]
+    async fn maybe_spawn_wsl_title_seed_skips_warranted_seed_when_disabled() {
+        let _env = crate::test_support::lock_env();
+        std::env::remove_var("WTA_WSL_SESSIONS");
+
+        let state = make_state();
+        // A row that WOULD warrant a seed if the flag were on (mirrors
+        // `wsl_title_seed_warranted_only_for_live_pane_bound_non_host_synthetic`).
+        let warranting = vec![live_synthetic_pane_row("wsl-sid")];
+
+        maybe_spawn_wsl_title_seed(&state, &warranting).await;
+
+        assert!(
+            state.wsl_titles_seed_at.lock().await.is_none(),
+            "the throttle must not be armed — the disabled gate returns before dispatch"
+        );
+        assert!(
+            !state
+                .wsl_seed_in_flight
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "no scan slot may be claimed while WSL sessions are disabled"
+        );
+    }
+
     #[test]
     fn row_refreshable_skips_only_definitively_cross_cli() {
         use crate::agent_sessions::CliSource;


### PR DESCRIPTION
## What

Adds end-to-end integration tests for the PR #407 fix ("Hide WSL delegate
sessions when WTA_WSL_SESSIONS is disabled").

The whole WSL surface is gated on `WTA_WSL_SESSIONS`. With it off, the master
must not surface any WSL session — historical scans and born-bound `?<prompt>`
WSL delegate rows included. Existing coverage tested the pure helpers
(`wsl_titles_from_scan`, `wsl_title_seed_warranted`) and the env parser
(`wsl_sessions_enabled`); this PR covers the master-side gate itself.

## Tests added (`tools/wta/src/master/mod.rs`)

- `spawn_wsl_seed_is_noop_when_wsl_sessions_disabled`: with the flag off,
  `spawn_wsl_seed` dispatches no distro scan, claims no scan slot, and surfaces
  no WSL row into the registry.
- `maybe_spawn_wsl_title_seed_skips_warranted_seed_when_disabled`: the poll path
  short-circuits before touching a distro or arming its throttle, even when a
  genuinely seed-warranting born-bound WSL row is present (live, synthetic,
  pane-bound, WSL-located, not host-listed).

## Supporting change

Migrates history_loader's `wsl_gate_defaults_off_and_honors_env` from its
private `WSL_ENV_LOCK` to the shared `test_support::lock_env()`, so the two
places that mutate/read the process-global `WTA_WSL_SESSIONS` serialize on one
lock and the new tests can't flake under parallel `cargo test`.

## Testing

`cargo test --manifest-path tools/wta/Cargo.toml` → **1117 passed, 0 failed**.

Test-only change; no production behavior touched.
