### PR TITLE
Add skill for integrating ACP-compatible agents

### DIFF
--- a/.github/skills/add-acp-agent-support/SKILL.md
+++ b/.github/skills/add-acp-agent-support/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: add-acp-agent-support
+description: 'Add first-class support for an ACP-compatible agent CLI to Intelligent Terminal. Use when integrating a new built-in AI agent, ACP server command, authentication flow, model selection, interactive delegation, branding, GPO policy, documentation, tests, build, deployment, or live ACP log verification.'
+---
+
+# Add ACP Agent Support
+
+Integrate a new built-in agent across WTA, Terminal UI, settings, policy,
+telemetry, documentation, and validation without leaving agent-specific
+behavior inconsistent between layers.
+
+## When to Use This Skill
+
+- Add a native ACP-speaking agent CLI to Intelligent Terminal.
+- Add an ACP adapter for a CLI that does not speak ACP itself.
+- Promote a custom ACP command into a first-class built-in agent.
+- Add or repair ACP authentication, model probing, delegate, icon, or policy
+  support for an existing agent.
+
+## Prerequisites
+
+- Work on a feature branch, never directly on `main` or `master`.
+- Read the repository and area-specific instructions before editing, including
+  `tools/wta/AGENTS.md` and the Rust instruction files for WTA changes.
+- Obtain the agent's official CLI documentation and install a pinned or known
+  version for live verification.
+- Confirm that the CLI either exposes a long-running ACP server over stdio or
+  has a maintained ACP adapter. A normal interactive TUI is not an ACP server.
+
+## Workflow
+
+Track the work with a TODO list because the Rust and C++ registries, UI,
+policy, tests, and live verification must stay synchronized.
+
+1. **Define the agent contract.** Complete the capability matrix in
+   [integration-map.md](./references/integration-map.md): executable, ACP
+   command, native-vs-adapter ownership, auth, model selection, interactive
+   delegate syntax, session resume, installation, and official branding.
+2. **Prove ACP behavior before editing.** Run the exact ACP command and verify
+   stdio initialization, session creation, model discovery, prompt streaming,
+   cancellation, and shutdown. Record the tested CLI/adapter version.
+3. **Inventory current integration surfaces.** Search for every existing
+   built-in agent ID and follow the current patterns. Do not rely on old line
+   numbers or assume the Rust registry is the only source of truth.
+4. **Implement the WTA profile and command behavior.** Add the profile,
+   ACP launch command, auth flow, model behavior, install guidance, and
+   resume metadata. Add delegate support only when the agent has a true
+   interactive initial-prompt invocation.
+5. **Wire Terminal surfaces.** Keep C++ built-in registries, ACP command
+   resolution, settings/model probing, telemetry sanitization, branding, and
+   policy-facing lists consistent. Use the detailed file map in
+   [integration-map.md](./references/integration-map.md).
+6. **Add focused tests.** Cover profile lookup, ACP command construction,
+   identification, auth command generation, and every delegate shell path that
+   applies: direct Windows, PowerShell 7, Windows PowerShell 5.1, and WSL.
+7. **Update user and administrator documentation.** Document support,
+   installation/auth requirements, limitations, delegate behavior, and the
+   `AllowedAgents` identifier. Do not advertise hooks or history integration
+   unless they were implemented and tested.
+8. **Validate end to end.** Follow
+   [validation.md](./references/validation.md), including the WTA test suite,
+   explicit-target WTA build, Terminal build, package deployment, live ACP
+   prompt, auth path, model selection, delegate behavior, GPO filtering, and
+   log inspection.
+9. **Prepare the PR.** Keep the diff scoped, cite the tested agent version and
+   ACP command, describe native-vs-adapter status, list unsupported features,
+   and link the tracking issue with a closing keyword when appropriate.
+
+## Decision Rules
+
+| Capability | Required decision |
+|------------|-------------------|
+| ACP launch | Prefer the CLI's native stdio mode. Use a maintained adapter only when native ACP is unavailable; pin the adapter when unbounded updates could break startup. |
+| Authentication | Use `InProtocol` only when ACP advertises and completes authentication. Use `External` when a separate CLI/provider login is required, then verify the running ACP process can refresh credentials. |
+| Models | Distinguish flags accepted by the ACP server process from flags accepted by the interactive delegate CLI. Prefer ACP model APIs when the server supports them. |
+| Delegation | Use an interactive TUI invocation with an initial prompt. If the only interface is one-shot, omit first-class delegate support or explicitly ask the user to accept an auto-closing tab. |
+| Resume | Configure resume/new-session metadata only after proving the exact CLI syntax and identifier semantics. |
+| Hooks/history | Treat these as separate integrations. ACP compatibility alone does not imply shell hooks or historical session support. |
+
+## Gotchas
+
+- **Never substitute a TUI or one-shot command for the ACP server command.**
+  The agent pane requires a long-running JSON-RPC/ACP stdio process.
+- **Never use a one-shot delegate subcommand when an interactive prompt flag
+  exists.** A successful one-shot process exits and Terminal closes its tab.
+- **Preserve the CLI's argument grammar.** Top-level flags, subcommands, model
+  flags, and prompt arguments may require a specific order.
+- **Test every quoting layer.** Multiline prompts and paths with spaces pass
+  through different escaping in direct Windows, pwsh, Windows PowerShell, and
+  WSL launches.
+- **Keep both registries synchronized.** Update Rust execution metadata and
+  C++ discoverability/GPO arrays together, including compile-time array sizes.
+- **Separate ACP and delegate model flags.** Passing a TUI-only model flag to
+  the ACP server can prevent startup even when delegation works.
+- **Treat agent IDs as telemetry-sensitive.** Add only the canonical built-in
+  ID to the allowlist; continue bucketing custom commands and paths as
+  `custom`.
+- **Use official, license-compatible branding.** Make header artwork respond
+  to light, dark, and high-contrast themes; do not silently reuse another
+  agent's logo.
+- **Build the explicit Cargo target before packaging.** CascadiaPackage prefers
+  `target/x86_64-pc-windows-msvc/.../wta.exe`; a stale binary there can shadow
+  a fresh host-target build.
+- **Update policy prose as well as runtime filtering.** `AllowedAgents` is
+  generic, but its ADML identifier list and built-in count can drift.
+
+## References
+
+- [Integration surface map](./references/integration-map.md)
+- [Validation and live verification](./references/validation.md)
+

--- a/.github/skills/add-acp-agent-support/references/integration-map.md
+++ b/.github/skills/add-acp-agent-support/references/integration-map.md
@@ -1,0 +1,152 @@
+# ACP Agent Integration Map
+
+Use this map as a search guide, not a promise that filenames or symbols never
+change. Search for all current built-in IDs before editing and follow the
+nearest current implementation.
+
+## Capability Matrix
+
+Record these facts before implementation:
+
+| Field | Evidence required |
+|-------|-------------------|
+| Canonical ID and display name | Stable lowercase ID and official product name |
+| Executable and search order | Actual Windows shims (`.exe`, `.cmd`, and others if needed) |
+| ACP ownership | Native CLI or named adapter package/repository |
+| Exact ACP command | Long-running stdio command, including required subcommand/flags |
+| ACP version behavior | Tested CLI/adapter version and protocol initialization result |
+| Authentication | ACP in-protocol method or exact external login/logout/status commands |
+| ACP model selection | ACP model API and/or server-start flags |
+| Delegate command | Interactive initial-prompt syntax, model syntax, and argument order |
+| Resume/new session | Exact flag/subcommand and identifier semantics, or unsupported |
+| Installation | Official package ID/command and documentation URL |
+| Branding | Official SVG source and license/usage terms |
+| Known limitations | Hooks, history, WSL, models, auth refresh, or delegate omissions |
+
+Do not infer capabilities from another agent. Exercise the installed CLI's
+help and ACP behavior directly.
+
+## WTA (Rust)
+
+### `tools/wta/src/agent_registry.rs`
+
+Add an `AgentProfile` and update tests for:
+
+- canonical ID and display name;
+- executable resolution;
+- native ACP flags or full adapter launch command;
+- ACP-specific versus delegate model flags;
+- `AcpAuthFlow`;
+- delegate prompt shape;
+- install and auth guidance;
+- resume and caller-chosen session ID support.
+
+Also inspect command-to-agent identification, adapter aliases, known-ID tests,
+and default/fallback behavior. If the new CLI needs a prompt shape the registry
+cannot represent, extend the type generically and test existing agents for
+regressions rather than hardcoding a one-off branch.
+
+### `tools/wta/src/agent_check.rs`
+
+Add the exact external login command only when external auth is real. Check
+whether enterprise-host arguments are agent-specific and must be ignored.
+Test login command generation.
+
+### `tools/wta/src/coordinator.rs`
+
+Delegate support must preserve:
+
+- executable and base arguments;
+- model argument placement;
+- interactive initial-prompt placement;
+- multiline prompt integrity;
+- quoting for direct Windows, pwsh, Windows PowerShell, and WSL;
+- clear rejection of empty or invalid executable command lines.
+
+Add assertions for the complete command shape, not merely the presence of the
+agent name.
+
+### `tools/wta/src/main.rs` and ACP modules
+
+Update user-facing supported-agent lists and inspect ACP initialization,
+authentication, model selection, and probing for agent-specific assumptions.
+Do not add protocol special cases when profile metadata or ACP capabilities can
+drive the behavior.
+
+## Terminal (C++/XAML)
+
+### `src/cascadia/inc/AgentRegistry.h`
+
+Add the agent to the ACP built-in list. Add it to the delegate list only when
+interactive delegation is supported. Update fixed array sizes and preserve GPO
+filtering through `FilteredAcpAgents()` and `FilteredDelegateAgents()`.
+
+### ACP command resolution
+
+Search `src/cascadia/TerminalApp/TerminalPage.cpp` and settings code for the
+existing built-in ACP command mappings. Ensure the agent pane and model probe
+resolve to the same exact ACP command:
+
+- `TerminalPage.cpp` for the runtime agent launch;
+- `TerminalSettingsEditor/AIAgentsViewModel.cpp` for model probing and setup
+  state.
+
+An ACP server may accept model changes through protocol even when its
+interactive CLI accepts a `--model` flag. Do not append unsupported flags to
+the server command.
+
+### Settings, telemetry, and discoverability
+
+Search these areas for explicit current-agent lists:
+
+- `TerminalSettingsModel/CascadiaSettingsSerialization.cpp` for sanitized
+  telemetry IDs;
+- Settings Editor and TerminalApp resources for localized/fallback names;
+- first-run experience and quick selector consumers of `AgentRegistry.h`;
+- CLI help text and settings schema/default descriptions.
+
+Keep custom commands classified as `custom`; never emit a path or arbitrary
+command as a telemetry provider ID.
+
+### Branding
+
+Search `TerminalApp/AgentPaneContent.cpp` and `.xaml` for logo selection and
+visibility. Add an official, license-compatible vector asset under the
+packaging asset area when appropriate. Ensure:
+
+- deterministic mapping from canonical/display name to the new logo;
+- an intentional unknown-agent fallback;
+- light and dark theme contrast;
+- high-contrast support through theme resources rather than a fixed fill;
+- only the selected logo is visible.
+
+## Policy and Documentation
+
+`policies/IntelligentTerminal.admx` defines the generic `AllowedAgents`
+`REG_MULTI_SZ`. Runtime filtering normally needs no per-agent schema change,
+but update `policies/en-US/IntelligentTerminal.adml`:
+
+- valid identifier list;
+- displayed built-in count;
+- textbox hint.
+
+Update `README.md` and `doc/faq.md` for support, installation/auth, and honest
+limitations. Search for every old built-in count or exhaustive agent list.
+Do not include the agent in hooks/history documentation unless those separate
+features are implemented.
+
+## Useful Searches
+
+Run narrow searches from the repository root:
+
+```powershell
+rg 'BuiltinAcpAgents|BuiltinDelegateAgents' src\cascadia
+rg 'copilot|claude|codex|gemini' tools\wta\src src\cascadia policies README.md doc\faq.md
+rg 'sanitizeProviderId|probe-models|build_login_cmd|delegate_prompt' tools\wta\src src\cascadia
+rg 'AgentLogoKind|AgentName_' src\cascadia
+rg 'AllowedAgents|built-in AI agents' policies
+```
+
+Replace the exemplar agent-ID expression with the current built-in set when
+the repository evolves.
+

--- a/.github/skills/add-acp-agent-support/references/validation.md
+++ b/.github/skills/add-acp-agent-support/references/validation.md
@@ -1,0 +1,129 @@
+# ACP Agent Validation
+
+Validation is complete only when the built package runs the newly built WTA
+binary and the live logs prove the intended agent command and ACP behavior.
+
+## Static Review
+
+1. Search for exhaustive built-in agent lists and confirm the new ID appears
+   everywhere required.
+2. Confirm Rust and C++ ACP/delegate registries agree.
+3. Confirm fixed C++ array sizes match their entries.
+4. Confirm agent-pane launch and Settings model probe use the same ACP command.
+5. Confirm telemetry accepts only the canonical ID, not arbitrary commands.
+6. Confirm ADML prose, built-in count, and textbox hint are current.
+7. Confirm documentation does not claim unsupported hooks/history features.
+8. Inspect `git diff --check` and the full diff for unrelated changes. Account
+   for this repository's existing CRLF files before treating every reported
+   line as newly introduced trailing whitespace.
+
+## Automated Tests
+
+Add or update tests for:
+
+- profile lookup by ID, executable, extension, and full path;
+- ACP launch command construction and adapter identification;
+- ACP model flags versus delegate model flags;
+- auth command generation and host-argument handling;
+- resume/new-session metadata when supported;
+- direct Windows delegate command shape;
+- PowerShell 7 and Windows PowerShell 5.1 delegate quoting;
+- WSL delegate quoting and multiline prompts;
+- invalid or empty delegate executable rejection;
+- policy filtering or settings serialization when those paths changed.
+
+Run the WTA suite from the repository root:
+
+```powershell
+cargo test --manifest-path tools\wta\Cargo.toml
+```
+
+Do not treat a successful build as a substitute for tests; WTA test-only code
+is not compiled by the C++ build.
+
+## Build
+
+Resolve and stop only the specific live WTA process IDs before rebuilding:
+
+```powershell
+Get-Process wta -ErrorAction SilentlyContinue |
+    ForEach-Object { Stop-Process -Id $_.Id -Force }
+cargo build --target x86_64-pc-windows-msvc --manifest-path tools\wta\Cargo.toml
+```
+
+Always use the explicit target for a package-validation cycle because
+CascadiaPackage prefers that output and can otherwise deploy a stale
+`wta.exe`.
+
+Build Terminal through the repository's razzle environment:
+
+```powershell
+cmd.exe /c "tools\razzle.cmd && bcz no_clean"
+```
+
+Use the Visual Studio/MSBuild version required by the current repository. If
+`.slnx` is not recognized or the toolset mismatches, fix the selected Visual
+Studio environment rather than changing project files.
+
+Deploy `CascadiaPackage` using F5 or its generated
+`CascadiaPackage.build.appxrecipe`. If the first command-line deployment
+reports `ManifestChanged`, retry once and require a successful clean reinstall.
+
+## Live ACP Verification
+
+1. Select the new built-in agent in Settings.
+2. Open the agent pane and confirm the intended logo and display name in light,
+   dark, and high-contrast modes.
+3. Confirm the spawned WTA master command contains the exact intended ACP
+   command and canonical `--agent-id`.
+4. Confirm the actual agent process is the native ACP server or intended
+   adapter, not the normal TUI or a stale binary.
+5. In `wta-main_master.log` and the current
+   `wta-main_helper-<pid>.log`, verify:
+   - ACP initialize succeeds;
+   - the expected agent/version is reported;
+   - `session/new` succeeds;
+   - model discovery succeeds or is explicitly unsupported;
+   - a prompt streams a response and reaches a terminal stop reason;
+   - cancellation and pane close do not tear down unrelated sessions;
+   - no unexpected error or panic is present.
+6. Exercise model selection and reconnect. Verify the selected model reaches
+   the ACP session through the protocol or supported server flag.
+7. Exercise unauthenticated startup, the advertised login flow, and credential
+   refresh. Verify logout returns the agent to the expected unauthenticated
+   state.
+
+Packaged logs live under the app package's
+`LocalCache\Local\IntelligentTerminal\logs\<package-version>` directory.
+Relevant files include `terminal-agent-pane.log`, `wta-main_master.log`,
+`wta-main_helper-<pid>.log`, `wta-probe.log`, and `wta-delegate.log`.
+
+## Delegate Verification
+
+Run this section only when the agent is in `BuiltinDelegateAgents`.
+
+1. Delegate a prompt from a Windows shell and, when supported, WSL.
+2. Confirm `wta-delegate.log` shows the intended executable, model, prompt
+   form, and shell path without leaking prompt contents or credentials.
+3. Confirm the new tab opens an interactive agent TUI with the initial prompt.
+4. Wait for the first task to finish and confirm the tab remains open and can
+   accept another prompt.
+5. Verify paths with spaces and multiline prompts.
+
+If the delegate exits successfully and the tab disappears, the integration is
+probably using a one-shot command. Find the CLI's interactive initial-prompt
+form; do not suppress Terminal's normal close-on-success behavior as a
+workaround.
+
+## Policy Verification
+
+Test `AllowedAgents` with the canonical ID:
+
+1. Unconfigured policy exposes the agent normally.
+2. An allowlist containing the ID exposes it in every supported ACP/delegate
+   selector.
+3. An allowlist excluding the ID hides or blocks it consistently.
+4. Match IDs case-insensitively if that is the existing policy contract.
+
+Record the tested CLI/adapter version, ACP command, test count, build
+configuration, package identity, and key log evidence in the PR description.


### PR DESCRIPTION
## Summary

- add a reusable workflow for first-class ACP-compatible agent integration
- document WTA, Terminal UI, settings, telemetry, branding, and GPO surfaces
- include automated, build, deployment, delegate, policy, and live log validation checklists

## Validation

- validated Skill frontmatter and bundled reference links
- confirmed the branch contains only the new Skill documentation