### PR TITLE
Move WTA failure classification into ACP domain

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -239,57 +239,21 @@ pub struct SetupState {
     pub subtitle: String,
 }
 
-/// True for the auth failures a post-login reconnect can hit when the shared
-/// master CLI was spawned with a stale token: the plain `AuthRequired`, AND the
-/// `HandshakeFailed { stage: NewSession }` that the pipe client wraps a
-/// still-`AuthRequired` `new_session` into after a *successful* `authenticate`
-/// (the Copilot CLI does not refresh its in-process auth on `authenticate`, so
-/// only respawning it recovers — see `run_acp_client_over_pipe`).
-///
-/// Deliberately does NOT match `HandshakeFailed { stage: Authenticate }`: that
-/// is a genuine `authenticate` RPC rejection or timeout (the credentials were
-/// not accepted / the agent hung), which a master restart would not fix — it
-/// routes to the sign-in screen via the normal `AgentError` path instead.
-fn is_post_login_auth_failure(failure: &crate::protocol::acp::failure::AgentFailure) -> bool {
-    use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
-    matches!(
-        failure,
-        AgentFailure::AuthRequired { .. }
-            | AgentFailure::HandshakeFailed {
-                stage: HandshakeStage::NewSession,
-                ..
-            }
-    )
-}
-
-/// True when a post-login reconnect could not even reach wta-master.
-///
-/// This is distinct from auth failure: after the IT setup flow installs Copilot,
-/// the old master may already be gone because it was spawned while `copilot`
-/// was missing. Login succeeds in the browser, but reconnecting to the saved
-/// pipe fails before initialize/authenticate/new_session can run. The right
-/// recovery is still the same fresh-master restart used for stale auth state.
-fn is_post_login_master_unavailable(
-    failure: &crate::protocol::acp::failure::AgentFailure,
-) -> bool {
-    use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
-    matches!(
-        failure,
-        AgentFailure::HandshakeFailed {
-            stage: HandshakeStage::PipeConnect,
-            ..
-        }
-    )
-}
-
+/// Decide whether a failed post-login reconnect should respawn the shared
+/// master. External-auth agents need this when the old process retained stale
+/// credentials through `session/new`; every agent needs it when the old master
+/// is no longer reachable. Other handshake failures follow normal error policy.
 fn should_trigger_post_login_recovery(
     post_login_auth: bool,
     is_external_auth_agent: bool,
     failure: &crate::protocol::acp::failure::AgentFailure,
 ) -> bool {
+    use crate::protocol::acp::failure::HandshakeStage;
+
     post_login_auth
-        && ((is_external_auth_agent && is_post_login_auth_failure(failure))
-            || is_post_login_master_unavailable(failure))
+        && ((is_external_auth_agent
+            && (failure.is_auth() || failure.failed_at(HandshakeStage::NewSession)))
+            || failure.failed_at(HandshakeStage::PipeConnect))
 }
 
 /// Build the diagnostic setup options list based on the configured agent state:

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -3538,65 +3538,6 @@ fn transport_loss_surfaces_restart_hint_even_behind_another_error() {
     assert_eq!(n, 1, "identical connection.lost must not duplicate");
 }
 
-/// `is_post_login_auth_failure` must catch BOTH the plain `AuthRequired`
-/// and the `HandshakeFailed { NewSession }` the pipe client wraps a
-/// still-AuthRequired post-login `new_session` into — `is_auth()` alone
-/// would miss the latter and the auth recovery would never fire. It must
-/// NOT match `HandshakeFailed { Authenticate }` (a genuine authenticate
-/// RPC rejection/timeout) — that routes to sign-in, not a master restart.
-#[test]
-fn post_login_auth_failure_matches_auth_required_and_handshake_new_session() {
-    use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
-    assert!(is_post_login_auth_failure(&AgentFailure::AuthRequired {
-        message: "auth".to_string()
-    }));
-    assert!(is_post_login_auth_failure(&AgentFailure::HandshakeFailed {
-        stage: HandshakeStage::NewSession,
-        detail: "still auth after authenticate".to_string()
-    }));
-    // An authenticate-RPC rejection/timeout must NOT trigger auth recovery
-    // (a master restart can't fix bad credentials) — it routes to sign-in.
-    assert!(!is_post_login_auth_failure(&AgentFailure::HandshakeFailed {
-        stage: HandshakeStage::Authenticate,
-        detail: "authenticate rejected/timed out".to_string()
-    }));
-    // A non-auth handshake stage must NOT trigger auth recovery.
-    assert!(!is_post_login_auth_failure(&AgentFailure::HandshakeFailed {
-        stage: HandshakeStage::Initialize,
-        detail: "boom".to_string()
-    }));
-}
-
-#[test]
-fn post_login_master_unavailable_matches_only_pipe_connect() {
-    use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
-
-    assert!(is_post_login_master_unavailable(
-        &AgentFailure::HandshakeFailed {
-            stage: HandshakeStage::PipeConnect,
-            detail: "pipe missing".to_string()
-        }
-    ));
-    assert!(!is_post_login_master_unavailable(
-        &AgentFailure::HandshakeFailed {
-            stage: HandshakeStage::Initialize,
-            detail: "init failed".to_string()
-        }
-    ));
-    assert!(!is_post_login_master_unavailable(
-        &AgentFailure::HandshakeFailed {
-            stage: HandshakeStage::Authenticate,
-            detail: "auth failed".to_string()
-        }
-    ));
-    assert!(!is_post_login_master_unavailable(
-        &AgentFailure::HandshakeFailed {
-            stage: HandshakeStage::NewSession,
-            detail: "session failed".to_string()
-        }
-    ));
-}
-
 #[test]
 fn typed_pipe_connect_failure_survives_classify_anyhow() {
     use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
@@ -3640,6 +3581,18 @@ fn post_login_recovery_route_covers_pipe_connect_without_external_auth_gate() {
         "non-post-login pipe failures should surface normally"
     );
 
+    let auth_required = AgentFailure::AuthRequired {
+        message: "auth".to_string(),
+    };
+    assert!(
+        should_trigger_post_login_recovery(true, true, &auth_required),
+        "external post-login auth failures should recover via a fresh master"
+    );
+    assert!(
+        !should_trigger_post_login_recovery(true, false, &auth_required),
+        "non-external auth failures should route to sign-in"
+    );
+
     let still_auth = AgentFailure::HandshakeFailed {
         stage: HandshakeStage::NewSession,
         detail: "still auth".to_string(),
@@ -3651,6 +3604,15 @@ fn post_login_recovery_route_covers_pipe_connect_without_external_auth_gate() {
     assert!(
         !should_trigger_post_login_recovery(true, false, &still_auth),
         "non-external auth failures should not use auth-stale recovery"
+    );
+
+    let authenticate_failed = AgentFailure::HandshakeFailed {
+        stage: HandshakeStage::Authenticate,
+        detail: "authenticate rejected".to_string(),
+    };
+    assert!(
+        !should_trigger_post_login_recovery(true, true, &authenticate_failed),
+        "authenticate failures should route to sign-in instead of restarting master"
     );
 }
 

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -2555,8 +2555,8 @@ pub async fn run_acp_client_over_pipe(
                 // but new_session STILL returns AuthRequired, do NOT route
                 // back to the login screen (that would recreate the auth
                 // loop). Surface a terminal HandshakeFailed tagged with the
-                // `NewSession` stage — the DISTINCT signal the App's auth
-                // recovery matches on (`is_post_login_auth_failure`). This is
+                // `NewSession` stage — the distinct signal the App's
+                // post-login recovery policy matches via `failed_at`. This is
                 // deliberately NOT the `Authenticate` stage: an authenticate
                 // RPC that itself fails/times out (above) stays `Authenticate`
                 // and must NOT trigger a master restart, only this

--- a/tools/wta/src/protocol/acp/failure.rs
+++ b/tools/wta/src/protocol/acp/failure.rs
@@ -104,6 +104,15 @@ impl AgentFailure {
         matches!(self, AgentFailure::Cancelled)
     }
 
+    /// True when this failure occurred at the specified startup handshake
+    /// stage. Recovery policy remains with the caller.
+    pub fn failed_at(&self, expected: HandshakeStage) -> bool {
+        matches!(
+            self,
+            AgentFailure::HandshakeFailed { stage, .. } if *stage == expected
+        )
+    }
+
     /// Short, stable class label for structured logging (`target=failure`).
     pub fn class(&self) -> &'static str {
         match self {
@@ -213,6 +222,17 @@ mod tests {
     fn cancelled_code_classifies_as_cancelled() {
         let e = acp::Error::new(-32800, "cancelled");
         assert!(AgentFailure::from_acp_error(&e).is_cancelled());
+    }
+
+    #[test]
+    fn failed_at_matches_only_the_handshake_stage() {
+        let failure = AgentFailure::HandshakeFailed {
+            stage: HandshakeStage::NewSession,
+            detail: "session failed".into(),
+        };
+        assert!(failure.failed_at(HandshakeStage::NewSession));
+        assert!(!failure.failed_at(HandshakeStage::Authenticate));
+        assert!(!AgentFailure::TransportLost.failed_at(HandshakeStage::NewSession));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a neutral handshake-stage query to `AgentFailure`
- remove App-local destructuring helpers for ACP failures
- keep post-login master restart decisions in the App recovery policy
- move pure failure classification coverage into the ACP failure module

## Design
This is a behavior-preserving ownership change. The ACP failure domain answers what kind of failure occurred; App continues to decide whether a post-login failure should restart the shared master.

Tracks #515.

## Validation
- focused ACP failure and post-login recovery tests
- `cargo test --manifest-path tools/wta/Cargo.toml` (1,194 passed)
- `cargo clippy --manifest-path tools/wta/Cargo.toml --all-targets -- -A clippy::never_loop`
- `cargo build --manifest-path tools/wta/Cargo.toml`
- manual smoke test of agent connection and chat