### PR TITLE
Add integration coverage for agent completion

### DIFF
--- a/doc/release-check-list.md
+++ b/doc/release-check-list.md
@@ -172,6 +172,8 @@ Net effect: UT shrinks the manual matrix to "did the wiring and UI connect", not
 - [ ] `C080` `[UT✓]` `[E2E]` **`/model` works:** Opens/selects model where supported; unsupported agents fail gracefully. _(UT: `slash_model_*`; picker render covered by `render_model_picker_lists_models`, full UI flow still E2E.)_
 - [x] `C081` `[UT✓]` **Unknown slash command is safe:** Unknown `/command` does not lose user input or crash.
 - [ ] `C225` `[E2E]` **`/agent` picker works:** `/agent` opens a keyboard-operable picker containing the current installed/allowed agents, and selecting the current agent is a safe no-op.
+- [ ] `C240` `[new]` `[E2E]` **`/agent` prefix completion works:** Typing `/agent <prefix>` shows matching installed and policy-allowed agents, renders the selected suffix inline, and Tab commits the full agent ID. _(#487; E2E: `Feature.PerTabAgent`.)_
+- [ ] `C241` `[new]` `[E2E]` **`/agent` completion selection is safe:** Enter activates the highlighted matching agent without rebuilding the pane or changing the global default when it is already selected. _(#487; E2E: `Feature.PerTabAgent`.)_
 - [ ] `C226` `[E2E]` **Invalid `/agent` selection is safe:** `/agent <id>` rejects an unavailable agent without rebuilding the pane or changing the global default.
 - [ ] `C082` `[E2E]` **Esc/back navigation works:** User can return from popups/session/model views to chat.
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -25,15 +25,15 @@ environment. Current status (run on the Store package):
 | `Feature.ShellIntegration.Tests.ps1` | §3 shell-integration OSC 133 marks (success/failure, ParserError dedup, handled errors, WinPS 5.1 errors) + non-integrated cmd.exe safety | 6 |
 | `Feature.AgentProposedCommand.Tests.ps1` | §2 agent-proposed command Insert/Run into the shell pane (non-autofix chat path) | 2 |
 | `Feature.AgentMatrix.Tests.ps1` | §2 non-Copilot built-in agents (Claude/Codex/Gemini) connect+chat through the ACP adapter — ONE consolidated case (Copilot is the in-depth suite); skips when none installed+authed | 1 |
-| `Feature.PerTabAgent.Tests.ps1` | C225-C228: `/agent` picker/direct selection, invalid-id safety, per-tab isolation/shared-master reuse, and global-default/override behavior | 6 |
+| `Feature.PerTabAgent.Tests.ps1` | C225-C228 + PR #487: `/agent` picker/prefix completion/direct selection, invalid-id safety, per-tab isolation/shared-master reuse, and global-default/override behavior | 8 |
 | `Feature.WslAgentBackend.Tests.ps1` | PR #481 profile-scoped WSL agent backend: settings hot reload, helper/master source routing, and authenticated chat | 2 (environment-gated) |
 | `Feature.AgentChat.Tests.ps1` / `Feature.AgentPopup.Tests.ps1` | agent chat + `/` popup/menu interaction | 1 + 3 |
 
-**Coverage: 103 of 104 automatable `[E2E]` checklist items are implemented.**
-**Test status: 98 baseline feature cases pass + 2 documented skips** (`wta sessions list` is
+**Coverage: 105 of 106 automatable `[E2E]` checklist items are implemented.**
+**Test status: 100 baseline feature cases pass + 2 documented skips** (`wta sessions list` is
 identity-gated — see `Feature.SessionList.Tests.ps1`), plus 2 PR #481 WSL-backend cases that
 run only when a dev package, runnable distro, and native supported agent are available; the
-chat case also requires authentication. The 103 implemented checklist items map to the
+chat case also requires authentication. The 105 implemented checklist items map to the
 baseline cases plus the deterministic settings/persistence assertions. The remaining new
 item is the profile Agent pane agent picker UI; it stays explicit E2E work rather than being
 falsely credited by the JSON-level runtime tests. Other

--- a/test/e2e/tests/Feature.PerTabAgent.Tests.ps1
+++ b/test/e2e/tests/Feature.PerTabAgent.Tests.ps1
@@ -1,8 +1,9 @@
 #Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
 # PR #296: `/agent` selects a runtime-only agent override for one tab while the
-# shared master keeps sibling tabs and their conversations alive.
-# Release checklist: C225-C226 cover the slash-command UX; C227-C228 cover
-# per-tab isolation and global-default/override behavior.
+# shared master keeps sibling tabs and their conversations alive. PR #487 adds
+# prefix-filtered agent completion and keyboard acceptance.
+# Release checklist: C225-C226 and the PR #487 items cover the slash-command UX;
+# C227-C228 cover per-tab isolation and global-default/override behavior.
 
 BeforeDiscovery {
     $script:Ready = [bool](
@@ -22,6 +23,45 @@ Describe 'Feature per-tab agent selection through /agent' -Tag 'Feature' -Skip:(
         $script:defaultPane = (Wait-NewAgentPaneSession -App $script:app -OwnerPaneSessionId $active.session_id -TimeoutSec 30).PaneSessionId
     }
     AfterAll { if ($script:app) { Stop-Terminal -App $script:app } }
+
+    It '/agent prefix completion works' {
+        try {
+            Clear-AgentInput -App $script:app -PaneSessionId $script:defaultPane | Out-Null
+            Send-AgentPrompt -App $script:app -PaneSessionId $script:defaultPane -Text '/agent cop' -NoSubmit | Out-Null
+
+            (Test-Until -TimeoutSec 10 -IntervalSec 0.25 -Condition {
+                    (Get-AgentPaneText -App $script:app -PaneSessionId $script:defaultPane -MaxLines 40) -match '(?i)/agent\s+copilot\s+.*Copilot'
+                }) | Should -BeTrue -Because 'typing an agent-id prefix must show the matching installed and policy-allowed agent'
+
+            $inputRow = '(?m)^\s*[│║|]\s+>\s+/agent copilot'
+            (Get-AgentPaneText -App $script:app -PaneSessionId $script:defaultPane -MaxLines 40) |
+                Should -Match $inputRow -Because 'the selected completion suffix must render inline as ghost text'
+
+            Send-AgentKey -App $script:app -PaneSessionId $script:defaultPane -Key Tab | Out-Null
+            Send-AgentPrompt -App $script:app -PaneSessionId $script:defaultPane -Text '-e2e' -NoSubmit | Out-Null
+            (Get-AgentPaneText -App $script:app -PaneSessionId $script:defaultPane -MaxLines 40) |
+                Should -Match '(?m)^\s*[│║|]\s+>\s+/agent copilot-e2e' -Because 'Tab must commit the full selected id into the editable input buffer'
+        }
+        finally {
+            Clear-AgentInput -App $script:app -PaneSessionId $script:defaultPane | Out-Null
+        }
+    }
+
+    It '/agent completion selection is safe' {
+        try {
+            Clear-AgentInput -App $script:app -PaneSessionId $script:defaultPane | Out-Null
+            Send-AgentPrompt -App $script:app -PaneSessionId $script:defaultPane -Text '/agent cop' -NoSubmit | Out-Null
+            Assert-AgentPaneText -App $script:app -PaneSessionId $script:defaultPane -Pattern '(?i)/agent\s+copilot\s+.*Copilot' -TimeoutSec 10
+
+            Send-AgentKey -App $script:app -PaneSessionId $script:defaultPane -Key Enter | Out-Null
+            (Get-AgentPaneSession -App $script:app -PaneSessionId $script:defaultPane) |
+                Should -Not -BeNullOrEmpty -Because 'Enter must dispatch the highlighted current agent without rebuilding its pane'
+            Assert-Setting -App $script:app -Key 'acpAgent' -Value 'copilot'
+        }
+        finally {
+            Clear-AgentInput -App $script:app -PaneSessionId $script:defaultPane | Out-Null
+        }
+    }
 
     It '/agent appears in the slash menu and opens a keyboard-operable picker' {
         $titleRe = Get-WtaLocalizedTextRegex -Key 'agent_picker.title'

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -386,14 +386,17 @@ fn seed_completion_agents(app: &mut App) {
         AvailableAgent {
             id: "copilot".into(),
             display_name: "GitHub Copilot".into(),
+            source: crate::agent_source::AgentSource::Host,
         },
         AvailableAgent {
             id: "codex".into(),
             display_name: "Codex".into(),
+            source: crate::agent_source::AgentSource::Host,
         },
         AvailableAgent {
             id: "gemini".into(),
             display_name: "Gemini".into(),
+            source: crate::agent_source::AgentSource::Host,
         },
     ];
 }


### PR DESCRIPTION
## Summary
- add live TUI/conpty coverage for the `/agent <prefix>` completion introduced by #487
- verify ghost-text rendering, Tab commitment, and Enter selection without rebuilding the current pane
- add release checklist coverage as C240 and C241
- repair the #487 Rust completion fixtures for the `AgentSource` field added by #481

## Integration boundary
The tests type and navigate through the packaged agent pane using `wtcli send-keys`, then assert the rendered TUI buffer, pane-session continuity, and persisted global setting.

## Testing
- `pwsh -NoProfile -File test/e2e/bootstrap.ps1 -Check`
- `pwsh -NoProfile -File test/e2e/Invoke-ItE2EReport.ps1 -Path test/e2e/tests/Feature.PerTabAgent.Tests.ps1 -UpdateReport` (8 passed)
- `cargo test --manifest-path tools/wta/Cargo.toml` (1165 passed)
- full and incremental release reports mark C240 and C241 `[x]`

Target: #487