### PR TITLE
Upgrade agent-client-protocol from 1.0.0 to 1.2.0

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -557,9 +557,9 @@ requirements are met without embedding any single crate's license body as
 if it were canonical for the whole group.
 
 - **adler2** v2.0.1 -- [https://github.com/oyvindln/adler2](https://github.com/oyvindln/adler2) -- `0BSD OR Apache-2.0 OR MIT`
-- **agent-client-protocol** v1.0.0 -- [https://github.com/agentclientprotocol/rust-sdk](https://github.com/agentclientprotocol/rust-sdk) -- `Apache-2.0`
-- **agent-client-protocol-derive** v1.0.0 -- [https://github.com/agentclientprotocol/rust-sdk](https://github.com/agentclientprotocol/rust-sdk) -- `Apache-2.0`
-- **agent-client-protocol-schema** v1.1.0 -- [https://github.com/agentclientprotocol/agent-client-protocol](https://github.com/agentclientprotocol/agent-client-protocol) -- `Apache-2.0`
+- **agent-client-protocol** v1.2.0 -- [https://github.com/agentclientprotocol/rust-sdk](https://github.com/agentclientprotocol/rust-sdk) -- `Apache-2.0`
+- **agent-client-protocol-derive** v1.2.0 -- [https://github.com/agentclientprotocol/rust-sdk](https://github.com/agentclientprotocol/rust-sdk) -- `Apache-2.0`
+- **agent-client-protocol-schema** v1.4.0 -- [https://github.com/agentclientprotocol/agent-client-protocol](https://github.com/agentclientprotocol/agent-client-protocol) -- `Apache-2.0`
 - **aho-corasick** v1.1.4 -- [https://github.com/BurntSushi/aho-corasick](https://github.com/BurntSushi/aho-corasick) -- `MIT OR Unlicense`
 - **allocator-api2** v0.2.21 -- [https://github.com/zakarumych/allocator-api2](https://github.com/zakarumych/allocator-api2) -- `Apache-2.0 OR MIT`
 - **anstream** v0.6.21 -- [https://github.com/rust-cli/anstyle.git](https://github.com/rust-cli/anstyle.git) -- `Apache-2.0 OR MIT`
@@ -856,7 +856,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 ### `Apache-2.0`
 
-Applies to 190 crate(s) (directly or via composite identifiers): adler2 v2.0.1, agent-client-protocol v1.0.0, agent-client-protocol-derive v1.0.0, agent-client-protocol-schema v1.1.0, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, ... (+182 more)
+Applies to 190 crate(s) (directly or via composite identifiers): adler2 v2.0.1, agent-client-protocol v1.2.0, agent-client-protocol-derive v1.2.0, agent-client-protocol-schema v1.4.0, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, ... (+182 more)
 
 _Canonical text reproduced from upstream `SPDX:Apache-2.0`:_
 

--- a/tools/wta/Cargo.lock
+++ b/tools/wta/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-client-protocol"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e981a7d0207a0e9eb67d0faafc04e8c6601dea572d67a3163798897c0024521d"
+checksum = "882b815ffa67b023e1b40e7ea3bab3f05869654e8565d6811870c5545285e1d3"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d589c28cbe2978c76f8714cc304bc08355ee2f05d120806717725d9ffa12143"
+checksum = "dd5ca63f112bd2459bcaf9eda0683b9ba95fc3b5e5fdd9036ca941c6a09345b1"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac542aba230234b1591ace7286a47c0514fe3efc3037d43296bde31ba7ee5728"
+checksum = "06679e1542356341f4550ccfb16338b64f37f6af70de2105446ef6fbb078234c"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/tools/wta/Cargo.toml
+++ b/tools/wta/Cargo.toml
@@ -10,7 +10,7 @@ name = "wta"
 path = "src/main.rs"
 
 [dependencies]
-agent-client-protocol = { version = "1.0" }
+agent-client-protocol = { version = "1.2.0" }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 async-trait = "0.1"

--- a/tools/wta/cgmanifest.json
+++ b/tools/wta/cgmanifest.json
@@ -15,7 +15,7 @@
         "type": "cargo",
         "cargo": {
           "name": "agent-client-protocol",
-          "version": "1.0.0"
+          "version": "1.2.0"
         }
       }
     },
@@ -24,7 +24,7 @@
         "type": "cargo",
         "cargo": {
           "name": "agent-client-protocol-derive",
-          "version": "1.0.0"
+          "version": "1.2.0"
         }
       }
     },
@@ -33,7 +33,7 @@
         "type": "cargo",
         "cargo": {
           "name": "agent-client-protocol-schema",
-          "version": "1.1.0"
+          "version": "1.4.0"
         }
       }
     },

--- a/tools/wta/src/protocol/acp/model_select.rs
+++ b/tools/wta/src/protocol/acp/model_select.rs
@@ -133,7 +133,7 @@ pub(crate) async fn apply_session_model(
                 .set_session_config_option(acp::schema::v1::SetSessionConfigOptionRequest::new(
                     session_id.clone(),
                     config_id,
-                    model_id.clone(),
+                    model_id.as_str(),
                 ))
                 .await
             {


### PR DESCRIPTION
## Summary
- upgrade agent-client-protocol from 1.0.0 to 1.2.0
- adapt model config selection to the updated schema API
- regenerate Cargo dependency notices and Component Governance metadata

## Testing
- cargo test --manifest-path tools/wta/Cargo.toml
- cargo build --manifest-path tools/wta/Cargo.toml