### PR TITLE
Refine agent pane activity indicators

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1086,13 +1086,6 @@ pub enum AppEvent {
     /// focus-in/out (CSI I / CSI O) delivered through conpty.
     FocusChanged(bool),
     ConnectionStage(String),
-    /// `session_id` lets us route the status update to the originating tab
-    /// once an ACP session is bound to it. Pre-session statuses (startup
-    /// stages) carry None and fall through to the active tab.
-    ProgressStatus {
-        session_id: Option<String>,
-        status: String,
-    },
     AgentConnected {
         name: String,
         model: Option<String>,
@@ -1484,9 +1477,6 @@ pub struct TabSession {
     /// chunks and structured tokens that cannot yet render do not clear it.
     pub waiting_for_first_visible_activity: bool,
 
-    // Agent-supplied progress message (e.g. "Reading file foo.rs"). Retained
-    // for turn lifecycle and activity-animation ticking.
-    pub progress_status: Option<String>,
     pub activity_frame: usize,
     /// Typewriter reveal cursor: how many characters of the *user-visible*
     /// streaming text are currently shown. The full text lives in
@@ -1706,7 +1696,6 @@ impl TabSession {
         // Dropping pending responders signals `Cancelled` back to the
         // agent — appropriate when the user wipes chat history mid-turn.
         self.permission.clear();
-        self.progress_status = None;
         self.activity_frame = 0;
         self.pending_agent_response.clear();
         self.pending_user_replay.clear();
@@ -4778,7 +4767,6 @@ impl App {
             AppEvent::Resize(_, _) => "resize",
             AppEvent::FocusChanged(_) => "focus_changed",
             AppEvent::ConnectionStage(_) => "connection_stage",
-            AppEvent::ProgressStatus { .. } => "progress_status",
             AppEvent::AgentConnected { .. } => "agent_connected",
             AppEvent::SessionAttached { .. } => "session_attached",
             AppEvent::TabError { .. } => "tab_error",
@@ -5222,11 +5210,13 @@ impl App {
         if self.mode == AppMode::Setup || self.mode == AppMode::Auth {
             return true; // spinner always ticks in setup/auth mode
         }
+        if matches!(self.state, ConnectionState::Connecting(_)) {
+            return true; // connecting shimmer
+        }
         if self.agents_view_awaiting_snapshot() {
             return true; // agents-view "Loading" shimmer
         }
-        let tab = self.current_tab();
-        tab.turn.is_in_flight() || tab.progress_status.is_some()
+        self.current_tab().turn.is_in_flight()
     }
 
     /// Get the most recent unacknowledged notification (for the banner).

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1484,8 +1484,8 @@ pub struct TabSession {
     /// chunks and structured tokens that cannot yet render do not clear it.
     pub waiting_for_first_visible_activity: bool,
 
-    // Agent-supplied progress message (e.g. "Reading file foo.rs"). Falls
-    // back to the spinner label derived from `turn` when None.
+    // Agent-supplied progress message (e.g. "Reading file foo.rs"). Retained
+    // for turn lifecycle and activity-animation ticking.
     pub progress_status: Option<String>,
     pub activity_frame: usize,
     /// Typewriter reveal cursor: how many characters of the *user-visible*

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -530,6 +530,7 @@ impl PermOption {
 }
 
 pub struct PermissionState {
+    pub tool_call_id: String,
     pub description: String,
     pub options: Vec<PermOption>,
     pub selected: usize,
@@ -1253,6 +1254,7 @@ pub enum AppEvent {
     },
     PermissionRequest {
         session_id: String,
+        tool_call_id: String,
         description: String,
         options: Vec<PermOption>,
         responder: tokio::sync::oneshot::Sender<String>,
@@ -1473,6 +1475,14 @@ pub struct TabSession {
     // Explicit per-turn lifecycle. Source of truth in the new state machine
     // (see `doc/specs/turn-state-refactor.md`).
     pub turn: TurnState,
+    /// One-way latch for the Thinking indicator.
+    ///
+    /// Rule: a newly submitted prompt shows Thinking only while it is waiting
+    /// for the first user-visible agent feedback. The first revealed text,
+    /// tool item, plan, permission card, or surfaced result clears this latch,
+    /// and it must never become true again during the same turn. Hidden thought
+    /// chunks and structured tokens that cannot yet render do not clear it.
+    pub waiting_for_first_visible_activity: bool,
 
     // Agent-supplied progress message (e.g. "Reading file foo.rs"). Falls
     // back to the spinner label derived from `turn` when None.
@@ -1616,6 +1626,14 @@ struct InputHistory {
 impl TabSession {
     pub fn scroll_to_bottom(&mut self) {
         self.chat_scroll.offset = 0;
+    }
+
+    pub(crate) fn mark_visible_agent_activity(&mut self) {
+        self.waiting_for_first_visible_activity = false;
+    }
+
+    pub(crate) fn should_show_thinking(&self) -> bool {
+        self.waiting_for_first_visible_activity && self.turn.is_in_flight()
     }
 
     /// Whether the input box is the live, enterable caret target. False when
@@ -5116,11 +5134,19 @@ impl App {
                 // Clamp down if the visible text shrank (e.g. a fenced JSON
                 // block replaced the streamed prose).
                 tab.reveal_chars = len;
+                if len > 0 {
+                    tab.mark_visible_agent_activity();
+                }
                 continue;
             }
             let backlog = len - tab.reveal_chars;
             let step = REVEAL_MIN_STEP.max(backlog / REVEAL_CATCHUP_FRAMES);
             tab.reveal_chars = (tab.reveal_chars + step).min(len);
+            if tab.reveal_chars > 0 {
+                // The first character is now actually visible, so Thinking
+                // hands off permanently to the streamed response for this turn.
+                tab.mark_visible_agent_activity();
+            }
         }
     }
 
@@ -5200,7 +5226,7 @@ impl App {
             return true; // agents-view "Loading" shimmer
         }
         let tab = self.current_tab();
-        tab.turn.spinner_label().is_some() || tab.progress_status.is_some()
+        tab.turn.is_in_flight() || tab.progress_status.is_some()
     }
 
     /// Get the most recent unacknowledged notification (for the banner).

--- a/tools/wta/src/app/turn_state.rs
+++ b/tools/wta/src/app/turn_state.rs
@@ -167,24 +167,6 @@ impl TurnState {
             .unwrap_or(false)
     }
 
-    /// Spinner label, if the state should drive a busy indicator.
-    /// `Submitted`, `Streaming`, and `Surfaced{end_pending:true}` show the
-    /// spinner. `Surfaced{end_pending:false}` and `Idle` do not.
-    ///
-    /// `Surfaced{end_pending:true}` is included because the UI gate is still
-    /// held open — `AgentMessageEnd` has not arrived yet. A permission request
-    /// can arrive in this window, and without the spinner the pane looks frozen
-    /// between the eager surface and the permission card appearing (issue #189).
-    pub fn spinner_label(&self) -> Option<&'static str> {
-        match self {
-            TurnState::Submitted(_) => Some("Thinking..."),
-            TurnState::Streaming { .. } => Some("Thinking..."),
-            TurnState::Surfaced {
-                end_pending: true, ..
-            } => Some("Thinking..."),
-            _ => None,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -236,7 +218,6 @@ mod tests {
         assert!(s.prompt().is_none());
         assert!(s.autofix_generation().is_none());
         assert!(!s.is_autofix());
-        assert!(s.spinner_label().is_none());
         assert!(!s.is_in_flight());
     }
 
@@ -249,7 +230,6 @@ mod tests {
         assert!(s.buffer().is_none());
         assert!(s.recommendations().is_none());
         assert!(s.prompt().is_some());
-        assert!(s.spinner_label().is_some());
         assert!(s.is_in_flight());
     }
 
@@ -265,7 +245,6 @@ mod tests {
         assert_eq!(s.buffer(), Some("partial"));
         assert!(s.recommendations().is_none());
         assert!(s.prompt().is_some());
-        assert!(s.spinner_label().is_some());
         assert!(s.is_in_flight());
     }
 
@@ -277,21 +256,19 @@ mod tests {
             end_pending: true,
         };
         assert!(!s.accepts_new_prompt());
-        // end_pending=true means AgentMessageEnd hasn't arrived yet — the UI
-        // gate is still held and the spinner must stay visible (issue #189).
-        assert!(s.spinner_label().is_some());
+        // end_pending=true means AgentMessageEnd hasn't arrived yet, so the UI
+        // gate remains held even though visible output may already be present.
         assert!(s.is_in_flight());
     }
 
     #[test]
-    fn surfaced_end_done_has_no_spinner() {
+    fn surfaced_end_done_is_not_in_flight() {
         let s = TurnState::Surfaced {
             prompt: prompt(),
             outcome: TurnOutcome::ChatTurn,
             end_pending: false,
         };
         assert!(s.accepts_new_prompt());
-        assert!(s.spinner_label().is_none());
         assert!(!s.is_in_flight());
     }
 

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -41,7 +41,7 @@ impl App {
                 // prompt should keep its shimmer phase advancing so when the
                 // user switches back the animation is in step.
                 for tab in self.tab_sessions.values_mut() {
-                    if tab.turn.is_in_flight() || tab.progress_status.is_some() {
+                    if tab.turn.is_in_flight() {
                         tab.activity_frame =
                             (tab.activity_frame + 1) % crate::ui::ACTIVITY_CYCLE_FRAMES;
                     }
@@ -85,14 +85,6 @@ impl App {
             AppEvent::ConnectionStage(stage) => {
                 self.state = ConnectionState::Connecting(stage);
                 self.publish_agent_status();
-            }
-            AppEvent::ProgressStatus { session_id, status } => {
-                let tab = match session_id {
-                    Some(sid) => self.session_tab_mut(&sid),
-                    None => self.current_tab_mut(),
-                };
-                tab.progress_status = Some(status);
-                tab.scroll_to_bottom();
             }
             AppEvent::AgentConnected {
                 name,
@@ -225,7 +217,6 @@ impl App {
                 let tab = self.tab_mut(&tab_id);
                 tab.loading_session = false;
                 tab.loading_target_session_id = None;
-                tab.progress_status = None;
                 tab.pending_agent_response.clear();
                 tab.pending_user_replay.clear();
                 tab.timing_note = None;
@@ -358,7 +349,6 @@ impl App {
                         Some(sid) => self.session_tab_mut(sid),
                         None => self.current_tab_mut(),
                     };
-                    tab.progress_status = None;
                     tab.activity_frame = 0;
                     tab.timing_note = None;
                     tab.turn = TurnState::Idle;
@@ -533,7 +523,6 @@ impl App {
                     let text = std::mem::take(&mut tab.pending_user_replay);
                     tab.messages.push(ChatMessage::User(text));
                 }
-                tab.progress_status = None;
                 tab.pending_agent_response.push_str(&text);
 
                 // Append to the streaming buffer. The state machine drops

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -41,7 +41,7 @@ impl App {
                 // prompt should keep its shimmer phase advancing so when the
                 // user switches back the animation is in step.
                 for tab in self.tab_sessions.values_mut() {
-                    if tab.turn.spinner_label().is_some() || tab.progress_status.is_some() {
+                    if tab.turn.is_in_flight() || tab.progress_status.is_some() {
                         tab.activity_frame =
                             (tab.activity_frame + 1) % crate::ui::ACTIVITY_CYCLE_FRAMES;
                     }
@@ -599,6 +599,7 @@ impl App {
                     .insert(id.clone(), (title.clone(), status.clone()));
                 tab.messages
                     .push(ChatMessage::ToolCall { id, title, status });
+                tab.mark_visible_agent_activity();
                 tab.scroll_to_bottom();
             }
             AppEvent::ToolCallUpdate {
@@ -646,10 +647,12 @@ impl App {
                     }
                 }
                 tab.messages.push(ChatMessage::Plan(entries));
+                tab.mark_visible_agent_activity();
                 tab.scroll_to_bottom();
             }
             AppEvent::PermissionRequest {
                 session_id,
+                tool_call_id,
                 description,
                 options,
                 responder,
@@ -666,11 +669,13 @@ impl App {
                 // one rendered + key-handled); resolving the front pops
                 // it and exposes the next.
                 tab.permission.push_back(PermissionState {
+                    tool_call_id,
                     description,
                     options,
                     selected: 0,
                     responder: Some(responder),
                 });
+                tab.mark_visible_agent_activity();
             }
             AppEvent::SystemMessage(message) => {
                 self.current_tab_mut()

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -4667,6 +4667,7 @@ fn perm_option_kind_matching_is_case_insensitive() {
 
     // PermissionState index helpers pick the first matching option.
     let perm = PermissionState {
+        tool_call_id: "tool".into(),
         description: String::new(),
         options: vec![opt("AllowOnce"), opt("RejectOnce")],
         selected: 0,
@@ -4676,20 +4677,9 @@ fn perm_option_kind_matching_is_case_insensitive() {
     assert_eq!(perm.reject_index(), Some(1));
 }
 
-/// Regression (issue #189): while the agent has queued a permission request
-/// but `AgentMessageEnd` has not yet arrived (turn is
-/// `Surfaced{end_pending:true}`), the thinking/activity indicator must
-/// remain visible. Previously `spinner_label()` returned `None` for any
-/// `Surfaced` variant, making the pane look frozen between the eager surface
-/// and the permission card appearing.
 #[test]
-fn thinking_indicator_visible_while_permission_pending_and_end_pending() {
+fn permission_request_permanently_clears_thinking_latch() {
     let mut app = test_app();
-
-    // Put the tab in `Surfaced{end_pending:true}` — the state that exists
-    // between an eager surface (recommendation / chat turn visible) and the
-    // `AgentMessageEnd` event that releases the UI gate. A permission
-    // request can arrive in this window.
     let prompt = SubmittedPrompt {
         id: 1,
         text: "test".into(),
@@ -4701,38 +4691,26 @@ fn thinking_indicator_visible_while_permission_pending_and_end_pending() {
         outcome: TurnOutcome::Empty,
         end_pending: true,
     };
-
-    // The spinner must be active while end_pending=true.
-    assert!(
-        app.current_tab().turn.spinner_label().is_some(),
-        "spinner_label must be Some while Surfaced{{end_pending:true}} (issue #189)"
-    );
-    assert!(
-        app.has_activity_indicator(),
-        "has_activity_indicator must be true while Surfaced{{end_pending:true}} (issue #189)"
-    );
-
-    // Simulate the PermissionRequest arriving in this window.
     app.tab_mut(DEFAULT_TAB_ID)
-        .permission
-        .push_back(PermissionState {
-            description: "Allow tool X?".into(),
-            options: vec![
-                PermOption { id: "allow-once".into(), name: "Allow".into(), kind: "AllowOnce".into() },
-                PermOption { id: "reject-once".into(), name: "Deny".into(), kind: "RejectOnce".into() },
-            ],
-            selected: 0,
-            responder: None,
-        });
+        .waiting_for_first_visible_activity = true;
 
-    // With a queued permission AND end_pending=true the spinner must still be on.
+    let (responder, _response) = tokio::sync::oneshot::channel();
+    app.handle_event(AppEvent::PermissionRequest {
+        session_id: DEFAULT_TAB_ID.into(),
+        tool_call_id: "tool".into(),
+        description: "Allow tool X?".into(),
+        options: vec![
+            PermOption { id: "allow-once".into(), name: "Allow".into(), kind: "AllowOnce".into() },
+            PermOption { id: "reject-once".into(), name: "Deny".into(), kind: "RejectOnce".into() },
+        ],
+        responder,
+    });
+
+    assert!(!app.current_tab().should_show_thinking());
+    app.current_tab_mut().permission.pop_front();
     assert!(
-        app.current_tab().turn.spinner_label().is_some(),
-        "spinner_label must remain Some after PermissionRequest queued while end_pending=true"
-    );
-    assert!(
-        app.has_activity_indicator(),
-        "has_activity_indicator must remain true after PermissionRequest queued"
+        !app.current_tab().should_show_thinking(),
+        "resolving permission must not re-enable Thinking in the same turn"
     );
 }
 
@@ -5091,6 +5069,7 @@ fn render_permission_card_shows_options() {
     let mut app = test_app();
     app.state = ConnectionState::Connected;
     app.current_tab_mut().permission.push_back(PermissionState {
+        tool_call_id: "tool".into(),
         description: "Run: echo PERM_XYZ".into(),
         options: vec![
             PermOption {
@@ -6010,6 +5989,7 @@ fn render_permission_compact_shows_hint() {
     app.state = ConnectionState::Connected;
     app.terminal_rows = 7; // ceiling = 4 < CARD_MIN_SIZE(5) → compact fallback
     app.current_tab_mut().permission.push_back(PermissionState {
+        tool_call_id: "tool".into(),
         description: "Run: echo PERM_COMPACT_XYZ".into(),
         options: vec![
             PermOption {
@@ -6130,11 +6110,17 @@ fn submit_clears_messages_and_pushes_user_bubble() {
 fn first_message_chunk_transitions_to_streaming_with_buf() {
     let mut app = test_app();
     submit_test_prompt(&mut app, "hi");
+    assert!(app.current_tab().should_show_thinking());
     let advanced = app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Message, "partial");
     assert!(advanced, "first message chunk must advance the buffer");
-    let tab = app.current_tab();
-    assert_eq!(tab.turn.buffer(), Some("partial"));
-    assert!(tab.turn.is_streaming());
+    assert_eq!(app.current_tab().turn.buffer(), Some("partial"));
+    assert!(app.current_tab().turn.is_streaming());
+    assert!(
+        app.current_tab().should_show_thinking(),
+        "Thinking remains until text is actually revealed"
+    );
+    app.advance_reveal();
+    assert!(!app.current_tab().should_show_thinking());
 }
 
 #[test]
@@ -6146,6 +6132,54 @@ fn thought_chunk_first_transitions_with_empty_buf() {
     let tab = app.current_tab();
     assert!(tab.turn.is_streaming());
     assert_eq!(tab.turn.buffer(), Some(""));
+    assert!(
+        tab.should_show_thinking(),
+        "hidden thought chunks are not user-visible feedback"
+    );
+}
+
+#[test]
+fn hidden_structured_tokens_keep_thinking_until_explanation_is_visible() {
+    let mut app = test_app();
+    submit_test_prompt(&mut app, "hi");
+    app.turn_observe_chunk(
+        DEFAULT_TAB_ID,
+        ChunkKind::Message,
+        r#"{"kind":"explanation""#,
+    );
+    app.advance_reveal();
+    assert!(app.current_tab().should_show_thinking());
+
+    app.turn_observe_chunk(
+        DEFAULT_TAB_ID,
+        ChunkKind::Message,
+        r#","explanation":"Visible answer"}"#,
+    );
+    app.advance_reveal();
+    assert!(!app.current_tab().should_show_thinking());
+}
+
+#[test]
+fn tool_call_permanently_clears_thinking_latch() {
+    let mut app = test_app();
+    submit_test_prompt(&mut app, "inspect");
+    app.handle_event(AppEvent::ToolCall {
+        session_id: DEFAULT_TAB_ID.into(),
+        id: "tool".into(),
+        title: "Find files".into(),
+        status: "InProgress".into(),
+    });
+    assert!(!app.current_tab().should_show_thinking());
+
+    app.handle_event(AppEvent::ToolCallUpdate {
+        session_id: DEFAULT_TAB_ID.into(),
+        id: "tool".into(),
+        status: "Completed".into(),
+    });
+    assert!(
+        !app.current_tab().should_show_thinking(),
+        "tool completion must not re-enable Thinking"
+    );
 }
 
 #[test]
@@ -6378,6 +6412,7 @@ use crate::ui::card::{card_content_width, CARD_H_CHROME, CARD_MIN_SIZE};
 
 fn perm_with(desc: &str) -> PermissionState {
     PermissionState {
+        tool_call_id: "tool".into(),
         description: desc.to_string(),
         options: vec![PermOption {
             id: "allow_once".into(),

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -5979,6 +5979,21 @@ fn render_chat_welcome_hint() {
     );
 }
 
+#[test]
+fn connecting_activity_row_is_included_in_estimated_chat_height() {
+    let mut app = test_app();
+    app.current_tab_mut()
+        .messages
+        .push(ChatMessage::User("hello".into()));
+
+    app.state = ConnectionState::Disconnected;
+    let without_activity = crate::ui::chat::estimated_block_height(&app, 80);
+    app.state = ConnectionState::Connecting("Starting agent".into());
+    let with_activity = crate::ui::chat::estimated_block_height(&app, 80);
+
+    assert_eq!(with_activity, without_activity + 1);
+}
+
 /// Render: when the pane is too short for a full permission card, the
 /// compact one-row fallback must paint the description and the `[Y/N]`
 /// hint. Lifts `render_compact` in `ui/permission.rs`. The compact path

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -5992,6 +5992,10 @@ fn connecting_activity_row_is_included_in_estimated_chat_height() {
     let with_activity = crate::ui::chat::estimated_block_height(&app, 80);
 
     assert_eq!(with_activity, without_activity + 1);
+    assert!(
+        app.has_activity_indicator(),
+        "Connecting must keep Tick redraws active for the shimmer"
+    );
 }
 
 /// Render: when the pane is too short for a full permission card, the

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -71,6 +71,7 @@ impl App {
         tab.activity_frame = 0;
         tab.timing_note = None;
         tab.turn = TurnState::Submitted(prompt);
+        tab.waiting_for_first_visible_activity = true;
 
         // Submitting a new prompt dismisses any prior leftover card (the
         // `selected_recommendation = 0` + turn reset above). If the helper
@@ -408,12 +409,12 @@ impl App {
     }
 
     /// Helper called at every turn-close path. Clears the agent-supplied
-    /// progress override and the shimmer animation phase; the UI spinner
-    /// otherwise drives off `tab.turn.spinner_label()`.
+    /// progress override, animation phase, and first-visible-activity latch.
     fn turn_clear_agent_progress(&mut self, session_id: &str) {
         let tab = self.session_tab_mut(session_id);
         tab.progress_status = None;
         tab.activity_frame = 0;
+        tab.mark_visible_agent_activity();
     }
 
     /// User pressed Enter while a card was visible — dispatch the selected
@@ -580,6 +581,7 @@ impl App {
         tab.rec_scroll.reset();
         tab.progress_status = None;
         tab.activity_frame = 0;
+        tab.mark_visible_agent_activity();
         tab.turn = TurnState::Idle;
 
         // Esc on a Send card or in-flight autofix exits the chip-override
@@ -629,6 +631,7 @@ impl App {
         tab.selected_completed_turn_idx = None;
         tab.progress_status = None;
         tab.activity_frame = 0;
+        tab.mark_visible_agent_activity();
         tab.turn = TurnState::Surfaced {
             prompt,
             outcome: TurnOutcome::Recommendation(recommendations),
@@ -708,6 +711,7 @@ impl App {
         tab.selection_visible_pending = true;
         tab.progress_status = None;
         tab.activity_frame = 0;
+        tab.mark_visible_agent_activity();
         tab.turn = TurnState::Surfaced {
             prompt,
             outcome: TurnOutcome::Recommendation(recommendations),
@@ -793,6 +797,7 @@ impl App {
         tab.rec_scroll.reset();
         tab.progress_status = None;
         tab.activity_frame = 0;
+        tab.mark_visible_agent_activity();
         tab.turn = TurnState::Surfaced {
             prompt,
             outcome: TurnOutcome::ChatTurn,

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -67,7 +67,6 @@ impl App {
             tab.messages.push(ChatMessage::User(user_text));
         }
         tab.scroll_to_bottom();
-        tab.progress_status = None;
         tab.activity_frame = 0;
         tab.timing_note = None;
         tab.turn = TurnState::Submitted(prompt);
@@ -105,11 +104,6 @@ impl App {
             }
         }
 
-        // `progress_status` (agent-supplied "Reading foo.rs" etc.) is left
-        // alone here — its natural lifetime is the whole turn. It's cleared
-        // at turn close (`turn_clear_agent_progress`) and overwritten by
-        // future `ProgressStatus` events. The old per-chunk wipe erased
-        // the value the moment a streaming agent would have it set.
         match (&mut tab.turn, kind) {
             // First message chunk: transition Submitted → Streaming.
             (TurnState::Submitted(_), ChunkKind::Message) => {
@@ -216,7 +210,7 @@ impl App {
                     current_gen,
                     "discarding stale autofix turn at close",
                 );
-                self.turn_clear_agent_progress(session_id);
+                self.turn_clear_agent_activity(session_id);
                 self.session_tab_mut(session_id).turn = TurnState::Idle;
                 return;
             }
@@ -228,7 +222,7 @@ impl App {
         } = &self.session_tab(session_id).turn
         {
             self.turn_release_end_pending_logged(session_id, "via=eager+end");
-            self.turn_clear_agent_progress(session_id);
+            self.turn_clear_agent_activity(session_id);
             return;
         }
 
@@ -250,7 +244,7 @@ impl App {
         } else {
             self.turn_close_finalize_planner(session_id, buf);
         }
-        self.turn_clear_agent_progress(session_id);
+        self.turn_clear_agent_activity(session_id);
     }
 
     /// Path (3): close a turn that received `AgentMessageEnd` with no
@@ -279,7 +273,7 @@ impl App {
             autofix.armed_at = None;
         }
         self.turn_release_end_pending(session_id);
-        self.turn_clear_agent_progress(session_id);
+        self.turn_clear_agent_activity(session_id);
     }
 
     /// Path (4a): autofix Streaming buffer reached `AgentMessageEnd` with
@@ -408,11 +402,10 @@ impl App {
         }
     }
 
-    /// Helper called at every turn-close path. Clears the agent-supplied
-    /// progress override, animation phase, and first-visible-activity latch.
-    fn turn_clear_agent_progress(&mut self, session_id: &str) {
+    /// Helper called at every turn-close path. Clears the animation phase and
+    /// first-visible-activity latch.
+    fn turn_clear_agent_activity(&mut self, session_id: &str) {
         let tab = self.session_tab_mut(session_id);
-        tab.progress_status = None;
         tab.activity_frame = 0;
         tab.mark_visible_agent_activity();
     }
@@ -579,7 +572,6 @@ impl App {
         tab.selected_recommendation = 0;
         tab.selected_button = 0;
         tab.rec_scroll.reset();
-        tab.progress_status = None;
         tab.activity_frame = 0;
         tab.mark_visible_agent_activity();
         tab.turn = TurnState::Idle;
@@ -629,7 +621,6 @@ impl App {
         tab.rec_scroll.reset();
         tab.selection_visible_pending = true;
         tab.selected_completed_turn_idx = None;
-        tab.progress_status = None;
         tab.activity_frame = 0;
         tab.mark_visible_agent_activity();
         tab.turn = TurnState::Surfaced {
@@ -709,7 +700,6 @@ impl App {
         tab.scroll_to_bottom();
         tab.selected_recommendation = rec_idx;
         tab.selection_visible_pending = true;
-        tab.progress_status = None;
         tab.activity_frame = 0;
         tab.mark_visible_agent_activity();
         tab.turn = TurnState::Surfaced {
@@ -795,7 +785,6 @@ impl App {
         tab.selected_recommendation = 0;
         tab.selected_button = 0;
         tab.rec_scroll.reset();
-        tab.progress_status = None;
         tab.activity_frame = 0;
         tab.mark_visible_agent_activity();
         tab.turn = TurnState::Surfaced {

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -3656,10 +3656,6 @@ async fn dispatch_prompt_body(
         include_template,
         &text,
     );
-    let _ = event_tx_task.send(AppEvent::ProgressStatus {
-        session_id: Some(prompt_session_id_str.clone()),
-        status: "Thinking...".to_string(),
-    });
     prompt_timing_task.mark_prompt_sent(&prompt_session_id_str);
 
     // Telemetry: prompt dispatched over ACP. WTA emits `AgentPromptSent`

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1541,6 +1541,7 @@ impl WtaClient {
             args.tool_call.fields.title
         ));
         let session_id = args.session_id.0.to_string();
+        let tool_call_id = args.tool_call.tool_call_id.to_string();
         let description = args
             .tool_call
             .fields
@@ -1565,6 +1566,7 @@ impl WtaClient {
 
         let _ = self.state.event_tx.send(AppEvent::PermissionRequest {
             session_id: session_id.clone(),
+            tool_call_id,
             description,
             options,
             responder: resp_tx,

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -1793,11 +1793,13 @@ async fn request_permission_returns_selected_option() {
             let responder = match rx.recv().await {
                 Some(AppEvent::PermissionRequest {
                     session_id,
+                    tool_call_id,
                     description,
                     options,
                     responder,
                 }) => {
                     assert_eq!(session_id, "s1");
+                    assert_eq!(tool_call_id, "mock-tool-1");
                     assert_eq!(description, "Run: echo hi");
                     assert_eq!(options.len(), 1);
                     assert_eq!(options[0].id, "allow-once");
@@ -1844,6 +1846,5 @@ async fn request_permission_cancelled_when_responder_dropped() {
         })
         .await;
 }
-
 
 

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -27,12 +27,9 @@ pub fn estimated_block_height(app: &App, area_width: u16) -> u16 {
     // be a redundant, measurable cost on the render hot path.
     let pending_text = pending_render_text(tab);
 
-    // Reserve the row only when the shimmer will actually render; mirrors
-    // the suppression rule in `build_activity_line` below.
-    let reveal_catching_up = pending_text
-        .as_deref()
-        .is_some_and(|text| tab.reveal_chars < text.chars().count());
-    let activity = if tab.turn.spinner_label().is_some() && !reveal_catching_up {
+    // Reserve the row only while this prompt is still waiting for its first
+    // user-visible agent feedback; mirrors `build_activity_line` below.
+    let activity = if should_show_turn_activity(tab) {
         1usize
     } else {
         0
@@ -142,6 +139,31 @@ fn tool_call_presentation(status: &str) -> (&'static str, Style, Option<&str>) {
     }
 }
 
+fn is_active_tool_call_status(status: &str) -> bool {
+    status.eq_ignore_ascii_case("pending")
+        || status.eq_ignore_ascii_case("inprogress")
+        || status.eq_ignore_ascii_case("running")
+}
+
+fn should_show_turn_activity(tab: &crate::app::TabSession) -> bool {
+    tab.should_show_thinking()
+}
+
+fn permission_tool_call_id(tab: &crate::app::TabSession) -> Option<&str> {
+    tab.permission
+        .front()
+        .map(|permission| permission.tool_call_id.as_str())
+}
+
+fn breathing_dot(frame: usize) -> &'static str {
+    match frame % 16 {
+        0..=3 => "●",
+        4..=7 => "•",
+        8..=11 => "·",
+        _ => "•",
+    }
+}
+
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let render_started = std::time::Instant::now();
 
@@ -172,9 +194,18 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let mut truncated = false;
 
-    for (idx, msg) in app.current_tab().messages.iter().enumerate().rev() {
+    let tab = app.current_tab();
+    let permission_tool_call_id = permission_tool_call_id(tab);
+    for (idx, msg) in tab.messages.iter().enumerate().rev() {
         let is_last_message = idx + 1 == app.current_tab().messages.len();
-        let mut message_lines = build_message_lines(msg, is_last_message, app.current_tab().turn.is_streaming(), wrap_width);
+        let mut message_lines = build_message_lines(
+            msg,
+            is_last_message,
+            tab.turn.is_streaming(),
+            permission_tool_call_id,
+            tab.activity_frame,
+            wrap_width,
+        );
         reversed_lines.extend(message_lines.drain(..).rev());
         if reversed_lines.len() >= requested_lines {
             truncated = true;
@@ -324,7 +355,7 @@ fn build_completed_turn_lines<'a>(
         // `agent_streaming=false` together suppress the streaming-cursor
         // path; details are always finalized by the time they land here.
         for msg in turn.details.iter() {
-            lines.extend(build_message_lines(msg, false, false, wrap_width));
+            lines.extend(build_message_lines(msg, false, false, None, 0, wrap_width));
         }
     }
 
@@ -358,17 +389,7 @@ fn build_activity_line(app: &App) -> Option<Line<'static>> {
         return Some(Line::from(shimmer::shimmer_spans(&label, app.activity_frame as usize)));
     }
     let tab = app.current_tab();
-    if tab.turn.spinner_label().is_none() {
-        return None;
-    }
-    // While the reveal is still catching up, the growing text is itself the
-    // activity signal, so skip the shimmer to avoid a duplicate. Once it
-    // catches up (e.g. the model narrated a step, then went quiet for a
-    // tool call / permission round-trip), the text goes static with no
-    // cursor of its own, so fall back to the shimmer so busy always shows
-    // *something* (issue #189 covered the empty-buffer case; this covers
-    // the non-empty-but-stalled one).
-    if is_reveal_catching_up(tab) {
+    if !should_show_turn_activity(tab) {
         return None;
     }
     let label = activity_label();
@@ -376,16 +397,6 @@ fn build_activity_line(app: &App) -> Option<Line<'static>> {
         &label,
         tab.activity_frame,
     )))
-}
-
-/// True while the reveal cursor hasn't caught up to the pending stream text,
-/// i.e. the growing text is still its own activity signal. `false` when
-/// there's no pending text, or the reveal has fully caught up.
-fn is_reveal_catching_up(tab: &crate::app::TabSession) -> bool {
-    match pending_render_text(tab) {
-        Some(text) => tab.reveal_chars < text.chars().count(),
-        None => false,
-    }
 }
 
 /// Incrementally extracts a JSON string field's decoded value from a
@@ -552,6 +563,8 @@ fn build_message_lines<'a>(
     msg: &'a ChatMessage,
     is_last_message: bool,
     agent_streaming: bool,
+    permission_tool_call_id: Option<&str>,
+    activity_frame: usize,
     wrap_width: usize,
 ) -> Vec<Line<'a>> {
     let mut lines = Vec::new();
@@ -581,8 +594,19 @@ fn build_message_lines<'a>(
             }
             lines.push(Line::default());
         }
-        ChatMessage::ToolCall { title, status, .. } => {
+        ChatMessage::ToolCall {
+            id,
+            title,
+            status,
+        } => {
             let (marker, marker_style, detail) = tool_call_presentation(status);
+            let marker = if permission_tool_call_id == Some(id.as_str())
+                || is_active_tool_call_status(status)
+            {
+                breathing_dot(activity_frame)
+            } else {
+                marker
+            };
             let mut spans = vec![
                 Span::styled(marker, marker_style),
                 Span::raw(" "),
@@ -662,6 +686,24 @@ fn push_dot_prefixed_lines<'a>(
     dot_style: Style,
     text_style: Style,
 ) {
+    push_dot_prefixed_lines_with_marker(
+        lines,
+        text,
+        wrap_width,
+        "●",
+        dot_style,
+        text_style,
+    );
+}
+
+fn push_dot_prefixed_lines_with_marker<'a>(
+    lines: &mut Vec<Line<'a>>,
+    text: &str,
+    wrap_width: usize,
+    dot: &str,
+    dot_style: Style,
+    text_style: Style,
+) {
     // Reserve 2 cells for either "● " or the continuation indent.
     let body_width = wrap_width.saturating_sub(2).max(1);
     let mut first_row = true;
@@ -684,7 +726,7 @@ fn push_dot_prefixed_lines<'a>(
             let piece_str = truncate_render_text(&piece).into_owned();
             if first_row {
                 lines.push(Line::from(vec![
-                    Span::styled("● ", dot_style),
+                    Span::styled(format!("{dot} "), dot_style),
                     Span::styled(piece_str, text_style),
                 ]));
                 first_row = false;
@@ -810,7 +852,7 @@ mod tests {
             title: "Run: cargo test".into(),
             status: status.into(),
         };
-        let lines = build_message_lines(&message, false, false, 80);
+        let lines = build_message_lines(&message, false, false, None, 0, 80);
         let line = &lines[0];
 
         assert_eq!(line_text(line), expected_text);
@@ -823,7 +865,7 @@ mod tests {
     fn tool_call_uses_semantic_status_markers() {
         assert_tool_call(
             "Pending",
-            "○ Run: cargo test",
+            "● Run: cargo test",
             theme::TOOL_CALL_PENDING,
             None,
         );
@@ -1012,8 +1054,6 @@ mod tests {
         assert_eq!(user_visible_stream_text("   \n  "), None);
     }
 
-    // ── is_reveal_catching_up ────────────────────────────────────────────────
-
     fn streaming_tab(buf: &str, reveal_chars: usize) -> crate::app::TabSession {
         let mut tab = crate::app::TabSession::default();
         tab.turn = crate::app::TurnState::Streaming {
@@ -1030,42 +1070,81 @@ mod tests {
     }
 
     #[test]
-    fn reveal_catching_up_true_while_behind_visible_length() {
-        // "hello" is 5 chars; reveal_chars=2 means the typewriter is still
-        // mid-reveal, so the growing text is still its own activity signal.
-        let tab = streaming_tab("hello", 2);
-        assert!(is_reveal_catching_up(&tab));
+    fn thinking_activity_is_a_one_way_per_prompt_latch() {
+        let mut tab = streaming_tab("", 0);
+        tab.waiting_for_first_visible_activity = true;
+        assert!(should_show_turn_activity(&tab));
+
+        tab.mark_visible_agent_activity();
+        assert!(!should_show_turn_activity(&tab));
+
+        tab.tool_calls
+            .insert("tool".into(), ("Run tests".into(), "Completed".into()));
+        assert!(
+            !should_show_turn_activity(&tab),
+            "later activity changes must not re-enable Thinking"
+        );
     }
 
     #[test]
-    fn reveal_catching_up_false_once_reveal_equals_visible_length() {
-        // reveal_chars caught up exactly to the visible length: the boundary
-        // case (`<` vs `>=`) that must flip to false, not stay true.
-        let tab = streaming_tab("hello", 5);
-        assert!(!is_reveal_catching_up(&tab));
+    fn breathing_dot_shrinks_then_grows() {
+        assert_eq!(breathing_dot(0), "●");
+        assert_eq!(breathing_dot(4), "•");
+        assert_eq!(breathing_dot(8), "·");
+        assert_eq!(breathing_dot(12), "•");
+        assert_eq!(breathing_dot(16), "●");
     }
 
     #[test]
-    fn reveal_catching_up_false_once_reveal_exceeds_visible_length() {
-        let tab = streaming_tab("hello", 99);
-        assert!(!is_reveal_catching_up(&tab));
+    fn permission_animates_only_its_matching_tool_call() {
+        let matching = ChatMessage::ToolCall {
+            id: "tool-2".into(),
+            title: "Read Cargo.toml".into(),
+            status: "Completed".into(),
+        };
+        let other = ChatMessage::ToolCall {
+            id: "tool-1".into(),
+            title: "Find files".into(),
+            status: "Completed".into(),
+        };
+
+        let matching_lines =
+            build_message_lines(&matching, false, false, Some("tool-2"), 8, 80);
+        let other_lines = build_message_lines(&other, false, false, Some("tool-2"), 8, 80);
+
+        assert_eq!(matching_lines[0].spans[0].content, "·");
+        assert_eq!(other_lines[0].spans[0].content, "✓");
     }
 
     #[test]
-    fn reveal_catching_up_false_when_buffer_empty() {
-        // Empty buffer (no narration streamed yet) has no pending text to
-        // catch up to — the empty-buffer case fixed for issue #189 must not
-        // be treated as "still revealing".
-        let tab = streaming_tab("", 0);
-        assert!(!is_reveal_catching_up(&tab));
+    fn active_tool_call_breathes_without_permission() {
+        for status in ["Pending", "InProgress", "running"] {
+            let message = ChatMessage::ToolCall {
+                id: "tool".into(),
+                title: "Find files".into(),
+                status: status.into(),
+            };
+            let lines = build_message_lines(&message, false, false, None, 8, 80);
+            assert_eq!(lines[0].spans[0].content, "·", "{status} should breathe");
+        }
     }
 
     #[test]
-    fn reveal_catching_up_false_when_not_streaming() {
-        // Idle (no turn in flight) has no `buffer()` at all: `pending_render_text`
-        // returns None, so there's nothing to catch up to.
-        let tab = crate::app::TabSession::default();
-        assert!(!is_reveal_catching_up(&tab));
+    fn permission_animation_follows_fifo_front() {
+        let mut tab = streaming_tab("", 0);
+        for id in ["tool-1", "tool-2"] {
+            tab.permission.push_back(crate::app::PermissionState {
+                tool_call_id: id.into(),
+                description: "Allow access?".into(),
+                options: Vec::new(),
+                selected: 0,
+                responder: None,
+            });
+        }
+
+        assert_eq!(permission_tool_call_id(&tab), Some("tool-1"));
+        tab.permission.pop_front();
+        assert_eq!(permission_tool_call_id(&tab), Some("tool-2"));
     }
 
     // ── truncate_render_text ────────────────────────────────────────────────

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -197,7 +197,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let tab = app.current_tab();
     let permission_tool_call_id = permission_tool_call_id(tab);
     for (idx, msg) in tab.messages.iter().enumerate().rev() {
-        let is_last_message = idx + 1 == app.current_tab().messages.len();
+        let is_last_message = idx + 1 == tab.messages.len();
         let mut message_lines = build_message_lines(
             msg,
             is_last_message,
@@ -686,24 +686,6 @@ fn push_dot_prefixed_lines<'a>(
     dot_style: Style,
     text_style: Style,
 ) {
-    push_dot_prefixed_lines_with_marker(
-        lines,
-        text,
-        wrap_width,
-        "●",
-        dot_style,
-        text_style,
-    );
-}
-
-fn push_dot_prefixed_lines_with_marker<'a>(
-    lines: &mut Vec<Line<'a>>,
-    text: &str,
-    wrap_width: usize,
-    dot: &str,
-    dot_style: Style,
-    text_style: Style,
-) {
     // Reserve 2 cells for either "● " or the continuation indent.
     let body_width = wrap_width.saturating_sub(2).max(1);
     let mut first_row = true;
@@ -726,7 +708,7 @@ fn push_dot_prefixed_lines_with_marker<'a>(
             let piece_str = truncate_render_text(&piece).into_owned();
             if first_row {
                 lines.push(Line::from(vec![
-                    Span::styled(format!("{dot} "), dot_style),
+                    Span::styled("● ", dot_style),
                     Span::styled(piece_str, text_style),
                 ]));
                 first_row = false;

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -20,16 +20,16 @@ const MAX_RENDER_LINE_CHARS: usize = 4096;
 pub fn estimated_block_height(app: &App, area_width: u16) -> u16 {
     let tab = app.current_tab();
     let wrap_width = (area_width as usize).max(1);
-    // Fetch once and reuse below for both the reveal-catchup check and the
-    // pending-height calc. `pending_render_text` re-parses the streaming
-    // buffer on every call (and allocates on the JSON-wrapper path via
-    // `extract_json_string_field`), so calling it twice per frame here would
-    // be a redundant, measurable cost on the render hot path.
+    // Fetch once for the pending-height calculation. `pending_render_text`
+    // re-parses the streaming buffer on every call (and allocates on the
+    // JSON-wrapper path via `extract_json_string_field`).
     let pending_text = pending_render_text(tab);
 
-    // Reserve the row only while this prompt is still waiting for its first
-    // user-visible agent feedback; mirrors `build_activity_line` below.
-    let activity = if should_show_turn_activity(tab) {
+    // Connecting and Thinking both pin one activity row in `render`; reserve
+    // that same row here so the surrounding layout cannot jump or clip.
+    let activity = if matches!(app.state, crate::app::ConnectionState::Connecting(_))
+        || should_show_turn_activity(tab)
+    {
         1usize
     } else {
         0
@@ -156,10 +156,10 @@ fn permission_tool_call_id(tab: &crate::app::TabSession) -> Option<&str> {
 }
 
 fn breathing_dot(frame: usize) -> &'static str {
-    match frame % 16 {
-        0..=3 => "●",
-        4..=7 => "•",
-        8..=11 => "·",
+    match frame % crate::ui::ACTIVITY_CYCLE_FRAMES {
+        0..=4 => "●",
+        5..=8 => "•",
+        9..=13 => "·",
         _ => "•",
     }
 }
@@ -1089,10 +1089,13 @@ mod tests {
     #[test]
     fn breathing_dot_shrinks_then_grows() {
         assert_eq!(breathing_dot(0), "●");
-        assert_eq!(breathing_dot(4), "•");
-        assert_eq!(breathing_dot(8), "·");
-        assert_eq!(breathing_dot(12), "•");
-        assert_eq!(breathing_dot(16), "●");
+        assert_eq!(breathing_dot(5), "•");
+        assert_eq!(breathing_dot(9), "·");
+        assert_eq!(breathing_dot(14), "•");
+        assert_eq!(
+            breathing_dot(crate::ui::ACTIVITY_CYCLE_FRAMES),
+            "●"
+        );
     }
 
     #[test]
@@ -1109,8 +1112,8 @@ mod tests {
         };
 
         let matching_lines =
-            build_message_lines(&matching, false, false, Some("tool-2"), 8, 80);
-        let other_lines = build_message_lines(&other, false, false, Some("tool-2"), 8, 80);
+            build_message_lines(&matching, false, false, Some("tool-2"), 9, 80);
+        let other_lines = build_message_lines(&other, false, false, Some("tool-2"), 9, 80);
 
         assert_eq!(matching_lines[0].spans[0].content, "·");
         assert_eq!(other_lines[0].spans[0].content, "✓");
@@ -1124,7 +1127,7 @@ mod tests {
                 title: "Find files".into(),
                 status: status.into(),
             };
-            let lines = build_message_lines(&message, false, false, None, 8, 80);
+            let lines = build_message_lines(&message, false, false, None, 9, 80);
             assert_eq!(lines[0].spans[0].content, "·", "{status} should breathe");
         }
     }


### PR DESCRIPTION
## Summary

- Limit the agent pane's **Thinking…** indicator to the interval between prompt submission and the first user-visible agent feedback. Hidden thought chunks and structured tokens that cannot render yet keep the indicator visible; once visible text, a tool item, plan, permission card, or result appears, the indicator stays off for the rest of that turn.
- Animate active tool-call status markers with a breathing `● → • → · → •` cycle during `Pending`, `InProgress`, and `Running`, replacing the redundant global Thinking indicator.
- Preserve ACP `tool_call_id` on permission requests so the currently displayed FIFO permission card animates only its matching tool item, then moves accurately to the next queued request.

## Behavior

| Turn phase | Activity feedback |
|---|---|
| Prompt submitted, no visible response yet | Thinking… shimmer |
| Hidden thought / non-renderable structured tokens | Thinking… shimmer |
| Agent text begins rendering | Streamed text; Thinking never returns for that turn |
| Tool executing | Matching tool status light breathes |
| Permission required | Permission card plus its matching tool status light |
| Tool completes / permission resolves | No Thinking rebound |

## Validation

- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- Built and exercised the updated `wta.exe` in the local Debug package.