### PR TITLE
Extract WTA app contracts

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -39,13 +39,6 @@ struct DeferredAcpParams {
     owner_tab_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AvailableAgent {
-    pub id: String,
-    pub display_name: String,
-    pub source: crate::agent_source::AgentSource,
-}
-
 fn agent_command_on_enter(
     input: &str,
     selected: Option<&AvailableAgent>,
@@ -109,6 +102,10 @@ pub fn resolve_sessions_origin_filter() -> crate::agent_sessions::OriginFilter {
 use crate::commands::{
     self, CommandKind, CommandSpec, MovePositionSpec, ParseOutcome, ParsedCommand,
 };
+pub use crate::app_contracts::{
+    AcpModelInfo, AppEvent, AvailableAgent, CheckStatus, DebugDir, DebugMessage, PermOption,
+    PlanEntry, PlanEntryStatus, PreflightResult,
+};
 use crate::coordinator::{
     parse_autofix_response, parse_recommendation_set, recommended_choice_index,
     validate_recommendation_set_for_coordinator_target, AutofixDecision, RecommendationChoice,
@@ -122,21 +119,7 @@ use crate::protocol::acp::client::{
 };
 use crate::ui;
 use crate::ui_trace;
-
-// --- Debug types ---
-
-#[derive(Debug, Clone)]
-pub enum DebugDir {
-    Sent,
-    Received,
-}
-
-#[derive(Debug, Clone)]
-pub struct DebugMessage {
-    pub timestamp: f64,
-    pub direction: DebugDir,
-    pub content: String,
-}
+use crate::wt_protocol_events::send as send_wt_protocol_event;
 
 // --- Application mode ---
 
@@ -249,65 +232,6 @@ pub struct SetupState {
     pub title: String,
     /// Dynamic subtitle for the setup screen.
     pub subtitle: String,
-}
-
-/// Status of a single preflight check.
-#[derive(Debug, Clone, PartialEq)]
-pub enum CheckStatus {
-    Checking,
-    Passed,
-    Failed(String),
-    Skipped,
-}
-
-/// Result of all preflight checks for an agent.
-#[derive(Debug, Clone)]
-pub struct PreflightResult {
-    pub agent_id: String,
-    pub display_name: String,
-    pub cli_status: CheckStatus,
-    pub cli_path: Option<String>,
-    pub auth_status: CheckStatus,
-    pub install_hint: String,
-    pub install_url: String,
-    pub auth_hint: String,
-}
-
-impl PreflightResult {
-    pub fn all_passed(&self) -> bool {
-        self.cli_status == CheckStatus::Passed
-            && matches!(self.auth_status, CheckStatus::Passed | CheckStatus::Skipped)
-    }
-
-    /// Synthesize a `Passed` preflight result for a custom or unknown agent
-    /// id. We deliberately do **not** run an out-of-band PATH check for these
-    /// — the user-supplied command can be anything (`.cmd`, `.ps1`,
-    /// `node script.js`, an alias) and any guess we make disagrees with what
-    /// the spawner actually does. Real spawn failures surface via the
-    /// `ConnectionFailed` → `ConnectionState::Failed` lifecycle, which is the
-    /// authoritative error path.
-    ///
-    /// Returning `cli_status=Passed` keeps the TUI out of Setup mode so the
-    /// chat input stays responsive. The display name is derived from the
-    /// canonical id (`custom:<name>` → `<name>`) so the UI never collapses
-    /// to the generic `DEFAULT_PROFILE` "Agent" label.
-    pub fn passed_for_custom_agent(canonical_id: &str) -> Self {
-        let display_name = canonical_id
-            .strip_prefix("custom:")
-            .filter(|s| !s.is_empty())
-            .map(str::to_string)
-            .unwrap_or_else(|| canonical_id.to_string());
-        Self {
-            agent_id: canonical_id.to_string(),
-            display_name,
-            cli_status: CheckStatus::Passed,
-            cli_path: None,
-            auth_status: CheckStatus::Skipped,
-            install_hint: String::new(),
-            install_url: String::new(),
-            auth_hint: String::new(),
-        }
-    }
 }
 
 /// True for the auth failures a post-login reconnect can hit when the shared
@@ -488,45 +412,6 @@ pub fn collapsed_prompt_preview(text: &str) -> String {
         out.push('…');
     }
     out
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct PlanEntry {
-    pub content: String,
-    pub status: PlanEntryStatus,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum PlanEntryStatus {
-    Pending,
-    InProgress,
-    Completed,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct PermOption {
-    pub id: String,
-    pub name: String,
-    pub kind: String,
-}
-
-impl PermOption {
-    /// True if this is an "allow" option. Case-insensitive because `kind`
-    /// is the ACP `PermissionOptionKind` rendered via `format!("{:?}", …)`,
-    /// which yields PascalCase variants like `AllowOnce` / `AllowAlways`.
-    /// Matching the leading `allow` prefix here keeps the `y`/`n` quick-keys
-    /// and the `[Y]`/`[N]` button labels in sync with the real wire values.
-    /// Prefix-checked (not lowercased) to stay allocation-free on the render /
-    /// key-handling hot path.
-    pub fn is_allow(&self) -> bool {
-        self.kind.get(..5).is_some_and(|p| p.eq_ignore_ascii_case("allow"))
-    }
-
-    /// True if this is a "reject" option. Allocation-free, case-insensitive —
-    /// see [`PermOption::is_allow`].
-    pub fn is_reject(&self) -> bool {
-        self.kind.get(..6).is_some_and(|p| p.eq_ignore_ascii_case("reject"))
-    }
 }
 
 pub struct PermissionState {
@@ -1027,14 +912,6 @@ pub fn classify_wt_event(
 /// One entry of an ACP agent's advertised model list, mirrored into the
 /// `agent_status` event so the XAML settings page can populate a real
 /// dropdown instead of asking the user to type a free-form string.
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct AcpModelInfo {
-    pub id: String,
-    pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-}
-
 /// Test-visible record of a wtcli command the App fired through the
 /// `wt_channel::spawn_*` helpers. Captured under `cfg(test)` so we can
 /// assert the agent session view dispatches the right shape of command
@@ -1068,308 +945,6 @@ pub struct DispatchedCommand {
     pub kind: DispatchedCommandKind,
     pub session_id: Option<String>,
     pub argv: Vec<String>,
-}
-
-pub enum AppEvent {
-    Key(KeyEvent),
-    Tick,
-    /// High-frequency (~30Hz) reveal animation tick. Drives the typewriter
-    /// smoothing of the streaming agent response (advances `reveal_chars`).
-    /// Separate from `Tick` so we can run the reveal at 30fps without
-    /// quadrupling the spinner's full-frame flush rate: a `RevealTick` only
-    /// forces a redraw when there is unrevealed pending text on the current
-    /// tab (`has_reveal_backlog`).
-    RevealTick,
-    Resize(u16, u16), // terminal resize (handled by ratatui)
-    /// XAML focus on our hosting TermControl changed — true when the agent
-    /// pane gained focus, false when it lost focus. Sourced from xterm
-    /// focus-in/out (CSI I / CSI O) delivered through conpty.
-    FocusChanged(bool),
-    ConnectionStage(String),
-    AgentConnected {
-        name: String,
-        model: Option<String>,
-        version: Option<String>,
-        /// Session id for the implicitly-created `DEFAULT_TAB_ID` ("0")
-        /// session at startup. Wires into App.session_to_tab. Other tabs
-        /// get their own sessions lazily on first prompt — see
-        /// `SessionAttached`.
-        session_id: String,
-        /// ACP-advertised models (NewSessionResponse.models.available_models).
-        /// Empty when the agent didn't fill the field.
-        available_models: Vec<AcpModelInfo>,
-        /// ACP-advertised current model id (NewSessionResponse.models.current_model_id).
-        current_model_id: Option<String>,
-        /// Whether the agent advertised the `loadSession` capability in
-        /// the initialize response. Used by the session management
-        /// view's Shift+Enter handler to short-circuit with a clear
-        /// error before opening a new tab when the agent can't
-        /// rehydrate ACP sessions.
-        load_session_supported: bool,
-        /// Whether the agent advertised the `image` prompt capability
-        /// (`promptCapabilities.image`) in its initialize response. Gates the
-        /// Alt+V image-paste handler so the user gets a clear message instead
-        /// of silently sending an image the agent will reject.
-        image_supported: bool,
-    },
-    /// A new ACP session has been created and bound to a tab. Carries the
-    /// per-tab model list (each ACP session can advertise its own).
-    SessionAttached {
-        tab_id: String,
-        session_id: String,
-        available_models: Vec<AcpModelInfo>,
-        current_model_id: Option<String>,
-    },
-    /// Error scoped to a specific tab. Used by paths that know the tab
-    /// (e.g. ACP `session/load` failure) but have no session_id yet
-    /// because the session never came up. Routes into that tab's chat as
-    /// a normal Error message; does NOT bounce through the auth/global
-    /// disconnect fallback that `AgentError` triggers.
-    TabError {
-        tab_id: String,
-        message: String,
-    },
-    /// Informational system message scoped to a specific tab. Used for
-    /// session/load progress notes ("Resuming...", "Session loaded.")
-    /// where we want the user to see something before the agent's
-    /// session/update replay (if any) arrives.
-    TabSystemMessage {
-        tab_id: String,
-        message: String,
-    },
-    AgentPasteTextReady {
-        tab_id: String,
-        generation: u64,
-        text: String,
-    },
-    AgentPasteTextFailed {
-        tab_id: String,
-        generation: u64,
-        error: String,
-    },
-    PromptTemplateLoaded {
-        name: String,
-    },
-    /// The working pane a manual `/fix` resolved to, plumbed back from the ACP
-    /// client task so the App can fill `AutofixContext.target_pane_id` on the
-    /// in-flight turn. The host fills `Send.parent` from it at execute time —
-    /// the agent never echoes a pane id for autofix turns. Routed by
-    /// `prompt_id` so a superseded turn (a newer `/fix`) is left untouched.
-    AutofixTargetResolved {
-        tab_id: Option<String>,
-        prompt_id: u64,
-        pane_id: String,
-    },
-    /// Errors raised before a session exists carry None for `session_id`
-    /// and route to the active tab; in-flight failures route to the
-    /// session's tab. `failure` is the typed classification that drives
-    /// recovery (sign-in / `/restart` / show-and-stay); `message` is the
-    /// human-readable line to display.
-    AgentError {
-        session_id: Option<String>,
-        failure: crate::protocol::acp::failure::AgentFailure,
-        message: String,
-    },
-    /// A turn that completed successfully at the protocol level but ended on a
-    /// soft stop (output-token limit, request budget, or refusal). NOT a
-    /// connection failure — the session stays `Connected`; this only appends an
-    /// informational line to the session's chat. Emitted *after*
-    /// `AgentMessageEnd` so the notice follows the agent's streamed content.
-    AgentSoftStop {
-        session_id: String,
-        reason: crate::protocol::acp::soft_stop::SoftStopReason,
-    },
-    /// Same-tab single-flight guard rejection. The user submitted a new
-    /// prompt while the previous one is still in flight on the same tab.
-    /// The ACP client side enforces this for safety; the front-end Enter
-    /// handler also has its own guard so the bounce is rare.
-    AgentBusy {
-        tab_id: String,
-    },
-    /// WT-side `tab_renamed` event: the user dragged a tab out into a new
-    /// window (or otherwise caused the tab's StableId to change). The
-    /// underlying helper process survives the drag (conpty + TermControl
-    /// are reattached via WT's ContentId mechanism), but the tab key WT
-    /// uses to address us has changed. Without rekeying, autofix /
-    /// per-tab state events targeting the new id wouldn't match any
-    /// entry in `tab_sessions`.
-    TabRenamed {
-        old_tab_id: String,
-        new_tab_id: String,
-        /// Dest window id (from WT's `tab_renamed` payload). When this
-        /// helper rekeys onto the new id, it also updates `self.window_id`
-        /// to this value so subsequent `set_agent_state` / `tab_changed`
-        /// events from the new window pass the per-window filter. `None`
-        /// for direct AppEvent dispatches that don't carry it (tests).
-        new_window_id: Option<String>,
-    },
-    ExecutionInfo(String),
-    AgentThoughtChunk {
-        session_id: String,
-        text: String,
-    },
-    AgentMessageChunk {
-        session_id: String,
-        text: String,
-    },
-    /// A `user_message_chunk` SessionUpdate received from the agent
-    /// during an ACP `session/load` replay. Carries the historical
-    /// user prompt that opens the next replayed turn. Accumulated into
-    /// `pending_user_replay` and flushed as a `ChatMessage::User` when
-    /// the next agent/tool/plan chunk lands or the load completes.
-    /// Outside of `loading_session` mode, dropped — copilot uses these
-    /// only during load.
-    UserMessageReplayChunk {
-        session_id: String,
-        text: String,
-    },
-    AgentMessageEnd {
-        session_id: String,
-    },
-    TimingMetric {
-        session_id: String,
-        note: String,
-    },
-    ToolCall {
-        session_id: String,
-        id: String,
-        title: String,
-        status: String,
-    },
-    ToolCallUpdate {
-        session_id: String,
-        id: String,
-        status: String,
-    },
-    Plan {
-        session_id: String,
-        entries: Vec<PlanEntry>,
-    },
-    PermissionRequest {
-        session_id: String,
-        tool_call_id: String,
-        description: String,
-        options: Vec<PermOption>,
-        responder: tokio::sync::oneshot::Sender<String>,
-    },
-    SystemMessage(String),
-    DebugPipeMessage(DebugMessage),
-    /// Push event from Windows Terminal protocol (VT sequence or connection state).
-    /// `pane_id` is the WT pane GUID where the event originated.
-    /// `tab_id` is the WT tab StableId that owns the pane — used by autofix
-    /// routing to send fixes to the failing tab's ACP session rather than
-    /// whatever tab WTA happens to be focused on. `None` for events from
-    /// older WT builds that don't yet carry tab_id.
-    WtEvent {
-        method: String,
-        pane_id: String,
-        tab_id: Option<String>,
-        params: serde_json::Value,
-    },
-    /// Background agent install completed — refresh the detected agents list.
-    AgentInstallComplete,
-    /// Login progress — device code received, display to user.
-    LoginProgress {
-        device_code: String,
-        verify_url: String,
-    },
-    /// Login flow completed.
-    LoginComplete {
-        agent_id: String,
-        success: bool,
-        /// On failure, the most specific error line captured from the login
-        /// process output (if any), surfaced to the user. `None` on success.
-        error: Option<String>,
-    },
-    /// Post-login auth recovery: a genuine post-login reconnect (helper/pipe
-    /// mode) for an External-auth agent STILL failed auth, which means the
-    /// shared long-lived master CLI was spawned with a stale token and
-    /// `authenticate` can't refresh it. The handler shows a transient
-    /// "Reconnecting…" and fires `restart_agent_stack` so a fresh master
-    /// (which re-reads the now-valid on-disk token) takes over.
-    PostLoginAuthRecovery {
-        failure: crate::protocol::acp::failure::AgentFailure,
-        tab_id: Option<String>,
-        agent_id: String,
-    },
-    /// Dead-man fallback for `PostLoginAuthRecovery`: a successful restart
-    /// tears this helper down before this fires; if it DOES fire (restart
-    /// dropped/slow), surface the sign-in screen instead of stranding the user
-    /// on a perpetual "Reconnecting…". `generation` pins this to the specific
-    /// recovery that armed it, so a stale timer can't act on a later state.
-    AuthRecoveryTimedOut {
-        agent_id: String,
-        generation: u64,
-    },
-    /// Result of a source-aware `/agent` discovery for the active working pane.
-    AgentSourcesDiscovered {
-        generation: u64,
-        wsl_sources: Vec<AvailableAgent>,
-    },
-    /// Result of `preflight::check_agent` run by main.rs before the TUI
-    /// loop starts. If `all_passed()` is false the App switches into
-    /// `AppMode::Setup` so the user can install / authenticate the CLI.
-    PreflightComplete(PreflightResult),
-    /// Background-thread callback from `wt_channel::spawn_wtcli_split_then_focus_with_callback`
-    /// (used by `dispatch_resume`) reaches the registry through this variant.
-    /// Posting via the main loop keeps `agent_sessions` access single-threaded
-    /// and lets `tracing::*` calls emit on a stable thread.
-    AgentSessionEvent(crate::agent_sessions::SessionEvent),
-    /// Initial bootstrap of the alive-session mirror from master, in
-    /// response to the helper's startup `session/list` request. The
-    /// payload replaces any existing entries and flips `alive_loaded`
-    /// to true so session management routing logic can start trusting `alive.lookup()`
-    /// misses as "session is gone". See
-    /// `crate::session_registry::apply_snapshot`.
-    AliveSnapshotLoaded(Vec<crate::session_registry::SessionInfo>),
-    /// Master broadcast a new alive session into the helper's mirror
-    /// via `intellterm.wta/session_added` ext-notification. Applied to
-    /// `App.alive` from the main event loop so the registry has a
-    /// single writer.
-    AliveSessionAdded(crate::session_registry::SessionInfo),
-    /// Master broadcast that an alive session is gone via
-    /// `intellterm.wta/session_removed`. Symmetric counterpart to
-    /// `AliveSessionAdded`.
-    AliveSessionRemoved(agent_client_protocol::schema::v1::SessionId),
-    /// Apply an "upgrade Historical/Ended → Live" join between the
-    /// historical-row registry (`agent_sessions`) and the alive-session
-    /// mirror. Posted from `AliveSnapshotLoaded` (master's bootstrap
-    /// reply): the handler converts each `SessionInfo` into a `(sid, pane)`
-    /// pair, dispatches `AliveJoinUpgrade`, and lets the main loop apply it
-    /// serialized w.r.t. other agent-sessions mutations.
-    ///
-    /// See [`crate::agent_sessions::AgentSessionRegistry::apply_alive_session_join`].
-    AliveJoinUpgrade(Vec<(String, Option<String>)>),
-    SessionsChanged,
-    AgentsSnapshotLoaded {
-        request_id: u64,
-        sessions: Vec<crate::session_registry::SessionInfo>,
-    },
-    /// `sessions/list` RPC failed or timed out — unblock the tab's
-    /// `refetch_in_flight` gate without overwriting the existing
-    /// snapshot, so the 5s periodic tick / next `SessionsChanged`
-    /// broadcast can retry. Emitted by `dispatch_master_ext_request`'s
-    /// `SessionsList` arm when `conn.ext_method(...)` returns Err or
-    /// `tokio::time::timeout` elapses. The timeout path is a
-    /// workaround for a `agent-client-protocol@0.10` cancellation-
-    /// safety bug in `RpcConnection::handle_io`: when
-    /// `select_biased!`'s outgoing arm preempts an in-progress
-    /// `read_line`, BufReader bytes already pulled off the pipe are
-    /// silently dropped, the next read returns a frame starting
-    /// mid-message, JSON parse fails, and the matching
-    /// `pending_responses` entry never resolves — so the
-    /// `ext_method` future would otherwise wait forever, keeping
-    /// `refetch_in_flight=true` permanently for the affected tab.
-    /// See the GH issue for upgrading to 0.12.
-    AgentsSnapshotFailed {
-        request_id: u64,
-    },
-    RegisterBornBoundSession {
-        event: crate::agent_sessions::SessionEvent,
-    },
-    MasterMutationCompleted {
-        request_id: u64,
-    },
 }
 
 // --- Per-tab session storage ---
@@ -6588,20 +6163,6 @@ fn format_recommendations_for_chat(set: &RecommendationSet) -> String {
 #[path = "app_status_projection.rs"]
 mod app_status_projection;
 
-/// Publish a raw JSON event via `wtcli publish`. The event flows through
-/// IProtocolServer::SendEvent; our modified COM server special-cases
-/// method=="autofix_state" and dispatches directly to TerminalPage.
-///
-/// Events are funnelled through a single background thread that waits
-/// for each `wtcli publish` subprocess to exit before launching the next.
-/// Without this, two rapid emits (e.g. armed → cleared) could race at
-/// the OS process-scheduling layer and arrive at WT out of order,
-/// leaving the bottom-bar stuck in the earlier state.
-pub fn send_wt_protocol_event(json_payload: String) {
-    let tx = publisher_sender();
-    let _ = tx.send(json_payload);
-}
-
 fn build_switch_agent_event(
     window_id: &str,
     tab_id: &str,
@@ -6637,49 +6198,6 @@ fn emit_agent_chip_target(tab_id: &str, pane_session_id: Option<&str>) {
         }
     });
     send_wt_protocol_event(evt.to_string());
-}
-
-fn publisher_sender() -> &'static std::sync::mpsc::Sender<String> {
-    static SENDER: std::sync::OnceLock<std::sync::mpsc::Sender<String>> =
-        std::sync::OnceLock::new();
-    SENDER.get_or_init(|| {
-        let (tx, rx) = std::sync::mpsc::channel::<String>();
-        std::thread::Builder::new()
-            .name("wt-event-publisher".into())
-            .spawn(move || {
-                while let Ok(payload) = rx.recv() {
-                    publish_event_blocking(&payload);
-                }
-            })
-            .expect("spawn wt-event-publisher thread");
-        tx
-    })
-}
-
-fn publish_event_blocking(json_payload: &str) {
-    let exe = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(|d| d.join("wtcli.exe")))
-        .filter(|p| p.exists())
-        .unwrap_or_else(|| std::path::PathBuf::from("wtcli.exe"));
-    let mut cmd = std::process::Command::new(exe);
-    cmd.arg("publish").arg(json_payload);
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-    }
-    cmd.stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .stdin(std::process::Stdio::null());
-    match cmd.spawn() {
-        Ok(mut child) => {
-            // Block the publisher thread until this publish finishes so
-            // the next event's subprocess can't overtake it.
-            let _ = child.wait();
-        }
-        Err(_) => {}
-    }
 }
 
 /// Resolve an agent command like "copilot --acp --stdio" to use the full

--- a/tools/wta/src/app_contracts/agent.rs
+++ b/tools/wta/src/app_contracts/agent.rs
@@ -1,0 +1,8 @@
+use crate::agent_source::AgentSource;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AvailableAgent {
+    pub id: String,
+    pub display_name: String,
+    pub source: AgentSource,
+}

--- a/tools/wta/src/app_contracts/diagnostics.rs
+++ b/tools/wta/src/app_contracts/diagnostics.rs
@@ -1,0 +1,12 @@
+#[derive(Debug, Clone)]
+pub enum DebugDir {
+    Sent,
+    Received,
+}
+
+#[derive(Debug, Clone)]
+pub struct DebugMessage {
+    pub timestamp: f64,
+    pub direction: DebugDir,
+    pub content: String,
+}

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -1,0 +1,164 @@
+use crossterm::event::KeyEvent;
+
+use super::{AcpModelInfo, AvailableAgent, DebugMessage, PermOption, PlanEntry, PreflightResult};
+
+pub enum AppEvent {
+    Key(KeyEvent),
+    Tick,
+    RevealTick,
+    Resize(u16, u16),
+    FocusChanged(bool),
+    ConnectionStage(String),
+    AgentConnected {
+        name: String,
+        model: Option<String>,
+        version: Option<String>,
+        session_id: String,
+        available_models: Vec<AcpModelInfo>,
+        current_model_id: Option<String>,
+        load_session_supported: bool,
+        image_supported: bool,
+    },
+    SessionAttached {
+        tab_id: String,
+        session_id: String,
+        available_models: Vec<AcpModelInfo>,
+        current_model_id: Option<String>,
+    },
+    TabError {
+        tab_id: String,
+        message: String,
+    },
+    TabSystemMessage {
+        tab_id: String,
+        message: String,
+    },
+    AgentPasteTextReady {
+        tab_id: String,
+        generation: u64,
+        text: String,
+    },
+    AgentPasteTextFailed {
+        tab_id: String,
+        generation: u64,
+        error: String,
+    },
+    PromptTemplateLoaded {
+        name: String,
+    },
+    AutofixTargetResolved {
+        tab_id: Option<String>,
+        prompt_id: u64,
+        pane_id: String,
+    },
+    AgentError {
+        session_id: Option<String>,
+        failure: crate::protocol::acp::failure::AgentFailure,
+        message: String,
+    },
+    AgentSoftStop {
+        session_id: String,
+        reason: crate::protocol::acp::soft_stop::SoftStopReason,
+    },
+    AgentBusy {
+        tab_id: String,
+    },
+    TabRenamed {
+        old_tab_id: String,
+        new_tab_id: String,
+        new_window_id: Option<String>,
+    },
+    ExecutionInfo(String),
+    AgentThoughtChunk {
+        session_id: String,
+        text: String,
+    },
+    AgentMessageChunk {
+        session_id: String,
+        text: String,
+    },
+    UserMessageReplayChunk {
+        session_id: String,
+        text: String,
+    },
+    AgentMessageEnd {
+        session_id: String,
+    },
+    TimingMetric {
+        session_id: String,
+        note: String,
+    },
+    ToolCall {
+        session_id: String,
+        id: String,
+        title: String,
+        status: String,
+    },
+    ToolCallUpdate {
+        session_id: String,
+        id: String,
+        status: String,
+    },
+    Plan {
+        session_id: String,
+        entries: Vec<PlanEntry>,
+    },
+    PermissionRequest {
+        session_id: String,
+        tool_call_id: String,
+        description: String,
+        options: Vec<PermOption>,
+        responder: tokio::sync::oneshot::Sender<String>,
+    },
+    SystemMessage(String),
+    DebugPipeMessage(DebugMessage),
+    WtEvent {
+        method: String,
+        pane_id: String,
+        tab_id: Option<String>,
+        params: serde_json::Value,
+    },
+    AgentInstallComplete,
+    LoginProgress {
+        device_code: String,
+        verify_url: String,
+    },
+    LoginComplete {
+        agent_id: String,
+        success: bool,
+        error: Option<String>,
+    },
+    PostLoginAuthRecovery {
+        failure: crate::protocol::acp::failure::AgentFailure,
+        tab_id: Option<String>,
+        agent_id: String,
+    },
+    AuthRecoveryTimedOut {
+        agent_id: String,
+        generation: u64,
+    },
+    AgentSourcesDiscovered {
+        generation: u64,
+        wsl_sources: Vec<AvailableAgent>,
+    },
+    PreflightComplete(PreflightResult),
+    AgentSessionEvent(crate::agent_sessions::SessionEvent),
+    AliveSnapshotLoaded(Vec<crate::session_registry::SessionInfo>),
+    AliveSessionAdded(crate::session_registry::SessionInfo),
+    AliveSessionRemoved(agent_client_protocol::schema::v1::SessionId),
+    AliveJoinUpgrade(Vec<(String, Option<String>)>),
+    SessionsChanged,
+    AgentsSnapshotLoaded {
+        request_id: u64,
+        sessions: Vec<crate::session_registry::SessionInfo>,
+    },
+    AgentsSnapshotFailed {
+        request_id: u64,
+    },
+    RegisterBornBoundSession {
+        event: crate::agent_sessions::SessionEvent,
+    },
+    MasterMutationCompleted {
+        request_id: u64,
+    },
+}

--- a/tools/wta/src/app_contracts/mod.rs
+++ b/tools/wta/src/app_contracts/mod.rs
@@ -1,0 +1,20 @@
+//! Data contracts shared by the App reducer and its event producers.
+//!
+//! These types carry data across application, ACP, input, and infrastructure
+//! boundaries. Mutable UI state remains owned by `app`.
+
+mod agent;
+mod diagnostics;
+mod event;
+mod model;
+mod permission;
+mod plan;
+mod preflight;
+
+pub use agent::AvailableAgent;
+pub use diagnostics::{DebugDir, DebugMessage};
+pub use event::AppEvent;
+pub use model::AcpModelInfo;
+pub use permission::PermOption;
+pub use plan::{PlanEntry, PlanEntryStatus};
+pub use preflight::{CheckStatus, PreflightResult};

--- a/tools/wta/src/app_contracts/model.rs
+++ b/tools/wta/src/app_contracts/model.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AcpModelInfo {
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}

--- a/tools/wta/src/app_contracts/permission.rs
+++ b/tools/wta/src/app_contracts/permission.rs
@@ -1,0 +1,23 @@
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct PermOption {
+    pub id: String,
+    pub name: String,
+    pub kind: String,
+}
+
+impl PermOption {
+    /// True if this is an "allow" option. Case-insensitive because `kind`
+    /// is the ACP `PermissionOptionKind` rendered via `format!("{:?}", ...)`.
+    pub fn is_allow(&self) -> bool {
+        self.kind
+            .get(..5)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("allow"))
+    }
+
+    /// True if this is a "reject" option.
+    pub fn is_reject(&self) -> bool {
+        self.kind
+            .get(..6)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("reject"))
+    }
+}

--- a/tools/wta/src/app_contracts/plan.rs
+++ b/tools/wta/src/app_contracts/plan.rs
@@ -1,0 +1,12 @@
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct PlanEntry {
+    pub content: String,
+    pub status: PlanEntryStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum PlanEntryStatus {
+    Pending,
+    InProgress,
+    Completed,
+}

--- a/tools/wta/src/app_contracts/preflight.rs
+++ b/tools/wta/src/app_contracts/preflight.rs
@@ -1,0 +1,47 @@
+/// Status of a single preflight check.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CheckStatus {
+    Checking,
+    Passed,
+    Failed(String),
+    Skipped,
+}
+
+/// Result of all preflight checks for an agent.
+#[derive(Debug, Clone)]
+pub struct PreflightResult {
+    pub agent_id: String,
+    pub display_name: String,
+    pub cli_status: CheckStatus,
+    pub cli_path: Option<String>,
+    pub auth_status: CheckStatus,
+    pub install_hint: String,
+    pub install_url: String,
+    pub auth_hint: String,
+}
+
+impl PreflightResult {
+    pub fn all_passed(&self) -> bool {
+        self.cli_status == CheckStatus::Passed
+            && matches!(self.auth_status, CheckStatus::Passed | CheckStatus::Skipped)
+    }
+
+    /// Synthesize a passed result for a custom or unknown agent command.
+    pub fn passed_for_custom_agent(canonical_id: &str) -> Self {
+        let display_name = canonical_id
+            .strip_prefix("custom:")
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| canonical_id.to_string());
+        Self {
+            agent_id: canonical_id.to_string(),
+            display_name,
+            cli_status: CheckStatus::Passed,
+            cli_path: None,
+            auth_status: CheckStatus::Skipped,
+            install_hint: String::new(),
+            install_url: String::new(),
+            auth_hint: String::new(),
+        }
+    }
+}

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration};
 
-use crate::app::AppEvent;
+use crate::app_contracts::AppEvent;
 use crate::shell::ShellManager;
 
 use crate::agent_registry::{self, PromptFlag};

--- a/tools/wta/src/event.rs
+++ b/tools/wta/src/event.rs
@@ -3,7 +3,7 @@ use futures::StreamExt;
 use tokio::sync::mpsc;
 use tokio::time::{self, Duration, MissedTickBehavior};
 
-use crate::app::AppEvent;
+use crate::app_contracts::AppEvent;
 
 /// Pure translation of a crossterm input `Event` into the `AppEvent` the TUI
 /// consumes, or `None` for events we deliberately drop.

--- a/tools/wta/src/helper/runtime.rs
+++ b/tools/wta/src/helper/runtime.rs
@@ -254,7 +254,7 @@ fn spawn_restart_agent_stack_forwarder(
                 "method": "restart_agent_stack",
                 "params": {},
             });
-            crate::app::send_wt_protocol_event(evt.to_string());
+            crate::wt_protocol_events::send(evt.to_string());
         }
     });
 }

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -8,6 +8,7 @@ mod agent_registry;
 mod agent_source;
 mod agent_sessions;
 mod app;
+mod app_contracts;
 mod clipboard_image;
 mod command_recall;
 mod commands;
@@ -41,6 +42,7 @@ mod ui_trace;
 mod win32;
 mod wsl;
 mod wsl_acp;
+mod wt_protocol_events;
 
 use agent_client_protocol as acp;
 use anyhow::{bail, Context, Result};

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -2720,7 +2720,7 @@ fn emit_restart_agent_pane(tab_id: &str, session_id: Option<&acp::schema::v1::Se
         session_id = ?session_id,
         "emitting restart_agent_pane (helper disconnected)"
     );
-    crate::app::send_wt_protocol_event(evt.to_string());
+    crate::wt_protocol_events::send(evt.to_string());
 }
 
 /// Pure builder for the `restart_agent_pane` WT-protocol event payload.

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -13,7 +13,7 @@ use std::sync::{
 use tokio::sync::mpsc;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
-use crate::app::{AppEvent, PermOption, PlanEntry, PlanEntryStatus};
+use crate::app_contracts::{AcpModelInfo, AppEvent, PermOption, PlanEntry, PlanEntryStatus};
 use crate::pane_context::PaneContext;
 use crate::shell::{ShellManager, TerminalConfig};
 
@@ -2533,7 +2533,7 @@ pub async fn run_acp_client_over_pipe(
             let _ = event_tx.send(AppEvent::ConnectionStage("Connecting...".to_string()));
             (
                 acp::schema::v1::SessionId::new(load_sid.to_string()),
-                Vec::<crate::app::AcpModelInfo>::new(),
+                Vec::<AcpModelInfo>::new(),
                 None,
                 false,
             )
@@ -2758,7 +2758,7 @@ pub async fn run_acp_client_over_pipe(
                 // the user sees a fresh session.
                 //
                 // Signal travels: helper → `wtcli publish` (see
-                // `app::send_wt_protocol_event`) → `IProtocolServer::SendEvent`
+                // `wt_protocol_events::send`) → `IProtocolServer::SendEvent`
                 // (route `RestartAgentStack`) →
                 // `TerminalPage::OnRestartAgentStackRequested`.
                 tracing::info!(
@@ -2771,7 +2771,7 @@ pub async fn run_acp_client_over_pipe(
                     "method": "restart_agent_stack",
                     "params": {},
                 });
-                crate::app::send_wt_protocol_event(evt.to_string());
+                crate::wt_protocol_events::send(evt.to_string());
             }
             Some(req) = cancel_rx.recv() => {
                 dispatch_cancel(req, &conn, &cancel_signals);
@@ -3748,7 +3748,7 @@ mod tests {
     };
     use super::acp;
     use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
-    use crate::app::AppEvent;
+    use crate::app_contracts::AppEvent;
     use tokio::sync::mpsc;
 
     /// `shell_from_active` resolves our own pid to a real exe name (the test
@@ -4597,7 +4597,7 @@ mod tests {
     /// not tear down the connection).
     mod ext_notification_tests {
         use super::super::{ClientState, WtaClient};
-        use crate::app::AppEvent;
+        use crate::app_contracts::AppEvent;
         use crate::session_registry::{
             build_session_added_notification, build_session_removed_notification,
             INTELLTERM_METHOD_SESSION_REMOVED,

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -19,7 +19,7 @@ use super::{
     CancelRequest, DropSessionRequest, LoadSessionForTab, MasterExtRequest, NewSessionForTab,
     PromptSubmission, RenameSessionRequest, TemplateMemo,
 };
-use crate::app::AppEvent;
+use crate::app_contracts::{AppEvent, PlanEntry, PlanEntryStatus};
 use crate::protocol::acp::conn;
 use crate::shell::ShellManager;
 use agent_client_protocol as acp;
@@ -1744,17 +1744,17 @@ async fn session_notification_routes_plan_with_status_mapping() {
             assert_eq!(
                 entries,
                 vec![
-                    crate::app::PlanEntry {
+                    PlanEntry {
                         content: "Step one".to_string(),
-                        status: crate::app::PlanEntryStatus::InProgress,
+                        status: PlanEntryStatus::InProgress,
                     },
-                    crate::app::PlanEntry {
+                    PlanEntry {
                         content: "Step two".to_string(),
-                        status: crate::app::PlanEntryStatus::Completed,
+                        status: PlanEntryStatus::Completed,
                     },
-                    crate::app::PlanEntry {
+                    PlanEntry {
                         content: "Step three".to_string(),
-                        status: crate::app::PlanEntryStatus::Pending,
+                        status: PlanEntryStatus::Pending,
                     },
                 ]
             );
@@ -1846,5 +1846,4 @@ async fn request_permission_cancelled_when_responder_dropped() {
         })
         .await;
 }
-
 

--- a/tools/wta/src/protocol/acp/model_select.rs
+++ b/tools/wta/src/protocol/acp/model_select.rs
@@ -19,7 +19,7 @@ use std::sync::RwLock;
 
 use agent_client_protocol as acp;
 
-use crate::app::AcpModelInfo;
+use crate::app_contracts::AcpModelInfo;
 
 /// How the current agent expects a model switch to be delivered. Refreshed on
 /// every `new_session` parse (see [`models_from_new_session`]) so an in-process

--- a/tools/wta/src/protocol/acp/probe.rs
+++ b/tools/wta/src/protocol/acp/probe.rs
@@ -22,7 +22,7 @@ use serde::Serialize;
 use std::time::Duration;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
-use crate::app::AcpModelInfo;
+use crate::app_contracts::AcpModelInfo;
 use crate::protocol::acp::conn;
 use crate::protocol::acp::spawn::{spawn_agent_process, AgentStderrLog};
 

--- a/tools/wta/src/shell/wt_channel/cli_channel.rs
+++ b/tools/wta/src/shell/wt_channel/cli_channel.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, bail, Context};
 use tokio::sync::mpsc;
 
 use super::WtChannel;
-use crate::app::DebugMessage;
+use crate::app_contracts::DebugMessage;
 
 /// Extract a JSON value as a string, handling both String and Number types.
 /// Protocol IDs may arrive as either strings or numbers depending on the caller.

--- a/tools/wta/src/wt_protocol_events.rs
+++ b/tools/wta/src/wt_protocol_events.rs
@@ -1,0 +1,43 @@
+/// Publish raw JSON events to Windows Terminal in submission order.
+pub fn send(json_payload: String) {
+    let _ = publisher_sender().send(json_payload);
+}
+
+fn publisher_sender() -> &'static std::sync::mpsc::Sender<String> {
+    static SENDER: std::sync::OnceLock<std::sync::mpsc::Sender<String>> =
+        std::sync::OnceLock::new();
+    SENDER.get_or_init(|| {
+        let (tx, rx) = std::sync::mpsc::channel::<String>();
+        std::thread::Builder::new()
+            .name("wt-event-publisher".into())
+            .spawn(move || {
+                while let Ok(payload) = rx.recv() {
+                    publish_blocking(&payload);
+                }
+            })
+            .expect("spawn wt-event-publisher thread");
+        tx
+    })
+}
+
+fn publish_blocking(json_payload: &str) {
+    let exe = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(|directory| directory.join("wtcli.exe")))
+        .filter(|path| path.exists())
+        .unwrap_or_else(|| std::path::PathBuf::from("wtcli.exe"));
+    let mut command = std::process::Command::new(exe);
+    command.arg("publish").arg(json_payload);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(0x08000000);
+    }
+    command
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .stdin(std::process::Stdio::null());
+    if let Ok(mut child) = command.spawn() {
+        let _ = child.wait();
+    }
+}


### PR DESCRIPTION
## Summary
- move `AppEvent` and cross-boundary payload models into focused `app_contracts` modules
- remove the ACP client's reverse dependency on `crate::app`
- move ordered WT protocol event publishing into an infrastructure module
- preserve `app` re-exports so existing UI consumers remain unchanged

## Validation
- 1,176 WTA tests passed
- WTA debug build passed
- Clippy passed with the pre-existing `ui/recommendations.rs` `never_loop` lint allowed
- manual sanity: connection, messaging, tool/permission flow, and agent-pane stash/restore