### PR TITLE
Durable sessions (step2): capture & resume the agent session on restore

### DIFF
--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -718,6 +718,20 @@ namespace winrt::TerminalApp::implementation
                 cwd = activeControl.WorkingDirectory();
             }
 
+            // If the tab has an agent pane, record its WT session GUID
+            // (pane_session_id) so restore can resolve it to the ACP session id
+            // (via wta's agent-pane-sessions.jsonl) and resume that conversation.
+            // FindAgentPane() also finds a stashed (hidden) agent pane, so a
+            // toggled-closed-but-alive agent session is captured too.
+            winrt::hstring agentPaneSessionId;
+            if (const auto agentPane = tabImpl->FindAgentPane())
+            {
+                if (const auto sid = agentPane->GetSessionId(); sid != winrt::guid{})
+                {
+                    agentPaneSessionId = winrt::hstring{ ::Microsoft::Console::Utils::GuidToPlainString(sid) };
+                }
+            }
+
             // wta-master is the SOLE owner of the durable shell-session store
             // (SQLite). We do NOT persist into WT's state.json; instead we ship
             // the whole snapshot as a `save_shell_session` event, which master's
@@ -741,6 +755,12 @@ namespace winrt::TerminalApp::implementation
                 guidsArr.append(winrt::to_string(guid));
             }
             params["buffer_guids"] = std::move(guidsArr);
+            // When the tab had an agent pane, forward its WT session GUID so
+            // master can persist it and restore can resume that conversation.
+            if (!agentPaneSessionId.empty())
+            {
+                params["agent_pane_session_id"] = winrt::to_string(agentPaneSessionId);
+            }
             evt["params"] = std::move(params);
 
             Json::StreamWriterBuilder wb;

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -718,13 +718,19 @@ namespace winrt::TerminalApp::implementation
                 cwd = activeControl.WorkingDirectory();
             }
 
-            // If the tab has an agent pane, record its WT session GUID
-            // (pane_session_id) so restore can resolve it to the ACP session id
-            // (via wta's agent-pane-sessions.jsonl) and resume that conversation.
-            // FindAgentPane() also finds a stashed (hidden) agent pane, so a
-            // toggled-closed-but-alive agent session is captured too.
+            // If the tab has an agent pane the user actually opened, record its
+            // WT session GUID (pane_session_id) so restore can resolve it to the
+            // ACP session id (via wta's agent-pane-sessions.jsonl) and resume
+            // that conversation, faithfully re-showing it.
+            //
+            // We deliberately capture ONLY a visible (open) agent pane, not a
+            // stashed/hidden one: every tab pre-warms a stashed agent pane with
+            // a fresh, empty ACP session (see `_InitializeTab`). Capturing that
+            // would resurrect an agent the user never engaged with — showing an
+            // empty pane on restore. Requiring `!IsHidden()` scopes capture to
+            // an agent the user had open, matching the saved display.
             winrt::hstring agentPaneSessionId;
-            if (const auto agentPane = tabImpl->FindAgentPane())
+            if (const auto agentPane = tabImpl->FindAgentPane(); agentPane && !agentPane->IsHidden())
             {
                 if (const auto sid = agentPane->GetSessionId(); sid != winrt::guid{})
                 {

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -6259,6 +6259,14 @@ namespace winrt::TerminalApp::implementation
                 // Persist the full layout into the workspace collection.
                 ApplicationState::SharedInstance().SaveWorkspace(windowName, layout);
 
+                // Durable sessions: also persist this workspace's scrollback so
+                // reopening it later restores terminal contents, not just the
+                // layout + working directories. The buffers use the standard
+                // `buffer_`/`elevated_` prefix (so the normal restore path picks
+                // them up on reopen) and are kept alive by the workspace-aware
+                // cleanup in `WindowEmperor::_finalizeSessionPersistence`.
+                _PersistWorkspaceBuffers();
+
                 // Build a minimal layout with just an openWorkspace action
                 // so the generic restore path re-opens this workspace by name.
                 std::vector<ActionAndArgs> actions;
@@ -6276,6 +6284,62 @@ namespace winrt::TerminalApp::implementation
             {
                 ApplicationState::SharedInstance().AppendPersistedWindowLayout(layout);
             }
+        }
+    }
+
+    // Persist every terminal pane's scrollback in this window to
+    // `buffer_{guid}.txt` (or `elevated_` when running as admin) next to
+    // state.json, so a saved workspace can restore its contents on reopen.
+    // Agent panes are skipped (excluded from the saved layout). Mirrors the
+    // per-pane persistence WindowEmperor does at app close, but runs when a
+    // workspace is saved so its buffers exist even if its window isn't live at
+    // the next shutdown — `_finalizeSessionPersistence` keeps the files it
+    // finds referenced by a saved workspace.
+    void TerminalPage::_PersistWorkspaceBuffers()
+    {
+        using namespace std::string_view_literals;
+
+        const std::filesystem::path settingsDirectory{ std::wstring_view{ CascadiaSettings::SettingsDirectory() } };
+        const auto filenamePrefix = IsRunningElevated() ? L"elevated_"sv : L"buffer_"sv;
+
+        for (const auto& tab : _tabs)
+        {
+            const auto tabImpl = winrt::get_self<implementation::Tab>(tab);
+            if (!tabImpl)
+            {
+                continue;
+            }
+            const auto rootPane = tabImpl->GetRootPane();
+            if (!rootPane)
+            {
+                continue;
+            }
+            rootPane->WalkTree([&](const std::shared_ptr<Pane>& p) {
+                if (!p->GetContent() || p->IsAgentPane())
+                {
+                    return;
+                }
+                const auto control = p->GetTerminalControl();
+                if (!control)
+                {
+                    return;
+                }
+                const auto connection = control.Connection();
+                if (!connection)
+                {
+                    return;
+                }
+                const auto sessionId = connection.SessionId();
+                if (sessionId == winrt::guid{})
+                {
+                    return;
+                }
+                const auto path = settingsDirectory / fmt::format(FMT_COMPILE(L"{}{}.txt"), filenamePrefix, sessionId);
+                if (wil::unique_hfile file{ CreateFileW(path.c_str(), GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_DELETE, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr) })
+                {
+                    control.PersistTo(reinterpret_cast<int64_t>(file.get()));
+                }
+            });
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -5189,7 +5189,8 @@ namespace winrt::TerminalApp::implementation
         _RequestAgentStateForTab(newTab, std::nullopt, /*pane_open*/ true);
     }
 
-    // Inbound event from WTA: {method:"restore_shell_session", params:{name, layout_json}}.
+    // Inbound event from WTA: {method:"restore_shell_session",
+    //   params:{name, layout_json, agent_session_id?, agent_cwd?}}.
     // Sent by the agent-pane `/shell-sessions` picker's Enter handler. The
     // `layout_json` comes straight from master's SQLite store (the sole owner of
     // durable shell sessions), so we deserialize it here and replay its startup
@@ -5198,6 +5199,10 @@ namespace winrt::TerminalApp::implementation
     // `<StateDir>\shell-session-buffers\{guid}.txt` file: we pre-mark the
     // layout's session GUIDs in `_pendingShellSessionBufferIds` so the
     // buffer-restore path (in `_MakePane`) reads the durable file.
+    //
+    // When the saved tab had an agent pane, wta resolves its ACP session id and
+    // passes it as `agent_session_id` (+ `agent_cwd`); we resume that
+    // conversation into the rebuilt tab (see `_RestoreShellSessionCoro`).
     void TerminalPage::OnRestoreShellSessionRequested(hstring eventJson)
     {
         _agentPaneLog("OnRestoreShellSessionRequested: received from wta");
@@ -5226,13 +5231,16 @@ namespace winrt::TerminalApp::implementation
             _agentPaneLog("OnRestoreShellSessionRequested: missing params object");
             return;
         }
-        const auto nameStr = evt["params"].get("name", "").asString();
-        const auto layoutJsonStr = evt["params"].get("layout_json", "").asString();
+        const auto& params = evt["params"];
+        const auto nameStr = params.get("name", "").asString();
+        const auto layoutJsonStr = params.get("layout_json", "").asString();
         if (layoutJsonStr.empty())
         {
             _agentPaneLog("OnRestoreShellSessionRequested: missing layout_json — ignoring");
             return;
         }
+        const auto agentSessionId = params.get("agent_session_id", "").asString();
+        const auto agentCwd = params.get("agent_cwd", "").asString();
 
         WindowLayout layout{ nullptr };
         try
@@ -5282,7 +5290,63 @@ namespace winrt::TerminalApp::implementation
         }
 
         _agentPaneLog("OnRestoreShellSessionRequested: rebuilding tab for session '" + nameStr + "'");
-        ProcessStartupActions(std::move(actions));
+        _RestoreShellSessionCoro(std::move(actions), agentSessionId, agentCwd);
+    }
+
+    // Rebuild a shell session's tab from its saved startup actions, then (when
+    // the saved tab had an agent pane) resume that agent session into the new
+    // tab. This is a coroutine so it can sequence the agent-pane open AFTER the
+    // async tab/pane construction has settled.
+    //
+    // Agent-pane handling mirrors `OnAgentPaneRestartRequested`: every new tab
+    // pre-warms a FRESH stashed agent pane (`_InitializeTab`), so we tear that
+    // down first (FindAgentPane also finds the stashed/hidden one) and then
+    // create a RESUMED pane via `--initial-load-session-id`. Because both steps
+    // run in one synchronous block on the UI thread, the pre-warm's deferred
+    // tick either already ran (we tear it down) or runs later and no-ops on our
+    // now-present pane — so we never end up with two agent panes.
+    safe_void_coroutine TerminalPage::_RestoreShellSessionCoro(std::vector<ActionAndArgs> actions, std::string agentSessionId, std::string agentCwd)
+    {
+        const auto strong = get_strong();
+
+        // Same replay shape as ProcessStartupActions: don't suspend before the
+        // first action if this is the first tab, but suspend between subsequent
+        // ones so WinUI can lay out each new control.
+        auto suspend = _tabs.Size() > 0;
+        for (const auto& action : actions)
+        {
+            if (suspend)
+            {
+                co_await wil::resume_foreground(Dispatcher(), CoreDispatcherPriority::Low);
+            }
+            _actionDispatch->DoAction(action);
+            suspend = true;
+        }
+
+        if (!agentSessionId.empty())
+        {
+            if (const auto newTab = _GetFocusedTabImpl())
+            {
+                _agentPaneLog("OnRestoreShellSessionRequested: resuming agent session " + agentSessionId + " into restored tab");
+                // Replace any pre-warmed (fresh-session) agent pane with a
+                // resumed one bound to the saved ACP session id.
+                _TeardownAgentPane(newTab, /*suppressMasterRestart*/ true);
+                _AutoCreateHiddenAgentPaneShared(newTab,
+                                                 /*intoSessionsView*/ false,
+                                                 /*autoStash*/ false,
+                                                 agentSessionId,
+                                                 agentCwd);
+            }
+        }
+
+        // Mirror ProcessStartupActions' tail: focus the active pane's content.
+        if (const auto& tabImpl{ _GetFocusedTabImpl() })
+        {
+            if (const auto& content{ tabImpl->GetActiveContent() })
+            {
+                content.Focus(FocusState::Programmatic);
+            }
+        }
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -688,6 +688,7 @@ namespace winrt::TerminalApp::implementation
         void _SaveShellSessionForTab(const winrt::TerminalApp::Tab& tab);
         std::vector<winrt::hstring> _PersistShellSessionBuffers(winrt::com_ptr<implementation::Tab> tabImpl);
         safe_void_coroutine _RestoreShellSessionCoro(std::vector<Microsoft::Terminal::Settings::Model::ActionAndArgs> actions, std::string agentSessionId, std::string agentCwd);
+        void _PersistWorkspaceBuffers();
 
         void _InitializeTab(winrt::com_ptr<Tab> newTabImpl, uint32_t insertPosition = -1, bool openInBackground = false);
         void _RegisterTerminalEvents(Microsoft::Terminal::Control::TermControl term);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -687,6 +687,7 @@ namespace winrt::TerminalApp::implementation
         // `save_shell_session` event; WT never persists it into state.json.
         void _SaveShellSessionForTab(const winrt::TerminalApp::Tab& tab);
         std::vector<winrt::hstring> _PersistShellSessionBuffers(winrt::com_ptr<implementation::Tab> tabImpl);
+        safe_void_coroutine _RestoreShellSessionCoro(std::vector<Microsoft::Terminal::Settings::Model::ActionAndArgs> actions, std::string agentSessionId, std::string agentCwd);
 
         void _InitializeTab(winrt::com_ptr<Tab> newTabImpl, uint32_t insertPosition = -1, bool openInBackground = false);
         void _RegisterTerminalEvents(Microsoft::Terminal::Control::TermControl term);

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -1462,6 +1462,47 @@ void WindowEmperor::_finalizeSessionPersistence() const
     // Now remove the "buffer_{guid}.txt" files that shouldn't be there.
     if (_needsPersistenceCleanup)
     {
+        // Durable workspaces: keep the scrollback files referenced by any saved
+        // workspace, even though that workspace's window isn't currently open.
+        // Without this the cleanup below would delete a saved workspace's
+        // buffers, so reopening it later would lose its terminal contents.
+        if (const auto workspaces = ApplicationState::SharedInstance().AllPersistedWorkspaces())
+        {
+            const auto rememberSessionArgs = [&](const auto& contentArgs) {
+                if (const auto termArgs = contentArgs.try_as<NewTerminalArgs>())
+                {
+                    if (const auto sid = termArgs.SessionId(); sid != winrt::guid{})
+                    {
+                        bufferFilenames.emplace(fmt::format(FMT_COMPILE(L"{}{}.txt"), filenamePrefix, sid));
+                    }
+                }
+            };
+            for (const auto& kv : workspaces)
+            {
+                const auto layout = kv.Value();
+                if (!layout)
+                {
+                    continue;
+                }
+                const auto tabLayout = layout.TabLayout();
+                if (!tabLayout)
+                {
+                    continue;
+                }
+                for (const auto& action : tabLayout)
+                {
+                    if (const auto newTabArgs = action.Args().try_as<NewTabArgs>())
+                    {
+                        rememberSessionArgs(newTabArgs.ContentArgs());
+                    }
+                    else if (const auto splitArgs = action.Args().try_as<SplitPaneArgs>())
+                    {
+                        rememberSessionArgs(splitArgs.ContentArgs());
+                    }
+                }
+            }
+        }
+
         const auto filter = fmt::format(FMT_COMPILE(L"{}\\{}*"), settingsDirectory.native(), filenamePrefix);
 
         // This could also use std::filesystem::directory_iterator.

--- a/tools/wta/src/agent_pane_origin.rs
+++ b/tools/wta/src/agent_pane_origin.rs
@@ -250,11 +250,61 @@ pub fn load_records_from(path: &std::path::Path) -> HashMap<String, OriginRecord
     out
 }
 
+/// Resolve the most recent ACP session id created for the given WT pane
+/// (`pane_session_id` — the agent pane's `WT_SESSION` GUID). Scans the index in
+/// append order across all default index paths and returns the last matching
+/// `session_id`, so a pane that hosted several sessions (via `/new`) resolves to
+/// its latest. The GUID comparison is case-insensitive. Returns `None` when
+/// nothing matches (e.g. the pane never hosted an agent-pane session, or the
+/// index is absent).
+///
+/// Used by the durable `/shell-sessions` restore to turn the pane GUID saved by
+/// Windows Terminal into an ACP session id it can `session/load`.
+pub fn resolve_latest_session_for_pane(pane_session_id: &str) -> Option<String> {
+    let needle = pane_session_id.trim();
+    if needle.is_empty() {
+        return None;
+    }
+    let mut found = None;
+    // Later paths (the current runtime's index) win over installed-package
+    // indices, matching the `default_index_paths` / `load_default_records` order.
+    for path in default_index_paths() {
+        if let Some(session_id) = last_session_for_pane_in(&path, needle) {
+            found = Some(session_id);
+        }
+    }
+    found
+}
+
+/// Scan one index file in append order, returning the `session_id` of the last
+/// record whose `pane_session_id` matches (case-insensitive), or `None`.
+fn last_session_for_pane_in(path: &std::path::Path, pane_session_id: &str) -> Option<String> {
+    let file = File::open(path).ok()?;
+    let mut last = None;
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        let Some(pane) = value.get("pane_session_id").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if !pane.eq_ignore_ascii_case(pane_session_id) {
+            continue;
+        }
+        if let Some(sid) = value.get("session_id").and_then(|v| v.as_str()) {
+            if !sid.is_empty() {
+                last = Some(sid.to_string());
+            }
+        }
+    }
+    last
+}
+
 fn rfc3339_now() -> String {
-    // Tiny RFC3339 emitter — we don't pull in chrono just for this. The
-    // exact format is unspecified by callers (the index is for our own
-    // consumption); a sortable UTC timestamp is enough for `tail -f`
-    // debugging.
     let secs = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -375,6 +425,30 @@ mod tests {
         let _ = std::fs::remove_file(&path);
         let set = load_set_from(&path);
         assert!(set.is_empty());
+    }
+
+    #[test]
+    fn resolve_latest_session_for_pane_returns_last_match() {
+        let path = tmp_index_path("resolve-pane");
+        // The same pane hosted two sessions over time (e.g. via `/new`); the
+        // latest (last appended) must win. GUID compare is case-insensitive.
+        append_to(&path, "sess-old", Some("PANE-GUID")).unwrap();
+        append_to(&path, "sess-new", Some("pane-guid")).unwrap();
+        append_to(&path, "other", Some("different-pane")).unwrap();
+
+        assert_eq!(
+            last_session_for_pane_in(&path, "pane-guid").as_deref(),
+            Some("sess-new")
+        );
+        assert_eq!(
+            last_session_for_pane_in(&path, "PANE-GUID").as_deref(),
+            Some("sess-new")
+        );
+        // Unknown pane, and a missing file, both resolve to None.
+        assert_eq!(last_session_for_pane_in(&path, "no-such-pane"), None);
+        let missing = std::env::temp_dir().join("no-such-index-77a1.jsonl");
+        let _ = std::fs::remove_file(&missing);
+        assert_eq!(last_session_for_pane_in(&missing, "pane-guid"), None);
     }
 
     #[test]

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -3150,22 +3150,65 @@ impl App {
     /// tab via a one-way `restore_shell_session` protocol event. The row
     /// carries master's authoritative `layout_json`, so we forward it (plus the
     /// name) and let the C++ side replay the layout and reconnect scrollback.
+    /// When the saved tab had an agent pane, resolve its WT pane GUID to the ACP
+    /// session id so WT can resume that conversation into the rebuilt tab.
     fn commit_shell_session_pick(&mut self) {
         let picked = {
             let tab = self.current_tab();
             let idx = tab.shell_sessions_picker_selected;
-            tab.shell_sessions
-                .get(idx)
-                .map(|entry| (entry.name.clone(), entry.layout_json.clone()))
+            tab.shell_sessions.get(idx).cloned()
         };
         self.close_shell_sessions_view();
-        let Some((name, layout_json)) = picked else {
+        let Some(picked) = picked else {
             return;
         };
+        let name = picked.name.clone();
+
+        let mut params = serde_json::Map::new();
+        params.insert("name".to_string(), serde_json::Value::String(name.clone()));
+        // master's authoritative WT layout — forwarded verbatim so C++ replays
+        // it without a second round-trip.
+        params.insert(
+            "layout_json".to_string(),
+            serde_json::Value::String(picked.layout_json.clone()),
+        );
+
+        // Resolve the saved agent pane's WT pane GUID (pane_session_id) to the
+        // latest ACP session id created in that pane, from the persistent
+        // agent-pane-sessions.jsonl index (survives a Terminal restart). Skip
+        // silently when the tab had no agent pane or the session can't be
+        // resolved — the shell session still restores without an agent.
+        if let Some(pane_id) = picked
+            .agent_pane_session_id
+            .as_deref()
+            .filter(|s| !s.is_empty())
+        {
+            if let Some(agent_session_id) =
+                crate::agent_pane_origin::resolve_latest_session_for_pane(pane_id)
+            {
+                params.insert(
+                    "agent_session_id".to_string(),
+                    serde_json::Value::String(agent_session_id),
+                );
+                if !picked.cwd.is_empty() {
+                    params.insert(
+                        "agent_cwd".to_string(),
+                        serde_json::Value::String(picked.cwd.clone()),
+                    );
+                }
+            } else {
+                tracing::info!(
+                    target: "shell_sessions",
+                    pane_id,
+                    "no ACP session found for saved agent pane; restoring shell only",
+                );
+            }
+        }
+
         let evt = serde_json::json!({
             "type": "event",
             "method": "restore_shell_session",
-            "params": { "name": name, "layout_json": layout_json },
+            "params": serde_json::Value::Object(params),
         });
         send_wt_protocol_event(evt.to_string());
         tracing::info!(target: "shell_sessions", %name, "restore_shell_session event published");

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -3334,6 +3334,13 @@ fn save_shell_session_from_event(params: &serde_json::Value) {
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
+    // Present only when the closed tab had an open agent pane (see the C++
+    // `_SaveShellSessionForTab`); resolved to an ACP session id on restore.
+    let agent_pane_session_id = params
+        .get("agent_pane_session_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
 
     let row = shell_sessions_db::ShellSessionRow {
         name: name.to_string(),
@@ -3341,6 +3348,7 @@ fn save_shell_session_from_event(params: &serde_json::Value) {
         saved_at,
         layout_json: layout_json.to_string(),
         buffer_guids,
+        agent_pane_session_id,
     };
 
     match shell_sessions_db::open(&db_path).and_then(|conn| shell_sessions_db::upsert(&conn, &row)) {
@@ -3417,6 +3425,7 @@ fn load_shell_sessions_for_list() -> Vec<crate::session_registry::ShellSessionIn
                 cwd: r.cwd,
                 saved_at: r.saved_at,
                 layout_json: r.layout_json,
+                agent_pane_session_id: r.agent_pane_session_id,
             })
             .collect(),
         Err(e) => {

--- a/tools/wta/src/master/shell_sessions_db.rs
+++ b/tools/wta/src/master/shell_sessions_db.rs
@@ -40,6 +40,11 @@ pub struct ShellSessionRow {
     /// `<it_root>\shell-session-buffers\{guid}.txt`. Used by TTL / upsert to
     /// delete the orphaned buffer files.
     pub buffer_guids: Vec<String>,
+    /// The agent pane's WT session GUID (`pane_session_id`) at save time, if the
+    /// saved tab had an open agent pane. `None` when it didn't. Resolved to an
+    /// ACP session id (via `agent_pane_origin`) on restore, so the agent
+    /// conversation is resumed into the rebuilt tab.
+    pub agent_pane_session_id: Option<String>,
 }
 
 /// Open (creating if needed) the shell-session DB at `db_path` and ensure the
@@ -72,7 +77,8 @@ fn init_schema(conn: &Connection) -> Result<()> {
              cwd          TEXT NOT NULL DEFAULT '',
              saved_at     INTEGER NOT NULL DEFAULT 0,
              layout_json  TEXT NOT NULL,
-             buffer_guids TEXT NOT NULL DEFAULT '[]'
+             buffer_guids TEXT NOT NULL DEFAULT '[]',
+             agent_pane_session_id TEXT
          );
          CREATE INDEX IF NOT EXISTS idx_sessions_saved_at ON sessions(saved_at);
          CREATE TABLE IF NOT EXISTS meta (
@@ -81,6 +87,24 @@ fn init_schema(conn: &Connection) -> Result<()> {
          );",
     )
     .context("initializing shell-session schema")?;
+    // Migrate DBs created before `agent_pane_session_id` existed (the column was
+    // added when durable agent-session resume landed). Idempotent: skipped once
+    // the column is present.
+    ensure_agent_pane_session_id_column(conn)?;
+    Ok(())
+}
+
+/// Add the `agent_pane_session_id` column to a pre-existing `sessions` table
+/// that was created before that column existed. No-op when it's already there.
+fn ensure_agent_pane_session_id_column(conn: &Connection) -> Result<()> {
+    let has_column = conn
+        .prepare("SELECT 1 FROM pragma_table_info('sessions') WHERE name = 'agent_pane_session_id'")
+        .and_then(|mut stmt| stmt.exists([]))
+        .context("checking for agent_pane_session_id column")?;
+    if !has_column {
+        conn.execute("ALTER TABLE sessions ADD COLUMN agent_pane_session_id TEXT", [])
+            .context("adding agent_pane_session_id column")?;
+    }
     Ok(())
 }
 
@@ -106,14 +130,22 @@ pub fn upsert(conn: &Connection, row: &ShellSessionRow) -> Result<Vec<String>> {
     let guids_json = serde_json::to_string(&row.buffer_guids)
         .context("serializing buffer_guids")?;
     conn.execute(
-        "INSERT INTO sessions (name, cwd, saved_at, layout_json, buffer_guids)
-         VALUES (?1, ?2, ?3, ?4, ?5)
+        "INSERT INTO sessions (name, cwd, saved_at, layout_json, buffer_guids, agent_pane_session_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
          ON CONFLICT(name) DO UPDATE SET
              cwd          = excluded.cwd,
              saved_at     = excluded.saved_at,
              layout_json  = excluded.layout_json,
-             buffer_guids = excluded.buffer_guids",
-        rusqlite::params![row.name, row.cwd, row.saved_at, row.layout_json, guids_json],
+             buffer_guids = excluded.buffer_guids,
+             agent_pane_session_id = excluded.agent_pane_session_id",
+        rusqlite::params![
+            row.name,
+            row.cwd,
+            row.saved_at,
+            row.layout_json,
+            guids_json,
+            row.agent_pane_session_id
+        ],
     )
     .with_context(|| format!("upserting shell session {}", row.name))?;
 
@@ -124,7 +156,7 @@ pub fn upsert(conn: &Connection, row: &ShellSessionRow) -> Result<Vec<String>> {
 pub fn list(conn: &Connection) -> Result<Vec<ShellSessionRow>> {
     let mut stmt = conn
         .prepare(
-            "SELECT name, cwd, saved_at, layout_json, buffer_guids
+            "SELECT name, cwd, saved_at, layout_json, buffer_guids, agent_pane_session_id
              FROM sessions ORDER BY saved_at DESC",
         )
         .context("preparing shell-session list query")?;
@@ -266,6 +298,7 @@ fn row_from_sqlite(r: &rusqlite::Row<'_>) -> rusqlite::Result<ShellSessionRow> {
         saved_at: r.get(2)?,
         layout_json: r.get(3)?,
         buffer_guids: parse_guids(&buffer_guids),
+        agent_pane_session_id: r.get(5)?,
     })
 }
 
@@ -286,6 +319,7 @@ mod tests {
             saved_at,
             layout_json: format!("{{\"tab\":\"{name}\"}}"),
             buffer_guids: guids.iter().map(|s| s.to_string()).collect(),
+            agent_pane_session_id: None,
         }
     }
 
@@ -445,5 +479,64 @@ mod tests {
         let all = list(&conn).unwrap();
         assert_eq!(all.len(), 1);
         assert!(all[0].buffer_guids.is_empty());
+    }
+
+    #[test]
+    fn upsert_round_trips_agent_pane_session_id() {
+        let conn = mem();
+        let mut with_agent = row("with-agent", 100, &["g1"]);
+        with_agent.agent_pane_session_id = Some("pane-guid-1".to_string());
+        upsert(&conn, &with_agent).unwrap();
+        upsert(&conn, &row("no-agent", 50, &["g2"])).unwrap();
+
+        let all = list(&conn).unwrap();
+        assert_eq!(all[0].name, "with-agent");
+        assert_eq!(
+            all[0].agent_pane_session_id.as_deref(),
+            Some("pane-guid-1")
+        );
+        assert_eq!(all[1].name, "no-agent");
+        assert_eq!(all[1].agent_pane_session_id, None);
+    }
+
+    #[test]
+    fn ensure_agent_pane_session_id_column_migrates_legacy_table() {
+        // Simulate a DB created before the column existed, then run the
+        // migration path (init_schema calls it) and confirm reads/writes work.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (
+                 name         TEXT PRIMARY KEY,
+                 cwd          TEXT NOT NULL DEFAULT '',
+                 saved_at     INTEGER NOT NULL DEFAULT 0,
+                 layout_json  TEXT NOT NULL,
+                 buffer_guids TEXT NOT NULL DEFAULT '[]'
+             );
+             CREATE TABLE meta (key TEXT PRIMARY KEY, value INTEGER NOT NULL);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions (name, cwd, saved_at, layout_json, buffer_guids)
+             VALUES ('legacy', '', 1, '{}', '[]')",
+            [],
+        )
+        .unwrap();
+
+        // Idempotent: running the migration twice must not error.
+        ensure_agent_pane_session_id_column(&conn).unwrap();
+        ensure_agent_pane_session_id_column(&conn).unwrap();
+
+        // The pre-existing row reads back with a NULL (None) agent id.
+        let all = list(&conn).unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].agent_pane_session_id, None);
+
+        // And new upserts can now store an agent id.
+        let mut r = row("fresh", 200, &["g1"]);
+        r.agent_pane_session_id = Some("pane-2".to_string());
+        upsert(&conn, &r).unwrap();
+        let all = list(&conn).unwrap();
+        assert_eq!(all[0].name, "fresh");
+        assert_eq!(all[0].agent_pane_session_id.as_deref(), Some("pane-2"));
     }
 }

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -347,6 +347,12 @@ pub struct ShellSessionInfo {
     /// Opaque WT `WindowLayout` JSON, replayed verbatim by the C++ side.
     #[serde(default)]
     pub layout_json: String,
+    /// The agent pane's WT session GUID (`pane_session_id`) at save time, if the
+    /// saved tab had an open agent pane. `None`/absent when it didn't. Resolved
+    /// to an ACP session id (via `agent_pane_origin`) when restoring, so the
+    /// agent conversation is resumed into the rebuilt tab.
+    #[serde(default)]
+    pub agent_pane_session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Durable sessions — step2 (stacked on step1)

**Base branch: `dev/yuazha/durable-shell-sessions` (step1).** Builds directly on step1, so review only the step2 diff here.

Captures and resumes the **agent session** as part of a durable shell session. When a tab that has an agent pane is saved on close, we record the agent pane's WT session GUID (`pane_session_id`); when the shell session is restored, WTA resolves it to the ACP `session_id` and WT resumes that conversation into the rebuilt tab via `session/load`.

### C++ (Windows Terminal)
- `_SaveShellSessionForTab`: if the tab has an agent pane (`FindAgentPane`, which also finds a stashed/hidden one), record `GuidToPlainString(GetSessionId())` as `agent_pane_session_id` in the `shell-sessions.json` sidecar.
- `OnRestoreShellSessionRequested` reads optional `agent_session_id`/`agent_cwd` and defers to `_RestoreShellSessionCoro`: a coroutine that replays the layout actions, then (restart-style) tears down the tab's pre-warmed *fresh* agent pane and opens a **resumed** one via `_AutoCreateHiddenAgentPaneShared(..., --initial-load-session-id)`. Teardown+create run in one synchronous UI-thread block so the pre-warm race can't leave two panes.

### Rust (wta)
- `agent_pane_origin::resolve_latest_session_for_pane`: reverse-lookup `pane_session_id → latest ACP session_id` from the persistent `agent-pane-sessions.jsonl` (append order, case-insensitive) — works across a Terminal restart.
- `ShellSessionEntry` gains `agent_pane_session_id`; `commit_shell_session_pick` resolves it and includes `agent_session_id` (+`agent_cwd`) in the event, falling back to shell-only restore when unresolved.

### Verification
- **Rust:** `cargo build` clean; **all 1133 tests pass** (incl. new resolver + sidecar-field tests).
- **C++:** `TerminalAppLib` compiles clean (`0 Error(s)`) with the save+restore changes.

> Note: when step1 (#437) merges into `dev/yuazha/eternal-terminal`, retarget this PR's base to `eternal-terminal`.