### PR TITLE
Cycle recommendation card focus through input

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -61,8 +61,8 @@ use autofix::*;
 use input_edit::{next_word_boundary, prev_word_boundary, INPUT_HISTORY_MAX_ENTRIES};
 pub(crate) use tab_state::DEFAULT_TAB_ID;
 pub use tab_state::{
-    collapsed_prompt_preview, AgentsViewState, ChatMessage, CompletedTurn, PermissionState, Scroll,
-    TabSession, View,
+    collapsed_prompt_preview, AgentsViewState, ChatMessage, CompletedTurn, PermissionState,
+    RecommendationFocus, Scroll, TabSession, View,
 };
 pub use turn_state::{AutofixContext, ChunkKind, SubmittedPrompt, TurnOutcome, TurnState};
 
@@ -5109,6 +5109,18 @@ impl App {
     /// leftmost button (Run for Send cards, the sole button for OpenAndSend).
     fn default_button_for_selected(&self) -> usize {
         0
+    }
+
+    fn focus_next_recommendation_action(&mut self) {
+        let button_count = self.button_count_for_selected();
+        let tab = self.current_tab_mut();
+        tab.selected_button = (tab.selected_button + 1) % button_count;
+    }
+
+    fn focus_previous_recommendation_action(&mut self) {
+        let button_count = self.button_count_for_selected();
+        let tab = self.current_tab_mut();
+        tab.selected_button = (tab.selected_button + button_count - 1) % button_count;
     }
 
     /// Returns true if the choice's primary action is Send (shell command).

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -4111,21 +4111,6 @@ impl App {
         }
     }
 
-    pub(super) fn accept_command_popup_completion(&mut self) {
-        if let Some(agent_id) = self
-            .selected_agent_command_candidate()
-            .map(|agent| agent.id.clone())
-        {
-            let tab = self.current_tab_mut();
-            tab.reset_input_history_navigation();
-            tab.input = format!("/agent {agent_id}");
-            tab.cursor_pos = tab.input.len();
-            tab.refresh_command_popup();
-        } else {
-            self.current_tab_mut().accept_command_popup_completion();
-        }
-    }
-
     pub(crate) fn command_ghost_suffix(&self) -> Option<&str> {
         let tab = self.current_tab();
         if tab.cursor_pos != tab.input.len() {

--- a/tools/wta/src/app/input_edit.rs
+++ b/tools/wta/src/app/input_edit.rs
@@ -225,26 +225,6 @@ impl TabSession {
             .copied()
     }
 
-    /// Tab-completion: replace the input buffer with `/<name> ` (with a
-    /// trailing space if the command takes args; otherwise just the
-    /// name) and reset the cursor to the end. Triggered by Tab when the
-    /// popup is visible.
-    pub fn accept_command_popup_completion(&mut self) {
-        self.reset_input_history_navigation();
-        if let Some(position) = self.selected_move_position() {
-            self.input = format!("/move {}", position.name);
-            self.cursor_pos = self.input.len();
-            self.refresh_command_popup();
-        } else if let Some(spec) = self.selected_command_spec() {
-            self.input = if spec.takes_args {
-                format!("/{} ", spec.name)
-            } else {
-                format!("/{}", spec.name)
-            };
-            self.cursor_pos = self.input.len();
-            self.refresh_command_popup();
-        }
-    }
 }
 
 pub(super) fn clamp_cursor_to_boundary(input: &str, cursor_pos: usize) -> usize {

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -125,6 +125,13 @@ impl PermissionState {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum RecommendationFocus {
+    #[default]
+    Button,
+    Input,
+}
+
 /// Single-axis scroll cursor. All mutations go through methods so callers
 /// don't reinvent saturating-math; the upper bound `max` is established by
 /// the layout/render pass once total content height is known and re-clamps
@@ -237,6 +244,7 @@ pub struct TabSession {
     // `turn.recommendations()`).
     pub selected_recommendation: usize,
     pub selected_button: usize,
+    pub recommendation_focus: RecommendationFocus,
     pub rec_scroll: Scroll,
 
     /// Last value the helper published for this tab in a
@@ -307,7 +315,8 @@ impl TabSession {
     /// Whether the input box is the live, enterable caret target.
     pub fn input_has_nav_focus(&self) -> bool {
         self.selected_completed_turn_idx.is_none()
-            && self.turn.recommendations().is_none()
+            && (self.turn.recommendations().is_none()
+                || self.recommendation_focus == RecommendationFocus::Input)
             && self.permission.is_empty()
             && !self.paste_pending
             && !self.model_picker_open
@@ -317,12 +326,16 @@ impl TabSession {
     pub fn clear_recommendations(&mut self) {
         self.selected_recommendation = 0;
         self.selected_button = 0;
+        self.recommendation_focus = RecommendationFocus::Button;
         self.rec_scroll.reset();
     }
 
     /// The pane the "Agent" chip should be pinned to while this tab has a
     /// recommendation card with a `Send` action selected.
     pub fn compute_chip_card_target(&self) -> Option<String> {
+        if self.recommendation_focus == RecommendationFocus::Input {
+            return None;
+        }
         let recs = self.turn.recommendations()?;
         let choice = recs.choices.get(self.selected_recommendation)?;
         let send_parent = choice.actions.iter().find_map(|action| match action {

--- a/tools/wta/src/app_keys.rs
+++ b/tools/wta/src/app_keys.rs
@@ -454,12 +454,30 @@ impl App {
         match key.code {
             KeyCode::Up if self.current_tab().turn.recommendations().is_some() =>
             {
-                if self.current_tab_mut().selected_recommendation > 0 {
+                if self.current_tab().recommendation_focus == RecommendationFocus::Input {
+                    let choices_len = self
+                        .current_tab()
+                        .turn
+                        .recommendations()
+                        .map(|r| r.choices.len())
+                        .unwrap_or(0);
+                    let tab = self.current_tab_mut();
+                    tab.recommendation_focus = RecommendationFocus::Button;
+                    tab.selected_recommendation = choices_len.saturating_sub(1);
+                    tab.selected_button = 0;
+                    self.scroll_rec_to_selected(self.main_area_width());
+                    let tab_id = self.active_tab_key().to_string();
+                    self.recompute_chip_override(&tab_id);
+                } else if self.current_tab().selected_recommendation > 0 {
                     self.current_tab_mut().selected_recommendation -= 1;
                     self.current_tab_mut().selected_button = self.default_button_for_selected();
                     self.scroll_rec_to_selected(self.main_area_width());
                     // Selection moved — the new card may target a different
                     // pane (or have no Send action), so re-pin the chip.
+                    let tab_id = self.active_tab_key().to_string();
+                    self.recompute_chip_override(&tab_id);
+                } else {
+                    self.current_tab_mut().recommendation_focus = RecommendationFocus::Input;
                     let tab_id = self.active_tab_key().to_string();
                     self.recompute_chip_override(&tab_id);
                 }
@@ -472,25 +490,33 @@ impl App {
                     .recommendations()
                     .map(|r| r.choices.len())
                     .unwrap_or(0);
-                if self.current_tab().selected_recommendation + 1 < choices_len {
-                    let default_btn = self.default_button_for_selected();
-                    self.current_tab_mut().selected_recommendation += 1;
-                    self.current_tab_mut().selected_button = default_btn;
+                if self.current_tab().recommendation_focus == RecommendationFocus::Input {
+                    let tab = self.current_tab_mut();
+                    tab.recommendation_focus = RecommendationFocus::Button;
+                    tab.selected_recommendation = 0;
+                    tab.selected_button = 0;
                     self.scroll_rec_to_selected(self.main_area_width());
+                    let tab_id = self.active_tab_key().to_string();
+                    self.recompute_chip_override(&tab_id);
+                } else if self.current_tab().selected_recommendation + 1 < choices_len {
+                    let default_button = self.default_button_for_selected();
+                    self.current_tab_mut().selected_recommendation += 1;
+                    self.current_tab_mut().selected_button = default_button;
+                    self.scroll_rec_to_selected(self.main_area_width());
+                    let tab_id = self.active_tab_key().to_string();
+                    self.recompute_chip_override(&tab_id);
+                } else {
+                    self.current_tab_mut().recommendation_focus = RecommendationFocus::Input;
                     let tab_id = self.active_tab_key().to_string();
                     self.recompute_chip_override(&tab_id);
                 }
             }
-            KeyCode::Right | KeyCode::Tab
-                if self.current_tab().turn.recommendations().is_some() =>
+            KeyCode::Right
+                if self.current_tab().turn.recommendations().is_some()
+                    && self.current_tab().recommendation_focus
+                        == RecommendationFocus::Button =>
             {
-                // Cycle button focus forward within the selected card.
-                // Send: 0=Run, 1=Insert. OpenAndSend has only index 0.
-                let button_count = self.button_count_for_selected();
-                if button_count > 1 {
-                    self.current_tab_mut().selected_button =
-                        (self.current_tab_mut().selected_button + 1) % button_count;
-                }
+                self.focus_next_recommendation_action();
             }
             KeyCode::Tab
                 if self.current_tab().input.is_empty()
@@ -517,15 +543,18 @@ impl App {
             KeyCode::Down if self.current_tab().selected_completed_turn_idx.is_some() => {
                 self.current_tab_mut().select_newer_completed_turn();
             }
-            KeyCode::Left | KeyCode::BackTab
+            KeyCode::Left
+                if self.current_tab().turn.recommendations().is_some()
+                    && self.current_tab().recommendation_focus
+                        == RecommendationFocus::Button =>
+            {
+                self.focus_previous_recommendation_action();
+            }
+            KeyCode::Tab | KeyCode::BackTab
                 if self.current_tab().turn.recommendations().is_some() =>
             {
-                // Cycle button focus backward.
-                let button_count = self.button_count_for_selected();
-                if button_count > 1 {
-                    self.current_tab_mut().selected_button =
-                        (self.current_tab_mut().selected_button + button_count - 1) % button_count;
-                }
+                // Recommendation focus is arrow-only. Consume Tab so a
+                // slash-command popup cannot edit the input behind a card.
             }
             KeyCode::F(12) => {
                 self.show_debug_panel = !self.show_debug_panel;
@@ -696,11 +725,12 @@ impl App {
                 self.current_tab_mut().toggle_selected_completed_turn();
             }
             KeyCode::Enter => {
-                if self.current_tab().turn.recommendations().is_some() {
-                    // Card is visible — it owns focus even when the input box
-                    // already has draft text. Keep the draft intact and route
-                    // Enter to the selected card action instead of submitting
-                    // or slash-parsing the input.
+                if self.current_tab().turn.recommendations().is_some()
+                    && self.current_tab().recommendation_focus == RecommendationFocus::Button
+                {
+                    // A card button owns focus even when the input box already
+                    // has draft text. Keep the draft intact and route Enter to
+                    // the selected action.
                     if self.state == ConnectionState::Connected {
                         let session_id = self.current_tab().session_id.clone();
                         if let Some(session_id) = session_id {
@@ -869,11 +899,9 @@ impl App {
             }
             KeyCode::Char(c) => {
                 // Only type into the input when it is the live caret target.
-                // When a recommendation/permission card or a past turn is
-                // highlighted the input is locked: keystrokes are ignored so
-                // the buffer can't fill invisibly (no caret) and strand the
-                // user (a non-empty buffer disables Tab/↑ history nav). Press
-                // Esc, or Tab/Shift+Tab back past the ends, to return focus.
+                // When a card button, permission card, or past turn is
+                // highlighted the input is locked so the buffer cannot fill
+                // invisibly without a caret.
                 if self.current_tab().input_has_nav_focus() {
                     self.current_tab_mut().insert_input_char(c);
                 }

--- a/tools/wta/src/app_keys.rs
+++ b/tools/wta/src/app_keys.rs
@@ -686,9 +686,6 @@ impl App {
             KeyCode::Down if self.command_popup_visible() => {
                 self.command_popup_down();
             }
-            KeyCode::Tab if self.command_popup_visible() => {
-                self.accept_command_popup_completion();
-            }
             KeyCode::Up
                 if self.current_tab().input_has_nav_focus()
                     && self.current_tab().input_history_is_browsing() =>

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -6930,8 +6930,8 @@ fn recommendation_card_cycles_buttons_and_input_with_arrows() {
         0,
         None,
     );
-    app.current_tab_mut().input = "draft".into();
-    app.current_tab_mut().cursor_pos = "draft".len();
+    app.current_tab_mut().input = "draft ".into();
+    app.current_tab_mut().cursor_pos = "draft ".len();
     app.current_tab_mut().chat_scroll.offset = 7;
 
     assert!(
@@ -6941,7 +6941,7 @@ fn recommendation_card_cycles_buttons_and_input_with_arrows() {
 
     app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
     assert_eq!(app.current_tab().selected_recommendation, 1);
-    assert_eq!(app.current_tab().input, "draft");
+    assert_eq!(app.current_tab().input, "draft ");
     assert_eq!(
         app.current_tab().chat_scroll.offset,
         7,
@@ -6966,7 +6966,7 @@ fn recommendation_card_cycles_buttons_and_input_with_arrows() {
     app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
     assert!(app.current_tab().input_has_nav_focus());
     app.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
-    assert_eq!(app.current_tab().input, "draftx");
+    assert_eq!(app.current_tab().input, "draft x");
 
     let cursor_before = app.current_tab().cursor_pos;
     app.handle_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -6921,7 +6921,7 @@ fn local_slash_command_is_not_recorded_in_input_history() {
 }
 
 #[test]
-fn recommendation_card_keeps_focus_when_input_has_draft() {
+fn recommendation_card_cycles_buttons_and_input_with_arrows() {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     let mut app = test_app();
     stage_surfaced_recommendation(
@@ -6953,15 +6953,40 @@ fn recommendation_card_keeps_focus_when_input_has_draft() {
 
     app.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
     assert_eq!(app.current_tab().selected_button, 1);
-    app.handle_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
-    assert_eq!(app.current_tab().selected_button, 0);
+    assert!(!app.current_tab().input_has_nav_focus());
 
+    app.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+    assert_eq!(app.current_tab().selected_button, 0);
+    assert!(!app.current_tab().input_has_nav_focus());
+
+    app.handle_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
+    assert_eq!(app.current_tab().selected_button, 1);
+    assert!(!app.current_tab().input_has_nav_focus());
+
+    app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+    assert!(app.current_tab().input_has_nav_focus());
     app.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
-    assert_eq!(
-        app.current_tab().input,
-        "draft",
-        "typing stays locked while the card owns focus",
-    );
+    assert_eq!(app.current_tab().input, "draftx");
+
+    let cursor_before = app.current_tab().cursor_pos;
+    app.handle_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
+    assert_eq!(app.current_tab().cursor_pos, cursor_before - 1);
+    assert!(app.current_tab().input_has_nav_focus());
+
+    app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+    assert_eq!(app.current_tab().selected_recommendation, 1);
+    assert!(!app.current_tab().input_has_nav_focus());
+    app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+    assert!(app.current_tab().input_has_nav_focus());
+    app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+    assert_eq!(app.current_tab().selected_recommendation, 0);
+    assert!(!app.current_tab().input_has_nav_focus());
+
+    app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+    assert_eq!(app.current_tab().selected_button, 0);
+    app.handle_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT));
+    assert_eq!(app.current_tab().selected_button, 0);
+    assert!(!app.current_tab().input_has_nav_focus());
 }
 
 #[test]
@@ -6988,6 +7013,52 @@ fn recommendation_card_enter_wins_over_draft_input() {
     assert!(
         !app.help_overlay_visible,
         "draft slash commands must not run while a recommendation card owns focus",
+    );
+}
+
+#[test]
+fn recommendation_input_focus_submits_draft_instead_of_executing_card() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().session_id = Some(DEFAULT_TAB_ID.into());
+    stage_surfaced_recommendation(&mut app, vec![send_choice("pane-A", "ls")], 0, None);
+    app.current_tab_mut().input = "new prompt".into();
+    app.current_tab_mut().cursor_pos = "new prompt".len();
+
+    app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+    assert!(app.current_tab().input_has_nav_focus());
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert!(app.current_tab().input.is_empty());
+    assert!(
+        app.current_tab().turn.recommendations().is_none(),
+        "submitting from the input must dismiss the old recommendation",
+    );
+    assert!(
+        matches!(app.current_tab().turn, TurnState::Submitted(_)),
+        "Enter must submit the draft instead of executing the selected card",
+    );
+}
+
+#[test]
+fn recommendation_card_swallow_tabs_without_completing_slash_command() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    let mut app = test_app();
+    stage_surfaced_recommendation(&mut app, vec![send_choice("pane-A", "ls")], 0, None);
+    app.current_tab_mut().input = "/h".into();
+    app.current_tab_mut().cursor_pos = 2;
+    app.current_tab_mut().refresh_command_popup();
+    assert!(app.command_popup_visible());
+
+    app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+    app.handle_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT));
+
+    assert_eq!(app.current_tab().input, "/h");
+    assert_eq!(
+        app.current_tab().recommendation_focus,
+        RecommendationFocus::Button,
     );
 }
 

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -59,6 +59,7 @@ impl App {
         // `Surfaced{end_pending:false}` is dismissed by the new submit.
         tab.selected_recommendation = 0;
         tab.selected_button = 0;
+        tab.recommendation_focus = RecommendationFocus::Button;
         tab.rec_scroll.reset();
         // Autofix prompts are synthesized by the system; they don't render
         // as a User bubble (the user already sees the error line in the
@@ -475,6 +476,7 @@ impl App {
         };
         tab.selected_recommendation = 0;
         tab.selected_button = 0;
+        tab.recommendation_focus = RecommendationFocus::Button;
         tab.rec_scroll.reset();
         // Stamp the matching completed_turn (pushed during surface) with an
         // "executed" marker so chat history reflects the user's choice.
@@ -569,6 +571,7 @@ impl App {
         tab.autofix.pane_id = None;
         tab.selected_recommendation = 0;
         tab.selected_button = 0;
+        tab.recommendation_focus = RecommendationFocus::Button;
         tab.rec_scroll.reset();
         tab.activity_frame = 0;
         tab.turn = TurnState::Idle;
@@ -615,6 +618,7 @@ impl App {
         tab.scroll_to_bottom();
         tab.selected_recommendation = rec_idx;
         tab.selected_button = 0;
+        tab.recommendation_focus = RecommendationFocus::Button;
         tab.rec_scroll.reset();
         tab.selection_visible_pending = true;
         tab.selected_completed_turn_idx = None;
@@ -695,6 +699,8 @@ impl App {
         tab.tool_calls.clear();
         tab.scroll_to_bottom();
         tab.selected_recommendation = rec_idx;
+        tab.selected_button = 0;
+        tab.recommendation_focus = RecommendationFocus::Button;
         tab.selection_visible_pending = true;
         tab.activity_frame = 0;
         tab.turn = TurnState::Surfaced {
@@ -779,6 +785,7 @@ impl App {
         let prompt = tab.turn.prompt().cloned().expect("prompt set");
         tab.selected_recommendation = 0;
         tab.selected_button = 0;
+        tab.recommendation_focus = RecommendationFocus::Button;
         tab.rec_scroll.reset();
         tab.activity_frame = 0;
         tab.turn = TurnState::Surfaced {

--- a/tools/wta/src/commands.rs
+++ b/tools/wta/src/commands.rs
@@ -65,10 +65,6 @@ pub struct CommandSpec {
     /// time so the popup follows the current locale.
     pub summary_key: &'static str,
     pub kind: CommandKind,
-    /// True if this command takes free-form arguments after the name.
-    /// MVP commands are all zero-arg; the field exists so the popup
-    /// knows whether to leave a trailing space after Tab-completion.
-    pub takes_args: bool,
 }
 
 impl CommandSpec {
@@ -89,63 +85,52 @@ pub const REGISTRY: &[CommandSpec] = &[
         name: "help",
         summary_key: "commands.help.summary",
         kind: CommandKind::Help,
-        takes_args: false,
     },
     CommandSpec {
         name: "clear",
         summary_key: "commands.clear.summary",
         kind: CommandKind::Clear,
-        takes_args: false,
     },
     CommandSpec {
         name: "new",
         summary_key: "commands.new.summary",
         kind: CommandKind::New,
-        takes_args: false,
     },
     CommandSpec {
         name: "fix",
         summary_key: "commands.fix.summary",
         kind: CommandKind::Fix,
-        // `/fix <hint>` — free-form text after the name steers the fix.
-        takes_args: true,
     },
     CommandSpec {
         name: "restart",
         summary_key: "commands.restart.summary",
         kind: CommandKind::Restart,
-        takes_args: false,
     },
     CommandSpec {
         name: "stop",
         summary_key: "commands.stop.summary",
         kind: CommandKind::Stop,
-        takes_args: false,
     },
     CommandSpec {
         name: "sessions",
         summary_key: "commands.sessions.summary",
         kind: CommandKind::Sessions,
-        takes_args: false,
     },
     CommandSpec {
         name: "agent",
         summary_key: "commands.agent.summary",
         kind: CommandKind::Agent,
-        takes_args: true,
     },
     CommandSpec {
         name: "model",
         summary_key: "commands.model.summary",
         // `/model <id>` switches directly; bare `/model` opens the picker.
         kind: CommandKind::Model,
-        takes_args: true,
     },
     CommandSpec {
         name: "move",
         summary_key: "commands.move.summary",
         kind: CommandKind::Move,
-        takes_args: true,
     },
 ];
 
@@ -403,7 +388,6 @@ mod tests {
         let trailing_space = parse("/agent ").unwrap();
         assert_eq!(trailing_space.kind, CommandKind::Agent);
         assert_eq!(trailing_space.rest, "");
-        assert!(lookup("agent").unwrap().takes_args);
     }
 
     #[test]
@@ -433,8 +417,6 @@ mod tests {
         let hinted = parse("/fix the path looks wrong").unwrap();
         assert_eq!(hinted.kind, CommandKind::Fix);
         assert_eq!(hinted.rest, "the path looks wrong");
-        // takes_args is advertised so Tab-completion leaves a trailing space.
-        assert!(lookup("fix").unwrap().takes_args);
     }
 
     #[test]

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -451,7 +451,7 @@ fn agent_trailing_space_opens_completion_with_all_agents() {
 }
 
 #[test]
-fn agent_argument_arrow_changes_ghost_and_tab_completes() {
+fn agent_argument_arrow_changes_ghost_but_tab_does_not_complete() {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     let mut app = test_app();
@@ -462,8 +462,8 @@ fn agent_argument_arrow_changes_ghost_and_tab_completes() {
     assert_eq!(app.command_ghost_suffix(), Some("dex"));
 
     app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
-    assert_eq!(app.current_tab().input, "/agent codex");
-    assert_eq!(app.command_ghost_suffix(), None);
+    assert_eq!(app.current_tab().input, "/agent co");
+    assert_eq!(app.command_ghost_suffix(), Some("dex"));
 }
 
 #[test]

--- a/tools/wta/src/ui/recommendations.rs
+++ b/tools/wta/src/ui/recommendations.rs
@@ -118,7 +118,10 @@ fn render_card(
 
     let button_inner = card::inset_horizontal(button_area, 2);
     if button_inner.width > 0 {
-        let focused = if is_selected {
+        let focused = if is_selected
+            && app.current_tab().recommendation_focus
+                == crate::app::RecommendationFocus::Button
+        {
             Some(app.current_tab().selected_button)
         } else {
             None

--- a/tools/wta/src/ui/recommendations.rs
+++ b/tools/wta/src/ui/recommendations.rs
@@ -88,9 +88,9 @@ fn render_card(
         return;
     }
 
-    // When a recommendation is visible, the card owns focus even if the prompt
-    // box contains draft text. Match the key routing so there is exactly one
-    // visible focus target.
+    // A selected card only paints button focus while recommendation navigation
+    // targets it; Up/Down can move that focus to the input while cards remain
+    // visible.
     let is_selected = idx == app.current_tab().selected_recommendation;
     let border_style = if is_selected {
         theme::CARD_BORDER_SELECTED


### PR DESCRIPTION
## Summary
- include the input box in recommendation-card vertical focus navigation
- use Up/Down to cycle between cards and input, while Left/Right cycles card actions
- keep Tab and Shift+Tab out of recommendation focus navigation
- preserve normal cursor movement and prompt submission while input is focused

## Testing
- cargo test --manifest-path tools/wta/Cargo.toml