### PR TITLE
Add transparent ACP tracing proxy

### DIFF
--- a/doc/specs/acp-1.0-conductor-migration.md
+++ b/doc/specs/acp-1.0-conductor-migration.md
@@ -196,6 +196,7 @@ flowchart TB
     end
 
     subgraph proxies["composable transform proxies — lifted out of app.rs / session subsystem, chained via _proxy/*"]
+        TRACE["wire tracing proxy<br/>no-op · method metadata only"]
         AFX["autofix proxy<br/>off-wire WtEvent → inject session/prompt"]
         CTX["context / prompt-injection proxy<br/>rewrite session/prompt (persona + template)"]
         REC["delegate / recommendation proxy<br/>parse RecommendationSet from session/update"]
@@ -219,14 +220,15 @@ flowchart TB
     BR --> SC
     SC -->|"select owning slot"| PCR
     PCR --> C
-    C -.->|"_proxy/initialize"| AFX
+    C -->|"_proxy/initialize"| TRACE
+    TRACE -->|"current: plain initialize"| CLI
+    TRACE -.->|"_proxy/successor"| AFX
     AFX -.->|"_proxy/successor"| CTX
     CTX -.->|"_proxy/successor"| REC
     REC -.->|"_proxy/successor"| SLU
     SLU -.->|"_proxy/successor"| SLE
     SLE -.->|"_proxy/successor"| SLA
     SLA -.->|"_proxy/successor"| CLI
-    C -->|"zero proxies: plain ACP initialize<br/>configured proxies: successor routing"| CLI
     MOD -.->|"folds into"| CTX
     PERM -.->|"folds into"| CB
 
@@ -234,7 +236,7 @@ flowchart TB
     classDef plumbing fill:#dae8fc,stroke:#6c8ebf,color:#000;
     classDef library fill:#d5e8d4,stroke:#82b366,color:#000;
     classDef handrolled fill:#f8cecc,stroke:#b85450,color:#000;
-    class AFX,CTX,REC,SLU,SLE,SLA,MOD,PERM proxyable;
+    class TRACE,AFX,CTX,REC,SLU,SLE,SLA,MOD,PERM proxyable;
     class PLUMB plumbing;
     class C,PCR library;
     class SC,BR handrolled;
@@ -365,14 +367,14 @@ request/response/notification/reverse-request forwarding inside the slot.
   identical.
 - **Phase 3 — prove the proxy wire.** Add one no-op tracing proxy that receives
   `_proxy/initialize` and forwards every request, response, notification, and
-  reverse request through `_proxy/successor`.
+  reverse request through `_proxy/successor`. **Complete.**
 - **Phase 4 — extract transform proxies.** Move the three strong transform cores
   out of `app.rs` — **autofix**, **context/prompt injection**, and
   **delegate/recommendation** — into standalone proxies wired via
   `_proxy/initialize` / `_proxy/successor`. This is where `_proxy/*` first becomes
   relevant, and it needs no further master change. See
-  [Phase 2 detail: extracting the transform proxies](#phase-2-detail-extracting-the-transform-proxies).
-- **Phase 3 (optional) — WT control via MCP-over-ACP.** Expose `wtcli` operations
+  [Phase 4 detail: extracting the transform proxies](#phase-4-detail-extracting-the-transform-proxies).
+- **Phase 5 (optional) — WT control via MCP-over-ACP.** Expose `wtcli` operations
   through `with_mcp_server` instead of shelling out. Larger rethink; separate
   spec.
 
@@ -653,6 +655,25 @@ This phase deliberately uses the upstream implementation rather than copying
 its dispatch algorithm. Phase 3 adds an explicit no-op tracing proxy to prove
 the successor wire before any feature changes message contents.
 
+### Phase 3 detail: explicit tracing proxy
+
+Each `ProxyChainRuntime` now configures
+`ProxiesAndAgent::new(final_agent).proxy(TracingProxy)`. The proxy handles
+`_proxy/initialize`, forwards the enclosed ordinary `initialize` to its
+successor, and uses `send_proxied_message_to` for every remaining dispatch in
+both directions. Request cancellation remains hop-scoped and is remapped by the
+ACP SDK while forwarding.
+
+The proxy is intentionally behavior-free: it does not deserialize, rewrite, or
+retain message parameters, results, or `_meta`. At `trace` level, target
+`proxy_chain` records only `direction`, `kind`, and `method`. This provides
+wire-level evidence without placing prompts, paths, tool arguments, or agent
+responses in the log.
+
+The focused chain test asserts proxy initialization, final-agent ordinary
+initialization, request/response forwarding, agent notifications, reverse
+requests/responses, metadata preservation, and final-agent EOF propagation.
+
 ### Phase 4 detail: extracting the transform proxies
 
 `app.rs` is the central event-loop + state hub (`App` struct + the `AppEvent`
@@ -707,6 +728,7 @@ flowchart LR
         CB["SessionRouter<br/>N:M control plane"]
         C["ConductorImpl<br/>per-slot linear chain"]
     end
+    TRACE["wire tracing proxy<br/>no-op · method metadata only"]
     AFX["autofix proxy<br/>WtEvent → inject session/prompt"]
     CTX["context/prompt proxy<br/>rewrite session/prompt"]
     REC["delegate/recommendation proxy<br/>parse RecommendationSet"]
@@ -719,7 +741,8 @@ flowchart LR
 
     H -->|"ACP/pipe"| CB
     CB --> C
-    C -.->|"_proxy/initialize"| AFX
+    C -->|"_proxy/initialize"| TRACE
+    TRACE -.->|"_proxy/successor"| AFX
     AFX -.->|"_proxy/successor"| CTX
     CTX -.->|"_proxy/successor"| REC
     REC -.->|"_proxy/successor"| SLU
@@ -821,19 +844,19 @@ activity observer, leaving the residual non-proxy core (liveness + cross-window
 sync) in the conductor (the two caveats above); (3) model / permission as fold-in
 decisions made only after (1).
 
-### Phase 3 detail: WT control via MCP-over-ACP
+### Phase 5 detail: WT control via MCP-over-ACP
 
 Today the agent reaches Windows Terminal by **shelling out**: it spawns `wta` /
 `wtcli`, which call WT's COM `IProtocolServer` (`CliChannel`). Every WT operation
 (`list-panes`, `capture-pane`, `send-keys`, `split-pane`, …) is a fresh
-subprocess. Phase 3 replaces that subprocess transport with **MCP-over-ACP**: the
+subprocess. Phase 5 replaces that subprocess transport with **MCP-over-ACP**: the
 conductor injects an MCP server into each `session/new` via
 `SessionBuilder::with_mcp_server(...)`, exposing the WT operations as typed MCP
 tools the agent calls **in-band** over the ACP connection.
 
 **What changes:**
 - `session/new` carries a master-published MCP server (the same hook
-  `inject_wta_mcp_servers` already prepares for HTTP-capable agents — Phase 3
+  `inject_wta_mcp_servers` already prepares for HTTP-capable agents — Phase 5
   generalizes it to the ACP-native `with_mcp_server` path).
 - Each `wtcli` verb becomes an MCP tool with a JSON schema; the agent discovers
   them via the MCP tool list instead of being told to shell out.
@@ -995,7 +1018,7 @@ connection/auth state machine, the tab registry) outside this spec's scope.
 - Phase 2 turns autofix/context-injection into composable proxies — reorderable
   and insertable by config rather than code.
 - MCP-over-ACP (`with_mcp_server`) could replace `wtcli` shell-outs for WT
-  control (Phase 3).
+  control (Phase 5).
 - The COM `IProtocolServer` surface could later retire the hand-written
   session-management reconciliation — out of scope here, tracked separately.
 
@@ -1044,5 +1067,10 @@ promotion. It is explicitly the outer control plane, not the proxy conductor.
 The final agent still receives plain `initialize`; WTA retains process launch,
 diagnostics, timeout, and exact-instance reap.
 
-**Next — Phase 3:** add a no-op tracing proxy and assert
-`_proxy/initialize`/`_proxy/successor` routing before migrating any feature.
+**Done — Phase 3:** each canonical conductor now owns an explicit no-op tracing
+proxy. It proves `_proxy/initialize`/`_proxy/successor` routing in both
+directions, preserves `_meta`, propagates final-agent EOF, and logs only
+direction/kind/method under target `proxy_chain`.
+
+**Next — Phase 4:** migrate one behavior at a time into standalone transform
+proxies, beginning with the clearest ACP method boundary.

--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -14,8 +14,8 @@ with an error.
   `ProxyChainRuntime`s (Copilot, Claude, Gemini, Codex, or custom), listens on a
   named pipe, and fans per-helper ACP sessions onto the selected runtime.
   Instance-scoped route/orphan lifetime lives in `src/master/session_router.rs`;
-  each runtime embeds the canonical ACP `ConductorImpl` from
-  `src/master/proxy_chain.rs`.
+  each runtime embeds the canonical ACP `ConductorImpl` and an explicit
+  pass-through tracing proxy from `src/master/proxy_chain.rs`.
 - **`wta-helper`** (`--connect-master <pipe>`, spawned once per agent pane by
   Windows Terminal) -- the per-pane **TUI**. Drives the ratatui chat UI (`app.rs`)
   but, instead of spawning its own agent CLI, speaks ACP/JSON-RPC to master over
@@ -73,7 +73,9 @@ because of the helper+master split:
 
 - **master ↔ proxy chain ↔ agent CLI**: master is the ACP **client** of each
   pooled canonical conductor, which owns an ordered linear proxy chain ending
-  at the agent CLI's stdio transport.
+  at the agent CLI's stdio transport. The first proxy is a no-op wire tracer:
+  it forwards all dispatches unchanged and records only direction, message kind,
+  and method under tracing target `proxy_chain`.
 - **helper ↔ master** (named pipe): master is an ACP **agent** (server) to each
   helper, and the helper is the ACP **client**. Master forwards helper requests
   to the agent CLI and routes inbound `session_notification`s back to the helper
@@ -198,6 +200,9 @@ Per-process logs in the helper+master architecture:
 - `wta-install-hooks.log` -- `hooks install` / uninstall
 - `wta-ensure-host.log` -- WT-side background ensure-running / SharedWta lifecycle
 - `wta-acp-debug.log` -- low-level ACP JSON-RPC wire trace
+
+The `proxy_chain` tracing target is metadata-only: it never logs message
+parameters, results, prompts, paths, tool arguments, or `_meta`.
 
 Two files in the same dir are written by **non-Rust** producers:
 `terminal-agent-pane.log` (C++ `AgentPaneLog`) and `hook-trace.log` (PowerShell

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -2319,7 +2319,7 @@ async fn spawn_one_agent(
             acp::on_receive_notification!(),
         );
     let final_agent = conn::byte_streams(stdin.compat_write(), stdout.compat());
-    let conductor = proxy_chain::transparent(final_agent);
+    let conductor = proxy_chain::traced(final_agent);
     let (conn, handle_io) = conn::spawn_client_component(builder, conductor);
 
     // I/O-loop driver + reaper. This task drives the ACP connection's
@@ -4523,8 +4523,8 @@ mod tests {
                     });
                 }
 
-                // Master's client side of hop 1: the zero-proxy canonical
-                // conductor sits between MasterClient and the final agent.
+                // Master's client side of hop 1: the canonical conductor and
+                // tracing proxy sit between MasterClient and the final agent.
                 // MasterClient routes the agent's reentrant request_permission
                 // back out to the owning helper.
                 let master_client = MasterClient {
@@ -4562,7 +4562,7 @@ mod tests {
                     let final_agent = conn::byte_streams(cw.compat_write(), cr.compat());
                     let (link, io) = conn::spawn_client_component(
                         builder,
-                        proxy_chain::transparent(final_agent),
+                        proxy_chain::traced(final_agent),
                     );
                     tokio::task::spawn_local(async move {
                         let _ = io.await;
@@ -4571,7 +4571,7 @@ mod tests {
                         acp::schema::ProtocolVersion::V1,
                     ))
                     .await
-                    .expect("zero-proxy conductor should initialize the final agent");
+                    .expect("proxy conductor should initialize the final agent");
                     link
                 };
 

--- a/tools/wta/src/master/proxy_chain.rs
+++ b/tools/wta/src/master/proxy_chain.rs
@@ -1,15 +1,555 @@
 //! Canonical ACP proxy-chain construction for one pooled agent instance.
 
 use agent_client_protocol as acp;
-use agent_client_protocol_conductor::{AgentOnly, ConductorImpl};
+use agent_client_protocol_conductor::{ConductorImpl, ProxiesAndAgent};
 
-/// Build the behavior-preserving first stage of the proxy migration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Direction {
+    ClientToAgent,
+    AgentToClient,
+}
+
+impl Direction {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::ClientToAgent => "client_to_agent",
+            Self::AgentToClient => "agent_to_client",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MessageKind {
+    Request,
+    Response,
+    Notification,
+}
+
+impl MessageKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Request => "request",
+            Self::Response => "response",
+            Self::Notification => "notification",
+        }
+    }
+}
+
+trait DispatchObserver: Clone + Send + Sync + 'static {
+    fn observe(&self, direction: Direction, kind: MessageKind, method: &str);
+}
+
+#[derive(Clone, Copy)]
+struct LogDispatch;
+
+impl DispatchObserver for LogDispatch {
+    fn observe(&self, direction: Direction, kind: MessageKind, method: &str) {
+        tracing::trace!(
+            target: "proxy_chain",
+            direction = direction.as_str(),
+            kind = kind.as_str(),
+            method,
+            "forwarding ACP dispatch"
+        );
+    }
+}
+
+struct TracingProxy<O> {
+    observer: O,
+}
+
+impl<O> TracingProxy<O> {
+    const fn new(observer: O) -> Self {
+        Self { observer }
+    }
+}
+
+impl<O: DispatchObserver> acp::ConnectTo<acp::Conductor> for TracingProxy<O> {
+    async fn connect_to(self, client: impl acp::ConnectTo<acp::Proxy>) -> Result<(), acp::Error> {
+        let initialize_observer = self.observer.clone();
+        acp::Proxy
+            .builder()
+            .name("wta-tracing-proxy")
+            .on_receive_request_from(
+                acp::Client,
+                async move |request: acp::schema::InitializeProxyRequest, responder, cx| {
+                    initialize_observer.observe(
+                        Direction::ClientToAgent,
+                        MessageKind::Request,
+                        responder.method(),
+                    );
+                    cx.send_request_to(acp::Agent, request.initialize)
+                        .forward_response_to(responder)
+                },
+                acp::on_receive_request!(),
+            )
+            .with_handler(TraceAndForward {
+                observer: self.observer,
+            })
+            .connect_to(client)
+            .await
+    }
+}
+
+struct TraceAndForward<O> {
+    observer: O,
+}
+
+impl<O: DispatchObserver> acp::HandleDispatchFrom<acp::Conductor> for TraceAndForward<O> {
+    async fn handle_dispatch_from(
+        &mut self,
+        message: acp::Dispatch,
+        connection: acp::ConnectionTo<acp::Conductor>,
+    ) -> Result<acp::Handled<acp::Dispatch>, acp::Error> {
+        use acp::util::MatchDispatchFrom;
+
+        MatchDispatchFrom::new(message, &connection)
+            .if_message_from(acp::Client, async |message: acp::Dispatch| {
+                self.observe(Direction::ClientToAgent, &message);
+                connection.send_proxied_message_to(acp::Agent, message)?;
+                Ok(acp::Handled::Yes)
+            })
+            .await
+            .if_message_from(acp::Agent, async |message: acp::Dispatch| {
+                self.observe(Direction::AgentToClient, &message);
+                connection.send_proxied_message_to(acp::Client, message)?;
+                Ok(acp::Handled::Yes)
+            })
+            .await
+            .done()
+    }
+
+    fn describe_chain(&self) -> impl std::fmt::Debug {
+        "TraceAndForward"
+    }
+}
+
+impl<O: DispatchObserver> TraceAndForward<O> {
+    fn observe(&self, direction: Direction, message: &acp::Dispatch) {
+        let kind = match message {
+            acp::Dispatch::Request(..) => MessageKind::Request,
+            acp::Dispatch::Response(..) => MessageKind::Response,
+            acp::Dispatch::Notification(..) => MessageKind::Notification,
+        };
+        self.observer.observe(direction, kind, message.method());
+    }
+}
+
+/// The ACP conductor isolates spawned component task completion. Mirror the
+/// final component's lifetime so WTA can still reap a dead pooled agent.
+struct FinalAgentWatch<C> {
+    component: C,
+    terminated: tokio::sync::oneshot::Sender<()>,
+    release: tokio::sync::oneshot::Receiver<()>,
+}
+
+impl<C> acp::ConnectTo<acp::Client> for FinalAgentWatch<C>
+where
+    C: acp::ConnectTo<acp::Client>,
+{
+    async fn connect_to(self, client: impl acp::ConnectTo<acp::Agent>) -> Result<(), acp::Error> {
+        let result = self.component.connect_to(client).await;
+        let _ = self.terminated.send(());
+        let _ = self.release.await;
+        result
+    }
+}
+
+pub(super) struct ProxyChain {
+    conductor: ConductorImpl<acp::Agent>,
+    final_agent_terminated: tokio::sync::oneshot::Receiver<()>,
+    release_final_agent: tokio::sync::oneshot::Sender<()>,
+}
+
+impl acp::ConnectTo<acp::Client> for ProxyChain {
+    async fn connect_to(self, client: impl acp::ConnectTo<acp::Agent>) -> Result<(), acp::Error> {
+        let Self {
+            conductor,
+            mut final_agent_terminated,
+            release_final_agent,
+        } = self;
+        let conductor = acp::ConnectTo::<acp::Client>::connect_to(conductor, client);
+        tokio::pin!(conductor);
+
+        tokio::select! {
+            biased;
+            result = &mut conductor => result,
+            _ = &mut final_agent_terminated => {
+                tracing::debug!(
+                    target: "proxy_chain",
+                    "final agent component terminated; draining proxy chain"
+                );
+                // The SDK queues final-agent dispatches separately from component
+                // completion. Keep driving the conductor briefly so a response
+                // written immediately before EOF reaches its waiting caller.
+                let result = match tokio::time::timeout(
+                    std::time::Duration::from_millis(100),
+                    &mut conductor,
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(_) => Err(acp::Error::internal_error()),
+                };
+                let _ = release_final_agent.send(());
+                result
+            }
+        }
+    }
+}
+
+/// Build the canonical chain with an explicit wire-observing pass-through proxy.
 ///
-/// The chain has no configured transform proxies, so every ACP message remains
-/// unchanged while initialization and routing run through the canonical
-/// conductor implementation.
-pub(super) fn transparent(
+/// The proxy records only routing metadata (direction, message kind, and method);
+/// message parameters, results, and metadata are forwarded unchanged and are
+/// never written to the trace.
+pub(super) fn traced(final_agent: impl acp::ConnectTo<acp::Client> + 'static) -> ProxyChain {
+    with_observer(final_agent, LogDispatch)
+}
+
+fn with_observer(
     final_agent: impl acp::ConnectTo<acp::Client> + 'static,
-) -> ConductorImpl<acp::Agent> {
-    ConductorImpl::new_agent("wta-master", AgentOnly(final_agent))
+    observer: impl DispatchObserver,
+) -> ProxyChain {
+    let (terminated, final_agent_terminated) = tokio::sync::oneshot::channel();
+    let (release_final_agent, release) = tokio::sync::oneshot::channel();
+    let final_agent = FinalAgentWatch {
+        component: final_agent,
+        terminated,
+        release,
+    };
+    let conductor = ConductorImpl::new_agent(
+        "wta-master",
+        ProxiesAndAgent::new(final_agent).proxy(TracingProxy::new(observer)),
+    );
+    ProxyChain {
+        conductor,
+        final_agent_terminated,
+        release_final_agent,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use acp::schema::v1::{
+        AgentCapabilities, ContentChunk, InitializeRequest, InitializeResponse, Meta,
+        NewSessionRequest, NewSessionResponse, PermissionOption, PermissionOptionId,
+        PermissionOptionKind, RequestPermissionOutcome, RequestPermissionRequest,
+        RequestPermissionResponse, SelectedPermissionOutcome, SessionId, SessionNotification,
+        SessionUpdate, ToolCallId, ToolCallUpdate, ToolCallUpdateFields,
+    };
+    use serde_json::Value;
+
+    use super::*;
+    use crate::protocol::acp::conn;
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct TraceEvent {
+        direction: Direction,
+        kind: MessageKind,
+        method: String,
+    }
+
+    #[derive(Clone, Default)]
+    struct RecordingObserver(Arc<Mutex<Vec<TraceEvent>>>);
+
+    impl DispatchObserver for RecordingObserver {
+        fn observe(&self, direction: Direction, kind: MessageKind, method: &str) {
+            self.0.lock().unwrap().push(TraceEvent {
+                direction,
+                kind,
+                method: method.to_string(),
+            });
+        }
+    }
+
+    struct RecordingAgent {
+        new_session_meta: Arc<Mutex<Option<Meta>>>,
+        permission_selected: Arc<Mutex<bool>>,
+    }
+
+    impl acp::ConnectTo<acp::Client> for RecordingAgent {
+        async fn connect_to(
+            self,
+            client: impl acp::ConnectTo<acp::Agent>,
+        ) -> Result<(), acp::Error> {
+            let new_session_meta = self.new_session_meta;
+            let permission_selected = self.permission_selected;
+
+            acp::Agent
+                .builder()
+                .name("recording-final-agent")
+                .on_receive_request(
+                    async |request: InitializeRequest, responder, _cx| {
+                        responder.respond(
+                            InitializeResponse::new(request.protocol_version)
+                                .agent_capabilities(AgentCapabilities::new()),
+                        )
+                    },
+                    acp::on_receive_request!(),
+                )
+                .on_receive_request(
+                    move |request: NewSessionRequest,
+                          responder: acp::Responder<NewSessionResponse>,
+                          cx: acp::ConnectionTo<acp::Client>| {
+                        let new_session_meta = Arc::clone(&new_session_meta);
+                        let permission_selected = Arc::clone(&permission_selected);
+                        async move {
+                            *new_session_meta.lock().unwrap() = request.meta;
+                            let session_id = SessionId::new("proxy-test-session");
+                            cx.send_notification(SessionNotification::new(
+                                session_id.clone(),
+                                SessionUpdate::AgentMessageChunk(ContentChunk::new("hello".into())),
+                            ))?;
+
+                            tokio::task::spawn_local(async move {
+                                let permission = RequestPermissionRequest::new(
+                                    session_id.clone(),
+                                    ToolCallUpdate::new(
+                                        ToolCallId::new("proxy-test-tool"),
+                                        ToolCallUpdateFields::new().title("Run test"),
+                                    ),
+                                    vec![PermissionOption::new(
+                                        PermissionOptionId::new("allow-once"),
+                                        "Allow once",
+                                        PermissionOptionKind::AllowOnce,
+                                    )],
+                                );
+                                let selected =
+                                    cx.send_request(permission).block_task().await.is_ok_and(
+                                        |response| {
+                                            matches!(
+                                                response.outcome,
+                                                RequestPermissionOutcome::Selected(_)
+                                            )
+                                        },
+                                    );
+                                *permission_selected.lock().unwrap() = selected;
+                                responder.respond(NewSessionResponse::new(session_id))
+                            });
+                            Ok(())
+                        }
+                    },
+                    acp::on_receive_request!(),
+                )
+                .connect_to(client)
+                .await
+        }
+    }
+
+    #[test]
+    fn tracing_proxy_forwards_both_directions_and_preserves_meta() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&rt, async {
+            let observer = RecordingObserver::default();
+            let events = Arc::clone(&observer.0);
+            let new_session_meta = Arc::new(Mutex::new(None));
+            let permission_selected = Arc::new(Mutex::new(false));
+            let notification_seen = Arc::new(Mutex::new(false));
+            let final_agent = RecordingAgent {
+                new_session_meta: Arc::clone(&new_session_meta),
+                permission_selected: Arc::clone(&permission_selected),
+            };
+            let conductor = with_observer(final_agent, observer);
+
+            let builder = acp::Client
+                .builder()
+                .name("proxy-test-client")
+                .on_receive_request(
+                    async |_request: RequestPermissionRequest, responder, _cx| {
+                        responder.respond(RequestPermissionResponse::new(
+                            RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(
+                                PermissionOptionId::new("allow-once"),
+                            )),
+                        ))
+                    },
+                    acp::on_receive_request!(),
+                )
+                .on_receive_notification(
+                    {
+                        let notification_seen = Arc::clone(&notification_seen);
+                        move |_notification: SessionNotification, _cx| {
+                            let notification_seen = Arc::clone(&notification_seen);
+                            async move {
+                                *notification_seen.lock().unwrap() = true;
+                                Ok(())
+                            }
+                        }
+                    },
+                    acp::on_receive_notification!(),
+                );
+            let (link, handle_io) = conn::spawn_client_component(builder, conductor);
+            let io_task = tokio::task::spawn_local(handle_io);
+
+            link.initialize(InitializeRequest::new(acp::schema::ProtocolVersion::V1))
+                .await
+                .expect("proxy chain should initialize");
+
+            let mut expected_meta = Meta::new();
+            expected_meta.insert(
+                "traceparent".into(),
+                Value::String("00-test-trace-context-01".into()),
+            );
+            link.new_session(NewSessionRequest::new("/tmp").meta(expected_meta.clone()))
+                .await
+                .expect("session/new should cross the proxy");
+
+            assert_eq!(*new_session_meta.lock().unwrap(), Some(expected_meta));
+            assert!(*notification_seen.lock().unwrap());
+            assert!(*permission_selected.lock().unwrap());
+
+            let events = events.lock().unwrap();
+            for expected in [
+                (
+                    Direction::ClientToAgent,
+                    MessageKind::Request,
+                    "_proxy/initialize",
+                ),
+                (
+                    Direction::AgentToClient,
+                    MessageKind::Response,
+                    "initialize",
+                ),
+                (
+                    Direction::ClientToAgent,
+                    MessageKind::Request,
+                    "session/new",
+                ),
+                (
+                    Direction::AgentToClient,
+                    MessageKind::Notification,
+                    "session/update",
+                ),
+                (
+                    Direction::AgentToClient,
+                    MessageKind::Request,
+                    "session/request_permission",
+                ),
+                (
+                    Direction::ClientToAgent,
+                    MessageKind::Response,
+                    "session/request_permission",
+                ),
+                (
+                    Direction::AgentToClient,
+                    MessageKind::Response,
+                    "session/new",
+                ),
+            ] {
+                assert!(
+                    events.iter().any(|event| {
+                        event.direction == expected.0
+                            && event.kind == expected.1
+                            && event.method == expected.2
+                    }),
+                    "missing trace event {expected:?}; observed {events:?}"
+                );
+            }
+
+            io_task.abort();
+        });
+    }
+
+    #[test]
+    fn tracing_proxy_chain_resolves_when_final_agent_dies() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&rt, async {
+            use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+            let (near, far) = tokio::io::duplex(64 * 1024);
+            let (near_r, near_w) = tokio::io::split(near);
+            let final_agent = conn::byte_streams(near_w.compat_write(), near_r.compat());
+            let conductor = traced(final_agent);
+            let builder = acp::Client
+                .builder()
+                .name("proxy-lifecycle-client")
+                .on_receive_request(
+                    |_request: acp::schema::v1::AgentRequest,
+                     responder: acp::Responder<serde_json::Value>,
+                     _cx| async move {
+                        responder.respond_with_error(acp::Error::method_not_found())
+                    },
+                    acp::on_receive_request!(),
+                );
+            let (link, handle_io) = conn::spawn_client_component(builder, conductor);
+            let handle_task = tokio::task::spawn_local(handle_io);
+            let (far_r, far_w) = tokio::io::split(far);
+            let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+            let shutdown_tx = Arc::new(Mutex::new(Some(shutdown_tx)));
+            let agent_task = tokio::task::spawn_local(async move {
+                acp::Agent
+                    .builder()
+                    .name("proxy-lifecycle-final-agent")
+                    .on_receive_request(
+                        |request: InitializeRequest,
+                         responder: acp::Responder<InitializeResponse>,
+                         _cx| async move {
+                            responder.respond(InitializeResponse::new(request.protocol_version))
+                        },
+                        acp::on_receive_request!(),
+                    )
+                    .on_receive_request(
+                        {
+                            let shutdown_tx = Arc::clone(&shutdown_tx);
+                            move |_request: NewSessionRequest,
+                                  responder: acp::Responder<NewSessionResponse>,
+                                  _cx| {
+                                let shutdown_tx = Arc::clone(&shutdown_tx);
+                                async move {
+                                    responder.respond(NewSessionResponse::new(SessionId::new(
+                                        "last-response",
+                                    )))?;
+                                    if let Some(shutdown_tx) = shutdown_tx.lock().unwrap().take() {
+                                        tokio::task::spawn_local(async move {
+                                            tokio::time::sleep(std::time::Duration::from_millis(
+                                                10,
+                                            ))
+                                            .await;
+                                            let _ = shutdown_tx.send(());
+                                        });
+                                    }
+                                    Ok(())
+                                }
+                            }
+                        },
+                        acp::on_receive_request!(),
+                    )
+                    .connect_with(
+                        acp::ByteStreams::new(far_w.compat_write(), far_r.compat()),
+                        async move |_cx| {
+                            let _ = shutdown_rx.await;
+                            Ok(())
+                        },
+                    )
+                    .await
+            });
+
+            link.initialize(InitializeRequest::new(acp::schema::ProtocolVersion::V1))
+                .await
+                .expect("proxy chain should initialize the final agent");
+            link.new_session(NewSessionRequest::new("/tmp"))
+                .await
+                .expect("the response immediately before EOF must be delivered");
+            agent_task
+                .await
+                .expect("final-agent task should not panic")
+                .expect("final-agent task should close cleanly");
+
+            let result = tokio::time::timeout(std::time::Duration::from_secs(3), handle_task)
+                .await
+                .expect("final-agent EOF must resolve the tracing proxy chain")
+                .expect("proxy-chain task should not panic");
+            assert!(result.is_err(), "final-agent EOF must fail the proxy chain");
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- insert an explicit ACP `Proxy` into every per-agent canonical conductor chain
- forward requests, responses, notifications, reverse requests, cancellation, and `_meta` unchanged
- emit privacy-safe `proxy_chain` traces containing only direction, message kind, and method
- preserve final-agent EOF reaping while draining dispatches written immediately before shutdown
- mark Phase 3 complete in the conductor migration spec

## Validation
- 1,134 WTA tests pass
- focused coverage proves `_proxy/initialize`, ordinary final-agent `initialize`, bidirectional forwarding, reverse requests, metadata preservation, and EOF lifecycle

Stacked on #453; merge that PR first.