### PR TITLE
Support WSL ACP agent sources in agent panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,13 @@ Inside the agent pane, type `/` to see available commands. Type `/help` at any t
 | `/restart` | Restart the agent with a clean session |
 | `/stop` | Cancel the in-flight prompt |
 | `/sessions` | Open agent management (same as <kbd>Ctrl+Shift+/</kbd>) |
+| `/agent [id]` | Pick the agent source for this tab. In a WSL pane, the picker includes agents installed on Windows and in that pane's WSL distro; it never offers other distros. |
 | `/model [id]` | Pick the model for this pane; bare `/model` opens a picker, `/model <id>` switches directly |
+
+When a WSL agent source is selected, its ACP server and terminal tools run
+inside that distro. The selection is scoped to the current tab. If the default
+Windows agent is unavailable, use **Select agent** on the agent-pane setup
+screen to choose an agent installed in the current WSL distro.
 
 ### Agent Management
 

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -138,20 +138,28 @@ namespace winrt::TerminalApp::implementation
         const winrt::hstring& AgentIdOverride() const noexcept { return _agentIdOverride; }
         const winrt::hstring& AgentModelOverride() const noexcept { return _agentModelOverride; }
         const winrt::hstring& AgentCustomCommandOverride() const noexcept { return _agentCustomCommandOverride; }
+        const winrt::hstring& AgentSourceOverride() const noexcept { return _agentSourceOverride; }
+        const winrt::hstring& AgentWslDistroOverride() const noexcept { return _agentWslDistroOverride; }
         bool HasAgentOverride() const noexcept { return !_agentIdOverride.empty(); }
         void SetAgentOverride(const winrt::hstring& agentId,
                               const winrt::hstring& model,
-                              const winrt::hstring& customCommand)
+                              const winrt::hstring& customCommand,
+                              const winrt::hstring& source = L"host",
+                              const winrt::hstring& wslDistro = {})
         {
             _agentIdOverride = agentId;
             _agentModelOverride = model;
             _agentCustomCommandOverride = customCommand;
+            _agentSourceOverride = source;
+            _agentWslDistroOverride = wslDistro;
         }
         void ClearAgentOverride() noexcept
         {
             _agentIdOverride = {};
             _agentModelOverride = {};
             _agentCustomCommandOverride = {};
+            _agentSourceOverride = {};
+            _agentWslDistroOverride = {};
         }
 
         // Stable per-tab identifier (GUID string). Survives tab reordering
@@ -243,6 +251,8 @@ namespace winrt::TerminalApp::implementation
         winrt::hstring _agentIdOverride{};
         winrt::hstring _agentModelOverride{};
         winrt::hstring _agentCustomCommandOverride{};
+        winrt::hstring _agentSourceOverride{};
+        winrt::hstring _agentWslDistroOverride{};
 
         winrt::Microsoft::Terminal::Settings::Model::IconStyle _lastIconStyle;
         winrt::hstring _lastIconPath{};

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1878,11 +1878,15 @@ namespace winrt::TerminalApp::implementation
         winrt::hstring effectiveAgentId;
         winrt::hstring effectiveModel;
         winrt::hstring agentCliPath;
+        winrt::hstring effectiveAgentSource{ L"host" };
+        winrt::hstring effectiveAgentWslDistro;
         const bool hasAgentOverride = tab->HasAgentOverride();
         if (hasAgentOverride)
         {
             effectiveAgentId = tab->AgentIdOverride();
             effectiveModel = tab->AgentModelOverride();
+            effectiveAgentSource = tab->AgentSourceOverride();
+            effectiveAgentWslDistro = tab->AgentWslDistroOverride();
             agentCliPath = _ResolveAgentCliPathForId(effectiveAgentId, effectiveModel, tab->AgentCustomCommandOverride());
         }
         // `_ResolveAgentCliPathForId` returns empty to signal "fall back"
@@ -1898,6 +1902,8 @@ namespace winrt::TerminalApp::implementation
         {
             effectiveAgentId = globals.EffectiveAcpAgent();
             effectiveModel = globals.AcpModel();
+            effectiveAgentSource = L"host";
+            effectiveAgentWslDistro = {};
             agentCliPath = _ResolveEffectiveAgentCliPath(globals, [this]() { return _DetectAgentCli(); });
             // When the global selection is absent/blocked,
             // _ResolveEffectiveAgentCliPath falls back to auto-detection and
@@ -2006,6 +2012,8 @@ namespace winrt::TerminalApp::implementation
         // master spawns/reuses the right agent CLI for THIS tab.
         appendHelperFlagValue(L"--agent", agentCliPath);
         appendHelperFlagValue(L"--agent-id", effectiveAgentId);
+        appendHelperFlagValue(L"--agent-source", effectiveAgentSource);
+        appendHelperFlagValue(L"--agent-wsl-distro", effectiveAgentWslDistro);
         {
             namespace Reg = ::Microsoft::Terminal::Settings::Model::AgentRegistry;
             std::wstring allowedIds;
@@ -2125,6 +2133,10 @@ namespace winrt::TerminalApp::implementation
             {
                 startingDirectory = winrt::hstring{ homePath };
             }
+        }
+        if (!startingDirectory.empty())
+        {
+            appendHelperFlagValue(L"--agent-source-cwd", startingDirectory);
         }
 
         NewTerminalArgs args;
@@ -4829,9 +4841,54 @@ namespace winrt::TerminalApp::implementation
 
         const auto tab = _FindTabByStableId(winrt::to_hstring(params["tab_id"].asString()));
         const auto agentId = winrt::to_hstring(params["agent_id"].asString());
+        const auto source = params.isMember("agent_source") && params["agent_source"].isString() ?
+                                winrt::to_hstring(params["agent_source"].asString()) :
+                                winrt::hstring{ L"host" };
+        const auto wslDistro = params.isMember("wsl_distro") && params["wsl_distro"].isString() ?
+                                   winrt::to_hstring(params["wsl_distro"].asString()) :
+                                   winrt::hstring{};
         if (!tab || agentId.empty())
         {
             return;
+        }
+        if (source != L"host" && source != L"wsl")
+        {
+            _agentPaneLog("OnAgentSwitchRequested: unknown agent source");
+            return;
+        }
+        if (source == L"wsl")
+        {
+            if (wslDistro.empty())
+            {
+                _agentPaneLog("OnAgentSwitchRequested: WSL source missing distro");
+                return;
+            }
+
+            auto effectivePane = tab->GetActivePane();
+            if (effectivePane && effectivePane->IsAgentPane())
+            {
+                if (const auto rootPane = tab->GetRootPane())
+                {
+                    rootPane->WalkTree([&](const auto& pane) {
+                        if (pane->IsSourceOfAgentPane())
+                        {
+                            effectivePane = pane;
+                        }
+                    });
+                }
+            }
+            winrt::Microsoft::Terminal::Control::TermControl control{ nullptr };
+            if (effectivePane)
+            {
+                control = effectivePane->GetTerminalControl();
+            }
+            std::wstring expectedShell{ L"wsl:" };
+            expectedShell.append(std::wstring_view{ wslDistro });
+            if (!control || control.ShellName() != expectedShell)
+            {
+                _agentPaneLog("OnAgentSwitchRequested: WSL source does not match the tab working pane");
+                return;
+            }
         }
 
         namespace Reg = ::Microsoft::Terminal::Settings::Model::AgentRegistry;
@@ -4853,12 +4910,18 @@ namespace winrt::TerminalApp::implementation
         const auto currentId = tab->HasAgentOverride() ?
                                    tab->AgentIdOverride() :
                                    _settings.GlobalSettings().EffectiveAcpAgent();
-        if (currentId == agentId)
+        const auto currentSource = tab->HasAgentOverride() ?
+                                       tab->AgentSourceOverride() :
+                                       winrt::hstring{ L"host" };
+        const auto currentWslDistro = tab->HasAgentOverride() ?
+                                          tab->AgentWslDistroOverride() :
+                                          winrt::hstring{};
+        if (currentId == agentId && currentSource == source && currentWslDistro == wslDistro)
         {
             return;
         }
 
-        tab->SetAgentOverride(agentId, winrt::hstring{}, winrt::hstring{});
+        tab->SetAgentOverride(agentId, winrt::hstring{}, winrt::hstring{}, source, wslDistro);
         _RebuildAgentPaneForTab(tab);
     }
 

--- a/tools/wta/src/agent_check.rs
+++ b/tools/wta/src/agent_check.rs
@@ -13,6 +13,8 @@
 use crate::agent_registry;
 
 const WSL_AGENT_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 // ─── Data types ─────────────────────────────────────────────────────────────
 
@@ -91,6 +93,13 @@ pub async fn find_wsl_exe(distro: &str, executable: &str) -> Option<String> {
         .arg(wsl_agent_probe_script(executable))
         .stdin(std::process::Stdio::null())
         .kill_on_drop(true);
+    // The probe runs from the interactive wta-helper. If wsl.exe attaches to
+    // that ConPTY it changes the console input mode on exit, after which
+    // crossterm receives arrow CSI sequences as literal '[' / 'B' characters
+    // and the entire agent-pane input appears frozen. Keep the probe off the
+    // helper's console; stdout/stderr are already captured through pipes.
+    #[cfg(windows)]
+    cmd.creation_flags(CREATE_NO_WINDOW);
 
     let output = match tokio::time::timeout(WSL_AGENT_PROBE_TIMEOUT, cmd.output()).await {
         Ok(Ok(output)) => output,

--- a/tools/wta/src/agent_check.rs
+++ b/tools/wta/src/agent_check.rs
@@ -12,6 +12,8 @@
 
 use crate::agent_registry;
 
+const WSL_AGENT_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 // ─── Data types ─────────────────────────────────────────────────────────────
 
 /// Status of a single agent, combining CLI detection and setup hints.
@@ -23,12 +25,13 @@ pub struct AgentStatus {
     pub cli_path: Option<String>,
     pub install_hint: String,
     pub auth_hint: String,
+    pub auto_installable: bool,
 }
 
 impl AgentStatus {
     /// Whether this agent can be auto-installed (e.g. via winget).
     pub fn can_auto_install(&self) -> bool {
-        self.id == "copilot"
+        self.auto_installable
     }
 }
 
@@ -66,6 +69,97 @@ pub fn find_exe(agent_id: &str) -> Option<String> {
     }
 
     None
+}
+
+/// Resolve a native Linux executable inside one WSL distro.
+///
+/// A login shell is required for npm-global, snap, and `~/.local/bin`
+/// installations. Windows executables leaked through WSL's appended Windows
+/// PATH are rejected so a source is never advertised when it cannot run with
+/// Linux dependencies.
+pub async fn find_wsl_exe(distro: &str, executable: &str) -> Option<String> {
+    if distro.trim().is_empty() || executable.trim().is_empty() {
+        return None;
+    }
+
+    let mut cmd = tokio::process::Command::new("wsl.exe");
+    cmd.arg("-d")
+        .arg(distro)
+        .arg("--")
+        .arg("bash")
+        .arg("-lc")
+        .arg(wsl_agent_probe_script(executable))
+        .stdin(std::process::Stdio::null())
+        .kill_on_drop(true);
+
+    let output = match tokio::time::timeout(WSL_AGENT_PROBE_TIMEOUT, cmd.output()).await {
+        Ok(Ok(output)) => output,
+        Ok(Err(error)) => {
+            tracing::warn!(
+                target: "agent_source",
+                distro,
+                executable,
+                %error,
+                "WSL agent availability probe failed to spawn"
+            );
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!(
+                target: "agent_source",
+                distro,
+                executable,
+                "WSL agent availability probe timed out"
+            );
+            return None;
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let resolved = stdout
+        .lines()
+        .skip_while(|line| *line != "__WTA_PROBE_BEGIN__")
+        .skip(1)
+        .take_while(|line| *line != "__WTA_PROBE_END__")
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or_default()
+        .to_string();
+    let available = is_native_wsl_resolution(&resolved);
+    tracing::info!(
+        target: "agent_source",
+        distro,
+        executable,
+        resolved_path = %resolved,
+        available,
+        "WSL agent availability probe"
+    );
+    available.then_some(resolved)
+}
+
+/// Whether a known ACP agent can start inside `distro`.
+pub async fn wsl_agent_available(distro: &str, agent_id: &str) -> bool {
+    if find_wsl_exe(distro, agent_id).await.is_none() {
+        return false;
+    }
+
+    let profile = agent_registry::lookup_profile_by_id(agent_id);
+    if profile.acp_launch_command.starts_with("npx ") {
+        return find_wsl_exe(distro, "npx").await.is_some();
+    }
+    true
+}
+
+pub(crate) fn wsl_agent_probe_script(executable: &str) -> String {
+    format!(
+        "printf '__WTA_PROBE_BEGIN__\\n'; command -v {} 2>/dev/null; \
+         printf '__WTA_PROBE_END__\\n'",
+        crate::coordinator::sh_quote(executable)
+    )
+}
+
+fn is_native_wsl_resolution(resolved: &str) -> bool {
+    !resolved.is_empty() && !resolved.starts_with("/mnt/")
 }
 
 /// Build the login command for an agent, resolving the full executable path.
@@ -235,6 +329,31 @@ pub fn check_agent(agent_id: &str) -> AgentStatus {
         cli_path,
         install_hint: profile.install_hint.to_string(),
         auth_hint: profile.auth_hint.to_string(),
+        auto_installable: agent_id == "copilot",
+    }
+}
+
+pub async fn check_agent_in_source(
+    agent_id: &str,
+    source: &crate::agent_source::AgentSource,
+) -> AgentStatus {
+    match source {
+        crate::agent_source::AgentSource::Host => check_agent(agent_id),
+        crate::agent_source::AgentSource::Wsl { distro } => {
+            let profile = agent_registry::lookup_profile_by_id(agent_id);
+            let cli_path = find_wsl_exe(distro, agent_id).await;
+            AgentStatus {
+                id: agent_id.to_string(),
+                display_name: format!("{} — {} (WSL)", profile.display_name, distro),
+                cli_found: cli_path.is_some()
+                    && (!profile.acp_launch_command.starts_with("npx ")
+                        || find_wsl_exe(distro, "npx").await.is_some()),
+                cli_path,
+                install_hint: profile.install_hint.to_string(),
+                auth_hint: profile.auth_hint.to_string(),
+                auto_installable: false,
+            }
+        }
     }
 }
 

--- a/tools/wta/src/agent_source.rs
+++ b/tools/wta/src/agent_source.rs
@@ -1,0 +1,122 @@
+//! Execution source for an ACP agent pane.
+//!
+//! The canonical agent id answers "which agent" (`copilot`, `claude`, ...).
+//! [`AgentSource`] answers "where that agent runs". Keeping the two dimensions
+//! separate lets `/agent` offer both Windows and the current WSL distro without
+//! changing policy identifiers, telemetry bucketing, or session CLI labels.
+
+use std::fmt;
+
+/// Environment that hosts an ACP agent process.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub enum AgentSource {
+    #[default]
+    Host,
+    Wsl {
+        distro: String,
+    },
+}
+
+impl AgentSource {
+    pub const HOST_KIND: &'static str = "host";
+    pub const WSL_KIND: &'static str = "wsl";
+
+    /// Parse the source fields carried on the helper command line or `_meta.wta`.
+    ///
+    /// Invalid/incomplete values fail closed to `Host`; callers log malformed
+    /// WSL requests before using this compatibility fallback.
+    pub fn from_wire(kind: Option<&str>, distro: Option<&str>) -> Self {
+        match kind.map(str::trim) {
+            Some(kind) if kind.eq_ignore_ascii_case(Self::WSL_KIND) => distro
+                .map(str::trim)
+                .filter(|distro| !distro.is_empty())
+                .map(|distro| Self::Wsl {
+                    distro: distro.to_string(),
+                })
+                .unwrap_or(Self::Host),
+            _ => Self::Host,
+        }
+    }
+
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Host => Self::HOST_KIND,
+            Self::Wsl { .. } => Self::WSL_KIND,
+        }
+    }
+
+    pub fn distro(&self) -> Option<&str> {
+        match self {
+            Self::Host => None,
+            Self::Wsl { distro } => Some(distro),
+        }
+    }
+
+    pub fn display_suffix(&self) -> String {
+        match self {
+            Self::Host => "Windows".to_string(),
+            Self::Wsl { distro } => format!("{distro} (WSL)"),
+        }
+    }
+
+    pub fn session_location(&self) -> crate::agent_sessions::SessionLocation {
+        match self {
+            Self::Host => crate::agent_sessions::SessionLocation::Host,
+            Self::Wsl { distro } => crate::agent_sessions::SessionLocation::Wsl {
+                distro: distro.clone(),
+            },
+        }
+    }
+}
+
+impl fmt::Display for AgentSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Host => f.write_str(Self::HOST_KIND),
+            Self::Wsl { distro } => write!(f, "{}:{distro}", Self::WSL_KIND),
+        }
+    }
+}
+
+/// Extract `wsl:<distro>` from the Terminal Protocol active-pane payload.
+pub fn active_pane_wsl_distro(active: Option<&serde_json::Value>) -> Option<&str> {
+    active
+        .and_then(|pane| pane.get("shell"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(|shell| shell.strip_prefix("wsl:"))
+        .map(str::trim)
+        .filter(|distro| !distro.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_source_requires_a_nonempty_wsl_distro() {
+        assert_eq!(
+            AgentSource::from_wire(Some("wsl"), Some("Ubuntu")),
+            AgentSource::Wsl {
+                distro: "Ubuntu".to_string()
+            }
+        );
+        assert_eq!(
+            AgentSource::from_wire(Some("wsl"), Some(" ")),
+            AgentSource::Host
+        );
+        assert_eq!(
+            AgentSource::from_wire(Some("unknown"), Some("Ubuntu")),
+            AgentSource::Host
+        );
+    }
+
+    #[test]
+    fn active_pane_distro_comes_from_shell_metadata() {
+        let pane = serde_json::json!({ "profile": "Renamed profile", "shell": "wsl:Ubuntu" });
+        assert_eq!(active_pane_wsl_distro(Some(&pane)), Some("Ubuntu"));
+        assert_eq!(
+            active_pane_wsl_distro(Some(&serde_json::json!({ "shell": "pwsh.exe" }))),
+            None
+        );
+    }
+}

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -12,6 +12,8 @@ use tokio::sync::mpsc;
 struct DeferredAcpParams {
     agent_cmd: String,
     acp_model: Option<String>,
+    agent_source: crate::agent_source::AgentSource,
+    source_cwd: Option<String>,
     prompt_rx: Option<mpsc::UnboundedReceiver<crate::protocol::acp::client::PromptSubmission>>,
     cancel_rx: Option<mpsc::UnboundedReceiver<crate::protocol::acp::client::CancelRequest>>,
     new_session_rx: Option<mpsc::UnboundedReceiver<crate::protocol::acp::client::NewSessionForTab>>,
@@ -41,6 +43,7 @@ struct DeferredAcpParams {
 pub struct AvailableAgent {
     pub id: String,
     pub display_name: String,
+    pub source: crate::agent_source::AgentSource,
 }
 
 mod turn_state;
@@ -198,6 +201,8 @@ impl SetupReason {
 /// A single option in the unified setup list.
 #[derive(Debug, Clone)]
 pub enum SetupOption {
+    /// Open the same source-aware picker as `/agent`.
+    ChooseAgentSource,
     /// Preflight: reinstall via winget (automatic)
     Install {
         agent_id: String,
@@ -381,6 +386,7 @@ pub fn build_setup_options(
     } else {
         opts.push(SetupOption::Retry);
     }
+    opts.push(SetupOption::ChooseAgentSource);
     opts
 }
 
@@ -1286,6 +1292,11 @@ pub enum AppEvent {
         agent_id: String,
         generation: u64,
     },
+    /// Result of a source-aware `/agent` discovery for the active working pane.
+    AgentSourcesDiscovered {
+        generation: u64,
+        wsl_sources: Vec<AvailableAgent>,
+    },
     /// Result of `preflight::check_agent` run by main.rs before the TUI
     /// loop starts. If `all_passed()` is false the App switches into
     /// `AppMode::Setup` so the user can install / authenticate the CLI.
@@ -1987,12 +1998,15 @@ pub struct App {
     pub state: ConnectionState,
     /// The agent ID we're trying to connect to (set at preflight/FRE time).
     pub current_agent_id: String,
+    /// Execution source paired with `current_agent_id`.
+    pub current_agent_source: crate::agent_source::AgentSource,
     /// Agent ids supplied by Windows Terminal after GPO filtering.
     allowed_agent_ids: Vec<String>,
     /// Distinguishes a manual/legacy launch from an explicitly empty policy.
     host_agent_allowlist_present: bool,
     /// Installed subset of the host-allowed agents, refreshed by `/agent`.
     pub available_agents: Vec<AvailableAgent>,
+    agent_source_probe_generation: u64,
     /// True when preflight detected an issue and is showing Setup screen.
     /// Prevents AgentError from overriding the preflight Setup.
     preflight_setup_active: bool,
@@ -2301,9 +2315,11 @@ impl App {
             deferred_acp: None,
             state: ConnectionState::Connecting(t!("connection.starting").into_owned()),
             current_agent_id: String::new(),
+            current_agent_source: crate::agent_source::AgentSource::Host,
             allowed_agent_ids: Vec::new(),
             host_agent_allowlist_present: false,
             available_agents: Vec::new(),
+            agent_source_probe_generation: 0,
             preflight_setup_active: false,
             agent_name: String::new(),
             agent_model: None,
@@ -2389,6 +2405,8 @@ impl App {
         pipe_name: String,
         agent_cmd: String,
         acp_model: Option<String>,
+        agent_source: crate::agent_source::AgentSource,
+        source_cwd: Option<String>,
         owner_tab_id: Option<String>,
         shell_mgr: Arc<crate::shell::ShellManager>,
         wt_connected: bool,
@@ -2396,6 +2414,8 @@ impl App {
         self.deferred_acp = Some(DeferredAcpParams {
             agent_cmd,
             acp_model,
+            agent_source,
+            source_cwd,
             prompt_rx: None,
             cancel_rx: None,
             new_session_rx: None,
@@ -2486,6 +2506,8 @@ impl App {
                 params.master_ext_rx.take(),
             ) {
                 let acp_model = params.acp_model.clone();
+                let agent_source = params.agent_source.clone();
+                let source_cwd = params.source_cwd.clone();
                 let event_tx = tx.clone();
                 let shell_mgr = Arc::clone(&params.shell_mgr);
                 let wt_connected = params.wt_connected;
@@ -2529,6 +2551,8 @@ impl App {
                                 pipe_name,
                                 acp_model,
                                 agent_id_opt,
+                                agent_source,
+                                source_cwd,
                                 owner_tab_opt,
                                 None, // initial_load_session_id: already handled by the dead initial task
                                 event_tx_for_pipe.clone(),
@@ -2754,11 +2778,80 @@ impl App {
                     || self.allowed_agent_ids.iter().any(|id| id == profile.id))
                     && crate::agent_check::find_exe(profile.id).is_some()
             })
-            .map(|profile| AvailableAgent {
-                id: profile.id.to_string(),
-                display_name: profile.display_name.to_string(),
+            .map(|profile| {
+                let source = crate::agent_source::AgentSource::Host;
+                AvailableAgent {
+                    id: profile.id.to_string(),
+                    display_name: format!(
+                        "{} — {}",
+                        profile.display_name,
+                        source.display_suffix()
+                    ),
+                    source,
+                }
             })
             .collect();
+    }
+
+    fn request_agent_source_picker(&mut self) {
+        self.refresh_available_agents();
+        self.agent_source_probe_generation = self.agent_source_probe_generation.wrapping_add(1);
+        let generation = self.agent_source_probe_generation;
+        let Some(event_tx) = self.event_tx.clone() else {
+            return;
+        };
+        let shell_mgr = Arc::clone(&self.shell_mgr);
+        let allowed_agent_ids = self.allowed_agent_ids.clone();
+        let allowlist_present = self.host_agent_allowlist_present;
+        tokio::task::spawn_local(async move {
+            let active_pane = shell_mgr.wt_get_active_pane().await.ok();
+            let Some(distro) =
+                crate::agent_source::active_pane_wsl_distro(active_pane.as_ref()).map(str::to_string)
+            else {
+                let _ = event_tx.send(AppEvent::AgentSourcesDiscovered {
+                    generation,
+                    wsl_sources: Vec::new(),
+                });
+                return;
+            };
+
+            use futures::StreamExt;
+            let candidates = crate::agent_registry::KNOWN_AGENTS
+                .iter()
+                .filter(|profile| {
+                    !allowlist_present
+                        || allowed_agent_ids.iter().any(|id| id == profile.id)
+                })
+                .map(|profile| (profile.id, profile.display_name));
+            let wsl_sources = futures::stream::iter(candidates)
+                .map(|(id, display_name)| {
+                    let distro = distro.clone();
+                    async move {
+                        crate::agent_check::wsl_agent_available(&distro, id)
+                            .await
+                            .then(|| {
+                                let source =
+                                    crate::agent_source::AgentSource::Wsl { distro };
+                                AvailableAgent {
+                                    id: id.to_string(),
+                                    display_name: format!(
+                                        "{display_name} — {}",
+                                        source.display_suffix()
+                                    ),
+                                    source,
+                                }
+                            })
+                    }
+                })
+                .buffer_unordered(crate::agent_registry::KNOWN_AGENTS.len())
+                .filter_map(async move |source| source)
+                .collect()
+                .await;
+            let _ = event_tx.send(AppEvent::AgentSourcesDiscovered {
+                generation,
+                wsl_sources,
+            });
+        });
     }
 
     fn agent_picker_visible(&self) -> bool {
@@ -2766,35 +2859,24 @@ impl App {
     }
 
     fn cmd_agent(&mut self, arg: String) {
-        self.refresh_available_agents();
         let arg = arg.trim();
-        if self.available_agents.is_empty() {
-            let tab = self.current_tab_mut();
-            tab.messages
-                .push(ChatMessage::System(t!("system.no_agents").into_owned()));
-            tab.scroll_to_bottom();
-            return;
-        }
         if arg.is_empty() {
-            let selected = self
-                .available_agents
-                .iter()
-                .position(|agent| agent.id == self.current_agent_id)
-                .unwrap_or(0);
-            self.open_agent_picker(selected);
+            self.request_agent_source_picker();
             return;
         }
 
+        self.refresh_available_agents();
         let selected = self
             .available_agents
             .iter()
             .find(|agent| {
-                agent.id.eq_ignore_ascii_case(arg)
-                    || agent.display_name.eq_ignore_ascii_case(arg)
+                agent.source == crate::agent_source::AgentSource::Host
+                    && (agent.id.eq_ignore_ascii_case(arg)
+                        || agent.display_name.eq_ignore_ascii_case(arg))
             })
             .cloned();
         match selected {
-            Some(agent) => self.apply_agent_pick(agent.id),
+            Some(agent) => self.apply_agent_pick(agent),
             None => {
                 let tab = self.current_tab_mut();
                 tab.messages.push(ChatMessage::System(
@@ -2831,15 +2913,15 @@ impl App {
 
     fn commit_agent_pick(&mut self) {
         let selected = self.current_tab().agent_picker_selected;
-        let agent_id = self.available_agents.get(selected).map(|agent| agent.id.clone());
+        let agent = self.available_agents.get(selected).cloned();
         self.close_agent_picker();
-        if let Some(agent_id) = agent_id {
-            self.apply_agent_pick(agent_id);
+        if let Some(agent) = agent {
+            self.apply_agent_pick(agent);
         }
     }
 
-    fn apply_agent_pick(&mut self, agent_id: String) {
-        if agent_id == self.current_agent_id {
+    fn apply_agent_pick(&mut self, agent: AvailableAgent) {
+        if agent.id == self.current_agent_id && agent.source == self.current_agent_source {
             return;
         }
         let Some(tab_id) = self.owner_tab_id.as_deref() else {
@@ -2850,7 +2932,12 @@ impl App {
             self.push_agent_switch_unavailable();
             return;
         };
-        send_wt_protocol_event(build_switch_agent_event(window_id, tab_id, &agent_id));
+        send_wt_protocol_event(build_switch_agent_event(
+            window_id,
+            tab_id,
+            &agent.id,
+            &agent.source,
+        ));
     }
 
     fn push_agent_switch_unavailable(&mut self) {
@@ -4204,6 +4291,9 @@ impl App {
     fn handle_setup_enter(&mut self, opt: SetupOption) {
         tracing::info!(target: "setup_key", option = ?std::mem::discriminant(&opt), "handle_setup_enter");
         match opt {
+            SetupOption::ChooseAgentSource => {
+                self.request_agent_source_picker();
+            }
             SetupOption::Install { agent_id, .. } => {
                 if let Some(ref setup) = self.setup {
                     if setup.install_in_progress {
@@ -4260,6 +4350,20 @@ impl App {
                 if let Some(ref setup) = self.setup {
                     let agent_id = setup.preflight.agent_id.clone();
                     if !agent_id.is_empty() {
+                        if matches!(
+                            self.current_agent_source,
+                            crate::agent_source::AgentSource::Wsl { .. }
+                        ) {
+                            self.update_deferred_acp_agent(&agent_id);
+                            self.state = ConnectionState::Connecting(
+                                t!("connection.reconnecting").into_owned(),
+                            );
+                            self.preflight_setup_active = false;
+                            if self.deferred_acp.is_some() {
+                                self.pending_acp_start = true;
+                            }
+                            return;
+                        }
                         let status = crate::agent_check::check_agent(&agent_id);
                         if status.cli_found {
                             // CLI found — try to connect (auth will be checked by ACP).
@@ -4547,6 +4651,7 @@ impl App {
             AppEvent::LoginComplete { .. } => "login_complete",
             AppEvent::PostLoginAuthRecovery { .. } => "post_login_auth_recovery",
             AppEvent::AuthRecoveryTimedOut { .. } => "auth_recovery_timed_out",
+            AppEvent::AgentSourcesDiscovered { .. } => "agent_sources_discovered",
             AppEvent::PreflightComplete(_) => "preflight_complete",
             AppEvent::AgentSessionEvent(_) => "agent_session_event",
             AppEvent::AliveSnapshotLoaded(_) => "alive_snapshot_loaded",
@@ -4587,9 +4692,29 @@ impl App {
     fn show_signin_setup_screen(&mut self, agent_id: String) {
         tracing::info!("show_signin_setup_screen: agent_id={}", agent_id);
         let profile = crate::agent_registry::lookup_profile(&agent_id);
-        let agent_status = crate::agent_check::check_agent(profile.id);
         let reason = SetupReason::AgentError;
-        let options = build_setup_options(&reason, Some(&agent_status));
+        let is_wsl_source = matches!(
+            self.current_agent_source,
+            crate::agent_source::AgentSource::Wsl { .. }
+        );
+        let agent_status = if is_wsl_source {
+            crate::agent_check::AgentStatus {
+                id: profile.id.to_string(),
+                display_name: profile.display_name.to_string(),
+                cli_found: true,
+                cli_path: None,
+                install_hint: profile.install_hint.to_string(),
+                auth_hint: profile.auth_hint.to_string(),
+                auto_installable: false,
+            }
+        } else {
+            crate::agent_check::check_agent(profile.id)
+        };
+        let options = if is_wsl_source {
+            build_setup_options(&reason, None)
+        } else {
+            build_setup_options(&reason, Some(&agent_status))
+        };
         self.mode = AppMode::Setup;
         self.state = ConnectionState::Disconnected;
         self.auth = None;
@@ -5091,9 +5216,16 @@ impl App {
                     };
                     tracing::info!("AgentError: resolved agent_id={}", agent_id);
                     let profile = crate::agent_registry::lookup_profile(&agent_id);
-                    let agent_status = crate::agent_check::check_agent(profile.id);
                     let reason = SetupReason::AgentError;
-                    let options = build_setup_options(&reason, Some(&agent_status));
+                    let options = if matches!(
+                        self.current_agent_source,
+                        crate::agent_source::AgentSource::Wsl { .. }
+                    ) {
+                        build_setup_options(&reason, None)
+                    } else {
+                        let agent_status = crate::agent_check::check_agent(profile.id);
+                        build_setup_options(&reason, Some(&agent_status))
+                    };
                     self.mode = AppMode::Setup;
                     self.state = ConnectionState::Disconnected;
                     self.auth = None;
@@ -5472,10 +5604,20 @@ impl App {
                 );
                 if !result.all_passed() {
                     let reason = SetupReason::AgentMissing;
-                    let current_status = crate::agent_check::check_agent(&result.agent_id);
-                    let options = build_setup_options(&reason, Some(&current_status));
+                    let current_status = if matches!(
+                        self.current_agent_source,
+                        crate::agent_source::AgentSource::Wsl { .. }
+                    ) {
+                        None
+                    } else {
+                        Some(crate::agent_check::check_agent(&result.agent_id))
+                    };
+                    let options = build_setup_options(&reason, current_status.as_ref());
                     let title = reason.title().to_string();
-                    let subtitle = if current_status.can_auto_install() {
+                    let subtitle = if current_status
+                        .as_ref()
+                        .is_some_and(crate::agent_check::AgentStatus::can_auto_install)
+                    {
                         t!(
                             "setup.subtitle.copilot_missing",
                             agent = &result.display_name
@@ -5499,6 +5641,35 @@ impl App {
                         title,
                         subtitle,
                     });
+                }
+            }
+            AppEvent::AgentSourcesDiscovered {
+                generation,
+                mut wsl_sources,
+            } => {
+                if generation != self.agent_source_probe_generation {
+                    return;
+                }
+                self.refresh_available_agents();
+                self.available_agents.append(&mut wsl_sources);
+                if self.available_agents.is_empty() {
+                    self.close_agent_picker();
+                    if self.mode == AppMode::Chat {
+                        self.current_tab_mut()
+                            .messages
+                            .push(ChatMessage::System(t!("system.no_agents").into_owned()));
+                        self.scroll_to_bottom();
+                    }
+                } else {
+                    let selected = self
+                        .available_agents
+                        .iter()
+                        .position(|agent| {
+                            agent.id == self.current_agent_id
+                                && agent.source == self.current_agent_source
+                        })
+                        .unwrap_or(0);
+                    self.open_agent_picker(selected);
                 }
             }
             AppEvent::AgentSessionEvent(ev) => {
@@ -6593,6 +6764,8 @@ impl App {
                         self.deferred_acp = Some(DeferredAcpParams {
                             agent_cmd: new_cmd,
                             acp_model: None,
+                            agent_source: self.current_agent_source.clone(),
+                            source_cwd: self.source_cwd.clone(),
                             prompt_rx: None, // try_start_acp will create fresh channels
                             cancel_rx: None,
                             new_session_rx: None,
@@ -6712,6 +6885,20 @@ impl App {
             // Don't clear `transient_hint` here — it has its own deadline and
             // ui::render checks expiry on each draw. Clearing on every key
             // would steal too much of the hint's visible lifetime.
+        }
+
+        // The source picker is also reachable from Setup when the configured
+        // Windows agent is missing, so it must receive keys before the
+        // mode-specific setup handler.
+        if self.agent_picker_visible() {
+            match key.code {
+                KeyCode::Up => self.agent_picker_up(),
+                KeyCode::Down => self.agent_picker_down(),
+                KeyCode::Enter => self.commit_agent_pick(),
+                KeyCode::Esc => self.close_agent_picker(),
+                _ => {}
+            }
+            return;
         }
 
         // Setup mode: diagnostic install/sign-in/retry flow.
@@ -7104,17 +7291,6 @@ impl App {
             return;
         }
 
-        if self.agent_picker_visible() {
-            match key.code {
-                KeyCode::Up => self.agent_picker_up(),
-                KeyCode::Down => self.agent_picker_down(),
-                KeyCode::Enter => self.commit_agent_pick(),
-                KeyCode::Esc => self.close_agent_picker(),
-                _ => {}
-            }
-            return;
-        }
-
         match key.code {
             KeyCode::Up if self.current_tab().turn.recommendations().is_some() =>
             {
@@ -7440,7 +7616,7 @@ impl App {
                         pane_id: self.pane_id.clone(),
                         tab_id: self.tab_id.clone(),
                         window_id: self.window_id.clone(),
-                        cwd: None,
+                        cwd: self.source_cwd.clone(),
                         source_pane_id: None,
                     };
                     // The echoed user message shows a marker for each queued
@@ -7770,6 +7946,7 @@ impl App {
             agents: &self.available_agents,
             selected: tab.agent_picker_selected,
             current_id: &self.current_agent_id,
+            current_source: &self.current_agent_source,
         })
     }
 
@@ -7971,7 +8148,10 @@ impl App {
             .unwrap_or_else(|| DEFAULT_TAB_ID.to_string());
         let _ = self
             .new_session_tx
-            .send(NewSessionForTab { tab_id, cwd: None });
+            .send(NewSessionForTab {
+                tab_id,
+                cwd: self.source_cwd.clone(),
+            });
         let tab = self.current_tab_mut();
         tab.clear_chat_history();
         tab.completed_turns.clear();
@@ -9850,7 +10030,12 @@ pub fn send_wt_protocol_event(json_payload: String) {
     let _ = tx.send(json_payload);
 }
 
-fn build_switch_agent_event(window_id: &str, tab_id: &str, agent_id: &str) -> String {
+fn build_switch_agent_event(
+    window_id: &str,
+    tab_id: &str,
+    agent_id: &str,
+    source: &crate::agent_source::AgentSource,
+) -> String {
     serde_json::json!({
         "type": "event",
         "method": "switch_agent",
@@ -9858,6 +10043,8 @@ fn build_switch_agent_event(window_id: &str, tab_id: &str, agent_id: &str) -> St
             "window_id": window_id,
             "tab_id": tab_id,
             "agent_id": agent_id,
+            "agent_source": source.kind(),
+            "wsl_distro": source.distro(),
         }
     })
     .to_string()
@@ -15262,10 +15449,12 @@ mod tests {
             AvailableAgent {
                 id: "copilot".into(),
                 display_name: "GitHub Copilot".into(),
+                source: crate::agent_source::AgentSource::Host,
             },
             AvailableAgent {
                 id: "claude".into(),
                 display_name: "Claude Test Agent".into(),
+                source: crate::agent_source::AgentSource::Host,
             },
         ];
         app.current_tab_mut().agent_picker_open = true;
@@ -15704,6 +15893,7 @@ mod tests {
             cli_path: None,
             install_hint: String::new(),
             auth_hint: String::new(),
+            auto_installable: id == "copilot",
         }
     }
 
@@ -15712,14 +15902,21 @@ mod tests {
         let copilot = agent_status_for_test("copilot", "GitHub Copilot", true);
         let copilot_options = build_setup_options(&SetupReason::AgentError, Some(&copilot));
         assert!(
-            matches!(copilot_options.as_slice(), [SetupOption::SignIn { agent_id, .. }] if agent_id == "copilot"),
+            matches!(
+                copilot_options.as_slice(),
+                [SetupOption::SignIn { agent_id, .. }, SetupOption::ChooseAgentSource]
+                    if agent_id == "copilot"
+            ),
             "Copilot auth failures must offer the in-app SignIn flow"
         );
 
         let codex = agent_status_for_test("codex", "Codex", true);
         let codex_options = build_setup_options(&SetupReason::AgentError, Some(&codex));
         assert!(
-            matches!(codex_options.as_slice(), [SetupOption::Retry]),
+            matches!(
+                codex_options.as_slice(),
+                [SetupOption::Retry, SetupOption::ChooseAgentSource]
+            ),
             "external-auth agents stay on the diagnostic Retry flow"
         );
     }

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2899,16 +2899,33 @@ impl App {
     }
 
     fn agent_picker_up(&mut self) {
+        let count = self.available_agents.len();
+        if count == 0 {
+            return;
+        }
         let tab = self.current_tab_mut();
-        tab.agent_picker_selected = tab.agent_picker_selected.saturating_sub(1);
+        tab.agent_picker_selected = (tab.agent_picker_selected + count - 1) % count;
+        tracing::debug!(
+            target: "agent_picker",
+            selected = tab.agent_picker_selected,
+            count,
+            "agent picker moved up"
+        );
     }
 
     fn agent_picker_down(&mut self) {
-        let last = self.available_agents.len().saturating_sub(1);
-        let tab = self.current_tab_mut();
-        if tab.agent_picker_selected < last {
-            tab.agent_picker_selected += 1;
+        let count = self.available_agents.len();
+        if count == 0 {
+            return;
         }
+        let tab = self.current_tab_mut();
+        tab.agent_picker_selected = (tab.agent_picker_selected + 1) % count;
+        tracing::debug!(
+            target: "agent_picker",
+            selected = tab.agent_picker_selected,
+            count,
+            "agent picker moved down"
+        );
     }
 
     fn commit_agent_pick(&mut self) {
@@ -2917,6 +2934,23 @@ impl App {
         self.close_agent_picker();
         if let Some(agent) = agent {
             self.apply_agent_pick(agent);
+        }
+    }
+
+    fn handle_agent_picker_key(&mut self, key: KeyEvent) {
+        tracing::debug!(
+            target: "agent_picker",
+            code = ?key.code,
+            selected = self.current_tab().agent_picker_selected,
+            count = self.available_agents.len(),
+            "agent picker key"
+        );
+        match key.code {
+            KeyCode::Up => self.agent_picker_up(),
+            KeyCode::Down => self.agent_picker_down(),
+            KeyCode::Enter => self.commit_agent_pick(),
+            KeyCode::Esc => self.close_agent_picker(),
+            _ => {}
         }
     }
 
@@ -6887,17 +6921,10 @@ impl App {
             // would steal too much of the hint's visible lifetime.
         }
 
-        // The source picker is also reachable from Setup when the configured
-        // Windows agent is missing, so it must receive keys before the
-        // mode-specific setup handler.
-        if self.agent_picker_visible() {
-            match key.code {
-                KeyCode::Up => self.agent_picker_up(),
-                KeyCode::Down => self.agent_picker_down(),
-                KeyCode::Enter => self.commit_agent_pick(),
-                KeyCode::Esc => self.close_agent_picker(),
-                _ => {}
-            }
+        // Setup consumes all keys before the normal picker/modal section below,
+        // so its source picker needs this narrow early route.
+        if self.mode == AppMode::Setup && self.agent_picker_visible() {
+            self.handle_agent_picker_key(key);
             return;
         }
 
@@ -7283,6 +7310,13 @@ impl App {
                 KeyCode::Esc => self.close_model_picker(),
                 _ => {}
             }
+            return;
+        }
+
+        // Keep the chat-mode `/agent` picker beside `/model`, matching the
+        // original modal ordering. Setup uses the early route above.
+        if self.agent_picker_visible() {
+            self.handle_agent_picker_key(key);
             return;
         }
 
@@ -15464,6 +15498,40 @@ mod tests {
             text.contains("Claude Test Agent"),
             "the agent picker must list available agents; rendered:\n{text}"
         );
+    }
+
+    #[test]
+    fn agent_picker_arrow_keys_move_and_wrap_selection() {
+        let mut app = test_app();
+        app.available_agents = vec![
+            AvailableAgent {
+                id: "copilot".into(),
+                display_name: "GitHub Copilot — Windows".into(),
+                source: crate::agent_source::AgentSource::Host,
+            },
+            AvailableAgent {
+                id: "copilot".into(),
+                display_name: "GitHub Copilot — Debian (WSL)".into(),
+                source: crate::agent_source::AgentSource::Wsl {
+                    distro: "Debian".into(),
+                },
+            },
+            AvailableAgent {
+                id: "claude".into(),
+                display_name: "Claude — Debian (WSL)".into(),
+                source: crate::agent_source::AgentSource::Wsl {
+                    distro: "Debian".into(),
+                },
+            },
+        ];
+        app.open_agent_picker(0);
+
+        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(app.current_tab().agent_picker_selected, 1);
+        app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(app.current_tab().agent_picker_selected, 0);
+        app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(app.current_tab().agent_picker_selected, 2);
     }
 
     /// Render: the setup diagnostic screen must paint its title and subtitle.

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2938,13 +2938,6 @@ impl App {
     }
 
     fn handle_agent_picker_key(&mut self, key: KeyEvent) {
-        tracing::debug!(
-            target: "agent_picker",
-            code = ?key.code,
-            selected = self.current_tab().agent_picker_selected,
-            count = self.available_agents.len(),
-            "agent picker key"
-        );
         match key.code {
             KeyCode::Up => self.agent_picker_up(),
             KeyCode::Down => self.agent_picker_down(),

--- a/tools/wta/src/cli_tests.rs
+++ b/tools/wta/src/cli_tests.rs
@@ -29,6 +29,26 @@ fn cli_initial_load_session_id_defaults_to_none() {
 }
 
 #[test]
+fn cli_parses_per_tab_wsl_agent_source() {
+    let cli = Cli::try_parse_from([
+        "wta",
+        "--agent-source",
+        "wsl",
+        "--agent-wsl-distro",
+        "Ubuntu",
+        "--agent-source-cwd",
+        "/home/user/project",
+    ])
+    .expect("WSL source flags must parse");
+    assert_eq!(cli.agent_source.as_deref(), Some("wsl"));
+    assert_eq!(cli.agent_wsl_distro.as_deref(), Some("Ubuntu"));
+    assert_eq!(
+        cli.agent_source_cwd.as_deref(),
+        Some("/home/user/project")
+    );
+}
+
+#[test]
 fn cli_initial_load_session_id_without_cwd_is_allowed() {
     // cwd is optional — the helper falls back to its process cwd when
     // omitted (matches the runtime `load_session` arm's behavior).
@@ -383,11 +403,11 @@ fn pane_with_shell(shell: &str) -> serde_json::Value {
 fn active_pane_wsl_distro_extracts_distro_name() {
     // `wsl:<distro>` → the distro name (drives `wsl -d <distro>`).
     assert_eq!(
-        active_pane_wsl_distro(Some(&pane_with_shell("wsl:Ubuntu"))),
+        crate::agent_source::active_pane_wsl_distro(Some(&pane_with_shell("wsl:Ubuntu"))),
         Some("Ubuntu")
     );
     assert_eq!(
-        active_pane_wsl_distro(Some(&pane_with_shell("wsl:Ubuntu-22.04"))),
+        crate::agent_source::active_pane_wsl_distro(Some(&pane_with_shell("wsl:Ubuntu-22.04"))),
         Some("Ubuntu-22.04")
     );
 }
@@ -395,22 +415,40 @@ fn active_pane_wsl_distro_extracts_distro_name() {
 #[test]
 fn active_pane_wsl_distro_rejects_non_wsl_shells() {
     // Non-WSL shells → None (host path).
-    assert_eq!(active_pane_wsl_distro(Some(&pane_with_shell("pwsh"))), None);
-    assert_eq!(active_pane_wsl_distro(Some(&pane_with_shell("cmd"))), None);
+    assert_eq!(
+        crate::agent_source::active_pane_wsl_distro(Some(&pane_with_shell("pwsh"))),
+        None
+    );
+    assert_eq!(
+        crate::agent_source::active_pane_wsl_distro(Some(&pane_with_shell("cmd"))),
+        None
+    );
     // A pane name that merely contains "wsl" is not the `wsl:` prefix.
-    assert_eq!(active_pane_wsl_distro(Some(&pane_with_shell("my-wsl"))), None);
+    assert_eq!(
+        crate::agent_source::active_pane_wsl_distro(Some(&pane_with_shell("my-wsl"))),
+        None
+    );
     // Bare `wsl:` with an empty distro name is not a valid WSL pane — shell
     // integration only emits `wsl:<distro>` when `$WSL_DISTRO_NAME` is set —
     // and would otherwise build an invalid `wsl -d "" …` command.
-    assert_eq!(active_pane_wsl_distro(Some(&pane_with_shell("wsl:"))), None);
+    assert_eq!(
+        crate::agent_source::active_pane_wsl_distro(Some(&pane_with_shell("wsl:"))),
+        None
+    );
     // `shell` field absent.
     let no_shell = serde_json::json!({ "cwd": "/home/u" });
-    assert_eq!(active_pane_wsl_distro(Some(&no_shell)), None);
+    assert_eq!(
+        crate::agent_source::active_pane_wsl_distro(Some(&no_shell)),
+        None
+    );
     // `shell` present but not a string.
     let numeric_shell = serde_json::json!({ "shell": 42 });
-    assert_eq!(active_pane_wsl_distro(Some(&numeric_shell)), None);
+    assert_eq!(
+        crate::agent_source::active_pane_wsl_distro(Some(&numeric_shell)),
+        None
+    );
     // No active pane at all.
-    assert_eq!(active_pane_wsl_distro(None), None);
+    assert_eq!(crate::agent_source::active_pane_wsl_distro(None), None);
 }
 
 #[test]
@@ -419,13 +457,15 @@ fn wsl_agent_probe_script_prints_command_v_resolution() {
     // rejects empty or /mnt results). Deliberately NOT wrapped in `$(…)`, which
     // returns empty for snap apps. sh_quote single-quotes the exe.
     assert_eq!(
-        wsl_agent_probe_script("copilot"),
-        "command -v 'copilot' 2>/dev/null"
+        crate::agent_check::wsl_agent_probe_script("copilot"),
+        "printf '__WTA_PROBE_BEGIN__\\n'; command -v 'copilot' 2>/dev/null; \
+         printf '__WTA_PROBE_END__\\n'"
     );
     // An agent identity with shell metacharacters stays contained in the quotes.
     assert_eq!(
-        wsl_agent_probe_script("my agent; rm -rf /"),
-        "command -v 'my agent; rm -rf /' 2>/dev/null"
+        crate::agent_check::wsl_agent_probe_script("my agent; rm -rf /"),
+        "printf '__WTA_PROBE_BEGIN__\\n'; command -v 'my agent; rm -rf /' 2>/dev/null; \
+         printf '__WTA_PROBE_END__\\n'"
     );
 }
 

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -5,6 +5,7 @@ mod agent_check;
 mod agent_hooks_installer;
 mod agent_pane_origin;
 mod agent_registry;
+mod agent_source;
 mod agent_sessions;
 mod app;
 mod clipboard_image;
@@ -158,6 +159,19 @@ struct Cli {
     /// `--agent-id` explicitly.
     #[arg(long)]
     agent_id: Option<String>,
+
+    /// Per-tab ACP execution source (`host` or `wsl`). Hidden because
+    /// TerminalPage owns source compatibility checks.
+    #[arg(long, hide = true, value_parser = ["host", "wsl"])]
+    agent_source: Option<String>,
+
+    /// WSL distro paired with `--agent-source wsl`.
+    #[arg(long, hide = true)]
+    agent_wsl_distro: Option<String>,
+
+    /// Working-pane cwd captured when this helper was created.
+    #[arg(long, hide = true)]
+    agent_source_cwd: Option<String>,
 
     /// Master-only allowlist of agent ids a helper may request over the
     /// pipe (the GPO-filtered set; built by TerminalPage::
@@ -2107,41 +2121,6 @@ async fn run_delegate(
 /// keeps us from ever building a `wsl -d "" …` command. Returns `None` when the
 /// pane is missing, has no `shell` field, or the shell is anything else
 /// (PowerShell, cmd, …).
-fn active_pane_wsl_distro(active: Option<&serde_json::Value>) -> Option<&str> {
-    active
-        .and_then(|p| p.get("shell"))
-        .and_then(|v| v.as_str())
-        .and_then(|s| s.strip_prefix("wsl:"))
-        .filter(|distro| !distro.is_empty())
-}
-
-/// The in-distro probe script used by [`wsl_delegate_agent_available`].
-///
-/// Prints the PATH resolution of `<exe>` (`command -v`, whose stdout the caller
-/// captures) or nothing when it is absent. The caller inspects the result:
-/// empty = absent; a path under `/mnt/` = a Windows CLI leaking in via WSL's
-/// `appendWindowsPath` interop (`/mnt/<drive>/…`), which is *not* a native
-/// install and fails when run under Linux (e.g. codex's "Missing optional
-/// dependency @openai/codex-linux-x64"); anything else = a native Linux install.
-///
-/// The resolution is emitted **directly to stdout — never wrapped in a `$(…)`
-/// command substitution.** On snap-provisioned distros `command -v <snap-app>`
-/// resolves the app (e.g. `/snap/bin/copilot`) on the shell's own stdout but
-/// yields an *empty* string inside `$(…)`, which would misreport a
-/// natively-installed CLI as absent and wrongly fall back to the host. Letting
-/// `command -v` write straight to the process stdout (captured by
-/// `Command::output`) sidesteps that. `sh_quote` guards against an agent
-/// identity with shell metacharacters.
-///
-/// Note: assumes the default DrvFs mount root `/mnt`; a distro configured to
-/// mount Windows drives under a different root would resolve them elsewhere.
-fn wsl_agent_probe_script(agent_exe: &str) -> String {
-    format!(
-        "command -v {} 2>/dev/null",
-        crate::coordinator::sh_quote(agent_exe)
-    )
-}
-
 /// Whether the delegate agent CLI is actually available inside `distro`.
 ///
 /// PR375 routes a `?<prompt>` from a WSL pane into the distro
@@ -2158,55 +2137,9 @@ fn wsl_agent_probe_script(agent_exe: &str) -> String {
 /// Windows host CLI instead of launching a doomed in-distro command that would
 /// silently drop the prompt.
 async fn wsl_delegate_agent_available(distro: &str, agent_exe: &str) -> bool {
-    if distro.is_empty() || agent_exe.is_empty() {
-        return false;
-    }
-    let mut cmd = tokio::process::Command::new("wsl.exe");
-    cmd.arg("-d")
-        .arg(distro)
-        .arg("--")
-        .arg("bash")
-        .arg("-lc")
-        .arg(wsl_agent_probe_script(agent_exe))
-        .stdin(std::process::Stdio::null())
-        .kill_on_drop(true);
-    let output = match tokio::time::timeout(std::time::Duration::from_secs(5), cmd.output()).await {
-        Ok(Ok(output)) => output,
-        Ok(Err(err)) => {
-            tracing::warn!(
-                target: "delegate",
-                distro,
-                agent = %agent_exe,
-                error = %err,
-                "WSL agent availability probe failed to spawn; falling back to host CLI",
-            );
-            return false;
-        }
-        Err(_elapsed) => {
-            tracing::warn!(
-                target: "delegate",
-                distro,
-                agent = %agent_exe,
-                "WSL agent availability probe timed out; falling back to host CLI",
-            );
-            return false;
-        }
-    };
-    let resolved = String::from_utf8_lossy(&output.stdout);
-    let resolved = resolved.trim();
-    // Accept only a native Linux install: a non-empty path that does not resolve
-    // under the `/mnt/<drive>` interop mount (a Windows binary whose Linux exec
-    // would fail).
-    let available = !resolved.is_empty() && !resolved.starts_with("/mnt/");
-    tracing::info!(
-        target: "delegate",
-        distro,
-        agent = %agent_exe,
-        resolved_path = %resolved,
-        available,
-        "WSL agent availability probe",
-    );
-    available
+    crate::agent_check::find_wsl_exe(distro, agent_exe)
+        .await
+        .is_some()
 }
 
 /// Whether the delegate agent should be treated as launchable for the active
@@ -2307,7 +2240,8 @@ async fn delegate_with_context(
     // installed): an in-distro launch would just print "<agent>: command not
     // found" and drop the prompt. Probe the distro once, up front, so the
     // launchable gate, the WSL branch, and the host fallback all agree.
-    let wsl_distro: Option<String> = active_pane_wsl_distro(active.as_ref()).map(str::to_string);
+    let wsl_distro: Option<String> =
+        crate::agent_source::active_pane_wsl_distro(active.as_ref()).map(str::to_string);
     let wsl_agent_available = match wsl_distro.as_deref() {
         Some(distro) => {
             let agent_exe =
@@ -2560,11 +2494,15 @@ async fn delegate_with_context(
 /// named pipe and forwards ACP traffic over it.
 pub(crate) async fn run_default_tui_over_pipe(cli: Cli, pipe_name: String) -> Result<()> {
     tracing::info!(target: "helper", pipe = %pipe_name, "=== wta-helper starting (TUI) ===");
+    let agent_source = crate::agent_source::AgentSource::from_wire(
+        cli.agent_source.as_deref(),
+        cli.agent_wsl_distro.as_deref(),
+    );
 
     // Debug channel for the helper TUI.
     let (debug_tx, debug_rx) = tokio::sync::mpsc::unbounded_channel::<app::DebugMessage>();
 
-    let mut shell_mgr = ShellManager::new();
+    let mut shell_mgr = ShellManager::new().with_agent_source(agent_source);
     let mut wt_event_rx = None;
     let mut wt_protocol_channel: Option<Arc<CliChannel>> = None;
     let wt_connected = match connect_to_wt_protocol(debug_tx.clone()).await {
@@ -2902,6 +2840,10 @@ async fn run_acp_app(
     connect_master_pipe: String,
 ) -> Result<()> {
     let agent_cmd = cli.agent.clone();
+    let agent_source = crate::agent_source::AgentSource::from_wire(
+        cli.agent_source.as_deref(),
+        cli.agent_wsl_distro.as_deref(),
+    );
 
     let local_set = tokio::task::LocalSet::new();
     local_set
@@ -3232,6 +3174,8 @@ async fn run_acp_app(
                 // this on its `Cli` all along; pre-multi-agent it dropped
                 // it (master owned the single agent CLI).
                 let agent_id = cli.agent_id.clone();
+                let agent_source_for_client = agent_source.clone();
+                let source_cwd = cli.agent_source_cwd.clone();
                 let owner_tab = cli.owner_tab_id.clone();
                 let initial_load_sid = cli.initial_load_session_id.clone();
                 tokio::task::spawn_local(async move {
@@ -3239,6 +3183,8 @@ async fn run_acp_app(
                         pipe_name,
                         acp_model,
                         agent_id,
+                        agent_source_for_client,
+                        source_cwd,
                         owner_tab,
                         initial_load_sid,
                         event_tx_for_pipe.clone(),
@@ -3339,6 +3285,8 @@ async fn run_acp_app(
                 connect_master_pipe.clone(),
                 agent_cmd.clone(),
                 cli.acp_model.clone(),
+                agent_source.clone(),
+                cli.agent_source_cwd.clone(),
                 cli.owner_tab_id.clone(),
                 Arc::clone(&shell_mgr),
                 wt_connected,
@@ -3346,6 +3294,7 @@ async fn run_acp_app(
 
             if cli.setup.is_none() {
                 app_state.current_agent_id = canonical_agent_id.clone();
+                app_state.current_agent_source = agent_source.clone();
                 tracing::info!(
                     target: "agents_view_filter",
                     agent_id = %canonical_agent_id,
@@ -3371,7 +3320,8 @@ async fn run_acp_app(
                     // the authoritative error via `ConnectionFailed`, so skip preflight.
                     app::PreflightResult::passed_for_custom_agent(&canonical_agent_id)
                 } else {
-                    let status = agent_check::check_agent(agent_id);
+                    let status =
+                        agent_check::check_agent_in_source(agent_id, &agent_source).await;
                     app::PreflightResult {
                         agent_id: canonical_agent_id.clone(),
                         display_name: status.display_name.clone(),
@@ -3718,7 +3668,8 @@ async fn run_acp_app(
                 .filter(|s| !s.is_empty());
             app_state.source_cwd = std::env::var("WTA_SOURCE_CWD")
                 .ok()
-                .filter(|s| !s.is_empty());
+                .filter(|s| !s.is_empty())
+                .or_else(|| cli.agent_source_cwd.clone());
 
             // ── env-gated raw agent_event chat logging (diagnostics) ──────
             app_state.log_agent_events = std::env::var("WTA_LOG_AGENT_EVENT")

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -59,7 +59,7 @@ use tokio::task::LocalSet;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::protocol::acp::conn;
-use crate::protocol::acp::spawn::{spawn_agent_process, AgentStderrLog};
+use crate::protocol::acp::spawn::{spawn_agent_process_for_source, AgentStderrLog};
 use crate::Cli;
 
 /// Opaque identifier for a helper connection. Used in logs only;
@@ -330,6 +330,10 @@ struct MasterStateInner {
 /// (Distinct from `agent_sessions::AgentKey`, which is a *session* id.)
 type AgentCmdKey = String;
 
+fn agent_cmd_key(command: &str, source: &crate::agent_source::AgentSource) -> AgentCmdKey {
+    format!("{source}\0{command}")
+}
+
 /// One spawned agent CLI subprocess and everything a helper needs to
 /// talk to it. Shared (`Arc`) across every helper currently bound to
 /// this agent.
@@ -347,6 +351,7 @@ struct AgentCli {
     /// F2 view labels each row with its real CLI (Gemini vs Claude),
     /// not one process-wide value.
     cli_source: Option<crate::agent_sessions::CliSource>,
+    source: crate::agent_source::AgentSource,
     /// The pool key (agent command line) this CLI was spawned under —
     /// the same `AgentCmdKey` used in [`MasterStateInner::agents`]. Lets
     /// helper-disconnect cleanup and `load_session` scope orphan tracking
@@ -951,12 +956,14 @@ impl HelperHandler {
         // otherwise falls back to the trusted `--agent` default. See
         // `resolve_agent_selection` for the full policy.
         let wta_meta = crate::session_registry::extract_wta_meta(&mut args.meta);
-        let (agent_cmd, agent_id) = resolve_agent_selection(
+        let (agent_cmd, agent_id, agent_source) = resolve_agent_selection(
             &self.state.default_agent_cmd,
             self.state.default_agent_id.as_deref(),
             self.state.allowed_agent_ids.as_ref(),
             wta_meta.agent_id.as_deref(),
             wta_meta.model.as_deref(),
+            wta_meta.agent_source.as_deref(),
+            wta_meta.wsl_distro.as_deref(),
             self.helper_id,
         );
         tracing::info!(
@@ -968,12 +975,18 @@ impl HelperHandler {
             requested_agent_id = ?wta_meta.agent_id,
             resolved_agent_cmd = %agent_cmd,
             resolved_agent_id = ?agent_id,
+            resolved_agent_source = %agent_source,
             "resolving agent CLI for helper"
         );
 
         // Lazily spawn (or reuse) the agent CLI for THIS tab's agent,
         // then bind it to this helper for the rest of the connection.
-        let agent = get_or_spawn_agent(&self.state, &agent_cmd, agent_id.as_deref())
+        let agent = get_or_spawn_agent(
+            &self.state,
+            &agent_cmd,
+            agent_id.as_deref(),
+            &agent_source,
+        )
             .await
             .map_err(|e| {
                 tracing::error!(
@@ -1079,6 +1092,7 @@ impl HelperHandler {
         // only), so master is the only one that can fill these fields.
         info.status = Some(crate::agent_sessions::AgentStatus::Idle);
         info.cli_source = agent.cli_source.clone();
+        info.location = agent.source.session_location();
         info.origin = Some(crate::agent_sessions::SessionOrigin::AgentPane);
         info.last_activity_at_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -1259,6 +1273,7 @@ impl HelperHandler {
         info.pane_session_id = wta_meta.pane_session_id;
         info.status = Some(crate::agent_sessions::AgentStatus::Idle);
         info.cli_source = agent.cli_source.clone();
+        info.location = agent.source.session_location();
         info.origin = Some(crate::agent_sessions::SessionOrigin::AgentPane);
         info.last_activity_at_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -2092,8 +2107,14 @@ fn resolve_agent_selection(
     allowed_ids: Option<&std::collections::HashSet<String>>,
     requested_id: Option<&str>,
     requested_model: Option<&str>,
+    requested_source: Option<&str>,
+    requested_wsl_distro: Option<&str>,
     helper_id: HelperId,
-) -> (String, Option<String>) {
+) -> (
+    String,
+    Option<String>,
+    crate::agent_source::AgentSource,
+) {
     let requested = requested_id
         .map(str::trim)
         .filter(|s| !s.is_empty())
@@ -2114,7 +2135,11 @@ fn resolve_agent_selection(
                 .map(str::trim)
                 .filter(|s| !s.is_empty());
             let cmd = crate::agent_registry::build_acp_command(id, model);
-            return (cmd, Some(id.to_string()));
+            let source = crate::agent_source::AgentSource::from_wire(
+                requested_source,
+                requested_wsl_distro,
+            );
+            return (cmd, Some(id.to_string()), source);
         }
 
         // A real selection we refused — surface why, then fall back.
@@ -2129,7 +2154,11 @@ fn resolve_agent_selection(
         );
     }
 
-    (default_cmd.to_string(), default_id.map(str::to_string))
+    (
+        default_cmd.to_string(),
+        default_id.map(str::to_string),
+        crate::agent_source::AgentSource::Host,
+    )
 }
 
 /// Get the agent CLI for `agent_cmd`, spawning + initializing it on
@@ -2141,8 +2170,9 @@ async fn get_or_spawn_agent(
     state: &Arc<MasterStateInner>,
     agent_cmd: &str,
     agent_id: Option<&str>,
+    source: &crate::agent_source::AgentSource,
 ) -> Result<Arc<AgentCli>> {
-    let key: AgentCmdKey = agent_cmd.to_string();
+    let key = agent_cmd_key(agent_cmd, source);
     let cell = {
         let mut agents = state.agents.lock().await;
         Arc::clone(
@@ -2157,7 +2187,9 @@ async fn get_or_spawn_agent(
     // helper requesting the same agent gets a fresh cell and retries
     // cleanly (no lingering dead slot, no leaked subprocess).
     let agent = cell
-        .get_or_try_init(|| async { spawn_one_agent(state, &key, agent_cmd, agent_id).await })
+        .get_or_try_init(|| async {
+            spawn_one_agent(state, &key, agent_cmd, agent_id, source).await
+        })
         .await?;
     Ok(Arc::clone(agent))
 }
@@ -2172,13 +2204,15 @@ async fn spawn_one_agent(
     key: &AgentCmdKey,
     agent_cmd: &str,
     agent_id: Option<&str>,
+    source: &crate::agent_source::AgentSource,
 ) -> Result<Arc<AgentCli>> {
-    let mut spawn_result = spawn_agent_process(agent_cmd, None)
+    let mut spawn_result = spawn_agent_process_for_source(agent_cmd, None, source)
         .with_context(|| format!("failed to spawn agent CLI: {agent_cmd}"))?;
     tracing::info!(
         target: "master",
         program = %spawn_result.resolved_program,
         agent_cmd = %agent_cmd,
+        agent_source = %source,
         "agent CLI spawned"
     );
 
@@ -2439,6 +2473,7 @@ async fn spawn_one_agent(
         conn,
         cached_init_resp: init_resp,
         cli_source,
+        source: source.clone(),
         cmd_key: key.clone(),
     }))
 }
@@ -3873,14 +3908,17 @@ mod tests {
         requested_id: Option<&str>,
         model: Option<&str>,
     ) -> (String, Option<String>) {
-        resolve_agent_selection(
+        let (command, agent_id, _source) = resolve_agent_selection(
             DEFAULT_CMD,
             Some("copilot"),
             allowed,
             requested_id,
             model,
+            None,
+            None,
             HelperId(1),
-        )
+        );
+        (command, agent_id)
     }
 
     #[test]
@@ -3890,6 +3928,33 @@ mod tests {
         let (cmd, id) = resolve(None, Some("gemini"), None);
         assert_eq!(cmd, "gemini --experimental-acp");
         assert_eq!(id.as_deref(), Some("gemini"));
+    }
+
+    #[test]
+    fn known_agent_selection_preserves_wsl_source() {
+        let (command, agent_id, source) = resolve_agent_selection(
+            DEFAULT_CMD,
+            Some("copilot"),
+            None,
+            Some("copilot"),
+            None,
+            Some("wsl"),
+            Some("Ubuntu"),
+            HelperId(1),
+        );
+        assert_eq!(command, "copilot --acp --stdio");
+        assert_eq!(agent_id.as_deref(), Some("copilot"));
+        assert_eq!(
+            source,
+            crate::agent_source::AgentSource::Wsl {
+                distro: "Ubuntu".to_string()
+            }
+        );
+        assert_ne!(
+            agent_cmd_key(&command, &crate::agent_source::AgentSource::Host),
+            agent_cmd_key(&command, &source),
+            "host and WSL instances must occupy separate pool slots"
+        );
     }
 
     #[test]
@@ -4166,6 +4231,7 @@ mod tests {
                         acp::schema::ProtocolVersion::V1,
                     ),
                     cli_source: None,
+                    source: crate::agent_source::AgentSource::Host,
                     cmd_key: "copilot --acp --stdio".to_string(),
                 }));
                 let handler = HelperHandler {
@@ -4440,6 +4506,7 @@ mod tests {
                         acp::schema::ProtocolVersion::V1,
                     ),
                     cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                    source: crate::agent_source::AgentSource::Host,
                     cmd_key: "copilot --acp --stdio".to_string(),
                 }));
                 let handler = HelperHandler {

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -2091,6 +2091,8 @@ pub async fn run_acp_client_over_pipe(
     // (it never executes a command string sent over the pipe). `None` →
     // master uses its `--agent` default (the legacy single-agent behavior).
     agent_id: Option<String>,
+    agent_source: crate::agent_source::AgentSource,
+    source_cwd: Option<String>,
     owner_tab_id: Option<String>,
     initial_load_session_id: Option<String>,
     event_tx: mpsc::UnboundedSender<AppEvent>,
@@ -2314,6 +2316,8 @@ pub async fn run_acp_client_over_pipe(
                 model: acp_model_override
                     .clone()
                     .filter(|s| !s.trim().is_empty()),
+                agent_source: Some(agent_source.kind().to_string()),
+                wsl_distro: agent_source.distro().map(str::to_string),
                 ..Default::default()
             },
         );
@@ -2496,7 +2500,10 @@ pub async fn run_acp_client_over_pipe(
     // bug: master used to register both the bootstrap and the loaded
     // sid (both bound to the same WT pane) and the session management view showed two
     // Live rows for the same agent pane.
-    let cwd = std::env::current_dir().unwrap_or_default();
+    let cwd = source_cwd
+        .as_deref()
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
     let (session_id, available_models, current_model_id, has_bootstrap) =
         if let Some(load_sid) = initial_load_session_id.as_deref() {
             // No bootstrap. AgentConnected fires with the to-be-loaded

--- a/tools/wta/src/protocol/acp/spawn.rs
+++ b/tools/wta/src/protocol/acp/spawn.rs
@@ -223,6 +223,7 @@ pub(crate) fn spawn_agent_process(agent_cmd: &str, cwd: Option<&Path>) -> Result
     if needs_cmd {
         cmd.arg("/c").arg(&resolved_program);
     }
+
     // The claude-code-acp adapter refuses to start when its recursion-
     // guard env var is set — that guard exists to block recursive
     // `claude` shells from sharing runtime, but doesn't apply to an
@@ -307,6 +308,79 @@ pub(crate) fn spawn_agent_process(agent_cmd: &str, cwd: Option<&Path>) -> Result
     })
 }
 
+/// Spawn an ACP agent in the selected per-tab execution source.
+pub(crate) fn spawn_agent_process_for_source(
+    agent_cmd: &str,
+    cwd: Option<&Path>,
+    source: &crate::agent_source::AgentSource,
+) -> Result<AgentSpawn> {
+    match source {
+        crate::agent_source::AgentSource::Host => spawn_agent_process(agent_cmd, cwd),
+        crate::agent_source::AgentSource::Wsl { distro } => {
+            spawn_wsl_agent_process(agent_cmd, distro)
+        }
+    }
+}
+
+fn spawn_wsl_agent_process(agent_cmd: &str, distro: &str) -> Result<AgentSpawn> {
+    let parts = crate::coordinator::split_windows_commandline(agent_cmd);
+    let raw_program = parts
+        .first()
+        .cloned()
+        .ok_or_else(|| anyhow!("empty agent command"))?;
+    let is_npx = ["npx", "npx.cmd", "npx.exe"]
+        .iter()
+        .any(|name| raw_program.eq_ignore_ascii_case(name));
+    let adapter_package = is_npx
+        .then(|| parts.iter().find(|arg| arg.starts_with('@')).cloned())
+        .flatten();
+    let script = wsl_agent_launch_script(&parts);
+
+    let child = tokio::process::Command::new("wsl.exe")
+        .arg("-d")
+        .arg(distro)
+        .arg("--")
+        .arg("bash")
+        .arg("--noprofile")
+        .arg("--norc")
+        .arg("-c")
+        .arg(script)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|error| {
+            anyhow!(
+                "failed to spawn agent '{}' in WSL distro '{}': {}",
+                agent_cmd,
+                distro,
+                error
+            )
+        })?;
+
+    Ok(AgentSpawn {
+        child,
+        raw_program,
+        resolved_program: format!("wsl.exe -d {distro}"),
+        is_npx,
+        adapter_package,
+    })
+}
+
+fn wsl_agent_launch_script(parts: &[String]) -> String {
+    let invocation = parts
+        .iter()
+        .map(|part| crate::coordinator::sh_quote(part))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let inner = format!("exec 1>&3 3>&-; unset CLAUDECODE; exec {invocation}");
+    format!(
+        "bash -lc {} 3>&1 >/dev/null",
+        crate::coordinator::sh_quote(&inner)
+    )
+}
+
 /// Convert a BCP-47 locale tag (e.g. `zh-CN`, `gd-gb`) to the POSIX
 /// `LANG`/`LC_ALL` form (e.g. `zh_CN.UTF-8`, `gd_GB.UTF-8`).
 ///
@@ -346,6 +420,20 @@ fn canonicalize_posix_locale(tag: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn wsl_launch_script_quotes_every_agent_argument() {
+        let parts = vec![
+            "copilot".to_string(),
+            "--model".to_string(),
+            "model; touch /tmp/nope".to_string(),
+        ];
+        assert_eq!(
+            wsl_agent_launch_script(&parts),
+            "bash -lc 'exec 1>&3 3>&-; unset CLAUDECODE; exec '\\''copilot'\\'' \
+             '\\''--model'\\'' '\\''model; touch /tmp/nope'\\''' 3>&1 >/dev/null"
+        );
+    }
 
     #[test]
     fn stderr_log_promotes_only_failed_startup_lines() {

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -58,6 +58,10 @@ pub struct WtaMeta {
     /// model later via `setSessionModel`). Carried as its own field
     /// because the master no longer trusts `agent_cmd` to carry it.
     pub model: Option<String>,
+    /// Execution environment selected for this tab (`host` or `wsl`).
+    pub agent_source: Option<String>,
+    /// WSL distribution paired with `agent_source=wsl`.
+    pub wsl_distro: Option<String>,
     /// The WT tab StableId (`--owner-tab-id`) of the agent pane that
     /// owns this session. Carried so master can address per-tab events
     /// (notably `restart_agent_pane` on helper crash recovery) by the
@@ -83,6 +87,8 @@ impl WtaMeta {
             && blank(&self.agent_cmd)
             && blank(&self.agent_id)
             && blank(&self.model)
+            && blank(&self.agent_source)
+            && blank(&self.wsl_distro)
             && blank(&self.owner_tab_id)
     }
 }
@@ -127,6 +133,8 @@ pub fn extract_wta_meta(meta: &mut Option<acp::schema::v1::Meta>) -> WtaMeta {
         agent_cmd: str_field("agent_cmd"),
         agent_id: str_field("agent_id"),
         model: str_field("model"),
+        agent_source: str_field("agent_source"),
+        wsl_distro: str_field("wsl_distro"),
         owner_tab_id: str_field("owner_tab_id"),
     }
 }
@@ -161,6 +169,8 @@ pub fn inject_wta_meta(meta: &mut Option<acp::schema::v1::Meta>, wta: &WtaMeta) 
     put("agent_cmd", &wta.agent_cmd);
     put("agent_id", &wta.agent_id);
     put("model", &wta.model);
+    put("agent_source", &wta.agent_source);
+    put("wsl_distro", &wta.wsl_distro);
     put("owner_tab_id", &wta.owner_tab_id);
     // Every field was absent/whitespace-only after filtering — nothing
     // meaningful to attach, so don't litter the wire with an empty
@@ -3312,6 +3322,8 @@ mod tests {
             agent_cmd: Some("npx -y @agentclientprotocol/claude-agent-acp".to_string()),
             agent_id: Some("gemini".to_string()),
             model: Some("gemini-2.5-pro".to_string()),
+            agent_source: Some("wsl".to_string()),
+            wsl_distro: Some("Ubuntu".to_string()),
             ..Default::default()
         };
         let mut meta: Option<acp::schema::v1::Meta> = None;
@@ -3359,6 +3371,8 @@ mod tests {
                 agent_cmd: Some(String::new()),
                 agent_id: Some("\t".to_string()),
                 model: Some(" ".to_string()),
+                agent_source: Some(" ".to_string()),
+                wsl_distro: Some("\t".to_string()),
                 owner_tab_id: Some("\n".to_string()),
             },
         );
@@ -3394,6 +3408,8 @@ mod tests {
                 agent_cmd: Some(String::new()),
                 agent_id: Some("\t".to_string()),
                 model: Some(" ".to_string()),
+                agent_source: Some(" ".to_string()),
+                wsl_distro: Some("\t".to_string()),
                 owner_tab_id: Some("\n".to_string()),
             }
             .is_empty(),

--- a/tools/wta/src/shell/shell_manager.rs
+++ b/tools/wta/src/shell/shell_manager.rs
@@ -8,6 +8,7 @@ use tokio::process::Command;
 use super::wt_channel::WtChannel;
 
 /// Configuration for creating a new terminal.
+#[derive(Debug)]
 pub struct TerminalConfig {
     pub command: String,
     pub args: Vec<String>,
@@ -48,6 +49,7 @@ pub struct ShellManager {
     terminals: Mutex<HashMap<String, Terminal>>,
     next_id: Mutex<u64>,
     wt_channel: Option<Arc<dyn WtChannel>>,
+    agent_source: crate::agent_source::AgentSource,
 }
 
 impl ShellManager {
@@ -56,11 +58,17 @@ impl ShellManager {
             terminals: Mutex::new(HashMap::new()),
             next_id: Mutex::new(1),
             wt_channel: None,
+            agent_source: crate::agent_source::AgentSource::Host,
         }
     }
 
     pub fn with_wt_channel(mut self, channel: Arc<dyn WtChannel>) -> Self {
         self.wt_channel = Some(channel);
+        self
+    }
+
+    pub fn with_agent_source(mut self, source: crate::agent_source::AgentSource) -> Self {
+        self.agent_source = source;
         self
     }
 
@@ -88,6 +96,7 @@ impl ShellManager {
         if self.should_force_local(&config) {
             return self.create_terminal_local(config).await;
         }
+        let config = self.prepare_terminal_config(config)?;
 
         if self.has_wt_channel() {
             match self.create_terminal_wt(&config).await {
@@ -99,6 +108,35 @@ impl ShellManager {
             }
         }
         self.create_terminal_local(config).await
+    }
+
+    fn prepare_terminal_config(&self, config: TerminalConfig) -> anyhow::Result<TerminalConfig> {
+        let crate::agent_source::AgentSource::Wsl { distro } = &self.agent_source else {
+            return Ok(config);
+        };
+
+        let mut args = vec!["-d".to_string(), distro.clone()];
+        if let Some(cwd) = config.cwd.as_deref().filter(|cwd| !cwd.trim().is_empty()) {
+            anyhow::ensure!(
+                cwd.starts_with('/'),
+                "WSL agent requested a non-Linux terminal cwd: {cwd}"
+            );
+            args.extend(["--cd".to_string(), cwd.to_string()]);
+        }
+        args.push("--".to_string());
+        if !config.env.is_empty() {
+            args.push("env".to_string());
+            args.extend(config.env.iter().map(|(name, value)| format!("{name}={value}")));
+        }
+        args.push(config.command);
+        args.extend(config.args);
+
+        Ok(TerminalConfig {
+            command: "wsl.exe".to_string(),
+            args,
+            cwd: None,
+            env: Vec::new(),
+        })
     }
 
     fn should_force_local(&self, config: &TerminalConfig) -> bool {
@@ -116,17 +154,10 @@ impl ShellManager {
         let wt = self.wt()?;
 
         // Build the commandline string: "command arg1 arg2 ..."
-        let mut cmdline = config.command.clone();
+        let mut cmdline = crate::coordinator::quote_windows_commandline_arg(&config.command);
         for arg in &config.args {
             cmdline.push(' ');
-            // Quote args containing spaces
-            if arg.contains(' ') {
-                cmdline.push('"');
-                cmdline.push_str(arg);
-                cmdline.push('"');
-            } else {
-                cmdline.push_str(arg);
-            }
+            cmdline.push_str(&crate::coordinator::quote_windows_commandline_arg(arg));
         }
 
         // Create a new tab in WT with the command
@@ -592,5 +623,64 @@ impl ShellManager {
         self.wt()?
             .request("get_active_pane", serde_json::json!({}))
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wsl_source_wraps_terminal_command_cwd_and_environment() {
+        let manager = ShellManager::new().with_agent_source(
+            crate::agent_source::AgentSource::Wsl {
+                distro: "Ubuntu".to_string(),
+            },
+        );
+        let wrapped = manager
+            .prepare_terminal_config(TerminalConfig {
+                command: "bash".to_string(),
+                args: vec!["-lc".to_string(), "printf hello".to_string()],
+                cwd: Some("/home/user/project".to_string()),
+                env: vec![("TOKEN".to_string(), "value with space".to_string())],
+            })
+            .expect("valid Linux terminal request");
+
+        assert_eq!(wrapped.command, "wsl.exe");
+        assert_eq!(
+            wrapped.args,
+            vec![
+                "-d",
+                "Ubuntu",
+                "--cd",
+                "/home/user/project",
+                "--",
+                "env",
+                "TOKEN=value with space",
+                "bash",
+                "-lc",
+                "printf hello",
+            ]
+        );
+        assert!(wrapped.cwd.is_none());
+        assert!(wrapped.env.is_empty());
+    }
+
+    #[test]
+    fn wsl_source_rejects_windows_terminal_cwd() {
+        let manager = ShellManager::new().with_agent_source(
+            crate::agent_source::AgentSource::Wsl {
+                distro: "Ubuntu".to_string(),
+            },
+        );
+        let error = manager
+            .prepare_terminal_config(TerminalConfig {
+                command: "bash".to_string(),
+                args: Vec::new(),
+                cwd: Some(r"C:\repo".to_string()),
+                env: Vec::new(),
+            })
+            .expect_err("Windows cwd must not leak into a WSL tool request");
+        assert!(error.to_string().contains("non-Linux terminal cwd"));
     }
 }

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -364,12 +364,21 @@ fn explicit_empty_agent_allowlist_is_fail_closed() {
 
 #[test]
 fn switch_agent_event_is_scoped_to_window_and_tab() {
-    let payload = build_switch_agent_event("42", "{tab-guid}", "claude");
+    let payload = build_switch_agent_event(
+        "42",
+        "{tab-guid}",
+        "claude",
+        &crate::agent_source::AgentSource::Wsl {
+            distro: "Ubuntu".to_string(),
+        },
+    );
     let event: serde_json::Value = serde_json::from_str(&payload).expect("valid event json");
     assert_eq!(event["method"], "switch_agent");
     assert_eq!(event["params"]["window_id"], "42");
     assert_eq!(event["params"]["tab_id"], "{tab-guid}");
     assert_eq!(event["params"]["agent_id"], "claude");
+    assert_eq!(event["params"]["agent_source"], "wsl");
+    assert_eq!(event["params"]["wsl_distro"], "Ubuntu");
 }
 
 // ---- Degraded (transport-lost) gating: only /restart runs ----

--- a/tools/wta/src/ui/agent_popup.rs
+++ b/tools/wta/src/ui/agent_popup.rs
@@ -15,6 +15,7 @@ pub struct AgentPopupState<'a> {
     pub agents: &'a [AvailableAgent],
     pub selected: usize,
     pub current_id: &'a str,
+    pub current_source: &'a crate::agent_source::AgentSource,
 }
 
 pub fn render_popup(frame: &mut Frame, state: AgentPopupState<'_>, input_area: Rect) {
@@ -30,7 +31,8 @@ pub fn render_popup(frame: &mut Frame, state: AgentPopupState<'_>, input_area: R
         .agents
         .iter()
         .map(|agent| {
-            let marker = if agent.id == state.current_id {
+            let marker =
+                if agent.id == state.current_id && &agent.source == state.current_source {
                 CURRENT_MARKER
             } else {
                 CURRENT_PAD

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -36,6 +36,9 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             .split(area);
         setup::render(frame, app, chunks[0]);
         input::render(frame, app, chunks[1]);
+        if let Some(agent_state) = app.agent_popup_state() {
+            agent_popup::render_popup(frame, agent_state, chunks[1]);
+        }
         return;
     }
 

--- a/tools/wta/src/ui/setup.rs
+++ b/tools/wta/src/ui/setup.rs
@@ -76,6 +76,9 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         let is_selected = i == setup.selected_index;
 
         let (label, status_text) = match opt {
+            SetupOption::ChooseAgentSource => {
+                (t!("agent_picker.title").into_owned(), String::new())
+            }
             SetupOption::Install { display_name, .. } => {
                 let status = if setup.install_in_progress {
                     format!("  {} {}", spinner_char, t!("setup.status.installing"))


### PR DESCRIPTION
## Summary

- extend `/agent` from agent IDs to per-tab agent sources
- list Windows sources for Windows panes and Windows plus the effective pane's distro for WSL panes
- run selected WSL ACP servers and ACP terminal tools inside that distro while keeping helper/master and WT COM routing on Windows
- expose the same source picker from the agent-pane Setup screen without changing the global Settings dropdown
- reject cross-distro selections and never silently fall back to another source

## Implementation

- carries `host` / `wsl:<distro>` through helper metadata and keys the shared master pool by source plus command
- launches WSL ACP over `wsl.exe` stdio with login-environment setup isolated from the ACP stdout stream
- preserves the source pane cwd and stamps live sessions with their WSL location
- validates the requested distro again in TerminalApp before applying the per-tab override

## Validation

- full WTA Rust test suite
- explicit-target `x86_64-pc-windows-msvc` WTA build
- targeted `TerminalApp` incremental build
- live Ubuntu/WSL checks for source probing and ACP stdout isolation
- two high-confidence code-review passes

## MVP limitations

- the Settings Agent dropdown remains the Windows-host default; WSL sources are selected per tab through `/agent`
- WSL authentication is completed inside the distro, followed by Retry in the agent pane
- a WSL-side shim for directly invoking packaged `wta` / `wtcli` is not included
