### PR TITLE
Add PowerShell Autofix integration coverage

### DIFF
--- a/doc/release-check-list.md
+++ b/doc/release-check-list.md
@@ -185,6 +185,10 @@ Net effect: UT shrinks the manual matrix to "did the wiring and UI connect", not
 - [ ] `C088` `[E2E]` **Missing shell integration is safe:** Without shell integration, failures do not crash or produce broken UI.
 - [x] `C089` `[UT✓]` **Failure detection works:** A failing command emits an event and is detected by Intelligent Terminal. _(UT: `classify_wt_event`.)_
 - [x] `C090` `[UT✓]` **Successful commands ignored:** Successful commands do not trigger autofix. _(UT: `classify_wt_event` + `success_exit_code_does_not_arm_autofix`.)_
+- [ ] `C230` `[new]` `[E2E]` **PowerShell parser errors trigger exactly one Autofix prompt:** A malformed PowerShell command emits a non-zero completion mark and submits one Autofix turn. _(#474; E2E: `Feature.AutofixParser`.)_
+- [ ] `C231` `[new]` `[E2E]` **Parser-error prompt redraw does not retrigger Autofix:** Pressing Enter on the fresh prompt after a parser error does not replay the prior failure or submit another Autofix turn. _(#474; E2E: `Feature.AutofixParser`.)_
+- [ ] `C232` `[new]` `[E2E]` **Successful PowerShell commands do not trigger Autofix:** A normal PowerShell command emits a zero-exit completion mark and does not submit an Autofix turn. _(#474; E2E: `Feature.AutofixParser`.)_
+- [ ] `C233` `[new]` `[E2E]` **Handled non-terminating PowerShell errors do not trigger Autofix:** A command that handles a non-terminating error and completes successfully remains distinct from a parser failure. _(#474; E2E: `Feature.AutofixParser`.)_
 - [x] `C091` `[UT✓]` **Detection off suppresses autofix:** With automatic error detection off, failures do not trigger autofix. _(UT: autofix reducer.)_
 - [x] `C092` `[UT✓]` **Detection on observes failures:** With detection on, failure notifications are observed. _(UT: autofix reducer.)_
 - [x] `C093` `[UT✓]` **Suggestion off suppresses LLM call:** With suggestion off, detection can show any expected local UI but does not ask the agent for a fix. _(UT: `suggestion_off_emits_detected_without_submitting_turn`.)_

--- a/test/e2e/ItE2E/Public/Ui.ps1
+++ b/test/e2e/ItE2E/Public/Ui.ps1
@@ -4,7 +4,7 @@
 function Get-WinAppPath {
     if ($script:ItWinAppPath -and (Test-Path $script:ItWinAppPath)) { return $script:ItWinAppPath }
     $c = (Get-Command winapp -ErrorAction SilentlyContinue).Source
-    if (-not $c) { throw "winapp (Windows App CLI) not found. Run bootstrap.ps1 or: winget install Microsoft.winappcli" }
+    if (-not $c) { throw "winapp (Windows App CLI) not found. Run bootstrap.ps1 or: winget install Microsoft.WinAppCli" }
     $script:ItWinAppPath = $c; $c
 }
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -18,9 +18,10 @@ environment. Current status (run on the Store package):
 | `Feature.FreExecutionPolicy.Tests.ps1` | §0 FRE execution-policy verdict (deterministic via registry; **Dev**, auto-skips) | 3 (1 conditional skip) |
 | `Feature.AgentPaneInteraction.Tests.ps1` | open/hide/focus, input/rendering, slash, Copilot chat | 14 |
 | `Feature.AutofixPane.Tests.ps1` | autofix card render/insert/run/reject/target/stashed + across layout | 10 |
+| `Feature.AutofixParser.Tests.ps1` | issue #474: PowerShell ParserError-to-Autofix pipeline + success/handled-error/blank-input negative controls | 4 |
 | `Feature.SessionList.Tests.ps1` | session view (button + `/sessions` slash), session states, view switching (incl. draft-preservation), focus/restore | 13 (+1 skip) |
 | `Feature.AgentRestart.Tests.ps1` | agent restart after a settings change (/restart reconnects and answers) | 1 |
-| `Feature.ShellIntegration.Tests.ps1` | §3 shell-integration OSC 133 marks (success/failure, including WinPS 5.1 PowerShell-level errors) + non-integrated cmd.exe safety | 4 |
+| `Feature.ShellIntegration.Tests.ps1` | §3 shell-integration OSC 133 marks (success/failure, ParserError dedup, handled errors, WinPS 5.1 errors) + non-integrated cmd.exe safety | 6 |
 | `Feature.AgentProposedCommand.Tests.ps1` | §2 agent-proposed command Insert/Run into the shell pane (non-autofix chat path) | 2 |
 | `Feature.AgentMatrix.Tests.ps1` | §2 non-Copilot built-in agents (Claude/Codex/Gemini) connect+chat through the ACP adapter — ONE consolidated case (Copilot is the in-depth suite); skips when none installed+authed | 1 |
 | `Feature.PerTabAgent.Tests.ps1` | C225-C228: `/agent` picker/direct selection, invalid-id safety, per-tab isolation/shared-master reuse, and global-default/override behavior | 6 |
@@ -55,7 +56,7 @@ Three planes, all built on self-verifying primitives:
 ## Prerequisites
 
 - Windows, **PowerShell 7+**
-- **Windows App CLI**: `winget install Microsoft.winappcli` (gives `winapp ui`)
+- **Windows App CLI**: `winget install Microsoft.WinAppCli` (gives `winapp ui`)
 - **Pester 5**: `Install-Module Pester -MinimumVersion 5.5.0 -Scope CurrentUser`
 - A deployed Intelligent Terminal package (Store `Microsoft.IntelligentTerminal_8wekyb3d8bbwe`
   or Dev `IntelligentTerminal_rd9vj3e6a2mbr`).

--- a/test/e2e/bootstrap.ps1
+++ b/test/e2e/bootstrap.ps1
@@ -24,11 +24,11 @@ Write-Host ("[{0}] Pester 5 {1}" -f ($(if ($pester) { 'ok' } else { 'miss' }), $
 
 if (-not $Check) {
     if (-not $haveWinapp) {
-        Write-Host "Installing Microsoft.winappcli via winget..." -ForegroundColor Cyan
-        winget install --id Microsoft.winappcli --source winget --accept-source-agreements --accept-package-agreements --disable-interactivity
+        Write-Host "Installing Microsoft.WinAppCli via winget..." -ForegroundColor Cyan
+        winget install --id Microsoft.WinAppCli --source winget --accept-source-agreements --accept-package-agreements --disable-interactivity
         # winget is a native exe: $ErrorActionPreference='Stop' does NOT trap its non-zero
         # exit, so check it explicitly or later "winapp not found" errors are confusing.
-        if ($LASTEXITCODE -ne 0) { throw "winget install Microsoft.winappcli failed (exit $LASTEXITCODE). Is the winget source reachable?" }
+        if ($LASTEXITCODE -ne 0) { throw "winget install Microsoft.WinAppCli failed (exit $LASTEXITCODE). Is the winget source reachable?" }
     }
     if (-not $pester) {
         Write-Host "Installing Pester 5..." -ForegroundColor Cyan

--- a/test/e2e/tests/Feature.AutofixParser.Tests.ps1
+++ b/test/e2e/tests/Feature.AutofixParser.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Feature: PowerShell parser errors trigger Autofix end-to-end' -Tag 'Fe
     }
     AfterAll { if ($script:app) { Stop-Terminal -App $script:app } }
 
-    It 'submits exactly one Autofix prompt for a PowerShell parser error' {
+    It 'PowerShell parser errors trigger exactly one Autofix prompt' {
         $listener = Start-WtEventListener -App $script:app
         try {
             Start-Sleep -Milliseconds 400
@@ -52,7 +52,7 @@ Describe 'Feature: PowerShell parser errors trigger Autofix end-to-end' -Tag 'Fe
         finally { Stop-WtEventListener -Listener $listener }
     }
 
-    It 'does not retrigger Autofix when the parser-error prompt is redrawn by blank Enter' {
+    It 'Parser-error prompt redraw does not retrigger Autofix' {
         $listener = Start-WtEventListener -App $script:app
         try {
             Start-Sleep -Milliseconds 400
@@ -87,7 +87,7 @@ Describe 'Feature: successful PowerShell completion does not trigger Autofix' -T
     }
     AfterAll { if ($script:app) { Stop-Terminal -App $script:app } }
 
-    It 'does not trigger Autofix for a normal successful command' {
+    It 'Successful PowerShell commands do not trigger Autofix' {
         $listener = Start-WtEventListener -App $script:app
         try {
             Start-Sleep -Milliseconds 400
@@ -106,7 +106,7 @@ Describe 'Feature: successful PowerShell completion does not trigger Autofix' -T
         finally { Stop-WtEventListener -Listener $listener }
     }
 
-    It 'does not trigger Autofix when a non-terminating error is handled successfully' {
+    It 'Handled non-terminating PowerShell errors do not trigger Autofix' {
         $missingPath = Join-Path $env:TEMP "it-autofix-parser-missing-$([guid]::NewGuid())"
         $escapedPath = $missingPath.Replace("'", "''")
         $listener = Start-WtEventListener -App $script:app

--- a/test/e2e/tests/Feature.AutofixParser.Tests.ps1
+++ b/test/e2e/tests/Feature.AutofixParser.Tests.ps1
@@ -1,0 +1,129 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+# Regression coverage for issue #474 and PR #477.
+#
+# Feature.ShellIntegration.Tests.ps1 verifies the PowerShell-side OSC 133 contract in
+# isolation. Feature.AutofixPane.Tests.ps1 verifies the existing Autofix UI and actions
+# with ordinary command failures. This suite closes the integration gap between them:
+# a real PowerShell parser error must cross the complete shell -> WT protocol -> WTA
+# pipeline and submit exactly one Autofix prompt, while ambiguous successful commands
+# must not submit one.
+
+BeforeDiscovery {
+    $script:Ready = [bool](
+        (Get-AppxPackage | Where-Object { $_.Name -like '*IntelligentTerminal*' }) -and
+        (Get-Command copilot -ErrorAction SilentlyContinue) -and
+        (Get-Command winapp -ErrorAction SilentlyContinue)
+    )
+}
+
+Describe 'Feature: PowerShell parser errors trigger Autofix end-to-end' -Tag 'Feature' -Skip:(-not $script:Ready) {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
+        $script:app = Start-Terminal -Package (Get-ItTestPackage) -PassFre $true -Settings @{
+            acpAgent      = 'copilot'
+            autoFixEnabled = $true
+        }
+        Open-AgentPane -App $script:app | Out-Null
+        Wait-AgentReady -App $script:app -TimeoutSec 60 |
+            Should -BeTrue -Because 'Autofix requires a connected ACP session'
+        $script:sid = (Get-ActivePane -App $script:app).session_id
+    }
+    AfterAll { if ($script:app) { Stop-Terminal -App $script:app } }
+
+    It 'submits exactly one Autofix prompt for a PowerShell parser error' {
+        $listener = Start-WtEventListener -App $script:app
+        try {
+            Start-Sleep -Milliseconds 400
+            Invoke-RunCommand -App $script:app -SessionId $script:sid -Command "'x'.like '*x*'" | Out-Null
+
+            $failure = Wait-WtCommandFailure -Listener $listener -PaneId $script:sid -TimeoutSec 20
+            "$($failure.params.sequence)" |
+                Should -Match '(?i)osc:133;D;(?!0(\b|;|$))' -Because 'the parser error must be corrected from stale exit code 0'
+
+            $autofix = Wait-Autofix -Listener $listener -TimeoutSec 45
+            $autofix | Should -Not -BeNullOrEmpty -Because 'the parser failure mark must reach the Autofix dispatcher'
+
+            Start-Sleep -Seconds 2
+            @(Get-WtEvents -Listener $listener -Predicate {
+                    $_.method -eq 'agent_event' -and
+                    "$($_.params.payload.initial_prompt)" -match 'command failed|Diagnose the error'
+                }) | Should -HaveCount 1 -Because 'one malformed command must submit one Autofix turn'
+        }
+        finally { Stop-WtEventListener -Listener $listener }
+    }
+
+    It 'does not retrigger Autofix when the parser-error prompt is redrawn by blank Enter' {
+        $listener = Start-WtEventListener -App $script:app
+        try {
+            Start-Sleep -Milliseconds 400
+            Send-WtKeys -App $script:app -SessionId $script:sid -Keys @('Enter') | Out-Null
+            Start-Sleep -Seconds 3
+
+            @(Get-WtEvents -Listener $listener -Predicate {
+                    $_.method -eq 'vt_sequence' -and
+                    "$($_.params.pane_id)" -eq "$script:sid" -and
+                    "$($_.params.sequence)" -match '(?i)osc:133;D;(?!0(\b|;|$))'
+                }) | Should -BeNullOrEmpty -Because 'blank input must not replay the previous parser failure'
+            @(Get-WtEvents -Listener $listener -Predicate {
+                    $_.method -eq 'agent_event' -and
+                    "$($_.params.payload.initial_prompt)" -match 'command failed|Diagnose the error'
+                }) | Should -BeNullOrEmpty -Because 'a prompt redraw must not submit another Autofix turn'
+        }
+        finally { Stop-WtEventListener -Listener $listener }
+    }
+}
+
+Describe 'Feature: successful PowerShell completion does not trigger Autofix' -Tag 'Feature' -Skip:(-not $script:Ready) {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
+        $script:app = Start-Terminal -Package (Get-ItTestPackage) -PassFre $true -Settings @{
+            acpAgent      = 'copilot'
+            autoFixEnabled = $true
+        }
+        Open-AgentPane -App $script:app | Out-Null
+        Wait-AgentReady -App $script:app -TimeoutSec 60 |
+            Should -BeTrue -Because 'negative assertions require a connected Autofix pipeline'
+        $script:sid = (Get-ActivePane -App $script:app).session_id
+    }
+    AfterAll { if ($script:app) { Stop-Terminal -App $script:app } }
+
+    It 'does not trigger Autofix for a normal successful command' {
+        $listener = Start-WtEventListener -App $script:app
+        try {
+            Start-Sleep -Milliseconds 400
+            Invoke-RunCommand -App $script:app -SessionId $script:sid -Command "Write-Output normal-ok-$([guid]::NewGuid())" | Out-Null
+            { Wait-WtEvent -Listener $listener -TimeoutSec 20 -Predicate {
+                    $_.method -eq 'vt_sequence' -and
+                    "$($_.params.pane_id)" -eq "$script:sid" -and
+                    "$($_.params.sequence)" -match '(?i)osc:133;D;0(\b|;|$)'
+                } } | Should -Not -Throw
+            Start-Sleep -Seconds 2
+            @(Get-WtEvents -Listener $listener -Predicate {
+                    $_.method -eq 'agent_event' -and
+                    "$($_.params.payload.initial_prompt)" -match 'command failed|Diagnose the error'
+                }) | Should -BeNullOrEmpty
+        }
+        finally { Stop-WtEventListener -Listener $listener }
+    }
+
+    It 'does not trigger Autofix when a non-terminating error is handled successfully' {
+        $missingPath = Join-Path $env:TEMP "it-autofix-parser-missing-$([guid]::NewGuid())"
+        $escapedPath = $missingPath.Replace("'", "''")
+        $listener = Start-WtEventListener -App $script:app
+        try {
+            Start-Sleep -Milliseconds 400
+            Invoke-RunCommand -App $script:app -SessionId $script:sid -Command "Get-Item '$escapedPath' -ErrorAction SilentlyContinue; Write-Output ok" | Out-Null
+            { Wait-WtEvent -Listener $listener -TimeoutSec 20 -Predicate {
+                    $_.method -eq 'vt_sequence' -and
+                    "$($_.params.pane_id)" -eq "$script:sid" -and
+                    "$($_.params.sequence)" -match '(?i)osc:133;D;0(\b|;|$)'
+                } } | Should -Not -Throw
+            Start-Sleep -Seconds 2
+            @(Get-WtEvents -Listener $listener -Predicate {
+                    $_.method -eq 'agent_event' -and
+                    "$($_.params.payload.initial_prompt)" -match 'command failed|Diagnose the error'
+                }) | Should -BeNullOrEmpty -Because 'handled errors that finish successfully must remain distinct from parser failures'
+        }
+        finally { Stop-WtEventListener -Listener $listener }
+    }
+}


### PR DESCRIPTION
## Summary
- add end-to-end regression coverage for the PowerShell parser-error Autofix pipeline from #474
- verify successful commands, handled non-terminating errors, and blank prompt redraws do not trigger Autofix
- link the four cases to release checklist items C230-C233 so full and incremental reports mark them automatically
- correct the Windows App CLI winget package ID used by the E2E bootstrap

## Validation
- `Feature.AutofixParser.Tests.ps1`: 4 passed, 0 failed, 0 skipped
- existing Shell Integration + Autofix suites: 14 passed, 0 failed, 4 environment/model-dependent skips
- `Invoke-ItE2EReport.ps1` and `Update-ReleaseReport.ps1`: C230-C233 marked `[x]`