### PR TITLE
Separate WTA CLI args from runtime config

### DIFF
--- a/tools/wta/src/cli/args.rs
+++ b/tools/wta/src/cli/args.rs
@@ -1,0 +1,519 @@
+use clap::{Parser, Subcommand};
+
+use crate::{agent_hooks_installer, agent_registry, agent_sessions, resolve_command};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "wta",
+    about = "Windows Terminal Agent — ACP TUI client / tmux-like CLI"
+)]
+pub(crate) struct Cli {
+    #[command(subcommand)]
+    pub(crate) command: Option<Command>,
+
+    /// Initial prompt to send to the agent (ACP mode only)
+    #[arg(value_name = "PROMPT")]
+    pub(crate) prompt: Option<String>,
+
+    /// Agent CLI command (e.g. "copilot --acp --stdio")
+    #[arg(long, default_value = agent_registry::DEFAULT_ACP_COMMAND)]
+    pub(crate) agent: String,
+
+    /// Canonical agent identifier (`copilot` / `claude` / `codex` / `gemini`
+    /// / `opencode` / `custom:<name>`). When the host (Windows Terminal) launches wta it
+    /// already knows which entry the user picked in settings, so it passes
+    /// the original `acpAgent` value through here. wta uses this id as the
+    /// authoritative identity for `current_agent_id` — driving the session-
+    /// management view's CLI filter, the preflight check, etc.
+    ///
+    /// When omitted (manual `wta` runs, older host builds, tests) wta falls
+    /// back to inferring the id by parsing the `--agent` command line via
+    /// `agent_registry::resolve_agent_id_from_cmd`. That fallback works for
+    /// bare names but is fragile for adapter-style launches (`npx … claude-
+    /// code-acp`) and full-path launches, so the host should always pass
+    /// `--agent-id` explicitly.
+    #[arg(long)]
+    pub(crate) agent_id: Option<String>,
+
+    /// Per-tab ACP execution source (`host` or `wsl`). Hidden because
+    /// TerminalPage owns source compatibility checks.
+    #[arg(long, hide = true, value_parser = ["host", "wsl"])]
+    pub(crate) agent_source: Option<String>,
+
+    /// WSL distro paired with `--agent-source wsl`.
+    #[arg(long, hide = true)]
+    pub(crate) agent_wsl_distro: Option<String>,
+
+    /// Working-pane cwd captured when this helper was created.
+    #[arg(long, hide = true)]
+    pub(crate) agent_source_cwd: Option<String>,
+
+    /// Master-only allowlist of agent ids a helper may request over the
+    /// pipe (the GPO-filtered set; built by TerminalPage::
+    /// _BuildSharedWtaExtraArgs from `FilteredAcpAgents()`). The master
+    /// reconstructs a helper's requested agent command from its declared
+    /// `agent_id` ONLY when that id is in this set — never executing a
+    /// command string sent over the pipe. An id outside the set (or a
+    /// custom/unknown id) falls back to `--agent` / `--agent-id`. An *absent*
+    /// flag means "no host allowlist" (manual runs, older hosts): the master
+    /// accepts any *known* agent id. A *present* flag is honored fail-closed —
+    /// even when it filters down to nothing, every helper-selected id is then
+    /// blocked (all panes fall back to the default) rather than widening back
+    /// to accept-any. Helpers use the same list only to filter `/agent`;
+    /// the master remains the authoritative enforcement point.
+    #[arg(long, hide = true, value_name = "IDS", value_delimiter = ',')]
+    pub(crate) allowed_agent_ids: Vec<String>,
+
+    /// Boot-time hint from Windows Terminal: start directly on the auth screen
+    /// for the given agent instead of attempting the initial ACP session. Used
+    /// when FRE just installed Copilot, where the next expected action is
+    /// signing in. Hidden — only Windows Terminal should pass it.
+    #[arg(long, hide = true, value_name = "AGENT_ID")]
+    pub(crate) initial_auth_agent: Option<String>,
+
+    /// Model override for the ACP agent. Sent via ACP setSessionModel after
+    /// handshake. Used by adapter-style launches (claude, codex via npx)
+    /// where the model can't be passed on the command line; native ACP
+    /// agents may use their own --model flag in `agent`.
+    #[arg(long)]
+    pub(crate) acp_model: Option<String>,
+
+    /// Delegate agent CLI command (e.g. "codex")
+    #[arg(long)]
+    pub(crate) delegate_agent: Option<String>,
+
+    /// Model override for the delegate agent
+    #[arg(long)]
+    pub(crate) delegate_model: Option<String>,
+
+    /// Disable auto-fix on command failure
+    #[arg(long)]
+    pub(crate) no_autofix: bool,
+
+    /// Enter diagnostic setup mode with the given reason instead of connecting directly.
+    /// Values: agent-missing, agent-error
+    #[arg(long)]
+    pub(crate) setup: Option<String>,
+
+    /// Initial TUI view to show on startup. `chat` (default) starts in the
+    /// chat view; `sessions` starts in the Agents (session list) view —
+    /// equivalent to the user pressing Ctrl+Shift+/ right after the pane opens.
+    /// Wired to WT's Ctrl+Shift+/ binding via TerminalPage.
+    #[arg(long, value_enum, default_value_t = InitialView::Chat)]
+    pub(crate) initial_view: InitialView,
+
+    /// UI language override, passed by Windows Terminal from the
+    /// `settings.json` `Language` field. When present, wta uses this
+    /// directly for i18n instead of detecting the OS locale — ensuring
+    /// the agent pane displays the same language as the Terminal chrome.
+    /// When absent, wta falls back to `sys_locale` (automatic detection).
+    #[arg(long)]
+    pub(crate) language: Option<String>,
+
+    /// Stable GUID of the WT tab that owns this wta process. Passed in by
+    /// TerminalPage when spawning the agent pane (both _OpenOrReuseAgentPane
+    /// and _AutoCreateHiddenAgentPane). Seeded into app_state.tab_id before
+    /// ACP init, so the first AgentConnected binds the session under the
+    /// real tab GUID instead of falling back to the implicit DEFAULT_TAB_ID
+    /// placeholder. Hidden because nothing outside WT should be setting it.
+    #[arg(long, hide = true)]
+    pub(crate) owner_tab_id: Option<String>,
+
+    /// Window ID of the WT window that owns this helper. Passed alongside
+    /// `--owner-tab-id` because PID-based pane discovery is best-effort and
+    /// may not find a newly spawned ConPTY helper before `/agent` is used.
+    #[arg(long, hide = true)]
+    pub(crate) owner_window_id: Option<String>,
+
+    /// Boot-time hint: instead of letting the helper create a fresh ACP
+    /// session via `session/new`, immediately resume the given session id
+    /// via `session/load`. Used by the "Enter on Historical/Ended row in
+    /// session manager" path: C++ spawns a new helper for the new
+    /// agent pane and bundles the resume request via these flags so the
+    /// resume is atomic — no separate `load_session` VT broadcast that
+    /// could race the helper's pipe-attach.
+    ///
+    /// Pair with `--initial-load-cwd`. Hidden — only Windows Terminal
+    /// should pass it. No-op outside `--connect-master` (only the helper
+    /// boot path consumes it).
+    #[arg(long, hide = true, value_name = "SESSION_ID")]
+    pub(crate) initial_load_session_id: Option<String>,
+
+    /// Working directory associated with `--initial-load-session-id`.
+    /// Passed to the agent CLI via the ACP `session/load` request so the
+    /// resumed conversation runs against the right repo root. Hidden.
+    #[arg(long, hide = true, value_name = "PATH")]
+    pub(crate) initial_load_cwd: Option<String>,
+
+    /// Pre-warm mode: the helper is being spawned for a tab whose agent
+    /// pane is *already stashed* on the C++ side (see TerminalPage::
+    /// _AutoCreateHiddenAgentPaneShared autoStash path). Without this
+    /// flag, the helper's `--owner-tab-id` startup branch seeds
+    /// `tab.pane_open = true` and echoes back `agent_state_changed
+    /// { pane_open: true }`, which C++ interprets as "user opened the
+    /// pane" and unstashes it — defeating pre-warm. With this flag the
+    /// helper seeds `tab.pane_open = false`, matching the C++ stash
+    /// state. Hidden because only WT's pre-warm path should set it.
+    #[arg(long, hide = true)]
+    pub(crate) start_stashed: bool,
+
+    /// Degraded-open mode: the helper is being spawned for a pane the user
+    /// opened *while wta-master is known to be down* (it died unexpectedly and
+    /// hasn't been recovered via /restart — see C++ `SharedWta::IsDegraded`).
+    /// Rather than the helper retrying the dead master pipe for ~75s and
+    /// showing a spinner, it comes up immediately in the disconnected state
+    /// (the same transport-lost view an orphaned pane shows), so the user can
+    /// /restart right there instead of hunting for another pane. Hidden — only
+    /// WT's degraded-open path should set it.
+    #[arg(long, hide = true)]
+    pub(crate) assume_master_down: bool,
+
+    // Legacy flags (hidden, backward compat)
+    #[arg(long, hide = true)]
+    pub(crate) info: bool,
+    #[arg(long, hide = true)]
+    pub(crate) test_pipe: bool,
+
+    /// Output raw JSON instead of human-readable format
+    #[arg(long, global = true)]
+    pub(crate) json: bool,
+
+    /// Run as the wta-master singleton (Z architecture). Listens on
+    /// the named pipe whose name is passed here for wta-helper
+    /// connections; owns the single ACP connection to the agent CLI
+    /// subprocess; multiplexes per-helper ACP sessions onto it. Used
+    /// by `SharedWta::AcquirePane` on the C++ side. Hidden — only
+    /// Windows Terminal should spawn it.
+    ///
+    /// Pipe name is typically `\\.\pipe\wta-master-<GUID>`.
+    #[arg(long, hide = true, value_name = "PIPE_NAME")]
+    pub(crate) master: Option<String>,
+
+    /// Connect to a wta-master singleton over the named pipe whose
+    /// path is passed here, rather than spawning our own agent CLI
+    /// subprocess. Used when this wta is acting as a per-pane helper
+    /// in the helper+master architecture (see
+    /// doc/specs/Multi-window-agent-pane.md). Hidden — only the C++
+    /// side should pass it.
+    ///
+    /// Logically mutually exclusive with `--master`: a process can be
+    /// either the master or a helper, never both. Enforced by clap so
+    /// a misconfigured invocation fails fast instead of silently
+    /// preferring `--master` (the previous behavior).
+    #[arg(long, hide = true, value_name = "PIPE_NAME", conflicts_with = "master")]
+    pub(crate) connect_master: Option<String>,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum Command {
+    /// Show Windows Terminal protocol connection info
+    Info,
+    /// Test protocol connection to Windows Terminal
+    TestPipe,
+    /// List all Windows Terminal windows
+    #[command(alias = "lsw")]
+    ListWindows,
+    /// List tabs in a window
+    #[command(alias = "lst")]
+    ListTabs {
+        /// Window ID (defaults to first window)
+        #[arg(short = 'w', long)]
+        window_id: Option<String>,
+    },
+    /// List panes in a tab
+    #[command(alias = "lsp")]
+    ListPanes {
+        /// Tab ID (defaults to active tab)
+        #[arg(short = 't', long)]
+        tab_id: Option<String>,
+        /// Window ID (used with tab_id)
+        #[arg(short = 'w', long)]
+        window_id: Option<String>,
+    },
+    /// Identify a command using the user's PowerShell profile
+    ResolveCommand {
+        /// Command name to identify (without arguments or a path)
+        #[arg(value_parser = resolve_command::parse_non_empty)]
+        token: String,
+        /// PowerShell executable to use
+        #[arg(long, default_value = "pwsh.exe", value_parser = resolve_command::parse_non_empty)]
+        shell: String,
+    },
+    /// Create a new tab
+    #[command(alias = "neww")]
+    NewTab {
+        /// Command to run in the new tab
+        #[arg(short = 'c', long)]
+        command: Option<String>,
+        /// Working directory
+        #[arg(short = 'd', long)]
+        cwd: Option<String>,
+        /// Tab title
+        #[arg(short = 'n', long)]
+        title: Option<String>,
+    },
+    /// Split the current pane
+    #[command(alias = "splitw")]
+    SplitPane {
+        /// Target pane ID
+        #[arg(short = 't', long)]
+        target: Option<String>,
+        /// Split horizontally (panes side by side)
+        #[arg(short = 'h', long)]
+        horizontal: bool,
+        /// Split vertically (panes stacked)
+        #[arg(short = 'v', long)]
+        vertical: bool,
+        /// Size as fraction (0.0-1.0)
+        #[arg(short = 's', long)]
+        size: Option<f64>,
+        /// Command to run in the new pane
+        #[arg(short = 'c', long)]
+        command: Option<String>,
+    },
+    /// Capture pane output (like tmux capture-pane -p)
+    #[command(alias = "capturep")]
+    CapturePane {
+        /// Target pane ID (defaults to active pane)
+        #[arg(short = 't', long)]
+        target: Option<String>,
+        /// Maximum lines to capture
+        #[arg(short = 'l', long)]
+        max_lines: Option<u32>,
+        /// Only return the most recent completed shell prompt
+        /// (command + output). Requires OSC 133 shell integration.
+        #[arg(long)]
+        last_prompt: bool,
+    },
+    /// Close/kill a pane
+    #[command(alias = "killp")]
+    KillPane {
+        /// Target pane ID (defaults to active pane)
+        #[arg(short = 't', long)]
+        target: Option<String>,
+    },
+    /// Show the currently active pane
+    ActivePane,
+    /// Show process status of a pane
+    PaneStatus {
+        /// Target pane ID (defaults to active pane)
+        #[arg(short = 't', long)]
+        target: Option<String>,
+    },
+    /// Wait for a pane's process to exit (delegates to `wtcli wait-for`)
+    WaitFor {
+        /// Target pane ID
+        #[arg(short = 't', long)]
+        target: String,
+        /// Poll interval in milliseconds
+        #[arg(long, default_value = "500")]
+        interval: u64,
+        /// Timeout in seconds (0 = wait forever)
+        #[arg(long, default_value = "0")]
+        timeout: u64,
+    },
+    /// Discover and print the WT COM CLSID used for protocol routing
+    PipeId,
+    /// Print shell commands to set WT_COM_CLSID
+    #[command(alias = "setenv")]
+    SetEnv {
+        /// Shell syntax: bash (default), powershell, cmd
+        #[arg(short = 's', long, default_value = "bash")]
+        shell: String,
+    },
+    /// Listen for events from Windows Terminal (VT sequences, connection state changes)
+    #[command(alias = "mon")]
+    Listen {
+        /// Filter by pane ID (show events from all panes if omitted)
+        #[arg(short = 't', long)]
+        target: Option<String>,
+    },
+    /// Open a configured delegate agent in a new tab (fire-and-forget). With a
+    /// PROMPT, the prompt is baked into the agent's launch; omit PROMPT to open
+    /// the agent interactively with no startup prompt.
+    Delegate {
+        /// The prompt to send to the delegate agent. Omit to open the agent
+        /// interactively in a new tab with no startup prompt.
+        #[arg(value_name = "PROMPT")]
+        prompt: Option<String>,
+        /// Agent CLI command (used to derive delegate agent commandline)
+        #[arg(long, default_value = agent_registry::DEFAULT_ACP_COMMAND)]
+        agent: String,
+        /// Delegate agent CLI command (e.g. "codex")
+        #[arg(long)]
+        delegate_agent: Option<String>,
+        /// Model override for the delegate agent
+        #[arg(long)]
+        delegate_model: Option<String>,
+        /// Working directory for the delegate agent tab
+        #[arg(long)]
+        cwd: Option<String>,
+    },
+    /// Manage the wt-agent-hooks bridge for supported CLI agents
+    /// (Copilot / Claude / Gemini). See `agent_hooks_installer` for
+    /// what each action does.
+    Hooks {
+        #[command(subcommand)]
+        action: HooksAction,
+    },
+    /// Inspect sessions known to the shared wta-master.
+    Sessions {
+        #[command(subcommand)]
+        action: SessionsAction,
+    },
+    /// One-shot ACP handshake to read an agent's advertised model list.
+    /// Spawned by the Settings UI when the user picks a new ACP agent so
+    /// the model dropdown can populate before any real agent pane is
+    /// rebuilt. Prints a single JSON object to stdout:
+    ///
+    ///   {"available_models":[{"id":"...","name":"...","description":"..."}],
+    ///    "current_model_id":"..."}
+    ///
+    /// On error: non-zero exit, message on stderr.
+    ProbeModels {
+        /// Full agent cmdline, same shape as `--agent` (e.g.
+        /// "copilot --acp --stdio" or "npx -y @agentclientprotocol/claude-agent-acp").
+        #[arg(long)]
+        agent: String,
+    },
+    /// List built-in ACP agents installed inside one WSL distro.
+    /// Used by the per-profile Settings picker.
+    #[command(hide = true)]
+    ProbeAgentSources {
+        #[arg(long)]
+        wsl_distro: String,
+    },
+    /// Diagnostic: spawn an agent CLI, ACP `initialize`, then call
+    /// `session/list` (`list_sessions`) and print what it returns.
+    /// Used to evaluate whether ACP session enumeration can replace
+    /// reading on-disk transcripts. Prints a pretty JSON object to
+    /// stdout; on error: non-zero exit, message on stderr.
+    ProbeSessions {
+        /// Full agent cmdline, same shape as `--agent` (e.g.
+        /// "copilot --acp --stdio" or "npx -y @agentclientprotocol/claude-agent-acp").
+        #[arg(long)]
+        agent: String,
+    },
+    /// Diagnostic: spawn an agent CLI, call ACP `session/list`, filter
+    /// agent-pane-origin rows, and print the host history rows WTA would
+    /// seed from the already-running master agent.
+    ProbeHostSessions {
+        /// Full agent cmdline, same shape as `--agent` (e.g.
+        /// "copilot --acp --stdio" or "npx -y @agentclientprotocol/claude-agent-acp").
+        #[arg(long)]
+        agent: String,
+    },
+    /// Diagnostic: run the production WSL history scan
+    /// (`wsl_acp::scan_running_distros_acp`) end-to-end against the
+    /// currently-running distros and print the discovered sessions as
+    /// JSON. Exercises the real `wsl.exe` spawn + ACP `session/list` path
+    /// that seeds the `/sessions` view. Prints `[]` when no distro is
+    /// running or none answer.
+    ProbeWslSessions {
+        /// Restrict to one CLI (`copilot` | `claude` | `codex`). Omitted
+        /// scans the three ACP-capable built-ins (Gemini has no
+        /// `session/list`).
+        #[arg(long)]
+        cli: Option<String>,
+    },
+}
+
+/// Subcommands for `wta sessions`.
+#[derive(Subcommand, Debug)]
+pub(crate) enum SessionsAction {
+    /// List sessions in the master registry.
+    List {
+        /// Override the wta-master named pipe path.
+        #[arg(long, value_name = "PIPE_NAME")]
+        master: Option<String>,
+        /// Restrict the list to a session origin. `all` (default) shows
+        /// every row — that matches the historical debug behavior.
+        /// `shell` shows only user-started shell-pane sessions (the
+        /// MVP sessions default). `agent-pane` shows only sessions that
+        /// WTA spawned for an Intelligent Terminal agent pane.
+        #[arg(long, value_enum, default_value_t = SessionsOriginArg::All)]
+        origin: SessionsOriginArg,
+    },
+}
+
+/// CLI value for `wta sessions list --origin`. Mirrors
+/// [`agent_sessions::OriginFilter`] but lives in `cli::args` so the
+/// clap derive can attach `ValueEnum` without polluting runtime modules
+/// with clap types.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SessionsOriginArg {
+    /// Shell-pane sessions only (Class B). Matches the MVP sessions picker.
+    Shell,
+    /// Agent-pane sessions only (Class A). Hidden from the MVP sessions
+    /// picker; surfaced here for debugging.
+    AgentPane,
+    /// Every row in the registry — historical debug default.
+    All,
+}
+
+impl SessionsOriginArg {
+    pub(crate) fn to_filter(self) -> agent_sessions::OriginFilter {
+        match self {
+            SessionsOriginArg::Shell => agent_sessions::OriginFilter::ShellOnly,
+            SessionsOriginArg::AgentPane => agent_sessions::OriginFilter::AgentPaneOnly,
+            SessionsOriginArg::All => agent_sessions::OriginFilter::All,
+        }
+    }
+}
+
+/// Subcommands for `wta hooks`.
+#[derive(Subcommand, Debug)]
+pub(crate) enum HooksAction {
+    /// (Re-)install the wt-agent-hooks bridge. Installs for all supported
+    /// CLIs by default, or a single CLI with `--cli`.
+    Install {
+        /// Which CLI to install for. Default: `all`.
+        #[arg(long, value_enum, default_value_t = HooksCliFilter::All)]
+        cli: HooksCliFilter,
+    },
+    /// Print per-CLI install state. Returns JSON with `--json`,
+    /// or a human-readable table by default.
+    Status,
+    /// Uninstall the bridge for one or all CLIs. Best-effort: missing
+    /// CLIs are skipped at info level. With `--json` returns a structured
+    /// per-CLI result report.
+    Uninstall {
+        /// Which CLI(s) to uninstall for. Default: `all`.
+        #[arg(long, value_enum, default_value_t = HooksCliFilter::All)]
+        cli: HooksCliFilter,
+    },
+}
+
+/// `--cli` filter for `wta hooks uninstall`.
+#[derive(Copy, Clone, Debug, clap::ValueEnum)]
+pub(crate) enum HooksCliFilter {
+    All,
+    Copilot,
+    Claude,
+    Gemini,
+    Codex,
+    #[value(name = "opencode")]
+    OpenCode,
+}
+
+impl HooksCliFilter {
+    pub(crate) fn into_scope(self) -> agent_hooks_installer::CliScope {
+        use agent_hooks_installer::{CliKind, CliScope};
+        match self {
+            HooksCliFilter::All => CliScope::All,
+            HooksCliFilter::Copilot => CliScope::One(CliKind::Copilot),
+            HooksCliFilter::Claude => CliScope::One(CliKind::Claude),
+            HooksCliFilter::Gemini => CliScope::One(CliKind::Gemini),
+            HooksCliFilter::Codex => CliScope::One(CliKind::Codex),
+            HooksCliFilter::OpenCode => CliScope::One(CliKind::OpenCode),
+        }
+    }
+}
+
+/// `--initial-view` selector. Drives whether the TUI starts in the chat
+/// view (default) or jumps straight to the Agents (session list) view.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum InitialView {
+    Chat,
+    Sessions,
+}

--- a/tools/wta/src/cli/mod.rs
+++ b/tools/wta/src/cli/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod args;

--- a/tools/wta/src/helper/config.rs
+++ b/tools/wta/src/helper/config.rs
@@ -1,0 +1,29 @@
+#[derive(Debug)]
+pub(crate) struct HelperConfig {
+    pub(crate) prompt: Option<String>,
+    pub(crate) agent: String,
+    pub(crate) agent_id: Option<String>,
+    pub(crate) agent_source: Option<String>,
+    pub(crate) agent_wsl_distro: Option<String>,
+    pub(crate) agent_source_cwd: Option<String>,
+    pub(crate) allowed_agent_ids: Vec<String>,
+    pub(crate) initial_auth_agent: Option<String>,
+    pub(crate) acp_model: Option<String>,
+    pub(crate) delegate_agent: Option<String>,
+    pub(crate) delegate_model: Option<String>,
+    pub(crate) no_autofix: bool,
+    pub(crate) setup: Option<String>,
+    pub(crate) initial_view: InitialView,
+    pub(crate) owner_tab_id: Option<String>,
+    pub(crate) owner_window_id: Option<String>,
+    pub(crate) initial_load_session_id: Option<String>,
+    pub(crate) initial_load_cwd: Option<String>,
+    pub(crate) start_stashed: bool,
+    pub(crate) assume_master_down: bool,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum InitialView {
+    Chat,
+    Sessions,
+}

--- a/tools/wta/src/helper/mod.rs
+++ b/tools/wta/src/helper/mod.rs
@@ -13,13 +13,15 @@
 
 use anyhow::Result;
 
-use crate::Cli;
+pub(crate) mod config;
 
 mod runtime;
+
+use config::HelperConfig;
 
 /// Helper-mode entry point. Routes the ACP traffic through a named pipe
 /// to the wta-master singleton instead of spawning a private agent CLI
 /// subprocess.
-pub async fn run_helper_mode(cli: Cli, pipe_name: String) -> Result<()> {
-    runtime::run_default_tui_over_pipe(cli, pipe_name).await
+pub async fn run_helper_mode(config: HelperConfig, pipe_name: String) -> Result<()> {
+    runtime::run_default_tui_over_pipe(config, pipe_name).await
 }

--- a/tools/wta/src/helper/runtime.rs
+++ b/tools/wta/src/helper/runtime.rs
@@ -15,21 +15,25 @@ use std::sync::Arc;
 use crate::shell::wt_channel::{CliChannel, WtChannel};
 use crate::shell::ShellManager;
 use crate::{
-    agent_check, agent_hooks_installer, agent_registry, app, event, logging, protocol, shell, Cli,
-    InitialView,
+    agent_check, agent_hooks_installer, agent_registry, app, event, logging, protocol, shell,
 };
+
+use super::config::{HelperConfig, InitialView};
 
 /// Drive the standard ACP TUI but use `pipe_name` as the ACP transport
 /// (helper mode). The helper attaches to wta-master over the supplied
 /// named pipe and forwards ACP traffic over it.
-pub(super) async fn run_default_tui_over_pipe(mut cli: Cli, pipe_name: String) -> Result<()> {
+pub(super) async fn run_default_tui_over_pipe(
+    mut config: HelperConfig,
+    pipe_name: String,
+) -> Result<()> {
     tracing::info!(target: "helper", pipe = %pipe_name, "=== wta-helper starting (TUI) ===");
     let agent_source = crate::agent_source::AgentSource::from_wire(
-        cli.agent_source.as_deref(),
-        cli.agent_wsl_distro.as_deref(),
+        config.agent_source.as_deref(),
+        config.agent_wsl_distro.as_deref(),
     );
-    cli.agent_source_cwd =
-        crate::agent_source::resolve_source_cwd(&agent_source, cli.agent_source_cwd.as_deref())
+    config.agent_source_cwd =
+        crate::agent_source::resolve_source_cwd(&agent_source, config.agent_source_cwd.as_deref())
             .await;
 
     // Debug channel for the helper TUI.
@@ -66,7 +70,7 @@ pub(super) async fn run_default_tui_over_pipe(mut cli: Cli, pipe_name: String) -
     // `run_acp_tui_mode`'s exit branch, which `process::exit`s rather than
     // returning Err — so there's no point wrapping the result here.
     run_acp_tui_mode(
-        cli,
+        config,
         shell_mgr,
         wt_connected,
         debug_rx,
@@ -162,7 +166,7 @@ impl Drop for TuiRestoreGuard {
 }
 
 async fn run_acp_tui_mode(
-    cli: Cli,
+    config: HelperConfig,
     shell_mgr: Arc<ShellManager>,
     wt_connected: bool,
     debug_rx: tokio::sync::mpsc::UnboundedReceiver<app::DebugMessage>,
@@ -189,7 +193,7 @@ async fn run_acp_tui_mode(
 
     let result = run_acp_app(
         &mut terminal,
-        cli,
+        config,
         shell_mgr,
         wt_connected,
         debug_rx,
@@ -255,7 +259,7 @@ fn spawn_restart_agent_stack_forwarder(
 
 async fn run_acp_app(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    cli: Cli,
+    config: HelperConfig,
     shell_mgr: Arc<ShellManager>,
     wt_connected: bool,
     mut debug_rx: tokio::sync::mpsc::UnboundedReceiver<app::DebugMessage>,
@@ -264,12 +268,12 @@ async fn run_acp_app(
     wt_protocol_channel: Option<Arc<CliChannel>>,
     connect_master_pipe: String,
 ) -> Result<()> {
-    let agent_cmd = cli.agent.clone();
+    let agent_cmd = config.agent.clone();
     let agent_source = crate::agent_source::AgentSource::from_wire(
-        cli.agent_source.as_deref(),
-        cli.agent_wsl_distro.as_deref(),
+        config.agent_source.as_deref(),
+        config.agent_wsl_distro.as_deref(),
     );
-    let agent_source_cwd = cli.agent_source_cwd.clone();
+    let agent_source_cwd = config.agent_source_cwd.clone();
 
     let local_set = tokio::task::LocalSet::new();
     local_set
@@ -442,9 +446,9 @@ async fn run_acp_app(
             // stamps `_meta.wta.owner_tab_id` on every session/new + session/load.
             // Master needs it to address `restart_agent_pane` crash-recovery
             // events by the same StableId C++ routes per-tab events with.
-            protocol::acp::client::set_helper_owner_tab_id(cli.owner_tab_id.as_deref());
+            protocol::acp::client::set_helper_owner_tab_id(config.owner_tab_id.as_deref());
 
-            let explicit_agent_id = cli
+            let explicit_agent_id = config
                 .agent_id
                 .as_deref()
                 .map(str::trim)
@@ -459,19 +463,19 @@ async fn run_acp_app(
             } else {
                 "resolved-from-cmd"
             };
-            let initial_load_requested = cli
+            let initial_load_requested = config
                 .initial_load_session_id
                 .as_deref()
                 .map(str::trim)
                 .map(|s| !s.is_empty())
                 .unwrap_or(false);
-            let initial_auth_agent = match cli
+            let initial_auth_agent = match config
                 .initial_auth_agent
                 .as_deref()
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
             {
-                Some(requested) if cli.assume_master_down => {
+                Some(requested) if config.assume_master_down => {
                     tracing::warn!(
                         target: "initial_auth",
                         requested_agent = %requested,
@@ -479,7 +483,7 @@ async fn run_acp_app(
                     );
                     None
                 }
-                Some(requested) if cli.start_stashed => {
+                Some(requested) if config.start_stashed => {
                     tracing::warn!(
                         target: "initial_auth",
                         requested_agent = %requested,
@@ -487,7 +491,7 @@ async fn run_acp_app(
                     );
                     None
                 }
-                Some(requested) if cli.setup.is_some() => {
+                Some(requested) if config.setup.is_some() => {
                     tracing::warn!(
                         target: "initial_auth",
                         requested_agent = %requested,
@@ -533,7 +537,7 @@ async fn run_acp_app(
             // pipe-attached variant immediately. FRE-installed Copilot is the
             // exception: `--initial-auth-agent copilot` starts on Auth and lets
             // `LoginComplete` spawn the first pipe client after sign-in.
-            if cli.assume_master_down {
+            if config.assume_master_down {
                 // Degraded open: master is known down, so don't even try the
                 // (dead) pipe — go straight to the disconnected view that an
                 // orphaned pane shows, where /restart is the one available
@@ -602,16 +606,16 @@ async fn run_acp_app(
                 let pipe_name = connect_master_pipe.clone();
                 let event_tx_for_pipe = event_tx.clone();
                 let shell_mgr_for_pipe = Arc::clone(&shell_mgr);
-                let acp_model = cli.acp_model.clone();
+                let acp_model = config.acp_model.clone();
                 // Per-tab agent identity passed through to the multi-agent
-                // master via the initialize handshake. The helper has had
-                // this on its `Cli` all along; pre-multi-agent it dropped
-                // it (master owned the single agent CLI).
-                let agent_id = cli.agent_id.clone();
+                // master via the initialize handshake. The helper receives
+                // this from the CLI boundary; pre-multi-agent it dropped it
+                // (master owned the single agent CLI).
+                let agent_id = config.agent_id.clone();
                 let agent_source_for_client = agent_source.clone();
                 let source_cwd = agent_source_cwd.clone();
-                let owner_tab = cli.owner_tab_id.clone();
-                let initial_load_sid = cli.initial_load_session_id.clone();
+                let owner_tab = config.owner_tab_id.clone();
+                let initial_load_sid = config.initial_load_session_id.clone();
                 tokio::task::spawn_local(async move {
                     if let Err(e) = protocol::acp::client::run_acp_client_over_pipe(
                         pipe_name,
@@ -675,9 +679,9 @@ async fn run_acp_app(
             // executor snapshots it per choice; the App rebuilds it on change.
             let delegate_agents = Arc::new(std::sync::Mutex::new(
                 crate::coordinator::default_delegate_agent_runtimes(
-                    cli.delegate_agent.as_deref(),
-                    Some(cli.agent.as_str()),
-                    cli.delegate_model.as_deref(),
+                    config.delegate_agent.as_deref(),
+                    Some(config.agent.as_str()),
+                    config.delegate_model.as_deref(),
                 ),
             ));
             tokio::spawn(crate::coordinator::run_recommendation_executor(
@@ -687,9 +691,9 @@ async fn run_acp_app(
                 Arc::clone(&delegate_agents),
             ));
 
-            let autofix_enabled = !cli.no_autofix;
+            let autofix_enabled = !config.no_autofix;
             let mut app_state = app::App::new(prompt_tx, recommendation_tx, permission_tx, cancel_tx, new_session_tx, load_session_tx, drop_session_tx, rename_session_tx, restart_tx, master_ext_tx, debug_capture_enabled, wt_connected, autofix_enabled, Arc::clone(&shell_mgr));
-            app_state.set_allowed_agent_ids(cli.allowed_agent_ids.clone());
+            app_state.set_allowed_agent_ids(config.allowed_agent_ids.clone());
             // Seed the hot-updatable runtime agent config: the shared
             // delegate runtime table, the helper's own agent_cmd (needed to
             // re-derive the delegate commandline when only the delegate
@@ -697,8 +701,8 @@ async fn run_acp_app(
             // (re-applied to future sessions so /new stays on the model).
             app_state.set_runtime_agent_config(
                 Arc::clone(&delegate_agents),
-                cli.agent.clone(),
-                cli.acp_model.clone(),
+                config.agent.clone(),
+                config.acp_model.clone(),
             );
             app_state.set_session_hook_tx(session_hook_tx);
 
@@ -719,15 +723,15 @@ async fn run_acp_app(
             app_state.set_master_pipe_acp_params(
                 connect_master_pipe.clone(),
                 agent_cmd.clone(),
-                cli.acp_model.clone(),
+                config.acp_model.clone(),
                 agent_source.clone(),
                 agent_source_cwd.clone(),
-                cli.owner_tab_id.clone(),
+                config.owner_tab_id.clone(),
                 Arc::clone(&shell_mgr),
                 wt_connected,
             );
 
-            if cli.setup.is_none() {
+            if config.setup.is_none() {
                 app_state.current_agent_id = canonical_agent_id.clone();
                 app_state.current_agent_source = agent_source.clone();
                 tracing::info!(
@@ -745,7 +749,7 @@ async fn run_acp_app(
             // ── Preflight: check the agent CLI before connecting ──────────
             // Skip preflight when FRE is active — FRE has its own agent
             // selection + auth flow and doesn't need the preflight wizard.
-            if cli.setup.is_none() && !start_in_initial_auth {
+            if config.setup.is_none() && !start_in_initial_auth {
                 let agent_id = canonical_agent_id.as_str();
                 let preflight_result =
                     if agent_id.starts_with("custom:") || !agent_registry::is_known_id(agent_id) {
@@ -826,13 +830,13 @@ async fn run_acp_app(
             // match. Without this, helper echoes `pane_open=true`, C++
             // sees a stashed pane and a `pane_open=true` echo, and
             // restores the pane — defeating pre-warm.
-            if let Some(ref owner_tab_id) = cli.owner_tab_id {
+            if let Some(ref owner_tab_id) = config.owner_tab_id {
                 if !owner_tab_id.is_empty() && app_state.tab_id.is_none() {
                     let tab = app_state
                         .tab_sessions
                         .entry(owner_tab_id.clone())
                         .or_default();
-                    tab.pane_open = !cli.start_stashed;
+                    tab.pane_open = !config.start_stashed;
                     app_state.tab_id = Some(owner_tab_id.clone());
                     app_state.owner_tab_id = Some(owner_tab_id.clone());
                 }
@@ -873,15 +877,15 @@ async fn run_acp_app(
             // (the load_session handler routes by tab id), so we
             // silently skip if owner_tab_id is unset. Logged so a
             // misconfigured spawn is easy to diagnose.
-            if let Some(ref sid) = cli.initial_load_session_id {
+            if let Some(ref sid) = config.initial_load_session_id {
                 if !sid.is_empty() {
                     let tab_id_opt = app_state
                         .owner_tab_id
                         .clone()
-                        .or_else(|| cli.owner_tab_id.clone());
+                        .or_else(|| config.owner_tab_id.clone());
                     match tab_id_opt {
                         Some(tab_id) if !tab_id.is_empty() => {
-                            let cwd = cli
+                            let cwd = config
                                 .initial_load_cwd
                                 .as_deref()
                                 .map(str::to_string)
@@ -948,9 +952,9 @@ async fn run_acp_app(
             //
             // Skip in setup mode: --setup takes the diagnostic path and the user
             // shouldn't be dropped into an empty session list.
-            if cli.setup.is_none()
+            if config.setup.is_none()
                 && !start_in_initial_auth
-                && cli.initial_view == InitialView::Sessions
+                && config.initial_view == InitialView::Sessions
             {
                 tracing::info!(target: "initial_view", "starting in agent session view");
                 let tab_id = app_state
@@ -983,8 +987,8 @@ async fn run_acp_app(
             // See doc/specs/per-cli-history-filtering.md.
 
             // Enter setup mode if --setup <reason> was passed.
-            tracing::info!("cli.setup = {:?}", cli.setup);
-            if let Some(ref reason_str) = cli.setup {
+            tracing::info!("cli.setup = {:?}", config.setup);
+            if let Some(ref reason_str) = config.setup {
                 tracing::info!("Entering diagnostic setup mode: reason={}", reason_str);
                 let reason = app::SetupReason::from_str(reason_str);
 
@@ -1033,7 +1037,7 @@ async fn run_acp_app(
             // WT knows the owning window authoritatively when it creates the
             // helper. Prefer that seed over best-effort PID discovery so
             // outbound per-window events work from the first render.
-            if let Some(owner_window_id) = cli
+            if let Some(owner_window_id) = config
                 .owner_window_id
                 .as_deref()
                 .map(str::trim)
@@ -1061,7 +1065,7 @@ async fn run_acp_app(
             // expects the active key to already be present, so without
             // pre-inserting we'd panic on the first render before any
             // event has had a chance to lazy-create it.
-            if let Some(owner_tab_id) = cli.owner_tab_id.clone() {
+            if let Some(owner_tab_id) = config.owner_tab_id.clone() {
                 if !owner_tab_id.is_empty() {
                     tracing::info!(
                         target: "tab_session",
@@ -1079,7 +1083,7 @@ async fn run_acp_app(
                     // pane_open=true. The exception is `--start-stashed`
                     // (pre-warm path) where C++ has already stashed the
                     // pane — see comment on the earlier seed block.
-                    tab.pane_open = !cli.start_stashed;
+                    tab.pane_open = !config.start_stashed;
                     app_state.tab_id = Some(owner_tab_id.clone());
 
                     // Publish an initial chip-target state for this tab so
@@ -1112,7 +1116,7 @@ async fn run_acp_app(
 
             // If a prompt was passed via CLI arg (e.g., from command palette creating
             // a new agent pane), delegate it to a new tab agent on startup.
-            if let Some(ref initial_prompt) = cli.prompt {
+            if let Some(ref initial_prompt) = config.prompt {
                 if !initial_prompt.is_empty() {
                     app_state.delegate_to_tab_agent(initial_prompt);
                 }

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -5,10 +5,11 @@ mod agent_check;
 mod agent_hooks_installer;
 mod agent_pane_origin;
 mod agent_registry;
-mod agent_source;
 mod agent_sessions;
+mod agent_source;
 mod app;
 mod app_contracts;
+mod cli;
 mod clipboard_image;
 mod command_recall;
 mod commands;
@@ -17,10 +18,10 @@ mod cwd_util;
 mod event;
 mod helper;
 mod history_loader;
-mod logging;
 #[cfg(test)]
 #[path = "locale_parity_tests.rs"]
 mod locale_parity_tests;
+mod logging;
 mod master;
 mod osc52;
 mod pane_context;
@@ -47,11 +48,16 @@ mod wt_protocol_events;
 
 use agent_client_protocol as acp;
 use anyhow::{bail, Context, Result};
-use clap::{Parser, Subcommand};
+use clap::Parser;
 use serde_json::json;
 use std::sync::Arc;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
+use cli::args::{
+    Cli, Command, HooksAction, HooksCliFilter, InitialView, SessionsAction,
+};
+#[cfg(test)]
+use cli::args::SessionsOriginArg;
 use shell::wt_channel::{CliChannel, WtChannel};
 use shell::ShellManager;
 
@@ -120,572 +126,43 @@ fn normalize_locale(locale: &str) -> String {
     "en-US".to_string()
 }
 
-// ─── CLI Definition ─────────────────────────────────────────────────────────
-
-#[derive(Parser, Debug)]
-#[command(
-    name = "wta",
-    about = "Windows Terminal Agent — ACP TUI client / tmux-like CLI"
-)]
-struct Cli {
-    #[command(subcommand)]
-    command: Option<Command>,
-
-    /// Initial prompt to send to the agent (ACP mode only)
-    #[arg(value_name = "PROMPT")]
-    prompt: Option<String>,
-
-    /// Agent CLI command (e.g. "copilot --acp --stdio")
-    #[arg(long, default_value = agent_registry::DEFAULT_ACP_COMMAND)]
-    agent: String,
-
-    /// Canonical agent identifier (`copilot` / `claude` / `codex` / `gemini`
-    /// / `opencode` / `custom:<name>`). When the host (Windows Terminal) launches wta it
-    /// already knows which entry the user picked in settings, so it passes
-    /// the original `acpAgent` value through here. wta uses this id as the
-    /// authoritative identity for `current_agent_id` — driving the session-
-    /// management view's CLI filter, the preflight check, etc.
-    ///
-    /// When omitted (manual `wta` runs, older host builds, tests) wta falls
-    /// back to inferring the id by parsing the `--agent` command line via
-    /// `agent_registry::resolve_agent_id_from_cmd`. That fallback works for
-    /// bare names but is fragile for adapter-style launches (`npx … claude-
-    /// code-acp`) and full-path launches, so the host should always pass
-    /// `--agent-id` explicitly.
-    #[arg(long)]
-    agent_id: Option<String>,
-
-    /// Per-tab ACP execution source (`host` or `wsl`). Hidden because
-    /// TerminalPage owns source compatibility checks.
-    #[arg(long, hide = true, value_parser = ["host", "wsl"])]
-    agent_source: Option<String>,
-
-    /// WSL distro paired with `--agent-source wsl`.
-    #[arg(long, hide = true)]
-    agent_wsl_distro: Option<String>,
-
-    /// Working-pane cwd captured when this helper was created.
-    #[arg(long, hide = true)]
-    agent_source_cwd: Option<String>,
-
-    /// Master-only allowlist of agent ids a helper may request over the
-    /// pipe (the GPO-filtered set; built by TerminalPage::
-    /// _BuildSharedWtaExtraArgs from `FilteredAcpAgents()`). The master
-    /// reconstructs a helper's requested agent command from its declared
-    /// `agent_id` ONLY when that id is in this set — never executing a
-    /// command string sent over the pipe. An id outside the set (or a
-    /// custom/unknown id) falls back to `--agent` / `--agent-id`. An *absent*
-    /// flag means "no host allowlist" (manual runs, older hosts): the master
-    /// accepts any *known* agent id. A *present* flag is honored fail-closed —
-    /// even when it filters down to nothing, every helper-selected id is then
-    /// blocked (all panes fall back to the default) rather than widening back
-    /// to accept-any. Helpers use the same list only to filter `/agent`;
-    /// the master remains the authoritative enforcement point.
-    #[arg(long, hide = true, value_name = "IDS", value_delimiter = ',')]
-    allowed_agent_ids: Vec<String>,
-
-    /// Boot-time hint from Windows Terminal: start directly on the auth screen
-    /// for the given agent instead of attempting the initial ACP session. Used
-    /// when FRE just installed Copilot, where the next expected action is
-    /// signing in. Hidden — only Windows Terminal should pass it.
-    #[arg(long, hide = true, value_name = "AGENT_ID")]
-    initial_auth_agent: Option<String>,
-
-    /// Model override for the ACP agent. Sent via ACP setSessionModel after
-    /// handshake. Used by adapter-style launches (claude, codex via npx)
-    /// where the model can't be passed on the command line; native ACP
-    /// agents may use their own --model flag in `agent`.
-    #[arg(long)]
-    acp_model: Option<String>,
-
-    /// Delegate agent CLI command (e.g. "codex")
-    #[arg(long)]
-    delegate_agent: Option<String>,
-
-    /// Model override for the delegate agent
-    #[arg(long)]
-    delegate_model: Option<String>,
-
-    /// Disable auto-fix on command failure
-    #[arg(long)]
-    no_autofix: bool,
-
-    /// Enter diagnostic setup mode with the given reason instead of connecting directly.
-    /// Values: agent-missing, agent-error
-    #[arg(long)]
-    setup: Option<String>,
-
-    /// Initial TUI view to show on startup. `chat` (default) starts in the
-    /// chat view; `sessions` starts in the Agents (session list) view —
-    /// equivalent to the user pressing Ctrl+Shift+/ right after the pane opens.
-    /// Wired to WT's Ctrl+Shift+/ binding via TerminalPage.
-    #[arg(long, value_enum, default_value_t = InitialView::Chat)]
-    initial_view: InitialView,
-
-    /// UI language override, passed by Windows Terminal from the
-    /// `settings.json` `Language` field. When present, wta uses this
-    /// directly for i18n instead of detecting the OS locale — ensuring
-    /// the agent pane displays the same language as the Terminal chrome.
-    /// When absent, wta falls back to `sys_locale` (automatic detection).
-    #[arg(long)]
-    language: Option<String>,
-
-    /// Stable GUID of the WT tab that owns this wta process. Passed in by
-    /// TerminalPage when spawning the agent pane (both _OpenOrReuseAgentPane
-    /// and _AutoCreateHiddenAgentPane). Seeded into app_state.tab_id before
-    /// ACP init, so the first AgentConnected binds the session under the
-    /// real tab GUID instead of falling back to the implicit DEFAULT_TAB_ID
-    /// placeholder. Hidden because nothing outside WT should be setting it.
-    #[arg(long, hide = true)]
-    owner_tab_id: Option<String>,
-
-    /// Window ID of the WT window that owns this helper. Passed alongside
-    /// `--owner-tab-id` because PID-based pane discovery is best-effort and
-    /// may not find a newly spawned ConPTY helper before `/agent` is used.
-    #[arg(long, hide = true)]
-    owner_window_id: Option<String>,
-
-    /// Boot-time hint: instead of letting the helper create a fresh ACP
-    /// session via `session/new`, immediately resume the given session id
-    /// via `session/load`. Used by the "Enter on Historical/Ended row in
-    /// session manager" path: C++ spawns a new helper for the new
-    /// agent pane and bundles the resume request via these flags so the
-    /// resume is atomic — no separate `load_session` VT broadcast that
-    /// could race the helper's pipe-attach.
-    ///
-    /// Pair with `--initial-load-cwd`. Hidden — only Windows Terminal
-    /// should pass it. No-op outside `--connect-master` (only the helper
-    /// boot path consumes it).
-    #[arg(long, hide = true, value_name = "SESSION_ID")]
-    initial_load_session_id: Option<String>,
-
-    /// Working directory associated with `--initial-load-session-id`.
-    /// Passed to the agent CLI via the ACP `session/load` request so the
-    /// resumed conversation runs against the right repo root. Hidden.
-    #[arg(long, hide = true, value_name = "PATH")]
-    initial_load_cwd: Option<String>,
-
-    /// Pre-warm mode: the helper is being spawned for a tab whose agent
-    /// pane is *already stashed* on the C++ side (see TerminalPage::
-    /// _AutoCreateHiddenAgentPaneShared autoStash path). Without this
-    /// flag, the helper's `--owner-tab-id` startup branch seeds
-    /// `tab.pane_open = true` and echoes back `agent_state_changed
-    /// { pane_open: true }`, which C++ interprets as "user opened the
-    /// pane" and unstashes it — defeating pre-warm. With this flag the
-    /// helper seeds `tab.pane_open = false`, matching the C++ stash
-    /// state. Hidden because only WT's pre-warm path should set it.
-    #[arg(long, hide = true)]
-    start_stashed: bool,
-
-    /// Degraded-open mode: the helper is being spawned for a pane the user
-    /// opened *while wta-master is known to be down* (it died unexpectedly and
-    /// hasn't been recovered via /restart — see C++ `SharedWta::IsDegraded`).
-    /// Rather than the helper retrying the dead master pipe for ~75s and
-    /// showing a spinner, it comes up immediately in the disconnected state
-    /// (the same transport-lost view an orphaned pane shows), so the user can
-    /// /restart right there instead of hunting for another pane. Hidden — only
-    /// WT's degraded-open path should set it.
-    #[arg(long, hide = true)]
-    assume_master_down: bool,
-
-    // Legacy flags (hidden, backward compat)
-    #[arg(long, hide = true)]
-    info: bool,
-    #[arg(long, hide = true)]
-    test_pipe: bool,
-
-    /// Output raw JSON instead of human-readable format
-    #[arg(long, global = true)]
-    json: bool,
-
-    /// Run as the wta-master singleton (Z architecture). Listens on
-    /// the named pipe whose name is passed here for wta-helper
-    /// connections; owns the single ACP connection to the agent CLI
-    /// subprocess; multiplexes per-helper ACP sessions onto it. Used
-    /// by `SharedWta::AcquirePane` on the C++ side. Hidden — only
-    /// Windows Terminal should spawn it.
-    ///
-    /// Pipe name is typically `\\.\pipe\wta-master-<GUID>`.
-    #[arg(long, hide = true, value_name = "PIPE_NAME")]
-    master: Option<String>,
-
-    /// Connect to a wta-master singleton over the named pipe whose
-    /// path is passed here, rather than spawning our own agent CLI
-    /// subprocess. Used when this wta is acting as a per-pane helper
-    /// in the helper+master architecture (see
-    /// doc/specs/Multi-window-agent-pane.md). Hidden — only the C++
-    /// side should pass it.
-    ///
-    /// Logically mutually exclusive with `--master`: a process can be
-    /// either the master or a helper, never both. Enforced by clap so
-    /// a misconfigured invocation fails fast instead of silently
-    /// preferring `--master` (the previous behavior).
-    #[arg(long, hide = true, value_name = "PIPE_NAME", conflicts_with = "master")]
-    connect_master: Option<String>,
-}
-
-#[derive(Subcommand, Debug)]
-enum Command {
-    /// Show Windows Terminal protocol connection info
-    Info,
-
-    /// Test protocol connection to Windows Terminal
-    TestPipe,
-
-    /// List all Windows Terminal windows
-    #[command(alias = "lsw")]
-    ListWindows,
-
-    /// List tabs in a window
-    #[command(alias = "lst")]
-    ListTabs {
-        /// Window ID (defaults to first window)
-        #[arg(short = 'w', long)]
-        window_id: Option<String>,
-    },
-
-    /// List panes in a tab
-    #[command(alias = "lsp")]
-    ListPanes {
-        /// Tab ID (defaults to active tab)
-        #[arg(short = 't', long)]
-        tab_id: Option<String>,
-
-        /// Window ID (used with tab_id)
-        #[arg(short = 'w', long)]
-        window_id: Option<String>,
-    },
-
-    /// Identify a command using the user's PowerShell profile
-    ResolveCommand {
-        /// Command name to identify (without arguments or a path)
-        #[arg(value_parser = resolve_command::parse_non_empty)]
-        token: String,
-
-        /// PowerShell executable to use
-        #[arg(
-            long,
-            default_value = "pwsh.exe",
-            value_parser = resolve_command::parse_non_empty
-        )]
-        shell: String,
-    },
-
-    /// Create a new tab
-    #[command(alias = "neww")]
-    NewTab {
-        /// Command to run in the new tab
-        #[arg(short = 'c', long)]
-        command: Option<String>,
-
-        /// Working directory
-        #[arg(short = 'd', long)]
-        cwd: Option<String>,
-
-        /// Tab title
-        #[arg(short = 'n', long)]
-        title: Option<String>,
-    },
-
-    /// Split the current pane
-    #[command(alias = "splitw")]
-    SplitPane {
-        /// Target pane ID
-        #[arg(short = 't', long)]
-        target: Option<String>,
-
-        /// Split horizontally (panes side by side)
-        #[arg(short = 'h', long)]
-        horizontal: bool,
-
-        /// Split vertically (panes stacked)
-        #[arg(short = 'v', long)]
-        vertical: bool,
-
-        /// Size as fraction (0.0-1.0)
-        #[arg(short = 's', long)]
-        size: Option<f64>,
-
-        /// Command to run in the new pane
-        #[arg(short = 'c', long)]
-        command: Option<String>,
-    },
-
-    /// Capture pane output (like tmux capture-pane -p)
-    #[command(alias = "capturep")]
-    CapturePane {
-        /// Target pane ID (defaults to active pane)
-        #[arg(short = 't', long)]
-        target: Option<String>,
-
-        /// Maximum lines to capture
-        #[arg(short = 'l', long)]
-        max_lines: Option<u32>,
-
-        /// Only return the most recent completed shell prompt
-        /// (command + output). Requires OSC 133 shell integration.
-        #[arg(long)]
-        last_prompt: bool,
-    },
-
-    /// Close/kill a pane
-    #[command(alias = "killp")]
-    KillPane {
-        /// Target pane ID (defaults to active pane)
-        #[arg(short = 't', long)]
-        target: Option<String>,
-    },
-
-    /// Show the currently active pane
-    ActivePane,
-
-    /// Show process status of a pane
-    PaneStatus {
-        /// Target pane ID (defaults to active pane)
-        #[arg(short = 't', long)]
-        target: Option<String>,
-    },
-
-    /// Wait for a pane's process to exit (delegates to `wtcli wait-for`)
-    WaitFor {
-        /// Target pane ID
-        #[arg(short = 't', long)]
-        target: String,
-
-        /// Poll interval in milliseconds
-        #[arg(long, default_value = "500")]
-        interval: u64,
-
-        /// Timeout in seconds (0 = wait forever)
-        #[arg(long, default_value = "0")]
-        timeout: u64,
-    },
-
-    /// Discover and print the WT COM CLSID used for protocol routing
-    PipeId,
-
-    /// Print shell commands to set WT_COM_CLSID
-    #[command(alias = "setenv")]
-    SetEnv {
-        /// Shell syntax: bash (default), powershell, cmd
-        #[arg(short = 's', long, default_value = "bash")]
-        shell: String,
-    },
-
-    /// Listen for events from Windows Terminal (VT sequences, connection state changes)
-    #[command(alias = "mon")]
-    Listen {
-        /// Filter by pane ID (show events from all panes if omitted)
-        #[arg(short = 't', long)]
-        target: Option<String>,
-    },
-
-    /// Open a configured delegate agent in a new tab (fire-and-forget). With a
-    /// PROMPT, the prompt is baked into the agent's launch; omit PROMPT to open
-    /// the agent interactively with no startup prompt.
-    Delegate {
-        /// The prompt to send to the delegate agent. Omit to open the agent
-        /// interactively in a new tab with no startup prompt.
-        #[arg(value_name = "PROMPT")]
-        prompt: Option<String>,
-
-        /// Agent CLI command (used to derive delegate agent commandline)
-        #[arg(long, default_value = agent_registry::DEFAULT_ACP_COMMAND)]
-        agent: String,
-
-        /// Delegate agent CLI command (e.g. "codex")
-        #[arg(long)]
-        delegate_agent: Option<String>,
-
-        /// Model override for the delegate agent
-        #[arg(long)]
-        delegate_model: Option<String>,
-
-        /// Working directory for the delegate agent tab
-        #[arg(long)]
-        cwd: Option<String>,
-    },
-
-    /// Manage the wt-agent-hooks bridge for supported CLI agents
-    /// (Copilot / Claude / Gemini). See `agent_hooks_installer` for
-    /// what each action does.
-    Hooks {
-        #[command(subcommand)]
-        action: HooksAction,
-    },
-
-    /// Inspect sessions known to the shared wta-master.
-    Sessions {
-        #[command(subcommand)]
-        action: SessionsAction,
-    },
-
-    /// One-shot ACP handshake to read an agent's advertised model list.
-    /// Spawned by the Settings UI when the user picks a new ACP agent so
-    /// the model dropdown can populate before any real agent pane is
-    /// rebuilt. Prints a single JSON object to stdout:
-    ///
-    ///   {"available_models":[{"id":"...","name":"...","description":"..."}],
-    ///    "current_model_id":"..."}
-    ///
-    /// On error: non-zero exit, message on stderr.
-    ProbeModels {
-        /// Full agent cmdline, same shape as `--agent` (e.g.
-        /// "copilot --acp --stdio" or "npx -y @agentclientprotocol/claude-agent-acp").
-        #[arg(long)]
-        agent: String,
-    },
-
-    /// List built-in ACP agents installed inside one WSL distro.
-    /// Used by the per-profile Settings picker.
-    #[command(hide = true)]
-    ProbeAgentSources {
-        #[arg(long)]
-        wsl_distro: String,
-    },
-
-    /// Diagnostic: spawn an agent CLI, ACP `initialize`, then call
-    /// `session/list` (`list_sessions`) and print what it returns.
-    /// Used to evaluate whether ACP session enumeration can replace
-    /// reading on-disk transcripts. Prints a pretty JSON object to
-    /// stdout; on error: non-zero exit, message on stderr.
-    ProbeSessions {
-        /// Full agent cmdline, same shape as `--agent` (e.g.
-        /// "copilot --acp --stdio" or "npx -y @agentclientprotocol/claude-agent-acp").
-        #[arg(long)]
-        agent: String,
-    },
-
-    /// Diagnostic: spawn an agent CLI, call ACP `session/list`, filter
-    /// agent-pane-origin rows, and print the host history rows WTA would
-    /// seed from the already-running master agent.
-    ProbeHostSessions {
-        /// Full agent cmdline, same shape as `--agent` (e.g.
-        /// "copilot --acp --stdio" or "npx -y @agentclientprotocol/claude-agent-acp").
-        #[arg(long)]
-        agent: String,
-    },
-
-    /// Diagnostic: run the production WSL history scan
-    /// (`wsl_acp::scan_running_distros_acp`) end-to-end against the
-    /// currently-running distros and print the discovered sessions as
-    /// JSON. Exercises the real `wsl.exe` spawn + ACP `session/list` path
-    /// that seeds the `/sessions` view. Prints `[]` when no distro is
-    /// running or none answer.
-    ProbeWslSessions {
-        /// Restrict to one CLI (`copilot` | `claude` | `codex`). Omitted
-        /// scans the three ACP-capable built-ins (Gemini has no
-        /// `session/list`).
-        #[arg(long)]
-        cli: Option<String>,
-    },
-}
-
-
-/// Subcommands for `wta sessions`.
-#[derive(Subcommand, Debug)]
-enum SessionsAction {
-    /// List sessions in the master registry.
-    List {
-        /// Override the wta-master named pipe path.
-        #[arg(long, value_name = "PIPE_NAME")]
-        master: Option<String>,
-
-        /// Restrict the list to a session origin. `all` (default) shows
-        /// every row — that matches the historical debug behavior.
-        /// `shell` shows only user-started shell-pane sessions (the
-        /// MVP sessions default). `agent-pane` shows only sessions that
-        /// WTA spawned for an Intelligent Terminal agent pane.
-        #[arg(long, value_enum, default_value_t = SessionsOriginArg::All)]
-        origin: SessionsOriginArg,
-    },
-}
-
-/// CLI value for `wta sessions list --origin`. Mirrors
-/// [`agent_sessions::OriginFilter`] but lives in `main.rs` so the
-/// clap derive can attach `ValueEnum` without polluting the library
-/// crate with clap as a dependency.
-#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
-enum SessionsOriginArg {
-    /// Shell-pane sessions only (Class B). Matches the MVP sessions picker.
-    Shell,
-    /// Agent-pane sessions only (Class A). Hidden from the MVP sessions
-    /// picker; surfaced here for debugging.
-    AgentPane,
-    /// Every row in the registry — historical debug default.
-    All,
-}
-
-impl SessionsOriginArg {
-    fn to_filter(self) -> agent_sessions::OriginFilter {
-        match self {
-            SessionsOriginArg::Shell     => agent_sessions::OriginFilter::ShellOnly,
-            SessionsOriginArg::AgentPane => agent_sessions::OriginFilter::AgentPaneOnly,
-            SessionsOriginArg::All       => agent_sessions::OriginFilter::All,
-        }
-    }
-}
-
-/// Subcommands for `wta hooks`.
-#[derive(Subcommand, Debug)]
-enum HooksAction {
-    /// (Re-)install the wt-agent-hooks bridge. Installs for all supported
-    /// CLIs by default, or a single CLI with `--cli`.
-    Install {
-        /// Which CLI to install for. Default: `all`.
-        #[arg(long, value_enum, default_value_t = HooksCliFilter::All)]
-        cli: HooksCliFilter,
-    },
-
-    /// Print per-CLI install state. Returns JSON with `--json`,
-    /// or a human-readable table by default.
-    Status,
-
-    /// Uninstall the bridge for one or all CLIs. Best-effort: missing
-    /// CLIs are skipped at info level. With `--json` returns a structured
-    /// per-CLI result report.
-    Uninstall {
-        /// Which CLI(s) to uninstall for. Default: `all`.
-        #[arg(long, value_enum, default_value_t = HooksCliFilter::All)]
-        cli: HooksCliFilter,
-    },
-}
-
-/// `--cli` filter for `wta hooks uninstall`.
-#[derive(Copy, Clone, Debug, clap::ValueEnum)]
-enum HooksCliFilter {
-    All,
-    Copilot,
-    Claude,
-    Gemini,
-    Codex,
-    #[value(name = "opencode")]
-    OpenCode,
-}
-
-impl HooksCliFilter {
-    fn into_scope(self) -> agent_hooks_installer::CliScope {
-        use agent_hooks_installer::{CliKind, CliScope};
-        match self {
-            HooksCliFilter::All => CliScope::All,
-            HooksCliFilter::Copilot => CliScope::One(CliKind::Copilot),
-            HooksCliFilter::Claude => CliScope::One(CliKind::Claude),
-            HooksCliFilter::Gemini => CliScope::One(CliKind::Gemini),
-            HooksCliFilter::Codex => CliScope::One(CliKind::Codex),
-            HooksCliFilter::OpenCode => CliScope::One(CliKind::OpenCode),
-        }
-    }
-}
-
-/// `--initial-view` selector. Drives whether the TUI starts in the chat
-/// view (default) or jumps straight to the Agents (session list) view.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
-enum InitialView {
-    Chat,
-    Sessions,
-}
-
 // ─── Entry Point ────────────────────────────────────────────────────────────
+
+fn helper_config(cli: Cli) -> helper::config::HelperConfig {
+    helper::config::HelperConfig {
+        prompt: cli.prompt,
+        agent: cli.agent,
+        agent_id: cli.agent_id,
+        agent_source: cli.agent_source,
+        agent_wsl_distro: cli.agent_wsl_distro,
+        agent_source_cwd: cli.agent_source_cwd,
+        allowed_agent_ids: cli.allowed_agent_ids,
+        initial_auth_agent: cli.initial_auth_agent,
+        acp_model: cli.acp_model,
+        delegate_agent: cli.delegate_agent,
+        delegate_model: cli.delegate_model,
+        no_autofix: cli.no_autofix,
+        setup: cli.setup,
+        initial_view: match cli.initial_view {
+            InitialView::Chat => helper::config::InitialView::Chat,
+            InitialView::Sessions => helper::config::InitialView::Sessions,
+        },
+        owner_tab_id: cli.owner_tab_id,
+        owner_window_id: cli.owner_window_id,
+        initial_load_session_id: cli.initial_load_session_id,
+        initial_load_cwd: cli.initial_load_cwd,
+        start_stashed: cli.start_stashed,
+        assume_master_down: cli.assume_master_down,
+    }
+}
+
+fn master_config(cli: Cli) -> master::config::MasterConfig {
+    master::config::MasterConfig {
+        agent: cli.agent,
+        agent_id: cli.agent_id,
+        allowed_agent_ids: cli.allowed_agent_ids,
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -697,7 +174,7 @@ async fn main() -> Result<()> {
     //      — aligns with C++ side's PrimaryLanguageOverride behavior
     //   2. sys_locale (GetUserPreferredUILanguages — automatic OS detection)
     //      — aligns with C++ side's MRT fallback when Language is empty
-    let cli = Cli::parse();
+    let mut cli = Cli::parse();
 
     // Initialize file logging exactly once, as the very first thing after
     // arg parsing, so even early-startup failures (locale, ETW registration,
@@ -752,7 +229,8 @@ async fn main() -> Result<()> {
     }
     let json_mode = cli.json;
 
-    let result = match cli.command {
+    let command = cli.command.take();
+    let result = match command {
         // Subcommand aliases for legacy modes
         Some(Command::Info) => run_info_mode().await,
         Some(Command::TestPipe) => run_test_pipe().await,
@@ -1001,7 +479,7 @@ async fn main() -> Result<()> {
         Some(Command::ProbeModels { agent }) => run_probe_models(&agent).await,
         Some(Command::ProbeAgentSources { wsl_distro }) => {
             run_probe_agent_sources(&wsl_distro).await
-        },
+        }
 
         // ── ACP session/list probe (diagnostic) ──
         Some(Command::ProbeSessions { agent }) => run_probe_sessions(&agent).await,
@@ -1023,9 +501,9 @@ async fn main() -> Result<()> {
         //    - neither: error — there is no standalone agent mode.
         None => {
             if let Some(pipe_name) = cli.master.clone() {
-                master::run_master_mode(cli, pipe_name).await
+                master::run_master_mode(master_config(cli), pipe_name).await
             } else if let Some(pipe_name) = cli.connect_master.clone() {
-                helper::run_helper_mode(cli, pipe_name).await
+                helper::run_helper_mode(helper_config(cli), pipe_name).await
             } else {
                 Err(anyhow::anyhow!(
                     "wta has no standalone agent mode: it runs as a Windows \
@@ -1220,8 +698,9 @@ async fn run_probe_host_sessions(agent: &str) -> Result<()> {
     // Resolve the CliSource from the agent command so the probe labels and
     // classifies rows the way production seeding does (which uses the real
     // `state.cli_source`), instead of assuming Copilot for every agent.
-    let cli_source =
-        CliSource::parse(Some(crate::agent_registry::resolve_agent_id_from_cmd(agent)));
+    let cli_source = CliSource::parse(Some(crate::agent_registry::resolve_agent_id_from_cmd(
+        agent,
+    )));
 
     let local = tokio::task::LocalSet::new();
     let rows = match local
@@ -1562,7 +1041,6 @@ async fn get_first_tab_id(channel: &CliChannel, window_id: &str) -> Result<Strin
         .ok_or_else(|| anyhow::anyhow!("{}", t!("output.no_tabs_in_window", window_id = window_id)))
 }
 
-
 // ─── sessions CLI helpers ───────────────────────────────────────────────────
 
 const MASTER_NOT_RUNNING: &str = "wta-master not running. Start Windows Terminal first.";
@@ -1613,15 +1091,16 @@ async fn fetch_sessions_from_master(
     });
 
     let init_started = std::time::Instant::now();
-    let init_result = conn.initialize(
-        acp::schema::v1::InitializeRequest::new(acp::schema::ProtocolVersion::V1)
-            .client_capabilities(acp::schema::v1::ClientCapabilities::new())
-            .client_info(
-                acp::schema::v1::Implementation::new("wta-sessions", env!("CARGO_PKG_VERSION"))
-                    .title("Windows Terminal Agent sessions CLI"),
-            ),
-    )
-    .await;
+    let init_result = conn
+        .initialize(
+            acp::schema::v1::InitializeRequest::new(acp::schema::ProtocolVersion::V1)
+                .client_capabilities(acp::schema::v1::ClientCapabilities::new())
+                .client_info(
+                    acp::schema::v1::Implementation::new("wta-sessions", env!("CARGO_PKG_VERSION"))
+                        .title("Windows Terminal Agent sessions CLI"),
+                ),
+        )
+        .await;
     telemetry::log_acp_initialize_complete(
         init_started.elapsed().as_secs_f64() * 1000.0,
         init_result.is_ok(),
@@ -1701,8 +1180,11 @@ async fn register_launched_session_with_master(
                 acp::schema::v1::InitializeRequest::new(acp::schema::ProtocolVersion::V1)
                     .client_capabilities(acp::schema::v1::ClientCapabilities::new())
                     .client_info(
-                        acp::schema::v1::Implementation::new("wta-delegate", env!("CARGO_PKG_VERSION"))
-                            .title("Windows Terminal Agent delegate"),
+                        acp::schema::v1::Implementation::new(
+                            "wta-delegate",
+                            env!("CARGO_PKG_VERSION"),
+                        )
+                        .title("Windows Terminal Agent delegate"),
                     ),
             )
             .await
@@ -1781,7 +1263,11 @@ fn format_sessions_table(sessions: &[session_registry::SessionInfo]) -> String {
     ));
     for (i, session) in sessions.iter().enumerate() {
         let sid = session.session_id.to_string();
-        let short_sid = if sid.len() > 24 { &sid[..24] } else { sid.as_str() };
+        let short_sid = if sid.len() > 24 {
+            &sid[..24]
+        } else {
+            sid.as_str()
+        };
         out.push_str(&format!(
             "{:<4} {:<24} {:<10} {:<10} {:<10} {:<16} {:<20} {:<20} {}\n",
             i + 1,
@@ -1799,15 +1285,17 @@ fn format_sessions_table(sessions: &[session_registry::SessionInfo]) -> String {
 }
 
 fn status_label(status: Option<&agent_sessions::AgentStatus>) -> String {
-    status.map(|s| format!("{s:?}")).unwrap_or_else(|| "-".to_string())
+    status
+        .map(|s| format!("{s:?}"))
+        .unwrap_or_else(|| "-".to_string())
 }
 
 fn cli_source_label(source: Option<&agent_sessions::CliSource>) -> String {
     match source {
-        Some(agent_sessions::CliSource::Claude)  => "Claude".to_string(),
-        Some(agent_sessions::CliSource::Codex)   => "Codex".to_string(),
+        Some(agent_sessions::CliSource::Claude) => "Claude".to_string(),
+        Some(agent_sessions::CliSource::Codex) => "Codex".to_string(),
         Some(agent_sessions::CliSource::Copilot) => "Copilot".to_string(),
-        Some(agent_sessions::CliSource::Gemini)  => "Gemini".to_string(),
+        Some(agent_sessions::CliSource::Gemini) => "Gemini".to_string(),
         Some(agent_sessions::CliSource::OpenCode) => "OpenCode".to_string(),
         Some(agent_sessions::CliSource::Unknown(s)) if !s.is_empty() => s.clone(),
         _ => "-".to_string(),
@@ -1822,8 +1310,8 @@ fn cli_source_label(source: Option<&agent_sessions::CliSource>) -> String {
 fn origin_label(origin: Option<&agent_sessions::SessionOrigin>) -> &'static str {
     match origin {
         Some(agent_sessions::SessionOrigin::AgentPane) => "AgentPane",
-        Some(agent_sessions::SessionOrigin::Unknown)   => "Shell",
-        None                                           => "-",
+        Some(agent_sessions::SessionOrigin::Unknown) => "Shell",
+        None => "-",
     }
 }
 
@@ -2131,7 +1619,11 @@ async fn run_delegate(
     cwd: Option<&str>,
 ) -> Result<()> {
     // Log the prompt length, not the text — the prompt is user content.
-    tracing::info!(prompt_chars = prompt.map(|p| p.chars().count()), agent = agent_cmd, "run_delegate started");
+    tracing::info!(
+        prompt_chars = prompt.map(|p| p.chars().count()),
+        agent = agent_cmd,
+        "run_delegate started"
+    );
     tracing::trace!(target: "delegate.content", prompt = ?prompt, "run_delegate prompt");
 
     let (debug_tx, _) = tokio::sync::mpsc::unbounded_channel::<app::DebugMessage>();
@@ -2519,7 +2011,8 @@ async fn delegate_with_context(
     tracing::trace!(target: "delegate.content", commandline, "delegate_with_context commandline");
 
     let windows_home = std::env::var("USERPROFILE").ok();
-    let sanitized_cwd = crate::coordinator::sanitize_windows_agent_cwd(cwd, windows_home.as_deref());
+    let sanitized_cwd =
+        crate::coordinator::sanitize_windows_agent_cwd(cwd, windows_home.as_deref());
 
     let create_resp = shell_mgr
         .wt_create_tab(Some(&commandline), sanitized_cwd.as_deref(), None, None)

--- a/tools/wta/src/master/config.rs
+++ b/tools/wta/src/master/config.rs
@@ -1,0 +1,6 @@
+#[derive(Debug)]
+pub(crate) struct MasterConfig {
+    pub(crate) agent: String,
+    pub(crate) agent_id: Option<String>,
+    pub(crate) allowed_agent_ids: Vec<String>,
+}

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -60,7 +60,10 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::protocol::acp::conn;
 use crate::protocol::acp::spawn::{spawn_agent_process_for_source, AgentStderrLog};
-use crate::Cli;
+
+pub(crate) mod config;
+
+use config::MasterConfig;
 
 /// Opaque identifier for a helper connection. Used in logs only;
 /// routing keys off `acp::schema::v1::SessionId`.
@@ -238,7 +241,7 @@ struct MasterStateInner {
     /// reading the CLI's on-disk files.
     agent_conn: OnceLock<conn::ClientLink>,
     /// The CLI provider master is multiplexing. Resolved once at
-    /// startup from `cli.agent` via `agent_registry::resolve_agent_id_from_cmd`.
+    /// startup from `config.agent` via `agent_registry::resolve_agent_id_from_cmd`.
     /// Used to stamp `cli_source` on every SessionInfo upserted from
     /// `session/new` and `session/load` so agent-pane sessions are not
     /// reported with cli_source=None (which would make session management Enter on a
@@ -1502,18 +1505,18 @@ impl HelperHandler {
 }
 
 /// Master mode entry point.
-pub async fn run_master_mode(cli: Cli, pipe_name: String) -> Result<()> {
+pub async fn run_master_mode(config: MasterConfig, pipe_name: String) -> Result<()> {
     // Logging is initialized once in `main()`; the WorkerGuard lives there for
     // the whole process so the non-blocking appender flushes on the graceful
     // shutdown path (see the `run_master_loop` shutdown notes below).
     tracing::info!(
         target: "master",
         pipe_name = %pipe_name,
-        agent_cmd = %cli.agent,
+        agent_cmd = %config.agent,
         "=== wta-master starting ==="
     );
 
-    if cli.agent.is_empty() {
+    if config.agent.is_empty() {
         return Err(anyhow!(
             "wta-master requires --agent <cmd>; nothing to multiplex onto"
         ));
@@ -1551,7 +1554,7 @@ pub async fn run_master_mode(cli: Cli, pipe_name: String) -> Result<()> {
 
     let local_set = LocalSet::new();
     let result = local_set
-        .run_until(async move { run_master_loop(cli, pipe_name).await })
+        .run_until(async move { run_master_loop(config, pipe_name).await })
         .await;
 
     // Every master-side failure (named-pipe create/connect, agent CLI spawn,
@@ -1802,7 +1805,7 @@ fn create_master_pipe_instance(
     }
 }
 
-async fn run_master_loop(cli: Cli, pipe_name: String) -> Result<()> {
+async fn run_master_loop(config: MasterConfig, pipe_name: String) -> Result<()> {
     // Best-effort wtcli/COM channel for intellterm.wta/focus_session AND
     // the WT connection_state -> PaneClosed bridge: master demotes F2 rows
     // to Ended on pane-close even when no helper publishes a `PaneClosed`
@@ -1838,18 +1841,18 @@ async fn run_master_loop(cli: Cli, pipe_name: String) -> Result<()> {
 
     // Agent CLIs are spawned LAZILY by `get_or_spawn_agent` the first time
     // a helper declares an agent in its `initialize` handshake — the master
-    // no longer owns a single eager agent CLI. `cli.agent` / `cli.agent_id`
+    // no longer owns a single eager agent CLI. `config.agent` / `config.agent_id`
     // become the fallback default for helpers that don't declare one.
     // Host-supplied allowlist (GPO-filtered) of agent ids a helper may
     // select. An *absent* flag means "no allowlist; accept any known id"
     // (`None`); a *present* flag is honored fail-closed even when it filters
     // down to nothing (`Some(empty_set)` ⇒ block all) — see
     // `normalize_allowed_agent_ids` for the absent-vs-present-empty split.
-    let allowed_agent_ids = normalize_allowed_agent_ids(&cli.allowed_agent_ids);
+    let allowed_agent_ids = normalize_allowed_agent_ids(&config.allowed_agent_ids);
     tracing::info!(
         target: "master",
         allowed_agent_ids = ?allowed_agent_ids,
-        default_agent_id = ?cli.agent_id,
+        default_agent_id = ?config.agent_id,
         "agent allowlist resolved"
     );
 
@@ -1859,15 +1862,15 @@ async fn run_master_loop(cli: Cli, pipe_name: String) -> Result<()> {
         helper_ext_subscribers: Mutex::new(HashMap::new()),
         wt,
         agents: Mutex::new(HashMap::new()),
-        default_agent_cmd: cli.agent.clone(),
-        default_agent_id: cli.agent_id.clone(),
+        default_agent_cmd: config.agent.clone(),
+        default_agent_id: config.agent_id.clone(),
         allowed_agent_ids,
         cached_init_resp: OnceLock::new(),
         agent_conn: OnceLock::new(),
         cli_source: crate::agent_sessions::CliSource::from_agent_id(
-            cli.agent_id
+            config.agent_id
                 .as_deref()
-                .unwrap_or_else(|| crate::agent_registry::resolve_agent_id_from_cmd(&cli.agent)),
+                .unwrap_or_else(|| crate::agent_registry::resolve_agent_id_from_cmd(&config.agent)),
         ),
         helper_meta: Mutex::new(HashMap::new()),
         hook_owned: Mutex::new(HashSet::new()),

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -236,7 +236,7 @@ fn host_empty_allowlist_flag_round_trips_as_block_all() {
     // which normalizes to block-all, and NOT into an absent flag (which
     // would mean "no policy / accept any known id" — the bypass we're closing).
     use clap::Parser;
-    let cli = crate::Cli::try_parse_from(["wta", "--allowed-agent-ids="])
+    let cli = crate::cli::args::Cli::try_parse_from(["wta", "--allowed-agent-ids="])
         .expect("--allowed-agent-ids= parses");
     assert_eq!(
         cli.allowed_agent_ids,
@@ -249,7 +249,7 @@ fn host_empty_allowlist_flag_round_trips_as_block_all() {
         "present-but-empty ⇒ block all (fail-closed)"
     );
     // And the flag entirely absent stays "no host policy".
-    let cli_absent = crate::Cli::try_parse_from(["wta"]).expect("parses");
+    let cli_absent = crate::cli::args::Cli::try_parse_from(["wta"]).expect("parses");
     assert_eq!(
         normalize_allowed_agent_ids(&cli_absent.allowed_agent_ids),
         None,
@@ -2405,4 +2405,3 @@ async fn resume_binding_events_are_born_bound_not_hook_owned() {
     );
     assert!(!state.hook_owned.lock().await.contains(&sid));
 }
-


### PR DESCRIPTION
## Summary
- move the Clap argument model from `main.rs` into `cli/args.rs`
- introduce role-specific `HelperConfig` and `MasterConfig` runtime types
- convert parsed arguments at the entry-point boundary
- remove production helper/master dependencies on the Clap `Cli` type

## Design
This establishes a one-way dependency from CLI parsing into the helper and master runtimes. Runtime modules now receive only the fields they consume and do not import Clap or the CLI argument model.

This is behavior-preserving: no flags, aliases, defaults, dispatch order, logging labels, or runtime behavior change. CLI command handlers intentionally remain in `main.rs` for a later scoped refactor.

Closes #519
Part of #515

## Validation
- 29 CLI parser tests passed
- focused explicit-empty allowlist coverage passed
- `cargo test --manifest-path tools/wta/Cargo.toml` (1,194 passed)
- `cargo clippy --manifest-path tools/wta/Cargo.toml --all-targets -- -A clippy::never_loop`
- `cargo build --manifest-path tools/wta/Cargo.toml`
- verified production `helper/` and `master/mod.rs` contain no `Cli`, `cli::args`, or Clap dependencies