### PR TITLE
Durable sessions (step3): faithful agent-pane display on restore (open-only capture)

### DIFF
--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -710,13 +710,19 @@ namespace winrt::TerminalApp::implementation
                 cwd = activeControl.WorkingDirectory();
             }
 
-            // If the tab has an agent pane, record its WT session GUID
-            // (pane_session_id) so restore can resolve it to the ACP session id
-            // (via wta's agent-pane-sessions.jsonl) and resume that conversation.
-            // FindAgentPane() also finds a stashed (hidden) agent pane, so a
-            // toggled-closed-but-alive agent session is captured too.
+            // If the tab has an agent pane the user actually opened, record its
+            // WT session GUID (pane_session_id) so restore can resolve it to the
+            // ACP session id (via wta's agent-pane-sessions.jsonl) and resume
+            // that conversation, faithfully re-showing it.
+            //
+            // We deliberately capture ONLY a visible (open) agent pane, not a
+            // stashed/hidden one: every tab pre-warms a stashed agent pane with
+            // a fresh, empty ACP session (see `_InitializeTab`). Capturing that
+            // would resurrect an agent the user never engaged with — showing an
+            // empty pane on restore. Requiring `!IsHidden()` scopes capture to
+            // an agent the user had open, matching the saved display.
             winrt::hstring agentPaneSessionId;
-            if (const auto agentPane = tabImpl->FindAgentPane())
+            if (const auto agentPane = tabImpl->FindAgentPane(); agentPane && !agentPane->IsHidden())
             {
                 if (const auto sid = agentPane->GetSessionId(); sid != winrt::guid{})
                 {

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -6239,6 +6239,14 @@ namespace winrt::TerminalApp::implementation
                 // Persist the full layout into the workspace collection.
                 ApplicationState::SharedInstance().SaveWorkspace(windowName, layout);
 
+                // Durable sessions: also persist this workspace's scrollback so
+                // reopening it later restores terminal contents, not just the
+                // layout + working directories. The buffers use the standard
+                // `buffer_`/`elevated_` prefix (so the normal restore path picks
+                // them up on reopen) and are kept alive by the workspace-aware
+                // cleanup in `WindowEmperor::_finalizeSessionPersistence`.
+                _PersistWorkspaceBuffers();
+
                 // Build a minimal layout with just an openWorkspace action
                 // so the generic restore path re-opens this workspace by name.
                 std::vector<ActionAndArgs> actions;
@@ -6256,6 +6264,62 @@ namespace winrt::TerminalApp::implementation
             {
                 ApplicationState::SharedInstance().AppendPersistedWindowLayout(layout);
             }
+        }
+    }
+
+    // Persist every terminal pane's scrollback in this window to
+    // `buffer_{guid}.txt` (or `elevated_` when running as admin) next to
+    // state.json, so a saved workspace can restore its contents on reopen.
+    // Agent panes are skipped (excluded from the saved layout). Mirrors the
+    // per-pane persistence WindowEmperor does at app close, but runs when a
+    // workspace is saved so its buffers exist even if its window isn't live at
+    // the next shutdown — `_finalizeSessionPersistence` keeps the files it
+    // finds referenced by a saved workspace.
+    void TerminalPage::_PersistWorkspaceBuffers()
+    {
+        using namespace std::string_view_literals;
+
+        const std::filesystem::path settingsDirectory{ std::wstring_view{ CascadiaSettings::SettingsDirectory() } };
+        const auto filenamePrefix = IsRunningElevated() ? L"elevated_"sv : L"buffer_"sv;
+
+        for (const auto& tab : _tabs)
+        {
+            const auto tabImpl = winrt::get_self<implementation::Tab>(tab);
+            if (!tabImpl)
+            {
+                continue;
+            }
+            const auto rootPane = tabImpl->GetRootPane();
+            if (!rootPane)
+            {
+                continue;
+            }
+            rootPane->WalkTree([&](const std::shared_ptr<Pane>& p) {
+                if (!p->GetContent() || p->IsAgentPane())
+                {
+                    return;
+                }
+                const auto control = p->GetTerminalControl();
+                if (!control)
+                {
+                    return;
+                }
+                const auto connection = control.Connection();
+                if (!connection)
+                {
+                    return;
+                }
+                const auto sessionId = connection.SessionId();
+                if (sessionId == winrt::guid{})
+                {
+                    return;
+                }
+                const auto path = settingsDirectory / fmt::format(FMT_COMPILE(L"{}{}.txt"), filenamePrefix, sessionId);
+                if (wil::unique_hfile file{ CreateFileW(path.c_str(), GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_DELETE, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr) })
+                {
+                    control.PersistTo(reinterpret_cast<int64_t>(file.get()));
+                }
+            });
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -687,6 +687,7 @@ namespace winrt::TerminalApp::implementation
         void _PersistShellSessionBuffers(winrt::com_ptr<implementation::Tab> tabImpl);
         void _WriteShellSessionsIndexEntry(const winrt::hstring& name, const winrt::hstring& cwd, const winrt::hstring& agentPaneSessionId);
         safe_void_coroutine _RestoreShellSessionCoro(std::vector<Microsoft::Terminal::Settings::Model::ActionAndArgs> actions, std::string agentSessionId, std::string agentCwd);
+        void _PersistWorkspaceBuffers();
 
         void _InitializeTab(winrt::com_ptr<Tab> newTabImpl, uint32_t insertPosition = -1, bool openInBackground = false);
         void _RegisterTerminalEvents(Microsoft::Terminal::Control::TermControl term);

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -1462,6 +1462,47 @@ void WindowEmperor::_finalizeSessionPersistence() const
     // Now remove the "buffer_{guid}.txt" files that shouldn't be there.
     if (_needsPersistenceCleanup)
     {
+        // Durable workspaces: keep the scrollback files referenced by any saved
+        // workspace, even though that workspace's window isn't currently open.
+        // Without this the cleanup below would delete a saved workspace's
+        // buffers, so reopening it later would lose its terminal contents.
+        if (const auto workspaces = ApplicationState::SharedInstance().AllPersistedWorkspaces())
+        {
+            const auto rememberSessionArgs = [&](const auto& contentArgs) {
+                if (const auto termArgs = contentArgs.try_as<NewTerminalArgs>())
+                {
+                    if (const auto sid = termArgs.SessionId(); sid != winrt::guid{})
+                    {
+                        bufferFilenames.emplace(fmt::format(FMT_COMPILE(L"{}{}.txt"), filenamePrefix, sid));
+                    }
+                }
+            };
+            for (const auto& kv : workspaces)
+            {
+                const auto layout = kv.Value();
+                if (!layout)
+                {
+                    continue;
+                }
+                const auto tabLayout = layout.TabLayout();
+                if (!tabLayout)
+                {
+                    continue;
+                }
+                for (const auto& action : tabLayout)
+                {
+                    if (const auto newTabArgs = action.Args().try_as<NewTabArgs>())
+                    {
+                        rememberSessionArgs(newTabArgs.ContentArgs());
+                    }
+                    else if (const auto splitArgs = action.Args().try_as<SplitPaneArgs>())
+                    {
+                        rememberSessionArgs(splitArgs.ContentArgs());
+                    }
+                }
+            }
+        }
+
         const auto filter = fmt::format(FMT_COMPILE(L"{}\\{}*"), settingsDirectory.native(), filenamePrefix);
 
         // This could also use std::filesystem::directory_iterator.


### PR DESCRIPTION
## Durable sessions — step3 (stacked on step2)

**Base branch: `dev/yuazha/durable-agent-session` (step2).**

Display-fidelity fix for the agent-session resume. Capture the agent session for a durable shell session **only when the agent pane is visible (open)** at save time — not when it is stashed/hidden.

Every tab pre-warms a *stashed* agent pane with a fresh, empty ACP session (`_InitializeTab`). step2 captured whatever `FindAgentPane()` returned (including that pre-warm), which would resurrect an agent the user never engaged with and pop an empty pane on restore. Requiring `!IsHidden()` scopes capture to an agent the user actually had open, so restore faithfully re-shows the conversation the user was looking at — rehydrated in-place by ACP `session/load`, reusing the existing turn/conversation chat display as-is.

### Verification
- **C++:** `TerminalAppLib` compiles clean (`0 Error(s)`).
- Rust unchanged.

> Retarget base to step2's eventual base when the stack merges down.