### PR TITLE
Upgrade Rust ACP SDK to 1.3.0

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -557,8 +557,8 @@ requirements are met without embedding any single crate's license body as
 if it were canonical for the whole group.
 
 - **adler2** v2.0.1 -- [https://github.com/oyvindln/adler2](https://github.com/oyvindln/adler2) -- `0BSD OR Apache-2.0 OR MIT`
-- **agent-client-protocol** v1.2.0 -- [https://github.com/agentclientprotocol/rust-sdk](https://github.com/agentclientprotocol/rust-sdk) -- `Apache-2.0`
-- **agent-client-protocol-derive** v1.2.0 -- [https://github.com/agentclientprotocol/rust-sdk](https://github.com/agentclientprotocol/rust-sdk) -- `Apache-2.0`
+- **agent-client-protocol** v1.3.0 -- [https://github.com/agentclientprotocol/rust-sdk](https://github.com/agentclientprotocol/rust-sdk) -- `Apache-2.0`
+- **agent-client-protocol-derive** v1.3.0 -- [https://github.com/agentclientprotocol/rust-sdk](https://github.com/agentclientprotocol/rust-sdk) -- `Apache-2.0`
 - **agent-client-protocol-schema** v1.4.0 -- [https://github.com/agentclientprotocol/agent-client-protocol](https://github.com/agentclientprotocol/agent-client-protocol) -- `Apache-2.0`
 - **aho-corasick** v1.1.4 -- [https://github.com/BurntSushi/aho-corasick](https://github.com/BurntSushi/aho-corasick) -- `MIT OR Unlicense`
 - **allocator-api2** v0.2.21 -- [https://github.com/zakarumych/allocator-api2](https://github.com/zakarumych/allocator-api2) -- `Apache-2.0 OR MIT`
@@ -856,7 +856,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 ### `Apache-2.0`
 
-Applies to 190 crate(s) (directly or via composite identifiers): adler2 v2.0.1, agent-client-protocol v1.2.0, agent-client-protocol-derive v1.2.0, agent-client-protocol-schema v1.4.0, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, ... (+182 more)
+Applies to 190 crate(s) (directly or via composite identifiers): adler2 v2.0.1, agent-client-protocol v1.3.0, agent-client-protocol-derive v1.3.0, agent-client-protocol-schema v1.4.0, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, ... (+182 more)
 
 _Canonical text reproduced from upstream `SPDX:Apache-2.0`:_
 

--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -66,7 +66,7 @@ a single implementation today:
 
 ### ACP (Agent Client Protocol)
 
-ACP (`agent-client-protocol = "0.10"`, JSON-RPC 2.0) is spoken on **two hops**,
+ACP (`agent-client-protocol = "1.3.0"`, JSON-RPC 2.0) is spoken on **two hops**,
 because of the helper+master split:
 
 - **master ↔ agent CLI** (stdio): master is the ACP **client** of the agent CLI
@@ -241,7 +241,7 @@ green build says nothing about the tests.
 
 | Crate | Version | Purpose |
 |-------|---------|---------|
-| `agent-client-protocol` | 0.10 | ACP client library |
+| `agent-client-protocol` | 1.3.0 | ACP client library |
 | `tokio` | 1 | Async runtime |
 | `ratatui` | 0.30 | TUI rendering |
 | `crossterm` | 0.29 | Terminal I/O |

--- a/tools/wta/Cargo.lock
+++ b/tools/wta/Cargo.lock
@@ -10,17 +10,19 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-client-protocol"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882b815ffa67b023e1b40e7ea3bab3f05869654e8565d6811870c5545285e1d3"
+checksum = "1d386d6a58f4dbe0ebfa98e915caa54005dabdefd419de3d4678b28cd5752444"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
+ "async-io",
  "async-process",
  "blocking",
  "futures",
  "futures-concurrency",
  "rustc-hash",
+ "rustix",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -32,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5ca63f112bd2459bcaf9eda0683b9ba95fc3b5e5fdd9036ca941c6a09345b1"
+checksum = "97b94934d118a69e921d14e94d4af5b3076563318c52662c89a0ecb3f139e1da"
 dependencies = [
  "quote",
  "syn 2.0.117",

--- a/tools/wta/Cargo.toml
+++ b/tools/wta/Cargo.toml
@@ -10,7 +10,7 @@ name = "wta"
 path = "src/main.rs"
 
 [dependencies]
-agent-client-protocol = { version = "1.2.0" }
+agent-client-protocol = { version = "1.3.0" }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 async-trait = "0.1"

--- a/tools/wta/OVERVIEW.md
+++ b/tools/wta/OVERVIEW.md
@@ -147,7 +147,7 @@ this way too — by shelling out to `wta` / `wtcli`, **not** via an MCP server.)
 
 ### WTA ↔ AI Agent (ACP, two hops)
 
-ACP (`agent-client-protocol = "0.10"`, JSON-RPC 2.0) is spoken on two hops:
+ACP (`agent-client-protocol = "1.3.0"`, JSON-RPC 2.0) is spoken on two hops:
 
 - **master ↔ agent CLI** (stdio): master is the ACP **client**; it spawns and
   owns the agent CLI.
@@ -173,7 +173,7 @@ ACP (`agent-client-protocol = "0.10"`, JSON-RPC 2.0) is spoken on two hops:
 | Async runtime | tokio |
 | CLI parsing | clap 4 |
 | TUI rendering | ratatui 0.30 + crossterm 0.29 |
-| ACP protocol | agent-client-protocol 0.10 |
+| ACP protocol | agent-client-protocol 1.3.0 |
 | Serialization | serde + serde_json |
 | Error handling | anyhow |
 | i18n | rust-i18n |

--- a/tools/wta/cgmanifest.json
+++ b/tools/wta/cgmanifest.json
@@ -15,7 +15,7 @@
         "type": "cargo",
         "cargo": {
           "name": "agent-client-protocol",
-          "version": "1.2.0"
+          "version": "1.3.0"
         }
       }
     },
@@ -24,7 +24,7 @@
         "type": "cargo",
         "cargo": {
           "name": "agent-client-protocol-derive",
-          "version": "1.2.0"
+          "version": "1.3.0"
         }
       }
     },


### PR DESCRIPTION
## Summary of the Pull Request

Upgrade WTA's Rust `agent-client-protocol` dependency from 1.2.0 to 1.3.0.

## References and Relevant Issues

N/A

## Detailed Description of the Pull Request / Additional comments

- Updates `agent-client-protocol` and `agent-client-protocol-derive` to 1.3.0.
- Refreshes the current WTA architecture documentation to match the resolved ACP SDK version.
- Regenerates Component Governance metadata and third-party notices.

## Validation Steps Performed

- `cargo test --manifest-path tools\wta\Cargo.toml` (1195 passed)

## PR Checklist
- [ ] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated (repository-internal WTA architecture docs; MicrosoftDocs update not applicable)
- [ ] Schema updated (not necessary)