### PR TITLE
Rename /move bottom direction to down

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -16,7 +16,7 @@ environment. Current status (run on the Store package):
 | `Feature.Settings.Tests.ps1` | §1 Settings>AI Agents + §0 FRE settings/positions/auto-error/session-mgmt | 18 |
 | `Feature.FreFlow.Tests.ps1` | §0 FRE overlay click-through (Next→Save, privacy link, close-safety) | 5 |
 | `Feature.FreExecutionPolicy.Tests.ps1` | §0 FRE execution-policy verdict (deterministic via registry; **Dev**, auto-skips) | 3 (1 conditional skip) |
-| `Feature.AgentPaneInteraction.Tests.ps1` | open/hide/focus, input/rendering, slash, Copilot chat | 13 |
+| `Feature.AgentPaneInteraction.Tests.ps1` | open/hide/focus, input/rendering, slash, Copilot chat | 14 |
 | `Feature.AutofixPane.Tests.ps1` | autofix card render/insert/run/reject/target/stashed + across layout | 10 |
 | `Feature.SessionList.Tests.ps1` | session view (button + `/sessions` slash), session states, view switching (incl. draft-preservation), focus/restore | 13 (+1 skip) |
 | `Feature.AgentRestart.Tests.ps1` | agent restart after a settings change (/restart reconnects and answers) | 1 |

--- a/test/e2e/tests/Feature.AgentPaneInteraction.Tests.ps1
+++ b/test/e2e/tests/Feature.AgentPaneInteraction.Tests.ps1
@@ -101,6 +101,22 @@ Describe 'Feature: agent pane open/hide/focus + input + slash + chat' -Tag 'Feat
     }
 
     Context 'Agent pane slash commands' {
+        It '/move down completes and repositions the agent pane' {
+            Clear-AgentInput -App $script:app | Out-Null
+            $sess = Send-AgentPrompt -App $script:app -Text '/move ' -NoSubmit
+            Assert-AgentPaneText -App $script:app -PaneSessionId $sess.PaneSessionId -Pattern '/move\s+down\s+\(d\)' -TimeoutSec 10
+            (Get-AgentPaneText -App $script:app -PaneSessionId $sess.PaneSessionId -MaxLines 40) |
+                Should -Not -Match '/move\s+bottom'
+
+            Clear-AgentInput -App $script:app -PaneSessionId $sess.PaneSessionId | Out-Null
+            Initialize-LogOffsets -App $script:app | Out-Null
+            Send-AgentPrompt -App $script:app -PaneSessionId $sess.PaneSessionId -Text '/move down' | Out-Null
+
+            # Agent-pane geometry is not reliably exposed through UIA. C++ logs the validated
+            # canonical position immediately before applying RepositionAgentPane.
+            Assert-Log -App $script:app -Name 'terminal-agent-pane.log' -Pattern 'OnAgentStateChanged:.*pane_position=bottom' -TimeoutSec 15
+        }
+
         It '/model opens the model picker (Copilot advertises models)' {
             Clear-AgentInput -App $script:app | Out-Null
             # Drive the REAL /model command (proven live: Copilot opens a "Select model" modal

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -8110,7 +8110,7 @@ impl App {
     }
 
     /// `/move <position>` — move only this tab's agent pane. Positions accept
-    /// full names (`left`, `right`, `up`, `bottom`) or `l/r/u/b`. Bare or
+    /// full names (`left`, `right`, `up`, `down`) or `l/r/u/d`. Bare or
     /// invalid input reopens the position completion popup.
     fn cmd_move(&mut self, position: String) {
         let Some(position) = commands::lookup_move_position(&position) else {
@@ -8121,7 +8121,7 @@ impl App {
             return;
         };
 
-        self.current_tab_mut().agent_pane_position = Some(position.name);
+        self.current_tab_mut().agent_pane_position = Some(position.pane_position);
         self.project_active_tab_state();
     }
 

--- a/tools/wta/src/commands.rs
+++ b/tools/wta/src/commands.rs
@@ -153,13 +153,30 @@ pub const REGISTRY: &[CommandSpec] = &[
 pub struct MovePositionSpec {
     pub name: &'static str,
     pub alias: &'static str,
+    pub pane_position: &'static str,
 }
 
 pub const MOVE_POSITIONS: &[MovePositionSpec] = &[
-    MovePositionSpec { name: "left", alias: "l" },
-    MovePositionSpec { name: "right", alias: "r" },
-    MovePositionSpec { name: "up", alias: "u" },
-    MovePositionSpec { name: "bottom", alias: "b" },
+    MovePositionSpec {
+        name: "left",
+        alias: "l",
+        pane_position: "left",
+    },
+    MovePositionSpec {
+        name: "right",
+        alias: "r",
+        pane_position: "right",
+    },
+    MovePositionSpec {
+        name: "up",
+        alias: "u",
+        pane_position: "up",
+    },
+    MovePositionSpec {
+        name: "down",
+        alias: "d",
+        pane_position: "bottom",
+    },
 ];
 
 #[derive(Debug, Clone)]
@@ -381,7 +398,12 @@ mod tests {
         assert_eq!(lookup_move_position(&direct.rest).unwrap().name, "left");
         assert_eq!(lookup_move_position("R").unwrap().name, "right");
         assert_eq!(lookup_move_position("up").unwrap().alias, "u");
-        assert_eq!(lookup_move_position("b").unwrap().name, "bottom");
+        assert_eq!(lookup_move_position("d").unwrap().name, "down");
+        assert_eq!(
+            lookup_move_position("down").unwrap().pane_position,
+            "bottom"
+        );
+        assert!(lookup_move_position("bottom").is_none());
         assert!(lookup_move_position("top").is_none());
     }
 
@@ -462,11 +484,12 @@ mod tests {
         assert_eq!(match_move_positions("l")[0].name, "left");
         assert_eq!(match_move_positions("ri")[0].name, "right");
         assert_eq!(match_move_positions("U")[0].name, "up");
+        assert_eq!(match_move_positions("do")[0].name, "down");
         assert!(match_move_positions("x").is_empty());
 
         assert_eq!(move_position_prefix("/move "), Some(""));
         assert_eq!(move_position_prefix("/MOVE r"), Some("r"));
-        assert_eq!(move_position_prefix("  /move bot"), Some("bot"));
+        assert_eq!(move_position_prefix("  /move dow"), Some("dow"));
         assert_eq!(move_position_prefix("/move"), None);
         assert_eq!(move_position_prefix("/move left extra"), None);
         assert_eq!(move_position_prefix("/model r"), None);

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -314,6 +314,19 @@ fn slash_move_changes_only_the_active_tab() {
 }
 
 #[test]
+fn slash_move_down_uses_bottom_pane_position() {
+    let mut app = test_app();
+
+    run_slash_args(&mut app, "move", "down");
+
+    assert_eq!(
+        app.current_tab().agent_pane_position,
+        Some("bottom"),
+        "/move down must map to the Terminal pane position named bottom"
+    );
+}
+
+#[test]
 fn slash_move_invalid_argument_reopens_position_completion() {
     let mut app = test_app();
 


### PR DESCRIPTION
## Summary
- rename the `/move` lower direction from `bottom`/`b` to `down`/`d`
- map `down` to the existing Terminal protocol value `bottom`
- add unit and Dev-package E2E coverage for completion and repositioning

## Testing
- `cargo test --manifest-path tools/wta/Cargo.toml --quiet`
- targeted `Feature.AgentPaneInteraction.Tests.ps1` `/move down` E2E against `ITE2E_PACKAGE=Dev`