### PR TITLE
Pin session IDs for structured recommendation agent launches

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1344,6 +1344,9 @@ pub enum AppEvent {
     AgentsSnapshotFailed {
         request_id: u64,
     },
+    RegisterBornBoundSession {
+        event: crate::agent_sessions::SessionEvent,
+    },
     MasterMutationCompleted {
         request_id: u64,
     },
@@ -4556,6 +4559,7 @@ impl App {
             AppEvent::SessionsChanged => "sessions_changed",
             AppEvent::AgentsSnapshotLoaded { .. } => "agents_snapshot_loaded",
             AppEvent::AgentsSnapshotFailed { .. } => "agents_snapshot_failed",
+            AppEvent::RegisterBornBoundSession { .. } => "register_born_bound_session",
             AppEvent::MasterMutationCompleted { .. } => "master_mutation_completed",
             AppEvent::RevealTick => "reveal_tick",
         }
@@ -5608,6 +5612,22 @@ impl App {
             }
             AppEvent::AgentsSnapshotFailed { request_id } => {
                 self.handle_agents_snapshot_failed(request_id);
+            }
+            AppEvent::RegisterBornBoundSession { event } => {
+                if self
+                    .master_request_tx
+                    .send(
+                        crate::protocol::acp::client::MasterExtRequest::SessionBornBound {
+                            event,
+                        },
+                    )
+                    .is_err()
+                {
+                    tracing::warn!(
+                        target: "coordinator",
+                        "born-bound registration queue is unavailable",
+                    );
+                }
             }
             AppEvent::MasterMutationCompleted { request_id } => {
                 tracing::debug!(target: "agents_view", request_id, "master mutation completed; refetching open views");
@@ -12048,6 +12068,35 @@ mod tests {
         }
         assert!(app.current_tab().agents_view.snapshot.is_some());
         assert!(app.current_tab().agents_view.refetch_in_flight);
+    }
+
+    #[test]
+    fn born_bound_registration_uses_current_master_request_sender() {
+        let (mut app, mut old_master_rx) = test_app_with_master_rx();
+        let (new_master_tx, mut new_master_rx) = tokio::sync::mpsc::unbounded_channel();
+        app.master_request_tx = new_master_tx;
+        let event = crate::agent_sessions::SessionEvent::SessionStarted {
+            key: "sid".to_string(),
+            cli_source: crate::agent_sessions::CliSource::Copilot,
+            pane_session_id: "pane".to_string(),
+            cwd: std::path::PathBuf::from("C:\\repo"),
+            title: String::new(),
+        };
+
+        app.handle_event(AppEvent::RegisterBornBoundSession {
+            event: event.clone(),
+        });
+
+        assert!(old_master_rx.try_recv().is_err());
+        match new_master_rx
+            .try_recv()
+            .expect("registration should use the replacement sender")
+        {
+            crate::protocol::acp::client::MasterExtRequest::SessionBornBound {
+                event: actual,
+            } => assert_eq!(actual, event),
+            other => panic!("expected SessionBornBound, got {other:?}"),
+        }
     }
 
     #[test]

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -335,7 +335,15 @@ pub async fn run_recommendation_executor(
 ) {
     while let Some(exec) = rx.recv().await {
         let delegate_agents = delegate_agents.lock().unwrap().clone();
-        match execute_choice(&exec.choice, exec.insert_only, &shell_mgr, &delegate_agents, &event_tx).await {
+        match execute_choice(
+            &exec.choice,
+            exec.insert_only,
+            &shell_mgr,
+            &delegate_agents,
+            &event_tx,
+        )
+        .await
+        {
             Ok(()) => {}
             Err(err) => {
                 let err_str = format!("{:#}", err);
@@ -448,8 +456,24 @@ async fn execute_choice(
                     Some(name) => format!("Opening {} for {}.", target_label, name),
                     None => format!("Opening {}.", target_label),
                 }));
+                let pinned_session_id = runtime.and_then(|runtime| {
+                    pinned_session_id_for_runtime(
+                        runtime,
+                        delegate_command_launchable(&runtime.commandline),
+                    )
+                });
+                coordinator_log(&format!(
+                    "open_and_send pin decision agent={:?} pinned_session_id={:?}",
+                    agent, pinned_session_id
+                ));
                 let commandline = runtime
-                    .map(|runtime| build_delegate_launch_commandline(runtime, Some(input), None))
+                    .map(|runtime| {
+                        build_delegate_launch_commandline(
+                            runtime,
+                            Some(input),
+                            pinned_session_id.as_deref(),
+                        )
+                    })
                     .transpose()?;
                 let pane_id = match target {
                     OpenTarget::Tab => {
@@ -499,6 +523,37 @@ async fn execute_choice(
                     "Opened {} pane {}.",
                     target_label, pane_id
                 )));
+                if let (Some(session_id), Some(runtime)) =
+                    (pinned_session_id.as_deref(), runtime)
+                {
+                    let event = crate::agent_sessions::SessionEvent::SessionStarted {
+                        key: session_id.to_string(),
+                        cli_source: crate::agent_sessions::CliSource::from(
+                            crate::session_registry::SessionHookCliSource::Known(
+                                runtime.id.clone(),
+                            ),
+                        ),
+                        pane_session_id: pane_id.clone(),
+                        cwd: cwd
+                            .as_deref()
+                            .map(std::path::PathBuf::from)
+                            .unwrap_or_default(),
+                        title: String::new(),
+                    };
+                    coordinator_log(&format!(
+                        "open_and_send born-bound registering session_id={} pane={} cli={}",
+                        session_id, pane_id, runtime.id
+                    ));
+                    if event_tx
+                        .send(AppEvent::RegisterBornBoundSession { event })
+                        .is_err()
+                    {
+                        tracing::warn!(
+                            target: "coordinator",
+                            "born-bound registration event queue is unavailable",
+                        );
+                    }
+                }
                 if matches!(delivery_mode, DelegatePromptDelivery::LaunchThenSend) {
                     send_input_to_new_pane(shell_mgr, &pane_id, input, event_tx).await?;
                 } else {
@@ -678,6 +733,21 @@ fn lookup_delegate_agent<'a>(
         .find(|agent| agent.id == id)
         .or_else(|| delegate_agents.first())
         .ok_or_else(|| anyhow!("no delegate agent configured"))
+}
+
+fn pinned_session_id_for_runtime(
+    runtime: &DelegateAgentRuntime,
+    launchable: bool,
+) -> Option<String> {
+    if !launchable {
+        return None;
+    }
+
+    agent_registry::lookup_profile_by_id(agent_registry::resolve_agent_id_from_cmd(
+        &runtime.commandline,
+    ))
+    .new_session_id_flag
+    .map(|_| uuid::Uuid::new_v4().to_string())
 }
 
 /// Build the delegate launch command line, optionally pinning a session id.
@@ -1591,9 +1661,10 @@ mod tests {
         build_windows_powershell_base64_launch, build_wsl_delegate_commandline,
         default_delegate_agent_runtimes, escape_for_intermediate_shell,
         is_direct_known_agent_command, parse_autofix_response, parse_recommendation_set,
-        pwsh_available, resolve_agent_profile, resolve_created_pane_id, sanitize_windows_agent_cwd,
-        validate_recommendation_set_for_coordinator_target, AutofixDecision, DelegateAgentRuntime,
-        DelegatePromptDelivery, OpenTarget, RecommendedAction,
+        pinned_session_id_for_runtime, pwsh_available, resolve_agent_profile,
+        resolve_created_pane_id, sanitize_windows_agent_cwd,
+        validate_recommendation_set_for_coordinator_target, AutofixDecision,
+        DelegateAgentRuntime, DelegatePromptDelivery, OpenTarget, RecommendedAction,
     };
     use serde_json::json;
     use std::os::windows::process::CommandExt;
@@ -1848,6 +1919,64 @@ mod tests {
             build_delegate_launch_commandline_with_session(&runtime, Some("hi"), None).unwrap();
 
         assert!(!commandline.contains("--session-id"));
+    }
+
+    #[test]
+    fn recommendation_launch_generates_session_id_for_copilot() {
+        let runtime = DelegateAgentRuntime {
+            id: "copilot".to_string(),
+            name: "Copilot".to_string(),
+            description: String::new(),
+            commandline: "copilot".to_string(),
+            prompt_delivery: DelegatePromptDelivery::LaunchWithStartupPrompt,
+            model: None,
+        };
+
+        let session_id = pinned_session_id_for_runtime(&runtime, true)
+            .expect("copilot should support pinning");
+        assert!(uuid::Uuid::parse_str(&session_id).is_ok());
+    }
+
+    #[test]
+    fn recommendation_launch_skips_session_id_for_codex() {
+        let runtime = DelegateAgentRuntime {
+            id: "codex".to_string(),
+            name: "Codex".to_string(),
+            description: String::new(),
+            commandline: "codex".to_string(),
+            prompt_delivery: DelegatePromptDelivery::LaunchWithStartupPrompt,
+            model: None,
+        };
+
+        assert!(pinned_session_id_for_runtime(&runtime, true).is_none());
+    }
+
+    #[test]
+    fn recommendation_launch_resolves_adapter_before_pinning() {
+        let runtime = DelegateAgentRuntime {
+            id: "claude".to_string(),
+            name: "Claude".to_string(),
+            description: String::new(),
+            commandline: "npx -y @agentclientprotocol/claude-agent-acp".to_string(),
+            prompt_delivery: DelegatePromptDelivery::LaunchWithStartupPrompt,
+            model: None,
+        };
+
+        assert!(pinned_session_id_for_runtime(&runtime, true).is_some());
+    }
+
+    #[test]
+    fn recommendation_launch_skips_session_id_when_agent_is_unavailable() {
+        let runtime = DelegateAgentRuntime {
+            id: "copilot".to_string(),
+            name: "Copilot".to_string(),
+            description: String::new(),
+            commandline: "copilot".to_string(),
+            prompt_delivery: DelegatePromptDelivery::LaunchWithStartupPrompt,
+            model: None,
+        };
+
+        assert!(pinned_session_id_for_runtime(&runtime, false).is_none());
     }
 
     #[test]

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -178,6 +178,9 @@ pub enum MasterExtRequest {
         /// returning the cached registry snapshot.
         rescan: bool,
     },
+    SessionBornBound {
+        event: crate::agent_sessions::SessionEvent,
+    },
     SessionResumeDispatched {
         request_id: u64,
         sid: acp::schema::v1::SessionId,
@@ -2904,6 +2907,31 @@ fn dispatch_master_ext_request(
                         );
                         let _ = event_tx.send(AppEvent::AgentsSnapshotFailed { request_id });
                     }
+                }
+            }
+            MasterExtRequest::SessionBornBound { event } => {
+                const BORN_BOUND_TIMEOUT: std::time::Duration =
+                    std::time::Duration::from_secs(8);
+                let wire = crate::session_registry::build_born_bound_request(&event);
+                match tokio::time::timeout(BORN_BOUND_TIMEOUT, conn.ext_method(wire)).await {
+                    Ok(Ok(response)) => tracing::debug!(
+                        target: "session_hook",
+                        event = ?event,
+                        response = %response.0.get(),
+                        "born-bound registration sent to master"
+                    ),
+                    Ok(Err(err)) => tracing::warn!(
+                        target: "session_hook",
+                        event = ?event,
+                        error = ?err,
+                        "born-bound registration ext-request failed"
+                    ),
+                    Err(_) => tracing::warn!(
+                        target: "session_hook",
+                        event = ?event,
+                        timeout_secs = BORN_BOUND_TIMEOUT.as_secs(),
+                        "born-bound registration timed out"
+                    ),
                 }
             }
             MasterExtRequest::SessionResumeDispatched { request_id, sid } => {


### PR DESCRIPTION
## What & why

When a recommendation-card `open_and_send` action launches a structured delegate agent, WTA currently lets the CLI generate a random session ID and waits for hooks to discover and bind it. This leaves the session temporarily untracked and drops it entirely when hooks are unavailable.

Pin a WTA-generated session ID for launchable agents that advertise a new-session ID flag, then born-bound-register the created pane immediately.

## Changes

- Generate a UUID for structured Copilot, Claude, and Gemini recommendation launches and pass it through the existing delegate command builder as `--session-id`.
- Skip pinning for unavailable agents and agents without new-session ID support, including Codex, OpenCode, and custom/unknown runtimes.
- Route born-bound registration through the App's current helper-to-master ACP channel so it survives authentication reconnects and does not block recommendation execution.
- Bound the registration RPC with an 8-second timeout.
- Add coverage for supported, unsupported, unavailable, adapter-based, and reconnect sender paths.

## Scope

- `agent=None` remains unchanged; WTA does not infer agent identity from free-form shell input.
- No planner prompt changes are included.

## Testing

- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`