### PR TITLE
Migrate Codex to official ACP adapter 1.1.0

### DIFF
--- a/doc/installing-dependencies.md
+++ b/doc/installing-dependencies.md
@@ -91,7 +91,7 @@ new `winget.exe` is picked up on `PATH`, then verify with
 distributed as npm packages. Intelligent Terminal also launches Claude and
 Codex through `npx` wrappers
 (`npx -y @agentclientprotocol/claude-agent-acp` and
-`npx -y @agentclientprotocol/codex-acp@1.1.2`), which require a working Node.js +
+`npx -y @agentclientprotocol/codex-acp@1.1.0`), which require a working Node.js +
 `npm` + `npx` toolchain on `PATH`. You can skip this section if you only
 plan to use GitHub Copilot CLI.
 
@@ -266,7 +266,7 @@ Intelligent Terminal launches it through the
 wrapper. The wrapper is fetched on demand at run time with:
 
 ```powershell
-npx -y @agentclientprotocol/codex-acp@1.1.2
+npx -y @agentclientprotocol/codex-acp@1.1.0
 ```
 
 You do **not** need to install anything for this — the only prerequisite

--- a/doc/installing-dependencies.md
+++ b/doc/installing-dependencies.md
@@ -91,7 +91,7 @@ new `winget.exe` is picked up on `PATH`, then verify with
 distributed as npm packages. Intelligent Terminal also launches Claude and
 Codex through `npx` wrappers
 (`npx -y @agentclientprotocol/claude-agent-acp` and
-`npx -y @zed-industries/codex-acp`), which require a working Node.js +
+`npx -y @agentclientprotocol/codex-acp@1.1.2`), which require a working Node.js +
 `npm` + `npx` toolchain on `PATH`. You can skip this section if you only
 plan to use GitHub Copilot CLI.
 
@@ -237,7 +237,7 @@ The first launch may take a few seconds while `npx` downloads the wrapper.
 **Status:** Supported, but **not installed by Intelligent Terminal**. You
 must install OpenAI's Codex CLI yourself before selecting Codex in the FRE.
 Intelligent Terminal launches Codex through the
-`@zed-industries/codex-acp` npx wrapper.
+`@agentclientprotocol/codex-acp` npx wrapper.
 
 #### Step 3.3.1 — Install Node.js
 
@@ -262,11 +262,11 @@ codex --version
 
 Codex does not speak the Agent Control Protocol (ACP) directly, so
 Intelligent Terminal launches it through the
-[`@zed-industries/codex-acp`](https://www.npmjs.com/package/@zed-industries/codex-acp)
+[`@agentclientprotocol/codex-acp`](https://www.npmjs.com/package/@agentclientprotocol/codex-acp)
 wrapper. The wrapper is fetched on demand at run time with:
 
 ```powershell
-npx -y @zed-industries/codex-acp
+npx -y @agentclientprotocol/codex-acp@1.1.2
 ```
 
 You do **not** need to install anything for this — the only prerequisite

--- a/doc/specs/session-history-via-acp.md
+++ b/doc/specs/session-history-via-acp.md
@@ -269,7 +269,7 @@ fallback is kept for it.
 
 The Codex results above were collected with the now-deprecated
 `@zed-industries/codex-acp`. The current runtime launch command is
-`npx -y @agentclientprotocol/codex-acp@1.1.2`; the original measurements and
+`npx -y @agentclientprotocol/codex-acp@1.1.0`; the original measurements and
 reproduction command below are retained as historical evidence.
 
 ### 2. `session/list` returns full on-disk history, not just live sessions — and only *real* sessions

--- a/doc/specs/session-history-via-acp.md
+++ b/doc/specs/session-history-via-acp.md
@@ -267,6 +267,11 @@ host-side jsonl parsing. **Gemini does not implement the capability**, and its C
 is dropping ACP upstream, so it is **out of scope** — the reason no file-reading
 fallback is kept for it.
 
+The Codex results above were collected with the now-deprecated
+`@zed-industries/codex-acp`. The current runtime launch command is
+`npx -y @agentclientprotocol/codex-acp@1.1.2`; the original measurements and
+reproduction command below are retained as historical evidence.
+
 ### 2. `session/list` returns full on-disk history, not just live sessions — and only *real* sessions
 
 Two facts made `session/list` a credible replacement for the disk loaders rather

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1072,7 +1072,7 @@ namespace winrt::TerminalApp::implementation
         }
         if (lower == "codex")
         {
-            return winrt::hstring{ L"npx -y @zed-industries/codex-acp" };
+            return winrt::hstring{ L"npx -y @agentclientprotocol/codex-acp@1.1.2" };
         }
 
         std::wstring cmd{ agentId };

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1072,7 +1072,7 @@ namespace winrt::TerminalApp::implementation
         }
         if (lower == "codex")
         {
-            return winrt::hstring{ L"npx -y @agentclientprotocol/codex-acp@1.1.2" };
+            return winrt::hstring{ L"npx -y @agentclientprotocol/codex-acp@1.1.0" };
         }
 
         std::wstring cmd{ agentId };

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
@@ -1079,7 +1079,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
         if (lower == "codex")
         {
-            return L"npx -y @agentclientprotocol/codex-acp@1.1.2";
+            return L"npx -y @agentclientprotocol/codex-acp@1.1.0";
         }
 
         std::wstring cmd{ acpAgent };

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
@@ -1079,7 +1079,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
         if (lower == "codex")
         {
-            return L"npx -y @zed-industries/codex-acp";
+            return L"npx -y @agentclientprotocol/codex-acp@1.1.2";
         }
 
         std::wstring cmd{ acpAgent };

--- a/src/cascadia/inc/AgentRegistry.h
+++ b/src/cascadia/inc/AgentRegistry.h
@@ -35,7 +35,7 @@ namespace Microsoft::Terminal::Settings::Model::AgentRegistry
     // ACP-capable agents. Either the CLI itself speaks the Agent Control
     // Protocol (copilot, gemini), or an npm-distributed adapter does
     // (claude via @agentclientprotocol/claude-agent-acp, codex via
-    // @zed-industries/codex-acp).
+    // @agentclientprotocol/codex-acp).
     // Only these agents can be hosted in an agent pane.
     inline constexpr std::array<BuiltinAgent, 4> BuiltinAcpAgents{ {
         { L"copilot", L"GitHub Copilot" },

--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -122,7 +122,7 @@ Claude and Codex are launched through ACP adapters:
 
 ```
 wta --agent "npx -y @agentclientprotocol/claude-agent-acp"
-wta --agent "npx -y @zed-industries/codex-acp"
+wta --agent "npx -y @agentclientprotocol/codex-acp@1.1.2"
 ```
 
 The Terminal settings layer resolves the built-in agent IDs to these adapter commands.

--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -122,7 +122,7 @@ Claude and Codex are launched through ACP adapters:
 
 ```
 wta --agent "npx -y @agentclientprotocol/claude-agent-acp"
-wta --agent "npx -y @agentclientprotocol/codex-acp@1.1.2"
+wta --agent "npx -y @agentclientprotocol/codex-acp@1.1.0"
 ```
 
 The Terminal settings layer resolves the built-in agent IDs to these adapter commands.

--- a/tools/wta/acp-multi-session-concurrency.md
+++ b/tools/wta/acp-multi-session-concurrency.md
@@ -52,6 +52,11 @@ The prompt was deliberately model-bound work that streams gradually:
 
 ## Results
 
+The Codex row below records the deprecated `@zed-industries/codex-acp`
+adapter used when this experiment was run. The current runtime uses
+`@agentclientprotocol/codex-acp@1.1.2`; these historical timings have not been
+re-attributed to the replacement adapter.
+
 Each agent received the same prompt twice (one per session) at `t = 0` after
 `tokio::join!`. Times below are wall-clock relative to the moment both prompts
 were fired.

--- a/tools/wta/acp-multi-session-concurrency.md
+++ b/tools/wta/acp-multi-session-concurrency.md
@@ -54,7 +54,7 @@ The prompt was deliberately model-bound work that streams gradually:
 
 The Codex row below records the deprecated `@zed-industries/codex-acp`
 adapter used when this experiment was run. The current runtime uses
-`@agentclientprotocol/codex-acp@1.1.2`; these historical timings have not been
+`@agentclientprotocol/codex-acp@1.1.0`; these historical timings have not been
 re-attributed to the replacement adapter.
 
 Each agent received the same prompt twice (one per session) at `t = 0` after

--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -124,7 +124,7 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         acp_flags: &[],
         // Codex CLI itself doesn't speak ACP. Use the ACP-project-maintained
         // adapter, pinned so a future npm release cannot silently break startup.
-        acp_launch_command: "npx -y @agentclientprotocol/codex-acp@1.1.2",
+        acp_launch_command: "npx -y @agentclientprotocol/codex-acp@1.1.0",
         acp_auth_flow: AcpAuthFlow::External,
         delegate_prompt_flag: PromptFlag::Positional,
         model_flags: &[],
@@ -475,7 +475,7 @@ mod tests {
             "claude",
         );
         assert_eq!(
-            resolve_agent_id_from_cmd("npx -y @agentclientprotocol/codex-acp@1.1.2"),
+            resolve_agent_id_from_cmd("npx -y @agentclientprotocol/codex-acp@1.1.0"),
             "codex",
         );
         // Adapter prefix with extra trailing args still resolves.

--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -122,8 +122,9 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         display_name: "Codex",
         exe_search_order: &[".exe", ".cmd"],
         acp_flags: &[],
-        // Codex CLI itself doesn't speak ACP. Same npx-adapter pattern as Claude.
-        acp_launch_command: "npx -y @zed-industries/codex-acp",
+        // Codex CLI itself doesn't speak ACP. Use the ACP-project-maintained
+        // adapter, pinned so a future npm release cannot silently break startup.
+        acp_launch_command: "npx -y @agentclientprotocol/codex-acp@1.1.2",
         acp_auth_flow: AcpAuthFlow::External,
         delegate_prompt_flag: PromptFlag::Positional,
         model_flags: &[],
@@ -474,7 +475,7 @@ mod tests {
             "claude",
         );
         assert_eq!(
-            resolve_agent_id_from_cmd("npx -y @zed-industries/codex-acp"),
+            resolve_agent_id_from_cmd("npx -y @agentclientprotocol/codex-acp@1.1.2"),
             "codex",
         );
         // Adapter prefix with extra trailing args still resolves.

--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -205,6 +205,32 @@ pub fn lookup_profile_by_id(id: &str) -> &'static AgentProfile {
         .unwrap_or(&DEFAULT_PROFILE)
 }
 
+// Identification-only aliases. The registry command remains the pinned launch
+// command used for new Codex sessions.
+const ACP_LAUNCH_COMMAND_ALIASES: &[(&str, &str)] = &[
+    ("npx -y @agentclientprotocol/codex-acp", "codex"),
+    ("npx -y @zed-industries/codex-acp", "codex"),
+];
+
+fn adapter_profile_from_tokens(tokens: &[String]) -> Option<&'static AgentProfile> {
+    let matches_command = |command: &str| {
+        let command_tokens = crate::coordinator::split_windows_commandline(command);
+        tokens.starts_with(&command_tokens)
+    };
+
+    KNOWN_AGENTS
+        .iter()
+        .find(|profile| {
+            !profile.acp_launch_command.is_empty() && matches_command(profile.acp_launch_command)
+        })
+        .or_else(|| {
+            ACP_LAUNCH_COMMAND_ALIASES
+                .iter()
+                .find(|(command, _)| matches_command(command))
+                .map(|(_, id)| lookup_profile_by_id(id))
+        })
+}
+
 /// Returns `true` iff `id` is a real, selectable agent id present in
 /// [`KNOWN_AGENTS`] (`"copilot"`, `"claude"`, `"codex"`, `"gemini"`).
 ///
@@ -240,23 +266,17 @@ pub fn resolve_agent_id_from_cmd(agent_cmd: &str) -> &'static str {
         return DEFAULT_PROFILE.id;
     }
 
-    // Adapter-style: the whole command equals a known profile's
-    // `acp_launch_command` (e.g. `"npx -y @agentclientprotocol/claude-agent-acp"`).
-    // Match exact first; fall back to prefix match so trailing flags don't
-    // hide the adapter (e.g. someone appending `--debug`).
-    if let Some(profile) = KNOWN_AGENTS
-        .iter()
-        .find(|p| !p.acp_launch_command.is_empty()
-                  && (p.acp_launch_command == trimmed
-                      || trimmed.starts_with(&format!("{} ", p.acp_launch_command))))
-    {
+    let tokens = crate::coordinator::split_windows_commandline(trimmed);
+
+    // Match complete command tokens so compatibility aliases cannot identify
+    // unrelated packages whose names merely contain an adapter package name.
+    if let Some(profile) = adapter_profile_from_tokens(&tokens) {
         return profile.id;
     }
 
     // Bare / path form: parse the first Windows commandline token so a quoted
     // executable path containing spaces stays intact, then let `lookup_profile`
     // strip path and extension before matching.
-    let tokens = crate::coordinator::split_windows_commandline(trimmed);
     tokens
         .first()
         .map(|first| lookup_profile(first).id)
@@ -307,13 +327,10 @@ pub fn strip_acp_flags_for_delegate(agent_cmd: &str) -> Option<String> {
     let tokens = crate::coordinator::split_windows_commandline(agent_cmd);
     let command = tokens.first()?;
 
-    // Adapter-style: input is something like "npx -y @zed/claude-code-acp".
+    // Adapter-style: input is something like
+    // "npx -y @agentclientprotocol/claude-agent-acp".
     // Find which agent owns this launch command and return its bare id.
-    let trimmed = agent_cmd.trim();
-    if let Some(profile) = KNOWN_AGENTS
-        .iter()
-        .find(|p| !p.acp_launch_command.is_empty() && p.acp_launch_command == trimmed)
-    {
+    if let Some(profile) = adapter_profile_from_tokens(&tokens) {
         return Some(profile.id.to_string());
     }
 
@@ -478,10 +495,57 @@ mod tests {
             resolve_agent_id_from_cmd("npx -y @agentclientprotocol/codex-acp@1.1.0"),
             "codex",
         );
+        assert_eq!(
+            resolve_agent_id_from_cmd("npx -y @agentclientprotocol/codex-acp"),
+            "codex",
+        );
+        assert_eq!(
+            resolve_agent_id_from_cmd("npx -y @zed-industries/codex-acp"),
+            "codex",
+        );
         // Adapter prefix with extra trailing args still resolves.
         assert_eq!(
             resolve_agent_id_from_cmd("npx -y @agentclientprotocol/claude-agent-acp --debug"),
             "claude",
+        );
+        assert_eq!(
+            resolve_agent_id_from_cmd("npx -y @zed-industries/codex-acp --debug"),
+            "codex",
+        );
+    }
+
+    #[test]
+    fn codex_adapter_recognition_requires_complete_command_tokens() {
+        for command in [
+            "npx -y @agentclientprotocol/codex-acp-extra",
+            "npx -y prefix-@agentclientprotocol/codex-acp",
+            "echo npx -y @agentclientprotocol/codex-acp",
+        ] {
+            assert_eq!(resolve_agent_id_from_cmd(command), "unknown");
+            assert_eq!(strip_acp_flags_for_delegate(command), None);
+        }
+    }
+
+    #[test]
+    fn strip_acp_flags_recognises_codex_adapter_compatibility_commands() {
+        for command in [
+            "npx -y @agentclientprotocol/codex-acp@1.1.0",
+            "npx -y @agentclientprotocol/codex-acp",
+            "npx -y @zed-industries/codex-acp",
+            "npx -y @zed-industries/codex-acp --debug",
+        ] {
+            assert_eq!(
+                strip_acp_flags_for_delegate(command),
+                Some("codex".to_string()),
+            );
+        }
+    }
+
+    #[test]
+    fn codex_acp_launch_command_stays_pinned() {
+        assert_eq!(
+            build_acp_command("codex", None),
+            "npx -y @agentclientprotocol/codex-acp@1.1.0",
         );
     }
 

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -2983,7 +2983,7 @@ mod tests {
             r#""C:\npm tools\codex.cmd" --search"#
         ));
         assert!(!is_direct_known_agent_command(
-            "npx -y @zed-industries/codex-acp"
+            "npx -y @agentclientprotocol/codex-acp@1.1.2"
         ));
     }
 

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -2983,7 +2983,7 @@ mod tests {
             r#""C:\npm tools\codex.cmd" --search"#
         ));
         assert!(!is_direct_known_agent_command(
-            "npx -y @agentclientprotocol/codex-acp@1.1.2"
+            "npx -y @agentclientprotocol/codex-acp@1.1.0"
         ));
     }
 

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -59,7 +59,7 @@ use tokio::task::LocalSet;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::protocol::acp::conn;
-use crate::protocol::acp::spawn::spawn_agent_process;
+use crate::protocol::acp::spawn::{spawn_agent_process, AgentStderrLog};
 use crate::Cli;
 
 /// Opaque identifier for a helper connection. Used in logs only;
@@ -2201,21 +2201,15 @@ async fn spawn_one_agent(
         .ok_or_else(|| anyhow!("agent CLI child has no stdout"))?;
     let is_npx = spawn_result.is_npx;
 
-    // Drain agent stderr to logs so failures are diagnosable. Logged at
-    // `debug`, NOT `warn`: agent stderr routinely carries prompt / file
-    // content and routine adapter chatter, so emitting it at `warn` would
-    // be noisy and an information-leak in release builds. The `agent` tag
-    // keeps multi-agent logs attributable.
-    if let Some(stderr) = spawn_result.child.stderr.take() {
-        let key_for_log = key.clone();
-        tokio::task::spawn_local(async move {
-            use tokio::io::{AsyncBufReadExt, BufReader};
-            let mut lines = BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                tracing::debug!(target: "agent_stderr", agent = %key_for_log, "{line}");
-            }
-        });
-    }
+    // Routine stderr stays at debug because it may contain prompt / file
+    // content. Pre-initialize stderr is buffered and promoted to warning only
+    // if startup fails, so release logs retain package-manager diagnostics.
+    let stderr_log = AgentStderrLog::new(key.to_string());
+    let _stderr_task = spawn_result
+        .child
+        .stderr
+        .take()
+        .map(|stderr| stderr_log.drain(stderr));
 
     let client = MasterClient {
         state: Arc::clone(state),
@@ -2374,15 +2368,20 @@ async fn spawn_one_agent(
     .await;
 
     let init_resp = match init_outcome {
-        Ok(Ok(resp)) => resp,
+        Ok(Ok(resp)) => {
+            stderr_log.mark_initialized();
+            resp
+        }
         Ok(Err(e)) => {
             // Kill the child so its stdio closes → the I/O task above ends
             // → `reap_agent` clears the pool slot. `kill_on_drop` is a
             // backstop when `child` drops at return.
+            stderr_log.mark_failed();
             let _ = child.start_kill();
             return Err(anyhow!("ACP initialize failed for '{agent_cmd}': {e}"));
         }
         Err(_) => {
+            stderr_log.mark_failed();
             let _ = child.start_kill();
             return Err(anyhow!(
                 "ACP initialize timed out after {init_timeout_secs}s — agent CLI '{agent_cmd}' did not respond"

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -2205,7 +2205,7 @@ async fn spawn_one_agent(
     // content. Pre-initialize stderr is buffered and promoted to warning only
     // if startup fails, so release logs retain package-manager diagnostics.
     let stderr_log = AgentStderrLog::new(key.to_string());
-    let _stderr_task = spawn_result
+    let stderr_task = spawn_result
         .child
         .stderr
         .take()
@@ -2376,13 +2376,15 @@ async fn spawn_one_agent(
             // Kill the child so its stdio closes → the I/O task above ends
             // → `reap_agent` clears the pool slot. `kill_on_drop` is a
             // backstop when `child` drops at return.
-            stderr_log.mark_failed();
-            let _ = child.start_kill();
+            stderr_log
+                .finish_failed_startup(&mut child, stderr_task)
+                .await;
             return Err(anyhow!("ACP initialize failed for '{agent_cmd}': {e}"));
         }
         Err(_) => {
-            stderr_log.mark_failed();
-            let _ = child.start_kill();
+            stderr_log
+                .finish_failed_startup(&mut child, stderr_task)
+                .await;
             return Err(anyhow!(
                 "ACP initialize timed out after {init_timeout_secs}s — agent CLI '{agent_cmd}' did not respond"
             ));

--- a/tools/wta/src/protocol/acp/probe.rs
+++ b/tools/wta/src/protocol/acp/probe.rs
@@ -20,12 +20,11 @@ use agent_client_protocol as acp;
 use anyhow::{anyhow, Result};
 use serde::Serialize;
 use std::time::Duration;
-use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::app::AcpModelInfo;
 use crate::protocol::acp::conn;
-use crate::protocol::acp::spawn::spawn_agent_process;
+use crate::protocol::acp::spawn::{spawn_agent_process, AgentStderrLog};
 
 #[derive(Serialize)]
 pub struct ProbeResult {
@@ -47,16 +46,12 @@ pub async fn probe_models(agent_cmd: &str) -> Result<ProbeResult> {
 
     let outgoing = spawned.child.stdin.take().expect("stdin piped").compat_write();
     let incoming = spawned.child.stdout.take().expect("stdout piped").compat();
-    if let Some(stderr) = spawned.child.stderr.take() {
-        // Drain stderr so npx startup banners don't fill the pipe and
-        // block the adapter.
-        tokio::task::spawn_local(async move {
-            let mut lines = BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                tracing::debug!("agent stderr: {}", line);
-            }
-        });
-    }
+    let stderr_log = AgentStderrLog::new(spawned.label().to_string());
+    let stderr_task = spawned
+        .child
+        .stderr
+        .take()
+        .map(|stderr| stderr_log.drain(stderr));
 
     let (conn, handle_io) =
         conn::spawn_client(acp::Client.builder().name("wta-probe"), conn::byte_streams(outgoing, incoming));
@@ -80,9 +75,18 @@ pub async fn probe_models(agent_cmd: &str) -> Result<ProbeResult> {
                 .title("WTA Model Probe"),
         );
     let init_started = std::time::Instant::now();
-    let init_result =
-        tokio::time::timeout(Duration::from_secs(init_timeout_secs), conn.initialize(init_req))
+    let init_result = tokio::time::timeout(
+        Duration::from_secs(init_timeout_secs),
+        conn.initialize(init_req),
+    )
+    .await;
+    if matches!(init_result, Ok(Ok(_))) {
+        stderr_log.mark_initialized();
+    } else {
+        stderr_log
+            .finish_failed_startup(&mut spawned.child, stderr_task)
             .await;
+    }
     crate::telemetry::log_acp_initialize_complete(
         init_started.elapsed().as_secs_f64() * 1000.0,
         matches!(init_result, Ok(Ok(_))),
@@ -195,16 +199,12 @@ pub async fn probe_sessions(agent_cmd: &str) -> Result<SessionProbeResult> {
 
     let outgoing = spawned.child.stdin.take().expect("stdin piped").compat_write();
     let incoming = spawned.child.stdout.take().expect("stdout piped").compat();
-    if let Some(stderr) = spawned.child.stderr.take() {
-        // Drain stderr so npx startup banners don't fill the pipe and
-        // block the adapter.
-        tokio::task::spawn_local(async move {
-            let mut lines = BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                tracing::debug!("agent stderr: {}", line);
-            }
-        });
-    }
+    let stderr_log = AgentStderrLog::new(spawned.label().to_string());
+    let stderr_task = spawned
+        .child
+        .stderr
+        .take()
+        .map(|stderr| stderr_log.drain(stderr));
 
     let (conn, handle_io) =
         conn::spawn_client(acp::Client.builder().name("wta-probe-sessions"), conn::byte_streams(outgoing, incoming));
@@ -221,19 +221,27 @@ pub async fn probe_sessions(agent_cmd: &str) -> Result<SessionProbeResult> {
             acp::schema::v1::Implementation::new("wta-probe-sessions", env!("CARGO_PKG_VERSION"))
                 .title("WTA Session Probe"),
         );
-    let init_resp = tokio::time::timeout(
+    let init_result = tokio::time::timeout(
         Duration::from_secs(init_timeout_secs),
         conn.initialize(init_req),
     )
-    .await
-    .map_err(|_| {
-        anyhow!(
-            "ACP initialize timed out after {}s during session probe (agent={})",
-            init_timeout_secs,
-            spawned.label()
-        )
-    })?
-    .map_err(|e| anyhow!("initialize failed: {}", e))?;
+    .await;
+    if matches!(init_result, Ok(Ok(_))) {
+        stderr_log.mark_initialized();
+    } else {
+        stderr_log
+            .finish_failed_startup(&mut spawned.child, stderr_task)
+            .await;
+    }
+    let init_resp = init_result
+        .map_err(|_| {
+            anyhow!(
+                "ACP initialize timed out after {}s during session probe (agent={})",
+                init_timeout_secs,
+                spawned.label()
+            )
+        })?
+        .map_err(|e| anyhow!("initialize failed: {}", e))?;
 
     let initialize_dump = format!("{init_resp:#?}");
 

--- a/tools/wta/src/protocol/acp/session_list.rs
+++ b/tools/wta/src/protocol/acp/session_list.rs
@@ -16,10 +16,10 @@
 use agent_client_protocol as acp;
 use anyhow::{anyhow, Result};
 use std::time::Duration;
-use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::protocol::acp::conn;
+use crate::protocol::acp::spawn::AgentStderrLog;
 
 /// The successful list outcome, or a human-readable reason it failed.
 ///
@@ -55,15 +55,8 @@ pub(crate) async fn fetch_session_list(
         .take()
         .ok_or_else(|| anyhow!("agent stdout not piped"))?
         .compat();
-    if let Some(stderr) = child.stderr.take() {
-        let label = client_label.to_string();
-        tokio::task::spawn_local(async move {
-            let mut lines = BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                tracing::debug!(target: "acp_session_list", agent = %label, "agent stderr: {}", line);
-            }
-        });
-    }
+    let stderr_log = AgentStderrLog::new(client_label.to_string());
+    let stderr_task = child.stderr.take().map(|stderr| stderr_log.drain(stderr));
 
     let (conn, handle_io) =
         conn::spawn_client(acp::Client.builder().name("wta-session-list"), conn::byte_streams(outgoing, incoming));
@@ -80,8 +73,13 @@ pub(crate) async fn fetch_session_list(
             acp::schema::v1::Implementation::new("wta-session-list", env!("CARGO_PKG_VERSION"))
                 .title("WTA Session List"),
         );
-    let init_resp = tokio::time::timeout(init_timeout, conn.initialize(init_req))
-        .await
+    let init_result = tokio::time::timeout(init_timeout, conn.initialize(init_req)).await;
+    if matches!(init_result, Ok(Ok(_))) {
+        stderr_log.mark_initialized();
+    } else {
+        stderr_log.finish_failed_startup(child, stderr_task).await;
+    }
+    let init_resp = init_result
         .map_err(|_| {
             anyhow!(
                 "ACP initialize timed out after {:?} (agent={})",

--- a/tools/wta/src/protocol/acp/spawn.rs
+++ b/tools/wta/src/protocol/acp/spawn.rs
@@ -9,9 +9,164 @@
 //! over the helper pipes; the probe attaches raw stdio, runs `initialize`
 //! + `new_session`, and exits.
 
+use std::collections::VecDeque;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use anyhow::{anyhow, Result};
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+const STARTUP_STDERR_MAX_LINES: usize = 32;
+const STARTUP_STDERR_MAX_CHARS_PER_LINE: usize = 1024;
+const STARTUP_STDERR_DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StderrPhase {
+    Startup,
+    Running,
+    Failed,
+}
+
+#[derive(Debug)]
+struct AgentStderrLogInner {
+    phase: StderrPhase,
+    startup_lines: VecDeque<String>,
+}
+
+/// Keeps routine agent stderr at debug level while preserving startup failures
+/// in release logs. Only the bounded pre-initialize buffer is promoted.
+#[derive(Clone)]
+pub(crate) struct AgentStderrLog {
+    agent: Arc<str>,
+    inner: Arc<Mutex<AgentStderrLogInner>>,
+}
+
+impl AgentStderrLog {
+    pub(crate) fn new(agent: impl Into<Arc<str>>) -> Self {
+        Self {
+            agent: agent.into(),
+            inner: Arc::new(Mutex::new(AgentStderrLogInner {
+                phase: StderrPhase::Startup,
+                startup_lines: VecDeque::with_capacity(STARTUP_STDERR_MAX_LINES),
+            })),
+        }
+    }
+
+    pub(crate) fn drain(&self, stderr: tokio::process::ChildStderr) -> tokio::task::JoinHandle<()> {
+        let log = self.clone();
+        tokio::task::spawn_local(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(line)) => log.log_line(&line),
+                    Ok(None) => break,
+                    Err(error) => {
+                        log.log_line(&format!("failed to read agent stderr: {error}"));
+                        break;
+                    }
+                }
+            }
+        })
+    }
+
+    pub(crate) async fn finish_failed_startup(
+        &self,
+        child: &mut tokio::process::Child,
+        stderr_task: Option<tokio::task::JoinHandle<()>>,
+    ) {
+        self.mark_failed();
+        let _ = child.start_kill();
+        if let Some(stderr_task) = stderr_task {
+            let _ = tokio::time::timeout(STARTUP_STDERR_DRAIN_TIMEOUT, stderr_task).await;
+        }
+    }
+
+    pub(crate) fn mark_initialized(&self) {
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        inner.phase = StderrPhase::Running;
+        inner.startup_lines.clear();
+    }
+
+    pub(crate) fn mark_failed(&self) {
+        let startup_lines = {
+            let mut inner = self
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if inner.phase != StderrPhase::Startup {
+                return;
+            }
+            inner.phase = StderrPhase::Failed;
+            inner.startup_lines.drain(..).collect::<Vec<_>>()
+        };
+
+        if !startup_lines.is_empty() {
+            tracing::warn!(
+                target: "agent_stderr",
+                agent = %self.agent,
+                phase = "startup_failure",
+                captured_lines = startup_lines.len(),
+                "agent startup failed; promoting captured stderr"
+            );
+        }
+        for line in startup_lines {
+            tracing::warn!(
+                target: "agent_stderr",
+                agent = %self.agent,
+                phase = "startup_failure",
+                "{line}"
+            );
+        }
+    }
+
+    fn log_line(&self, line: &str) {
+        let warn = {
+            let mut inner = self
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            match inner.phase {
+                StderrPhase::Startup => {
+                    if inner.startup_lines.len() == STARTUP_STDERR_MAX_LINES {
+                        inner.startup_lines.pop_front();
+                    }
+                    inner.startup_lines.push_back(truncate_stderr_line(line));
+                    false
+                }
+                StderrPhase::Running => false,
+                StderrPhase::Failed => true,
+            }
+        };
+
+        if warn {
+            let line = truncate_stderr_line(line);
+            tracing::warn!(
+                target: "agent_stderr",
+                agent = %self.agent,
+                phase = "startup_failure",
+                "{line}"
+            );
+        } else {
+            tracing::debug!(target: "agent_stderr", agent = %self.agent, "{line}");
+        }
+    }
+}
+
+fn truncate_stderr_line(line: &str) -> String {
+    let mut chars = line.chars();
+    let mut truncated = chars
+        .by_ref()
+        .take(STARTUP_STDERR_MAX_CHARS_PER_LINE)
+        .collect::<String>();
+    if chars.next().is_some() {
+        truncated.push_str("...");
+    }
+    truncated
+}
 
 pub(crate) struct AgentSpawn {
     pub child: tokio::process::Child,
@@ -196,6 +351,47 @@ mod tests {
     use super::*;
 
     #[test]
+    fn stderr_log_promotes_only_failed_startup_lines() {
+        let log = AgentStderrLog::new("test-agent");
+        let clone = log.clone();
+
+        for index in 0..STARTUP_STDERR_MAX_LINES + 1 {
+            log.log_line(&format!("startup line {index}"));
+        }
+        {
+            let inner = log
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            assert_eq!(inner.phase, StderrPhase::Startup);
+            assert_eq!(inner.startup_lines.len(), STARTUP_STDERR_MAX_LINES);
+            assert_eq!(inner.startup_lines.front().unwrap(), "startup line 1");
+        }
+
+        clone.mark_failed();
+        let inner = log
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(inner.phase, StderrPhase::Failed);
+        assert!(inner.startup_lines.is_empty());
+    }
+
+    #[test]
+    fn stderr_log_discards_buffer_after_initialize() {
+        let log = AgentStderrLog::new("test-agent");
+        log.log_line("startup detail");
+        log.mark_initialized();
+
+        let inner = log
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(inner.phase, StderrPhase::Running);
+        assert!(inner.startup_lines.is_empty());
+    }
+
+    #[test]
     fn canonicalizes_simple_lang_region() {
         assert_eq!(canonicalize_posix_locale("zh-CN"), "zh_CN.UTF-8");
         assert_eq!(canonicalize_posix_locale("en-US"), "en_US.UTF-8");
@@ -218,4 +414,3 @@ mod tests {
         assert_eq!(canonicalize_posix_locale("en"), "en.UTF-8");
     }
 }
-

--- a/tools/wta/src/protocol/acp/spawn.rs
+++ b/tools/wta/src/protocol/acp/spawn.rs
@@ -75,11 +75,17 @@ impl AgentStderrLog {
         child: &mut tokio::process::Child,
         stderr_task: Option<tokio::task::JoinHandle<()>>,
     ) {
-        self.mark_failed();
         let _ = child.start_kill();
-        if let Some(stderr_task) = stderr_task {
-            let _ = tokio::time::timeout(STARTUP_STDERR_DRAIN_TIMEOUT, stderr_task).await;
+        if let Some(mut stderr_task) = stderr_task {
+            if tokio::time::timeout(STARTUP_STDERR_DRAIN_TIMEOUT, &mut stderr_task)
+                .await
+                .is_err()
+            {
+                stderr_task.abort();
+                let _ = stderr_task.await;
+            }
         }
+        self.mark_failed();
     }
 
     pub(crate) fn mark_initialized(&self) {
@@ -124,7 +130,7 @@ impl AgentStderrLog {
     }
 
     fn log_line(&self, line: &str) {
-        let warn = {
+        {
             let mut inner = self
                 .inner
                 .lock()
@@ -135,24 +141,12 @@ impl AgentStderrLog {
                         inner.startup_lines.pop_front();
                     }
                     inner.startup_lines.push_back(truncate_stderr_line(line));
-                    false
                 }
-                StderrPhase::Running => false,
-                StderrPhase::Failed => true,
+                StderrPhase::Running | StderrPhase::Failed => {}
             }
-        };
-
-        if warn {
-            let line = truncate_stderr_line(line);
-            tracing::warn!(
-                target: "agent_stderr",
-                agent = %self.agent,
-                phase = "startup_failure",
-                "{line}"
-            );
-        } else {
-            tracing::debug!(target: "agent_stderr", agent = %self.agent, "{line}");
         }
+
+        tracing::debug!(target: "agent_stderr", agent = %self.agent, "{line}");
     }
 }
 
@@ -369,6 +363,7 @@ mod tests {
         }
 
         clone.mark_failed();
+        log.log_line("late failure detail");
         let inner = log
             .inner
             .lock()

--- a/tools/wta/src/protocol/acp/spawn.rs
+++ b/tools/wta/src/protocol/acp/spawn.rs
@@ -151,14 +151,17 @@ impl AgentStderrLog {
 }
 
 fn truncate_stderr_line(line: &str) -> String {
-    let mut chars = line.chars();
-    let mut truncated = chars
-        .by_ref()
-        .take(STARTUP_STDERR_MAX_CHARS_PER_LINE)
-        .collect::<String>();
-    if chars.next().is_some() {
-        truncated.push_str("...");
+    const ELLIPSIS: &str = "...";
+
+    if line.chars().count() <= STARTUP_STDERR_MAX_CHARS_PER_LINE {
+        return line.to_string();
     }
+
+    let mut truncated = line
+        .chars()
+        .take(STARTUP_STDERR_MAX_CHARS_PER_LINE - ELLIPSIS.chars().count())
+        .collect::<String>();
+    truncated.push_str(ELLIPSIS);
     truncated
 }
 
@@ -384,6 +387,50 @@ mod tests {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         assert_eq!(inner.phase, StderrPhase::Running);
         assert!(inner.startup_lines.is_empty());
+    }
+
+    #[test]
+    fn stderr_line_at_limit_is_unchanged() {
+        let line = "a".repeat(STARTUP_STDERR_MAX_CHARS_PER_LINE);
+
+        assert_eq!(truncate_stderr_line(&line), line);
+    }
+
+    #[test]
+    fn stderr_line_over_limit_includes_ellipsis_within_limit() {
+        let line = "a".repeat(STARTUP_STDERR_MAX_CHARS_PER_LINE + 1);
+        let truncated = truncate_stderr_line(&line);
+
+        assert_eq!(
+            truncated.chars().count(),
+            STARTUP_STDERR_MAX_CHARS_PER_LINE
+        );
+        assert!(truncated.ends_with("..."));
+        assert_eq!(
+            truncated,
+            format!(
+                "{}...",
+                "a".repeat(STARTUP_STDERR_MAX_CHARS_PER_LINE - 3)
+            )
+        );
+    }
+
+    #[test]
+    fn stderr_line_truncation_preserves_unicode_characters() {
+        let line = "界".repeat(STARTUP_STDERR_MAX_CHARS_PER_LINE + 1);
+        let truncated = truncate_stderr_line(&line);
+
+        assert_eq!(
+            truncated.chars().count(),
+            STARTUP_STDERR_MAX_CHARS_PER_LINE
+        );
+        assert_eq!(
+            truncated,
+            format!(
+                "{}...",
+                "界".repeat(STARTUP_STDERR_MAX_CHARS_PER_LINE - 3)
+            )
+        );
     }
 
     #[test]

--- a/tools/wta/src/wsl_acp.rs
+++ b/tools/wta/src/wsl_acp.rs
@@ -273,7 +273,7 @@ mod tests {
         );
         assert_eq!(
             acp_command_for(&CliSource::Codex).as_deref(),
-            Some("npx -y @agentclientprotocol/codex-acp@1.1.2")
+            Some("npx -y @agentclientprotocol/codex-acp@1.1.0")
         );
         assert!(acp_command_for(&CliSource::Gemini).is_none());
         assert!(acp_command_for(&CliSource::Unknown("x".into())).is_none());

--- a/tools/wta/src/wsl_acp.rs
+++ b/tools/wta/src/wsl_acp.rs
@@ -273,7 +273,7 @@ mod tests {
         );
         assert_eq!(
             acp_command_for(&CliSource::Codex).as_deref(),
-            Some("npx -y @zed-industries/codex-acp")
+            Some("npx -y @agentclientprotocol/codex-acp@1.1.2")
         );
         assert!(acp_command_for(&CliSource::Gemini).is_none());
         assert!(acp_command_for(&CliSource::Unknown("x".into())).is_none());


### PR DESCRIPTION
## Summary
- replace deprecated `@zed-industries/codex-acp` with official `@agentclientprotocol/codex-acp@1.1.0`
- pin to the newest version currently downloadable through the Microsoft package feed
- update WTA command resolution and WSL/coordinator coverage
- promote bounded pre-initialize adapter stderr to release-visible warnings only when ACP startup fails
- update current documentation while preserving old benchmark results as explicitly historical

## Validation
- `npx -y @agentclientprotocol/codex-acp@1.1.0 --version` succeeds through the default Microsoft feed
- WTA ACP v1 initialize, model discovery, and session-list probes succeed
- `cargo test --manifest-path tools/wta/Cargo.toml --quiet` (1129 passed)
- full incremental C++ build (0 errors)
- `WTA_LOG=info` failure probes record npm policy failures in release-visible logs