### PR TITLE
fix(wta): buffer + replay pre-binding session notifications instead of dropping

### DIFF
--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -58,6 +58,8 @@ use tokio::sync::{mpsc, Mutex};
 use tokio::task::LocalSet;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
+mod orphan_notifications;
+
 use crate::protocol::acp::conn;
 use crate::protocol::acp::spawn::spawn_agent_process;
 use crate::Cli;
@@ -138,6 +140,17 @@ struct MasterStateInner {
     /// blocking would freeze notification delivery for every other
     /// helper sharing this master.
     session_to_helper: Mutex<HashMap<acp::schema::v1::SessionId, HelperRoute>>,
+    /// Notifications the agent CLI emitted for a session *before* its
+    /// `session_to_helper` route existed, held for replay once the route
+    /// is installed. Populated by `MasterClient::session_notification`'s
+    /// unbound-session path and drained by `new_session` (see
+    /// [`orphan_notifications`] for the why).
+    ///
+    /// **Lock ordering:** always taken *while holding* `session_to_helper`
+    /// (both the buffering path and the replay path re-take
+    /// `session_to_helper` first), so the two can't interleave and strand
+    /// a buffered notification after the queue was already drained.
+    orphan_notifications: Mutex<orphan_notifications::OrphanNotificationBuffer>,
     /// Authoritative live-session set, owned by master. Mirrors what
     /// helpers learn via ext-notifications and what the session management view sees
     /// via the standard ACP `session/list` request. Kept beside
@@ -645,12 +658,53 @@ impl MasterClient {
                 }
             }
             None => {
-                tracing::warn!(
-                    target: "master",
-                    session_id = ?sid,
-                    kind = %kind,
-                    "agent CLI emitted session_notification for unknown SessionId — no helper to route to"
-                );
+                // The session's route isn't installed yet. For a
+                // brand-new session this is the normal pre-binding race:
+                // the agent CLI emits `available_commands_update` (and
+                // occasionally an opening chunk) synchronously while
+                // `session/new` is still returning, so the notification
+                // reaches master a few ms before `new_session` records
+                // the route. Rather than drop it — the old behavior, a
+                // WARN on every session create with the slash-command
+                // list silently lost — buffer it for `new_session` to
+                // replay once the route lands. See the
+                // `orphan_notifications` module.
+                //
+                // Re-lock `session_to_helper` and re-check: the route may
+                // have been installed between the snapshot above and now.
+                // If so, deliver directly (best-effort). Otherwise buffer
+                // *while still holding* `session_to_helper` so the replay
+                // drain in `new_session` can't run between our check and
+                // our insert and leave this entry stranded (the
+                // lock-ordering invariant documented on
+                // `MasterStateInner::orphan_notifications`).
+                let map = self.state.session_to_helper.lock().await;
+                if let Some(route) = map.get(&sid) {
+                    let tx = route.notif_tx.clone();
+                    drop(map);
+                    let _ = tx.try_send(args);
+                } else {
+                    let evicted = {
+                        let mut orphans = self.state.orphan_notifications.lock().await;
+                        orphans.buffer(sid.clone(), args, std::time::Instant::now())
+                    };
+                    drop(map);
+                    for e in evicted {
+                        tracing::warn!(
+                            target: "master",
+                            session_id = ?e.session_id,
+                            dropped = e.dropped,
+                            reason = ?e.reason,
+                            "dropping buffered session notifications for a session that never bound to a helper"
+                        );
+                    }
+                    tracing::debug!(
+                        target: "master",
+                        session_id = ?sid,
+                        kind = %kind,
+                        "buffered session notification for a not-yet-bound session; will replay after route install"
+                    );
+                }
             }
         }
         Ok(())
@@ -797,6 +851,43 @@ fn notification_kind(notif: &acp::schema::v1::SessionNotification) -> &'static s
         AvailableCommandsUpdate { .. } => "available_commands_update",
         _ => "other",
     }
+}
+
+/// Drain and replay any notifications buffered for `sid` before its
+/// `session_to_helper` route existed (the new-session pre-binding race —
+/// see the [`orphan_notifications`] module and
+/// `MasterClient::session_notification`).
+///
+/// The caller MUST hold the `session_to_helper` lock across this call so
+/// a concurrently-arriving post-binding notification (which takes the
+/// same lock before delivering directly) can't be enqueued ahead of the
+/// replayed ones, preserving arrival order across the bind transition.
+async fn replay_orphan_notifications(
+    state: &MasterStateInner,
+    notif_tx: &mpsc::Sender<acp::schema::v1::SessionNotification>,
+    sid: &acp::schema::v1::SessionId,
+) {
+    let buffered = {
+        let mut orphans = state.orphan_notifications.lock().await;
+        orphans.take(sid)
+    };
+    if buffered.is_empty() {
+        return;
+    }
+    let replayed = buffered.len();
+    for notif in buffered {
+        // The helper's channel was just created (empty), so `Full` is
+        // effectively impossible here; `Closed` only if the helper
+        // vanished between binding and now. Best-effort is correct —
+        // there's no better fallback than the normal drop path.
+        let _ = notif_tx.try_send(notif);
+    }
+    tracing::debug!(
+        target: "master",
+        session_id = ?sid,
+        replayed = replayed,
+        "replayed buffered session notifications after route install"
+    );
 }
 
 /// `acp::Agent` impl wired into one helper's `AgentSideConnection`.
@@ -1058,6 +1149,16 @@ impl HelperHandler {
                     consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
                 },
             );
+            // Replay any notifications the agent CLI emitted for this
+            // brand-new session before the route above existed — the
+            // pre-binding race (e.g. `available_commands_update` fired
+            // synchronously during `session/new`; see
+            // `MasterClient::session_notification`). Drained + enqueued
+            // while still holding `session_to_helper` so a concurrent
+            // post-binding notification (which must take this same lock)
+            // can't jump ahead of the replayed ones — arrival order is
+            // preserved across the bind transition.
+            replay_orphan_notifications(&self.state, &self.notif_tx, &resp.session_id).await;
             map.len()
         };
         // Mirror the binding into the live-session registry. Lock
@@ -1850,6 +1951,9 @@ async fn run_master_loop(cli: Cli, pipe_name: String) -> Result<()> {
 
     let inner = Arc::new(MasterStateInner {
         session_to_helper: Mutex::new(HashMap::new()),
+        orphan_notifications: Mutex::new(
+            orphan_notifications::OrphanNotificationBuffer::default(),
+        ),
         registry: crate::session_registry::InMemoryRegistry::shared(),
         helper_ext_subscribers: Mutex::new(HashMap::new()),
         wt,
@@ -4104,6 +4208,9 @@ mod tests {
     fn make_state() -> Arc<MasterStateInner> {
         Arc::new(MasterStateInner {
             session_to_helper: Mutex::new(HashMap::new()),
+            orphan_notifications: Mutex::new(
+                orphan_notifications::OrphanNotificationBuffer::default(),
+            ),
             registry: crate::session_registry::InMemoryRegistry::shared(),
             helper_ext_subscribers: Mutex::new(HashMap::new()),
             wt: None,
@@ -4630,6 +4737,84 @@ mod tests {
         assert!(
             rx2.try_recv().is_err(),
             "helper 2 should NOT have received helper 1's notification"
+        );
+    }
+
+    /// A notification for a session with no route yet is buffered (not
+    /// dropped), and a later `replay_orphan_notifications` — as issued by
+    /// `new_session` once the route lands — delivers it to the newly
+    /// bound helper in arrival order. This is the pre-binding race the
+    /// old code warned-and-dropped on every session create.
+    #[tokio::test]
+    async fn unbound_notification_is_buffered_then_replayed_on_bind() {
+        let state = make_state();
+        let sid = SessionId::new("late-bound");
+
+        // Two notifications arrive before the route exists.
+        route(&state, make_notif(&sid)).await;
+        route(&state, make_notif(&sid)).await;
+
+        assert_eq!(
+            state.orphan_notifications.lock().await.session_count(),
+            1,
+            "both notifications buffered under one session"
+        );
+
+        // The helper binds: install its route, then replay (production
+        // does the replay while holding session_to_helper — here the test
+        // is single-threaded so ordering is trivially preserved).
+        let (tx, mut rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+        {
+            let mut map = state.session_to_helper.lock().await;
+            map.insert(
+                sid.clone(),
+                HelperRoute {
+                    helper_id: HelperId(1),
+                    notif_tx: tx.clone(),
+                    forwarder: None,
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            );
+        }
+        replay_orphan_notifications(&state, &tx, &sid).await;
+
+        assert!(rx.try_recv().is_ok(), "first buffered notification replayed");
+        assert!(rx.try_recv().is_ok(), "second buffered notification replayed");
+        assert!(rx.try_recv().is_err(), "exactly two replayed");
+        assert_eq!(
+            state.orphan_notifications.lock().await.session_count(),
+            0,
+            "buffer drained on replay"
+        );
+    }
+
+    /// A notification whose route already exists never gets buffered — it
+    /// is delivered directly, and the orphan buffer stays empty.
+    #[tokio::test]
+    async fn bound_session_notification_is_not_buffered() {
+        let state = make_state();
+        let (tx, mut rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+        let sid = SessionId::new("already-bound");
+        {
+            let mut map = state.session_to_helper.lock().await;
+            map.insert(
+                sid.clone(),
+                HelperRoute {
+                    helper_id: HelperId(1),
+                    notif_tx: tx,
+                    forwarder: None,
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            );
+        }
+
+        route(&state, make_notif(&sid)).await;
+
+        assert!(rx.try_recv().is_ok(), "delivered directly to the helper");
+        assert_eq!(
+            state.orphan_notifications.lock().await.session_count(),
+            0,
+            "nothing buffered for an already-bound session"
         );
     }
 
@@ -5348,6 +5533,9 @@ mod tests {
     ) -> Arc<MasterStateInner> {
         Arc::new(MasterStateInner {
             session_to_helper: Mutex::new(HashMap::new()),
+            orphan_notifications: Mutex::new(
+                orphan_notifications::OrphanNotificationBuffer::default(),
+            ),
             registry: crate::session_registry::InMemoryRegistry::shared(),
             helper_ext_subscribers: Mutex::new(HashMap::new()),
             wt: Some(wt),

--- a/tools/wta/src/master/orphan_notifications.rs
+++ b/tools/wta/src/master/orphan_notifications.rs
@@ -1,0 +1,286 @@
+// tools/wta/src/master/orphan_notifications.rs
+//
+// Buffer for `session/update` notifications that arrive from the agent
+// CLI *before* master has installed the `session_to_helper` route for
+// their session.
+//
+// Why this exists: for a brand-new session the `SessionId` is only known
+// once the agent CLI answers `session/new`, so master cannot pre-register
+// the route the way `load_session` does (there the id is a request
+// input). Agents commonly emit `session/update` notifications —
+// `available_commands_update`, and occasionally an opening message chunk
+// — *synchronously while `session/new` is still returning*. Those land in
+// `MasterClient::session_notification` a few milliseconds before
+// `new_session` records the route, so without buffering they hit the
+// "unknown SessionId" path and are dropped (a WARN on every session
+// create, and the slash-command list silently lost).
+//
+// This buffer holds such notifications briefly, keyed by session id, so
+// `new_session` can replay them in arrival order once the route is
+// installed. Anything still unbound after `ORPHAN_TTL` is a genuine drop
+// (agent bug / vanished helper) and is surfaced to the caller for a WARN.
+
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use agent_client_protocol as acp;
+
+/// How long a buffered notification is retained waiting for its session
+/// to bind to a helper. The pre-binding race resolves in single-digit
+/// milliseconds, so this window is generous; anything still unbound after
+/// it is treated as a real dropped notification.
+pub(super) const ORPHAN_TTL: Duration = Duration::from_secs(30);
+
+/// Max buffered notifications retained per not-yet-bound session. Bounds
+/// memory if an agent streams into a session that never binds. Oldest
+/// entries are dropped first once the cap is exceeded.
+pub(super) const PER_SESSION_CAP: usize = 256;
+
+/// Max number of distinct not-yet-bound sessions buffered at once. A hard
+/// safety cap; steady state is 0–2 (each cleared within ~1 s by binding).
+pub(super) const MAX_SESSIONS: usize = 256;
+
+/// Why a session's buffered notifications were evicted without ever being
+/// replayed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum EvictReason {
+    /// The session stayed unbound past [`ORPHAN_TTL`].
+    Ttl,
+    /// The distinct-session count exceeded [`MAX_SESSIONS`] and this was
+    /// the oldest victim.
+    MaxSessions,
+}
+
+/// A session whose buffered notifications were dropped without replay — a
+/// genuine lost-notification event the caller surfaces at WARN.
+#[derive(Debug, Clone)]
+pub(super) struct Evicted {
+    pub session_id: acp::schema::v1::SessionId,
+    pub dropped: usize,
+    pub reason: EvictReason,
+}
+
+struct Entry {
+    received_at: Instant,
+    notification: acp::schema::v1::SessionNotification,
+}
+
+/// Bounded, TTL-pruned store of pre-binding session notifications, keyed
+/// by session id. Not thread-safe on its own — the master wraps it in a
+/// `Mutex` and only ever touches it while holding the `session_to_helper`
+/// lock, which serializes buffering against replay (see the module doc
+/// and `MasterClient::session_notification`).
+#[derive(Default)]
+pub(super) struct OrphanNotificationBuffer {
+    by_session: HashMap<acp::schema::v1::SessionId, VecDeque<Entry>>,
+}
+
+impl OrphanNotificationBuffer {
+    /// Buffer `notification` for a session that has no route yet. Prunes
+    /// TTL-expired sessions and enforces the session-count cap first.
+    /// Returns any sessions evicted in the process so the caller can log
+    /// them at WARN.
+    pub(super) fn buffer(
+        &mut self,
+        session_id: acp::schema::v1::SessionId,
+        notification: acp::schema::v1::SessionNotification,
+        now: Instant,
+    ) -> Vec<Evicted> {
+        let mut evicted = self.prune_expired(now);
+
+        let queue = self.by_session.entry(session_id.clone()).or_default();
+        queue.push_back(Entry {
+            received_at: now,
+            notification,
+        });
+        while queue.len() > PER_SESSION_CAP {
+            queue.pop_front();
+        }
+
+        // Session-count safety net. If we're tracking too many distinct
+        // unbound sessions, evict the one with the oldest head entry
+        // (closest to TTL expiry anyway). Never evict the session we just
+        // buffered into.
+        while self.by_session.len() > MAX_SESSIONS {
+            let Some(victim) = self.oldest_session_except(&session_id) else {
+                break;
+            };
+            if let Some(queue) = self.by_session.remove(&victim) {
+                evicted.push(Evicted {
+                    session_id: victim,
+                    dropped: queue.len(),
+                    reason: EvictReason::MaxSessions,
+                });
+            }
+        }
+        evicted
+    }
+
+    /// Remove and return every notification buffered for `session_id`, in
+    /// arrival order. Called right after the route is installed so the
+    /// caller can replay them to the newly-bound helper.
+    pub(super) fn take(
+        &mut self,
+        session_id: &acp::schema::v1::SessionId,
+    ) -> Vec<acp::schema::v1::SessionNotification> {
+        self.by_session
+            .remove(session_id)
+            .map(|queue| queue.into_iter().map(|entry| entry.notification).collect())
+            .unwrap_or_default()
+    }
+
+    /// Drop every session whose oldest buffered entry has aged past the
+    /// TTL, returning them for logging.
+    fn prune_expired(&mut self, now: Instant) -> Vec<Evicted> {
+        let expired: Vec<acp::schema::v1::SessionId> = self
+            .by_session
+            .iter()
+            .filter(|(_, queue)| {
+                queue
+                    .front()
+                    .map_or(true, |entry| now.duration_since(entry.received_at) >= ORPHAN_TTL)
+            })
+            .map(|(sid, _)| sid.clone())
+            .collect();
+        expired
+            .into_iter()
+            .filter_map(|sid| {
+                self.by_session.remove(&sid).map(|queue| Evicted {
+                    session_id: sid,
+                    dropped: queue.len(),
+                    reason: EvictReason::Ttl,
+                })
+            })
+            .collect()
+    }
+
+    /// The session (other than `except`) whose oldest buffered entry is
+    /// the earliest — the best MaxSessions eviction victim.
+    fn oldest_session_except(
+        &self,
+        except: &acp::schema::v1::SessionId,
+    ) -> Option<acp::schema::v1::SessionId> {
+        self.by_session
+            .iter()
+            .filter(|(sid, _)| *sid != except)
+            .min_by_key(|(_, queue)| queue.front().map(|entry| entry.received_at))
+            .map(|(sid, _)| sid.clone())
+    }
+
+    #[cfg(test)]
+    pub(super) fn session_count(&self) -> usize {
+        self.by_session.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sid(s: &str) -> acp::schema::v1::SessionId {
+        acp::schema::v1::SessionId::new(s.to_string())
+    }
+
+    fn notif(sid_str: &str) -> acp::schema::v1::SessionNotification {
+        acp::schema::v1::SessionNotification::new(
+            sid(sid_str),
+            acp::schema::v1::SessionUpdate::AvailableCommandsUpdate(
+                acp::schema::v1::AvailableCommandsUpdate::new(Vec::new()),
+            ),
+        )
+    }
+
+    #[test]
+    fn buffers_and_takes_in_arrival_order() {
+        let mut buf = OrphanNotificationBuffer::default();
+        let now = Instant::now();
+        assert!(buf.buffer(sid("a"), notif("a"), now).is_empty());
+        assert!(buf.buffer(sid("a"), notif("a"), now).is_empty());
+        assert_eq!(buf.session_count(), 1);
+
+        let taken = buf.take(&sid("a"));
+        assert_eq!(taken.len(), 2, "both notifications replayed");
+        assert_eq!(buf.session_count(), 0, "queue removed on take");
+    }
+
+    #[test]
+    fn take_of_unknown_session_is_empty() {
+        let mut buf = OrphanNotificationBuffer::default();
+        assert!(buf.take(&sid("missing")).is_empty());
+    }
+
+    #[test]
+    fn take_leaves_other_sessions_intact() {
+        let mut buf = OrphanNotificationBuffer::default();
+        let now = Instant::now();
+        buf.buffer(sid("a"), notif("a"), now);
+        buf.buffer(sid("b"), notif("b"), now);
+
+        assert_eq!(buf.take(&sid("a")).len(), 1);
+        assert_eq!(buf.session_count(), 1, "b still buffered");
+        assert_eq!(buf.take(&sid("b")).len(), 1);
+    }
+
+    #[test]
+    fn expired_session_is_evicted_on_next_buffer() {
+        let mut buf = OrphanNotificationBuffer::default();
+        let start = Instant::now();
+        buf.buffer(sid("stale"), notif("stale"), start);
+
+        // A later buffer for a different session past the TTL evicts the
+        // stale one and reports it.
+        let later = start + ORPHAN_TTL + Duration::from_secs(1);
+        let evicted = buf.buffer(sid("fresh"), notif("fresh"), later);
+
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].session_id, sid("stale"));
+        assert_eq!(evicted[0].dropped, 1);
+        assert_eq!(evicted[0].reason, EvictReason::Ttl);
+        // The stale queue is gone; only the fresh one remains.
+        assert!(buf.take(&sid("stale")).is_empty());
+        assert_eq!(buf.take(&sid("fresh")).len(), 1);
+    }
+
+    #[test]
+    fn per_session_cap_drops_oldest() {
+        let mut buf = OrphanNotificationBuffer::default();
+        let now = Instant::now();
+        for _ in 0..(PER_SESSION_CAP + 5) {
+            buf.buffer(sid("a"), notif("a"), now);
+        }
+        assert_eq!(
+            buf.take(&sid("a")).len(),
+            PER_SESSION_CAP,
+            "queue capped at PER_SESSION_CAP"
+        );
+    }
+
+    #[test]
+    fn max_sessions_evicts_oldest_head() {
+        let mut buf = OrphanNotificationBuffer::default();
+        let base = Instant::now();
+        // Fill exactly to the cap, each session with a distinct (older →
+        // newer) head timestamp.
+        for i in 0..MAX_SESSIONS {
+            let when = base + Duration::from_millis(i as u64);
+            buf.buffer(sid(&format!("s{i}")), notif("x"), when);
+        }
+        assert_eq!(buf.session_count(), MAX_SESSIONS);
+
+        // One more distinct session tips us over; the oldest head (s0) is
+        // evicted as MaxSessions.
+        let when = base + Duration::from_millis(MAX_SESSIONS as u64);
+        let evicted = buf.buffer(sid("overflow"), notif("x"), when);
+
+        let max_evictions: Vec<_> = evicted
+            .iter()
+            .filter(|e| e.reason == EvictReason::MaxSessions)
+            .collect();
+        assert_eq!(max_evictions.len(), 1);
+        assert_eq!(max_evictions[0].session_id, sid("s0"));
+        assert_eq!(buf.session_count(), MAX_SESSIONS);
+        assert!(buf.take(&sid("s0")).is_empty(), "oldest evicted");
+        assert_eq!(buf.take(&sid("overflow")).len(), 1, "newcomer kept");
+    }
+}


### PR DESCRIPTION
## Problem

Every new agent session logged **two** `WARN`s in `wta-main_master.log`, immediately before the session bound:

```
WARN master: agent CLI emitted session_notification for unknown SessionId — no helper to route to
     session_id=1c9ce06e... kind=available_commands_update   (x2)
INFO master: session bound to helper session_id=1c9ce06e...
```

Reproduced for **every** session in a real log (`1c9ce06e / c7f69a00 / 5b2e532c / 40b8adb8 / 505f8ba2`).

### Root cause

For a brand-new session the `SessionId` is only known once the agent CLI answers `session/new`, so master **cannot** pre-register the `session_to_helper` route the way `load_session` does (there the id is a request input). Copilot emits `session/update` notifications — notably `available_commands_update` — **synchronously while `session/new` is still returning**, so they land in `MasterClient::session_notification` a few ms before `new_session` records the route. The old code dropped them via the "unknown SessionId" path.

`load_session` already fixed the analogous "resume shows no scrollback" case via pre-registration; `new_session` couldn't, so the window stayed open. Currently the dropped `available_commands_update` is unconsumed helper-side (so no visible break **yet**), but it's a latent bug — any early notification (opening chunk, model/mode update) would be silently lost — plus the per-session WARN spam.

## Fix

- New `tools/wta/src/master/orphan_notifications.rs`: a bounded, TTL-pruned `OrphanNotificationBuffer` keyed by `SessionId` (TTL 30s, per-session cap 256, session-count cap 256).
- `session_notification` unbound-session path now **buffers** instead of dropping, re-checking under the `session_to_helper` lock so it can't race the drain.
- `new_session` replays the buffer in arrival order **while still holding `session_to_helper`**, so replayed notifications land ahead of any post-binding notification — order preserved across the bind transition.
- Only notifications that stay unbound past the TTL or overflow the caps are surfaced at `WARN`, killing the false positives while keeping the diagnostic for genuine drops.

**Lock ordering:** `session_to_helper` (outer) → `orphan_notifications` (inner), consistent on both the buffer and replay paths — no deadlock.

## Tests

`cargo test --manifest-path tools/wta/Cargo.toml` → **1123 passed, 0 failed**. Adds 8 tests:
- 6 buffer-semantics unit tests (arrival order, TTL eviction, per-session cap, max-sessions eviction, take semantics).
- 2 end-to-end tests through `session_notification`: unbound → buffered → replayed on bind; already-bound → delivered directly, never buffered.

## Scope

Rust-only, entirely within `wta-master`. No C++/protocol/settings changes.
