### PR TITLE
Support OpenCode session resume

### DIFF
--- a/.github/skills/add-acp-agent-support/SKILL.md
+++ b/.github/skills/add-acp-agent-support/SKILL.md
@@ -44,15 +44,17 @@ policy, tests, and live verification must stay synchronized.
    numbers or assume the Rust registry is the only source of truth.
 4. **Implement the WTA profile and command behavior.** Add the profile,
    ACP launch command, auth flow, model behavior, install guidance, and
-   resume metadata. Add delegate support only when the agent has a true
-   interactive initial-prompt invocation.
+   resume metadata. Wire the canonical ID through the session subsystem when
+   session listing or resume is supported. Add delegate support only when the
+   agent has a true interactive initial-prompt invocation.
 5. **Wire Terminal surfaces.** Keep C++ built-in registries, ACP command
    resolution, settings/model probing, telemetry sanitization, branding, and
    policy-facing lists consistent. Use the detailed file map in
    [integration-map.md](./references/integration-map.md).
 6. **Add focused tests.** Cover profile lookup, ACP command construction,
-   identification, auth command generation, and every delegate shell path that
-   applies: direct Windows, PowerShell 7, Windows PowerShell 5.1, and WSL.
+   identification, session source round-trips and resume dispatch, auth command
+   generation, and every delegate shell path that applies: direct Windows,
+   PowerShell 7, Windows PowerShell 5.1, and WSL.
 7. **Update user and administrator documentation.** Document support,
    installation/auth requirements, limitations, delegate behavior, and the
    `AllowedAgents` identifier. Do not advertise hooks or history integration
@@ -74,7 +76,7 @@ policy, tests, and live verification must stay synchronized.
 | Authentication | Use `InProtocol` only when ACP advertises and completes authentication. Use `External` when a separate CLI/provider login is required, then verify the running ACP process can refresh credentials. |
 | Models | Distinguish flags accepted by the ACP server process from flags accepted by the interactive delegate CLI. Prefer ACP model APIs when the server supports them. |
 | Delegation | Use an interactive TUI invocation with an initial prompt. If the only interface is one-shot, omit first-class delegate support or explicitly ask the user to accept an auto-closing tab. |
-| Resume | Configure resume/new-session metadata only after proving the exact CLI syntax and identifier semantics. |
+| Resume | Configure resume/new-session metadata only after proving the exact CLI syntax and identifier semantics. Also add the agent to the session source type and every conversion boundary; profile metadata alone does not make a session resumable. |
 | Hooks/history | Treat these as separate integrations. ACP compatibility alone does not imply shell hooks or historical session support. |
 
 ## Gotchas
@@ -90,6 +92,12 @@ policy, tests, and live verification must stay synchronized.
   WSL launches.
 - **Keep both registries synchronized.** Update Rust execution metadata and
   C++ discoverability/GPO arrays together, including compile-time array sizes.
+- **Do not stop at `AgentProfile` for session support.** Add the canonical agent
+  to `CliSource`, parsing/filtering, wire conversions, labels, resume command
+  synthesis, and ACP/WSL session discovery where supported. Otherwise
+  `session/list` rows can appear as `Unknown("custom")` and Enter fails with
+  "source agent is unknown to this build" even though the agent profile has a
+  valid resume flag.
 - **Separate ACP and delegate model flags.** Passing a TUI-only model flag to
   the ACP server can prevent startup even when delegation works.
 - **Treat agent IDs as telemetry-sensitive.** Add only the canonical built-in
@@ -108,4 +116,3 @@ policy, tests, and live verification must stay synchronized.
 
 - [Integration surface map](./references/integration-map.md)
 - [Validation and live verification](./references/validation.md)
-

--- a/.github/skills/add-acp-agent-support/references/integration-map.md
+++ b/.github/skills/add-acp-agent-support/references/integration-map.md
@@ -52,6 +52,40 @@ Add the exact external login command only when external auth is real. Check
 whether enterprise-host arguments are agent-specific and must be ignored.
 Test login command generation.
 
+### Session management
+
+If the agent supports ACP `session/list`, ACP `session/load`, or an interactive
+CLI resume command, wire its canonical ID through the complete session
+subsystem. Updating `AgentProfile.resume_flag` alone is insufficient.
+
+Search for every exhaustive `CliSource` match and update the applicable
+surfaces:
+
+- `agent_sessions.rs`: add the typed variant plus `parse` and `from_agent_id`;
+- `app.rs`: map the typed source back to the canonical ID so resume capability
+  checks and `<cli> <resume flag> <session id>` synthesis work;
+- `session_registry.rs`: preserve the source through helper/master wire
+  serialization instead of degrading it to `Unknown`;
+- `session_history.rs`, `main.rs`, and `ui/agents_view.rs`: keep diagnostic and
+  UI labels exhaustive;
+- `wsl_acp.rs`: add ACP session discovery only when the agent's ACP server
+  actually supports `session/list`.
+
+Add regression tests for ID parsing, wire round-trips, current-agent filtering,
+resume dispatch, and the exact CLI resume command. For CLI resume tabs, pass the
+stored session title to `wtcli new-tab`; do not force suppression of later
+application-title updates unless the product explicitly requires a fixed title.
+
+The characteristic missed-mapping failure is:
+
+```text
+Cannot resume session <id>: its source agent is unknown to this build.
+```
+
+When this appears, inspect the helper log's
+`activate_agent_session_with_shift` entry. A known built-in showing
+`cli=Unknown("custom")` means a session conversion boundary is missing.
+
 ### `tools/wta/src/coordinator.rs`
 
 Delegate support must preserve:
@@ -143,10 +177,10 @@ Run narrow searches from the repository root:
 rg 'BuiltinAcpAgents|BuiltinDelegateAgents' src\cascadia
 rg 'copilot|claude|codex|gemini' tools\wta\src src\cascadia policies README.md doc\faq.md
 rg 'sanitizeProviderId|probe-models|build_login_cmd|delegate_prompt' tools\wta\src src\cascadia
+rg 'enum CliSource|known_cli_id|SessionHookCliSource|clis_to_scan' tools\wta\src
 rg 'AgentLogoKind|AgentName_' src\cascadia
 rg 'AllowedAgents|built-in AI agents' policies
 ```
 
 Replace the exemplar agent-ID expression with the current built-in set when
 the repository evolves.
-

--- a/.github/skills/add-acp-agent-support/references/validation.md
+++ b/.github/skills/add-acp-agent-support/references/validation.md
@@ -13,7 +13,9 @@ binary and the live logs prove the intended agent command and ACP behavior.
 5. Confirm telemetry accepts only the canonical ID, not arbitrary commands.
 6. Confirm ADML prose, built-in count, and textbox hint are current.
 7. Confirm documentation does not claim unsupported hooks/history features.
-8. Inspect `git diff --check` and the full diff for unrelated changes. Account
+8. When session listing or resume is supported, confirm the canonical ID has a
+   typed `CliSource` and survives helper/master wire round-trips.
+9. Inspect `git diff --check` and the full diff for unrelated changes. Account
    for this repository's existing CRLF files before treating every reported
    line as newly introduced trailing whitespace.
 
@@ -26,6 +28,8 @@ Add or update tests for:
 - ACP model flags versus delegate model flags;
 - auth command generation and host-argument handling;
 - resume/new-session metadata when supported;
+- session source parsing, filtering, wire round-trips, labels, and exact resume
+  dispatch when session management is supported;
 - direct Windows delegate command shape;
 - PowerShell 7 and Windows PowerShell 5.1 delegate quoting;
 - WSL delegate quoting and multiline prompts;
@@ -92,6 +96,10 @@ reports `ManifestChanged`, retry once and require a successful clean reinstall.
 7. Exercise unauthenticated startup, the advertised login flow, and credential
    refresh. Verify logout returns the agent to the expected unauthenticated
    state.
+8. If session management is supported, open `/sessions`, select a historical
+   row from the new agent, and verify Enter chooses the intended CLI/ACP resume
+   path rather than `UnknownCli`. Confirm the resumed tab starts with the stored
+   session title and the helper log records the typed source.
 
 Packaged logs live under the app package's
 `LocalCache\Local\IntelligentTerminal\logs\<package-version>` directory.

--- a/tools/wta/src/agent_sessions.rs
+++ b/tools/wta/src/agent_sessions.rs
@@ -37,6 +37,7 @@ pub enum CliSource {
     Codex,
     Copilot,
     Gemini,
+    OpenCode,
     Unknown(String),
 }
 
@@ -47,6 +48,7 @@ impl CliSource {
             "codex"   => Self::Codex,
             "copilot" => Self::Copilot,
             "gemini"  => Self::Gemini,
+            "opencode" => Self::OpenCode,
             ""        => Self::Unknown(String::new()),
             other     => Self::Unknown(other.to_string()),
         }
@@ -63,6 +65,7 @@ impl CliSource {
             "codex"   => Some(Self::Codex),
             "copilot" => Some(Self::Copilot),
             "gemini"  => Some(Self::Gemini),
+            "opencode" => Some(Self::OpenCode),
             _ => None,
         }
     }
@@ -2188,6 +2191,7 @@ mod tests {
         assert_eq!(CliSource::from_agent_id("copilot"), Some(CliSource::Copilot));
         assert_eq!(CliSource::from_agent_id("claude"),  Some(CliSource::Claude));
         assert_eq!(CliSource::from_agent_id("gemini"),  Some(CliSource::Gemini));
+        assert_eq!(CliSource::from_agent_id("opencode"), Some(CliSource::OpenCode));
         // Case-insensitive — `current_agent_id` is conventionally lowercase
         // but mixed-case must not silently drop the filter.
         assert_eq!(CliSource::from_agent_id("Copilot"), Some(CliSource::Copilot));
@@ -2218,6 +2222,12 @@ mod tests {
         // Note: CliSource has `pub fn parse(Option<&str>) -> Self` (not FromStr).
         assert_eq!(CliSource::parse(Some("Codex")), CliSource::Codex);
         assert_eq!(CliSource::parse(Some("codex")), CliSource::Codex);
+    }
+
+    #[test]
+    fn cli_source_parse_round_trips_opencode() {
+        assert_eq!(CliSource::parse(Some("OpenCode")), CliSource::OpenCode);
+        assert_eq!(CliSource::parse(Some("opencode")), CliSource::OpenCode);
     }
 
     #[test]

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2234,6 +2234,7 @@ pub(crate) fn known_cli_id(src: &crate::agent_sessions::CliSource) -> Option<&'s
         CliSource::Codex   => Some("codex"),
         CliSource::Copilot => Some("copilot"),
         CliSource::Gemini  => Some("gemini"),
+        CliSource::OpenCode => Some("opencode"),
         CliSource::Unknown(_) => None,
     }
 }
@@ -3038,9 +3039,9 @@ impl App {
     /// Filter to apply to the session management view based on which
     /// agent CLI the WTA agent pane is currently driving. Returns
     /// `Some(CliSource::*)` when `current_agent_id` resolves to a tracked
-    /// CLI (copilot / claude / gemini) so only matching rows are listed.
-    /// Returns `None` when no agent has been selected yet or the agent is
-    /// not one the session registry tracks (codex / unknown) — in that
+    /// CLI so only matching rows are listed. Returns `None` when no agent
+    /// has been selected yet or the agent is not one the session registry
+    /// tracks (custom / unknown) — in that
     /// case the view falls back to showing every row so the user can still
     /// see and resume their history.
     pub fn current_cli_filter(&self) -> Option<crate::agent_sessions::CliSource> {
@@ -3118,7 +3119,7 @@ impl App {
         let shift = shift && !s.location.is_wsl();
         // Ambient: load_session capability is set during ACP init;
         // resume-flag support is a per-CLI profile constant — true for
-        // Claude / Codex / Copilot / Gemini (all four CLIs accept some
+        // Claude / Codex / Copilot / Gemini / OpenCode (all five CLIs accept some
         // form of `--resume`/`resume <id>` re-attach surface).
         let cli_supports_resume_flag = match known_cli_id(&s.cli_source) {
             Some(id) => !crate::agent_registry::lookup_profile_by_id(id)
@@ -3431,6 +3432,10 @@ impl App {
             "-c".to_string(),
             launch_commandline.clone(),
         ];
+        if !s.title.is_empty() {
+            argv.push("--title".to_string());
+            argv.push(s.title.clone());
+        }
         if let Some(ref cwd) = valid_cwd {
             argv.push("-d".to_string());
             argv.push(cwd.clone());
@@ -12869,7 +12874,7 @@ mod tests {
             cli_source: CliSource::Claude,
             pane_session_id: "p".into(),
             cwd: real_cwd.clone(),
-            title: "t".into(),
+            title: "Fix the build".into(),
         });
         app.agent_sessions.apply(SessionEvent::SessionStopped {
             key: "abc-123".into(),
@@ -12893,6 +12898,11 @@ mod tests {
             !argv.contains("split-pane"),
             "argv must NOT use split-pane: {}",
             argv
+        );
+        assert!(
+            cmd.argv.windows(2).any(|args| args == ["--title", "Fix the build"]),
+            "resume tab must use the session title: {:?}",
+            cmd.argv
         );
         // The CLI invocation is still wrapped in `cmd /c` so .cmd shims
         // resolve via PATHEXT, but the legacy `cd /d` prefix is gone —
@@ -17036,6 +17046,7 @@ mod tests {
         assert_eq!(known_cli_id(&CliSource::Codex),   Some("codex"));
         assert_eq!(known_cli_id(&CliSource::Copilot), Some("copilot"));
         assert_eq!(known_cli_id(&CliSource::Gemini),  Some("gemini"));
+        assert_eq!(known_cli_id(&CliSource::OpenCode), Some("opencode"));
     }
 
     #[test]

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -1212,12 +1212,13 @@ async fn run_probe_wsl_sessions(cli: Option<&str>) -> Result<()> {
         Some("claude") => Some(CliSource::Claude),
         Some("codex") => Some(CliSource::Codex),
         Some("gemini") => Some(CliSource::Gemini),
+        Some("opencode") => Some(CliSource::OpenCode),
         Some(other) => {
             // Reject unknown values rather than silently widening to "scan all"
             // (Unknown → clis_to_scan → every built-in), which would make the
             // diagnostic's output contradict the requested restriction.
             anyhow::bail!(
-                "unknown --cli value {other:?}; expected one of: copilot, claude, codex, gemini"
+                "unknown --cli value {other:?}; expected one of: copilot, claude, codex, gemini, opencode"
             );
         }
     };
@@ -1711,6 +1712,7 @@ fn cli_source_label(source: Option<&agent_sessions::CliSource>) -> String {
         Some(agent_sessions::CliSource::Codex)   => "Codex".to_string(),
         Some(agent_sessions::CliSource::Copilot) => "Copilot".to_string(),
         Some(agent_sessions::CliSource::Gemini)  => "Gemini".to_string(),
+        Some(agent_sessions::CliSource::OpenCode) => "OpenCode".to_string(),
         Some(agent_sessions::CliSource::Unknown(s)) if !s.is_empty() => s.clone(),
         _ => "-".to_string(),
     }

--- a/tools/wta/src/session_history.rs
+++ b/tools/wta/src/session_history.rs
@@ -65,6 +65,7 @@ pub(crate) fn cli_label(cli: &CliSource) -> &'static str {
         CliSource::Claude => "claude",
         CliSource::Codex => "codex",
         CliSource::Gemini => "gemini",
+        CliSource::OpenCode => "opencode",
         CliSource::Unknown(_) => "agent",
     }
 }

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -631,6 +631,7 @@ impl From<&crate::agent_sessions::CliSource> for SessionHookCliSource {
             crate::agent_sessions::CliSource::Codex => Self::Known("Codex".to_string()),
             crate::agent_sessions::CliSource::Copilot => Self::Known("Copilot".to_string()),
             crate::agent_sessions::CliSource::Gemini => Self::Known("Gemini".to_string()),
+            crate::agent_sessions::CliSource::OpenCode => Self::Known("OpenCode".to_string()),
             crate::agent_sessions::CliSource::Unknown(value) => Self::Unknown {
                 value: value.clone(),
             },
@@ -646,6 +647,7 @@ impl From<SessionHookCliSource> for crate::agent_sessions::CliSource {
                 "Codex"  | "codex"  => Self::Codex,
                 "Copilot" | "copilot" => Self::Copilot,
                 "Gemini" | "gemini" => Self::Gemini,
+                "OpenCode" | "opencode" => Self::OpenCode,
                 other => Self::Unknown(other.to_string()),
             },
             SessionHookCliSource::Unknown { value } => Self::Unknown(value),
@@ -3225,6 +3227,15 @@ mod tests {
         let wire = SessionHookCliSource::Known("codex".to_string());
         let typed: CliSource = wire.into();
         assert_eq!(typed, CliSource::Codex);
+    }
+
+    #[test]
+    fn session_hook_cli_source_round_trips_opencode() {
+        use crate::agent_sessions::CliSource;
+        let wire: SessionHookCliSource = (&CliSource::OpenCode).into();
+        assert!(matches!(wire, SessionHookCliSource::Known(ref s) if s == "OpenCode"));
+        let typed: CliSource = wire.into();
+        assert_eq!(typed, CliSource::OpenCode);
     }
 
     #[test]

--- a/tools/wta/src/ui/agents_view.rs
+++ b/tools/wta/src/ui/agents_view.rs
@@ -446,7 +446,7 @@ fn badge_style(s: &AgentSession) -> Style {
     }
 }
 
-/// Show the CLI provider (`claude`, `codex`, `copilot`, `gemini`) only on the
+/// Show the CLI provider (`claude`, `codex`, `copilot`, `gemini`, `opencode`) only on the
 /// active row or the keyboard-selected row — matches the Figma where the
 /// agent icon appears only on the currently-engaged session and avoids
 /// cluttering the historical list.
@@ -460,6 +460,7 @@ fn cli_suffix_for(s: &AgentSession, selected: bool) -> String {
         CliSource::Codex => "codex",
         CliSource::Copilot => "copilot",
         CliSource::Gemini => "gemini",
+        CliSource::OpenCode => "opencode",
         CliSource::Unknown(_) => return String::new(),
     };
     format!("· {}", label)

--- a/tools/wta/src/wsl_acp.rs
+++ b/tools/wta/src/wsl_acp.rs
@@ -95,7 +95,7 @@ pub(crate) async fn scan_running_distros_acp(cli: Option<&CliSource>) -> Vec<Age
 
 /// Which CLIs to query for a given filter. Known ACP-capable CLIs map to
 /// themselves. `None` (the all-CLI session view) and custom/unknown agents both
-/// map to "scan the built-in ACP-capable CLIs" (copilot, claude, codex) — WTA
+/// map to "scan the built-in ACP-capable CLIs" (copilot, claude, codex, opencode) — WTA
 /// has no bespoke launch command for a custom agent inside a distro, so it falls
 /// back to the known set. Gemini is always excluded: it has no ACP
 /// `session/list`.
@@ -105,10 +105,16 @@ fn clis_to_scan(cli: Option<&CliSource>) -> Vec<CliSource> {
         Some(CliSource::Claude) => vec![CliSource::Claude],
         Some(CliSource::Codex) => vec![CliSource::Codex],
         Some(CliSource::Gemini) => Vec::new(),
+        Some(CliSource::OpenCode) => vec![CliSource::OpenCode],
         // `None` = the all-CLI view; a custom/unknown agent likewise maps
         // to "scan the known ACP-capable built-ins".
         None | Some(CliSource::Unknown(_)) => {
-            vec![CliSource::Copilot, CliSource::Claude, CliSource::Codex]
+            vec![
+                CliSource::Copilot,
+                CliSource::Claude,
+                CliSource::Codex,
+                CliSource::OpenCode,
+            ]
         }
     }
 }
@@ -172,6 +178,7 @@ fn acp_command_for(cli: &CliSource) -> Option<String> {
         CliSource::Copilot => "copilot",
         CliSource::Claude => "claude",
         CliSource::Codex => "codex",
+        CliSource::OpenCode => "opencode",
         CliSource::Gemini | CliSource::Unknown(_) => return None,
     };
     Some(crate::agent_registry::build_acp_command(id, None))
@@ -246,18 +253,32 @@ mod tests {
             clis_to_scan(Some(&CliSource::Codex)),
             vec![CliSource::Codex]
         );
+        assert_eq!(
+            clis_to_scan(Some(&CliSource::OpenCode)),
+            vec![CliSource::OpenCode]
+        );
         // Gemini has no ACP session/list → never queried.
         assert!(clis_to_scan(Some(&CliSource::Gemini)).is_empty());
-        // None / custom → the three ACP-capable built-ins (no Gemini).
+        // None / custom → all ACP-capable built-ins (no Gemini).
         let all = clis_to_scan(None);
         assert_eq!(
             all,
-            vec![CliSource::Copilot, CliSource::Claude, CliSource::Codex]
+            vec![
+                CliSource::Copilot,
+                CliSource::Claude,
+                CliSource::Codex,
+                CliSource::OpenCode,
+            ]
         );
         assert!(!all.contains(&CliSource::Gemini));
         assert_eq!(
             clis_to_scan(Some(&CliSource::Unknown("custom:x".into()))),
-            vec![CliSource::Copilot, CliSource::Claude, CliSource::Codex]
+            vec![
+                CliSource::Copilot,
+                CliSource::Claude,
+                CliSource::Codex,
+                CliSource::OpenCode,
+            ]
         );
     }
 
@@ -274,6 +295,10 @@ mod tests {
         assert_eq!(
             acp_command_for(&CliSource::Codex).as_deref(),
             Some("npx -y @agentclientprotocol/codex-acp@1.1.0")
+        );
+        assert_eq!(
+            acp_command_for(&CliSource::OpenCode).as_deref(),
+            Some("opencode acp")
         );
         assert!(acp_command_for(&CliSource::Gemini).is_none());
         assert!(acp_command_for(&CliSource::Unknown("x".into())).is_none());


### PR DESCRIPTION
## Summary
- recognize OpenCode as a first-class session source instead of degrading it to `Unknown`
- resume OpenCode history with `opencode --session <id>` and support ACP session discovery in WSL
- use the stored session title for newly opened resume tabs

## Testing
- `cargo test --manifest-path tools/wta/Cargo.toml`
- manually resumed an OpenCode session from `/sessions`