### PR TITLE
localize agent-pane double-Ctrl+C close hint

### DIFF
--- a/tools/wta/locales/af-ZA.yml
+++ b/tools/wta/locales/af-ZA.yml
@@ -119,6 +119,7 @@ connection.connecting_activity: "Koppel tans aan agent…"
 connection.lost: "Verbinding met die agent is verloor. Tik /restart om weer te koppel."  # {Locked="/restart"}
 
 # ── Stelselboodskappe (src/app.rs) ────────────────────────────────────────
+system.close_pane_hint: "Druk Ctrl+C weer om die paneel te sluit"  # {Locked="Ctrl+C"}
 system.cancelled: "Gekanselleer."
 system.no_prompt_in_flight: "Geen opdrag onderweg nie."
 system.authentication_failed: "Stawing het misluk"

--- a/tools/wta/locales/am-ET.yml
+++ b/tools/wta/locales/am-ET.yml
@@ -119,6 +119,7 @@ connection.connecting_activity: "ከኤጅንት ጋር በመገናኘት ላ�
 connection.lost: "ከኤጅንት ጋር ያለው ግንኙነት ጠፍቷል። እንደገና ለመገናኘት /restart ብለው ይተይቡ።"  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "pane ለመዝጋት Ctrl+C እንደገና ይጫኑ"  # {Locked="Ctrl+C"}
 system.cancelled: "Cancelled."
 system.no_prompt_in_flight: "No prompt in flight."
 system.authentication_failed: "Authentication failed"

--- a/tools/wta/locales/ar-SA.yml
+++ b/tools/wta/locales/ar-SA.yml
@@ -132,6 +132,7 @@ connection.connecting_activity: "جارٍ الاتصال بعامل الذكاء
 connection.lost: "فُقد الاتصال بعامل الذكاء الاصطناعي. اكتب /restart لإعادة الاتصال."  # {Locked="/restart"}
 
 # ── رسائل النظام (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "اضغط Ctrl+C مرة أخرى لإغلاق اللوحة"  # {Locked="Ctrl+C"}
 system.cancelled: "تم الإلغاء."
 system.no_prompt_in_flight: "لا يوجد أمر قيد التنفيذ."
 system.authentication_failed: "فشلت المصادقة"

--- a/tools/wta/locales/as-IN.yml
+++ b/tools/wta/locales/as-IN.yml
@@ -132,6 +132,7 @@ connection.connecting_activity: "এজেণ্টলৈ সংযোগ হৈ
 connection.lost: "এজেণ্টৰ সৈতে সংযোগ হেৰাই গ'ল। পুনৰ সংযোগ কৰিবলৈ /restart টাইপ কৰক।"  # {Locked="/restart"}
 
 # ── ছিষ্টেম বাৰ্তা (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "পেন বন্ধ কৰিবলৈ Ctrl+C আকৌ টিপক"  # {Locked="Ctrl+C"}
 system.cancelled: "বাতিল কৰা হৈছে।"
 system.no_prompt_in_flight: "প্ৰগতিত কোনো প্ৰমপ্ট নাই।"
 system.authentication_failed: "প্ৰমাণীকৰণ বিফল"

--- a/tools/wta/locales/az-Latn-AZ.yml
+++ b/tools/wta/locales/az-Latn-AZ.yml
@@ -132,6 +132,7 @@ connection.connecting_activity: "Agentə qoşulur…"
 connection.lost: "Agentlə bağlantı itdi. Yenidən qoşulmaq üçün /restart yazın."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Paneli bağlamaq üçün Ctrl+C-ni yenidən basın"  # {Locked="Ctrl+C"}
 system.cancelled: "Ləğv edildi."
 system.no_prompt_in_flight: "İcra olunan sorğu yoxdur."
 system.authentication_failed: "Kimlik doğrulaması uğursuz oldu"

--- a/tools/wta/locales/bg-BG.yml
+++ b/tools/wta/locales/bg-BG.yml
@@ -128,6 +128,7 @@ connection.connecting_activity: "Свързване с агента…"
 connection.lost: "Връзката с агента беше загубена. Въведете /restart, за да се свържете отново."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Натиснете Ctrl+C отново, за да затворите панела"  # {Locked="Ctrl+C"}
 system.cancelled: "Отменено."
 system.no_prompt_in_flight: "Няма активна заявка."
 system.authentication_failed: "Удостоверяването е неуспешно"

--- a/tools/wta/locales/bn-IN.yml
+++ b/tools/wta/locales/bn-IN.yml
@@ -132,6 +132,7 @@ connection.connecting_activity: "এজেন্টের সাথে সংয
 connection.lost: "এজেন্টের সাথে সংযোগ হারিয়ে গেছে। পুনরায় সংযোগ করতে /restart টাইপ করুন।"  # {Locked="/restart"}
 
 # ── সিস্টেম বার্তা (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "পেন বন্ধ করতে আবার Ctrl+C চাপুন"  # {Locked="Ctrl+C"}
 system.cancelled: "বাতিল করা হয়েছে।"
 system.no_prompt_in_flight: "কোনো প্রম্পট চলমান নেই।"
 system.authentication_failed: "প্রমাণীকরণ ব্যর্থ"

--- a/tools/wta/locales/bs-Latn-BA.yml
+++ b/tools/wta/locales/bs-Latn-BA.yml
@@ -128,6 +128,7 @@ connection.connecting_activity: "Povezivanje s agentom…"
 connection.lost: "Veza s agentom je izgubljena. Upišite /restart za ponovno povezivanje."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Pritisnite Ctrl+C ponovo da zatvorite panel"  # {Locked="Ctrl+C"}
 system.cancelled: "Otkazano."
 system.no_prompt_in_flight: "Nema aktivnog zahtjeva."
 system.authentication_failed: "Autentifikacija nije uspjela"

--- a/tools/wta/locales/ca-ES.yml
+++ b/tools/wta/locales/ca-ES.yml
@@ -119,6 +119,7 @@ connection.connecting_activity: "S'està connectant a l'agent…"
 connection.lost: "S'ha perdut la connexió amb l'agent. Escriviu /restart per tornar-vos a connectar."  # {Locked="/restart"}
 
 # ── Missatges del sistema (src/app.rs) ────────────────────────────────────────
+system.close_pane_hint: "Premeu Ctrl+C un altre cop per tancar el tauler"  # {Locked="Ctrl+C"}
 system.cancelled: "Cancel·lat."
 system.no_prompt_in_flight: "No hi ha cap indicació en curs."
 system.authentication_failed: "L'autenticació ha fallat"

--- a/tools/wta/locales/ca-Es-VALENCIA.yml
+++ b/tools/wta/locales/ca-Es-VALENCIA.yml
@@ -119,6 +119,7 @@ connection.connecting_activity: "S'està connectant a l'agent…"
 connection.lost: "S'ha perdut la connexió amb l'agent. Escriviu /restart per tornar-vos a connectar."  # {Locked="/restart"}
 
 # ── Missatges del sistema (src/app.rs) ────────────────────────────────────────
+system.close_pane_hint: "Premeu Ctrl+C una altra volta per a tancar el panell"  # {Locked="Ctrl+C"}
 system.cancelled: "Cancel·lat."
 system.no_prompt_in_flight: "No hi ha cap indicació en curs."
 system.authentication_failed: "L'autenticació ha fallat"

--- a/tools/wta/locales/cs-CZ.yml
+++ b/tools/wta/locales/cs-CZ.yml
@@ -128,6 +128,7 @@ connection.connecting_activity: "Připojování k agentovi…"
 connection.lost: "Připojení k agentovi bylo ztraceno. Zadáním /restart se znovu připojíte."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Stiskněte Ctrl+C znovu pro zavření panelu"  # {Locked="Ctrl+C"}
 system.cancelled: "Zrušeno."
 system.no_prompt_in_flight: "Žádný dotaz neprobíhá."
 system.authentication_failed: "Ověření se nezdařilo"

--- a/tools/wta/locales/cy-GB.yml
+++ b/tools/wta/locales/cy-GB.yml
@@ -119,6 +119,7 @@ connection.connecting_activity: "Yn cysylltu â'r asiant…"
 connection.lost: "Collwyd y cysylltiad â'r asiant. Teipiwch /restart i ailgysylltu."  # {Locked="/restart"}
 
 # ── Negeseuon system (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Pwyswch Ctrl+C eto i gau'r baen"  # {Locked="Ctrl+C"}
 system.cancelled: "Wedi'i ganslo."
 system.no_prompt_in_flight: "Dim anogaeth ar y gweill."
 system.authentication_failed: "Methwyd â dilysu"

--- a/tools/wta/locales/da-DK.yml
+++ b/tools/wta/locales/da-DK.yml
@@ -119,6 +119,7 @@ connection.connecting_activity: "Opretter forbindelse til agenten…"
 connection.lost: "Forbindelsen til agenten gik tabt. Skriv /restart for at oprette forbindelse igen."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Tryk på Ctrl+C igen for at lukke panelet"  # {Locked="Ctrl+C"}
 system.cancelled: "Annulleret."
 system.no_prompt_in_flight: "Ingen forespørgsel i gang."
 system.authentication_failed: "Godkendelse mislykkedes"

--- a/tools/wta/locales/de-DE.yml
+++ b/tools/wta/locales/de-DE.yml
@@ -119,6 +119,7 @@ connection.connecting_activity: "Verbindung mit dem Agenten wird hergestellt…"
 connection.lost: "Die Verbindung mit dem Agenten wurde getrennt. Geben Sie /restart ein, um die Verbindung wiederherzustellen."  # {Locked="/restart"}
 
 # ── Systemnachrichten (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "Drücken Sie Ctrl+C erneut, um den Bereich zu schließen"  # {Locked="Ctrl+C"}
 system.cancelled: "Abgebrochen."
 system.no_prompt_in_flight: "Kein Prompt aktiv."
 system.authentication_failed: "Authentifizierung fehlgeschlagen"

--- a/tools/wta/locales/el-GR.yml
+++ b/tools/wta/locales/el-GR.yml
@@ -119,6 +119,7 @@ connection.connecting_activity: "Σύνδεση με τον παράγοντα�
 connection.lost: "Η σύνδεση με τον παράγοντα χάθηκε. Πληκτρολογήστε /restart για επανασύνδεση."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Πατήστε ξανά Ctrl+C για να κλείσετε το πλαίσιο"  # {Locked="Ctrl+C"}
 system.cancelled: "Ακυρώθηκε."
 system.no_prompt_in_flight: "Δεν υπάρχει ενεργή εντολή."
 system.authentication_failed: "Ο έλεγχος ταυτότητας απέτυχε"

--- a/tools/wta/locales/en-GB.yml
+++ b/tools/wta/locales/en-GB.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Connecting to agent…"
 connection.lost: "Connection to the agent was lost. Type /restart to reconnect."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Press Ctrl+C again to close pane"  # {Locked="Ctrl+C"}
 system.cancelled: "Cancelled."
 system.no_prompt_in_flight: "No prompt in flight."
 system.authentication_failed: "Authentication failed"

--- a/tools/wta/locales/en-US.yml
+++ b/tools/wta/locales/en-US.yml
@@ -187,6 +187,9 @@ connection.connecting_activity: "Connecting to agent…"
 connection.lost: "Connection to the agent was lost. Type /restart to reconnect."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+# Shown as a one-line hint when the user presses Ctrl+C once with empty input — the second press closes the pane.
+# {Locked="Ctrl+C"} - key name, do not translate
+system.close_pane_hint: "Press Ctrl+C again to close pane"
 system.cancelled: "Cancelled."
 system.no_prompt_in_flight: "No prompt in flight."
 system.authentication_failed: "Authentication failed"

--- a/tools/wta/locales/es-ES.yml
+++ b/tools/wta/locales/es-ES.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Conectando con el agente…"
 connection.lost: "Se perdió la conexión con el agente. Escribe /restart para volver a conectar."  # {Locked="/restart"}
 
 # ── Mensajes del sistema (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "Pulsa Ctrl+C de nuevo para cerrar el panel"  # {Locked="Ctrl+C"}
 system.cancelled: "Cancelado."
 system.no_prompt_in_flight: "No hay ningún indicador en curso."
 system.authentication_failed: "Error de autenticación"

--- a/tools/wta/locales/es-MX.yml
+++ b/tools/wta/locales/es-MX.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Conectando con el agente…"
 connection.lost: "Se perdió la conexión con el agente. Escribe /restart para volver a conectar."  # {Locked="/restart"}
 
 # ── Mensajes del sistema (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "Presiona Ctrl+C de nuevo para cerrar el panel"  # {Locked="Ctrl+C"}
 system.cancelled: "Cancelado."
 system.no_prompt_in_flight: "No hay ningún indicador en curso."
 system.authentication_failed: "Error de autenticación"

--- a/tools/wta/locales/et-EE.yml
+++ b/tools/wta/locales/et-EE.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Agendiga ühenduse loomine…"
 connection.lost: "Ühendus agendiga katkes. Uuesti ühendamiseks tippige /restart."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Paneeli sulgemiseks vajutage Ctrl+C uuesti"  # {Locked="Ctrl+C"}
 system.cancelled: "Tühistatud."
 system.no_prompt_in_flight: "Aktiivset päringut pole."
 system.authentication_failed: "Autentimine nurjus"

--- a/tools/wta/locales/eu-ES.yml
+++ b/tools/wta/locales/eu-ES.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Agentearekin konektatzen…"
 connection.lost: "Agentearekiko konexioa galdu da. Idatzi /restart berriro konektatzeko."  # {Locked="/restart"}
 
 # ── Sistema-mezuak (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Sakatu Ctrl+C berriro panela ixteko"  # {Locked="Ctrl+C"}
 system.cancelled: "Bertan behera utzia."
 system.no_prompt_in_flight: "Ez dago gonbidapenik abian."
 system.authentication_failed: "Autentifikazioak huts egin du"

--- a/tools/wta/locales/fa-IR.yml
+++ b/tools/wta/locales/fa-IR.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "در حال اتصال به عامل هوش م�
 connection.lost: "اتصال به عامل هوش مصنوعی قطع شد. برای اتصال مجدد، /restart را تایپ کنید."  # {Locked="/restart"}
 
 # ── پیام‌های سیستم (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "برای بستن پنل، دوباره Ctrl+C را فشار دهید"  # {Locked="Ctrl+C"}
 system.cancelled: "لغو شد."
 system.no_prompt_in_flight: "هیچ درخواستی در حال اجرا نیست."
 system.authentication_failed: "احراز هویت ناموفق بود"

--- a/tools/wta/locales/fi-FI.yml
+++ b/tools/wta/locales/fi-FI.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Yhdistetään agenttiin…"
 connection.lost: "Yhteys agenttiin katkesi. Muodosta yhteys uudelleen kirjoittamalla /restart."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Sulje paneeli painamalla Ctrl+C uudelleen"  # {Locked="Ctrl+C"}
 system.cancelled: "Peruutettu."
 system.no_prompt_in_flight: "Ei käynnissä olevaa kehotetta."
 system.authentication_failed: "Todennus epäonnistui"

--- a/tools/wta/locales/fil-PH.yml
+++ b/tools/wta/locales/fil-PH.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Kumokonekta sa agent…"
 connection.lost: "Nawala ang koneksyon sa agent. I-type ang /restart para kumonektang muli."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Pindutin muli ang Ctrl+C para isara ang pane"  # {Locked="Ctrl+C"}
 system.cancelled: "Kinansela."
 system.no_prompt_in_flight: "Walang prompt na kasalukuyang pinapatakbo."
 system.authentication_failed: "Nabigo ang authentication"

--- a/tools/wta/locales/fr-CA.yml
+++ b/tools/wta/locales/fr-CA.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Connexion à l'agent…"
 connection.lost: "La connexion à l'agent a été perdue. Tapez /restart pour vous reconnecter."  # {Locked="/restart"}
 
 # ── Messages système (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "Appuyez de nouveau sur Ctrl+C pour fermer le volet"  # {Locked="Ctrl+C"}
 system.cancelled: "Annulé."
 system.no_prompt_in_flight: "Aucune invite en cours."
 system.authentication_failed: "Échec de l'authentification"

--- a/tools/wta/locales/fr-FR.yml
+++ b/tools/wta/locales/fr-FR.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Connexion à l'agent…"
 connection.lost: "La connexion à l'agent a été perdue. Tapez /restart pour vous reconnecter."  # {Locked="/restart"}
 
 # ── Messages système (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "Appuyez de nouveau sur Ctrl+C pour fermer le volet"  # {Locked="Ctrl+C"}
 system.cancelled: "Annulé."
 system.no_prompt_in_flight: "Aucune invite en cours."
 system.authentication_failed: "Échec de l'authentification"

--- a/tools/wta/locales/ga-IE.yml
+++ b/tools/wta/locales/ga-IE.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Ag ceangal leis an ngníomhaire…"
 connection.lost: "Cailleadh an ceangal leis an ngníomhaire. Clóscríobh /restart chun athcheangal."  # {Locked="/restart"}
 
 # ── Teachtaireachtaí córais (src/app.rs) ────────────────────────────────────
+system.close_pane_hint: "Brúigh Ctrl+C arís chun an pána a dhúnadh"  # {Locked="Ctrl+C"}
 system.cancelled: "Cealaithe."
 system.no_prompt_in_flight: "Níl aon leid ar siúl."
 system.authentication_failed: "Theip ar fhíordheimhniú"

--- a/tools/wta/locales/gd-gb.yml
+++ b/tools/wta/locales/gd-gb.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "A' ceangal ris an àidseant…"
 connection.lost: "Chaidh an ceangal ris an àidseant a chall. Sgrìobh /restart gus ath-cheangal."  # {Locked="/restart"}
 
 # ── Teachdaireachdan siostam (src/app.rs) ────────────────────────────────────
+system.close_pane_hint: "Brùth Ctrl+C a-rithist gus a’ phanail a dhùnadh"  # {Locked="Ctrl+C"}
 system.cancelled: "Air a sgur dheth."
 system.no_prompt_in_flight: "Chan eil brodadh air an t-slighe."
 system.authentication_failed: "Dh'fhàillig an dearbhadh"

--- a/tools/wta/locales/gl-ES.yml
+++ b/tools/wta/locales/gl-ES.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Conectando co axente…"
 connection.lost: "Perdeuse a conexión co axente. Escribe /restart para volver conectar."  # {Locked="/restart"}
 
 # ── Mensaxes do sistema (src/app.rs) ────────────────────────────────────────
+system.close_pane_hint: "Preme Ctrl+C de novo para pechar o panel"  # {Locked="Ctrl+C"}
 system.cancelled: "Cancelado."
 system.no_prompt_in_flight: "Non hai ningún aviso en curso."
 system.authentication_failed: "A autenticación fallou"

--- a/tools/wta/locales/gu-IN.yml
+++ b/tools/wta/locales/gu-IN.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "એજન્ટ સાથે કનેક્ટ
 connection.lost: "એજન્ટ સાથેનું કનેક્શન તૂટી ગયું. ફરીથી કનેક્ટ કરવા માટે /restart ટાઇપ કરો."  # {Locked="/restart"}
 
 # ── સિસ્ટમ સંદેશા (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "પેન બંધ કરવા માટે Ctrl+C ફરી દબાવો"  # {Locked="Ctrl+C"}
 system.cancelled: "રદ કરવામાં આવ્યું."
 system.no_prompt_in_flight: "પ્રગતિમાં કોઈ પ્રોમ્પ્ટ નથી."
 system.authentication_failed: "પ્રમાણીકરણ નિષ્ફળ"

--- a/tools/wta/locales/he-IL.yml
+++ b/tools/wta/locales/he-IL.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "מתחבר לסוכן…"
 connection.lost: "החיבור לסוכן אבד. הקלד /restart כדי להתחבר מחדש."  # {Locked="/restart"}
 
 # ── הודעות מערכת (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "לחץ שוב על Ctrl+C כדי לסגור את החלונית"  # {Locked="Ctrl+C"}
 system.cancelled: "בוטל."
 system.no_prompt_in_flight: "אין בקשה בתהליך."
 system.authentication_failed: "האימות נכשל"

--- a/tools/wta/locales/hi-IN.yml
+++ b/tools/wta/locales/hi-IN.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "एजेंट से कनेक्ट ह�
 connection.lost: "एजेंट से कनेक्शन टूट गया. फिर से कनेक्ट करने के लिए /restart टाइप करें."  # {Locked="/restart"}
 
 # ── सिस्टम संदेश (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "पेन बंद करने के लिए Ctrl+C फिर से दबाएँ"  # {Locked="Ctrl+C"}
 system.cancelled: "रद्द किया गया।"
 system.no_prompt_in_flight: "कोई प्रॉम्प्ट प्रगति में नहीं है।"
 system.authentication_failed: "प्रमाणीकरण विफल"

--- a/tools/wta/locales/hr-HR.yml
+++ b/tools/wta/locales/hr-HR.yml
@@ -127,6 +127,7 @@ connection.connecting_activity: "Povezivanje s agentom…"
 connection.lost: "Veza s agentom je izgubljena. Upišite /restart za ponovno povezivanje."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Ponovno pritisnite Ctrl+C da biste zatvorili okno"  # {Locked="Ctrl+C"}
 system.cancelled: "Otkazano."
 system.no_prompt_in_flight: "Nema aktivnog upita."
 system.authentication_failed: "Provjera autentičnosti nije uspjela"

--- a/tools/wta/locales/hu-HU.yml
+++ b/tools/wta/locales/hu-HU.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Kapcsolódás az ügynökhöz…"
 connection.lost: "Megszakadt a kapcsolat az ügynökkel. Az újrakapcsolódáshoz írja be: /restart."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Nyomja meg újra a Ctrl+C billentyűkombinációt a panel bezárásához"  # {Locked="Ctrl+C"}
 system.cancelled: "Megszakítva."
 system.no_prompt_in_flight: "Nincs folyamatban lévő kérés."
 system.authentication_failed: "A hitelesítés sikertelen"

--- a/tools/wta/locales/hy-AM.yml
+++ b/tools/wta/locales/hy-AM.yml
@@ -145,6 +145,7 @@ connection.connecting_activity: "Միանում է ագենտին…"
 connection.lost: "Ագենտի հետ կապը կորել է։ Մուտքագրեք /restart՝ նորից միանալու համար։"  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────────────────────────────
+system.close_pane_hint: "Սեղմեք Ctrl+C կրկին՝ վահանակը փակելու համար"  # {Locked="Ctrl+C"}
 system.cancelled: "Չեղարկված է։"
 system.no_prompt_in_flight: "Գործընթացում գտնվող հարցում չկա։"
 system.authentication_failed: "Նույնականացումը ձախողվեց"

--- a/tools/wta/locales/id-ID.yml
+++ b/tools/wta/locales/id-ID.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Menyambungkan ke agen AI…"
 connection.lost: "Koneksi ke agen AI terputus. Ketik /restart untuk menyambungkan kembali."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Tekan Ctrl+C lagi untuk menutup panel"  # {Locked="Ctrl+C"}
 system.cancelled: "Dibatalkan."
 system.no_prompt_in_flight: "Tidak ada prompt yang sedang berjalan."
 system.authentication_failed: "Autentikasi gagal"

--- a/tools/wta/locales/is-IS.yml
+++ b/tools/wta/locales/is-IS.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Tengist agent…"
 connection.lost: "Tengingin við agent rofnaði. Sláðu inn /restart til að tengjast aftur."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Ýttu aftur á Ctrl+C til að loka spjaldinu"  # {Locked="Ctrl+C"}
 system.cancelled: "Hætt við."
 system.no_prompt_in_flight: "Engin fyrirspurn í gangi."
 system.authentication_failed: "Auðkenning mistókst"

--- a/tools/wta/locales/it-IT.yml
+++ b/tools/wta/locales/it-IT.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Connessione all'agente…"
 connection.lost: "La connessione all'agente è stata persa. Digita /restart per riconnetterti."  # {Locked="/restart"}
 
 # ── Messaggi di sistema (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "Premi di nuovo Ctrl+C per chiudere il riquadro"  # {Locked="Ctrl+C"}
 system.cancelled: "Annullato."
 system.no_prompt_in_flight: "Nessun prompt in corso."
 system.authentication_failed: "Autenticazione non riuscita"

--- a/tools/wta/locales/ja-JP.yml
+++ b/tools/wta/locales/ja-JP.yml
@@ -114,6 +114,7 @@ connection.connecting_activity: "エージェントに接続中…"
 connection.lost: "エージェントへの接続が失われました。再接続するには /restart と入力してください。"  # {Locked="/restart"}
 
 # ── システム メッセージ (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "ペインを閉じるには、もう一度 Ctrl+C を押してください"  # {Locked="Ctrl+C"}
 system.cancelled: "キャンセルされました。"
 system.no_prompt_in_flight: "進行中のプロンプトはありません。"
 system.authentication_failed: "認証に失敗しました"

--- a/tools/wta/locales/ka-GE.yml
+++ b/tools/wta/locales/ka-GE.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "აგენტთან დაკავში�
 connection.lost: "აგენტთან კავშირი დაიკარგა. ხელახლა დასაკავშირებლად აკრიფეთ /restart."  # {Locked="/restart"}
 
 # ── სისტემური შეტყობინებები (src/app.rs) ────────────────────────────────────
+system.close_pane_hint: "პანელის დასახურად კვლავ დააჭირეთ Ctrl+C"  # {Locked="Ctrl+C"}
 system.cancelled: "გაუქმებულია."
 system.no_prompt_in_flight: "მიმდინარე მოთხოვნა არ არის."
 system.authentication_failed: "ავთენტიფიკაცია ვერ მოხერხდა"

--- a/tools/wta/locales/kk-KZ.yml
+++ b/tools/wta/locales/kk-KZ.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "Агентке қосылуда…"
 connection.lost: "Агентпен байланыс жоғалды. Қайта қосылу үшін /restart деп теріңіз."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Панельді жабу үшін Ctrl+C пернелерін қайта басыңыз"  # {Locked="Ctrl+C"}
 system.cancelled: "Бас тартылды."
 system.no_prompt_in_flight: "Орындалып жатқан сұрау жоқ."
 system.authentication_failed: "Аутентификация сәтсіз аяқталды"

--- a/tools/wta/locales/km-KH.yml
+++ b/tools/wta/locales/km-KH.yml
@@ -132,6 +132,7 @@ connection.connecting_activity: "កំពុងភ្ជាប់ទៅ AI អ�
 connection.lost: "ការតភ្ជាប់ទៅ AI អេជេន្ត់បានបាត់បង់។ វាយ /restart ដើម្បីភ្ជាប់ឡើងវិញ។"  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ──────────────────────────────────────────────────────────────────
+system.close_pane_hint: "ចុច Ctrl+C ម្តងទៀត ដើម្បីបិទផ្តាំង"  # {Locked="Ctrl+C"}
 system.cancelled: "បានបោះបង់។"
 system.no_prompt_in_flight: "គ្មានសំណើកំពុងដំណើរការ។"
 system.authentication_failed: "ការផ្ទៀងផ្ទាត់បរាជ័យ"

--- a/tools/wta/locales/kn-IN.yml
+++ b/tools/wta/locales/kn-IN.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "ಏಜೆಂಟ್‌ಗೆ ಸಂಪರ್ಕ�
 connection.lost: "ಏಜೆಂಟ್‌ಗೆ ಸಂಪರ್ಕ ಕಳೆದುಹೋಯಿತು. ಮರುಸಂಪರ್ಕಿಸಲು /restart ಟೈಪ್ ಮಾಡಿ."  # {Locked="/restart"}
 
 # ── ಸಿಸ್ಟಮ್ ಸಂದೇಶಗಳು (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "ಪೇನ್ ಮುಚ್ಚಲು Ctrl+C ಅನ್ನು ಮತ್ತೊಮ್ಮೆ ಒತ್ತಿರಿ"  # {Locked="Ctrl+C"}
 system.cancelled: "ರದ್ದುಮಾಡಲಾಗಿದೆ."
 system.no_prompt_in_flight: "ಪ್ರಗತಿಯಲ್ಲಿ ಯಾವುದೇ ಪ್ರಾಂಪ್ಟ್ ಇಲ್ಲ."
 system.authentication_failed: "ದೃಢೀಕರಣ ವಿಫಲವಾಗಿದೆ"

--- a/tools/wta/locales/ko-KR.yml
+++ b/tools/wta/locales/ko-KR.yml
@@ -114,6 +114,7 @@ connection.connecting_activity: "에이전트에 연결 중…"
 connection.lost: "에이전트와의 연결이 끊어졌습니다. 다시 연결하려면 /restart 명령을 입력하세요."  # {Locked="/restart"}
 
 # ── 시스템 메시지 (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "창을 닫으려면 Ctrl+C 를 한 번 더 누르세요"  # {Locked="Ctrl+C"}
 system.cancelled: "취소되었습니다."
 system.no_prompt_in_flight: "진행 중인 프롬프트가 없습니다."
 system.authentication_failed: "인증 실패"

--- a/tools/wta/locales/kok-IN.yml
+++ b/tools/wta/locales/kok-IN.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "एजेंटाक जोडटा…"
 connection.lost: "एजेंटाशी जोडणी तुटली. परतून जोडपाक /restart टायप करात."  # {Locked="/restart"}
 
 # ── सिस्टम संदेश (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "पेन बंद करपाक परत एक फावट Ctrl+C दामात."  # {Locked="Ctrl+C"}
 system.cancelled: "रद्द केलें."
 system.no_prompt_in_flight: "प्रगतींत कसलोच प्रॉम्प्ट ना."
 system.authentication_failed: "प्रमाणीकरण अपेशी"

--- a/tools/wta/locales/lb-LU.yml
+++ b/tools/wta/locales/lb-LU.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Verbindung mam Agent gëtt hiergestallt…"
 connection.lost: "D'Verbindung mam Agent ass verluer gaangen. Tippt /restart fir nei ze verbannen."  # {Locked="/restart"}
 
 # ── System-Messagen (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Dréckt Ctrl+C nach eng Kéier fir de Panell zouzemaachen."  # {Locked="Ctrl+C"}
 system.cancelled: "Ofgebrach."
 system.no_prompt_in_flight: "Keen Prompt ënnerwee."
 system.authentication_failed: "Authentifizéierung gescheitert"

--- a/tools/wta/locales/lo-LA.yml
+++ b/tools/wta/locales/lo-LA.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "ກຳລັງເຊື່ອມຕໍ່ຫ�
 connection.lost: "ການເຊື່ອມຕໍ່ຫາ agent ຂາດຫາຍໄປ. ພິມ /restart ເພື່ອເຊື່ອມຕໍ່ໃໝ່."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "ກົດ Ctrl+C ອີກຄັ້ງເພື່ອປິດ pane."  # {Locked="Ctrl+C"}
 system.cancelled: "Cancelled."
 system.no_prompt_in_flight: "No prompt in flight."
 system.authentication_failed: "Authentication failed"

--- a/tools/wta/locales/lt-LT.yml
+++ b/tools/wta/locales/lt-LT.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Jungiamasi prie agento…"
 connection.lost: "Ryšys su agentu nutrūko. Įveskite /restart, kad prisijungtumėte iš naujo."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Paspauskite Ctrl+C dar kartą, kad uždarytumėte skydelį."  # {Locked="Ctrl+C"}
 system.cancelled: "Atšaukta."
 system.no_prompt_in_flight: "Nėra vykdomos užklausos."
 system.authentication_failed: "Autentifikavimas nepavyko"

--- a/tools/wta/locales/lv-LV.yml
+++ b/tools/wta/locales/lv-LV.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Savienojas ar aģentu…"
 connection.lost: "Savienojums ar aģentu tika zaudēts. Ierakstiet /restart, lai izveidotu savienojumu atkārtoti."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Nospiediet Ctrl+C vēlreiz, lai aizvērtu paneli."  # {Locked="Ctrl+C"}
 system.cancelled: "Atcelts."
 system.no_prompt_in_flight: "Nav aktīvu pieprasījumu."
 system.authentication_failed: "Autentifikācija neizdevās"

--- a/tools/wta/locales/mi-NZ.yml
+++ b/tools/wta/locales/mi-NZ.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "E hono ana ki te agent…"
 connection.lost: "Kua ngaro te hononga ki te agent. Patohia /restart kia hono anō."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Pēhia anō a Ctrl+C kia kati ai te papa."  # {Locked="Ctrl+C"}
 system.cancelled: "Kua whakakorea."
 system.no_prompt_in_flight: "Karekau he tohutohu e rere ana."
 system.authentication_failed: "I rahua te whakamanatu"

--- a/tools/wta/locales/mk-MK.yml
+++ b/tools/wta/locales/mk-MK.yml
@@ -127,6 +127,7 @@ connection.connecting_activity: "Поврзување со агентот…"
 connection.lost: "Врската со агентот беше изгубена. Внесете /restart за повторно поврзување."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Притиснете Ctrl+C повторно за да го затворите панелот."  # {Locked="Ctrl+C"}
 system.cancelled: "Откажано."
 system.no_prompt_in_flight: "Нема активно барање."
 system.authentication_failed: "Автентикацијата не успеа"

--- a/tools/wta/locales/ml-IN.yml
+++ b/tools/wta/locales/ml-IN.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "ഏജന്റുമായി കണക്റ�
 connection.lost: "ഏജന്റുമായുള്ള കണക്ഷൻ നഷ്ടപ്പെട്ടു. വീണ്ടും കണക്റ്റ് ചെയ്യാൻ /restart ടൈപ്പ് ചെയ്യുക."  # {Locked="/restart"}
 
 # ── സിസ്റ്റം സന്ദേശങ്ങള്‍ (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "പേന്‍ അടയ്ക്കാൻ Ctrl+C വീണ്ടും അമർത്തുക."  # {Locked="Ctrl+C"}
 system.cancelled: "റദ്ദാക്കി."
 system.no_prompt_in_flight: "പുരോഗതിയില്‍ പ്രോംപ്റ്റ് ഇല്ല."
 system.authentication_failed: "പ്രമാണീകരണം പരാജയപ്പെട്ടു"

--- a/tools/wta/locales/mr-IN.yml
+++ b/tools/wta/locales/mr-IN.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "एजंटशी कनेक्ट होत
 connection.lost: "एजंटशी कनेक्शन तुटले. पुन्हा कनेक्ट करण्यासाठी /restart टाइप करा."  # {Locked="/restart"}
 
 # ── सिस्टम संदेश (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "पेन बंद करण्यासाठी Ctrl+C पुन्हा दाबा."  # {Locked="Ctrl+C"}
 system.cancelled: "रद्द केले."
 system.no_prompt_in_flight: "प्रगतीत कोणताही प्रॉम्प्ट नाही."
 system.authentication_failed: "प्रमाणीकरण अयशस्वी"

--- a/tools/wta/locales/ms-MY.yml
+++ b/tools/wta/locales/ms-MY.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Menyambung kepada ejen AI…"
 connection.lost: "Sambungan kepada ejen AI terputus. Taip /restart untuk menyambung semula."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Tekan Ctrl+C sekali lagi untuk menutup anak tetingkap."  # {Locked="Ctrl+C"}
 system.cancelled: "Dibatalkan."
 system.no_prompt_in_flight: "Tiada prompt sedang berjalan."
 system.authentication_failed: "Pengesahan gagal"

--- a/tools/wta/locales/mt-MT.yml
+++ b/tools/wta/locales/mt-MT.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Qed tikkonnettja mal-aġent…"
 connection.lost: "Il-konnessjoni mal-aġent intilfet. Ittajpja /restart biex terġa' tikkonnettja."  # {Locked="/restart"}
 
 # ── Messaġġi tas-sistema (src/app.rs) ────────────────────────────────────────
+system.close_pane_hint: "Agħfas Ctrl+C għal darb'oħra biex tagħlaq il-pannell."  # {Locked="Ctrl+C"}
 system.cancelled: "Ikkanċellat."
 system.no_prompt_in_flight: "L-ebda prompt fl-arja."
 system.authentication_failed: "L-awtentikazzjoni falliet"

--- a/tools/wta/locales/nb-NO.yml
+++ b/tools/wta/locales/nb-NO.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Kobler til agenten…"
 connection.lost: "Tilkoblingen til agenten gikk tapt. Skriv /restart for å koble til på nytt."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Trykk Ctrl+C én gang til for å lukke panelet."  # {Locked="Ctrl+C"}
 system.cancelled: "Avbrutt."
 system.no_prompt_in_flight: "Ingen forespørsel pågår."
 system.authentication_failed: "Autentisering mislyktes"

--- a/tools/wta/locales/ne-NP.yml
+++ b/tools/wta/locales/ne-NP.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "एजेन्टसँग जडान हु
 connection.lost: "एजेन्टसँगको जडान हरायो। पुनः जडान गर्न /restart टाइप गर्नुहोस्।"  # {Locked="/restart"}
 
 # ── प्रणाली सन्देशहरू (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "पेन बन्द गर्न Ctrl+C फेरि थिच्नुहोस्।"  # {Locked="Ctrl+C"}
 system.cancelled: "रद्द गरियो।"
 system.no_prompt_in_flight: "प्रगतिमा कुनै प्रम्प्ट छैन।"
 system.authentication_failed: "प्रमाणीकरण विफल"

--- a/tools/wta/locales/nl-NL.yml
+++ b/tools/wta/locales/nl-NL.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Verbinding maken met agent…"
 connection.lost: "De verbinding met de agent is verbroken. Typ /restart om opnieuw verbinding te maken."  # {Locked="/restart"}
 
 # ── Systeemberichten (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "Druk nogmaals op Ctrl+C om het deelvenster te sluiten."  # {Locked="Ctrl+C"}
 system.cancelled: "Geannuleerd."
 system.no_prompt_in_flight: "Geen prompt actief."
 system.authentication_failed: "Verificatie mislukt"

--- a/tools/wta/locales/nn-NO.yml
+++ b/tools/wta/locales/nn-NO.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Koplar til agenten…"
 connection.lost: "Tilkoblinga til agenten gjekk tapt. Skriv /restart for å kople til på nytt."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Trykk Ctrl+C ein gong til for å lukke panelet"  # {Locked="Ctrl+C"}
 system.cancelled: "Avbrote."
 system.no_prompt_in_flight: "Ingen førespurnad pågår."
 system.authentication_failed: "Autentisering mislukkast"

--- a/tools/wta/locales/or-IN.yml
+++ b/tools/wta/locales/or-IN.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "ଏଜେଣ୍ଟ ସହ ସଂଯୋଗ ହ�
 connection.lost: "ଏଜେଣ୍ଟ ସହିତ ସଂଯୋଗ ହରାଇଗଲା। ପୁଣି ସଂଯୋଗ କରିବାକୁ /restart ଟାଇପ୍ କରନ୍ତୁ।"  # {Locked="/restart"}
 
 # ── ସିଷ୍ଟମ ସନ୍ଦେଶ (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "ପେନ୍ ବନ୍ଦ କରିବା ପାଇଁ Ctrl+C ପୁଣିଥରେ ଦବାନ୍ତୁ"  # {Locked="Ctrl+C"}
 system.cancelled: "ବାତିଲ ହୋଇଛି।"
 system.no_prompt_in_flight: "ପ୍ରଗତିରେ କୌଣସି ପ୍ରମ୍ପ୍ଟ ନାହିଁ।"
 system.authentication_failed: "ପ୍ରମାଣୀକରଣ ବିଫଳ"

--- a/tools/wta/locales/pa-IN.yml
+++ b/tools/wta/locales/pa-IN.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "ਏਜੰਟ ਨਾਲ ਕਨੈਕਟ ਹੋ �
 connection.lost: "ਏਜੰਟ ਨਾਲ ਕਨੈਕਸ਼ਨ ਟੁੱਟ ਗਿਆ। ਮੁੜ ਕਨੈਕਟ ਕਰਨ ਲਈ /restart ਟਾਈਪ ਕਰੋ।"  # {Locked="/restart"}
 
 # ── ਸਿਸਟਮ ਸੁਨੇਹੇ (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "ਪੈਨ ਨੂੰ ਬੰਦ ਕਰਨ ਲਈ Ctrl+C ਦੁਬਾਰਾ ਦਬਾਓ"  # {Locked="Ctrl+C"}
 system.cancelled: "ਰੱਦ ਕੀਤਾ ਗਿਆ।"
 system.no_prompt_in_flight: "ਕੋਈ ਪ੍ਰੋਮਪਟ ਚੱਲ ਨਹੀਂ ਰਿਹਾ।"
 system.authentication_failed: "ਪ੍ਰਮਾਣਿਕਤਾ ਅਸਫਲ"

--- a/tools/wta/locales/pl-PL.yml
+++ b/tools/wta/locales/pl-PL.yml
@@ -127,6 +127,7 @@ connection.connecting_activity: "Łączenie z agentem…"
 connection.lost: "Połączenie z agentem zostało utracone. Wpisz /restart, aby połączyć się ponownie."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Naciśnij ponownie Ctrl+C, aby zamknąć panel"  # {Locked="Ctrl+C"}
 system.cancelled: "Anulowano."
 system.no_prompt_in_flight: "Brak aktywnego zapytania."
 system.authentication_failed: "Uwierzytelnianie nie powiodło się"

--- a/tools/wta/locales/pt-BR.yml
+++ b/tools/wta/locales/pt-BR.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Conectando ao agente…"
 connection.lost: "A conexão com o agente foi perdida. Digite /restart para reconectar."  # {Locked="/restart"}
 
 # ── Mensagens do sistema (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "Pressione Ctrl+C novamente para fechar o painel"  # {Locked="Ctrl+C"}
 system.cancelled: "Cancelado."
 system.no_prompt_in_flight: "Nenhum prompt em andamento."
 system.authentication_failed: "Falha na autenticação"

--- a/tools/wta/locales/pt-PT.yml
+++ b/tools/wta/locales/pt-PT.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "A estabelecer ligação ao agente…"
 connection.lost: "A ligação ao agente foi perdida. Escreva /restart para restabelecer a ligação."  # {Locked="/restart"}
 
 # ── Mensagens do sistema (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "Prima Ctrl+C novamente para fechar o painel"  # {Locked="Ctrl+C"}
 system.cancelled: "Cancelado."
 system.no_prompt_in_flight: "Nenhum pedido em curso."
 system.authentication_failed: "Falha na autenticação"

--- a/tools/wta/locales/qps-ploc.yml
+++ b/tools/wta/locales/qps-ploc.yml
@@ -120,6 +120,7 @@ connection.connecting_activity: "[Çöññéçţïñğ ţö åğéñţ…!!]"
 connection.lost: "[Çöññéçţïöñ ţö ţĥé åğéñţ ŵåś ĺöśţ. Ţýṗé /restart ţö ŕéçöññéçţ.!!]"  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "[Ṗŕéśś Ctrl+C åğåïñ ţö çĺöśé ṗåñé!!!! !!!!]"  # {Locked="Ctrl+C"}
 system.cancelled: "[Çåñçéĺĺéď.!!]"
 system.no_prompt_in_flight: "[Ñö ṗŕöḿṗţ ïñ ƒĺïğĥţ.!!!! !!!!]"
 system.authentication_failed: "[Àûţĥéñţïçåţïöñ ƒåïĺéď!!!! !!!!]"

--- a/tools/wta/locales/qps-ploca.yml
+++ b/tools/wta/locales/qps-ploca.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "[!!_Connecting to agent…_!!]"
 connection.lost: "[!!_Connection to the agent was lost. Type /restart to reconnect._!!]"  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "[!!_Press Ctrl+C again to close pane_!!]"  # {Locked="Ctrl+C"}
 system.cancelled: "[!!_Cancelled._!!]"
 system.no_prompt_in_flight: "[!!_No prompt in flight._!!]"
 system.authentication_failed: "[!!_Authentication failed_!!]"

--- a/tools/wta/locales/qps-plocm.yml
+++ b/tools/wta/locales/qps-plocm.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "[!! Conn_ecting to agent… !!]"
 connection.lost: "[!! Conn_ection to the agent was lost. Type /restart to reconnect. !!]"  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "[!! Pre_ss Ctrl+C again to close pane !!]"  # {Locked="Ctrl+C"}
 system.cancelled: "[!! Can_celled. !!]"
 system.no_prompt_in_flight: "[!! No_ prompt in flight. !!]"
 system.authentication_failed: "[!! Aut_hentication failed !!]"

--- a/tools/wta/locales/quz-PE.yml
+++ b/tools/wta/locales/quz-PE.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Agente-man t'inkichkan…"
 connection.lost: "Agente-man t'inkiy chinkarun. Watiqmanta t'inkinapaq /restart qillqay."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "K'itita wichq'anaykipaq Ctrl+C yapay ñit'iy."  # {Locked="Ctrl+C"}
 system.cancelled: "Chinkachisqa."
 system.no_prompt_in_flight: "Mana tapukuy purichkanchu."
 system.authentication_failed: "Yaykuy mana allinchu"

--- a/tools/wta/locales/ro-RO.yml
+++ b/tools/wta/locales/ro-RO.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Se conectează la agent…"
 connection.lost: "Conexiunea la agent s-a pierdut. Tastați /restart pentru reconectare."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Apăsați din nou Ctrl+C pentru a închide panoul"  # {Locked="Ctrl+C"}
 system.cancelled: "Anulat."
 system.no_prompt_in_flight: "Nicio solicitare în curs."
 system.authentication_failed: "Autentificarea a eșuat"

--- a/tools/wta/locales/ru-RU.yml
+++ b/tools/wta/locales/ru-RU.yml
@@ -127,6 +127,7 @@ connection.connecting_activity: "Подключение к агенту…"
 connection.lost: "Подключение к агенту потеряно. Введите /restart, чтобы подключиться снова."  # {Locked="/restart"}
 
 # ── Системные сообщения (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "Нажмите Ctrl+C ещё раз, чтобы закрыть панель"  # {Locked="Ctrl+C"}
 system.cancelled: "Отменено."
 system.no_prompt_in_flight: "Нет активного запроса."
 system.authentication_failed: "Ошибка аутентификации"

--- a/tools/wta/locales/sk-SK.yml
+++ b/tools/wta/locales/sk-SK.yml
@@ -127,6 +127,7 @@ connection.connecting_activity: "Pripájanie k agentovi…"
 connection.lost: "Pripojenie k agentovi sa stratilo. Zadaním /restart sa znova pripojíte."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Stlačte Ctrl+C ešte raz, aby ste zatvorili panel"  # {Locked="Ctrl+C"}
 system.cancelled: "Zrušené."
 system.no_prompt_in_flight: "Žiadna prebiehajúca požiadavka."
 system.authentication_failed: "Overenie zlyhalo"

--- a/tools/wta/locales/sl-SI.yml
+++ b/tools/wta/locales/sl-SI.yml
@@ -127,6 +127,7 @@ connection.connecting_activity: "Vzpostavljanje povezave z agentom…"
 connection.lost: "Povezava z agentom je bila izgubljena. Vnesite /restart za ponovno povezavo."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Pritisnite Ctrl+C še enkrat, da zaprete podokno"  # {Locked="Ctrl+C"}
 system.cancelled: "Preklicano."
 system.no_prompt_in_flight: "Nobena zahteva ni v teku."
 system.authentication_failed: "Preverjanje pristnosti ni uspelo"

--- a/tools/wta/locales/sq-AL.yml
+++ b/tools/wta/locales/sq-AL.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Po lidhet me agjentin…"
 connection.lost: "Lidhja me agjentin u humb. Shkruani /restart për t'u rilidhur."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Shtypni sërish Ctrl+C për të mbyllur panelin"  # {Locked="Ctrl+C"}
 system.cancelled: "U anulua."
 system.no_prompt_in_flight: "Asnjë kërkesë nuk është në proces."
 system.authentication_failed: "Vërtetimi dështoi"

--- a/tools/wta/locales/sr-Cyrl-BA.yml
+++ b/tools/wta/locales/sr-Cyrl-BA.yml
@@ -127,6 +127,7 @@ connection.connecting_activity: "Повезивање са агентом…"
 connection.lost: "Веза са агентом је изгубљена. Унесите /restart да бисте се поново повезали."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Притисните Ctrl+C поново да бисте затворили панел"  # {Locked="Ctrl+C"}
 system.cancelled: "Отказано."
 system.no_prompt_in_flight: "Нема активног захтјева."
 system.authentication_failed: "Аутентификација није успјела"

--- a/tools/wta/locales/sr-Cyrl-RS.yml
+++ b/tools/wta/locales/sr-Cyrl-RS.yml
@@ -127,6 +127,7 @@ connection.connecting_activity: "Повезивање са агентом…"
 connection.lost: "Веза са агентом је изгубљена. Унесите /restart да бисте се поново повезали."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Притисните Ctrl+C поново да бисте затворили панел"  # {Locked="Ctrl+C"}
 system.cancelled: "Отказано."
 system.no_prompt_in_flight: "Нема активног захтева."
 system.authentication_failed: "Аутентификација није успела"

--- a/tools/wta/locales/sr-Latn-RS.yml
+++ b/tools/wta/locales/sr-Latn-RS.yml
@@ -127,6 +127,7 @@ connection.connecting_activity: "Povezivanje sa agentom…"
 connection.lost: "Veza sa agentom je izgubljena. Unesite /restart da biste se ponovo povezali."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Ponovo pritisnite Ctrl+C da biste zatvorili panel."  # {Locked="Ctrl+C"}
 system.cancelled: "Otkazano."
 system.no_prompt_in_flight: "Nema aktivnog zahteva."
 system.authentication_failed: "Autentifikacija nije uspela"

--- a/tools/wta/locales/sv-SE.yml
+++ b/tools/wta/locales/sv-SE.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Ansluter till agenten…"
 connection.lost: "Anslutningen till agenten bröts. Skriv /restart för att återansluta."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Tryck på Ctrl+C igen för att stänga panelen."  # {Locked="Ctrl+C"}
 system.cancelled: "Avbröts."
 system.no_prompt_in_flight: "Ingen fråga pågår."
 system.authentication_failed: "Autentisering misslyckades"

--- a/tools/wta/locales/ta-IN.yml
+++ b/tools/wta/locales/ta-IN.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "ஏஜெண்டுடன் இணைக்�
 connection.lost: "ஏஜெண்டுடனான இணைப்பு துண்டிக்கப்பட்டது. மீண்டும் இணைக்க /restart என தட்டச்சு செய்யவும்."  # {Locked="/restart"}
 
 # ── கணினி செய்திகள் (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "பலகத்தை மூட Ctrl+C ஐ மீண்டும் அழுத்தவும்."  # {Locked="Ctrl+C"}
 system.cancelled: "ரத்துசெய்யப்பட்டது."
 system.no_prompt_in_flight: "நிலுவையில் எந்தப் பிராம்ப்ட்டும் இல்லை."
 system.authentication_failed: "அங்கீகாரம் தோல்வியடைந்தது"

--- a/tools/wta/locales/te-IN.yml
+++ b/tools/wta/locales/te-IN.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "ఏజెంట్‌కు కనెక్ట�
 connection.lost: "ఏజెంట్‌తో కనెక్షన్ కోల్పోయింది. మళ్లీ కనెక్ట్ చేయడానికి /restart అని టైప్ చేయండి."  # {Locked="/restart"}
 
 # ── సిస్టమ్ సందేశాలు (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "పేన్‌ను మూసివేయడానికి Ctrl+C ని మళ్లీ నొక్కండి."  # {Locked="Ctrl+C"}
 system.cancelled: "రద్దు చేయబడింది."
 system.no_prompt_in_flight: "ప్రగతిలో ఎటువంటి ప్రాంప్ట్ లేదు."
 system.authentication_failed: "ప్రమాణీకరణ విఫలమైంది"

--- a/tools/wta/locales/th-TH.yml
+++ b/tools/wta/locales/th-TH.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "กำลังเชื่อมต่อก�
 connection.lost: "การเชื่อมต่อกับเอเจนต์ขาดหายไป พิมพ์ /restart เพื่อเชื่อมต่อใหม่"  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "กด Ctrl+C อีกครั้งเพื่อปิดแผง"  # {Locked="Ctrl+C"}
 system.cancelled: "ยกเลิกแล้ว"
 system.no_prompt_in_flight: "ไม่มีพร้อมท์ที่กำลังดำเนินการ"
 system.authentication_failed: "การยืนยันตัวตนล้มเหลว"

--- a/tools/wta/locales/tr-TR.yml
+++ b/tools/wta/locales/tr-TR.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "Aracıya bağlanılıyor…"
 connection.lost: "Aracı bağlantısı kesildi. Yeniden bağlanmak için /restart yazın."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Paneli kapatmak için Ctrl+C tuşlarına tekrar basın."  # {Locked="Ctrl+C"}
 system.cancelled: "İptal edildi."
 system.no_prompt_in_flight: "Devam eden istem yok."
 system.authentication_failed: "Kimlik doğrulama başarısız"

--- a/tools/wta/locales/tt-RU.yml
+++ b/tools/wta/locales/tt-RU.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "Агентка тоташу…"
 connection.lost: "Агент белән тоташу югалды. Яңадан тоташу өчен /restart дип языгыз."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Панельне ябу өчен Ctrl+C төймәләренә тагын бер кат басыгыз."  # {Locked="Ctrl+C"}
 system.cancelled: "Баш тартылды."
 system.no_prompt_in_flight: "Башкарылучы сорау юк."
 system.authentication_failed: "Аутентификация уңышсыз булды"

--- a/tools/wta/locales/ug-CN.yml
+++ b/tools/wta/locales/ug-CN.yml
@@ -140,6 +140,7 @@ connection.connecting_activity: "AI ئاگېنتىغا باغلىنىۋاتىد�
 connection.lost: "AI ئاگېنتى بىلەن بولغان باغلىنىش ئۈزۈلدى. قايتا باغلىنىش ئۈچۈن /restart دەپ كىرگۈزۈڭ."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ──────────────────────────────────────────────────────────────
+system.close_pane_hint: "تاختىنى تاقاش ئۈچۈن Ctrl+C نى يەنە بىر قېتىم بېسىڭ."  # {Locked="Ctrl+C"}
 system.cancelled: "بېكىت قىلىندى."
 system.no_prompt_in_flight: "ئېۋەتىلىۋاتقان سوراق يوق."
 system.authentication_failed: "تونۇقتۇرۇش مەغلۇب بولدى"

--- a/tools/wta/locales/uk-UA.yml
+++ b/tools/wta/locales/uk-UA.yml
@@ -127,6 +127,7 @@ connection.connecting_activity: "Підключення до агента…"
 connection.lost: "Підключення до агента втрачено. Введіть /restart, щоб підключитися знову."  # {Locked="/restart"}
 
 # ── Системні повідомлення (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "Натисніть Ctrl+C ще раз, щоб закрити панель."  # {Locked="Ctrl+C"}
 system.cancelled: "Скасовано."
 system.no_prompt_in_flight: "Немає активного запиту."
 system.authentication_failed: "Помилка автентифікації"

--- a/tools/wta/locales/ur-PK.yml
+++ b/tools/wta/locales/ur-PK.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "ایجنٹ سے جڑ رہا ہے…"
 connection.lost: "ایجنٹ سے کنیکشن ختم ہو گیا۔ دوبارہ جڑنے کے لیے /restart ٹائپ کریں۔"  # {Locked="/restart"}
 
 # ── نظام پیغامات (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "پین بند کرنے کے لیے Ctrl+C دوبارہ دبائیں۔"  # {Locked="Ctrl+C"}
 system.cancelled: "منسوخ کیا گیا۔"
 system.no_prompt_in_flight: "کوئی پرامپٹ زیر عمل نہیں ہے۔"
 system.authentication_failed: "تصدیق ناکام"

--- a/tools/wta/locales/uz-Latn-UZ.yml
+++ b/tools/wta/locales/uz-Latn-UZ.yml
@@ -131,6 +131,7 @@ connection.connecting_activity: "Agentga ulanilmoqda…"
 connection.lost: "Agent bilan ulanish uzildi. Qayta ulanish uchun /restart deb yozing."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Panelni yopish uchun Ctrl+C ni yana bosing."  # {Locked="Ctrl+C"}
 system.cancelled: "Bekor qilindi."
 system.no_prompt_in_flight: "Bajarilayotgan soʻrov yoʻq."
 system.authentication_failed: "Autentifikatsiya amalga oshmadi"

--- a/tools/wta/locales/vi-VN.yml
+++ b/tools/wta/locales/vi-VN.yml
@@ -118,6 +118,7 @@ connection.connecting_activity: "Đang kết nối với tác nhân AI…"
 connection.lost: "Đã mất kết nối với tác nhân AI. Nhập /restart để kết nối lại."  # {Locked="/restart"}
 
 # ── System messages (src/app.rs) ────────────────────────────────────────────
+system.close_pane_hint: "Nhấn Ctrl+C lần nữa để đóng bảng."  # {Locked="Ctrl+C"}
 system.cancelled: "Đã hủy."
 system.no_prompt_in_flight: "Không có lệnh nào đang chạy."
 system.authentication_failed: "Xác thực thất bại"

--- a/tools/wta/locales/zh-CN.yml
+++ b/tools/wta/locales/zh-CN.yml
@@ -114,6 +114,7 @@ connection.connecting_activity: "正在连接智能体…"
 connection.lost: "与智能体的连接已断开。键入 /restart 以重新连接。"  # {Locked="/restart"}
 
 # ── 系统消息 (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "再次按 Ctrl+C 以关闭窗格。"  # {Locked="Ctrl+C"}
 system.cancelled: "已取消。"
 system.no_prompt_in_flight: "没有正在进行的提示。"
 system.authentication_failed: "身份验证失败"

--- a/tools/wta/locales/zh-TW.yml
+++ b/tools/wta/locales/zh-TW.yml
@@ -114,6 +114,7 @@ connection.connecting_activity: "正在連線到智能體…"
 connection.lost: "與智能體的連線已中斷。輸入 /restart 以重新連線。"  # {Locked="/restart"}
 
 # ── 系統訊息 (src/app.rs) ────────────────────────────────────────────────
+system.close_pane_hint: "再次按 Ctrl+C 以關閉窗格。"  # {Locked="Ctrl+C"}
 system.cancelled: "已取消。"
 system.no_prompt_in_flight: "沒有進行中的提示。"
 system.authentication_failed: "驗證失敗"

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2271,7 +2271,7 @@ pub struct App {
     /// other key, on prompt activity, or after the window elapses.
     pub close_pane_armed_at: Option<std::time::Instant>,
     /// Transient one-line hint rendered at the bottom of the chat area
-    /// (e.g. "Press Ctrl+C again to close pane"). Auto-clears at the
+    /// (localized via `system.close_pane_hint`). Auto-clears at the
     /// recorded deadline.
     pub transient_hint: Option<(String, std::time::Instant)>,
     /// Mirror of master's authoritative live-session set, pushed via
@@ -2290,7 +2290,7 @@ pub struct App {
     pub alive_loaded: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
-/// How long the "Press Ctrl+C again to close pane" arm stays live. Long
+/// How long the close-pane arm (localized via `system.close_pane_hint`) stays live. Long
 /// enough that the user can react after seeing the hint; short enough that
 /// a stale arm doesn't bite the next time they want to clear input.
 pub const CLOSE_PANE_ARM_WINDOW: std::time::Duration = std::time::Duration::from_millis(1500);

--- a/tools/wta/src/app_keys.rs
+++ b/tools/wta/src/app_keys.rs
@@ -595,7 +595,7 @@ impl App {
                     } else {
                         self.close_pane_armed_at = Some(now);
                         self.transient_hint = Some((
-                            "Press Ctrl+C again to close pane".to_string(),
+                            t!("system.close_pane_hint").into_owned(),
                             now + CLOSE_PANE_ARM_WINDOW,
                         ));
                     }


### PR DESCRIPTION
## Summary of the Pull Request

The "Press Ctrl+C again to close pane" hint in the agent pane was hard-coded in English. This change moves it into the localization system so it can be translated.

## Detailed Description of the Pull Request / Additional comments

- Replaced the hard-coded string with a call to `t!("system.close_pane_hint")` — the same pattern used by all other localizable strings in the file.
- Added a new key `system.close_pane_hint` to `en-US.yml` with a note that "Ctrl+C" should stay as-is in translations.
- Updated comments that referenced the old hard-coded string.

## PR Checklist

- [x] Closes #496