### PR TITLE
Extract autofix ACP transform proxy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,15 @@ or `Ctrl+C×2` in the TUI. See spec §8.
 
 Detects command failures in other panes and auto-suggests fixes via the agent.
 
-**Pipeline**: Shell emits `OSC 133;D;<exit_code>` → `TerminalPage` raises `ProtocolVtSequenceReceived` → COM server forwards to clients → WTA (via `wtcli listen --json`) classifies → `maybe_trigger_autofix()`.
+**Pipeline**: Shell emits `OSC 133;D;<exit_code>` → `TerminalPage` raises
+`ProtocolVtSequenceReceived` → COM server forwards to clients → the per-tab WTA
+helper classifies and builds the prompt → `_intellterm.wta/autofix` crosses the
+helper/master ACP hop → the pooled slot's `AutofixProxy` transforms it to ordinary
+`session/prompt` → the tracing proxy and agent CLI.
+
+WT/tab/UI policy remains helper-side: enablement, connected/busy and generation
+gates, source-pane context, template construction, and bottom-bar state do not
+belong to a per-agent 1:1 proxy.
 
 **Requirements**: PowerShell shell integration (OSC 133 marks), a helper
 whose ACP session has reached `Connected`, `wtcli` on PATH. The pane does

--- a/doc/specs/acp-1.0-conductor-migration.md
+++ b/doc/specs/acp-1.0-conductor-migration.md
@@ -694,7 +694,7 @@ it is TUI/state/connection/tab plumbing that stays in the helper.
 | Auth / connection / lifecycle | `auth\|login\|preflight\|setup` 529; ConnectionState; AgentConnected/Error/Busy/SoftStop | ❌ conductor/helper plumbing | — | — |
 | TUI view / input / state | render, chip, scroll, help/debug overlay, Key/Resize/Focus, RevealTick (heavy render lives in `ui/`) | ❌ stays in helper UI | — | — |
 | Multi-tab routing | `tab_session\|tab_changed\|renamed` 161; owner_tab_id/window_id; session_to_tab | ❌ helper's N-tab fan-out | — | — |
-| **Autofix** | `classify_*` (10), `classify_wt_event`, `submit_autofix_prompt`, `fix_target_pane`, `AutofixTargetResolved`, WtEvent (303) | ✅ proxy | off-wire `WtEvent` → inject `session/prompt`: classify an actionable failure (OSC 133;D exit / connection state) and inject a fix prompt | `app/autofix.rs` |
+| **Autofix** | `classify_*` (10), `classify_wt_event`, `submit_autofix_prompt`, `fix_target_pane`, `AutofixTargetResolved`, WtEvent (303) | ✅ split helper + proxy | helper classifies the off-wire `WtEvent`, resolves tab/pane context, and sends `_intellterm.wta/autofix`; proxy transforms that request into ordinary `session/prompt` | `app/autofix.rs` + `protocol/acp/autofix.rs` |
 | **Context / prompt injection** | `prompt\|persona\|planner` 355; PromptTemplateLoaded; `turn_submit_prompt`; `turn_close_finalize_planner` | ✅ proxy | `session/new` (build) + `session/prompt` (rewrite): prepend persona / template / context | `protocol/acp/prompt.rs` |
 | **Delegate / recommendation** | `delegate\|recommend\|coordinator` 252; recommendation_tx; ChoiceExecution; DispatchedCommand; `turn_surface_recommendation` | ✅ proxy | `session/update` (response): parse a `RecommendationSet`, surface Run/Insert cards | `coordinator.rs` |
 | Model pinning / override | `model` 282; `apply_global_acp_model`; `send_session_model`; SessionAttached re-apply; acp_model | 🟡 shim | `session/new` (request): rewrite the model field — folds into **context** | `apply_global_acp_model` |
@@ -712,9 +712,9 @@ cards / pickers / TUI stay in the helper. Feature-proxy extraction is **Phase
 
 #### Structure after Phase 4 (conductor + chained transform proxies)
 
-The conductor from Phase 2 is unchanged; the three `app.rs` transform cores
-(autofix / context / delegate) become standalone proxies chained between it and
-the agent via `_proxy/initialize` / `_proxy/successor` — and the session-proxy family
+The conductor from Phase 2 is unchanged; the ACP-transform portions of the three
+`app.rs` concerns (autofix / context / delegate) become standalone proxies chained
+between it and the agent via `_proxy/initialize` / `_proxy/successor` — and the session-proxy family
 + the model / permission shims chain in the same way. The full chain below carries
 the **same proxy set as the *Target* diagram** (this is just the LR chain view). Each
 proxy is reorderable/insertable by config rather than by editing `app.rs`. The helper
@@ -728,8 +728,8 @@ flowchart LR
         CB["SessionRouter<br/>N:M control plane"]
         C["ConductorImpl<br/>per-slot linear chain"]
     end
-    TRACE["wire tracing proxy<br/>no-op · method metadata only"]
-    AFX["autofix proxy<br/>WtEvent → inject session/prompt"]
+    AFX["autofix proxy<br/>_intellterm.wta/autofix → session/prompt"]
+    TRACE["wire tracing proxy<br/>successor method metadata only"]
     CTX["context/prompt proxy<br/>rewrite session/prompt"]
     REC["delegate/recommendation proxy<br/>parse RecommendationSet"]
     SLU["session: list-union proxy<br/>host + WSL history (session/list)"]
@@ -741,9 +741,9 @@ flowchart LR
 
     H -->|"ACP/pipe"| CB
     CB --> C
-    C -->|"_proxy/initialize"| TRACE
-    TRACE -.->|"_proxy/successor"| AFX
-    AFX -.->|"_proxy/successor"| CTX
+    C -->|"_proxy/initialize"| AFX
+    AFX -.->|"_proxy/successor"| TRACE
+    TRACE -.->|"_proxy/successor"| CTX
     CTX -.->|"_proxy/successor"| REC
     REC -.->|"_proxy/successor"| SLU
     SLU -.->|"_proxy/successor"| SLE
@@ -757,9 +757,31 @@ flowchart LR
 > Only the dashed `_proxy/*` chain is new vs Phase 1. The WTA conductor still owns
 > the N:M bridge and session lifecycle; proxies are optional pure 1:1 transforms in the
 > chain. `app.rs` keeps the cards/pickers + TUI/tab/connection plumbing; only each
-> proxy's decision/transform core moved out. Landing order within Phase 2: the three
+> proxy's ACP transform core moves out. Landing order within Phase 4: the three
 > `app.rs` cores (autofix / context / delegate) first, then the `session:` family
 > (from the session subsystem), with model / permission as optional fold-in shims.
+
+#### Autofix first extraction: split control-plane and transform responsibilities
+
+The per-agent proxy chain cannot consume WT events directly. OSC/COM events arrive
+at a per-tab helper, while a pooled proxy knows only ACP sessions and has no
+independent authority to select a window, tab, or helper. Therefore the first
+functional proxy deliberately keeps these responsibilities in the helper:
+
+- WT failure classification, enablement policy, connected/busy gating, and
+  generation/stale-response handling;
+- tab and source-pane resolution, prompt template/context construction, and
+  bottom-bar `Detected` / `Pending` / `Review` projection;
+- lazy ACP session creation and the existing `session/cancel` path.
+
+After resolving the `SessionId` and complete `PromptRequest`, the helper sends the
+typed ACP extension `_intellterm.wta/autofix`. `SessionRouter` selects the already
+bound agent slot, `AutofixProxy` intercepts that request, and forwards its unchanged
+payload to the successor as ordinary `session/prompt`. The response type is
+`PromptResponse`, so stop reasons, errors, cancellation, notifications, and reverse
+requests retain the existing end-to-end behavior. `TracingProxy` follows
+`AutofixProxy` in the ordered chain and therefore observes the transformed
+`session/prompt`, never the WTA-only extension method.
 
 ### Proxy criterion & count (how many proxies, and why)
 
@@ -778,7 +800,7 @@ core` row is the counter-example — no ACP seam, so it stays in the conductor/h
 
 | Concern | ACP method intercepted | Transform | Standalone viability | Likely outcome |
 |---|---|---|---|---|
-| autofix | off-wire `WtEvent` → inject `session/prompt` | inject a fix prompt | existing `app/autofix.rs` (566) + tests; clear boundary | ✅ standalone |
+| autofix | `_intellterm.wta/autofix` request | transform a helper-resolved prompt into `session/prompt` | helper retains off-wire WT/tab/UI control plane; `AutofixProxy` owns the ACP method transform | ✅ standalone |
 | context / prompt injection | `session/prompt` (request) | prepend template / persona | existing `prompt.rs` (347); clear transform pipeline | ✅ standalone |
 | delegate / recommendation | `session/update` (response) | parse `RecommendationSet`, surface cards | existing `coordinator.rs` (1861); clear boundary | ✅ standalone |
 | session: list-union (discovery) | `session/list` (response) | union host + WSL history from the agent's `session/list` (already master-fetched), subtract Class-A index | host+WSL history **already** routes through `session/list`, so the seam exists | ✅ standalone (1 of 1–2) |

--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -14,8 +14,8 @@ with an error.
   `ProxyChainRuntime`s (Copilot, Claude, Gemini, Codex, or custom), listens on a
   named pipe, and fans per-helper ACP sessions onto the selected runtime.
   Instance-scoped route/orphan lifetime lives in `src/master/session_router.rs`;
-  each runtime embeds the canonical ACP `ConductorImpl` and an explicit
-  pass-through tracing proxy from `src/master/proxy_chain.rs`.
+  each runtime embeds the canonical ACP `ConductorImpl`, an autofix transform
+  proxy, and a pass-through tracing proxy from `src/master/proxy_chain.rs`.
 - **`wta-helper`** (`--connect-master <pipe>`, spawned once per agent pane by
   Windows Terminal) -- the per-pane **TUI**. Drives the ratatui chat UI (`app.rs`)
   but, instead of spawning its own agent CLI, speaks ACP/JSON-RPC to master over
@@ -73,9 +73,10 @@ because of the helper+master split:
 
 - **master ↔ proxy chain ↔ agent CLI**: master is the ACP **client** of each
   pooled canonical conductor, which owns an ordered linear proxy chain ending
-  at the agent CLI's stdio transport. The first proxy is a no-op wire tracer:
-  it forwards all dispatches unchanged and records only direction, message kind,
-  and method under tracing target `proxy_chain`.
+  at the agent CLI's stdio transport. `AutofixProxy` transforms the helper's
+  `_intellterm.wta/autofix` request into ordinary `session/prompt`; the following
+  no-op tracing proxy records only successor-wire direction, message kind, and
+  method under tracing target `proxy_chain`.
 - **helper ↔ master** (named pipe): master is an ACP **agent** (server) to each
   helper, and the helper is the ACP **client**. Master forwards helper requests
   to the agent CLI and routes inbound `session_notification`s back to the helper

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -1390,6 +1390,67 @@ impl HelperHandler {
             .await
     }
 
+    async fn autofix_prompt(
+        &self,
+        args: crate::protocol::acp::autofix::AutofixPromptRequest,
+        responder: acp::Responder<acp::schema::v1::PromptResponse>,
+    ) -> acp::Result<()> {
+        let helper_id = self.helper_id;
+        let session_id = args.prompt().session_id.clone();
+        let started = std::time::Instant::now();
+        tracing::info!(
+            target: "master",
+            step = "helper→proxy",
+            op = "autofix",
+            helper_id = ?helper_id,
+            session_id = ?session_id,
+            "forwarding autofix request to proxy chain (non-blocking)"
+        );
+        self.resolved_agent("autofix")?
+            .conn
+            .autofix_prompt_forwarding(args, move |resp| async move {
+                let elapsed_ms = started.elapsed().as_millis() as u64;
+                match &resp {
+                    Ok(ok) => tracing::info!(
+                        target: "master",
+                        step = "helper→proxy",
+                        op = "autofix",
+                        helper_id = ?helper_id,
+                        session_id = ?session_id,
+                        stop_reason = ?ok.stop_reason,
+                        elapsed_ms,
+                        "autofix completed"
+                    ),
+                    Err(err) => tracing::warn!(
+                        target: "master",
+                        step = "helper→proxy",
+                        op = "autofix",
+                        helper_id = ?helper_id,
+                        session_id = ?session_id,
+                        error = %err,
+                        elapsed_ms,
+                        "autofix failed"
+                    ),
+                }
+                let result = match resp {
+                    Ok(response) => responder.respond(response),
+                    Err(err) => responder.respond_with_error(err),
+                };
+                if let Err(err) = result {
+                    tracing::info!(
+                        target: "master",
+                        op = "autofix",
+                        helper_id = ?helper_id,
+                        session_id = ?session_id,
+                        error = %err,
+                        "dropping orphan autofix result (helper gone)"
+                    );
+                }
+                Ok(())
+            })
+            .await
+    }
+
     async fn cancel(&self, args: acp::schema::v1::CancelNotification) -> acp::Result<()> {
         tracing::info!(
             target: "master",
@@ -2560,6 +2621,18 @@ async fn serve_helper(
     let builder = acp::Agent
         .builder()
         .name("wta-master-helper")
+        .on_receive_request(
+            {
+                let h = handler.clone();
+                move |req: crate::protocol::acp::autofix::AutofixPromptRequest,
+                      responder,
+                      _cx| {
+                    let h = h.clone();
+                    async move { h.autofix_prompt(req, responder).await }
+                }
+            },
+            acp::on_receive_request!(),
+        )
         .on_receive_request(
             {
                 let h = handler.clone();

--- a/tools/wta/src/master/proxy_chain.rs
+++ b/tools/wta/src/master/proxy_chain.rs
@@ -3,6 +3,8 @@
 use agent_client_protocol as acp;
 use agent_client_protocol_conductor::{ConductorImpl, ProxiesAndAgent};
 
+use crate::protocol::acp::autofix::AutofixPromptRequest;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Direction {
     ClientToAgent,
@@ -88,6 +90,69 @@ impl<O: DispatchObserver> acp::ConnectTo<acp::Conductor> for TracingProxy<O> {
             })
             .connect_to(client)
             .await
+    }
+}
+
+struct AutofixProxy;
+
+impl acp::ConnectTo<acp::Conductor> for AutofixProxy {
+    async fn connect_to(self, client: impl acp::ConnectTo<acp::Proxy>) -> Result<(), acp::Error> {
+        acp::Proxy
+            .builder()
+            .name("wta-autofix-proxy")
+            .on_receive_request_from(
+                acp::Client,
+                async |request: acp::schema::InitializeProxyRequest, responder, cx| {
+                    cx.send_request_to(acp::Agent, request.initialize)
+                        .forward_response_to(responder)
+                },
+                acp::on_receive_request!(),
+            )
+            .on_receive_request_from(
+                acp::Client,
+                async |request: AutofixPromptRequest, responder, cx| {
+                    tracing::debug!(
+                        target: "autofix_proxy",
+                        session_id = %request.prompt().session_id,
+                        "transforming autofix request into session/prompt"
+                    );
+                    cx.send_request_to(acp::Agent, request.into_prompt())
+                        .forward_response_to(responder)
+                },
+                acp::on_receive_request!(),
+            )
+            .with_handler(ForwardAll)
+            .connect_to(client)
+            .await
+    }
+}
+
+struct ForwardAll;
+
+impl acp::HandleDispatchFrom<acp::Conductor> for ForwardAll {
+    async fn handle_dispatch_from(
+        &mut self,
+        message: acp::Dispatch,
+        connection: acp::ConnectionTo<acp::Conductor>,
+    ) -> Result<acp::Handled<acp::Dispatch>, acp::Error> {
+        use acp::util::MatchDispatchFrom;
+
+        MatchDispatchFrom::new(message, &connection)
+            .if_message_from(acp::Client, async |message: acp::Dispatch| {
+                connection.send_proxied_message_to(acp::Agent, message)?;
+                Ok(acp::Handled::Yes)
+            })
+            .await
+            .if_message_from(acp::Agent, async |message: acp::Dispatch| {
+                connection.send_proxied_message_to(acp::Client, message)?;
+                Ok(acp::Handled::Yes)
+            })
+            .await
+            .done()
+    }
+
+    fn describe_chain(&self) -> impl std::fmt::Debug {
+        "ForwardAll"
     }
 }
 
@@ -220,7 +285,9 @@ fn with_observer(
     };
     let conductor = ConductorImpl::new_agent(
         "wta-master",
-        ProxiesAndAgent::new(final_agent).proxy(TracingProxy::new(observer)),
+        ProxiesAndAgent::new(final_agent)
+            .proxy(AutofixProxy)
+            .proxy(TracingProxy::new(observer)),
     );
     ProxyChain {
         conductor,
@@ -236,9 +303,10 @@ mod tests {
     use acp::schema::v1::{
         AgentCapabilities, ContentChunk, InitializeRequest, InitializeResponse, Meta,
         NewSessionRequest, NewSessionResponse, PermissionOption, PermissionOptionId,
-        PermissionOptionKind, RequestPermissionOutcome, RequestPermissionRequest,
-        RequestPermissionResponse, SelectedPermissionOutcome, SessionId, SessionNotification,
-        SessionUpdate, ToolCallId, ToolCallUpdate, ToolCallUpdateFields,
+        PermissionOptionKind, PromptRequest, PromptResponse, RequestPermissionOutcome,
+        RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome, SessionId,
+        SessionNotification, SessionUpdate, StopReason, ToolCallId, ToolCallUpdate,
+        ToolCallUpdateFields,
     };
     use serde_json::Value;
 
@@ -268,6 +336,7 @@ mod tests {
     struct RecordingAgent {
         new_session_meta: Arc<Mutex<Option<Meta>>>,
         permission_selected: Arc<Mutex<bool>>,
+        prompts: Arc<Mutex<Vec<PromptRequest>>>,
     }
 
     impl acp::ConnectTo<acp::Client> for RecordingAgent {
@@ -277,6 +346,7 @@ mod tests {
         ) -> Result<(), acp::Error> {
             let new_session_meta = self.new_session_meta;
             let permission_selected = self.permission_selected;
+            let prompts = self.prompts;
 
             acp::Agent
                 .builder()
@@ -334,6 +404,18 @@ mod tests {
                     },
                     acp::on_receive_request!(),
                 )
+                .on_receive_request(
+                    move |request: PromptRequest,
+                          responder: acp::Responder<PromptResponse>,
+                          _cx| {
+                        let prompts = Arc::clone(&prompts);
+                        async move {
+                            prompts.lock().unwrap().push(request);
+                            responder.respond(PromptResponse::new(StopReason::EndTurn))
+                        }
+                    },
+                    acp::on_receive_request!(),
+                )
                 .connect_to(client)
                 .await
         }
@@ -351,10 +433,12 @@ mod tests {
             let events = Arc::clone(&observer.0);
             let new_session_meta = Arc::new(Mutex::new(None));
             let permission_selected = Arc::new(Mutex::new(false));
+            let prompts = Arc::new(Mutex::new(Vec::new()));
             let notification_seen = Arc::new(Mutex::new(false));
             let final_agent = RecordingAgent {
                 new_session_meta: Arc::clone(&new_session_meta),
                 permission_selected: Arc::clone(&permission_selected),
+                prompts: Arc::clone(&prompts),
             };
             let conductor = with_observer(final_agent, observer);
 
@@ -400,9 +484,32 @@ mod tests {
                 .await
                 .expect("session/new should cross the proxy");
 
+            link.prompt(PromptRequest::new(
+                SessionId::new("proxy-test-session"),
+                vec!["normal".into()],
+            ))
+            .await
+            .expect("normal prompt should pass through unchanged");
+
+            let mut autofix_meta = Meta::new();
+            autofix_meta.insert("wta-test".into(), Value::String("preserved".into()));
+            link.autofix_prompt(AutofixPromptRequest::new(
+                PromptRequest::new(SessionId::new("proxy-test-session"), vec!["autofix".into()])
+                    .meta(autofix_meta.clone()),
+            ))
+            .await
+            .expect("autofix proxy should transform the request");
+
             assert_eq!(*new_session_meta.lock().unwrap(), Some(expected_meta));
             assert!(*notification_seen.lock().unwrap());
             assert!(*permission_selected.lock().unwrap());
+            let prompts = prompts.lock().unwrap();
+            assert_eq!(prompts.len(), 2);
+            assert_eq!(prompts[0].prompt, vec!["normal".into()]);
+            assert_eq!(prompts[1].session_id, SessionId::new("proxy-test-session"));
+            assert_eq!(prompts[1].prompt, vec!["autofix".into()]);
+            assert_eq!(prompts[1].meta, Some(autofix_meta));
+            drop(prompts);
 
             let events = events.lock().unwrap();
             for expected in [
@@ -441,6 +548,16 @@ mod tests {
                     MessageKind::Response,
                     "session/new",
                 ),
+                (
+                    Direction::ClientToAgent,
+                    MessageKind::Request,
+                    "session/prompt",
+                ),
+                (
+                    Direction::AgentToClient,
+                    MessageKind::Response,
+                    "session/prompt",
+                ),
             ] {
                 assert!(
                     events.iter().any(|event| {
@@ -451,6 +568,12 @@ mod tests {
                     "missing trace event {expected:?}; observed {events:?}"
                 );
             }
+            assert!(
+                events
+                    .iter()
+                    .all(|event| event.method != "_intellterm.wta/autofix"),
+                "tracing proxy should observe the transformed successor wire: {events:?}"
+            );
 
             io_task.abort();
         });

--- a/tools/wta/src/protocol/acp/autofix.rs
+++ b/tools/wta/src/protocol/acp/autofix.rs
@@ -1,0 +1,28 @@
+//! WTA's ACP extension request for an autofix turn.
+
+use acp::schema::v1::{PromptRequest, PromptResponse};
+use agent_client_protocol as acp;
+use serde::{Deserialize, Serialize};
+
+/// Helper-to-proxy request marking a fully resolved prompt as autofix traffic.
+///
+/// The payload intentionally has the same wire shape as `session/prompt`; the
+/// autofix proxy changes only the method and forwards the inner prompt unchanged.
+#[derive(Debug, Clone, Serialize, Deserialize, acp::JsonRpcRequest)]
+#[request(method = "_intellterm.wta/autofix", response = PromptResponse)]
+#[serde(transparent)]
+pub struct AutofixPromptRequest(PromptRequest);
+
+impl AutofixPromptRequest {
+    pub fn new(prompt: PromptRequest) -> Self {
+        Self(prompt)
+    }
+
+    pub fn prompt(&self) -> &PromptRequest {
+        &self.0
+    }
+
+    pub fn into_prompt(self) -> PromptRequest {
+        self.0
+    }
+}

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -3670,10 +3670,22 @@ async fn dispatch_prompt_body(
     // through master → agent CLI verbatim; the agent only receives them if it
     // advertised `promptCapabilities.image` (the UI gates Alt+V on that flag).
     let content = build_prompt_content(&text, &prompt.images);
-    let prompt_fut = conn_task.prompt(acp::schema::v1::PromptRequest::new(
+    let prompt_request = acp::schema::v1::PromptRequest::new(
         prompt_session_id.clone(),
         content,
-    ));
+    );
+    let is_autofix = prompt.is_autofix;
+    let prompt_fut = async {
+        if is_autofix {
+            conn_task
+                .autofix_prompt(crate::protocol::acp::autofix::AutofixPromptRequest::new(
+                    prompt_request,
+                ))
+                .await
+        } else {
+            conn_task.prompt(prompt_request).await
+        }
+    };
     tokio::pin!(prompt_fut);
 
     let cancelled = tokio::select! {

--- a/tools/wta/src/protocol/acp/conn.rs
+++ b/tools/wta/src/protocol/acp/conn.rs
@@ -42,6 +42,8 @@ use acp::schema::v1::{
 };
 use serde::{Deserialize, Serialize};
 
+use super::autofix::AutofixPromptRequest;
+
 /// Legacy `session/set_model` request, removed from schema 1.1 but still spoken
 /// by Copilot/Gemini. Re-declared locally as a typed JSON-RPC request so the
 /// model-switch path keeps the exact wire shape (`sessionId` / `modelId`).
@@ -134,6 +136,13 @@ impl ClientLink {
         self.cx().await?.send_request(req).block_task().await
     }
 
+    pub async fn autofix_prompt(
+        &self,
+        req: AutofixPromptRequest,
+    ) -> acp::Result<PromptResponse> {
+        self.cx().await?.send_request(req).block_task().await
+    }
+
     /// Non-blocking counterpart of [`ClientLink::prompt`], for use **from
     /// inside an ACP `on_receive_request` dispatch handler**.
     ///
@@ -148,6 +157,20 @@ impl ClientLink {
     pub async fn prompt_forwarding<Fut>(
         &self,
         req: PromptRequest,
+        on_response: impl FnOnce(acp::Result<PromptResponse>) -> Fut + 'static + Send,
+    ) -> acp::Result<()>
+    where
+        Fut: Future<Output = acp::Result<()>> + 'static + Send,
+    {
+        self.cx()
+            .await?
+            .send_request(req)
+            .on_receiving_result(on_response)
+    }
+
+    pub async fn autofix_prompt_forwarding<Fut>(
+        &self,
+        req: AutofixPromptRequest,
         on_response: impl FnOnce(acp::Result<PromptResponse>) -> Fut + 'static + Send,
     ) -> acp::Result<()>
     where

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -360,6 +360,20 @@ fn spawn_mock_pair(
     let agent_builder = acp::Agent
         .builder()
         .name("mock-agent")
+        .on_receive_request({
+            let m = mock.clone();
+            move |req: crate::protocol::acp::autofix::AutofixPromptRequest,
+                  responder: acp::Responder<acp::schema::v1::PromptResponse>,
+                  _cx| {
+                let m = m.clone();
+                async move {
+                    match m.prompt(req.into_prompt()).await {
+                        Ok(response) => responder.respond(response),
+                        Err(err) => responder.respond_with_error(err),
+                    }
+                }
+            }
+        }, acp::on_receive_request!())
         .on_receive_request({ let m = mock.clone(); move |req: acp::schema::v1::ClientRequest, responder, _cx| { let m = m.clone(); async move {
             use acp::schema::v1::{ClientRequest as Q, AgentResponse as R};
             match req {
@@ -1844,6 +1858,5 @@ async fn request_permission_cancelled_when_responder_dropped() {
         })
         .await;
 }
-
 
 

--- a/tools/wta/src/protocol/acp/mod.rs
+++ b/tools/wta/src/protocol/acp/mod.rs
@@ -1,3 +1,4 @@
+pub mod autofix;
 pub mod client;
 pub mod conn;
 pub mod failure;


### PR DESCRIPTION
## Summary
- add a typed autofix ACP request and transform it to ordinary \session/prompt\ inside the canonical proxy chain
- keep WT event classification, tab/pane context, generation gates, and bottom-bar UI state in the per-tab helper
- place the tracing proxy after autofix so it observes the transformed successor wire
- update the migration spec to document the real helper/control-plane and proxy boundary

## Validation
- \cargo check --tests --manifest-path tools/wta/Cargo.toml\`n- \cargo test --manifest-path tools/wta/Cargo.toml --bin wta\ (1,134 passed)
- targeted autofix and proxy-chain tests
- specialist code review: no significant issues