### PR TITLE
docs(e2e): track delegate title-echo guard as checklist item C229 (#400)

### DIFF
--- a/doc/release-check-list.md
+++ b/doc/release-check-list.md
@@ -269,6 +269,7 @@ Net effect: UT shrinks the manual matrix to "did the wiring and UI connect", not
 - [ ] `C142` `[E2E]` `[MANUAL]` **Delegate with Copilot works:** Copilot delegate task starts and responds.
 - [ ] `C143` `[E2E]` `[MANUAL]` **Delegate with non-Copilot agents works:** Claude/Codex/Gemini delegate tasks start and respond where supported by delegate mode.
 - [ ] `C144` `[UT~]` `[E2E]` **Delegate errors are actionable:** Missing CLI/auth errors are clear.
+- [ ] `C229` `[UT✓]` `[E2E]` **Delegate session title is clean:** The delegate's baked `## Terminal Context (pane …)` first message never surfaces as the session's `session/list` title — no injected pane-context/GUID leak, and the row heals to the CLI's real summary.
 
 ## 6. Custom agents
 

--- a/test/e2e/release-coverage-map.psd1
+++ b/test/e2e/release-coverage-map.psd1
@@ -204,6 +204,11 @@
     'Delegate provider is correct'      = 'Delegate provider is correct'
     'Delegate with Copilot works'       = 'Delegate with Copilot works'
     'Delegate errors are actionable'    = 'Delegate errors are actionable'
+    # C229 (#400): the delegate must not surface its baked `## Terminal Context (pane …)` first
+    # message as a session/list title (no injected pane-context/GUID leak). The E2E case is
+    # OPPORTUNISTIC — the echo only appears in a timing window — so the item's deterministic
+    # backing is the Rust UT session_registry::title_is_injected_context_echo_detects_delegate_marker_only.
+    'Delegate session title is clean'   = 'Delegate session title does not leak the injected terminal-context echo'
     # §5 non-Copilot delegate (Feature.DelegateNonCopilot) — claude/gemini delegate tab launches.
     'Delegate with non-Copilot agents works' = 'Delegate with non-Copilot agents works'
 }


### PR DESCRIPTION
## What

Follow-up to #431 (merged). Registers the opportunistic delegate title-echo e2e
test (added in #431) as a tracked release-checklist item so the generated release
report credits it.

## Changes

- **`doc/release-check-list.md`** — add §5 item `C229` **Delegate session title is
  clean**: the delegate's baked `## Terminal Context (pane …)` first message must
  never surface as a `session/list` title (no injected pane-context/GUID leak; the
  row heals to the CLI's real summary). Tagged `[UT✓] [E2E]`.
- **`test/e2e/release-coverage-map.psd1`** — map that item title to the e2e case
  `Delegate session title does not leak the injected terminal-context echo`
  (`Feature.Delegate.Tests.ps1`), with a NOTE that the E2E is opportunistic and the
  deterministic backing is the Rust UT
  `session_registry::title_is_injected_context_echo_detects_delegate_marker_only`.

## Notes

- ID assigned via `Set-ChecklistIds.ps1` (idempotent — only 1 new ID `C229`
  assigned; no existing IDs renumbered).
- Verified: the map imports cleanly (no duplicate keys); the report's title-strip of
  the `C229` line yields exactly the map key `Delegate session title is clean`; and
  the mapped regex matches the e2e test's full name — so a passing e2e run credits
  `C229` as `[x]`.

Docs/coverage-map only; no product or test-logic change.
