### PR TITLE
Update ACP request cancellation documentation

### DIFF
--- a/tools/wta/src/protocol/acp/failure.rs
+++ b/tools/wta/src/protocol/acp/failure.rs
@@ -73,10 +73,9 @@ pub enum AgentFailure {
 impl AgentFailure {
     /// Classify a typed ACP JSON-RPC error by its `code`.
     ///
-    /// Matching is numeric so it is independent of which `unstable_*` Cargo
-    /// features gate the corresponding `ErrorCode` variant (e.g.
-    /// `RequestCancelled` is behind `unstable_cancel_request`, which we do not
-    /// enable — without numeric matching it would not even be nameable here).
+    /// Matching remains numeric so standard and agent-defined codes share one
+    /// forward-compatible classification path. `RequestCancelled` (`-32800`)
+    /// is stable as of agent-client-protocol 1.1.
     pub fn from_acp_error(e: &acp::Error) -> Self {
         let code: i32 = e.code.into();
         match code {


### PR DESCRIPTION
## Summary
- update the ACP failure classification documentation after request cancellation became stable
- clarify why numeric error-code matching remains intentional

Codex already uses the official ACP adapter through PR #450.

## Testing
- cargo test --manifest-path tools/wta/Cargo.toml protocol::acp::failure::tests