### PR TITLE
Align selection styling across agent pane pickers

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -7684,6 +7684,7 @@ impl App {
         Some(crate::ui::PopupState {
             candidates,
             selected: tab.command_popup_selected,
+            pane_focused: self.pane_focused,
             current_model: self.current_model_display(),
         })
     }
@@ -7757,6 +7758,7 @@ impl App {
         Some(crate::ui::ModelPopupState {
             models: &self.available_models,
             selected: tab.model_picker_selected,
+            pane_focused: self.pane_focused,
             current_id,
         })
     }
@@ -7769,6 +7771,7 @@ impl App {
         Some(crate::ui::AgentPopupState {
             agents: &self.available_agents,
             selected: tab.agent_picker_selected,
+            pane_focused: self.pane_focused,
             current_id: &self.current_agent_id,
         })
     }

--- a/tools/wta/src/theme.rs
+++ b/tools/wta/src/theme.rs
@@ -18,17 +18,11 @@ pub const IN_PROGRESS: Style = Style::new()
     .add_modifier(Modifier::BOLD)
     .add_modifier(Modifier::ITALIC);
 pub const DIM: Style = Style::new().fg(Color::DarkGray);
-pub const SELECTED: Style = Style::new()
-    .fg(Color::Black)
-    .bg(Color::Yellow)
-    .add_modifier(Modifier::BOLD);
-// Selected row while the pane is unfocused: same shape, muted to a gray bar
-// so the selection is preserved (and restored on refocus) without reading as
-// the live, active target. Light foreground keeps it legible on the dim bg.
-pub const SELECTED_INACTIVE: Style = Style::new()
-    .fg(Color::White)
-    .bg(Color::DarkGray)
-    .add_modifier(Modifier::BOLD);
+// Match the /sessions cursor: cyan foreground with no full-row background.
+pub const SELECTED: Style = Style::new().fg(Color::Cyan);
+// Preserve the selection when the pane loses focus without presenting it as
+// the active keyboard target.
+pub const SELECTED_INACTIVE: Style = Style::new().fg(Color::DarkGray);
 pub const DEBUG_SENT: Style = Style::new().fg(Color::Green);
 pub const DEBUG_RECEIVED: Style = Style::new().fg(Color::Cyan);
 pub const RECOMMENDATION_TITLE: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);

--- a/tools/wta/src/theme.rs
+++ b/tools/wta/src/theme.rs
@@ -22,7 +22,9 @@ pub const DIM: Style = Style::new().fg(Color::DarkGray);
 pub const SELECTED: Style = Style::new().fg(Color::Cyan);
 // Preserve the selection when the pane loses focus without presenting it as
 // the active keyboard target.
-pub const SELECTED_INACTIVE: Style = Style::new().fg(Color::DarkGray);
+pub const SELECTED_INACTIVE: Style = Style::new()
+    .fg(Color::Cyan)
+    .add_modifier(Modifier::DIM);
 pub const DEBUG_SENT: Style = Style::new().fg(Color::Green);
 pub const DEBUG_RECEIVED: Style = Style::new().fg(Color::Cyan);
 pub const RECOMMENDATION_TITLE: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);

--- a/tools/wta/src/ui/agent_popup.rs
+++ b/tools/wta/src/ui/agent_popup.rs
@@ -14,6 +14,7 @@ const CURRENT_PAD: &str = "  ";
 pub struct AgentPopupState<'a> {
     pub agents: &'a [AvailableAgent],
     pub selected: usize,
+    pub pane_focused: bool,
     pub current_id: &'a str,
 }
 
@@ -46,9 +47,14 @@ pub fn render_popup(frame: &mut Frame, state: AgentPopupState<'_>, input_area: R
         })
         .collect();
 
+    let selected_style = if state.pane_focused {
+        theme::SELECTED
+    } else {
+        theme::SELECTED_INACTIVE
+    };
     let list = List::new(items)
         .block(popup::block(t!("agent_picker.title").into_owned()))
-        .highlight_style(theme::SELECTED)
+        .highlight_style(selected_style)
         .highlight_symbol("> ");
     let mut list_state = ListState::default();
     list_state.select(Some(state.selected.min(state.agents.len() - 1)));

--- a/tools/wta/src/ui/agents_view.rs
+++ b/tools/wta/src/ui/agents_view.rs
@@ -12,12 +12,12 @@ use crate::agent_sessions::{
     AgentSession, AgentSessionRegistry, AgentStatus, CliSource, OriginFilter, SessionOrigin,
 };
 use crate::session_registry::SessionInfo;
+use crate::theme;
 use crate::ui::shimmer;
 
 // Status accents use named ANSI colors (not fixed RGB from Figma) so they map
 // through the active color scheme and stay readable on light schemes too — a
 // hardcoded bright yellow/cyan washed out on a light background (#234).
-const ACCENT_CYAN: Color = Color::Cyan; // Selected-row title / cursor
 const ACCENT_GREEN: Color = Color::Green; // Active status badge
 const ACCENT_YELLOW: Color = Color::Yellow; // Waiting for input
 const ACCENT_RED: Color = Color::Red; // Error
@@ -46,6 +46,7 @@ pub fn render(
     // even when the list already has rows. Caller (ui::layout) computes it from
     // `refetch_in_flight && (snapshot.is_empty() || rescan_in_flight)`.
     show_loading: bool,
+    pane_focused: bool,
 ) {
     // No in-TUI header: the "Agent sessions" title lives in the C++ agent
     // bar above this pane (AgentPaneContent::SetSessionsView), so we render
@@ -178,7 +179,7 @@ pub fn render(
     // list also gives F5 an unmistakable "refreshing now" signal even when rows
     // are already present.
     if show_loading {
-        render_left_bar(f, area.x, list_area, None);
+        render_left_bar(f, area.x, list_area, None, pane_focused);
         let mut spans: Vec<Span<'static>> = vec![Span::raw("  ")];
         let loading_label = t!("agents.loading").into_owned();
         spans.extend(shimmer::shimmer_spans(&loading_label, activity_frame));
@@ -195,7 +196,7 @@ pub fn render(
     let rows: Vec<ListItem> = sorted
         .iter()
         .enumerate()
-        .map(|(i, s)| row_for(s, Some(i) == selected, row_width))
+        .map(|(i, s)| row_for(s, Some(i) == selected, pane_focused, row_width))
         .collect();
 
     // No `highlight_style` — selection is conveyed by the `>` prefix and
@@ -212,7 +213,7 @@ pub fn render(
     let selected_visible_row = selected
         .and_then(|s| s.checked_sub(offset))
         .filter(|v| (*v as u16) < list_area.height);
-    render_left_bar(f, area.x, list_area, selected_visible_row);
+    render_left_bar(f, area.x, list_area, selected_visible_row, pane_focused);
 
     if let Some(hint_area) = hint_area {
         render_footer_hint(f, hint_area);
@@ -224,14 +225,24 @@ pub fn render(
 /// `selected_row`, when set, is the list-relative row index whose bar
 /// segment paints cyan instead of muted, mirroring the selection cursor
 /// in the row itself.
-fn render_left_bar(f: &mut Frame, bar_x: u16, list_area: Rect, selected_row: Option<usize>) {
+fn render_left_bar(
+    f: &mut Frame,
+    bar_x: u16,
+    list_area: Rect,
+    selected_row: Option<usize>,
+    pane_focused: bool,
+) {
     if list_area.height == 0 {
         return;
     }
     let bar_lines: Vec<Line<'static>> = (0..list_area.height)
         .map(|i| {
             let style = if Some(i as usize) == selected_row {
-                Style::default().fg(ACCENT_CYAN)
+                if pane_focused {
+                    theme::SELECTED
+                } else {
+                    theme::SELECTED_INACTIVE
+                }
             } else {
                 Style::default().fg(MUTED_WHITE)
             };
@@ -267,7 +278,12 @@ fn render_footer_hint(f: &mut Frame, area: Rect) {
     );
 }
 
-fn row_for(s: &AgentSession, selected: bool, row_width: usize) -> ListItem<'static> {
+fn row_for(
+    s: &AgentSession,
+    selected: bool,
+    pane_focused: bool,
+    row_width: usize,
+) -> ListItem<'static> {
     let origin_prefix = origin_prefix_for(s);
     let prefix_w = origin_prefix
         .as_deref()
@@ -290,7 +306,11 @@ fn row_for(s: &AgentSession, selected: bool, row_width: usize) -> ListItem<'stat
     // an unselected Working session still gets a cyan "Active" badge but
     // its title stays the default foreground.
     let title_style = if selected {
-        Style::default().fg(ACCENT_CYAN)
+        if pane_focused {
+            theme::SELECTED
+        } else {
+            theme::SELECTED_INACTIVE
+        }
     } else {
         Style::default()
     };
@@ -298,12 +318,7 @@ fn row_for(s: &AgentSession, selected: bool, row_width: usize) -> ListItem<'stat
     // Leftmost column: `>` cursor for the selected row, blank otherwise.
     // Two cells (caret + space) so titles line up regardless of selection.
     let caret = if selected {
-        Span::styled(
-            "> ",
-            Style::default()
-                .fg(ACCENT_CYAN)
-                .add_modifier(Modifier::BOLD),
-        )
+        Span::styled("> ", title_style.add_modifier(Modifier::BOLD))
     } else {
         Span::raw("  ")
     };

--- a/tools/wta/src/ui/agents_view.rs
+++ b/tools/wta/src/ui/agents_view.rs
@@ -318,7 +318,12 @@ fn row_for(
     // Leftmost column: `>` cursor for the selected row, blank otherwise.
     // Two cells (caret + space) so titles line up regardless of selection.
     let caret = if selected {
-        Span::styled("> ", title_style.add_modifier(Modifier::BOLD))
+        let caret_style = if pane_focused {
+            title_style.add_modifier(Modifier::BOLD)
+        } else {
+            title_style
+        };
+        Span::styled("> ", caret_style)
     } else {
         Span::raw("  ")
     };

--- a/tools/wta/src/ui/command_popup.rs
+++ b/tools/wta/src/ui/command_popup.rs
@@ -22,6 +22,7 @@ const POPUP_MAX_VISIBLE: usize = 6;
 pub struct PopupState<'a> {
     pub candidates: PopupCandidates<'a>,
     pub selected: usize,
+    pub pane_focused: bool,
     /// Effective model for the active pane (per-pane `/model` override, else
     /// the global one). Appended to the `/model` row so the user sees what
     /// they're currently on while typing the command. `None` when no model
@@ -85,9 +86,14 @@ pub fn render_popup(frame: &mut Frame, state: PopupState<'_>, input_area: Rect) 
             .collect(),
     };
 
+    let selected_style = if state.pane_focused {
+        theme::SELECTED
+    } else {
+        theme::SELECTED_INACTIVE
+    };
     let list = List::new(items)
         .block(popup::block(t!("commands.popup_title").into_owned()))
-        .highlight_style(theme::SELECTED)
+        .highlight_style(selected_style)
         .highlight_symbol("> ");
 
     let mut list_state = ListState::default();

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -50,6 +50,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         let activity_frame = app.activity_frame as usize;
         let cli_filter = app.current_cli_filter();
         let origin_filter = app.sessions_origin_filter;
+        let pane_focused = app.pane_focused;
         let tab = app.tab_sessions.entry(tab_id).or_default();
         // Show the loading shimmer while waiting on the very first
         // `session/list` response from master (empty placeholder snapshot +
@@ -74,6 +75,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             cli_filter.as_ref(),
             origin_filter,
             show_loading,
+            pane_focused,
         );
         return;
     }

--- a/tools/wta/src/ui/model_popup.rs
+++ b/tools/wta/src/ui/model_popup.rs
@@ -24,6 +24,7 @@ const CURRENT_PAD: &str = "  ";
 pub struct ModelPopupState<'a> {
     pub models: &'a [AcpModelInfo],
     pub selected: usize,
+    pub pane_focused: bool,
     /// Id of the model the pane is currently effectively on, if any — drawn
     /// with a leading marker so the user can see "where we are".
     pub current_id: Option<&'a str>,
@@ -62,9 +63,14 @@ pub fn render_popup(frame: &mut Frame, state: ModelPopupState<'_>, input_area: R
         })
         .collect();
 
+    let selected_style = if state.pane_focused {
+        theme::SELECTED
+    } else {
+        theme::SELECTED_INACTIVE
+    };
     let list = List::new(items)
         .block(popup::block(t!("model_picker.title").into_owned()))
-        .highlight_style(theme::SELECTED)
+        .highlight_style(selected_style)
         .highlight_symbol("> ");
 
     let mut list_state = ListState::default();


### PR DESCRIPTION
## Summary
- align command, model, and agent picker selection with the /sessions cyan foreground treatment
- align completed prompt selection while retaining a muted inactive state
- leave Autofix, permission, and setup selection styling unchanged

## Testing
- cargo test --manifest-path tools/wta/Cargo.toml (1111 passed)
- manually launched the deployed Debug package for visual testing
<img width="1489" height="386" alt="image" src="https://github.com/user-attachments/assets/aaba49d8-1f29-4bf6-be00-4135eb21285c" />
<img width="431" height="149" alt="image" src="https://github.com/user-attachments/assets/fa41178c-43d6-4583-8cce-c0a454042042" />
<img width="1017" height="287" alt="image" src="https://github.com/user-attachments/assets/a8cea40f-a3b8-4c2f-8df3-606a92560513" />
When lose focus:
<img width="1363" height="724" alt="image" src="https://github.com/user-attachments/assets/c2261b51-9048-4aee-88ea-1eb52a1052b0" />

Fixes #465