### PR TITLE
Add OpenCode ACP agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ winget install --id Microsoft.IntelligentTerminal -e
 
 ## Get Started
 
-1. On first launch, choose your agent. Intelligent Terminal auto-detects several [ACP-compatible](https://agentclientprotocol.com/get-started/agents) agent CLIs on your machine (Copilot/Claude/Codex/Gemini). If none are found, it defaults to GitHub Copilot CLI and installs it for you via WinGet.
+1. On first launch, choose your agent. Intelligent Terminal auto-detects several [ACP-compatible](https://agentclientprotocol.com/get-started/agents) agent CLIs on your machine (Copilot/Claude/Codex/Gemini/OpenCode). If none are found, it defaults to GitHub Copilot CLI and installs it for you via WinGet.
 3. If you aren't already authenticated, the agent pane walks you through sign-in.
 4. Start asking questions and using the agent pane for assistance. The agent has context on your shell output, no copy-pasting needed.
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ winget install --id Microsoft.IntelligentTerminal -e
 ## Get Started
 
 1. On first launch, choose your agent. Intelligent Terminal auto-detects several [ACP-compatible](https://agentclientprotocol.com/get-started/agents) agent CLIs on your machine (Copilot/Claude/Codex/Gemini/OpenCode). If none are found, it defaults to GitHub Copilot CLI and installs it for you via WinGet.
-3. If you aren't already authenticated, the agent pane walks you through sign-in.
-4. Start asking questions and using the agent pane for assistance. The agent has context on your shell output, no copy-pasting needed.
+2. If you aren't already authenticated, the agent pane walks you through sign-in.
+3. Start asking questions and using the agent pane for assistance. The agent has context on your shell output, no copy-pasting needed.
 
 > [!TIP]
 > If you see "running scripts is disabled on this system" or an `UnauthorizedAccess` error in PowerShell, your execution policy is blocking your profile and Intelligent Terminal can't initialize shell integration. Run:

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -34,7 +34,7 @@ The FRE only sets up the session-tracking hooks for the agents you went through 
 
 ## 4. Can I use a custom ACP-compatible agent (Qwen, Cline, Goose, Cursor, …)?
 
-Yes. Intelligent Terminal can drive any agent CLI that implements the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/get-started/agents) — the [linked list](https://agentclientprotocol.com/get-started/agents) on that page covers Qwen Code, Cline, Goose, Cursor, Kimi CLI, Kiro CLI, OpenHands, and many more, in addition to the ones Intelligent Terminal sets up for you (Copilot, Claude, Codex, Gemini).
+Yes. Intelligent Terminal can drive any agent CLI that implements the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/get-started/agents) — the [linked list](https://agentclientprotocol.com/get-started/agents) on that page covers Qwen Code, Cline, Goose, Cursor, Kimi CLI, Kiro CLI, OpenHands, and many more, in addition to the ones Intelligent Terminal sets up for you (Copilot, Claude, Codex, Gemini, OpenCode).
 
 **How to wire one up:** open **Settings → Agent**, then in either the **Agent** (agent pane) or **Delegate agent** dropdown, pick **+ Add new…** and enter the command that launches your CLI:
 
@@ -43,7 +43,7 @@ Yes. Intelligent Terminal can drive any agent CLI that implements the [Agent Cli
 
 You must install and authenticate the agent CLI yourself first (Intelligent Terminal does not install bring-your-own agents — see [`installing-dependencies.md`](./installing-dependencies.md) for the pattern).
 
-**Limitation:** **Agent session management does not yet work for custom agents.** The session-tracking hooks ship only for the four built-in agents (Copilot, Claude, Codex, Gemini), so custom-agent sessions will not appear in the agent session management panel even after you install hooks. The agent pane and delegate flows themselves work normally.
+**Limitation:** **Agent session management does not yet work for custom agents or OpenCode.** The session-tracking hooks currently ship for Copilot, Claude, Codex, and Gemini, so other agent sessions will not appear in the agent session management panel even after you install hooks. The agent pane and delegate flows themselves work normally.
 
 ## 5. Why does the Model dropdown stay greyed out / show "default" after I change agents?
 

--- a/policies/en-US/IntelligentTerminal.adml
+++ b/policies/en-US/IntelligentTerminal.adml
@@ -28,10 +28,11 @@ Valid agent identifiers:
   claude    — Claude (Anthropic)
   codex     — Codex (OpenAI)
   gemini    — Gemini (Google)
+  opencode  — OpenCode
 
 These are the only recognized values. Identifiers are case-insensitive.
 
-If this policy is configured, only the listed agents will be available. Agents not in the list are hidden from the UI and blocked at runtime. Unrecognized identifiers (e.g. typos) are silently ignored — if all entries are invalid, the user will see no available agents. If not configured (default), all four agents are available.
+If this policy is configured, only the listed agents will be available. Agents not in the list are hidden from the UI and blocked at runtime. Unrecognized identifiers (e.g. typos) are silently ignored — if all entries are invalid, the user will see no available agents. If not configured (default), all five agents are available.
 
 To control custom agent commands (custom:&lt;command&gt;), use the "Allow Custom AI Agents" policy instead.</string>
       <string id="AllowCustomAgents">Allow Custom AI Agents</string>
@@ -52,7 +53,7 @@ If you enable this policy or do not configure it, users can install and manage a
         <multiTextBox refId="DisabledProfileSources">List of disabled sources (one per line)</multiTextBox>
       </presentation>
       <presentation id="AllowedAgents">
-        <multiTextBox refId="AllowedAgents">Allowed agent identifiers, one per line (copilot, claude, codex, gemini)</multiTextBox>
+        <multiTextBox refId="AllowedAgents">Allowed agent identifiers, one per line (copilot, claude, codex, gemini, opencode)</multiTextBox>
       </presentation>
     </presentationTable>
   </resources>

--- a/src/cascadia/CascadiaPackage/AgentIcons/opencode.svg
+++ b/src/cascadia/CascadiaPackage/AgentIcons/opencode.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#131010"/>
+  <path d="M320 224V352H192V224H320Z" fill="#5A5858"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M384 416H128V96H384V416ZM320 160H192V352H320V160Z" fill="#FFFFFF"/>
+</svg>

--- a/src/cascadia/TerminalApp/AgentPaneContent.cpp
+++ b/src/cascadia/TerminalApp/AgentPaneContent.cpp
@@ -26,6 +26,7 @@ namespace winrt::TerminalApp::implementation
             Claude,
             Gemini,
             Codex,
+            OpenCode,
         };
 
         // Map the agent's display name (case-insensitive substring) to its
@@ -40,6 +41,7 @@ namespace winrt::TerminalApp::implementation
             if (lower.find(L"openai") != std::wstring::npos) return AgentLogoKind::Codex;
             if (lower.find(L"gpt") != std::wstring::npos) return AgentLogoKind::Codex;
             if (lower.find(L"gemini") != std::wstring::npos) return AgentLogoKind::Gemini;
+            if (lower.find(L"opencode") != std::wstring::npos) return AgentLogoKind::OpenCode;
             return AgentLogoKind::Copilot;
         }
 
@@ -262,6 +264,7 @@ namespace winrt::TerminalApp::implementation
         ClaudeLogo().Visibility(logo == AgentLogoKind::Claude ? Visibility::Visible : Visibility::Collapsed);
         GeminiLogo().Visibility(logo == AgentLogoKind::Gemini ? Visibility::Visible : Visibility::Collapsed);
         CodexLogo().Visibility(logo == AgentLogoKind::Codex ? Visibility::Visible : Visibility::Collapsed);
+        OpenCodeLogo().Visibility(logo == AgentLogoKind::OpenCode ? Visibility::Visible : Visibility::Collapsed);
         AgentLogo().Visibility(Visibility::Visible);
     }
 

--- a/src/cascadia/TerminalApp/AgentPaneContent.xaml
+++ b/src/cascadia/TerminalApp/AgentPaneContent.xaml
@@ -83,9 +83,9 @@
                                  Visibility="Collapsed">
                             <Grid Width="512"
                                   Height="512">
-                                <Rectangle Fill="#131010" />
                                 <Path Data="M320 224V352H192V224H320Z"
-                                     Fill="#5A5858"
+                                     Fill="{Binding Foreground, ElementName=AgentLabelText}"
+                                     Opacity="0.45"
                                      Stretch="Uniform" />
                                 <Path Data="F0 M384 416H128V96H384V416ZM320 160H192V352H320V160Z"
                                      Fill="{Binding Foreground, ElementName=AgentLabelText}"

--- a/src/cascadia/TerminalApp/AgentPaneContent.xaml
+++ b/src/cascadia/TerminalApp/AgentPaneContent.xaml
@@ -32,10 +32,9 @@
                 <StackPanel Orientation="Horizontal"
                             VerticalAlignment="Center"
                             Spacing="4">
-                    <!--  Each packaged agent SVG contains a single path. Keep
-                          those paths as XAML vectors so Fill can bind directly
-                          to the title text's theme-aware Foreground (#348).
-                          Viewbox preserves each source SVG's viewBox.  -->
+                    <!--  Keep agent marks as XAML vectors so their primary Fill
+                          can bind to the title text's theme-aware Foreground
+                          (#348). Viewbox preserves each source SVG's viewBox.  -->
                     <Grid x:Name="AgentLogo"
                           Width="14"
                           Height="14">
@@ -77,6 +76,21 @@
                                   Data="M14.949 6.547a3.94 3.94 0 0 0-.348-3.273 4.11 4.11 0 0 0-4.4-1.934A4.1 4.1 0 0 0 8.423.2 4.15 4.15 0 0 0 6.305.086a4.1 4.1 0 0 0-1.891.948 4.04 4.04 0 0 0-1.158 1.753 4.1 4.1 0 0 0-1.563.679A4 4 0 0 0 .554 4.72a3.99 3.99 0 0 0 .502 4.731 3.94 3.94 0 0 0 .346 3.274 4.11 4.11 0 0 0 4.402 1.933c.382.425.852.764 1.377.995.526.231 1.095.35 1.67.346 1.78.002 3.358-1.132 3.901-2.804a4.1 4.1 0 0 0 1.563-.68 4 4 0 0 0 1.14-1.253 3.99 3.99 0 0 0-.506-4.716m-6.097 8.406a3.05 3.05 0 0 1-1.945-.694l.096-.054 3.23-1.838a.53.53 0 0 0 .265-.455v-4.49l1.366.778q.02.011.025.035v3.722c-.003 1.653-1.361 2.992-3.037 2.996m-6.53-2.75a2.95 2.95 0 0 1-.36-2.01l.095.057L5.29 12.09a.53.53 0 0 0 .527 0l3.949-2.246v1.555a.05.05 0 0 1-.022.041L6.473 13.3c-1.454.826-3.311.335-4.15-1.098m-.85-6.94A3.02 3.02 0 0 1 3.07 3.949v3.785a.51.51 0 0 0 .262.451l3.93 2.237-1.366.779a.05.05 0 0 1-.048 0L2.585 9.342a2.98 2.98 0 0 1-1.113-4.094zm11.216 2.571L8.747 5.576l1.362-.776a.05.05 0 0 1 .048 0l3.265 1.86a3 3 0 0 1 1.173 1.207 2.96 2.96 0 0 1-.27 3.2 3.05 3.05 0 0 1-1.36.997V8.279a.52.52 0 0 0-.276-.445m1.36-2.015-.097-.057-3.226-1.855a.53.53 0 0 0-.53 0L6.249 6.153V4.598a.04.04 0 0 1 .019-.04L9.533 2.7a3.07 3.07 0 0 1 3.257.139c.474.325.843.778 1.066 1.303.223.526.289 1.103.191 1.664zM5.503 8.575 4.139 7.8a.05.05 0 0 1-.026-.037V4.049c0-.57.166-1.127.476-1.607s.752-.864 1.275-1.105a3.08 3.08 0 0 1 3.234.41l-.096.054-3.23 1.838a.53.53 0 0 0-.265.455zm.742-1.577 1.758-1 1.762 1v2l-1.755 1-1.762-1z"
                                   Fill="{Binding Foreground, ElementName=AgentLabelText}"
                                   Stretch="Uniform" />
+                        </Viewbox>
+                        <Viewbox x:Name="OpenCodeLogo"
+                                 Width="14"
+                                 Height="14"
+                                 Visibility="Collapsed">
+                            <Grid Width="512"
+                                  Height="512">
+                                <Rectangle Fill="#131010" />
+                                <Path Data="M320 224V352H192V224H320Z"
+                                     Fill="#5A5858"
+                                     Stretch="Uniform" />
+                                <Path Data="F0 M384 416H128V96H384V416ZM320 160H192V352H320V160Z"
+                                     Fill="{Binding Foreground, ElementName=AgentLabelText}"
+                                     Stretch="Uniform" />
+                            </Grid>
                         </Viewbox>
                     </Grid>
                     <TextBlock x:Name="AgentLabelText"

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1074,6 +1074,10 @@ namespace winrt::TerminalApp::implementation
         {
             return winrt::hstring{ L"npx -y @agentclientprotocol/codex-acp@1.1.0" };
         }
+        if (lower == "opencode")
+        {
+            return winrt::hstring{ L"opencode acp" };
+        }
 
         std::wstring cmd{ agentId };
         if (lower == "copilot")

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
@@ -1081,6 +1081,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         {
             return L"npx -y @agentclientprotocol/codex-acp@1.1.0";
         }
+        if (lower == "opencode")
+        {
+            return L"opencode acp";
+        }
 
         std::wstring cmd{ acpAgent };
         if (lower == "copilot")

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -1991,7 +1991,7 @@ void CascadiaSettings::LogSettingChanges(bool isJsonLoad) const
         // custom agent IDs may contain user file paths or commands,
         // so we bucket those as "custom".
         static const auto sanitizeProviderId = [](const winrt::hstring& id) -> std::string {
-            if (id == L"copilot" || id == L"claude" || id == L"codex" || id == L"gemini")
+            if (id == L"copilot" || id == L"claude" || id == L"codex" || id == L"gemini" || id == L"opencode")
             {
                 return winrt::to_string(id);
             }

--- a/src/cascadia/inc/AgentRegistry.h
+++ b/src/cascadia/inc/AgentRegistry.h
@@ -33,26 +33,28 @@ namespace Microsoft::Terminal::Settings::Model::AgentRegistry
     };
 
     // ACP-capable agents. Either the CLI itself speaks the Agent Control
-    // Protocol (copilot, gemini), or an npm-distributed adapter does
+    // Protocol (copilot, gemini, opencode), or an npm-distributed adapter does
     // (claude via @agentclientprotocol/claude-agent-acp, codex via
     // @agentclientprotocol/codex-acp).
     // Only these agents can be hosted in an agent pane.
-    inline constexpr std::array<BuiltinAgent, 4> BuiltinAcpAgents{ {
+    inline constexpr std::array<BuiltinAgent, 5> BuiltinAcpAgents{ {
         { L"copilot", L"GitHub Copilot" },
         { L"claude", L"Claude" },
         { L"codex", L"Codex" },
         { L"gemini", L"Gemini" },
+        { L"opencode", L"OpenCode" },
     } };
 
     // Delegate agents. Invoked for `?<prompt>` background delegation and
     // similar flows. The set is broader than ACP because delegation doesn't
     // require an ACP-speaking agent — any CLI agent that accepts a prompt
     // as input works.
-    inline constexpr std::array<BuiltinAgent, 4> BuiltinDelegateAgents{ {
+    inline constexpr std::array<BuiltinAgent, 5> BuiltinDelegateAgents{ {
         { L"copilot", L"GitHub Copilot" },
         { L"claude", L"Claude" },
         { L"codex", L"Codex" },
         { L"gemini", L"Gemini" },
+        { L"opencode", L"OpenCode" },
     } };
 
     // Return only agents whose IDs are permitted by GPO policy.

--- a/tools/wta/src/agent_check.rs
+++ b/tools/wta/src/agent_check.rs
@@ -81,7 +81,7 @@ pub fn build_login_cmd(agent_id: &str, enterprise_host: Option<&str>) -> String 
     // Agent-specific login subcommand
     let subcommand = match agent_id {
         "codex" => "auth",
-        "gemini" => "auth login",
+        "gemini" | "opencode" => "auth login",
         _ => "login",
     };
 
@@ -540,5 +540,15 @@ mod tests {
         let codex = build_login_cmd("codex", Some("mycompany.ghe.com"));
         assert!(codex.contains("auth"), "codex auth: {codex}");
         assert!(!codex.contains("--host"), "codex must ignore host: {codex}");
+
+        let opencode = build_login_cmd("opencode", Some("mycompany.ghe.com"));
+        assert!(
+            opencode.contains("auth login"),
+            "OpenCode login: {opencode}"
+        );
+        assert!(
+            !opencode.contains("--host"),
+            "OpenCode must ignore host: {opencode}"
+        );
     }
 }

--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -13,6 +13,8 @@ pub enum PromptFlag {
     Flag(&'static str),
     /// Prompt is a bare positional argument, e.g. `codex "prompt"`.
     Positional,
+    /// Subcommand immediately after the executable, e.g. `opencode run "prompt"`.
+    Subcommand(&'static str),
 }
 
 /// How the agent handles authentication in ACP mode.
@@ -171,7 +173,7 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         // mode accepts `--model` on `opencode run`.
         acp_model_flags: &[],
         acp_auth_flow: AcpAuthFlow::External,
-        delegate_prompt_flag: PromptFlag::Flag("run"),
+        delegate_prompt_flag: PromptFlag::Subcommand("run"),
         model_flags: &["--model", "-m"],
         install_hint: "npm install -g opencode-ai",
         install_url: "https://opencode.ai/docs/",
@@ -591,7 +593,10 @@ mod tests {
             Some("opencode".to_string())
         );
         let profile = lookup_profile_by_id("opencode");
-        assert_eq!(profile.delegate_prompt_flag, PromptFlag::Flag("run"));
+        assert_eq!(
+            profile.delegate_prompt_flag,
+            PromptFlag::Subcommand("run")
+        );
         assert_eq!(profile.model_flags, &["--model", "-m"]);
         assert_eq!(profile.resume_flag, "--session");
     }

--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -48,6 +48,9 @@ pub struct AgentProfile {
     /// `"npx -y @agentclientprotocol/claude-agent-acp"` for an adapter package).
     /// When empty, `build_acp_command` falls back to `id + acp_flags`.
     pub acp_launch_command: &'static str,
+    /// Model flags accepted by the ACP server command. This may differ from
+    /// `model_flags` when ACP model selection is protocol-only.
+    pub acp_model_flags: &'static [&'static str],
     /// Authentication flow required for ACP sessions.
     pub acp_auth_flow: AcpAuthFlow,
 
@@ -86,6 +89,7 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         exe_search_order: &[".exe", ".cmd"],
         acp_flags: &["--acp", "--stdio"],
         acp_launch_command: "",
+        acp_model_flags: &["--model", "-m"],
         acp_auth_flow: AcpAuthFlow::External,
         delegate_prompt_flag: PromptFlag::Flag("-i"),
         model_flags: &["--model", "-m"],
@@ -107,6 +111,7 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         // delegate mode does. (Renamed from the deprecated
         // `@zed-industries/claude-code-acp`; see issue #257.)
         acp_launch_command: "npx -y @agentclientprotocol/claude-agent-acp",
+        acp_model_flags: &[],
         acp_auth_flow: AcpAuthFlow::External,
         delegate_prompt_flag: PromptFlag::Positional,
         model_flags: &[],
@@ -125,6 +130,7 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         // Codex CLI itself doesn't speak ACP. Use the ACP-project-maintained
         // adapter, pinned so a future npm release cannot silently break startup.
         acp_launch_command: "npx -y @agentclientprotocol/codex-acp@1.1.0",
+        acp_model_flags: &[],
         acp_auth_flow: AcpAuthFlow::External,
         delegate_prompt_flag: PromptFlag::Positional,
         model_flags: &[],
@@ -144,6 +150,7 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         exe_search_order: &[".exe", ".cmd"],
         acp_flags: &["--experimental-acp"],
         acp_launch_command: "",
+        acp_model_flags: &["--model", "-m"],
         acp_auth_flow: AcpAuthFlow::InProtocol,
         delegate_prompt_flag: PromptFlag::Positional,
         model_flags: &["--model", "-m"],
@@ -154,6 +161,25 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         resume_flag: "--resume",
         new_session_id_flag: Some("--session-id"),
     },
+    AgentProfile {
+        id: "opencode",
+        display_name: "OpenCode",
+        exe_search_order: &[".exe", ".cmd"],
+        acp_flags: &["acp"],
+        acp_launch_command: "",
+        // `opencode acp` accepts model changes through ACP, while delegate
+        // mode accepts `--model` on `opencode run`.
+        acp_model_flags: &[],
+        acp_auth_flow: AcpAuthFlow::External,
+        delegate_prompt_flag: PromptFlag::Flag("run"),
+        model_flags: &["--model", "-m"],
+        install_hint: "npm install -g opencode-ai",
+        install_url: "https://opencode.ai/docs/",
+        auth_check_command: "",
+        auth_hint: "Run: opencode auth login",
+        resume_flag: "--session",
+        new_session_id_flag: None,
+    },
 ];
 
 pub const DEFAULT_PROFILE: AgentProfile = AgentProfile {
@@ -162,6 +188,7 @@ pub const DEFAULT_PROFILE: AgentProfile = AgentProfile {
     exe_search_order: &[".exe", ".cmd"],
     acp_flags: &[],
     acp_launch_command: "",
+    acp_model_flags: &[],
     acp_auth_flow: AcpAuthFlow::None,
     delegate_prompt_flag: PromptFlag::Flag("-i"),
     model_flags: &["--model", "-m"],
@@ -232,7 +259,8 @@ fn adapter_profile_from_tokens(tokens: &[String]) -> Option<&'static AgentProfil
 }
 
 /// Returns `true` iff `id` is a real, selectable agent id present in
-/// [`KNOWN_AGENTS`] (`"copilot"`, `"claude"`, `"codex"`, `"gemini"`).
+/// [`KNOWN_AGENTS`] (`"copilot"`, `"claude"`, `"codex"`, `"gemini"`,
+/// `"opencode"`).
 ///
 /// Prefer this over `lookup_profile_by_id(id).id != DEFAULT_PROFILE.id` when
 /// distinguishing a known agent from the unknown/custom fallback: this checks
@@ -246,7 +274,7 @@ pub fn is_known_id(id: &str) -> bool {
 
 /// Resolve a full agent command line (e.g. the value of `--agent`) into the
 /// canonical agent id known to [`KNOWN_AGENTS`] — `"copilot"`, `"claude"`,
-/// `"codex"`, `"gemini"` — or `"unknown"` if nothing matches.
+/// `"codex"`, `"gemini"`, `"opencode"` — or `"unknown"` if nothing matches.
 ///
 /// This is the right thing to use whenever we need to *identify* the agent
 /// from a launch command rather than execute it. It handles three input
@@ -306,7 +334,7 @@ pub fn build_acp_command(agent_id: &str, model: Option<&str>) -> String {
         parts.push(flag.to_string());
     }
     if let Some(model) = model {
-        if let Some(flag) = profile.model_flags.first() {
+        if let Some(flag) = profile.acp_model_flags.first() {
             parts.push(flag.to_string());
             parts.push(model.to_string());
         }
@@ -481,6 +509,7 @@ mod tests {
     fn resolve_agent_id_from_cmd_recognises_bare_names_with_flags() {
         assert_eq!(resolve_agent_id_from_cmd("copilot --acp --stdio"), "copilot");
         assert_eq!(resolve_agent_id_from_cmd("gemini --experimental-acp"), "gemini");
+        assert_eq!(resolve_agent_id_from_cmd("opencode acp"), "opencode");
         assert_eq!(resolve_agent_id_from_cmd("claude --resume foo"), "claude");
     }
 
@@ -547,6 +576,24 @@ mod tests {
             build_acp_command("codex", None),
             "npx -y @agentclientprotocol/codex-acp@1.1.0",
         );
+    }
+
+    #[test]
+    fn opencode_builds_native_acp_and_delegate_commands() {
+        assert_eq!(build_acp_command("opencode", None), "opencode acp");
+        assert_eq!(
+            build_acp_command("opencode", Some("anthropic/claude-sonnet-4-5")),
+            "opencode acp",
+            "OpenCode model selection is sent through ACP"
+        );
+        assert_eq!(
+            strip_acp_flags_for_delegate("opencode acp"),
+            Some("opencode".to_string())
+        );
+        let profile = lookup_profile_by_id("opencode");
+        assert_eq!(profile.delegate_prompt_flag, PromptFlag::Flag("run"));
+        assert_eq!(profile.model_flags, &["--model", "-m"]);
+        assert_eq!(profile.resume_flag, "--session");
     }
 
     #[test]

--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -13,8 +13,6 @@ pub enum PromptFlag {
     Flag(&'static str),
     /// Prompt is a bare positional argument, e.g. `codex "prompt"`.
     Positional,
-    /// Subcommand immediately after the executable, e.g. `opencode run "prompt"`.
-    Subcommand(&'static str),
 }
 
 /// How the agent handles authentication in ACP mode.
@@ -169,11 +167,11 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         exe_search_order: &[".exe", ".cmd"],
         acp_flags: &["acp"],
         acp_launch_command: "",
-        // `opencode acp` accepts model changes through ACP, while delegate
-        // mode accepts `--model` on `opencode run`.
+        // `opencode acp` accepts model changes through ACP, while the
+        // interactive TUI accepts `--model` and an initial `--prompt`.
         acp_model_flags: &[],
         acp_auth_flow: AcpAuthFlow::External,
-        delegate_prompt_flag: PromptFlag::Subcommand("run"),
+        delegate_prompt_flag: PromptFlag::Flag("--prompt"),
         model_flags: &["--model", "-m"],
         install_hint: "npm install -g opencode-ai",
         install_url: "https://opencode.ai/docs/",
@@ -593,10 +591,7 @@ mod tests {
             Some("opencode".to_string())
         );
         let profile = lookup_profile_by_id("opencode");
-        assert_eq!(
-            profile.delegate_prompt_flag,
-            PromptFlag::Subcommand("run")
-        );
+        assert_eq!(profile.delegate_prompt_flag, PromptFlag::Flag("--prompt"));
         assert_eq!(profile.model_flags, &["--model", "-m"]);
         assert_eq!(profile.resume_flag, "--session");
     }

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -719,15 +719,26 @@ fn build_delegate_launch_commandline(
         commandline,
     ));
 
+    // Subcommands must immediately follow the executable, before model/session flags.
+    let with_subcommand = match profile.delegate_prompt_flag {
+        PromptFlag::Subcommand(subcommand) => {
+            let mut tokens = split_windows_commandline(&resolved);
+            tokens.insert(1, subcommand.to_string());
+            let args = tokens.iter().map(String::as_str).collect::<Vec<_>>();
+            join_windows_commandline(&args)
+        }
+        _ => resolved.clone(),
+    };
+
     // If a model is configured, append --model <value> using the agent's model flags.
     let with_model = if let Some(ref model) = runtime.model {
         if let Some(flag) = profile.model_flags.first() {
-            format!("{} {} {}", resolved, flag, model)
+            format!("{} {} {}", with_subcommand, flag, model)
         } else {
-            resolved.clone()
+            with_subcommand
         }
     } else {
-        resolved.clone()
+        with_subcommand
     };
 
     // Pin a caller-chosen session id when the agent supports it, so the launched
@@ -860,6 +871,10 @@ fn build_pwsh_base64_launch(
         }
         call.push_str(&ps_single_quote(tok));
     }
+    if let PromptFlag::Subcommand(subcommand) = profile.delegate_prompt_flag {
+        call.push(' ');
+        call.push_str(&ps_single_quote(subcommand));
+    }
     if let (Some(model), Some(flag)) = (model, profile.model_flags.first()) {
         call.push(' ');
         call.push_str(&ps_single_quote(flag));
@@ -924,6 +939,10 @@ fn build_windows_powershell_base64_launch(
             call.push(' ');
         }
         call.push_str(&ps_single_quote(token));
+    }
+    if let PromptFlag::Subcommand(subcommand) = profile.delegate_prompt_flag {
+        call.push(' ');
+        call.push_str(&ps_single_quote(subcommand));
     }
     if let (Some(model), Some(flag)) = (model, profile.model_flags.first()) {
         call.push(' ');
@@ -1222,6 +1241,9 @@ pub(crate) fn build_wsl_delegate_commandline(
     if parts.is_empty() {
         bail!("delegate agent runtime commandline is empty");
     }
+    if let PromptFlag::Subcommand(subcommand) = profile.delegate_prompt_flag {
+        parts.push(sh_quote(subcommand));
+    }
     if let Some(ref model) = runtime.model {
         if let Some(flag) = profile.model_flags.first() {
             parts.push(sh_quote(flag));
@@ -1253,7 +1275,7 @@ pub(crate) fn build_wsl_delegate_commandline(
             let b64 = crate::osc52::base64_encode(input.as_bytes());
             let prompt_arg = match profile.delegate_prompt_flag {
                 PromptFlag::Flag(flag) => format!("{} \"$prompt\"", sh_quote(flag)),
-                PromptFlag::Positional => "\"$prompt\"".to_string(),
+                PromptFlag::Positional | PromptFlag::Subcommand(_) => "\"$prompt\"".to_string(),
             };
             format!("prompt=$(base64 -d <<< '{b64}'); exec {agent_invocation} {prompt_arg}")
         }
@@ -2644,18 +2666,51 @@ mod tests {
 
     #[test]
     fn opencode_delegate_uses_run_subcommand() {
-        let runtime = base64_runtime("opencode");
+        let mut runtime = base64_runtime("opencode");
+        runtime.model = Some("anthropic/claude-sonnet-4-5".to_string());
         let cmd = build_wsl_delegate_commandline(&runtime, Some("hi\nthere"), None).expect("cmd");
         assert!(
-            cmd.contains("'opencode' 'run' \"\\$prompt\""),
+            cmd.contains(
+                "'opencode' 'run' '--model' 'anthropic/claude-sonnet-4-5' \"\\$prompt\""
+            ),
             "OpenCode delegate form: {cmd}"
         );
 
         let profile = crate::agent_registry::lookup_profile_by_id("opencode");
-        let cmd = build_pwsh_base64_launch("opencode", profile, None, None, "hi\nthere");
+        let cmd = build_pwsh_base64_launch(
+            "opencode",
+            profile,
+            Some("anthropic/claude-sonnet-4-5"),
+            None,
+            "hi\nthere",
+        );
         assert!(
-            cmd.contains("& 'opencode' 'run' $p; exit $LASTEXITCODE"),
+            cmd.contains(
+                "& 'opencode' 'run' '--model' 'anthropic/claude-sonnet-4-5' $p; exit $LASTEXITCODE"
+            ),
             "OpenCode PowerShell delegate form: {cmd}"
+        );
+
+        let cmd = build_windows_powershell_base64_launch(
+            "opencode",
+            profile,
+            Some("anthropic/claude-sonnet-4-5"),
+            None,
+            "hi\nthere",
+        );
+        assert!(
+            cmd.contains(
+                "& 'opencode' 'run' '--model' 'anthropic/claude-sonnet-4-5' $p;exit $LASTEXITCODE"
+            ),
+            "OpenCode Windows PowerShell delegate form: {cmd}"
+        );
+
+        runtime.commandline = r"C:\tools\opencode.exe".to_string();
+        let cmd = build_delegate_launch_commandline(&runtime, Some("hi there"), None)
+            .expect("OpenCode direct command");
+        assert_eq!(
+            cmd,
+            r#"C:\tools\opencode.exe run --model anthropic/claude-sonnet-4-5 "hi there""#
         );
     }
 

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -701,6 +701,9 @@ fn build_delegate_launch_commandline(
     if commandline.is_empty() {
         bail!("delegate agent runtime commandline is empty");
     }
+    if split_windows_commandline(commandline).is_empty() {
+        bail!("delegate agent runtime commandline has no executable");
+    }
     // Resolve bare names (e.g. "claude" → "claude.exe") at launch time so we
     // always see the current PATH, not a stale snapshot from process startup.
     let resolved = resolve_commandline_executable(commandline);
@@ -2711,6 +2714,19 @@ mod tests {
         assert_eq!(
             cmd,
             r#"C:\tools\opencode.exe run --model anthropic/claude-sonnet-4-5 "hi there""#
+        );
+    }
+
+    #[test]
+    fn delegate_launch_rejects_commandline_without_executable() {
+        let mut runtime = base64_runtime("opencode");
+        runtime.commandline = "\"\"".to_string();
+
+        let error = build_delegate_launch_commandline(&runtime, Some("hi"), None)
+            .expect_err("quote-only commandline should be rejected");
+        assert!(
+            error.to_string().contains("has no executable"),
+            "unexpected error: {error:#}"
         );
     }
 

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -726,7 +726,7 @@ fn build_delegate_launch_commandline(
     let with_subcommand = match profile.delegate_prompt_flag {
         PromptFlag::Subcommand(subcommand) => {
             let mut tokens = split_windows_commandline(&resolved);
-            tokens.insert(1, subcommand.to_string());
+            ensure_delegate_subcommand(&mut tokens, subcommand);
             let args = tokens.iter().map(String::as_str).collect::<Vec<_>>();
             join_windows_commandline(&args)
         }
@@ -843,6 +843,12 @@ fn powershell_invocation_tokens(
     tokens
 }
 
+fn ensure_delegate_subcommand(tokens: &mut Vec<String>, subcommand: &str) {
+    if !tokens.is_empty() && tokens.get(1).map(String::as_str) != Some(subcommand) {
+        tokens.insert(1, subcommand.to_string());
+    }
+}
+
 /// Build a delegate launch commandline that runs a `.cmd`/`.bat` shim agent from
 /// PowerShell 7 with the prompt delivered as inline base64 (issue #403).
 ///
@@ -865,18 +871,15 @@ fn build_pwsh_base64_launch(
     // `& <agent tokens> [flags] $p` — every literal token single-quoted for
     // PowerShell; `$p` (the decoded prompt) stays a bare variable reference.
     let mut call = String::from("& ");
-    for (i, tok) in powershell_invocation_tokens(commandline, profile)
-        .iter()
-        .enumerate()
-    {
+    let mut invocation_tokens = powershell_invocation_tokens(commandline, profile);
+    if let PromptFlag::Subcommand(subcommand) = profile.delegate_prompt_flag {
+        ensure_delegate_subcommand(&mut invocation_tokens, subcommand);
+    }
+    for (i, tok) in invocation_tokens.iter().enumerate() {
         if i > 0 {
             call.push(' ');
         }
         call.push_str(&ps_single_quote(tok));
-    }
-    if let PromptFlag::Subcommand(subcommand) = profile.delegate_prompt_flag {
-        call.push(' ');
-        call.push_str(&ps_single_quote(subcommand));
     }
     if let (Some(model), Some(flag)) = (model, profile.model_flags.first()) {
         call.push(' ');
@@ -934,18 +937,15 @@ fn build_windows_powershell_base64_launch(
 ) -> String {
     let b64 = crate::osc52::base64_encode(input.as_bytes());
     let mut call = String::from("& ");
-    for (i, token) in powershell_invocation_tokens(commandline, profile)
-        .iter()
-        .enumerate()
-    {
+    let mut invocation_tokens = powershell_invocation_tokens(commandline, profile);
+    if let PromptFlag::Subcommand(subcommand) = profile.delegate_prompt_flag {
+        ensure_delegate_subcommand(&mut invocation_tokens, subcommand);
+    }
+    for (i, token) in invocation_tokens.iter().enumerate() {
         if i > 0 {
             call.push(' ');
         }
         call.push_str(&ps_single_quote(token));
-    }
-    if let PromptFlag::Subcommand(subcommand) = profile.delegate_prompt_flag {
-        call.push(' ');
-        call.push_str(&ps_single_quote(subcommand));
     }
     if let (Some(model), Some(flag)) = (model, profile.model_flags.first()) {
         call.push(' ');
@@ -1237,16 +1237,17 @@ pub(crate) fn build_wsl_delegate_commandline(
 
     // Agent invocation: the CLI tokens plus model / session-id flags, each
     // single-quoted for the inner bash.
-    let mut parts: Vec<String> = split_windows_commandline(agent_cmd)
-        .into_iter()
-        .map(|t| sh_quote(&t))
-        .collect();
-    if parts.is_empty() {
+    let mut invocation_tokens = split_windows_commandline(agent_cmd);
+    if invocation_tokens.is_empty() {
         bail!("delegate agent runtime commandline is empty");
     }
     if let PromptFlag::Subcommand(subcommand) = profile.delegate_prompt_flag {
-        parts.push(sh_quote(subcommand));
+        ensure_delegate_subcommand(&mut invocation_tokens, subcommand);
     }
+    let mut parts: Vec<String> = invocation_tokens
+        .into_iter()
+        .map(|token| sh_quote(&token))
+        .collect();
     if let Some(ref model) = runtime.model {
         if let Some(flag) = profile.model_flags.first() {
             parts.push(sh_quote(flag));
@@ -2669,7 +2670,7 @@ mod tests {
 
     #[test]
     fn opencode_delegate_uses_run_subcommand() {
-        let mut runtime = base64_runtime("opencode");
+        let mut runtime = base64_runtime("opencode run");
         runtime.model = Some("anthropic/claude-sonnet-4-5".to_string());
         let cmd = build_wsl_delegate_commandline(&runtime, Some("hi\nthere"), None).expect("cmd");
         assert!(
@@ -2681,7 +2682,7 @@ mod tests {
 
         let profile = crate::agent_registry::lookup_profile_by_id("opencode");
         let cmd = build_pwsh_base64_launch(
-            "opencode",
+            "opencode run",
             profile,
             Some("anthropic/claude-sonnet-4-5"),
             None,
@@ -2695,7 +2696,7 @@ mod tests {
         );
 
         let cmd = build_windows_powershell_base64_launch(
-            "opencode",
+            "opencode run",
             profile,
             Some("anthropic/claude-sonnet-4-5"),
             None,
@@ -2708,7 +2709,7 @@ mod tests {
             "OpenCode Windows PowerShell delegate form: {cmd}"
         );
 
-        runtime.commandline = r"C:\tools\opencode.exe".to_string();
+        runtime.commandline = r"C:\tools\opencode.exe run".to_string();
         let cmd = build_delegate_launch_commandline(&runtime, Some("hi there"), None)
             .expect("OpenCode direct command");
         assert_eq!(

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -722,26 +722,15 @@ fn build_delegate_launch_commandline(
         commandline,
     ));
 
-    // Subcommands must immediately follow the executable, before model/session flags.
-    let with_subcommand = match profile.delegate_prompt_flag {
-        PromptFlag::Subcommand(subcommand) => {
-            let mut tokens = split_windows_commandline(&resolved);
-            ensure_delegate_subcommand(&mut tokens, subcommand);
-            let args = tokens.iter().map(String::as_str).collect::<Vec<_>>();
-            join_windows_commandline(&args)
-        }
-        _ => resolved.clone(),
-    };
-
     // If a model is configured, append --model <value> using the agent's model flags.
     let with_model = if let Some(ref model) = runtime.model {
         if let Some(flag) = profile.model_flags.first() {
-            format!("{} {} {}", with_subcommand, flag, model)
+            format!("{} {} {}", resolved, flag, model)
         } else {
-            with_subcommand
+            resolved.clone()
         }
     } else {
-        with_subcommand
+        resolved.clone()
     };
 
     // Pin a caller-chosen session id when the agent supports it, so the launched
@@ -843,12 +832,6 @@ fn powershell_invocation_tokens(
     tokens
 }
 
-fn ensure_delegate_subcommand(tokens: &mut Vec<String>, subcommand: &str) {
-    if !tokens.is_empty() && tokens.get(1).map(String::as_str) != Some(subcommand) {
-        tokens.insert(1, subcommand.to_string());
-    }
-}
-
 /// Build a delegate launch commandline that runs a `.cmd`/`.bat` shim agent from
 /// PowerShell 7 with the prompt delivered as inline base64 (issue #403).
 ///
@@ -871,11 +854,10 @@ fn build_pwsh_base64_launch(
     // `& <agent tokens> [flags] $p` — every literal token single-quoted for
     // PowerShell; `$p` (the decoded prompt) stays a bare variable reference.
     let mut call = String::from("& ");
-    let mut invocation_tokens = powershell_invocation_tokens(commandline, profile);
-    if let PromptFlag::Subcommand(subcommand) = profile.delegate_prompt_flag {
-        ensure_delegate_subcommand(&mut invocation_tokens, subcommand);
-    }
-    for (i, tok) in invocation_tokens.iter().enumerate() {
+    for (i, tok) in powershell_invocation_tokens(commandline, profile)
+        .iter()
+        .enumerate()
+    {
         if i > 0 {
             call.push(' ');
         }
@@ -937,11 +919,10 @@ fn build_windows_powershell_base64_launch(
 ) -> String {
     let b64 = crate::osc52::base64_encode(input.as_bytes());
     let mut call = String::from("& ");
-    let mut invocation_tokens = powershell_invocation_tokens(commandline, profile);
-    if let PromptFlag::Subcommand(subcommand) = profile.delegate_prompt_flag {
-        ensure_delegate_subcommand(&mut invocation_tokens, subcommand);
-    }
-    for (i, token) in invocation_tokens.iter().enumerate() {
+    for (i, token) in powershell_invocation_tokens(commandline, profile)
+        .iter()
+        .enumerate()
+    {
         if i > 0 {
             call.push(' ');
         }
@@ -1237,17 +1218,13 @@ pub(crate) fn build_wsl_delegate_commandline(
 
     // Agent invocation: the CLI tokens plus model / session-id flags, each
     // single-quoted for the inner bash.
-    let mut invocation_tokens = split_windows_commandline(agent_cmd);
-    if invocation_tokens.is_empty() {
-        bail!("delegate agent runtime commandline is empty");
-    }
-    if let PromptFlag::Subcommand(subcommand) = profile.delegate_prompt_flag {
-        ensure_delegate_subcommand(&mut invocation_tokens, subcommand);
-    }
-    let mut parts: Vec<String> = invocation_tokens
+    let mut parts: Vec<String> = split_windows_commandline(agent_cmd)
         .into_iter()
         .map(|token| sh_quote(&token))
         .collect();
+    if parts.is_empty() {
+        bail!("delegate agent runtime commandline is empty");
+    }
     if let Some(ref model) = runtime.model {
         if let Some(flag) = profile.model_flags.first() {
             parts.push(sh_quote(flag));
@@ -1279,7 +1256,7 @@ pub(crate) fn build_wsl_delegate_commandline(
             let b64 = crate::osc52::base64_encode(input.as_bytes());
             let prompt_arg = match profile.delegate_prompt_flag {
                 PromptFlag::Flag(flag) => format!("{} \"$prompt\"", sh_quote(flag)),
-                PromptFlag::Positional | PromptFlag::Subcommand(_) => "\"$prompt\"".to_string(),
+                PromptFlag::Positional => "\"$prompt\"".to_string(),
             };
             format!("prompt=$(base64 -d <<< '{b64}'); exec {agent_invocation} {prompt_arg}")
         }
@@ -2669,20 +2646,20 @@ mod tests {
     }
 
     #[test]
-    fn opencode_delegate_uses_run_subcommand() {
-        let mut runtime = base64_runtime("opencode run");
+    fn opencode_delegate_uses_interactive_prompt_flag() {
+        let mut runtime = base64_runtime("opencode");
         runtime.model = Some("anthropic/claude-sonnet-4-5".to_string());
         let cmd = build_wsl_delegate_commandline(&runtime, Some("hi\nthere"), None).expect("cmd");
         assert!(
             cmd.contains(
-                "'opencode' 'run' '--model' 'anthropic/claude-sonnet-4-5' \"\\$prompt\""
+                "'opencode' '--model' 'anthropic/claude-sonnet-4-5' '--prompt' \"\\$prompt\""
             ),
             "OpenCode delegate form: {cmd}"
         );
 
         let profile = crate::agent_registry::lookup_profile_by_id("opencode");
         let cmd = build_pwsh_base64_launch(
-            "opencode run",
+            "opencode",
             profile,
             Some("anthropic/claude-sonnet-4-5"),
             None,
@@ -2690,13 +2667,13 @@ mod tests {
         );
         assert!(
             cmd.contains(
-                "& 'opencode' 'run' '--model' 'anthropic/claude-sonnet-4-5' $p; exit $LASTEXITCODE"
+                "& 'opencode' '--model' 'anthropic/claude-sonnet-4-5' '--prompt' $p; exit $LASTEXITCODE"
             ),
             "OpenCode PowerShell delegate form: {cmd}"
         );
 
         let cmd = build_windows_powershell_base64_launch(
-            "opencode run",
+            "opencode",
             profile,
             Some("anthropic/claude-sonnet-4-5"),
             None,
@@ -2704,17 +2681,17 @@ mod tests {
         );
         assert!(
             cmd.contains(
-                "& 'opencode' 'run' '--model' 'anthropic/claude-sonnet-4-5' $p;exit $LASTEXITCODE"
+                "& 'opencode' '--model' 'anthropic/claude-sonnet-4-5' '--prompt' $p;exit $LASTEXITCODE"
             ),
             "OpenCode Windows PowerShell delegate form: {cmd}"
         );
 
-        runtime.commandline = r"C:\tools\opencode.exe run".to_string();
+        runtime.commandline = r"C:\tools\opencode.exe".to_string();
         let cmd = build_delegate_launch_commandline(&runtime, Some("hi there"), None)
             .expect("OpenCode direct command");
         assert_eq!(
             cmd,
-            r#"C:\tools\opencode.exe run --model anthropic/claude-sonnet-4-5 "hi there""#
+            r#"C:\tools\opencode.exe --model anthropic/claude-sonnet-4-5 --prompt "hi there""#
         );
     }
 

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -2643,6 +2643,23 @@ mod tests {
     }
 
     #[test]
+    fn opencode_delegate_uses_run_subcommand() {
+        let runtime = base64_runtime("opencode");
+        let cmd = build_wsl_delegate_commandline(&runtime, Some("hi\nthere"), None).expect("cmd");
+        assert!(
+            cmd.contains("'opencode' 'run' \"\\$prompt\""),
+            "OpenCode delegate form: {cmd}"
+        );
+
+        let profile = crate::agent_registry::lookup_profile_by_id("opencode");
+        let cmd = build_pwsh_base64_launch("opencode", profile, None, None, "hi\nthere");
+        assert!(
+            cmd.contains("& 'opencode' 'run' $p; exit $LASTEXITCODE"),
+            "OpenCode PowerShell delegate form: {cmd}"
+        );
+    }
+
+    #[test]
     fn wsl_delegate_interactive_has_no_base64() {
         let runtime = base64_runtime("claude");
         let cmd = build_wsl_delegate_commandline(&runtime, None, None).expect("cmd");

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -144,7 +144,7 @@ struct Cli {
     agent: String,
 
     /// Canonical agent identifier (`copilot` / `claude` / `codex` / `gemini`
-    /// / `custom:<name>`). When the host (Windows Terminal) launches wta it
+    /// / `opencode` / `custom:<name>`). When the host (Windows Terminal) launches wta it
     /// already knows which entry the user picked in settings, so it passes
     /// the original `acpAgent` value through here. wta uses this id as the
     /// authoritative identity for `current_agent_id` — driving the session-
@@ -185,7 +185,7 @@ struct Cli {
     /// Model override for the ACP agent. Sent via ACP setSessionModel after
     /// handshake. Used by adapter-style launches (claude, codex via npx)
     /// where the model can't be passed on the command line; native ACP
-    /// agents (copilot, gemini) use their own --model flag in `agent`.
+    /// agents may use their own --model flag in `agent`.
     #[arg(long)]
     acp_model: Option<String>,
 


### PR DESCRIPTION
## Summary
- add OpenCode as a built-in ACP and delegate agent
- launch agent panes with `opencode acp` and interactive delegation tabs with `opencode --prompt <prompt>`
- support protocol-based model selection, setup guidance, policy filtering, and telemetry
- add the official OpenCode mark to the agent pane header

## Validation
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml` (1115 passed)
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- `cmd.exe /c "tools\razzle.cmd && bcz no_clean"`
- TerminalApp and CascadiaPackage `bx` builds
- local MSIX deployment and OpenCode 1.17.18 launch
- live `?<prompt>` delegation verified to launch the interactive OpenCode TUI and keep the tab open
- session
- agent pane, auto fix works as expected

## Limitations
- OpenCode shell-session hooks and history discovery are not included


Fixes #460