### PR TITLE
localize agent-pane double-Ctrl+C close hint

### DIFF
--- a/tools/wta/locales/en-US.yml
+++ b/tools/wta/locales/en-US.yml
@@ -175,6 +175,9 @@ connection.connecting_activity: "Connecting to agent…"
 connection.lost: "Connection to the agent was lost. Type /restart to reconnect."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+# Shown as a one-line hint when the user presses Ctrl+C once with empty input — the second press closes the pane.
+# {Locked="Ctrl+C"} - key name, do not translate
+system.close_pane_hint: "Press Ctrl+C again to close pane"
 system.cancelled: "Cancelled."
 system.no_prompt_in_flight: "No prompt in flight."
 system.authentication_failed: "Authentication failed"

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2042,7 +2042,7 @@ pub struct App {
     /// other key, on prompt activity, or after the window elapses.
     pub close_pane_armed_at: Option<std::time::Instant>,
     /// Transient one-line hint rendered at the bottom of the chat area
-    /// (e.g. "Press Ctrl+C again to close pane"). Auto-clears at the
+    /// (localized via `system.close_pane_hint`). Auto-clears at the
     /// recorded deadline.
     pub transient_hint: Option<(String, std::time::Instant)>,
     /// Mirror of master's authoritative live-session set, pushed via
@@ -2061,7 +2061,7 @@ pub struct App {
     pub alive_loaded: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
-/// How long the "Press Ctrl+C again to close pane" arm stays live. Long
+/// How long the close-pane arm (localized via `system.close_pane_hint`) stays live. Long
 /// enough that the user can react after seeing the hint; short enough that
 /// a stale arm doesn't bite the next time they want to clear input.
 pub const CLOSE_PANE_ARM_WINDOW: std::time::Duration = std::time::Duration::from_millis(1500);
@@ -6818,7 +6818,7 @@ impl App {
                     } else {
                         self.close_pane_armed_at = Some(now);
                         self.transient_hint = Some((
-                            "Press Ctrl+C again to close pane".to_string(),
+                            t!("system.close_pane_hint").into_owned(),
                             now + CLOSE_PANE_ARM_WINDOW,
                         ));
                     }


### PR DESCRIPTION
## Summary of the Pull Request

The "Press Ctrl+C again to close pane" hint in the agent pane was hard-coded in English. This change moves it into the localization system so it can be translated.

## Detailed Description of the Pull Request / Additional comments

- Replaced the hard-coded string with a call to `t!("system.close_pane_hint")` — the same pattern used by all other localizable strings in the file.
- Added a new key `system.close_pane_hint` to `en-US.yml` with a note that "Ctrl+C" should stay as-is in translations.
- Updated comments that referenced the old hard-coded string.

## PR Checklist


