### PR TITLE
Add E2E coverage for WSL profile agents

### DIFF
--- a/doc/release-check-list.md
+++ b/doc/release-check-list.md
@@ -97,6 +97,11 @@ Net effect: UT shrinks the manual matrix to "did the wiring and UI connect", not
 - [ ] `C047` `[E2E]` **Session hooks remove works:** Per-CLI remove buttons remove hook state without breaking the Settings page.
 - [ ] `C048` `[UT~]` `[E2E]` **Policy lock UI works:** Locked controls are disabled and show the policy message. _(UT: Effective*/IsLocked gates.)_
 
+### Profile Agent pane agent
+
+- [ ] `C237` `[new]` `[UT~]` `[E2E]` **Profile Agent pane agent picker works:** Each profile's Agent pane agent picker lists installed, policy-allowed Windows agents plus agents installed natively in that profile's WSL distro; saving persists `agentPaneBackend`, while an unconfigured profile inherits the global Windows agent. _(#481; UT: `ProfileTests::AgentPaneBackendDefaultsAndInherits`.)_
+- [ ] `C238` `[new]` `[E2E]` **Profile WSL agent routing is strict:** Changing a profile to a WSL backend rebuilds its helper, routes the exact selected agent through `wsl:<distro>`, and does not fall back to a Windows-hosted agent. _(#481; E2E: `Feature.WslAgentBackend`.)_
+
 ## 2. Agent pane chat
 
 **Feature definition:** The agent pane is a per-tab AI chat pane backed by WTA helper/master and an ACP-capable agent. It should be reusable, able to be hidden, and stable across tab/window operations.
@@ -131,6 +136,7 @@ Net effect: UT shrinks the manual matrix to "did the wiring and UI connect", not
 - [ ] `C057` `[E2E]` `[MANUAL]` **Copilot chat works:** User can send a prompt and Copilot responds successfully.
 - [x] `C058` `[UT✓]` `[E2E]` **Copilot missing CLI path works:** Missing Copilot shows actionable setup/auth guidance, not a silent failure. _(UT: `is_cli_available_*` availability check + the auth/setup screen renders `render_auth_sign_in_card` / `render_auth_screen_shows_agent_name`; a missing binary degrades to a guidance screen, not a silent failure. Exercising a truly uninstalled Copilot stays MANUAL.)_
 - [ ] `C059` `[E2E]` **Non-Copilot agents chat works:** Each installed+authenticated non-Copilot built-in agent (Claude/Codex/Gemini) connects through its ACP adapter and answers a prompt. _(One consolidated matrix case — all built-in agents share the same agent-pane/ACP path, so per-agent behavioural depth is covered by the Copilot suites.)_
+- [ ] `C239` `[new]` `[E2E]` **Profile WSL agent chat works:** An installed and authenticated agent selected by a WSL profile connects through the helper/master architecture from inside that distro and completes a real chat round trip. _(#481; E2E: `Feature.WslAgentBackend`.)_
 - [x] `C060` `[UT✓]` `[E2E]` **Agent auth failure works:** Unauthenticated agents show clear login guidance and can recover after sign-in. _(UT: `auth_error_routes_to_signin_not_connection_lost` (AuthRequired → sign-in, not a generic failure) + the in-pane auth screen renders `render_auth_screen_shows_agent_name` / `render_auth_sign_in_card` / `render_auth_checking_with_status_message` (login guidance + post-sign-in checking state). Driving a real sign-out stays MANUAL.)_
 - [ ] `C216` `[new]` `[E2E]` **GitHub Enterprise Copilot sign-in works:** On the auth screen, pressing **E** lets the user enter a GHE domain (e.g. `*.ghe.com`) and sign in; the last-used host is remembered and the device-verification URL targets that host. _(#362.)_
 - [ ] `C061` `[E2E]` **Agent restart after settings change works:** Changing the selected agent or model restarts/reconnects cleanly.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -29,12 +29,14 @@ environment. Current status (run on the Store package):
 | `Feature.WslAgentBackend.Tests.ps1` | PR #481 profile-scoped WSL agent backend: settings hot reload, helper/master source routing, and authenticated chat | 2 (environment-gated) |
 | `Feature.AgentChat.Tests.ps1` / `Feature.AgentPopup.Tests.ps1` | agent chat + `/` popup/menu interaction | 1 + 3 |
 
-**Coverage: all 101 automatable `[E2E]` checklist items are implemented.**
+**Coverage: 103 of 104 automatable `[E2E]` checklist items are implemented.**
 **Test status: 98 baseline feature cases pass + 2 documented skips** (`wta sessions list` is
 identity-gated — see `Feature.SessionList.Tests.ps1`), plus 2 PR #481 WSL-backend cases that
 run only when a dev package, runnable distro, and native supported agent are available; the
-chat case also requires authentication. The 101 checklist items map to the baseline cases
-plus the deterministic settings/persistence assertions. Remaining
+chat case also requires authentication. The 103 implemented checklist items map to the
+baseline cases plus the deterministic settings/persistence assertions. The remaining new
+item is the profile Agent pane agent picker UI; it stays explicit E2E work rather than being
+falsely credited by the JSON-level runtime tests. Other
 environment-dependent items are tracked and auto-skipped when their prerequisite is absent:
 **other agent CLIs** (`Feature.AgentMatrix.Tests.ps1` now covers Claude/Codex/Gemini chat,
 auth-gated per CLI — each Context runs only when that CLI is installed *and* authenticated,

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -26,12 +26,15 @@ environment. Current status (run on the Store package):
 | `Feature.AgentProposedCommand.Tests.ps1` | §2 agent-proposed command Insert/Run into the shell pane (non-autofix chat path) | 2 |
 | `Feature.AgentMatrix.Tests.ps1` | §2 non-Copilot built-in agents (Claude/Codex/Gemini) connect+chat through the ACP adapter — ONE consolidated case (Copilot is the in-depth suite); skips when none installed+authed | 1 |
 | `Feature.PerTabAgent.Tests.ps1` | C225-C228: `/agent` picker/direct selection, invalid-id safety, per-tab isolation/shared-master reuse, and global-default/override behavior | 6 |
+| `Feature.WslAgentBackend.Tests.ps1` | PR #481 profile-scoped WSL agent backend: settings hot reload, helper/master source routing, and authenticated chat | 2 (environment-gated) |
 | `Feature.AgentChat.Tests.ps1` / `Feature.AgentPopup.Tests.ps1` | agent chat + `/` popup/menu interaction | 1 + 3 |
 
 **Coverage: all 101 automatable `[E2E]` checklist items are implemented.**
-**Test status: 98 feature cases pass + 2 documented skips** (`wta sessions list` is
-identity-gated — see `Feature.SessionList.Tests.ps1`); the 101 checklist items map to these
-cases plus the deterministic settings/persistence assertions. Remaining
+**Test status: 98 baseline feature cases pass + 2 documented skips** (`wta sessions list` is
+identity-gated — see `Feature.SessionList.Tests.ps1`), plus 2 PR #481 WSL-backend cases that
+run only when a dev package, runnable distro, and native supported agent are available; the
+chat case also requires authentication. The 101 checklist items map to the baseline cases
+plus the deterministic settings/persistence assertions. Remaining
 environment-dependent items are tracked and auto-skipped when their prerequisite is absent:
 **other agent CLIs** (`Feature.AgentMatrix.Tests.ps1` now covers Claude/Codex/Gemini chat,
 auth-gated per CLI — each Context runs only when that CLI is installed *and* authenticated,

--- a/test/e2e/release-coverage-map.psd1
+++ b/test/e2e/release-coverage-map.psd1
@@ -36,6 +36,11 @@
     # §1 settings
     'Model control appears'             = 'Model control / model changes apply'
     'Model changes apply'               = 'Model control / model changes apply'
+    # PR #481 profile-scoped WSL backend runtime. The profile picker UI is deliberately
+    # NOT mapped: Feature.WslAgentBackend writes the profile JSON directly and therefore
+    # cannot prove that the Settings picker renders or saves correctly.
+    'Profile WSL agent routing is strict' = 'Hot reload routes the profile agent through its WSL distro without host fallback'
+    'Profile WSL agent chat works'        = 'profile-selected WSL agent connects and answers a chat round trip'
 
     # §0 FRE auto-error (on/off both covered by the single off/on test)
     'Automatic error detection on'      = 'Automatic error detection off/on'

--- a/test/e2e/tests/Feature.WslAgentBackend.Tests.ps1
+++ b/test/e2e/tests/Feature.WslAgentBackend.Tests.ps1
@@ -36,38 +36,38 @@ Describe 'Feature profile-scoped WSL agent backend' -Tag 'Feature' -Skip:(-not $
         }
 
         # Match the product's source probe: reject Windows executables leaked
-        # through WSL interop, and require npx for adapter-backed agents.
-        $agentProbeScript = @'
-for id in copilot gemini opencode claude codex; do
-    path="$(command -v "$id" 2>/dev/null || true)"
-    [ -n "$path" ] || continue
-    lower="$(printf '%s' "$path" | tr '[:upper:]' '[:lower:]')"
-    case "$lower" in
-        /mnt/*|*.exe|*.cmd|*.bat) continue ;;
-    esac
-    case "$id" in
-        claude|codex)
-            npx_path="$(command -v npx 2>/dev/null || true)"
-            npx_lower="$(printf '%s' "$npx_path" | tr '[:upper:]' '[:lower:]')"
-            case "$npx_lower" in
-                ''|/mnt/*|*.exe|*.cmd|*.bat) continue ;;
-            esac
-            ;;
-    esac
-    printf '%s\n' "$id"
-    break
-done
-'@
-        $agentProbe = Invoke-Native -FilePath 'wsl.exe' -Arguments @(
-            '-d', $script:distro, '--', 'bash', '-lc', $agentProbeScript
-        ) -TimeoutSec 45
+        # through WSL interop, and require native npx for adapter-backed agents.
+        # Probe one literal command at a time; wsl.exe's command-line expansion
+        # can consume loop variables in a compound bash script before bash runs.
         $knownAgents = @('copilot', 'gemini', 'opencode', 'claude', 'codex')
-        $script:agent = @(
-            $agentProbe.StdOut -split '\r?\n' |
-                ForEach-Object { $_.Trim() } |
-                Where-Object { $_ -in $knownAgents }
-        ) | Select-Object -First 1
-        if ($agentProbe.ExitCode -ne 0 -or -not $script:agent) {
+        $script:agent = $null
+        foreach ($candidate in $knownAgents) {
+            $pathProbe = Invoke-Native -FilePath 'wsl.exe' -Arguments @(
+                '-d', $script:distro, '--', 'sh', '-lc', "command -v $candidate 2>/dev/null"
+            ) -TimeoutSec 15
+            $path = $pathProbe.StdOut.Trim()
+            if ($pathProbe.ExitCode -ne 0 -or
+                -not $path -or
+                $path -match '(?i)^/mnt/[a-z]/|\.(exe|cmd|bat)$') {
+                continue
+            }
+
+            if ($candidate -in @('claude', 'codex')) {
+                $npxProbe = Invoke-Native -FilePath 'wsl.exe' -Arguments @(
+                    '-d', $script:distro, '--', 'sh', '-lc', 'command -v npx 2>/dev/null'
+                ) -TimeoutSec 15
+                $npxPath = $npxProbe.StdOut.Trim()
+                if ($npxProbe.ExitCode -ne 0 -or
+                    -not $npxPath -or
+                    $npxPath -match '(?i)^/mnt/[a-z]/|\.(exe|cmd|bat)$') {
+                    continue
+                }
+            }
+
+            $script:agent = $candidate
+            break
+        }
+        if (-not $script:agent) {
             $script:skipReason = "$($script:distro) has no supported native Linux ACP agent"
             return
         }

--- a/test/e2e/tests/Feature.WslAgentBackend.Tests.ps1
+++ b/test/e2e/tests/Feature.WslAgentBackend.Tests.ps1
@@ -1,0 +1,164 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+# PR #481: a profile can pin its agent pane to a supported ACP agent installed
+# inside that profile's WSL distro. The routing assertion is deterministic once
+# a native WSL agent is present; the chat assertion additionally requires auth.
+
+BeforeDiscovery {
+    $devPkg = Get-AppxPackage | Where-Object { $_.PackageFamilyName -like 'IntelligentTerminal_*' }
+    $script:Ready = [bool](
+        $devPkg -and
+        (Get-Command winapp -ErrorAction SilentlyContinue) -and
+        (Get-Command wsl.exe -ErrorAction SilentlyContinue)
+    )
+}
+
+Describe 'Feature profile-scoped WSL agent backend' -Tag 'Feature' -Skip:(-not $script:Ready) {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
+
+        $script:app = $null
+        $script:skipReason = $null
+        $script:oldAgentPaneId = $null
+        $script:profileGuid = '{e2e48100-4810-4810-9810-000000000001}'
+        $script:profileName = 'ITE2E PR481 WSL Agent'
+
+        $distroProbe = Invoke-Native -FilePath 'wsl.exe' -Arguments @(
+            '-e', 'sh', '-lc', 'printf "%s" "${WSL_DISTRO_NAME:-}"'
+        ) -TimeoutSec 45
+        $script:distro = $distroProbe.StdOut.Trim()
+        if ($distroProbe.ExitCode -ne 0 -or -not $script:distro) {
+            $script:skipReason = 'no runnable default WSL distro is available'
+            return
+        }
+        if ($script:distro -match '["\r\n]') {
+            $script:skipReason = 'the default WSL distro name cannot be represented safely in a test profile'
+            return
+        }
+
+        # Match the product's source probe: reject Windows executables leaked
+        # through WSL interop, and require npx for adapter-backed agents.
+        $agentProbeScript = @'
+for id in copilot gemini opencode claude codex; do
+    path="$(command -v "$id" 2>/dev/null || true)"
+    [ -n "$path" ] || continue
+    lower="$(printf '%s' "$path" | tr '[:upper:]' '[:lower:]')"
+    case "$lower" in
+        /mnt/*|*.exe|*.cmd|*.bat) continue ;;
+    esac
+    case "$id" in
+        claude|codex)
+            npx_path="$(command -v npx 2>/dev/null || true)"
+            npx_lower="$(printf '%s' "$npx_path" | tr '[:upper:]' '[:lower:]')"
+            case "$npx_lower" in
+                ''|/mnt/*|*.exe|*.cmd|*.bat) continue ;;
+            esac
+            ;;
+    esac
+    printf '%s\n' "$id"
+    break
+done
+'@
+        $agentProbe = Invoke-Native -FilePath 'wsl.exe' -Arguments @(
+            '-d', $script:distro, '--', 'bash', '-lc', $agentProbeScript
+        ) -TimeoutSec 45
+        $knownAgents = @('copilot', 'gemini', 'opencode', 'claude', 'codex')
+        $script:agent = @(
+            $agentProbe.StdOut -split '\r?\n' |
+                ForEach-Object { $_.Trim() } |
+                Where-Object { $_ -in $knownAgents }
+        ) | Select-Object -First 1
+        if ($agentProbe.ExitCode -ne 0 -or -not $script:agent) {
+            $script:skipReason = "$($script:distro) has no supported native Linux ACP agent"
+            return
+        }
+
+        $unconfiguredProfile = [pscustomobject][ordered]@{
+            guid        = $script:profileGuid
+            name        = $script:profileName
+            commandline = "wsl.exe -d `"$($script:distro)`""
+        }
+        $unconfiguredProfiles = [pscustomobject][ordered]@{
+            defaults = [pscustomobject]@{}
+            list     = @($unconfiguredProfile)
+        }
+        $script:backend = "wsl:$($script:distro):$($script:agent)"
+        $script:app = Start-Terminal -Package Dev -PassFre $true -Settings @{
+            acpAgent       = $script:agent
+            defaultProfile = $script:profileGuid
+            profiles       = $unconfiguredProfiles
+        }
+        $oldAgentPane = Get-AgentPaneSession -App $script:app
+        if ($oldAgentPane) {
+            $script:oldAgentPaneId = $oldAgentPane.PaneSessionId
+        }
+
+        # Apply the profile backend only after Start-Terminal has captured log
+        # offsets. This exercises settings hot reload and keeps source-routing
+        # assertions scoped to this run.
+        $configuredProfile = [pscustomobject][ordered]@{
+            guid             = $script:profileGuid
+            name             = $script:profileName
+            commandline      = "wsl.exe -d `"$($script:distro)`""
+            agentPaneBackend = $script:backend
+        }
+        $configuredProfiles = [pscustomobject][ordered]@{
+            defaults = [pscustomobject]@{}
+            list     = @($configuredProfile)
+        }
+        Set-WtSetting -App $script:app -Key 'profiles' -Value $configuredProfiles | Out-Null
+        Open-AgentPane -App $script:app | Out-Null
+    }
+    AfterAll {
+        if ($script:app) {
+            Stop-Terminal -App $script:app
+        }
+    }
+
+    It 'Hot reload routes the profile agent through its WSL distro without host fallback' {
+        if ($script:skipReason) {
+            Set-ItResult -Skipped -Because $script:skipReason
+            return
+        }
+
+        $settings = Get-WtSettingsObject -App $script:app
+        $profile = @($settings.profiles.list) |
+            Where-Object { $_.guid -eq $script:profileGuid } |
+            Select-Object -First 1
+        $profile.agentPaneBackend | Should -Be $script:backend
+
+        if ($script:oldAgentPaneId) {
+            (Test-Until -TimeoutSec 30 -IntervalSec 0.5 -Condition {
+                    -not (Get-AgentPaneSession -App $script:app -PaneSessionId $script:oldAgentPaneId)
+                }) | Should -BeTrue -Because 'changing this profile backend must replace its old host helper'
+        }
+
+        $agentPattern = [regex]::Escape($script:agent)
+        $sourcePattern = [regex]::Escape("wsl:$($script:distro)")
+        Assert-Log -App $script:app -Name 'wta-main_master.log' -Pattern (
+            'resolving agent CLI for helper.*requested_agent_id=Some\("' + $agentPattern +
+            '"\).*resolved_agent_source=' + $sourcePattern
+        ) -TimeoutSec 60
+        Assert-Log -App $script:app -Name 'wta-main_master.log' -Pattern (
+            'agent CLI spawned.*agent_source=' + $sourcePattern
+        ) -TimeoutSec 60
+    }
+
+    It 'The profile-selected WSL agent connects and answers a chat round trip' {
+        if ($script:skipReason) {
+            Set-ItResult -Skipped -Because $script:skipReason
+            return
+        }
+        if (-not (Wait-AgentReady -App $script:app -TimeoutSec 150)) {
+            Set-ItResult -Skipped -Because "$($script:agent) is installed in $($script:distro) but is not authenticated or its ACP server did not connect"
+            return
+        }
+
+        $oldAgentPaneIds = @($script:oldAgentPaneId) | Where-Object { $_ }
+        $agentPane = Wait-NewAgentPaneSession -App $script:app `
+            -ExcludePaneSessionId $oldAgentPaneIds -TimeoutSec 30
+        Send-AgentPrompt -App $script:app -PaneSessionId $agentPane.PaneSessionId `
+            -Text 'What is 480 plus 1? Reply with only the number.' | Out-Null
+        Assert-AgentPaneText -App $script:app -PaneSessionId $agentPane.PaneSessionId `
+            -Pattern '\b481\b' -TimeoutSec 150
+    }
+}


### PR DESCRIPTION
## Summary

- add environment-gated E2E coverage for the profile-scoped WSL agent backend introduced by #481
- verify profile settings hot reload replaces the host helper and routes the selected agent through the expected WSL distro
- exercise an authenticated chat round trip when the WSL agent is available and signed in

## Testing

- PowerShell AST parse
- Pester discovery: 2 tests
- Live run not performed; requires a deployed PR #481 Dev package, WSL, and a native supported agent

Stacked on #481.