### PR TITLE
Fix razzle.cmd MSBuild detection silently failing on VS 2026 (18.x)

### DIFF
--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -68,11 +68,20 @@ rem (not `in (`command`)`, so no paren-counting issue) and let the loop body
 rem overwrite MSBUILD on every line, same as the original `for /f` did --
 rem this preserves "last match wins" if -find ever globs multiple paths,
 rem instead of the "first line wins" behavior a plain `set /p` would give.
-set VSWHERE_MSBUILD_TMP=%TEMP%\razzle-vswhere-msbuild-%RANDOM%.txt
+rem
+rem We `pushd` into %TEMP% and reference the temp file by a plain relative
+rem name (no directory component) so that the text inside `in (...)` never
+rem contains the expanded %TEMP% path. If %TEMP% itself contained a ')'
+rem (e.g. a profile directory like "C:\Users\Jane (Admin)\AppData\..."),
+rem that same naive paren-counting parser bug would truncate the `in (...)`
+rem clause again -- this sidesteps it entirely.
+pushd "%TEMP%" >nul 2>nul
+set "VSWHERE_MSBUILD_TMP=razzle-vswhere-msbuild-%RANDOM%.txt"
 "%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,19.0)" -find MSBuild\**\Bin\MSBuild.exe > "%VSWHERE_MSBUILD_TMP%" 2>nul
-for /f "usebackq delims=" %%B in ("%VSWHERE_MSBUILD_TMP%") do (set MSBUILD=%%B)
-del "%VSWHERE_MSBUILD_TMP%" 2>nul
-set VSWHERE_MSBUILD_TMP=
+for /f "usebackq delims=" %%B in ("%VSWHERE_MSBUILD_TMP%") do (set "MSBUILD=%%B")
+del /q "%VSWHERE_MSBUILD_TMP%" 2>nul
+set "VSWHERE_MSBUILD_TMP="
+popd >nul 2>nul
 
 if not defined MSBUILD (
     echo Could not find MSBuild on your machine. Please set the MSBUILD variable to the location of MSBuild.exe and run razzle again.

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -62,11 +62,15 @@ rem the -version range "[17.0,19.0)" is inside quotes, so it prematurely closes
 rem the `in (...)` clause and truncates the command, silently leaving MSBUILD
 rem unset even when a matching VS install exists. Escaping it (^)) or swapping
 rem to "[17.0,19.0]" does not help -- the same truncation still happens.
-rem Route through a temp file + `set /p` instead, which sidesteps backtick/paren
-rem parsing entirely.
+rem Route through a temp file instead, which sidesteps backtick/paren parsing
+rem entirely. We then read the file back with `for /f ... in ("file")`
+rem (not `in (`command`)`, so no paren-counting issue) and let the loop body
+rem overwrite MSBUILD on every line, same as the original `for /f` did --
+rem this preserves "last match wins" if -find ever globs multiple paths,
+rem instead of the "first line wins" behavior a plain `set /p` would give.
 set VSWHERE_MSBUILD_TMP=%TEMP%\razzle-vswhere-msbuild-%RANDOM%.txt
 "%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,19.0)" -find MSBuild\**\Bin\MSBuild.exe > "%VSWHERE_MSBUILD_TMP%" 2>nul
-set /p MSBUILD=<"%VSWHERE_MSBUILD_TMP%"
+for /f "usebackq delims=" %%B in ("%VSWHERE_MSBUILD_TMP%") do (set MSBUILD=%%B)
 del "%VSWHERE_MSBUILD_TMP%" 2>nul
 set VSWHERE_MSBUILD_TMP=
 

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -49,37 +49,26 @@ if not defined VSWHERE (
 
 rem Add path to MSBuild Binaries
 rem
-rem We accept the latest prerelease of VS in the 17.x or 18.x range. The -version
-rem range [17.0,19.0) picks up both VS 2022 (17.x) and VS 18 (including previews)
-rem but not a still-newer major whose toolset may be incompatible. VS 18 uses our
-rem v145 PlatformToolset (see src\common.build.pre.props); older VS versions default
-rem to v143.
+rem We accept the latest prerelease of VS in the 17.x or 18.x range: -version
+rem "[17.0,19.0)" covers VS 2022 (17.x) and VS 18, but not a newer major whose
+rem toolset may be incompatible. VS 18 uses v145 PlatformToolset (see
+rem src\common.build.pre.props); older VS versions default to v143.
 rem
-rem NOTE: this does NOT use `for /f ... in (`command`)` to capture vswhere's
-rem output. cmd.exe's `for /f` parser finds the closing ')' of `in (...)` by
-rem naive character counting, so the ')' in "[17.0,19.0)" prematurely closes
-rem the clause and silently truncates the command (escaping or switching to
-rem "[17.0,19.0]" does not help). Instead we redirect vswhere's output to a
-rem temp file and read it back with `for /f ... in ("file")`, which has no
-rem command/paren to miscount. We `pushd` into %TEMP% first and use a plain
-rem relative filename so the temp path itself can't reintroduce a ')' (e.g.
-rem from a profile dir like "...\Jane (Admin)\..."). `pushd` can fail (TEMP
-rem unset/missing); we still try vswhere in that case (file lands in the
-rem current directory) and only `popd` if `pushd` actually succeeded
-rem (tracked via VSWHERE_TEMP_PUSHED), so a failed pushd can't disturb the
-rem caller's directory stack.
+rem Redirect vswhere's output to a temp file and read it back via for /f,
+rem instead of `for /f ... in (`vswhere ...`)`, to avoid cmd.exe miscounting
+rem the ')' in "[17.0,19.0)" as closing the for/f clause. pushd into %TEMP%
+rem and use a relative filename to keep any ')' in the %TEMP% path out of
+rem the for/f clause too; only popd if pushd succeeded, to avoid disturbing
+rem the caller's directory stack on failure.
 set "VSWHERE_TEMP_PUSHED=0"
 pushd "%TEMP%" >nul 2>nul
 if not errorlevel 1 set "VSWHERE_TEMP_PUSHED=1"
 
 rem Two %RANDOM% components avoid filename collisions between concurrent
-rem razzle.cmd runs. Set/read as plain sequential lines (not inside an
-rem `if ( ... )` block) since cmd.exe expands %VAR% in a parenthesized
-rem block at parse time, before any `set` inside it has run.
+rem razzle.cmd runs.
 set "VSWHERE_MSBUILD_TMP=razzle-vswhere-msbuild-%RANDOM%%RANDOM%.txt"
 "%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,19.0)" -find MSBuild\**\Bin\MSBuild.exe > "%VSWHERE_MSBUILD_TMP%" 2>nul
-rem `if exist` avoids a "system cannot find the file" message masking the
-rem "Could not find MSBuild" error below when vswhere itself failed.
+rem if exist avoids a spurious "file not found" message when vswhere failed.
 if exist "%VSWHERE_MSBUILD_TMP%" (
     for /f "usebackq delims=" %%B in ("%VSWHERE_MSBUILD_TMP%") do (set "MSBUILD=%%B")
 )

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -76,23 +76,27 @@ rem (e.g. a profile directory like "C:\Users\Jane (Admin)\AppData\..."),
 rem that same naive paren-counting parser bug would truncate the `in (...)`
 rem clause again -- this sidesteps it entirely.
 rem
-rem `pushd` itself can fail (e.g. %TEMP% unset or unwritable), in which case
-rem it neither changes directory nor pushes anything onto the directory
-rem stack. Skip straight to :AFTER_TEMP_READ in that case -- and only
-rem `popd` when `pushd` actually succeeded -- so a failure here can't pop a
-rem pre-existing directory stack entry from the caller's shell and yank
-rem them to an unrelated directory.
+rem `pushd` itself can fail (e.g. %TEMP% unset or pointing at a directory
+rem that no longer exists), in which case it neither changes directory nor
+rem pushes anything onto the directory stack. We still attempt vswhere
+rem discovery in that case -- the temp file simply lands in the current
+rem directory instead of %TEMP% -- rather than giving up on finding
+rem MSBuild entirely just because %TEMP% is misconfigured. We only call
+rem `popd` when the matching `pushd` actually succeeded, tracked via
+rem VSWHERE_TEMP_PUSHED, so a failed pushd can't pop a preexisting
+rem directory stack entry from the caller's shell and yank them to an
+rem unrelated directory.
 rem
-rem NOTE: this deliberately avoids wrapping the steps below in an
-rem `if not errorlevel 1 ( ... )` block. Without `setlocal
-rem enabledelayedexpansion`, cmd.exe expands all %VAR% references in a
-rem parenthesized block at parse time, before any `set` inside that same
-rem block has run -- so VSWHERE_MSBUILD_TMP would still resolve to its
-rem prior (unset) value everywhere it's used below. Using a plain
-rem `goto`/label sidesteps that, since each line is parsed and expanded
-rem only when reached.
+rem NOTE: none of the steps below are wrapped in an `if ( ... )` block.
+rem Without `setlocal enabledelayedexpansion`, cmd.exe expands all %VAR%
+rem references in a parenthesized block at parse time, before any `set`
+rem inside that same block has run -- so VSWHERE_MSBUILD_TMP would still
+rem resolve to its prior (unset) value everywhere it's used below. Plain
+rem sequential lines sidestep that, since each is parsed and expanded only
+rem when reached.
+set "VSWHERE_TEMP_PUSHED=0"
 pushd "%TEMP%" >nul 2>nul
-if errorlevel 1 goto :AFTER_TEMP_READ
+if not errorlevel 1 set "VSWHERE_TEMP_PUSHED=1"
 
 set "VSWHERE_MSBUILD_TMP=razzle-vswhere-msbuild-%RANDOM%.txt"
 "%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,19.0)" -find MSBuild\**\Bin\MSBuild.exe > "%VSWHERE_MSBUILD_TMP%" 2>nul
@@ -106,9 +110,8 @@ if exist "%VSWHERE_MSBUILD_TMP%" (
 )
 del /q "%VSWHERE_MSBUILD_TMP%" 2>nul
 set "VSWHERE_MSBUILD_TMP="
-popd >nul 2>nul
-
-:AFTER_TEMP_READ
+if "%VSWHERE_TEMP_PUSHED%"=="1" popd >nul 2>nul
+set "VSWHERE_TEMP_PUSHED="
 
 if not defined MSBUILD (
     echo Could not find MSBuild on your machine. Please set the MSBUILD variable to the location of MSBuild.exe and run razzle again.

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -87,18 +87,23 @@ rem VSWHERE_TEMP_PUSHED, so a failed pushd can't pop a preexisting
 rem directory stack entry from the caller's shell and yank them to an
 rem unrelated directory.
 rem
-rem NOTE: none of the steps below are wrapped in an `if ( ... )` block.
-rem Without `setlocal enabledelayedexpansion`, cmd.exe expands all %VAR%
-rem references in a parenthesized block at parse time, before any `set`
-rem inside that same block has run -- so VSWHERE_MSBUILD_TMP would still
-rem resolve to its prior (unset) value everywhere it's used below. Plain
-rem sequential lines sidestep that, since each is parsed and expanded only
-rem when reached.
+rem NOTE: VSWHERE_TEMP_PUSHED and VSWHERE_MSBUILD_TMP above are deliberately
+rem set and read as plain sequential lines, not inside an `if ( ... )`
+rem block. Without `setlocal enabledelayedexpansion`, cmd.exe expands all
+rem %VAR% references in a parenthesized block at parse time, before any
+rem `set` inside that same block has run -- so setting a variable and then
+rem reading it later within the same block would still see its prior
+rem value. The `if exist ( ... )` block below is fine despite being
+rem parenthesized: it only *sets* MSBUILD inside the block and never reads
+rem it back within that same block, so the pitfall doesn't apply there.
 set "VSWHERE_TEMP_PUSHED=0"
 pushd "%TEMP%" >nul 2>nul
 if not errorlevel 1 set "VSWHERE_TEMP_PUSHED=1"
 
-set "VSWHERE_MSBUILD_TMP=razzle-vswhere-msbuild-%RANDOM%.txt"
+rem Two %RANDOM% components (cmd.exe's %RANDOM% is only 0-32767) make an
+rem accidental filename collision between concurrent razzle.cmd instances
+rem astronomically unlikely, so one run can't read or delete another's file.
+set "VSWHERE_MSBUILD_TMP=razzle-vswhere-msbuild-%RANDOM%%RANDOM%.txt"
 "%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,19.0)" -find MSBuild\**\Bin\MSBuild.exe > "%VSWHERE_MSBUILD_TMP%" 2>nul
 rem Guard the read: if the temp file never got created (e.g. the
 rem vswhere invocation above failed outright), skip the for /f entirely

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -75,13 +75,31 @@ rem contains the expanded %TEMP% path. If %TEMP% itself contained a ')'
 rem (e.g. a profile directory like "C:\Users\Jane (Admin)\AppData\..."),
 rem that same naive paren-counting parser bug would truncate the `in (...)`
 rem clause again -- this sidesteps it entirely.
+rem
+rem `pushd` itself can fail (e.g. %TEMP% unset or unwritable), in which case
+rem it neither changes directory nor pushes anything onto the directory
+rem stack. Skip straight to :AFTER_TEMP_READ in that case -- and only
+rem `popd` when `pushd` actually succeeded -- so a failure here can't pop a
+rem pre-existing directory stack entry from the caller's shell and yank
+rem them to an unrelated directory.
+rem
+rem NOTE: this deliberately avoids wrapping the steps below in an
+rem `if not errorlevel 1 ( ... )` block. Without `setlocal
+rem enabledelayedexpansion`, cmd.exe expands all %VAR% references in a
+rem parenthesized block at parse time, before any `set` inside that same
+rem block has run -- so VSWHERE_MSBUILD_TMP would still resolve to its
+rem prior (unset) value everywhere it's used below. Using a plain
+rem `goto`/label sidesteps that, since each line is parsed and expanded
+rem only when reached.
 pushd "%TEMP%" >nul 2>nul
+if errorlevel 1 goto :AFTER_TEMP_READ
+
 set "VSWHERE_MSBUILD_TMP=razzle-vswhere-msbuild-%RANDOM%.txt"
 "%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,19.0)" -find MSBuild\**\Bin\MSBuild.exe > "%VSWHERE_MSBUILD_TMP%" 2>nul
-rem Guard the read: if the temp file never got created (e.g. %TEMP% unset/
-rem unwritable, or the vswhere invocation above failed outright), skip the
-rem for /f entirely instead of letting it print "The system cannot find the
-rem file specified." -- that noise would mask the real "Could not find
+rem Guard the read: if the temp file never got created (e.g. the
+rem vswhere invocation above failed outright), skip the for /f entirely
+rem instead of letting it print "The system cannot find the file
+rem specified." -- that noise would mask the real "Could not find
 rem MSBuild" error reported below.
 if exist "%VSWHERE_MSBUILD_TMP%" (
     for /f "usebackq delims=" %%B in ("%VSWHERE_MSBUILD_TMP%") do (set "MSBUILD=%%B")
@@ -89,6 +107,8 @@ if exist "%VSWHERE_MSBUILD_TMP%" (
 del /q "%VSWHERE_MSBUILD_TMP%" 2>nul
 set "VSWHERE_MSBUILD_TMP="
 popd >nul 2>nul
+
+:AFTER_TEMP_READ
 
 if not defined MSBUILD (
     echo Could not find MSBuild on your machine. Please set the MSBUILD variable to the location of MSBuild.exe and run razzle again.

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -78,7 +78,14 @@ rem clause again -- this sidesteps it entirely.
 pushd "%TEMP%" >nul 2>nul
 set "VSWHERE_MSBUILD_TMP=razzle-vswhere-msbuild-%RANDOM%.txt"
 "%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,19.0)" -find MSBuild\**\Bin\MSBuild.exe > "%VSWHERE_MSBUILD_TMP%" 2>nul
-for /f "usebackq delims=" %%B in ("%VSWHERE_MSBUILD_TMP%") do (set "MSBUILD=%%B")
+rem Guard the read: if the temp file never got created (e.g. %TEMP% unset/
+rem unwritable, or the vswhere invocation above failed outright), skip the
+rem for /f entirely instead of letting it print "The system cannot find the
+rem file specified." -- that noise would mask the real "Could not find
+rem MSBuild" error reported below.
+if exist "%VSWHERE_MSBUILD_TMP%" (
+    for /f "usebackq delims=" %%B in ("%VSWHERE_MSBUILD_TMP%") do (set "MSBUILD=%%B")
+)
 del /q "%VSWHERE_MSBUILD_TMP%" 2>nul
 set "VSWHERE_MSBUILD_TMP="
 popd >nul 2>nul

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -55,61 +55,31 @@ rem but not a still-newer major whose toolset may be incompatible. VS 18 uses ou
 rem v145 PlatformToolset (see src\common.build.pre.props); older VS versions default
 rem to v143.
 rem
-rem NOTE: this intentionally does NOT use `for /f ... in (`command`)` to capture
-rem vswhere's output. cmd.exe's parser scans for the closing ')' of a `for /f`
-rem block by naive character counting -- it does not understand that the ')' in
-rem the -version range "[17.0,19.0)" is inside quotes, so it prematurely closes
-rem the `in (...)` clause and truncates the command, silently leaving MSBUILD
-rem unset even when a matching VS install exists. Escaping it (^)) or swapping
-rem to "[17.0,19.0]" does not help -- the same truncation still happens.
-rem Route through a temp file instead, which sidesteps backtick/paren parsing
-rem entirely. We then read the file back with `for /f ... in ("file")`
-rem (not `in (`command`)`, so no paren-counting issue) and let the loop body
-rem overwrite MSBUILD on every line, same as the original `for /f` did --
-rem this preserves "last match wins" if -find ever globs multiple paths,
-rem instead of the "first line wins" behavior a plain `set /p` would give.
-rem
-rem We `pushd` into %TEMP% and reference the temp file by a plain relative
-rem name (no directory component) so that the text inside `in (...)` never
-rem contains the expanded %TEMP% path. If %TEMP% itself contained a ')'
-rem (e.g. a profile directory like "C:\Users\Jane (Admin)\AppData\..."),
-rem that same naive paren-counting parser bug would truncate the `in (...)`
-rem clause again -- this sidesteps it entirely.
-rem
-rem `pushd` itself can fail (e.g. %TEMP% unset or pointing at a directory
-rem that no longer exists), in which case it neither changes directory nor
-rem pushes anything onto the directory stack. We still attempt vswhere
-rem discovery in that case -- the temp file simply lands in the current
-rem directory instead of %TEMP% -- rather than giving up on finding
-rem MSBuild entirely just because %TEMP% is misconfigured. We only call
-rem `popd` when the matching `pushd` actually succeeded, tracked via
-rem VSWHERE_TEMP_PUSHED, so a failed pushd can't pop a preexisting
-rem directory stack entry from the caller's shell and yank them to an
-rem unrelated directory.
-rem
-rem NOTE: VSWHERE_TEMP_PUSHED and VSWHERE_MSBUILD_TMP above are deliberately
-rem set and read as plain sequential lines, not inside an `if ( ... )`
-rem block. Without `setlocal enabledelayedexpansion`, cmd.exe expands all
-rem %VAR% references in a parenthesized block at parse time, before any
-rem `set` inside that same block has run -- so setting a variable and then
-rem reading it later within the same block would still see its prior
-rem value. The `if exist ( ... )` block below is fine despite being
-rem parenthesized: it only *sets* MSBUILD inside the block and never reads
-rem it back within that same block, so the pitfall doesn't apply there.
+rem NOTE: this does NOT use `for /f ... in (`command`)` to capture vswhere's
+rem output. cmd.exe's `for /f` parser finds the closing ')' of `in (...)` by
+rem naive character counting, so the ')' in "[17.0,19.0)" prematurely closes
+rem the clause and silently truncates the command (escaping or switching to
+rem "[17.0,19.0]" does not help). Instead we redirect vswhere's output to a
+rem temp file and read it back with `for /f ... in ("file")`, which has no
+rem command/paren to miscount. We `pushd` into %TEMP% first and use a plain
+rem relative filename so the temp path itself can't reintroduce a ')' (e.g.
+rem from a profile dir like "...\Jane (Admin)\..."). `pushd` can fail (TEMP
+rem unset/missing); we still try vswhere in that case (file lands in the
+rem current directory) and only `popd` if `pushd` actually succeeded
+rem (tracked via VSWHERE_TEMP_PUSHED), so a failed pushd can't disturb the
+rem caller's directory stack.
 set "VSWHERE_TEMP_PUSHED=0"
 pushd "%TEMP%" >nul 2>nul
 if not errorlevel 1 set "VSWHERE_TEMP_PUSHED=1"
 
-rem Two %RANDOM% components (cmd.exe's %RANDOM% is only 0-32767) make an
-rem accidental filename collision between concurrent razzle.cmd instances
-rem astronomically unlikely, so one run can't read or delete another's file.
+rem Two %RANDOM% components avoid filename collisions between concurrent
+rem razzle.cmd runs. Set/read as plain sequential lines (not inside an
+rem `if ( ... )` block) since cmd.exe expands %VAR% in a parenthesized
+rem block at parse time, before any `set` inside it has run.
 set "VSWHERE_MSBUILD_TMP=razzle-vswhere-msbuild-%RANDOM%%RANDOM%.txt"
 "%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,19.0)" -find MSBuild\**\Bin\MSBuild.exe > "%VSWHERE_MSBUILD_TMP%" 2>nul
-rem Guard the read: if the temp file never got created (e.g. the
-rem vswhere invocation above failed outright), skip the for /f entirely
-rem instead of letting it print "The system cannot find the file
-rem specified." -- that noise would mask the real "Could not find
-rem MSBuild" error reported below.
+rem `if exist` avoids a "system cannot find the file" message masking the
+rem "Could not find MSBuild" error below when vswhere itself failed.
 if exist "%VSWHERE_MSBUILD_TMP%" (
     for /f "usebackq delims=" %%B in ("%VSWHERE_MSBUILD_TMP%") do (set "MSBUILD=%%B")
 )

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -55,9 +55,20 @@ rem but not a still-newer major whose toolset may be incompatible. VS 18 uses ou
 rem v145 PlatformToolset (see src\common.build.pre.props); older VS versions default
 rem to v143.
 rem
-for /f "usebackq tokens=*" %%B in (`"%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,19.0)" -find MSBuild\**\Bin\MSBuild.exe 2^>nul`) do (
-    set MSBUILD=%%B
-)
+rem NOTE: this intentionally does NOT use `for /f ... in (`command`)` to capture
+rem vswhere's output. cmd.exe's parser scans for the closing ')' of a `for /f`
+rem block by naive character counting -- it does not understand that the ')' in
+rem the -version range "[17.0,19.0)" is inside quotes, so it prematurely closes
+rem the `in (...)` clause and truncates the command, silently leaving MSBUILD
+rem unset even when a matching VS install exists. Escaping it (^)) or swapping
+rem to "[17.0,19.0]" does not help -- the same truncation still happens.
+rem Route through a temp file + `set /p` instead, which sidesteps backtick/paren
+rem parsing entirely.
+set VSWHERE_MSBUILD_TMP=%TEMP%\razzle-vswhere-msbuild-%RANDOM%.txt
+"%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,19.0)" -find MSBuild\**\Bin\MSBuild.exe > "%VSWHERE_MSBUILD_TMP%" 2>nul
+set /p MSBUILD=<"%VSWHERE_MSBUILD_TMP%"
+del "%VSWHERE_MSBUILD_TMP%" 2>nul
+set VSWHERE_MSBUILD_TMP=
 
 if not defined MSBUILD (
     echo Could not find MSBuild on your machine. Please set the MSBUILD variable to the location of MSBuild.exe and run razzle again.


### PR DESCRIPTION
## Problem
`tools\razzle.cmd` failed with "Could not find MSBuild on your machine" even though a matching Visual Studio (2026 / 18.x) install was present, unless MSBuild's bin dir was already on PATH.

## Root cause
The MSBuild-discovery step captures vswhere's output via a `for /f` backtick capture whose command line includes `-version "[17.0,19.0)"`.

cmd.exe's parser matches the closing `)` of a `for /f ... in (...)` clause by naive character counting over the raw text — it does not understand that the `)` inside the quoted `-version "[17.0,19.0)"` range is just data. It truncates the captured backtick command right there, so vswhere either errors or returns nothing, and `MSBUILD` is left unset (even with a valid VS install).

I confirmed escaping it as `^)` or switching to the inclusive `[17.0,19.0]` form does **not** help — the same truncation happens regardless, since the block-parsing pass doesn't respect quoting either way. Only avoiding a parenthesis-bearing arg inside the backtick-captured command fixes it.

## Fix
Route vswhere's output through a temp file + `set /p` instead of a `for /f` backtick capture, which sidesteps the parenthesis-counting bug entirely.

## Testing
- Reproduced the truncation in isolation: the exact original `for /f` invocation captured zero lines even though running the same vswhere command directly (outside a `for /f`) returned the MSBuild path.
- Confirmed the temp-file approach reliably captures the path.
- Ran `tools\razzle.cmd && bcz no_clean` end-to-end against a real VS 2026 (18.8) install with nothing pre-added to PATH: MSBuild is now detected automatically and the full solution builds with 0 errors.
