### PR TITLE
Pin TUI thinking indicator above input

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1469,15 +1469,6 @@ pub struct TabSession {
     // Explicit per-turn lifecycle. Source of truth in the new state machine
     // (see `doc/specs/turn-state-refactor.md`).
     pub turn: TurnState,
-    /// One-way latch for the Thinking indicator.
-    ///
-    /// Rule: a newly submitted prompt shows Thinking only while it is waiting
-    /// for the first user-visible agent feedback. The first revealed text,
-    /// tool item, plan, permission card, or surfaced result clears this latch,
-    /// and it must never become true again during the same turn. Hidden thought
-    /// chunks and structured tokens that cannot yet render do not clear it.
-    pub waiting_for_first_visible_activity: bool,
-
     pub activity_frame: usize,
     /// Typewriter reveal cursor: how many characters of the *user-visible*
     /// streaming text are currently shown. The full text lives in
@@ -1619,12 +1610,8 @@ impl TabSession {
         self.chat_scroll.offset = 0;
     }
 
-    pub(crate) fn mark_visible_agent_activity(&mut self) {
-        self.waiting_for_first_visible_activity = false;
-    }
-
     pub(crate) fn should_show_thinking(&self) -> bool {
-        self.waiting_for_first_visible_activity && self.turn.is_in_flight()
+        self.turn.is_in_flight()
     }
 
     /// Whether the input box is the live, enterable caret target. False when
@@ -5129,19 +5116,11 @@ impl App {
                 // Clamp down if the visible text shrank (e.g. a fenced JSON
                 // block replaced the streamed prose).
                 tab.reveal_chars = len;
-                if len > 0 {
-                    tab.mark_visible_agent_activity();
-                }
                 continue;
             }
             let backlog = len - tab.reveal_chars;
             let step = REVEAL_MIN_STEP.max(backlog / REVEAL_CATCHUP_FRAMES);
             tab.reveal_chars = (tab.reveal_chars + step).min(len);
-            if tab.reveal_chars > 0 {
-                // The first character is now actually visible, so Thinking
-                // hands off permanently to the streamed response for this turn.
-                tab.mark_visible_agent_activity();
-            }
         }
     }
 

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -644,7 +644,6 @@ impl App {
                     .insert(id.clone(), (title.clone(), status.clone()));
                 tab.messages
                     .push(ChatMessage::ToolCall { id, title, status });
-                tab.mark_visible_agent_activity();
                 tab.scroll_to_bottom();
             }
             AppEvent::ToolCallUpdate {
@@ -692,7 +691,6 @@ impl App {
                     }
                 }
                 tab.messages.push(ChatMessage::Plan(entries));
-                tab.mark_visible_agent_activity();
                 tab.scroll_to_bottom();
             }
             AppEvent::PermissionRequest {
@@ -720,7 +718,6 @@ impl App {
                     selected: 0,
                     responder: Some(responder),
                 });
-                tab.mark_visible_agent_activity();
             }
             AppEvent::SystemMessage(message) => {
                 self.current_tab_mut()

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -6204,18 +6204,24 @@ fn tool_call_keeps_thinking_while_turn_is_in_flight() {
 
 #[test]
 fn thinking_is_pinned_one_row_above_input() {
+    const WIDTH: u16 = 80;
+    const HEIGHT: u16 = 24;
+
     let mut app = test_app();
     app.state = ConnectionState::Connected;
     submit_test_prompt(&mut app, "inspect");
 
-    let text = render_to_text(&mut app, 80, 24);
+    let input_height =
+        crate::ui::input_height(&app.current_tab().input, app.current_tab().cursor_pos, WIDTH);
+    let text = render_to_text(&mut app, WIDTH, HEIGHT);
     let label = t!("chat.activity_thinking").into_owned();
     let row = text
         .lines()
         .position(|line| line.contains(&label))
         .expect("Thinking row must render");
+    let expected_row = usize::from(HEIGHT - input_height - 1);
 
-    assert_eq!(row, 20, "Thinking must sit directly above the 3-row input box");
+    assert_eq!(row, expected_row, "Thinking must sit directly above the input box");
 }
 
 #[test]

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -4678,7 +4678,7 @@ fn perm_option_kind_matching_is_case_insensitive() {
 }
 
 #[test]
-fn permission_request_permanently_clears_thinking_latch() {
+fn permission_request_keeps_thinking_until_turn_ends() {
     let mut app = test_app();
     let prompt = SubmittedPrompt {
         id: 1,
@@ -4691,9 +4691,6 @@ fn permission_request_permanently_clears_thinking_latch() {
         outcome: TurnOutcome::Empty,
         end_pending: true,
     };
-    app.tab_mut(DEFAULT_TAB_ID)
-        .waiting_for_first_visible_activity = true;
-
     let (responder, _response) = tokio::sync::oneshot::channel();
     app.handle_event(AppEvent::PermissionRequest {
         session_id: DEFAULT_TAB_ID.into(),
@@ -4706,12 +4703,14 @@ fn permission_request_permanently_clears_thinking_latch() {
         responder,
     });
 
-    assert!(!app.current_tab().should_show_thinking());
+    assert!(app.current_tab().should_show_thinking());
     app.current_tab_mut().permission.pop_front();
-    assert!(
-        !app.current_tab().should_show_thinking(),
-        "resolving permission must not re-enable Thinking in the same turn"
-    );
+    assert!(app.current_tab().should_show_thinking());
+    let TurnState::Surfaced { end_pending, .. } = &mut app.current_tab_mut().turn else {
+        panic!("expected surfaced turn");
+    };
+    *end_pending = false;
+    assert!(!app.current_tab().should_show_thinking());
 }
 
 /// Tool-call card: when the mock proposes a command (a `ToolCall`
@@ -5944,9 +5943,8 @@ fn render_chat_completed_turn_expanded_with_marker() {
     }
 }
 
-/// Render: while the helper is still connecting, the chat must paint the
-/// animated "Connecting…" activity line. Lifts the `Connecting` branch of
-/// `build_activity_line` in `ui/chat.rs`.
+/// Render: while the helper is still connecting, the fixed activity row must
+/// paint the animated "Connecting…" label.
 #[test]
 fn render_chat_connecting_activity_line() {
     let mut app = test_app();
@@ -5980,7 +5978,7 @@ fn render_chat_welcome_hint() {
 }
 
 #[test]
-fn connecting_activity_row_is_included_in_estimated_chat_height() {
+fn fixed_activity_row_does_not_change_estimated_chat_height() {
     let mut app = test_app();
     app.current_tab_mut()
         .messages
@@ -5991,7 +5989,7 @@ fn connecting_activity_row_is_included_in_estimated_chat_height() {
     app.state = ConnectionState::Connecting("Starting agent".into());
     let with_activity = crate::ui::chat::estimated_block_height(&app, 80);
 
-    assert_eq!(with_activity, without_activity + 1);
+    assert_eq!(with_activity, without_activity);
     assert!(
         app.has_activity_indicator(),
         "Connecting must keep Tick redraws active for the shimmer"
@@ -6136,10 +6134,13 @@ fn first_message_chunk_transitions_to_streaming_with_buf() {
     assert!(app.current_tab().turn.is_streaming());
     assert!(
         app.current_tab().should_show_thinking(),
-        "Thinking remains until text is actually revealed"
+        "Thinking remains throughout the in-flight turn"
     );
     app.advance_reveal();
-    assert!(!app.current_tab().should_show_thinking());
+    assert!(
+        app.current_tab().should_show_thinking(),
+        "revealing response text must not hide Thinking before turn end"
+    );
 }
 
 #[test]
@@ -6158,7 +6159,7 @@ fn thought_chunk_first_transitions_with_empty_buf() {
 }
 
 #[test]
-fn hidden_structured_tokens_keep_thinking_until_explanation_is_visible() {
+fn structured_stream_keeps_thinking_after_explanation_is_visible() {
     let mut app = test_app();
     submit_test_prompt(&mut app, "hi");
     app.turn_observe_chunk(
@@ -6175,11 +6176,11 @@ fn hidden_structured_tokens_keep_thinking_until_explanation_is_visible() {
         r#","explanation":"Visible answer"}"#,
     );
     app.advance_reveal();
-    assert!(!app.current_tab().should_show_thinking());
+    assert!(app.current_tab().should_show_thinking());
 }
 
 #[test]
-fn tool_call_permanently_clears_thinking_latch() {
+fn tool_call_keeps_thinking_while_turn_is_in_flight() {
     let mut app = test_app();
     submit_test_prompt(&mut app, "inspect");
     app.handle_event(AppEvent::ToolCall {
@@ -6188,7 +6189,7 @@ fn tool_call_permanently_clears_thinking_latch() {
         title: "Find files".into(),
         status: "InProgress".into(),
     });
-    assert!(!app.current_tab().should_show_thinking());
+    assert!(app.current_tab().should_show_thinking());
 
     app.handle_event(AppEvent::ToolCallUpdate {
         session_id: DEFAULT_TAB_ID.into(),
@@ -6196,9 +6197,25 @@ fn tool_call_permanently_clears_thinking_latch() {
         status: "Completed".into(),
     });
     assert!(
-        !app.current_tab().should_show_thinking(),
-        "tool completion must not re-enable Thinking"
+        app.current_tab().should_show_thinking(),
+        "tool completion does not end the agent turn"
     );
+}
+
+#[test]
+fn thinking_is_pinned_one_row_above_input() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    submit_test_prompt(&mut app, "inspect");
+
+    let text = render_to_text(&mut app, 80, 24);
+    let label = t!("chat.activity_thinking").into_owned();
+    let row = text
+        .lines()
+        .position(|line| line.contains(&label))
+        .expect("Thinking row must render");
+
+    assert_eq!(row, 20, "Thinking must sit directly above the 3-row input box");
 }
 
 #[test]

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -70,7 +70,6 @@ impl App {
         tab.activity_frame = 0;
         tab.timing_note = None;
         tab.turn = TurnState::Submitted(prompt);
-        tab.waiting_for_first_visible_activity = true;
 
         // Submitting a new prompt dismisses any prior leftover card (the
         // `selected_recommendation = 0` + turn reset above). If the helper
@@ -407,7 +406,6 @@ impl App {
     fn turn_clear_agent_activity(&mut self, session_id: &str) {
         let tab = self.session_tab_mut(session_id);
         tab.activity_frame = 0;
-        tab.mark_visible_agent_activity();
     }
 
     /// User pressed Enter while a card was visible — dispatch the selected
@@ -573,7 +571,6 @@ impl App {
         tab.selected_button = 0;
         tab.rec_scroll.reset();
         tab.activity_frame = 0;
-        tab.mark_visible_agent_activity();
         tab.turn = TurnState::Idle;
 
         // Esc on a Send card or in-flight autofix exits the chip-override
@@ -622,7 +619,6 @@ impl App {
         tab.selection_visible_pending = true;
         tab.selected_completed_turn_idx = None;
         tab.activity_frame = 0;
-        tab.mark_visible_agent_activity();
         tab.turn = TurnState::Surfaced {
             prompt,
             outcome: TurnOutcome::Recommendation(recommendations),
@@ -701,7 +697,6 @@ impl App {
         tab.selected_recommendation = rec_idx;
         tab.selection_visible_pending = true;
         tab.activity_frame = 0;
-        tab.mark_visible_agent_activity();
         tab.turn = TurnState::Surfaced {
             prompt,
             outcome: TurnOutcome::Recommendation(recommendations),
@@ -786,7 +781,6 @@ impl App {
         tab.selected_button = 0;
         tab.rec_scroll.reset();
         tab.activity_frame = 0;
-        tab.mark_visible_agent_activity();
         tab.turn = TurnState::Surfaced {
             prompt,
             outcome: TurnOutcome::ChatTurn,

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -13,8 +13,8 @@ fn activity_label() -> String { t!("chat.activity_thinking").into_owned() }
 const MAX_RENDER_LINE_CHARS: usize = 4096;
 
 /// Estimate the chat block's natural height (in visual rows) given the
-/// rendering width. Counts wraps for each message + completed turn plus the
-/// pinned activity row when active. Used by `layout::render` to size the
+/// rendering width. Counts wraps for each message + completed turn. Used by
+/// `layout::render` to size the
 /// chat area so the rec panel sits directly below content instead of being
 /// pushed to the pane bottom by a `Min(1)` spacer.
 pub fn estimated_block_height(app: &App, area_width: u16) -> u16 {
@@ -24,16 +24,6 @@ pub fn estimated_block_height(app: &App, area_width: u16) -> u16 {
     // re-parses the streaming buffer on every call (and allocates on the
     // JSON-wrapper path via `extract_json_string_field`).
     let pending_text = pending_render_text(tab);
-
-    // Connecting and Thinking both pin one activity row in `render`; reserve
-    // that same row here so the surrounding layout cannot jump or clip.
-    let activity = if matches!(app.state, crate::app::ConnectionState::Connecting(_))
-        || should_show_turn_activity(tab)
-    {
-        1usize
-    } else {
-        0
-    };
 
     let messages: usize = tab.messages.iter().map(|m| message_height(m, wrap_width)).sum();
     let turns: usize = tab.completed_turns.iter().map(|t| turn_height(t, wrap_width)).sum();
@@ -57,7 +47,7 @@ pub fn estimated_block_height(app: &App, area_width: u16) -> u16 {
         0
     };
 
-    (activity + messages + turns + pending + welcome).max(1).min(u16::MAX as usize) as u16
+    (messages + turns + pending + welcome).max(1).min(u16::MAX as usize) as u16
 }
 
 fn wrap_count(text: &str, width: usize) -> usize {
@@ -167,20 +157,8 @@ fn breathing_dot(frame: usize) -> &'static str {
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let render_started = std::time::Instant::now();
 
-    // Pin the activity indicator to a dedicated bottom row when active so a
-    // long user prompt that wraps past the chat height can never push it
-    // off-screen. The remaining rows scroll normally.
-    let activity_line = build_activity_line(app);
-    let (chat_area, activity_area) = match (&activity_line, area.height) {
-        (Some(_), h) if h > 0 => (
-            Rect { height: h - 1, ..area },
-            Some(Rect { x: area.x, y: area.y + h - 1, width: area.width, height: 1 }),
-        ),
-        _ => (area, None),
-    };
-
     let inner = Block::default().borders(Borders::NONE);
-    let inner_area = inner.inner(chat_area);
+    let inner_area = inner.inner(area);
     let visible_height = inner_area.height as usize;
     let wrap_width = inner_area.width as usize;
     let requested_lines = visible_height
@@ -254,11 +232,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         .wrap(Wrap { trim: false })
         .scroll((scroll as u16, 0));
 
-    frame.render_widget(paragraph, chat_area);
-
-    if let (Some(line), Some(act_area)) = (activity_line, activity_area) {
-        frame.render_widget(Paragraph::new(line), act_area);
-    }
+    frame.render_widget(paragraph, area);
 
     // Update the scroll bound only when the build saw all of history;
     // otherwise the true max is still unknown and the stored value (possibly
@@ -376,7 +350,7 @@ fn build_completed_turn_lines<'a>(
     lines
 }
 
-fn build_activity_line(app: &App) -> Option<Line<'static>> {
+pub fn render_activity(frame: &mut Frame, app: &App, area: Rect) {
     // While the helper is still establishing its connection to the agent,
     // show an animated "Connecting to agent…" line (F7). The handshake
     // (pipe connect → ACP init → session/new) can take tens of seconds on a
@@ -386,17 +360,20 @@ fn build_activity_line(app: &App) -> Option<Line<'static>> {
     // turn spinner because no turn can be in flight before we're connected.
     if matches!(app.state, crate::app::ConnectionState::Connecting(_)) {
         let label = t!("connection.connecting_activity").into_owned();
-        return Some(Line::from(shimmer::shimmer_spans(&label, app.activity_frame as usize)));
+        let line = Line::from(shimmer::shimmer_spans(&label, app.activity_frame as usize));
+        frame.render_widget(Paragraph::new(line), area);
+        return;
     }
     let tab = app.current_tab();
     if !should_show_turn_activity(tab) {
-        return None;
+        return;
     }
     let label = activity_label();
-    Some(Line::from(shimmer::shimmer_spans(
+    let line = Line::from(shimmer::shimmer_spans(
         &label,
         tab.activity_frame,
-    )))
+    ));
+    frame.render_widget(Paragraph::new(line), area);
 }
 
 /// Incrementally extracts a JSON string field's decoded value from a
@@ -1052,20 +1029,12 @@ mod tests {
     }
 
     #[test]
-    fn thinking_activity_is_a_one_way_per_prompt_latch() {
+    fn thinking_activity_follows_turn_lifecycle() {
         let mut tab = streaming_tab("", 0);
-        tab.waiting_for_first_visible_activity = true;
         assert!(should_show_turn_activity(&tab));
 
-        tab.mark_visible_agent_activity();
+        tab.turn = crate::app::TurnState::Idle;
         assert!(!should_show_turn_activity(&tab));
-
-        tab.tool_calls
-            .insert("tool".into(), ("Run tests".into(), "Completed".into()));
-        assert!(
-            !should_show_turn_activity(&tab),
-            "later activity changes must not re-enable Thinking"
-        );
     }
 
     #[test]

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -132,8 +132,9 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     //
     // Layout: chat sized to its content, rec panel right below, blank
     // filler, optional one-row transient hint, optional one-row rec nav
-    // hint (sits directly above the input box whenever recs are visible),
-    // input at the bottom. Cap chat at `pane_height - rec - input - hints`
+    // hint, a permanently reserved activity row directly above the input,
+    // and input at the bottom. Cap chat at
+    // `pane_height - rec - input - activity - hints`
     // so the recommendation card always renders in full — chat_scroll lets
     // the user reach older history if it overflows.
     let chat_content_width = main_area.width.saturating_sub(2); // h_chat 1+1 padding
@@ -142,7 +143,8 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         .saturating_add(perm_panel_h)
         .saturating_add(input_height)
         .saturating_add(hint_h)
-        .saturating_add(rec_hint_h);
+        .saturating_add(rec_hint_h)
+        .saturating_add(1);
     let chat_max = main_area.height.saturating_sub(reserved_below).max(1);
     let chat_height = chat_estimate.min(chat_max);
     let chunks = Layout::default()
@@ -154,6 +156,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             Constraint::Min(0),
             Constraint::Length(hint_h),
             Constraint::Length(rec_hint_h),
+            Constraint::Length(1),
             Constraint::Length(input_height),
         ])
         .split(main_area);
@@ -183,6 +186,14 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             Constraint::Length(1),
         ])
         .split(chunks[2]);
+    let h_activity = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(0),
+            Constraint::Length(1),
+        ])
+        .split(chunks[6]);
 
     chat::render(frame, app, h_chat[1]);
     app.sync_rec_scroll_max(main_area.width);
@@ -214,30 +225,31 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     if app.current_tab().turn.recommendations().is_some() {
         recommendations::render_hint(frame, chunks[5]);
     }
-    input::render(frame, app, chunks[6]);
+    chat::render_activity(frame, app, h_activity[1]);
+    input::render(frame, app, chunks[7]);
 
     if let Some(debug_area) = debug_area {
         debug_panel::render(frame, app, debug_area);
     }
 
     // Slash-command autocomplete: pinned directly above the input box
-    // (`chunks[6]`). Anchoring to the input box rather than the filler row
+    // (`chunks[7]`). Anchoring to the input box rather than the filler row
     // keeps the popup glued to the input regardless of how much empty space
     // sits above it — otherwise a short chat leaves a tall filler and the
     // popup floats far up the pane (worst in side-by-side layouts).
     if let Some(popup_state) = app.command_popup_state() {
-        command_popup::render_popup(frame, popup_state, chunks[6]);
+        command_popup::render_popup(frame, popup_state, chunks[7]);
     }
 
     // `/model` picker modal: same anchor as the autocomplete popup. The two
     // are mutually exclusive — opening the picker clears the input, so the
     // command popup isn't visible while it's up.
     if let Some(model_state) = app.model_popup_state() {
-        model_popup::render_popup(frame, model_state, chunks[6]);
+        model_popup::render_popup(frame, model_state, chunks[7]);
     }
 
     if let Some(agent_state) = app.agent_popup_state() {
-        agent_popup::render_popup(frame, agent_state, chunks[6]);
+        agent_popup::render_popup(frame, agent_state, chunks[7]);
     }
 
     // `/help` overlay sits on top of everything so the user can always

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -134,7 +134,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     // filler, optional one-row transient hint, optional one-row rec nav
     // hint, a permanently reserved activity row directly above the input,
     // and input at the bottom. Cap chat at
-    // `pane_height - rec - input - activity - hints`
+    // `pane_height - rec - permission - input - activity - hints`
     // so the recommendation card always renders in full — chat_scroll lets
     // the user reach older history if it overflows.
     let chat_content_width = main_area.width.saturating_sub(2); // h_chat 1+1 padding

--- a/tools/wta/src/ui/mod.rs
+++ b/tools/wta/src/ui/mod.rs
@@ -16,6 +16,7 @@ pub mod shimmer;
 
 pub use agent_popup::AgentPopupState;
 pub use command_popup::{PopupCandidates, PopupState};
+pub(crate) use input::input_height;
 pub use layout::render;
 pub use model_popup::ModelPopupState;
 pub use shimmer::CYCLE_FRAMES as ACTIVITY_CYCLE_FRAMES;

--- a/tools/wta/src/ui/mod.rs
+++ b/tools/wta/src/ui/mod.rs
@@ -16,6 +16,7 @@ pub mod shimmer;
 
 pub use agent_popup::AgentPopupState;
 pub use command_popup::{PopupCandidates, PopupState};
+#[cfg(test)]
 pub(crate) use input::input_height;
 pub use layout::render;
 pub use model_popup::ModelPopupState;


### PR DESCRIPTION
## Summary
- reserve a fixed activity row directly above the TUI input box
- keep Thinking visible for the entire in-flight turn
- remove the first-visible-activity latch and chat-area positioning

## Testing
- cargo test --manifest-path tools/wta/Cargo.toml (1195 passed)
- built, deployed, and launched the x64 Debug package for manual verification

<img width="793" height="1112" alt="image" src="https://github.com/user-attachments/assets/0de3dc3b-b5c8-4c51-ba31-6ddba657aa7d" />
