### PR TITLE
Trigger autofix for PowerShell parser errors

### DIFF
--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -431,39 +431,43 @@ void ShellIntegrationTests::PowerShell_ScriptContent_TracksUnhistoriedErrors()
 {
     const auto script = ShellIntegrationScriptContent();
     const auto readLineWrapper = script.find("function Global:PSConsoleHostReadLine");
-    const auto parseInput = script.find("Language.Parser]::ParseInput", readLineWrapper);
-    const auto parserFlagSet = script.find("$Global:__ShellInteg_LastInputHadParserError = $parseErrors.Count -gt 0", parseInput);
+    const auto lineStored = script.find("$Global:__ShellInteg_LastSubmittedLine =", readLineWrapper);
     const auto promptStart = script.find("function prompt");
-    const auto parserFlagCapture = script.find("$inputHadParserError = $Global:__ShellInteg_LastInputHadParserError", promptStart);
-    const auto capture = script.find("$errorRecord", parserFlagCapture);
+    const auto lineCaptured = script.find("$submittedLine = $Global:__ShellInteg_LastSubmittedLine", promptStart);
+    const auto capture = script.find("$errorRecord", lineCaptured);
     const auto historyCheck = script.find("$historyAdvanced =", capture);
     const auto errorCheck = script.find("$newErrorRecord =", historyCheck);
     const auto referenceCheck = script.find("[object]::ReferenceEquals", errorCheck);
-    const auto staleZeroCheck = script.find("if (($inputHadParserError -or (-not $historyAdvanced -and $newErrorRecord)) -and $gle -eq 0)", referenceCheck);
+    const auto lazyParseGuard = script.find("($newErrorRecord -or -not $historyAdvanced)", referenceCheck);
+    const auto parseInput = script.find("Language.Parser]::ParseInput", lazyParseGuard);
+    const auto parserFlagSet = script.find("$inputHadParserError = $parseErrors.Count -gt 0", parseInput);
+    const auto staleZeroCheck = script.find("if ($inputHadParserError -and $gle -eq 0)", parserFlagSet);
     const auto sentinelAssignment = script.find("$gle = -1", staleZeroCheck);
     const auto untrackedErrorCheck = script.find("$newUntrackedError = -not $historyAdvanced -and $gle -ne 0 -and $newErrorRecord", sentinelAssignment);
     const auto combinedCheck = script.find("if ($historyAdvanced -or $newUntrackedError -or $inputHadParserError)", untrackedErrorCheck);
     const auto originalPrompt = script.find("$originalOutput = & $Global:__ShellInteg_OriginalPrompt", combinedCheck);
     const auto consumeError = script.find("$Global:__ShellInteg_LastErrorRecord = $Error[0]", originalPrompt);
-    const auto consumeParserFlag = script.find("$Global:__ShellInteg_LastInputHadParserError = $false", consumeError);
+    const auto consumeLine = script.find("$Global:__ShellInteg_LastSubmittedLine = $null", consumeError);
 
-    VERIFY_ARE_NOT_EQUAL(std::string::npos, consumeParserFlag);
-    VERIFY_IS_TRUE(readLineWrapper < parseInput &&
-                       parseInput < parserFlagSet &&
-                       parserFlagSet < promptStart &&
-                       promptStart < parserFlagCapture &&
-                       parserFlagCapture < capture &&
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, consumeLine);
+    VERIFY_IS_TRUE(readLineWrapper < lineStored &&
+                       lineStored < promptStart &&
+                       promptStart < lineCaptured &&
+                       lineCaptured < capture &&
                        capture < historyCheck &&
                        historyCheck < errorCheck &&
                        errorCheck < referenceCheck &&
-                       referenceCheck < staleZeroCheck &&
+                       referenceCheck < lazyParseGuard &&
+                       lazyParseGuard < parseInput &&
+                       parseInput < parserFlagSet &&
+                       parserFlagSet < staleZeroCheck &&
                        staleZeroCheck < sentinelAssignment &&
                        sentinelAssignment < untrackedErrorCheck &&
                        untrackedErrorCheck < combinedCheck &&
                        combinedCheck < originalPrompt &&
                        originalPrompt < consumeError &&
-                       consumeError < consumeParserFlag,
-                   L"Parser errors must be captured at the PSReadLine boundary, emitted once with a non-zero exit code, and consumed after prompt rendering");
+                       consumeError < consumeLine,
+                   L"Submitted input must be retained at the PSReadLine boundary, parsed only after normal completion signals are absent, and consumed after prompt rendering");
 }
 
 void ShellIntegrationTests::PowerShell_ScriptContent_GatesRestrictedLanguageFeatures()
@@ -471,15 +475,17 @@ void ShellIntegrationTests::PowerShell_ScriptContent_GatesRestrictedLanguageFeat
     const auto script = ShellIntegrationScriptContent();
     const auto languageMode = script.find("$ExecutionContext.SessionState.LanguageMode -eq 'FullLanguage'");
     const auto readLineGuard = script.find("if ($Global:__ShellInteg_CanInspectErrors -and (Test-Path Function:\\PSConsoleHostReadLine))", languageMode);
-    const auto parseInput = script.find("Language.Parser]::ParseInput", readLineGuard);
-    const auto errorRecordGuard = script.find("$newErrorRecord = $Global:__ShellInteg_CanInspectErrors", parseInput);
+    const auto errorRecordGuard = script.find("$newErrorRecord = $Global:__ShellInteg_CanInspectErrors", readLineGuard);
     const auto referenceCheck = script.find("[object]::ReferenceEquals", errorRecordGuard);
+    const auto lazyParseGuard = script.find("if ($Global:__ShellInteg_CanInspectErrors -and", referenceCheck);
+    const auto parseInput = script.find("Language.Parser]::ParseInput", lazyParseGuard);
 
-    VERIFY_ARE_NOT_EQUAL(std::string::npos, referenceCheck);
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, parseInput);
     VERIFY_IS_TRUE(languageMode < readLineGuard &&
-                       readLineGuard < parseInput &&
-                       parseInput < errorRecordGuard &&
-                       errorRecordGuard < referenceCheck,
+                       readLineGuard < errorRecordGuard &&
+                       errorRecordGuard < referenceCheck &&
+                       referenceCheck < lazyParseGuard &&
+                       lazyParseGuard < parseInput,
                    L"Constrained Language Mode must bypass static parser and reference-identity method calls");
 }
 

--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -50,6 +50,8 @@ class TerminalCoreUnitTests::ShellIntegrationTests final
     TEST_METHOD(BuildBlock_ContainsMarkersAndScriptFilename);
     TEST_METHOD(BuildBlock_HonoursEolParameter);
     TEST_METHOD(PowerShell_ScriptContent_HandlesNullLastExitCode);
+    TEST_METHOD(PowerShell_ScriptContent_TracksUnhistoriedErrors);
+    TEST_METHOD(PowerShell_ScriptContent_GatesRestrictedLanguageFeatures);
 
     // Install scenarios.
     TEST_METHOD(Install_EmptyPath_Fails);
@@ -423,6 +425,62 @@ void ShellIntegrationTests::PowerShell_ScriptContent_HandlesNullLastExitCode()
                        nativeReturn < sentinelReturn &&
                        sentinelReturn < functionEnd,
                    L"The exit-code helper must guard null/zero before returning a native code, then fall back to a numeric non-zero sentinel");
+}
+
+void ShellIntegrationTests::PowerShell_ScriptContent_TracksUnhistoriedErrors()
+{
+    const auto script = ShellIntegrationScriptContent();
+    const auto readLineWrapper = script.find("function Global:PSConsoleHostReadLine");
+    const auto parseInput = script.find("Language.Parser]::ParseInput", readLineWrapper);
+    const auto parserFlagSet = script.find("$Global:__ShellInteg_LastInputHadParserError = $parseErrors.Count -gt 0", parseInput);
+    const auto promptStart = script.find("function prompt");
+    const auto parserFlagCapture = script.find("$inputHadParserError = $Global:__ShellInteg_LastInputHadParserError", promptStart);
+    const auto capture = script.find("$errorRecord", parserFlagCapture);
+    const auto historyCheck = script.find("$historyAdvanced =", capture);
+    const auto errorCheck = script.find("$newErrorRecord =", historyCheck);
+    const auto referenceCheck = script.find("[object]::ReferenceEquals", errorCheck);
+    const auto staleZeroCheck = script.find("if (($inputHadParserError -or (-not $historyAdvanced -and $newErrorRecord)) -and $gle -eq 0)", referenceCheck);
+    const auto sentinelAssignment = script.find("$gle = -1", staleZeroCheck);
+    const auto untrackedErrorCheck = script.find("$newUntrackedError = -not $historyAdvanced -and $gle -ne 0 -and $newErrorRecord", sentinelAssignment);
+    const auto combinedCheck = script.find("if ($historyAdvanced -or $newUntrackedError -or $inputHadParserError)", untrackedErrorCheck);
+    const auto originalPrompt = script.find("$originalOutput = & $Global:__ShellInteg_OriginalPrompt", combinedCheck);
+    const auto consumeError = script.find("$Global:__ShellInteg_LastErrorRecord = $Error[0]", originalPrompt);
+    const auto consumeParserFlag = script.find("$Global:__ShellInteg_LastInputHadParserError = $false", consumeError);
+
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, consumeParserFlag);
+    VERIFY_IS_TRUE(readLineWrapper < parseInput &&
+                       parseInput < parserFlagSet &&
+                       parserFlagSet < promptStart &&
+                       promptStart < parserFlagCapture &&
+                       parserFlagCapture < capture &&
+                       capture < historyCheck &&
+                       historyCheck < errorCheck &&
+                       errorCheck < referenceCheck &&
+                       referenceCheck < staleZeroCheck &&
+                       staleZeroCheck < sentinelAssignment &&
+                       sentinelAssignment < untrackedErrorCheck &&
+                       untrackedErrorCheck < combinedCheck &&
+                       combinedCheck < originalPrompt &&
+                       originalPrompt < consumeError &&
+                       consumeError < consumeParserFlag,
+                   L"Parser errors must be captured at the PSReadLine boundary, emitted once with a non-zero exit code, and consumed after prompt rendering");
+}
+
+void ShellIntegrationTests::PowerShell_ScriptContent_GatesRestrictedLanguageFeatures()
+{
+    const auto script = ShellIntegrationScriptContent();
+    const auto languageMode = script.find("$ExecutionContext.SessionState.LanguageMode -eq 'FullLanguage'");
+    const auto readLineGuard = script.find("if ($Global:__ShellInteg_CanInspectErrors -and (Test-Path Function:\\PSConsoleHostReadLine))", languageMode);
+    const auto parseInput = script.find("Language.Parser]::ParseInput", readLineGuard);
+    const auto errorRecordGuard = script.find("$newErrorRecord = $Global:__ShellInteg_CanInspectErrors", parseInput);
+    const auto referenceCheck = script.find("[object]::ReferenceEquals", errorRecordGuard);
+
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, referenceCheck);
+    VERIFY_IS_TRUE(languageMode < readLineGuard &&
+                       readLineGuard < parseInput &&
+                       parseInput < errorRecordGuard &&
+                       errorRecordGuard < referenceCheck,
+                   L"Constrained Language Mode must bypass static parser and reference-identity method calls");
 }
 
 // ─── Install ──────────────────────────────────────────────────────────────────

--- a/src/cascadia/inc/PowerShellShellIntegration.h
+++ b/src/cascadia/inc/PowerShellShellIntegration.h
@@ -373,8 +373,8 @@ namespace Microsoft::Terminal::ShellIntegration::Powershell
     //
     // v6: PowerShell 7 discards parser failures before prompt runs: $? is
     // true, $Error[0] is null, and Get-History has no entry. Wrap
-    // PSConsoleHostReadLine to parse each submitted line before the engine
-    // receives it, then consume that parser-error signal once in prompt.
+    // PSConsoleHostReadLine to retain the submitted line, then parse it lazily
+    // in prompt only when no normal completion signal exists.
     // ───────────────────────────────────────────────────────────────────
     inline constexpr int kVersion = 6;
 
@@ -432,28 +432,20 @@ if (-not $Global:__ShellInteg_Installed) {
     $Global:__ShellInteg_OriginalPrompt = $function:prompt
     $Global:__ShellInteg_LastHistoryId  = -1
     $Global:__ShellInteg_LastErrorRecord = $Error[0]
-    $Global:__ShellInteg_LastInputHadParserError = $false
+    $Global:__ShellInteg_LastSubmittedLine = $null
     $Global:__ShellInteg_CanInspectErrors =
         $ExecutionContext.SessionState.LanguageMode -eq 'FullLanguage'
     $Global:__ShellInteg_Installed      = $true
 
     # PowerShell 7 drops parser failures before prompt runs, leaving no
-    # observable status there. Capture the submitted line at the PSReadLine
-    # boundary and parse it without changing what is returned to the engine.
+    # observable status there. Retain the submitted line at the PSReadLine
+    # boundary without changing what is returned to the engine.
     if ($Global:__ShellInteg_CanInspectErrors -and (Test-Path Function:\PSConsoleHostReadLine)) {
         $Global:__ShellInteg_OriginalPSConsoleHostReadLine = $function:PSConsoleHostReadLine
         function Global:PSConsoleHostReadLine {
             $line = & $Global:__ShellInteg_OriginalPSConsoleHostReadLine @args
-            $Global:__ShellInteg_LastInputHadParserError = $false
-            if ($line -is [string]) {
-                $tokens = $null
-                $parseErrors = $null
-                [void][System.Management.Automation.Language.Parser]::ParseInput(
-                    $line,
-                    [ref]$tokens,
-                    [ref]$parseErrors)
-                $Global:__ShellInteg_LastInputHadParserError = $parseErrors.Count -gt 0
-            }
+            $Global:__ShellInteg_LastSubmittedLine =
+                if ($line -is [string]) { $line } else { $null }
             return $line
         }
     }
@@ -474,13 +466,13 @@ if (-not $Global:__ShellInteg_Installed) {
 
     function prompt {
         # ── Capture exit code FIRST — before anything else can clobber $? ──
-        $gle                 = $(__ShellInteg_GetLastExitCode)
-        $inputHadParserError = $Global:__ShellInteg_LastInputHadParserError
-        $errorRecord         = $Error[0]
-        $entry               = Get-History -Count 1
-        $loc                 = $executionContext.SessionState.Path.CurrentLocation
-        $E                   = $Global:__ShellInteg_ESC
-        $B                   = $Global:__ShellInteg_BEL
+        $gle           = $(__ShellInteg_GetLastExitCode)
+        $submittedLine = $Global:__ShellInteg_LastSubmittedLine
+        $errorRecord   = $Error[0]
+        $entry         = Get-History -Count 1
+        $loc           = $executionContext.SessionState.Path.CurrentLocation
+        $E             = $Global:__ShellInteg_ESC
+        $B             = $Global:__ShellInteg_BEL
 
         $prefix = ''
         $suffix = ''
@@ -490,7 +482,20 @@ if (-not $Global:__ShellInteg_Installed) {
         $newErrorRecord = $Global:__ShellInteg_CanInspectErrors -and
             $null -ne $errorRecord -and
             -not [object]::ReferenceEquals($errorRecord, $Global:__ShellInteg_LastErrorRecord)
-        if (($inputHadParserError -or (-not $historyAdvanced -and $newErrorRecord)) -and $gle -eq 0) {
+        $inputHadParserError = $false
+        if ($Global:__ShellInteg_CanInspectErrors -and
+            $gle -eq 0 -and
+            $null -ne $submittedLine -and
+            ($newErrorRecord -or -not $historyAdvanced)) {
+            $tokens = $null
+            $parseErrors = $null
+            [void][System.Management.Automation.Language.Parser]::ParseInput(
+                $submittedLine,
+                [ref]$tokens,
+                [ref]$parseErrors)
+            $inputHadParserError = $parseErrors.Count -gt 0
+        }
+        if ($inputHadParserError -and $gle -eq 0) {
             $gle = -1
         }
         $newUntrackedError = -not $historyAdvanced -and $gle -ne 0 -and $newErrorRecord
@@ -520,7 +525,7 @@ if (-not $Global:__ShellInteg_Installed) {
 
         $Global:__ShellInteg_LastHistoryId = if ($entry) { $entry.Id } else { -1 }
         $Global:__ShellInteg_LastErrorRecord = $Error[0]
-        $Global:__ShellInteg_LastInputHadParserError = $false
+        $Global:__ShellInteg_LastSubmittedLine = $null
 
         return "${prefix}${originalOutput}${suffix}"
     }

--- a/src/cascadia/inc/PowerShellShellIntegration.h
+++ b/src/cascadia/inc/PowerShellShellIntegration.h
@@ -365,8 +365,18 @@ namespace Microsoft::Terminal::ShellIntegration::Powershell
     // native process was started. Treat null like the stale zero used by
     // PowerShell-level errors so OSC 133;D always carries a numeric non-zero
     // failure code.
+    //
+    // v5: track newly observed ErrorRecords as a fallback for failures that
+    // do not enter Get-History, and consume errors raised by custom prompt
+    // rendering so prompt redraws do not emit duplicate command-finished
+    // marks.
+    //
+    // v6: PowerShell 7 discards parser failures before prompt runs: $? is
+    // true, $Error[0] is null, and Get-History has no entry. Wrap
+    // PSConsoleHostReadLine to parse each submitted line before the engine
+    // receives it, then consume that parser-error signal once in prompt.
     // ───────────────────────────────────────────────────────────────────
-    inline constexpr int kVersion = 4;
+    inline constexpr int kVersion = 6;
 
     inline std::wstring ScriptFileName()
     {
@@ -421,7 +431,32 @@ if (-not $Global:__ShellInteg_Installed) {
     # ── Snapshot the user's current prompt before we touch it ──────────
     $Global:__ShellInteg_OriginalPrompt = $function:prompt
     $Global:__ShellInteg_LastHistoryId  = -1
+    $Global:__ShellInteg_LastErrorRecord = $Error[0]
+    $Global:__ShellInteg_LastInputHadParserError = $false
+    $Global:__ShellInteg_CanInspectErrors =
+        $ExecutionContext.SessionState.LanguageMode -eq 'FullLanguage'
     $Global:__ShellInteg_Installed      = $true
+
+    # PowerShell 7 drops parser failures before prompt runs, leaving no
+    # observable status there. Capture the submitted line at the PSReadLine
+    # boundary and parse it without changing what is returned to the engine.
+    if ($Global:__ShellInteg_CanInspectErrors -and (Test-Path Function:\PSConsoleHostReadLine)) {
+        $Global:__ShellInteg_OriginalPSConsoleHostReadLine = $function:PSConsoleHostReadLine
+        function Global:PSConsoleHostReadLine {
+            $line = & $Global:__ShellInteg_OriginalPSConsoleHostReadLine @args
+            $Global:__ShellInteg_LastInputHadParserError = $false
+            if ($line -is [string]) {
+                $tokens = $null
+                $parseErrors = $null
+                [void][System.Management.Automation.Language.Parser]::ParseInput(
+                    $line,
+                    [ref]$tokens,
+                    [ref]$parseErrors)
+                $Global:__ShellInteg_LastInputHadParserError = $parseErrors.Count -gt 0
+            }
+            return $line
+        }
+    }
 
     function Global:__ShellInteg_GetLastExitCode {
         # $? still reflects the *user's* last command here because this
@@ -439,17 +474,27 @@ if (-not $Global:__ShellInteg_Installed) {
 
     function prompt {
         # ── Capture exit code FIRST — before anything else can clobber $? ──
-        $gle   = $(__ShellInteg_GetLastExitCode)
-        $entry = Get-History -Count 1
-        $loc   = $executionContext.SessionState.Path.CurrentLocation
-        $E     = $Global:__ShellInteg_ESC
-        $B     = $Global:__ShellInteg_BEL
+        $gle                 = $(__ShellInteg_GetLastExitCode)
+        $inputHadParserError = $Global:__ShellInteg_LastInputHadParserError
+        $errorRecord         = $Error[0]
+        $entry               = Get-History -Count 1
+        $loc                 = $executionContext.SessionState.Path.CurrentLocation
+        $E                   = $Global:__ShellInteg_ESC
+        $B                   = $Global:__ShellInteg_BEL
 
         $prefix = ''
         $suffix = ''
 
         # ── Previous command finished (OSC 133;D with exit code) ──
-        if ($entry -and $entry.Id -ne $Global:__ShellInteg_LastHistoryId) {
+        $historyAdvanced = $entry -and $entry.Id -ne $Global:__ShellInteg_LastHistoryId
+        $newErrorRecord = $Global:__ShellInteg_CanInspectErrors -and
+            $null -ne $errorRecord -and
+            -not [object]::ReferenceEquals($errorRecord, $Global:__ShellInteg_LastErrorRecord)
+        if (($inputHadParserError -or (-not $historyAdvanced -and $newErrorRecord)) -and $gle -eq 0) {
+            $gle = -1
+        }
+        $newUntrackedError = -not $historyAdvanced -and $gle -ne 0 -and $newErrorRecord
+        if ($historyAdvanced -or $newUntrackedError -or $inputHadParserError) {
             $prefix += "${E}]133;D;${gle}${B}"
         }
 
@@ -474,6 +519,8 @@ if (-not $Global:__ShellInteg_Installed) {
         $originalOutput = & $Global:__ShellInteg_OriginalPrompt
 
         $Global:__ShellInteg_LastHistoryId = if ($entry) { $entry.Id } else { -1 }
+        $Global:__ShellInteg_LastErrorRecord = $Error[0]
+        $Global:__ShellInteg_LastInputHadParserError = $false
 
         return "${prefix}${originalOutput}${suffix}"
     }

--- a/test/e2e/tests/Feature.ShellIntegration.Tests.ps1
+++ b/test/e2e/tests/Feature.ShellIntegration.Tests.ps1
@@ -60,6 +60,74 @@ Describe 'Feature §3 Shell integration and detection' -Tag 'Feature' -Skip:(-no
         }
     }
 
+    It 'PowerShell parser errors emit one command-finished mark per malformed command' {
+        $sid = (Get-ActivePane -App $script:app).session_id
+        $malformedCommand = "'x'.like '*x*'"
+
+        $listener = Start-WtEventListener -App $script:app
+        try {
+            Invoke-RunCommand -App $script:app -SessionId $sid -Command $malformedCommand | Out-Null
+            $ev = Wait-WtCommandFailure -Listener $listener -PaneId $sid -TimeoutSec 20
+            "$($ev.params.sequence)" | Should -Match '(?i)osc:133;D;(?!0(\b|;|$))'
+            Start-Sleep -Seconds 2
+            @(Get-WtEvents -Listener $listener -Predicate {
+                    $_.method -eq 'vt_sequence' -and
+                    "$($_.params.pane_id)" -eq "$sid" -and
+                    $_.params.sequence -match '(?i)osc:133;D;(?!0(\b|;|$))(-?\d+)'
+                }) | Should -HaveCount 1
+        }
+        finally { Stop-WtEventListener -Listener $listener }
+
+        $listener = Start-WtEventListener -App $script:app
+        try {
+            Send-WtKeys -App $script:app -SessionId $sid -Keys @('Enter') | Out-Null
+            Start-Sleep -Seconds 3
+            $duplicateFailures = @(Get-WtEvents -Listener $listener -Predicate {
+                    $_.method -eq 'vt_sequence' -and
+                    "$($_.params.pane_id)" -eq "$sid" -and
+                    $_.params.sequence -match '(?i)osc:133;D;(?!0(\b|;|$))(-?\d+)'
+                })
+            $duplicateFailures | Should -BeNullOrEmpty
+        }
+        finally { Stop-WtEventListener -Listener $listener }
+
+        $listener = Start-WtEventListener -App $script:app
+        try {
+            Invoke-RunCommand -App $script:app -SessionId $sid -Command $malformedCommand | Out-Null
+            $ev = Wait-WtCommandFailure -Listener $listener -PaneId $sid -TimeoutSec 20
+            "$($ev.params.sequence)" | Should -Match '(?i)osc:133;D;(?!0(\b|;|$))'
+            Start-Sleep -Seconds 2
+            @(Get-WtEvents -Listener $listener -Predicate {
+                    $_.method -eq 'vt_sequence' -and
+                    "$($_.params.pane_id)" -eq "$sid" -and
+                    $_.params.sequence -match '(?i)osc:133;D;(?!0(\b|;|$))(-?\d+)'
+                }) | Should -HaveCount 1
+        }
+        finally { Stop-WtEventListener -Listener $listener }
+    }
+
+    It 'PowerShell commands that handle a non-terminating error still emit a zero-exit mark' {
+        $sid = (Get-ActivePane -App $script:app).session_id
+        $missingPath = Join-Path $env:TEMP "it-shell-integration-missing-$([guid]::NewGuid())"
+        $command = "Get-Item '$($missingPath.Replace("'", "''"))' -ErrorAction SilentlyContinue; Write-Output ok"
+        $listener = Start-WtEventListener -App $script:app
+        try {
+            Invoke-RunCommand -App $script:app -SessionId $sid -Command $command | Out-Null
+            { Wait-WtEvent -Listener $listener -TimeoutSec 20 -Predicate {
+                    $_.method -eq 'vt_sequence' -and
+                    "$($_.params.pane_id)" -eq "$sid" -and
+                    "$($_.params.sequence)" -match '(?i)osc:133;D;0(\b|;|$)'
+                } } | Should -Not -Throw
+            Start-Sleep -Seconds 2
+            @(Get-WtEvents -Listener $listener -Predicate {
+                    $_.method -eq 'vt_sequence' -and
+                    "$($_.params.pane_id)" -eq "$sid" -and
+                    $_.params.sequence -match '(?i)osc:133;D;(?!0(\b|;|$))(-?\d+)'
+                }) | Should -BeNullOrEmpty
+        }
+        finally { Stop-WtEventListener -Listener $listener }
+    }
+
     It 'PowerShell shell integration emits a zero-exit mark on success (OSC 133;D;0)' {
         $sid = (Get-ActivePane -App $script:app).session_id
         $listener = Start-WtEventListener -App $script:app


### PR DESCRIPTION
## Summary
- capture submitted PSReadLine input before PowerShell discards parser failures
- emit one non-zero OSC 133 completion mark per parser error without repeating on prompt redraw
- preserve zero-exit reporting for commands that handle a non-terminating error and ultimately succeed
- bypass unsupported parser/reference inspection in Constrained Language Mode

## Validation
- built `UnitTests_TerminalCore` and passed all `PowerShell_ScriptContent*` tests
- live `wtcli listen` verification: first parser error `D;-1`, blank redraw no `D`, repeated parser error `D;-1`
- live handled-error verification: successful tail emits `D;0`
- sourced and invoked the generated script under Constrained Language Mode without adding errors

Fixes #474