### PR TITLE
Add agent subcommand autocomplete

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2000,14 +2000,6 @@ impl TabSession {
         }
     }
 
-    pub fn command_popup_down(&mut self) {
-        let candidate_count =
-            self.command_popup_candidates.len() + self.move_position_candidates.len();
-        if self.command_popup_selected + 1 < candidate_count {
-            self.command_popup_selected += 1;
-        }
-    }
-
     pub fn selected_command_spec(&self) -> Option<&'static CommandSpec> {
         self.command_popup_candidates
             .get(self.command_popup_selected)
@@ -7472,13 +7464,13 @@ impl App {
                 self.current_tab_mut().clear_input();
             }
             KeyCode::Up if self.command_popup_visible() => {
-                self.current_tab_mut().command_popup_up();
+                self.command_popup_up();
             }
             KeyCode::Down if self.command_popup_visible() => {
-                self.current_tab_mut().command_popup_down();
+                self.command_popup_down();
             }
             KeyCode::Tab if self.command_popup_visible() => {
-                self.current_tab_mut().accept_command_popup_completion();
+                self.accept_command_popup_completion();
             }
             KeyCode::Up
                 if self.current_tab().input_has_nav_focus()
@@ -7812,7 +7804,7 @@ impl App {
     /// popup should not be drawn this frame. Reads from the active tab.
     pub fn command_popup_state(&self) -> Option<crate::ui::PopupState<'_>> {
         let tab = self.current_tab();
-        if !tab.command_popup_visible() {
+        if !self.command_popup_visible() {
             return None;
         }
         // When the transport to master is lost, only /restart can run — so the
@@ -7820,8 +7812,9 @@ impl App {
         // them). Collapse the candidate list to /restart if it's among the
         // prefix matches; otherwise show nothing (the typed prefix excludes
         // it, e.g. "/new"), and the Enter handler surfaces the reconnect hint.
-        // Normal path borrows the tab's list (no per-frame allocation on the
-        // render hot path); only the degraded filter allocates.
+        // Static command and move candidates borrow the tab's lists. Agent
+        // candidates are filtered from the small cached available-agent list.
+        let agent_candidates = self.agent_command_candidates();
         let candidates = if self.transport_lost {
             let filtered: Vec<&'static crate::commands::CommandSpec> = tab
                 .command_popup_candidates
@@ -7833,6 +7826,8 @@ impl App {
                 return None;
             }
             crate::ui::PopupCandidates::Commands(std::borrow::Cow::Owned(filtered))
+        } else if !agent_candidates.is_empty() {
+            crate::ui::PopupCandidates::Agents(agent_candidates)
         } else if !tab.move_position_candidates.is_empty() {
             crate::ui::PopupCandidates::MovePositions(tab.move_position_candidates.as_slice())
         } else {
@@ -7883,7 +7878,9 @@ impl App {
     /// their normal behavior instead of swallowing the key against an
     /// invisible popup.
     fn command_popup_visible(&self) -> bool {
-        if !self.current_tab().command_popup_visible() {
+        if !self.current_tab().command_popup_visible()
+            && self.agent_command_candidates().is_empty()
+        {
             return false;
         }
         if self.transport_lost {
@@ -7896,6 +7893,79 @@ impl App {
                 .any(|s| s.kind == crate::commands::CommandKind::Restart);
         }
         true
+    }
+
+    fn agent_command_candidates(&self) -> Vec<&AvailableAgent> {
+        if self.transport_lost {
+            return Vec::new();
+        }
+        let Some(prefix) = commands::agent_id_prefix(&self.current_tab().input) else {
+            return Vec::new();
+        };
+        if prefix.is_empty() {
+            return Vec::new();
+        }
+        let prefix = prefix.to_ascii_lowercase();
+        self.available_agents
+            .iter()
+            .filter(|agent| agent.id.to_ascii_lowercase().starts_with(&prefix))
+            .collect()
+    }
+
+    fn selected_agent_command_candidate(&self) -> Option<&AvailableAgent> {
+        let candidates = self.agent_command_candidates();
+        let selected = self
+            .current_tab()
+            .command_popup_selected
+            .min(candidates.len().saturating_sub(1));
+        candidates.get(selected).copied()
+    }
+
+    fn command_popup_candidate_count(&self) -> usize {
+        let agent_count = self.agent_command_candidates().len();
+        if agent_count > 0 {
+            agent_count
+        } else {
+            let tab = self.current_tab();
+            tab.command_popup_candidates.len() + tab.move_position_candidates.len()
+        }
+    }
+
+    fn command_popup_up(&mut self) {
+        self.current_tab_mut().command_popup_up();
+    }
+
+    fn command_popup_down(&mut self) {
+        let candidate_count = self.command_popup_candidate_count();
+        let tab = self.current_tab_mut();
+        if tab.command_popup_selected + 1 < candidate_count {
+            tab.command_popup_selected += 1;
+        }
+    }
+
+    fn accept_command_popup_completion(&mut self) {
+        if let Some(agent_id) = self
+            .selected_agent_command_candidate()
+            .map(|agent| agent.id.clone())
+        {
+            let tab = self.current_tab_mut();
+            tab.reset_input_history_navigation();
+            tab.input = format!("/agent {agent_id}");
+            tab.cursor_pos = tab.input.len();
+            tab.refresh_command_popup();
+        } else {
+            self.current_tab_mut().accept_command_popup_completion();
+        }
+    }
+
+    pub(crate) fn command_ghost_suffix(&self) -> Option<&str> {
+        let tab = self.current_tab();
+        if tab.cursor_pos != tab.input.len() {
+            return None;
+        }
+        let prefix = commands::agent_id_prefix(&tab.input)?;
+        let candidate = self.selected_agent_command_candidate()?;
+        candidate.id.get(prefix.len()..).filter(|suffix| !suffix.is_empty())
     }
 
     /// Per-frame state for the `/model` picker modal, or `None` when it's not
@@ -7958,6 +8028,20 @@ impl App {
             // spec if it's in the filtered candidate list; otherwise there's
             // nothing to run, so consume Enter and show the reconnect hint.
             if !self.transport_lost {
+                if let Some(agent_id) = self
+                    .selected_agent_command_candidate()
+                    .map(|agent| agent.id.clone())
+                {
+                    let spec = commands::lookup("agent").expect("/agent is registered");
+                    let parsed = ParsedCommand {
+                        kind: CommandKind::Agent,
+                        spec,
+                        rest: agent_id,
+                    };
+                    self.current_tab_mut().clear_input();
+                    self.handle_slash_command(parsed);
+                    return true;
+                }
                 if let Some(position) = self.current_tab().selected_move_position() {
                     let spec = commands::lookup("move").expect("/move is registered");
                     let parsed = ParsedCommand {

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -7905,7 +7905,7 @@ impl App {
         let prefix = prefix.to_ascii_lowercase();
         self.available_agents
             .iter()
-            .filter(|agent| agent.id.to_ascii_lowercase().starts_with(&prefix))
+            .filter(|agent| agent.id.starts_with(&prefix))
             .collect()
     }
 

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -43,6 +43,23 @@ pub struct AvailableAgent {
     pub display_name: String,
 }
 
+fn agent_command_on_enter(
+    input: &str,
+    selected: Option<&AvailableAgent>,
+) -> Option<ParsedCommand> {
+    let prefix = commands::agent_id_prefix(input)?;
+    let rest = if prefix.is_empty() {
+        String::new()
+    } else {
+        selected?.id.clone()
+    };
+    Some(ParsedCommand {
+        kind: CommandKind::Agent,
+        spec: commands::lookup("agent").expect("/agent is registered"),
+        rest,
+    })
+}
+
 mod turn_state;
 mod autofix;
 use autofix::*;
@@ -8025,16 +8042,10 @@ impl App {
             // spec if it's in the filtered candidate list; otherwise there's
             // nothing to run, so consume Enter and show the reconnect hint.
             if !self.transport_lost {
-                if let Some(agent_id) = self
-                    .selected_agent_command_candidate()
-                    .map(|agent| agent.id.clone())
+                let selected_agent = self.selected_agent_command_candidate();
+                if let Some(parsed) =
+                    agent_command_on_enter(&self.current_tab().input, selected_agent)
                 {
-                    let spec = commands::lookup("agent").expect("/agent is registered");
-                    let parsed = ParsedCommand {
-                        kind: CommandKind::Agent,
-                        spec,
-                        rest: agent_id,
-                    };
                     self.current_tab_mut().clear_input();
                     self.handle_slash_command(parsed);
                     return true;

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -7831,7 +7831,7 @@ impl App {
         // it, e.g. "/new"), and the Enter handler surfaces the reconnect hint.
         // Static command and move candidates borrow the tab's lists. Agent
         // candidates are filtered from the small cached available-agent list.
-        let agent_candidates = self.agent_command_candidates();
+        let agent_candidates: Vec<_> = self.agent_command_candidates().collect();
         let candidates = if self.transport_lost {
             let filtered: Vec<&'static crate::commands::CommandSpec> = tab
                 .command_popup_candidates
@@ -7896,7 +7896,7 @@ impl App {
     /// invisible popup.
     fn command_popup_visible(&self) -> bool {
         if !self.current_tab().command_popup_visible()
-            && self.agent_command_candidates().is_empty()
+            && self.agent_command_candidates().next().is_none()
         {
             return false;
         }
@@ -7912,31 +7912,33 @@ impl App {
         true
     }
 
-    fn agent_command_candidates(&self) -> Vec<&AvailableAgent> {
-        if self.transport_lost {
-            return Vec::new();
-        }
-        let Some(prefix) = commands::agent_id_prefix(&self.current_tab().input) else {
-            return Vec::new();
+    fn agent_command_candidates(&self) -> impl Iterator<Item = &AvailableAgent> {
+        let prefix = if self.transport_lost {
+            None
+        } else {
+            commands::agent_id_prefix(&self.current_tab().input)
         };
-        let prefix = prefix.to_ascii_lowercase();
         self.available_agents
             .iter()
-            .filter(|agent| agent.id.starts_with(&prefix))
-            .collect()
+            .filter(move |agent| {
+                prefix.is_some_and(|prefix| {
+                    agent
+                        .id
+                        .get(..prefix.len())
+                        .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix))
+                })
+            })
     }
 
     fn selected_agent_command_candidate(&self) -> Option<&AvailableAgent> {
-        let candidates = self.agent_command_candidates();
-        let selected = self
-            .current_tab()
-            .command_popup_selected
-            .min(candidates.len().saturating_sub(1));
-        candidates.get(selected).copied()
+        let selected = self.current_tab().command_popup_selected;
+        self.agent_command_candidates()
+            .take(selected.saturating_add(1))
+            .last()
     }
 
     fn command_popup_candidate_count(&self) -> usize {
-        let agent_count = self.agent_command_candidates().len();
+        let agent_count = self.agent_command_candidates().count();
         if agent_count > 0 {
             agent_count
         } else {

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -47,16 +47,11 @@ fn agent_command_on_enter(
     input: &str,
     selected: Option<&AvailableAgent>,
 ) -> Option<ParsedCommand> {
-    let prefix = commands::agent_id_prefix(input)?;
-    let rest = if prefix.is_empty() {
-        String::new()
-    } else {
-        selected?.id.clone()
-    };
+    commands::agent_id_prefix(input)?;
     Some(ParsedCommand {
         kind: CommandKind::Agent,
         spec: commands::lookup("agent").expect("/agent is registered"),
-        rest,
+        rest: selected?.id.clone(),
     })
 }
 

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -7902,9 +7902,6 @@ impl App {
         let Some(prefix) = commands::agent_id_prefix(&self.current_tab().input) else {
             return Vec::new();
         };
-        if prefix.is_empty() {
-            return Vec::new();
-        }
         let prefix = prefix.to_ascii_lowercase();
         self.available_agents
             .iter()

--- a/tools/wta/src/commands.rs
+++ b/tools/wta/src/commands.rs
@@ -319,15 +319,27 @@ pub fn match_move_positions(prefix: &str) -> Vec<&'static MovePositionSpec> {
         .collect()
 }
 
+/// Return the canonical agent-id prefix while completing `/agent <id>`.
+///
+/// The command name must be complete and followed by whitespace. Agent IDs
+/// are single tokens, so a second argument hides completion.
+pub fn agent_id_prefix(input: &str) -> Option<&str> {
+    single_argument_prefix(input, "agent")
+}
+
 /// Return the argument prefix while the input is completing `/move <position>`.
 ///
 /// The command name must be complete and followed by whitespace. A second
 /// argument hides the popup because `/move` accepts exactly one position.
 pub fn move_position_prefix(input: &str) -> Option<&str> {
+    single_argument_prefix(input, "move")
+}
+
+fn single_argument_prefix<'a>(input: &'a str, command: &str) -> Option<&'a str> {
     let trimmed = input.trim_start();
     let rest = trimmed.strip_prefix('/')?;
     let command_end = rest.find(char::is_whitespace)?;
-    if !rest[..command_end].eq_ignore_ascii_case("move") {
+    if !rest[..command_end].eq_ignore_ascii_case(command) {
         return None;
     }
     let argument = rest[command_end..].trim_start();
@@ -387,6 +399,10 @@ mod tests {
         let direct = parse("/agent claude").unwrap();
         assert_eq!(direct.kind, CommandKind::Agent);
         assert_eq!(direct.rest, "claude");
+
+        let trailing_space = parse("/agent ").unwrap();
+        assert_eq!(trailing_space.kind, CommandKind::Agent);
+        assert_eq!(trailing_space.rest, "");
         assert!(lookup("agent").unwrap().takes_args);
     }
 
@@ -493,6 +509,16 @@ mod tests {
         assert_eq!(move_position_prefix("/move"), None);
         assert_eq!(move_position_prefix("/move left extra"), None);
         assert_eq!(move_position_prefix("/model r"), None);
+    }
+
+    #[test]
+    fn agent_id_prefix_accepts_one_argument() {
+        assert_eq!(agent_id_prefix("/agent "), Some(""));
+        assert_eq!(agent_id_prefix("/AGENT co"), Some("co"));
+        assert_eq!(agent_id_prefix("  /agent gem"), Some("gem"));
+        assert_eq!(agent_id_prefix("/agent"), None);
+        assert_eq!(agent_id_prefix("/agent copilot extra"), None);
+        assert_eq!(agent_id_prefix("/model co"), None);
     }
 
     #[test]

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -410,17 +410,22 @@ fn agent_argument_completion_uses_available_agents_in_registry_order() {
 }
 
 #[test]
-fn agent_without_argument_keeps_existing_picker_command_path() {
+fn agent_trailing_space_opens_completion_with_all_agents() {
     let mut app = test_app();
     seed_completion_agents(&mut app);
     type_input(&mut app, "/agent ");
 
-    assert!(app.command_popup_state().is_none());
-    let ParseOutcome::Command(command) = commands::classify(&app.current_tab().input) else {
-        panic!("expected /agent command");
+    let state = app.command_popup_state().expect("all agent candidates");
+    let crate::ui::PopupCandidates::Agents(candidates) = state.candidates else {
+        panic!("expected agent candidates");
     };
-    assert_eq!(command.kind, CommandKind::Agent);
-    assert!(command.rest.is_empty());
+    assert_eq!(
+        candidates
+            .iter()
+            .map(|agent| agent.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["copilot", "codex", "gemini"]
+    );
 }
 
 #[test]

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -372,6 +372,119 @@ fn switch_agent_event_is_scoped_to_window_and_tab() {
     assert_eq!(event["params"]["agent_id"], "claude");
 }
 
+fn seed_completion_agents(app: &mut App) {
+    app.available_agents = vec![
+        AvailableAgent {
+            id: "copilot".into(),
+            display_name: "GitHub Copilot".into(),
+        },
+        AvailableAgent {
+            id: "codex".into(),
+            display_name: "Codex".into(),
+        },
+        AvailableAgent {
+            id: "gemini".into(),
+            display_name: "Gemini".into(),
+        },
+    ];
+}
+
+#[test]
+fn agent_argument_completion_uses_available_agents_in_registry_order() {
+    let mut app = test_app();
+    seed_completion_agents(&mut app);
+    type_input(&mut app, "/AGENT CO");
+
+    let state = app.command_popup_state().expect("agent candidates");
+    let crate::ui::PopupCandidates::Agents(candidates) = state.candidates else {
+        panic!("expected agent candidates");
+    };
+    assert_eq!(
+        candidates
+            .iter()
+            .map(|agent| agent.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["copilot", "codex"]
+    );
+    assert_eq!(app.command_ghost_suffix(), Some("pilot"));
+}
+
+#[test]
+fn agent_without_argument_keeps_existing_picker_command_path() {
+    let mut app = test_app();
+    seed_completion_agents(&mut app);
+    type_input(&mut app, "/agent ");
+
+    assert!(app.command_popup_state().is_none());
+    let ParseOutcome::Command(command) = commands::classify(&app.current_tab().input) else {
+        panic!("expected /agent command");
+    };
+    assert_eq!(command.kind, CommandKind::Agent);
+    assert!(command.rest.is_empty());
+}
+
+#[test]
+fn agent_argument_arrow_changes_ghost_and_tab_completes() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let mut app = test_app();
+    seed_completion_agents(&mut app);
+    type_input(&mut app, "/agent co");
+
+    app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+    assert_eq!(app.command_ghost_suffix(), Some("dex"));
+
+    app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+    assert_eq!(app.current_tab().input, "/agent codex");
+    assert_eq!(app.command_ghost_suffix(), None);
+}
+
+#[test]
+fn agent_ghost_requires_cursor_at_end() {
+    let mut app = test_app();
+    seed_completion_agents(&mut app);
+    type_input(&mut app, "/agent co");
+    app.current_tab_mut().move_cursor_left();
+
+    assert_eq!(app.command_ghost_suffix(), None);
+}
+
+#[test]
+fn agent_argument_enter_dispatches_highlighted_agent() {
+    let mut app = test_app();
+    seed_completion_agents(&mut app);
+    app.current_agent_id = "copilot".into();
+    type_input(&mut app, "/agent co");
+
+    assert!(app.try_handle_slash_on_enter());
+    assert!(app.current_tab().input.is_empty());
+    assert!(
+        app.current_tab().messages.is_empty(),
+        "the selected exact agent must dispatch; the raw prefix must not reach unknown-agent handling"
+    );
+}
+
+#[test]
+fn unknown_agent_prefix_does_not_open_completion() {
+    let mut app = test_app();
+    seed_completion_agents(&mut app);
+    type_input(&mut app, "/agent zzz");
+
+    assert!(app.command_popup_state().is_none());
+    assert_eq!(app.command_ghost_suffix(), None);
+}
+
+#[test]
+fn agent_argument_completion_is_hidden_when_transport_is_lost() {
+    let mut app = test_app();
+    seed_completion_agents(&mut app);
+    type_input(&mut app, "/agent co");
+    app.transport_lost = true;
+
+    assert!(app.command_popup_state().is_none());
+    assert_eq!(app.command_ghost_suffix(), None);
+}
+
 // ---- Degraded (transport-lost) gating: only /restart runs ----
 
 #[test]

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -426,6 +426,16 @@ fn agent_trailing_space_opens_completion_with_all_agents() {
             .collect::<Vec<_>>(),
         vec!["copilot", "codex", "gemini"]
     );
+
+    let highlighted = app.selected_agent_command_candidate();
+    assert_eq!(highlighted.map(|agent| agent.id.as_str()), Some("copilot"));
+    let command =
+        agent_command_on_enter(&app.current_tab().input, highlighted).expect("agent command");
+    assert_eq!(command.kind, CommandKind::Agent);
+    assert!(
+        command.rest.is_empty(),
+        "Enter must dispatch bare /agent so cmd_agent opens the picker"
+    );
 }
 
 #[test]
@@ -458,15 +468,13 @@ fn agent_ghost_requires_cursor_at_end() {
 fn agent_argument_enter_dispatches_highlighted_agent() {
     let mut app = test_app();
     seed_completion_agents(&mut app);
-    app.current_agent_id = "copilot".into();
     type_input(&mut app, "/agent co");
 
-    assert!(app.try_handle_slash_on_enter());
-    assert!(app.current_tab().input.is_empty());
-    assert!(
-        app.current_tab().messages.is_empty(),
-        "the selected exact agent must dispatch; the raw prefix must not reach unknown-agent handling"
-    );
+    let highlighted = app.selected_agent_command_candidate();
+    let command =
+        agent_command_on_enter(&app.current_tab().input, highlighted).expect("agent command");
+    assert_eq!(command.kind, CommandKind::Agent);
+    assert_eq!(command.rest, "copilot");
 }
 
 #[test]

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -432,9 +432,9 @@ fn agent_trailing_space_opens_completion_with_all_agents() {
     let command =
         agent_command_on_enter(&app.current_tab().input, highlighted).expect("agent command");
     assert_eq!(command.kind, CommandKind::Agent);
-    assert!(
-        command.rest.is_empty(),
-        "Enter must dispatch bare /agent so cmd_agent opens the picker"
+    assert_eq!(
+        command.rest, "copilot",
+        "Enter must dispatch the highlighted agent once the completion list is visible"
     );
 }
 

--- a/tools/wta/src/ui/command_popup.rs
+++ b/tools/wta/src/ui/command_popup.rs
@@ -11,7 +11,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Clear, List, ListItem, ListState, Paragraph};
 
 use super::popup;
-use crate::app::App;
+use crate::app::{App, AvailableAgent};
 use crate::commands::{CommandSpec, MovePositionSpec, REGISTRY};
 use crate::theme;
 
@@ -33,6 +33,7 @@ pub struct PopupState<'a> {
 pub enum PopupCandidates<'a> {
     Commands(Cow<'a, [&'static CommandSpec]>),
     MovePositions(&'a [&'static MovePositionSpec]),
+    Agents(Vec<&'a AvailableAgent>),
 }
 
 /// Render the autocomplete popup just above `input_area`. If there isn't
@@ -43,6 +44,7 @@ pub fn render_popup(frame: &mut Frame, state: PopupState<'_>, input_area: Rect) 
     let candidate_count = match &state.candidates {
         PopupCandidates::Commands(candidates) => candidates.len(),
         PopupCandidates::MovePositions(candidates) => candidates.len(),
+        PopupCandidates::Agents(candidates) => candidates.len(),
     };
     if candidate_count == 0 {
         return;
@@ -81,6 +83,15 @@ pub fn render_popup(frame: &mut Frame, state: PopupState<'_>, input_area: Rect) 
                         theme::INPUT_TEXT,
                     ),
                     Span::styled(format!("({})", position.alias), theme::DIM),
+                ]))
+            })
+            .collect(),
+        PopupCandidates::Agents(candidates) => candidates
+            .iter()
+            .map(|agent| {
+                ListItem::new(Line::from(vec![
+                    Span::styled(format!(" /agent {:<8} ", agent.id), theme::INPUT_TEXT),
+                    Span::styled(agent.display_name.as_str(), theme::DIM),
                 ]))
             })
             .collect(),

--- a/tools/wta/src/ui/input.rs
+++ b/tools/wta/src/ui/input.rs
@@ -60,6 +60,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         .width
         .saturating_sub(INPUT_LEFT_PAD + 2 + INPUT_PROMPT_WIDTH);
     let viewport = input_viewport(&tab.input, tab.cursor_pos, text_width);
+    let ghost_suffix = app.command_ghost_suffix();
 
     // The caret is painted as a buffer cell (not the OS cursor) in every
     // state, but only when the input box is the live caret target: the pane
@@ -125,10 +126,17 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 // keep the OS cursor hidden in every state.
                 if input_active && i == viewport.cursor_row {
                     let mut spans = vec![prefix];
-                    push_caret_spans(&mut spans, line, viewport.cursor_col);
+                    push_caret_spans(&mut spans, line, viewport.cursor_col, ghost_suffix);
                     Line::from(spans)
                 } else {
-                    Line::from(vec![prefix, Span::styled(line.clone(), theme::INPUT_TEXT)])
+                    let mut spans =
+                        vec![prefix, Span::styled(line.clone(), theme::INPUT_TEXT)];
+                    if i == viewport.cursor_row {
+                        if let Some(suffix) = ghost_suffix {
+                            spans.push(Span::styled(suffix.to_string(), theme::DIM));
+                        }
+                    }
+                    Line::from(spans)
                 }
             })
             .collect()
@@ -152,7 +160,12 @@ pub(crate) fn input_height(input: &str, cursor_pos: usize, total_width: u16) -> 
 /// a space when the caret sits past the last char at end of line) painted as
 /// an inverse block, and the text after. `caret_col` is a display-cell column
 /// produced by `wrap_input`, so it always lands on a char boundary.
-fn push_caret_spans(spans: &mut Vec<Span<'static>>, line: &str, caret_col: usize) {
+fn push_caret_spans(
+    spans: &mut Vec<Span<'static>>,
+    line: &str,
+    caret_col: usize,
+    ghost_suffix: Option<&str>,
+) {
     let mut before = String::new();
     let mut col = 0usize;
     let mut chars = line.chars();
@@ -166,7 +179,16 @@ fn push_caret_spans(spans: &mut Vec<Span<'static>>, line: &str, caret_col: usize
         col += char_display_width(ch);
     }
     let after: String = chars.collect();
-    let caret_text = caret_ch.map(|c| c.to_string()).unwrap_or_else(|| " ".to_string());
+    let mut ghost_chars = ghost_suffix.unwrap_or_default().chars();
+    let ghost_caret = if caret_ch.is_none() {
+        ghost_chars.next()
+    } else {
+        None
+    };
+    let caret_text = caret_ch
+        .or(ghost_caret)
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| " ".to_string());
 
     if !before.is_empty() {
         spans.push(Span::styled(before, theme::INPUT_TEXT));
@@ -176,10 +198,18 @@ fn push_caret_spans(spans: &mut Vec<Span<'static>>, line: &str, caret_col: usize
     // light background once the pane follows the scheme — #234).
     spans.push(Span::styled(
         caret_text,
-        Style::new().add_modifier(Modifier::REVERSED),
+        if ghost_caret.is_some() {
+            theme::DIM.add_modifier(Modifier::REVERSED)
+        } else {
+            Style::new().add_modifier(Modifier::REVERSED)
+        },
     ));
     if !after.is_empty() {
         spans.push(Span::styled(after, theme::INPUT_TEXT));
+    }
+    let ghost_rest: String = ghost_chars.collect();
+    if !ghost_rest.is_empty() {
+        spans.push(Span::styled(ghost_rest, theme::DIM));
     }
 }
 
@@ -366,7 +396,7 @@ mod tests {
     fn caret_past_end_of_short_line_uses_blank_cell() {
         // Short line: the caret sits in the blank cell right after the text.
         let mut spans = Vec::new();
-        push_caret_spans(&mut spans, "ab", 2);
+        push_caret_spans(&mut spans, "ab", 2, None);
 
         assert_eq!(spans.len(), 2);
         assert_eq!(spans[0].content.as_ref(), "ab");
@@ -376,11 +406,22 @@ mod tests {
     #[test]
     fn caret_in_middle_splits_before_glyph_after() {
         let mut spans = Vec::new();
-        push_caret_spans(&mut spans, "abcd", 1);
+        push_caret_spans(&mut spans, "abcd", 1, None);
 
         assert_eq!(spans.len(), 3);
         assert_eq!(spans[0].content.as_ref(), "a");
         assert_eq!(spans[1].content.as_ref(), "b");
         assert_eq!(spans[2].content.as_ref(), "cd");
+    }
+
+    #[test]
+    fn ghost_suffix_starts_under_end_caret() {
+        let mut spans = Vec::new();
+        push_caret_spans(&mut spans, "/agent co", 9, Some("pilot"));
+
+        assert_eq!(spans.len(), 3);
+        assert_eq!(spans[0].content.as_ref(), "/agent co");
+        assert_eq!(spans[1].content.as_ref(), "p");
+        assert_eq!(spans[2].content.as_ref(), "ilot");
     }
 }


### PR DESCRIPTION
## Summary
- add installed and policy-allowed agent suggestions for `/agent <prefix>`
- render the selected agent ID suffix as inline ghost text and support Up/Down/Tab/Enter completion
- preserve the existing bare `/agent` picker and transport-lost behavior

## Testing
- `cargo test --manifest-path tools/wta/Cargo.toml`
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- built, deployed, and launched the x64 Debug Cascadia package
- 
<img width="667" height="315" alt="image" src="https://github.com/user-attachments/assets/ec3e4027-692f-405d-9a3a-d48247c738be" />