### PR TITLE
Improve tool call status styling

### DIFF
--- a/tools/wta/src/theme.rs
+++ b/tools/wta/src/theme.rs
@@ -10,7 +10,11 @@ pub const INPUT_TEXT: Style = Style::new().fg(Color::Reset);
 // schemes. A hardcoded white was invisible on light color schemes (#234).
 pub const AGENT_TEXT: Style = Style::new().fg(Color::Reset);
 pub const SYSTEM_TEXT: Style = Style::new().fg(Color::Cyan);
-pub const TOOL_CALL: Style = Style::new().fg(Color::DarkGray);
+pub const TOOL_CALL_TITLE: Style = Style::new().fg(Color::Reset);
+pub const TOOL_CALL_PENDING: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+pub const TOOL_CALL_RUNNING: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+pub const TOOL_CALL_SUCCESS: Style = Style::new().fg(Color::Green).add_modifier(Modifier::BOLD);
+pub const TOOL_CALL_FAILURE: Style = Style::new().fg(Color::Red).add_modifier(Modifier::BOLD);
 pub const PLAN_STYLE: Style = Style::new().fg(Color::Cyan);
 pub const ERROR_STYLE: Style = Style::new().fg(Color::Red);
 pub const IN_PROGRESS: Style = Style::new()

--- a/tools/wta/src/theme.rs
+++ b/tools/wta/src/theme.rs
@@ -15,6 +15,7 @@ pub const TOOL_CALL_PENDING: Style = Style::new().fg(Color::Yellow).add_modifier
 pub const TOOL_CALL_RUNNING: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
 pub const TOOL_CALL_SUCCESS: Style = Style::new().fg(Color::Green).add_modifier(Modifier::BOLD);
 pub const TOOL_CALL_FAILURE: Style = Style::new().fg(Color::Red).add_modifier(Modifier::BOLD);
+pub const TOOL_CALL_CANCELED: Style = Style::new().fg(Color::DarkGray).add_modifier(Modifier::ITALIC);
 pub const PLAN_STYLE: Style = Style::new().fg(Color::Cyan);
 pub const ERROR_STYLE: Style = Style::new().fg(Color::Red);
 pub const IN_PROGRESS: Style = Style::new()

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -764,6 +764,36 @@ mod tests {
             theme::TOOL_CALL_FAILURE,
             Some(theme::DIM),
         );
+        // "Exited (0)" is a success alias (distinct from the generic
+        // "exited (" failure prefix matched above) and carries no detail.
+        assert_tool_call(
+            "Exited (0)",
+            "✓ Run: cargo test",
+            theme::TOOL_CALL_SUCCESS,
+            None,
+        );
+        // Status matching is case-insensitive across the success paths.
+        assert_tool_call(
+            "COMPLETED",
+            "✓ Run: cargo test",
+            theme::TOOL_CALL_SUCCESS,
+            None,
+        );
+        assert_tool_call(
+            "eXiTeD (0)",
+            "✓ Run: cargo test",
+            theme::TOOL_CALL_SUCCESS,
+            None,
+        );
+        // Unknown/future statuses fall back to a dim marker with the raw
+        // status surfaced as dim detail text, instead of panicking or
+        // silently dropping the status.
+        assert_tool_call(
+            "SomeFutureStatus",
+            "• Run: cargo test · SomeFutureStatus",
+            theme::DIM,
+            Some(theme::DIM),
+        );
         assert_ne!(theme::TOOL_CALL_CANCELED, theme::DIM);
     }
 

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -112,6 +112,30 @@ fn turn_height(turn: &CompletedTurn, wrap_width: usize) -> usize {
     h
 }
 
+fn tool_call_presentation(status: &str) -> (&'static str, Style, Option<&str>) {
+    if status.eq_ignore_ascii_case("pending") {
+        ("○", theme::TOOL_CALL_PENDING, None)
+    } else if status.eq_ignore_ascii_case("inprogress") || status.eq_ignore_ascii_case("running") {
+        ("●", theme::TOOL_CALL_RUNNING, None)
+    } else if status.eq_ignore_ascii_case("completed") || status.eq_ignore_ascii_case("exited (0)") {
+        ("✓", theme::TOOL_CALL_SUCCESS, None)
+    } else if status.eq_ignore_ascii_case("failed") {
+        ("✗", theme::TOOL_CALL_FAILURE, None)
+    } else if let Some((kind, reason)) = status.split_once(':') {
+        if kind.eq_ignore_ascii_case("failed") {
+            ("✗", theme::TOOL_CALL_FAILURE, Some(reason.trim()))
+        } else {
+            ("•", theme::DIM, Some(status))
+        }
+    } else if status.starts_with("exited (") {
+        ("✗", theme::TOOL_CALL_FAILURE, Some(status))
+    } else if status.eq_ignore_ascii_case("cancelled") || status.eq_ignore_ascii_case("canceled") {
+        ("−", theme::DIM, None)
+    } else {
+        ("•", theme::DIM, Some(status))
+    }
+}
+
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let render_started = std::time::Instant::now();
 
@@ -534,14 +558,19 @@ fn build_message_lines<'a>(
             lines.push(Line::default());
         }
         ChatMessage::ToolCall { title, status, .. } => {
-            lines.push(Line::from(Span::styled(
-                format!(
-                    "[{}] {}",
-                    truncate_render_text(title),
-                    truncate_render_text(status)
-                ),
-                theme::TOOL_CALL,
-            )));
+            let (marker, marker_style, detail) = tool_call_presentation(status);
+            let mut spans = vec![
+                Span::styled(marker, marker_style),
+                Span::raw(" "),
+                Span::styled(truncate_render_text(title), theme::TOOL_CALL_TITLE),
+            ];
+            if let Some(detail) = detail.filter(|detail| !detail.is_empty()) {
+                spans.push(Span::styled(
+                    format!(" · {}", truncate_render_text(detail)),
+                    theme::DIM,
+                ));
+            }
+            lines.push(Line::from(spans));
         }
         ChatMessage::Plan(entries) => {
             lines.push(Line::from(Span::styled(t!("chat.plan_header").into_owned(), theme::PLAN_STYLE)));
@@ -669,6 +698,27 @@ mod tests {
 
     fn line_text(line: &Line) -> String {
         line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    fn tool_call_line(status: &str) -> String {
+        let message = ChatMessage::ToolCall {
+            id: "tool".into(),
+            title: "Run: cargo test".into(),
+            status: status.into(),
+        };
+        line_text(&build_message_lines(&message, false, false, 80)[0])
+    }
+
+    #[test]
+    fn tool_call_uses_semantic_status_markers() {
+        assert_eq!(tool_call_line("Pending"), "○ Run: cargo test");
+        assert_eq!(tool_call_line("running"), "● Run: cargo test");
+        assert_eq!(tool_call_line("Completed"), "✓ Run: cargo test");
+        assert_eq!(
+            tool_call_line("Failed: exit code 1"),
+            "✗ Run: cargo test · exit code 1"
+        );
+        assert_eq!(tool_call_line("Canceled"), "− Run: cargo test");
     }
 
     // ── extract_json_string_field: escape decoding ──────────────────────────

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -112,6 +112,12 @@ fn turn_height(turn: &CompletedTurn, wrap_width: usize) -> usize {
     h
 }
 
+fn starts_with_ignore_ascii_case(value: &str, prefix: &str) -> bool {
+    value
+        .get(..prefix.len())
+        .is_some_and(|start| start.eq_ignore_ascii_case(prefix))
+}
+
 fn tool_call_presentation(status: &str) -> (&'static str, Style, Option<&str>) {
     if status.eq_ignore_ascii_case("pending") {
         ("○", theme::TOOL_CALL_PENDING, None)
@@ -127,10 +133,10 @@ fn tool_call_presentation(status: &str) -> (&'static str, Style, Option<&str>) {
         } else {
             ("•", theme::DIM, Some(status))
         }
-    } else if status.starts_with("exited (") {
+    } else if starts_with_ignore_ascii_case(status, "exited (") {
         ("✗", theme::TOOL_CALL_FAILURE, Some(status))
     } else if status.eq_ignore_ascii_case("cancelled") || status.eq_ignore_ascii_case("canceled") {
-        ("−", theme::DIM, None)
+        ("−", theme::TOOL_CALL_CANCELED, None)
     } else {
         ("•", theme::DIM, Some(status))
     }
@@ -700,25 +706,65 @@ mod tests {
         line.spans.iter().map(|s| s.content.as_ref()).collect()
     }
 
-    fn tool_call_line(status: &str) -> String {
+    fn assert_tool_call(
+        status: &str,
+        expected_text: &str,
+        expected_marker_style: Style,
+        expected_detail_style: Option<Style>,
+    ) {
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
             title: "Run: cargo test".into(),
             status: status.into(),
         };
-        line_text(&build_message_lines(&message, false, false, 80)[0])
+        let lines = build_message_lines(&message, false, false, 80);
+        let line = &lines[0];
+
+        assert_eq!(line_text(line), expected_text);
+        assert_eq!(line.spans[0].style, expected_marker_style);
+        assert_eq!(line.spans[2].style, theme::TOOL_CALL_TITLE);
+        assert_eq!(line.spans.get(3).map(|span| span.style), expected_detail_style);
     }
 
     #[test]
     fn tool_call_uses_semantic_status_markers() {
-        assert_eq!(tool_call_line("Pending"), "○ Run: cargo test");
-        assert_eq!(tool_call_line("running"), "● Run: cargo test");
-        assert_eq!(tool_call_line("Completed"), "✓ Run: cargo test");
-        assert_eq!(
-            tool_call_line("Failed: exit code 1"),
-            "✗ Run: cargo test · exit code 1"
+        assert_tool_call(
+            "Pending",
+            "○ Run: cargo test",
+            theme::TOOL_CALL_PENDING,
+            None,
         );
-        assert_eq!(tool_call_line("Canceled"), "− Run: cargo test");
+        assert_tool_call(
+            "running",
+            "● Run: cargo test",
+            theme::TOOL_CALL_RUNNING,
+            None,
+        );
+        assert_tool_call(
+            "Completed",
+            "✓ Run: cargo test",
+            theme::TOOL_CALL_SUCCESS,
+            None,
+        );
+        assert_tool_call(
+            "Failed: exit code 1",
+            "✗ Run: cargo test · exit code 1",
+            theme::TOOL_CALL_FAILURE,
+            Some(theme::DIM),
+        );
+        assert_tool_call(
+            "Canceled",
+            "− Run: cargo test",
+            theme::TOOL_CALL_CANCELED,
+            None,
+        );
+        assert_tool_call(
+            "Exited (1)",
+            "✗ Run: cargo test · Exited (1)",
+            theme::TOOL_CALL_FAILURE,
+            Some(theme::DIM),
+        );
+        assert_ne!(theme::TOOL_CALL_CANCELED, theme::DIM);
     }
 
     // ── extract_json_string_field: escape decoding ──────────────────────────


### PR DESCRIPTION
## Summary
- replace bracketed tool-call protocol statuses with semantic status markers
- apply distinct pending, running, success, failure, and canceled colors
- retain actionable failure details while hiding redundant completed/pending labels
- cover the rendered status variants with a focused unit test

## Testing
- `cargo test --manifest-path tools/wta/Cargo.toml`
- manually verified in the Intelligent Terminal agent pane
<img width="1055" height="322" alt="image" src="https://github.com/user-attachments/assets/7f7465b7-359b-4843-b047-b531ba533a7c" />
