### PR TITLE
Make recommendation pane routing host-owned

### DIFF
--- a/tools/wta/prompts/terminal-agent.md
+++ b/tools/wta/prompts/terminal-agent.md
@@ -69,7 +69,7 @@ These rules exist because cwd can be ambiguous across tool calls. When Terminal 
 
 Action types:
 
-- `send` — type `input` plus Enter into an existing pane identified by `parent`. Used in Mode A.
+- `send` — type `input` plus Enter into the active pane selected by the host. Used in Mode A.
 - `open_and_send` — create a new shell or agent destination, then type `input` plus Enter into it. Used in Mode C, or in Mode A when the user explicitly asked for a new tab/panel.
 - `open` — create a new empty shell tab or panel and do NOT send any input. Use only when the user explicitly asked for a new tab/panel with no command (e.g. "open a new tab here", "split a pane right").
 
@@ -80,21 +80,21 @@ Rules:
 - Keep `title` short. Keep `rationale` to one sentence.
 
 `send` rules (Mode A):
-- `parent` MUST be the literal `activeTarget` value from the Terminal Context JSON. Never invent pane IDs.
+- Omit `parent`. The host binds the action to the `activeTarget` captured for this turn.
 - `input` must match the active pane's shell — determine it from `shell` (the actual executable). PowerShell/pwsh → `Get-ChildItem`, `Get-Location`, `Set-Location`, `Get-Content`, `Remove-Item`. cmd → `dir`, `cd`, `type`, `del`. bash/WSL → `ls`, `pwd`, `cd`, `cat`, `rm`. Default to PowerShell when `shell` is missing.
 - For Mode A inspection commands, prefer a single `send` choice on the active pane unless the user explicitly asked for isolation.
 
 `open_and_send` rules (Mode C, or new-destination A):
 - Must include `target` (`"tab"` or `"panel"`) and `input`.
 - Must include `cwd` so the new shell starts in the right directory (use the runtime cwd unless the user named a different directory).
-- For `target: "panel"`: set `parent` to `activeTarget`. You may include `direction` (`"right"` / `"left"` / `"up"` / `"down"` / `"auto"`).
+- For `target: "panel"`: omit `parent`; the host binds it to the captured `activeTarget`. You may include `direction` (`"right"` / `"left"` / `"up"` / `"down"` / `"auto"`).
 - For `target: "tab"`: omit `parent`. `direction` is invalid.
 - When delegating (Mode C), set `agent` to an ID from the supported delegate agent JSON. WTA will launch that agent in the new destination and send `input` as the agent's first prompt.
 - The delegated `input` should be a self-contained briefing: tell the delegate agent the cwd, the goal, the constraints, and what "done" looks like.
 
 `open` rules:
 - Must include `target` (`"tab"` or `"panel"`). MUST NOT include `input` or `agent`.
-- Should include `cwd`. May include `title`. For panels, set `parent` to `activeTarget`, optionally `direction`.
+- Should include `cwd`. May include `title`. For panels, omit `parent`; the host supplies it. You may include `direction`.
 
 `activeTarget` rules:
 - If `activeTarget` is missing from the Terminal Context, do NOT emit `send` or any `target: "panel"` action — there is no pane to attach to. Fall back to `target: "tab"` or to a Mode B / chat answer.
@@ -120,7 +120,6 @@ Rules:
       "actions": [
         {
           "type": "send",
-          "parent": "10",
           "input": "cargo test"
         }
       ]

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -65,6 +65,7 @@ pub use tab_state::{
     RecommendationFocus, Scroll, TabSession, View,
 };
 pub use turn_state::{AutofixContext, ChunkKind, SubmittedPrompt, TurnOutcome, TurnState};
+pub use crate::turn_context::TurnContext;
 
 // ─── MVP sessions origin filter ────────────────────────────────────────────────────
 //
@@ -4386,8 +4387,8 @@ impl App {
     /// Differences from auto-triggered autofix (`maybe_trigger_autofix`):
     /// there is no failing-pane notification, so (1) the helper's captured
     /// source pane is resolved in the ACP client task; and
-    /// (2) `target_pane_id` starts empty and is late-bound once the client task
-    /// resolves that working pane (`AppEvent::PromptTargetResolved` →
+    /// (2) the turn context starts without a target and is late-bound once
+    /// the client task resolves that working pane (`AppEvent::PromptTargetResolved` →
     /// `apply_prompt_target_resolved`), so `turn_execute_card` fills
     /// `Send.parent` with a real pane. The bottom-bar Pending pill is *not*
     /// armed — that UI is tied to a specific failing pane, and a command typed
@@ -4432,13 +4433,12 @@ impl App {
             id: prompt.id,
             text: prompt.text.clone(),
             submitted_at_unix_s: prompt.submitted_at_unix_s,
-            target_pane_id: source_pane_id.clone(),
-            autofix: Some(AutofixContext {
+            context: TurnContext {
                 // Normally captured when the helper starts. If unavailable,
                 // the ACP client resolves the active source and late-binds it.
-                target_pane_id: source_pane_id.unwrap_or_default(),
-                generation,
-            }),
+                target_pane_id: source_pane_id,
+            },
+            autofix: Some(AutofixContext { generation }),
         };
         tracing::info!(
             target: "slash_cmd",
@@ -4494,10 +4494,7 @@ impl App {
         if prompt.id != prompt_id {
             return;
         }
-        prompt.target_pane_id = Some(pane_id.clone());
-        if let Some(autofix) = prompt.autofix.as_mut() {
-            autofix.target_pane_id = pane_id.clone();
-        }
+        prompt.context.target_pane_id = Some(pane_id.clone());
         tracing::info!(
             target: "pane_routing",
             tab = %key,

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -113,8 +113,7 @@ pub use crate::app_contracts::{
 };
 use crate::coordinator::{
     parse_autofix_response, parse_recommendation_set, recommended_choice_index,
-    validate_recommendation_set_for_coordinator_target, AutofixDecision, RecommendationChoice,
-    RecommendationSet,
+    AutofixDecision, RecommendationChoice, RecommendationSet,
 };
 use crate::pane_context::PaneContext;
 
@@ -3499,7 +3498,7 @@ impl App {
             AppEvent::AgentPasteTextReady { .. } => "agent_paste_text_ready",
             AppEvent::AgentPasteTextFailed { .. } => "agent_paste_text_failed",
             AppEvent::PromptTemplateLoaded { .. } => "prompt_template_loaded",
-            AppEvent::AutofixTargetResolved { .. } => "autofix_target_resolved",
+            AppEvent::PromptTargetResolved { .. } => "prompt_target_resolved",
             AppEvent::AgentError { .. } => "agent_error",
             AppEvent::AgentSoftStop { .. } => "agent_soft_stop",
             AppEvent::AgentBusy { .. } => "agent_busy",
@@ -4385,13 +4384,11 @@ impl App {
     /// after `/fix` is appended as an extra steer.
     ///
     /// Differences from auto-triggered autofix (`maybe_trigger_autofix`):
-    /// there is no failing-pane notification, so (1) the source pane is
-    /// resolved in the ACP client task — `PaneContext.source_pane_id` is left
-    /// `None` and `build_prompt_text` falls back to WT's active pane, which
-    /// GetActivePane maps from the agent pane to the user's working pane; and
+    /// there is no failing-pane notification, so (1) the helper's captured
+    /// source pane is resolved in the ACP client task; and
     /// (2) `target_pane_id` starts empty and is late-bound once the client task
-    /// resolves that working pane (`AppEvent::AutofixTargetResolved` →
-    /// `apply_autofix_target_resolved`), so `turn_execute_card` fills
+    /// resolves that working pane (`AppEvent::PromptTargetResolved` →
+    /// `apply_prompt_target_resolved`), so `turn_execute_card` fills
     /// `Send.parent` with a real pane. The bottom-bar Pending pill is *not*
     /// armed — that UI is tied to a specific failing pane, and a command typed
     /// into the agent pane surfaces its result there directly.
@@ -4420,13 +4417,13 @@ impl App {
             tab.autofix.generation
         };
 
+        let source_pane_id = self.source_session_id.clone();
         let pane_context = PaneContext {
             pane_id: self.pane_id.clone(),
             tab_id: Some(target_tab_id.clone()),
             window_id: self.window_id.clone(),
             cwd: None,
-            // None → the client task resolves the active working pane itself.
-            source_pane_id: None,
+            source_pane_id: source_pane_id.clone(),
         };
 
         let hint = hint.trim().to_string();
@@ -4435,12 +4432,11 @@ impl App {
             id: prompt.id,
             text: prompt.text.clone(),
             submitted_at_unix_s: prompt.submitted_at_unix_s,
+            target_pane_id: source_pane_id.clone(),
             autofix: Some(AutofixContext {
-                // Placeholder — the working pane isn't known synchronously here.
-                // The ACP client task resolves it and `apply_autofix_target_resolved`
-                // late-binds it (matched by prompt id) before the card surfaces,
-                // so `turn_execute_card` fills `Send.parent` with a real pane.
-                target_pane_id: String::new(),
+                // Normally captured when the helper starts. If unavailable,
+                // the ACP client resolves the active source and late-binds it.
+                target_pane_id: source_pane_id.unwrap_or_default(),
                 generation,
             }),
         };
@@ -4457,16 +4453,15 @@ impl App {
 
     /// Late-bind a manual `/fix`'s target pane. The working pane is resolved
     /// in the ACP client task (it isn't known when `cmd_fix` submits) and
-    /// plumbed back via [`AppEvent::AutofixTargetResolved`]. We patch the
-    /// matching in-flight turn's `AutofixContext.target_pane_id` so that
-    /// `turn_execute_card` fills `Send.parent` with a real pane — without it,
-    /// the host's send has no destination ("SendInput failed: no parent").
+    /// plumbed back via [`AppEvent::PromptTargetResolved`]. The same event
+    /// binds ordinary planner turns so execution never trusts a
+    /// model-generated pane target.
     ///
     /// Routed by `prompt_id`: a superseded turn (the user fired a newer `/fix`)
     /// won't match, so a stale resolution is dropped. The event is emitted
     /// before the agent responds, so the patch lands while the turn is still
     /// `Submitted` — well before the fix card surfaces or the user executes it.
-    fn apply_autofix_target_resolved(
+    fn apply_prompt_target_resolved(
         &mut self,
         tab_id: Option<String>,
         prompt_id: u64,
@@ -4475,26 +4470,40 @@ impl App {
         if pane_id.is_empty() {
             return;
         }
-        let key = tab_id.unwrap_or_else(|| self.active_tab_key().to_string());
-        let Some(tab) = self.tab_sessions.get_mut(&key) else {
+        let preferred_key = tab_id.unwrap_or_else(|| self.active_tab_key().to_string());
+        let key = self
+            .tab_sessions
+            .get(&preferred_key)
+            .filter(|tab| tab.turn.prompt().is_some_and(|prompt| prompt.id == prompt_id))
+            .map(|_| preferred_key)
+            .or_else(|| {
+                self.tab_sessions.iter().find_map(|(key, tab)| {
+                    tab.turn
+                        .prompt()
+                        .is_some_and(|prompt| prompt.id == prompt_id)
+                        .then(|| key.clone())
+                })
+            });
+        let Some(key) = key else {
             return;
         };
+        let tab = self.tab_sessions.get_mut(&key).expect("resolved tab exists");
         let Some(prompt) = tab.turn.prompt_mut() else {
             return;
         };
         if prompt.id != prompt_id {
             return;
         }
-        let Some(autofix) = prompt.autofix.as_mut() else {
-            return;
-        };
-        autofix.target_pane_id = pane_id.clone();
+        prompt.target_pane_id = Some(pane_id.clone());
+        if let Some(autofix) = prompt.autofix.as_mut() {
+            autofix.target_pane_id = pane_id.clone();
+        }
         tracing::info!(
-            target: "slash_cmd",
+            target: "pane_routing",
             tab = %key,
             prompt_id,
             pane = %pane_id,
-            "bound /fix target pane",
+            "bound authoritative prompt target pane",
         );
     }
 

--- a/tools/wta/src/app/autofix.rs
+++ b/tools/wta/src/app/autofix.rs
@@ -257,11 +257,8 @@ impl App {
             id: prompt.id,
             text: prompt.text.clone(),
             submitted_at_unix_s: prompt.submitted_at_unix_s,
-            target_pane_id: Some(notification.pane_id.clone()),
-            autofix: Some(AutofixContext {
-                target_pane_id: notification.pane_id.clone(),
-                generation: new_gen,
-            }),
+            context: TurnContext::with_target_pane(notification.pane_id.clone()),
+            autofix: Some(AutofixContext { generation: new_gen }),
         };
         // Install the turn on the target tab — bypasses session_to_tab
         // lookup so a tab with no ACP session yet still gets the prompt
@@ -467,7 +464,7 @@ impl App {
                 .send(crate::coordinator::ChoiceExecution {
                     choice,
                     insert_only: false,
-                    target_pane_id: Some(armed_pane),
+                    context: TurnContext::with_target_pane(armed_pane),
                 });
         }
         self.push_execution_info(format!("Auto-executing choice {}.", choice_label));

--- a/tools/wta/src/app/autofix.rs
+++ b/tools/wta/src/app/autofix.rs
@@ -257,6 +257,7 @@ impl App {
             id: prompt.id,
             text: prompt.text.clone(),
             submitted_at_unix_s: prompt.submitted_at_unix_s,
+            target_pane_id: Some(notification.pane_id.clone()),
             autofix: Some(AutofixContext {
                 target_pane_id: notification.pane_id.clone(),
                 generation: new_gen,
@@ -466,6 +467,7 @@ impl App {
                 .send(crate::coordinator::ChoiceExecution {
                     choice,
                     insert_only: false,
+                    target_pane_id: Some(armed_pane),
                 });
         }
         self.push_execution_info(format!("Auto-executing choice {}.", choice_label));

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -338,15 +338,6 @@ impl TabSession {
         }
         let recs = self.turn.recommendations()?;
         let choice = recs.choices.get(self.selected_recommendation)?;
-        let send_parent = choice.actions.iter().find_map(|action| match action {
-            crate::coordinator::RecommendedAction::Send { parent, .. } if !parent.is_empty() => {
-                Some(parent.clone())
-            }
-            _ => None,
-        });
-        if send_parent.is_some() {
-            return send_parent;
-        }
         if choice
             .actions
             .iter()
@@ -355,9 +346,7 @@ impl TabSession {
             return self
                 .turn
                 .prompt()
-                .and_then(|prompt| prompt.autofix.as_ref())
-                .map(|autofix| autofix.target_pane_id.clone())
-                .filter(|pane_id| !pane_id.is_empty());
+                .and_then(|prompt| prompt.context.target_pane_id().map(str::to_string));
         }
         None
     }

--- a/tools/wta/src/app/turn_state.rs
+++ b/tools/wta/src/app/turn_state.rs
@@ -9,6 +9,7 @@
 //! effects live on `App` methods in `app.rs`.
 
 use crate::coordinator::RecommendationSet;
+use crate::turn_context::TurnContext;
 
 /// Per-tab turn state.
 #[derive(Debug, Clone, PartialEq)]
@@ -44,16 +45,13 @@ pub struct SubmittedPrompt {
     pub id: u64,
     pub text: String,
     pub submitted_at_unix_s: f64,
-    /// Pane resolved by the host while assembling this prompt.
-    pub target_pane_id: Option<String>,
+    pub context: TurnContext,
     pub autofix: Option<AutofixContext>,
 }
 
 /// Extra context attached to autofix-initiated turns.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AutofixContext {
-    /// Pane that produced the failing command.
-    pub target_pane_id: String,
     /// `App.autofix_generation` at submit time. Compared against current
     /// generation on every chunk / end event; mismatch means a newer autofix
     /// (or an Esc cancel) has invalidated this turn — drop the response.
@@ -143,8 +141,7 @@ impl TurnState {
     }
 
     /// Mutable prompt info for the in-flight or just-surfaced turn. Used to
-    /// late-bind a manual `/fix`'s `AutofixContext.target_pane_id` once the
-    /// client task has resolved the working pane (see
+    /// late-bind the host-resolved turn context (see
     /// `App::apply_prompt_target_resolved`).
     pub fn prompt_mut(&mut self) -> Option<&mut SubmittedPrompt> {
         match self {
@@ -181,7 +178,7 @@ mod tests {
             id: 1,
             text: "hello".into(),
             submitted_at_unix_s: 0.0,
-            target_pane_id: None,
+            context: TurnContext::default(),
             autofix: None,
         }
     }
@@ -191,11 +188,8 @@ mod tests {
             id: 2,
             text: "autofix".into(),
             submitted_at_unix_s: 0.0,
-            target_pane_id: Some("pane-1".into()),
-            autofix: Some(AutofixContext {
-                target_pane_id: "pane-1".into(),
-                generation: gen,
-            }),
+            context: TurnContext::with_target_pane("pane-1"),
+            autofix: Some(AutofixContext { generation: gen }),
         }
     }
 

--- a/tools/wta/src/app/turn_state.rs
+++ b/tools/wta/src/app/turn_state.rs
@@ -44,6 +44,8 @@ pub struct SubmittedPrompt {
     pub id: u64,
     pub text: String,
     pub submitted_at_unix_s: f64,
+    /// Pane resolved by the host while assembling this prompt.
+    pub target_pane_id: Option<String>,
     pub autofix: Option<AutofixContext>,
 }
 
@@ -143,7 +145,7 @@ impl TurnState {
     /// Mutable prompt info for the in-flight or just-surfaced turn. Used to
     /// late-bind a manual `/fix`'s `AutofixContext.target_pane_id` once the
     /// client task has resolved the working pane (see
-    /// `App::apply_autofix_target_resolved`).
+    /// `App::apply_prompt_target_resolved`).
     pub fn prompt_mut(&mut self) -> Option<&mut SubmittedPrompt> {
         match self {
             TurnState::Idle => None,
@@ -179,6 +181,7 @@ mod tests {
             id: 1,
             text: "hello".into(),
             submitted_at_unix_s: 0.0,
+            target_pane_id: None,
             autofix: None,
         }
     }
@@ -188,6 +191,7 @@ mod tests {
             id: 2,
             text: "autofix".into(),
             submitted_at_unix_s: 0.0,
+            target_pane_id: Some("pane-1".into()),
             autofix: Some(AutofixContext {
                 target_pane_id: "pane-1".into(),
                 generation: gen,

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -47,7 +47,7 @@ pub enum AppEvent {
     PromptTemplateLoaded {
         name: String,
     },
-    AutofixTargetResolved {
+    PromptTargetResolved {
         tab_id: Option<String>,
         prompt_id: u64,
         pane_id: String,

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -288,12 +288,12 @@ impl App {
             AppEvent::PromptTemplateLoaded { name } => {
                 self.prompt_name = Some(name);
             }
-            AppEvent::AutofixTargetResolved {
+            AppEvent::PromptTargetResolved {
                 tab_id,
                 prompt_id,
                 pane_id,
             } => {
-                self.apply_autofix_target_resolved(tab_id, prompt_id, pane_id);
+                self.apply_prompt_target_resolved(tab_id, prompt_id, pane_id);
             }
             AppEvent::AgentBusy { tab_id } => {
                 let tab = self.tab_mut(&tab_id);

--- a/tools/wta/src/app_keys.rs
+++ b/tools/wta/src/app_keys.rs
@@ -807,7 +807,7 @@ impl App {
                         tab_id: self.tab_id.clone(),
                         window_id: self.window_id.clone(),
                         cwd: self.source_cwd.clone(),
-                        source_pane_id: None,
+                        source_pane_id: self.source_session_id.clone(),
                     };
                     // The echoed user message shows a marker for each queued
                     // image; the ACP text block stays raw (the image rides as a
@@ -844,6 +844,7 @@ impl App {
                         id: prompt.id,
                         text: display_text,
                         submitted_at_unix_s: prompt.submitted_at_unix_s,
+                        target_pane_id: None,
                         autofix: None,
                     };
                     self.turn_submit_prompt(&session_id, submitted);

--- a/tools/wta/src/app_keys.rs
+++ b/tools/wta/src/app_keys.rs
@@ -844,7 +844,7 @@ impl App {
                         id: prompt.id,
                         text: display_text,
                         submitted_at_unix_s: prompt.submitted_at_unix_s,
-                        target_pane_id: None,
+                        context: TurnContext::default(),
                         autofix: None,
                     };
                     self.turn_submit_prompt(&session_id, submitted);

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -4394,6 +4394,7 @@ fn submit_test_prompt(app: &mut App, text: &str) {
         id: 42,
         text: text.into(),
         submitted_at_unix_s: 0.0,
+        target_pane_id: None,
         autofix: None,
     };
     app.turn_submit_prompt(DEFAULT_TAB_ID, prompt);
@@ -4652,6 +4653,7 @@ fn permission_request_keeps_thinking_until_turn_ends() {
         id: 1,
         text: "test".into(),
         submitted_at_unix_s: 0.0,
+        target_pane_id: None,
         autofix: None,
     };
     app.tab_mut(DEFAULT_TAB_ID).turn = TurnState::Surfaced {
@@ -5854,6 +5856,7 @@ fn render_recommendation_card_shows_command() {
             id: 1,
             text: "fix it".into(),
             submitted_at_unix_s: 0.0,
+            target_pane_id: None,
             autofix: None,
         },
         outcome: TurnOutcome::Recommendation(RecommendationSet {
@@ -6065,6 +6068,7 @@ fn submit_autofix_prompt(app: &mut App, pane: &str) {
         id: 99,
         text: "diagnose this".into(),
         submitted_at_unix_s: 0.0,
+        target_pane_id: Some(pane.into()),
         autofix: Some(AutofixContext {
             target_pane_id: pane.into(),
             generation: gen,
@@ -6086,6 +6090,7 @@ fn submit_fix_prompt(app: &mut App, id: u64) {
         id,
         text: String::new(),
         submitted_at_unix_s: 0.0,
+        target_pane_id: None,
         autofix: Some(AutofixContext {
             target_pane_id: String::new(),
             generation: gen,
@@ -6113,16 +6118,59 @@ fn fix_target_pane_is_late_bound_by_prompt_id() {
     assert_eq!(fix_target_pane(&app), "", "starts unbound");
 
     // A resolution for a different prompt id (a superseded /fix) is ignored.
-    app.apply_autofix_target_resolved(Some(DEFAULT_TAB_ID.into()), 7, "pane-X".into());
+    app.apply_prompt_target_resolved(Some(DEFAULT_TAB_ID.into()), 7, "pane-X".into());
     assert_eq!(fix_target_pane(&app), "", "stale prompt_id must not patch");
 
     // An empty pane id is a no-op.
-    app.apply_autofix_target_resolved(Some(DEFAULT_TAB_ID.into()), 42, String::new());
+    app.apply_prompt_target_resolved(Some(DEFAULT_TAB_ID.into()), 42, String::new());
     assert_eq!(fix_target_pane(&app), "", "empty pane id is ignored");
 
     // The matching prompt id binds the resolved working pane.
-    app.apply_autofix_target_resolved(Some(DEFAULT_TAB_ID.into()), 42, "pane-7".into());
+    app.apply_prompt_target_resolved(Some(DEFAULT_TAB_ID.into()), 42, "pane-7".into());
     assert_eq!(fix_target_pane(&app), "pane-7", "matching id binds the pane");
+    assert_eq!(
+        app.current_tab()
+            .turn
+            .prompt()
+            .unwrap()
+            .target_pane_id
+            .as_deref(),
+        Some("pane-7")
+    );
+}
+
+#[test]
+fn manual_fix_uses_the_helpers_captured_source_target() {
+    let mut app = test_app();
+    app.source_session_id = Some("captured-source-pane".into());
+
+    app.cmd_fix(false, String::new());
+
+    let prompt = app.current_tab().turn.prompt().unwrap();
+    assert_eq!(prompt.target_pane_id.as_deref(), Some("captured-source-pane"));
+    assert_eq!(
+        prompt.autofix.as_ref().unwrap().target_pane_id,
+        "captured-source-pane"
+    );
+}
+
+#[test]
+fn prompt_target_binding_survives_tab_rename() {
+    let mut app = test_app();
+    submit_fix_prompt(&mut app, 42);
+    app.rename_tab_session(DEFAULT_TAB_ID, "renamed-tab", None);
+
+    app.apply_prompt_target_resolved(Some(DEFAULT_TAB_ID.into()), 42, "pane-7".into());
+
+    assert_eq!(
+        app.tab_sessions["renamed-tab"]
+            .turn
+            .prompt()
+            .unwrap()
+            .target_pane_id
+            .as_deref(),
+        Some("pane-7")
+    );
 }
 
 #[test]
@@ -6512,6 +6560,7 @@ fn install_recs(app: &mut App, choices: Vec<RecommendationChoice>) {
             id: 1,
             text: "p".into(),
             submitted_at_unix_s: 0.0,
+            target_pane_id: None,
             autofix: None,
         },
         outcome: TurnOutcome::Recommendation(RecommendationSet {
@@ -7150,6 +7199,7 @@ fn stage_surfaced_recommendation(
         id: 1,
         text: "p".into(),
         submitted_at_unix_s: 0.0,
+        target_pane_id: autofix_target.map(str::to_string),
         autofix: autofix_target.map(|t| AutofixContext {
             target_pane_id: t.into(),
             generation: 0,

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -4394,7 +4394,7 @@ fn submit_test_prompt(app: &mut App, text: &str) {
         id: 42,
         text: text.into(),
         submitted_at_unix_s: 0.0,
-        target_pane_id: None,
+        context: TurnContext::default(),
         autofix: None,
     };
     app.turn_submit_prompt(DEFAULT_TAB_ID, prompt);
@@ -4653,7 +4653,7 @@ fn permission_request_keeps_thinking_until_turn_ends() {
         id: 1,
         text: "test".into(),
         submitted_at_unix_s: 0.0,
-        target_pane_id: None,
+        context: TurnContext::default(),
         autofix: None,
     };
     app.tab_mut(DEFAULT_TAB_ID).turn = TurnState::Surfaced {
@@ -5856,7 +5856,7 @@ fn render_recommendation_card_shows_command() {
             id: 1,
             text: "fix it".into(),
             submitted_at_unix_s: 0.0,
-            target_pane_id: None,
+            context: TurnContext::default(),
             autofix: None,
         },
         outcome: TurnOutcome::Recommendation(RecommendationSet {
@@ -6068,11 +6068,8 @@ fn submit_autofix_prompt(app: &mut App, pane: &str) {
         id: 99,
         text: "diagnose this".into(),
         submitted_at_unix_s: 0.0,
-        target_pane_id: Some(pane.into()),
-        autofix: Some(AutofixContext {
-            target_pane_id: pane.into(),
-            generation: gen,
-        }),
+        context: TurnContext::with_target_pane(pane),
+        autofix: Some(AutofixContext { generation: gen }),
     };
     app.turn_submit_prompt(DEFAULT_TAB_ID, prompt);
 }
@@ -6090,11 +6087,8 @@ fn submit_fix_prompt(app: &mut App, id: u64) {
         id,
         text: String::new(),
         submitted_at_unix_s: 0.0,
-        target_pane_id: None,
-        autofix: Some(AutofixContext {
-            target_pane_id: String::new(),
-            generation: gen,
-        }),
+        context: TurnContext::default(),
+        autofix: Some(AutofixContext { generation: gen }),
     };
     app.turn_submit_prompt(DEFAULT_TAB_ID, prompt);
 }
@@ -6104,11 +6098,10 @@ fn fix_target_pane(app: &App) -> String {
         .turn
         .prompt()
         .unwrap()
-        .autofix
-        .as_ref()
-        .unwrap()
+        .context
         .target_pane_id
         .clone()
+        .unwrap_or_default()
 }
 
 #[test]
@@ -6133,6 +6126,7 @@ fn fix_target_pane_is_late_bound_by_prompt_id() {
             .turn
             .prompt()
             .unwrap()
+            .context
             .target_pane_id
             .as_deref(),
         Some("pane-7")
@@ -6147,10 +6141,9 @@ fn manual_fix_uses_the_helpers_captured_source_target() {
     app.cmd_fix(false, String::new());
 
     let prompt = app.current_tab().turn.prompt().unwrap();
-    assert_eq!(prompt.target_pane_id.as_deref(), Some("captured-source-pane"));
     assert_eq!(
-        prompt.autofix.as_ref().unwrap().target_pane_id,
-        "captured-source-pane"
+        prompt.context.target_pane_id.as_deref(),
+        Some("captured-source-pane")
     );
 }
 
@@ -6167,6 +6160,7 @@ fn prompt_target_binding_survives_tab_rename() {
             .turn
             .prompt()
             .unwrap()
+            .context
             .target_pane_id
             .as_deref(),
         Some("pane-7")
@@ -6560,7 +6554,7 @@ fn install_recs(app: &mut App, choices: Vec<RecommendationChoice>) {
             id: 1,
             text: "p".into(),
             submitted_at_unix_s: 0.0,
-            target_pane_id: None,
+            context: TurnContext::default(),
             autofix: None,
         },
         outcome: TurnOutcome::Recommendation(RecommendationSet {
@@ -7193,17 +7187,16 @@ fn stage_surfaced_recommendation(
     app: &mut App,
     choices: Vec<crate::coordinator::RecommendationChoice>,
     selected: usize,
-    autofix_target: Option<&str>,
+    target_pane_id: Option<&str>,
 ) {
     let prompt = SubmittedPrompt {
         id: 1,
         text: "p".into(),
         submitted_at_unix_s: 0.0,
-        target_pane_id: autofix_target.map(str::to_string),
-        autofix: autofix_target.map(|t| AutofixContext {
-            target_pane_id: t.into(),
-            generation: 0,
-        }),
+        context: TurnContext {
+            target_pane_id: target_pane_id.map(str::to_string),
+        },
+        autofix: target_pane_id.map(|_| AutofixContext { generation: 0 }),
     };
     let recs = crate::coordinator::RecommendationSet {
         recommended_choice: Some(selected),
@@ -7253,17 +7246,17 @@ fn chip_target_returns_none_when_idle() {
 }
 
 #[test]
-fn chip_target_uses_send_parent_when_set() {
+fn chip_target_uses_turn_context_instead_of_model_parent() {
     let mut app = test_app();
     stage_surfaced_recommendation(
         &mut app,
         vec![send_choice("pane-A", "ls")],
         0,
-        None,
+        Some("pane-host"),
     );
     assert_eq!(
         app.current_tab().compute_chip_card_target(),
-        Some("pane-A".to_string()),
+        Some("pane-host".to_string()),
     );
 }
 
@@ -7314,16 +7307,16 @@ fn chip_target_tracks_selected_index() {
         &mut app,
         vec![send_choice("pane-A", "ls"), send_choice("pane-B", "pwd")],
         0,
-        None,
+        Some("pane-host"),
     );
     assert_eq!(
         app.current_tab().compute_chip_card_target(),
-        Some("pane-A".to_string()),
+        Some("pane-host".to_string()),
     );
     app.current_tab_mut().selected_recommendation = 1;
     assert_eq!(
         app.current_tab().compute_chip_card_target(),
-        Some("pane-B".to_string()),
+        Some("pane-host".to_string()),
     );
 }
 
@@ -7338,12 +7331,12 @@ fn chip_recompute_dedupes_and_releases_on_idle() {
         &mut app,
         vec![send_choice("pane-A", "ls")],
         0,
-        None,
+        Some("pane-host"),
     );
     app.recompute_chip_override(DEFAULT_TAB_ID);
     assert_eq!(
         app.tab_mut(DEFAULT_TAB_ID).last_emitted_chip_override,
-        Some("pane-A".to_string()),
+        Some("pane-host".to_string()),
     );
 
     // Drop the surfaced state — chip target now resolves to None and

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -257,8 +257,7 @@ impl App {
         let autofix_pane = prompt
             .autofix
             .as_ref()
-            .map(|a| a.target_pane_id.clone())
-            .filter(|s| !s.is_empty());
+            .and(prompt.context.target_pane_id().map(str::to_string));
         tab.turn = TurnState::Surfaced {
             prompt,
             outcome: TurnOutcome::Empty,
@@ -409,7 +408,7 @@ impl App {
     /// choice to the coordinator and transition to `Surfaced { Empty, .. }`
     /// while preserving the ACP single-flight gate.
     pub fn turn_execute_card(&mut self, session_id: &str) {
-        let Some(mut choice) = self.selected_recommendation_choice().cloned() else {
+        let Some(choice) = self.selected_recommendation_choice().cloned() else {
             return;
         };
         let tab = self.session_tab(session_id);
@@ -426,41 +425,19 @@ impl App {
         let executed_title = choice.title.clone();
         let insert_only =
             self.session_tab(session_id).selected_button == 1 && self.is_send_choice(&choice);
-        // Autofill parent for Send actions when this is an autofix turn.
-        if let Some(pane_id) = self
-            .session_tab(session_id)
-            .turn
-            .prompt()
-            .and_then(|p| p.autofix.as_ref())
-            .map(|a| a.target_pane_id.clone())
-        {
-            for action in &mut choice.actions {
-                if let crate::coordinator::RecommendedAction::Send { ref mut parent, .. } = action {
-                    if parent.is_empty() {
-                        *parent = pane_id.clone();
-                    }
-                }
-            }
-        }
         let target_tab = self.tab_for_session(session_id);
-        let authoritative_target = self
+        let context = self
             .session_tab(session_id)
             .turn
             .prompt()
-            .and_then(|p| {
-                p.target_pane_id.clone().or_else(|| {
-                    p.autofix
-                        .as_ref()
-                        .map(|autofix| autofix.target_pane_id.clone())
-                        .filter(|pane_id| !pane_id.is_empty())
-                })
-            });
+            .map(|prompt| prompt.context.clone())
+            .unwrap_or_default();
         let _ = self
             .recommendation_tx
             .send(crate::coordinator::ChoiceExecution {
                 choice,
                 insert_only,
-                target_pane_id: authoritative_target,
+                context,
             });
         if self
             .session_tab(session_id)
@@ -516,8 +493,12 @@ impl App {
             tab.autofix.generation = tab.autofix.generation.wrapping_add(1);
             tab.turn
                 .prompt()
-                .and_then(|p| p.autofix.as_ref())
-                .map(|a| a.target_pane_id.clone())
+                .and_then(|prompt| {
+                    prompt
+                        .autofix
+                        .as_ref()
+                        .and(prompt.context.target_pane_id().map(str::to_string))
+                })
                 .or_else(|| tab.autofix.pane_id.clone())
         };
         if pane_id.is_some() {
@@ -653,21 +634,16 @@ impl App {
         recommendations: RecommendationSet,
         phase_name: &str,
     ) {
-        let target_pane_id = self
-            .session_tab(session_id)
-            .turn
-            .prompt()
-            .and_then(|p| p.autofix.as_ref())
-            .map(|a| a.target_pane_id.clone());
         // Defensive: only autofix turns surface a fix card here.
-        let Some(target_pane_id) = target_pane_id else {
+        let prompt = self.session_tab(session_id).turn.prompt();
+        let Some(prompt) = prompt.filter(|prompt| prompt.autofix.is_some()) else {
             return;
         };
-        // An empty `target_pane_id` is a manually-invoked `/fix` with no
-        // concrete failing pane. Still surface the card below, but skip the
+        // A manual `/fix` may have no concrete failing pane. Still surface the
+        // card below, but skip the
         // bottom-bar / suggested-pane side effects — they key off a real
         // failing pane (the Review pill, the Ctrl+Alt+. hotkey target).
-        let bar_pane = (!target_pane_id.is_empty()).then_some(target_pane_id);
+        let bar_pane = prompt.context.target_pane_id().map(str::to_string);
         self.log_selection_phase_for(
             session_id,
             phase_name,
@@ -733,20 +709,15 @@ impl App {
         explanation: String,
         phase_name: &str,
     ) {
-        let target_pane_id = self
-            .session_tab(session_id)
-            .turn
-            .prompt()
-            .and_then(|p| p.autofix.as_ref())
-            .map(|a| a.target_pane_id.clone());
         // Defensive: only autofix turns surface an explain answer here.
-        let Some(target_pane_id) = target_pane_id else {
+        let prompt = self.session_tab(session_id).turn.prompt();
+        let Some(prompt) = prompt.filter(|prompt| prompt.autofix.is_some()) else {
             return;
         };
-        // Empty `target_pane_id` = a manually-invoked `/fix` with no concrete
-        // failing pane: surface the explanation, but skip the bottom-bar /
+        // A manual `/fix` may have no concrete failing pane: surface the
+        // explanation, but skip the bottom-bar /
         // suggested-pane side effects below.
-        let bar_pane = (!target_pane_id.is_empty()).then_some(target_pane_id);
+        let bar_pane = prompt.context.target_pane_id().map(str::to_string);
         self.log_selection_phase_for(
             session_id,
             phase_name,

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -178,9 +178,7 @@ impl App {
                 AutofixDecision::Ignore => {}
             }
         } else {
-            let parsed = parse_recommendation_set(&buf).and_then(|r| {
-                validate_recommendation_set_for_coordinator_target(&r, self.pane_id.as_deref())
-            });
+            let parsed = parse_recommendation_set(&buf);
             if let Ok(recommendations) = parsed {
                 self.turn_surface_recommendation(
                     session_id,
@@ -340,9 +338,7 @@ impl App {
     /// Path (4b): non-autofix Streaming buffer. Try `RecommendationSet`
     /// parse first; on failure, commit as a chat turn (chat-mode answer).
     fn turn_close_finalize_planner(&mut self, session_id: &str, buf: String) {
-        let parsed = parse_recommendation_set(&buf).and_then(|r| {
-            validate_recommendation_set_for_coordinator_target(&r, self.pane_id.as_deref())
-        });
+        let parsed = parse_recommendation_set(&buf);
         match parsed {
             Ok(recommendations) => {
                 self.turn_surface_recommendation(session_id, recommendations, "selection_ready");
@@ -447,19 +443,32 @@ impl App {
             }
         }
         let target_tab = self.tab_for_session(session_id);
-        let armed_pane = self
+        let authoritative_target = self
             .session_tab(session_id)
             .turn
             .prompt()
-            .and_then(|p| p.autofix.as_ref())
-            .map(|a| a.target_pane_id.clone());
+            .and_then(|p| {
+                p.target_pane_id.clone().or_else(|| {
+                    p.autofix
+                        .as_ref()
+                        .map(|autofix| autofix.target_pane_id.clone())
+                        .filter(|pane_id| !pane_id.is_empty())
+                })
+            });
         let _ = self
             .recommendation_tx
             .send(crate::coordinator::ChoiceExecution {
                 choice,
                 insert_only,
+                target_pane_id: authoritative_target,
             });
-        if armed_pane.is_some() {
+        if self
+            .session_tab(session_id)
+            .turn
+            .prompt()
+            .and_then(|p| p.autofix.as_ref())
+            .is_some()
+        {
             self.emit_autofix_state_cleared(&target_tab);
         }
         let autofix = &mut self.session_tab_mut(session_id).autofix;

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -8,6 +8,7 @@ use tokio::time::{sleep, Duration};
 
 use crate::app_contracts::AppEvent;
 use crate::shell::ShellManager;
+use crate::turn_context::TurnContext;
 
 use crate::agent_registry::{self, PromptFlag};
 
@@ -107,8 +108,8 @@ pub struct ChoiceExecution {
     pub choice: RecommendationChoice,
     /// When true, Send actions paste text without a trailing Enter (insert-only).
     pub insert_only: bool,
-    /// Host-resolved pane associated with the prompt that produced this choice.
-    pub target_pane_id: Option<String>,
+    /// Host-owned context associated with the turn that produced this choice.
+    pub context: TurnContext,
 }
 
 pub fn default_supported_delegate_agents() -> Vec<SupportedDelegateAgent> {
@@ -295,7 +296,10 @@ pub async fn run_recommendation_executor(
 ) {
     while let Some(mut exec) = rx.recv().await {
         let delegate_agents = delegate_agents.lock().unwrap().clone();
-        let result = match bind_choice_target(&mut exec.choice, exec.target_pane_id.as_deref()) {
+        let result = match bind_choice_target(
+            &mut exec.choice,
+            exec.context.target_pane_id.as_deref(),
+        ) {
             Ok(()) => {
                 execute_choice(
                     &exec.choice,

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -107,6 +107,8 @@ pub struct ChoiceExecution {
     pub choice: RecommendationChoice,
     /// When true, Send actions paste text without a trailing Enter (insert-only).
     pub insert_only: bool,
+    /// Host-resolved pane associated with the prompt that produced this choice.
+    pub target_pane_id: Option<String>,
 }
 
 pub fn default_supported_delegate_agents() -> Vec<SupportedDelegateAgent> {
@@ -268,48 +270,6 @@ pub fn parse_autofix_response(text: &str) -> AutofixDecision {
     }
 }
 
-/// Filter out choices that target the coordinator's own pane.
-/// Returns the filtered set. If all choices are removed, returns an error.
-pub fn validate_recommendation_set_for_coordinator_target(
-    set: &RecommendationSet,
-    coordinator_target: Option<&str>,
-) -> Result<RecommendationSet> {
-    let Some(coordinator_target) = coordinator_target
-        .map(str::trim)
-        .filter(|id| !id.is_empty())
-    else {
-        return Ok(set.clone());
-    };
-
-    let filtered: Vec<RecommendationChoice> = set
-        .choices
-        .iter()
-        .filter(|choice| {
-            !choice.actions.iter().any(|action| {
-                matches!(action, RecommendedAction::Send { parent, .. } if parent == coordinator_target)
-            })
-        })
-        .cloned()
-        .collect();
-
-    if filtered.is_empty() {
-        bail!(
-            "all choices target the current coordinator pane {}",
-            coordinator_target
-        );
-    }
-
-    // Adjust recommended_choice if the original was filtered out.
-    let recommended_choice = set.recommended_choice.filter(|rc| {
-        filtered.iter().any(|c| c.choice == *rc)
-    });
-
-    Ok(RecommendationSet {
-        recommended_choice,
-        choices: filtered,
-    })
-}
-
 pub fn recommended_choice_index(set: &RecommendationSet) -> usize {
     if let Some(choice_no) = set.recommended_choice {
         if let Some(idx) = set
@@ -333,17 +293,22 @@ pub async fn run_recommendation_executor(
     // (one entry) and the lock is never held across an await.
     delegate_agents: Arc<std::sync::Mutex<Vec<DelegateAgentRuntime>>>,
 ) {
-    while let Some(exec) = rx.recv().await {
+    while let Some(mut exec) = rx.recv().await {
         let delegate_agents = delegate_agents.lock().unwrap().clone();
-        match execute_choice(
-            &exec.choice,
-            exec.insert_only,
-            &shell_mgr,
-            &delegate_agents,
-            &event_tx,
-        )
-        .await
-        {
+        let result = match bind_choice_target(&mut exec.choice, exec.target_pane_id.as_deref()) {
+            Ok(()) => {
+                execute_choice(
+                    &exec.choice,
+                    exec.insert_only,
+                    &shell_mgr,
+                    &delegate_agents,
+                    &event_tx,
+                )
+                .await
+            }
+            Err(err) => Err(err),
+        };
+        match result {
             Ok(()) => {}
             Err(err) => {
                 let err_str = format!("{:#}", err);
@@ -358,6 +323,43 @@ pub async fn run_recommendation_executor(
             }
         }
     }
+}
+
+fn bind_choice_target(
+    choice: &mut RecommendationChoice,
+    target_pane_id: Option<&str>,
+) -> Result<()> {
+    for action in &mut choice.actions {
+        let requires_target = matches!(action, RecommendedAction::Send { .. })
+            || matches!(
+                action,
+                RecommendedAction::OpenAndSend {
+                    target: OpenTarget::Panel,
+                    ..
+                } | RecommendedAction::Open {
+                    target: OpenTarget::Panel,
+                    ..
+                }
+            );
+        if requires_target {
+            let target = target_pane_id
+                .map(str::trim)
+                .filter(|target| !target.is_empty())
+                .context("the host could not resolve a target pane for this recommendation")?;
+            match action {
+                RecommendedAction::Send { parent, .. } => *parent = target.to_string(),
+                RecommendedAction::OpenAndSend { parent, .. }
+                | RecommendedAction::Open { parent, .. } => *parent = Some(target.to_string()),
+            }
+        } else {
+            match action {
+                RecommendedAction::OpenAndSend { parent, .. }
+                | RecommendedAction::Open { parent, .. } => *parent = None,
+                RecommendedAction::Send { .. } => unreachable!(),
+            }
+        }
+    }
+    Ok(())
 }
 
 async fn execute_choice(
@@ -676,9 +678,6 @@ fn validate_action(action: &RecommendedAction) -> Result<()> {
             if let Some(agent) = agent.as_deref() {
                 ensure_non_empty("agent", agent)?;
             }
-            if matches!(target, OpenTarget::Panel) {
-                required_parent(parent.as_deref(), "open_and_send")?;
-            }
             validate_direction(direction.as_deref(), target)?;
         }
         RecommendedAction::Open {
@@ -689,9 +688,6 @@ fn validate_action(action: &RecommendedAction) -> Result<()> {
         } => {
             if let Some(parent) = parent.as_deref() {
                 ensure_non_empty("parent", parent)?;
-            }
-            if matches!(target, OpenTarget::Panel) {
-                required_parent(parent.as_deref(), "open")?;
             }
             validate_direction(direction.as_deref(), target)?;
         }
@@ -1657,13 +1653,12 @@ mod tests {
         build_delegate_launch_commandline, build_delegate_launch_commandline_with_session,
         build_pwsh_base64_launch, build_shell_multiline_delegate_launch,
         build_windows_powershell_base64_launch, build_wsl_delegate_commandline,
-        default_delegate_agent_runtimes, escape_for_intermediate_shell, execute_choice,
-        is_direct_known_agent_command, parse_autofix_response, parse_recommendation_set,
-        pinned_session_id_for_runtime, pwsh_available, resolve_agent_profile,
+        bind_choice_target, default_delegate_agent_runtimes, escape_for_intermediate_shell,
+        execute_choice, is_direct_known_agent_command, parse_autofix_response,
+        parse_recommendation_set, pinned_session_id_for_runtime, pwsh_available, resolve_agent_profile,
         resolve_created_pane_id, sanitize_windows_agent_cwd,
-        validate_recommendation_set_for_coordinator_target, AutofixDecision,
-        DelegateAgentRuntime, DelegatePromptDelivery, OpenTarget, RecommendationChoice,
-        RecommendedAction,
+        AutofixDecision, DelegateAgentRuntime, DelegatePromptDelivery, OpenTarget,
+        RecommendationChoice, RecommendedAction,
     };
     use crate::shell::wt_channel::WtChannel;
     use crate::shell::ShellManager;
@@ -1694,6 +1689,57 @@ mod tests {
         fn is_available(&self) -> bool {
             true
         }
+    }
+
+    #[test]
+    fn host_target_overrides_model_generated_pane_targets() {
+        let mut choice = RecommendationChoice {
+            choice: 1,
+            title: "Check port".to_string(),
+            rationale: String::new(),
+            actions: vec![
+                RecommendedAction::Send {
+                    parent: "10".to_string(),
+                    input: "Get-NetTCPConnection -LocalPort 8000".to_string(),
+                },
+                RecommendedAction::Open {
+                    target: OpenTarget::Panel,
+                    parent: Some("invented-pane".to_string()),
+                    cwd: None,
+                    title: None,
+                    direction: None,
+                    profile: None,
+                },
+            ],
+        };
+
+        bind_choice_target(&mut choice, Some("real-pane-guid")).unwrap();
+
+        assert!(matches!(
+            &choice.actions[0],
+            RecommendedAction::Send { parent, .. } if parent == "real-pane-guid"
+        ));
+        assert!(matches!(
+            &choice.actions[1],
+            RecommendedAction::Open { parent: Some(parent), .. } if parent == "real-pane-guid"
+        ));
+    }
+
+    #[test]
+    fn target_requiring_action_fails_when_host_has_no_target() {
+        let mut choice = RecommendationChoice {
+            choice: 1,
+            title: "Check port".to_string(),
+            rationale: String::new(),
+            actions: vec![RecommendedAction::Send {
+                parent: "10".to_string(),
+                input: "Get-NetTCPConnection -LocalPort 8000".to_string(),
+            }],
+        };
+
+        let err = bind_choice_target(&mut choice, None).unwrap_err();
+
+        assert!(format!("{err:#}").contains("host could not resolve a target pane"));
     }
 
     #[tokio::test]
@@ -2475,7 +2521,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_open_panel_without_parent() {
+    fn accepts_open_panel_without_model_owned_parent() {
         let text = r#"```json
 {
   "recommended_choice": 1,
@@ -2494,68 +2540,11 @@ mod tests {
 }
 ```"#;
 
-        assert!(parse_recommendation_set(text).is_err());
+        assert!(parse_recommendation_set(text).is_ok());
     }
 
     #[test]
-    fn rejects_send_to_current_coordinator_target() {
-        let text = r#"```json
-{
-  "recommended_choice": 1,
-  "choices": [
-    {
-      "choice": 1,
-      "title": "Reply in the current pane",
-      "actions": [
-        {
-          "type": "send",
-          "parent": "14",
-          "input": "Continue in this pane"
-        }
-      ]
-    },
-    {
-      "choice": 2,
-      "title": "Run locally",
-      "actions": [
-        {
-          "type": "send",
-          "parent": "1",
-          "input": "pwd"
-        }
-      ]
-    },
-    {
-      "choice": 3,
-      "title": "Delegate",
-      "actions": [
-        {
-          "type": "open_and_send",
-          "target": "tab",
-          "input": "Inspect the repo",
-          "agent": "copilot",
-          "cwd": "C:\\repo"
-        }
-      ]
-    }
-  ]
-}
-```"#;
-
-        let parsed = parse_recommendation_set(text).expect("recommendation set should parse");
-        let filtered = validate_recommendation_set_for_coordinator_target(&parsed, Some("14"))
-            .expect("should filter instead of rejecting");
-
-        // Choice 1 (self-targeted) should be removed, choices 2 and 3 remain.
-        assert_eq!(filtered.choices.len(), 2);
-        assert_eq!(filtered.choices[0].choice, 2);
-        assert_eq!(filtered.choices[1].choice, 3);
-        // recommended_choice was 1 (now filtered out), so it should be None.
-        assert_eq!(filtered.recommended_choice, None);
-    }
-
-    #[test]
-    fn rejects_open_and_send_panel_without_parent() {
+    fn accepts_open_and_send_panel_without_model_owned_parent() {
         let text = r#"```json
 {
   "recommended_choice": 1,
@@ -2597,10 +2586,7 @@ mod tests {
 }
 ```"#;
 
-        let err =
-            parse_recommendation_set(text).expect_err("panel without parent should be rejected");
-        assert!(format!("{err:#}")
-            .contains("field 'parent' is required for open_and_send target panel"));
+        assert!(parse_recommendation_set(text).is_ok());
     }
 
     #[test]

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -1742,6 +1742,52 @@ mod tests {
         assert!(format!("{err:#}").contains("host could not resolve a target pane"));
     }
 
+    #[test]
+    fn tab_target_actions_discard_model_provided_parent_even_with_host_target() {
+        // Tab-targeted open/open_and_send actions don't need a parent pane at
+        // all (they create a brand new tab), so any model-invented parent
+        // must be wiped rather than bound to the host's resolved pane.
+        let mut choice = RecommendationChoice {
+            choice: 1,
+            title: "Delegate to a new tab".to_string(),
+            rationale: String::new(),
+            actions: vec![
+                RecommendedAction::OpenAndSend {
+                    target: OpenTarget::Tab,
+                    parent: Some("model-invented-tab-parent".to_string()),
+                    input: "Inspect the repo".to_string(),
+                    agent: Some("copilot".to_string()),
+                    cwd: None,
+                    title: None,
+                    direction: None,
+                    profile: None,
+                },
+                RecommendedAction::Open {
+                    target: OpenTarget::Tab,
+                    parent: Some("another-model-invented-parent".to_string()),
+                    cwd: None,
+                    title: None,
+                    direction: None,
+                    profile: None,
+                },
+            ],
+        };
+
+        // Even though the host resolved a real target pane, tab actions must
+        // never inherit it (or retain the model's guess) since they open a
+        // brand new tab rather than routing into an existing pane.
+        bind_choice_target(&mut choice, Some("real-pane-guid")).unwrap();
+
+        assert!(matches!(
+            &choice.actions[0],
+            RecommendedAction::OpenAndSend { parent: None, .. }
+        ));
+        assert!(matches!(
+            &choice.actions[1],
+            RecommendedAction::Open { parent: None, .. }
+        ));
+    }
+
     #[tokio::test]
     async fn insert_into_terminal_focuses_target_pane_after_sending_input() {
         let channel = Arc::new(RecordingWtChannel::default());

--- a/tools/wta/src/main.rs
+++ b/tools/wta/src/main.rs
@@ -39,6 +39,7 @@ mod telemetry;
 mod test_support;
 mod text_selection;
 mod theme;
+mod turn_context;
 mod ui;
 mod ui_trace;
 mod win32;

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -2661,7 +2661,7 @@ async fn dispatch_prompt_body(
         &prompt.text,
         prompt.submitted_at_unix_s,
     );
-    let (text, prompt_source, prompt_name, resolved_fix_pane) = build_prompt_text(
+    let (text, prompt_source, prompt_name, resolved_target_pane) = build_prompt_text(
         prompt.id,
         prompt.submitted_at_unix_s,
         &prompt.text,
@@ -2672,11 +2672,10 @@ async fn dispatch_prompt_body(
         prompt.pane_context.as_ref(),
     )
     .await;
-    // A manual `/fix` resolved its working pane in build_prompt_text (it had no
-    // explicit source pane). Plumb it back so the App fills the turn's
-    // `target_pane_id`; the host fills `Send.parent` from it at execute time.
-    if let Some(pane_id) = resolved_fix_pane {
-        let _ = event_tx_task.send(AppEvent::AutofixTargetResolved {
+    // Bind the pane used to build this prompt to the matching turn. The host
+    // uses this authoritative value instead of a model-generated action target.
+    if let Some(pane_id) = resolved_target_pane {
+        let _ = event_tx_task.send(AppEvent::PromptTargetResolved {
             tab_id: prompt
                 .pane_context
                 .as_ref()

--- a/tools/wta/src/protocol/acp/prompt_builder.rs
+++ b/tools/wta/src/protocol/acp/prompt_builder.rs
@@ -105,9 +105,9 @@ pub(crate) async fn build_prompt_text(
     // Autofix turns resolve the failing pane, its canonical shell, and its last
     // output once; the providers below borrow these from the `ContextRequest`.
     // Planner turns need none of it (their providers query the shell manager
-    // directly). Resolving here also keeps the `resolved_fix_pane` side-output
-    // out of the provider chain. For a manual `/fix`, that side-output is the
-    // active working pane; the App uses it to fill `AutofixContext.target_pane_id`.
+    // directly). Resolving here also keeps the authoritative target pane
+    // side-output out of the provider chain. The App binds it to the matching
+    // turn context before any recommendation can execute.
     let resolved_context =
         prompt_context::resolve_provider_context(is_autofix, wt_connected, shell_mgr, pane_context)
             .await;

--- a/tools/wta/src/protocol/acp/prompt_builder.rs
+++ b/tools/wta/src/protocol/acp/prompt_builder.rs
@@ -124,6 +124,7 @@ pub(crate) async fn build_prompt_text(
         context_pane: resolved_context.context_pane.as_ref(),
         shell_exe: resolved_context.shell_exe.as_deref(),
         terminal_output: resolved_context.terminal_output.as_deref(),
+        planner_terminal_context: resolved_context.planner_terminal_context.as_deref(),
     };
     for provider in prompt_context::default_providers() {
         if !provider.applies(&context_request) {
@@ -194,7 +195,9 @@ pub(crate) async fn build_prompt_text(
         prompt,
         planner_template.source_label,
         planner_template.display_name,
-        resolved_context.resolved_fix_pane,
+        resolved_context
+            .resolved_fix_pane
+            .or(resolved_context.resolved_planner_pane),
     )
 }
 
@@ -392,13 +395,12 @@ mod tests {
     }
 
     /// A planner turn with `include_template=true` ships the persona template,
-    /// the delegate-agents section, and appends the user request. It never
-    /// resolves a fix pane.
+    /// the delegate-agents section, and appends the user request.
     #[tokio::test]
     async fn build_prompt_text_planner_includes_template_and_user_request() {
         let mgr = ShellManager::new();
         let expected = prompt::load_planner_prompt_template();
-        let (built_prompt, _source, display_name, fix_pane) =
+        let (built_prompt, _source, display_name, target_pane) =
             build_prompt_text(1, 0.0, "list files", false, true, &mgr, false, None).await;
         assert_eq!(display_name, expected.display_name);
         assert!(
@@ -409,7 +411,59 @@ mod tests {
             built_prompt.contains("## User Request\nlist files"),
             "planner must append the user text"
         );
-        assert!(fix_pane.is_none(), "planner turns never resolve a fix pane");
+        assert!(target_pane.is_none(), "no WT channel means no target pane");
+    }
+
+    #[tokio::test]
+    async fn build_prompt_text_planner_returns_the_injected_active_target() {
+        let mgr = shell_mgr_with_pane(serde_json::json!({
+            "session_id": "real-pane-guid",
+            "cwd": "C:\\repo",
+            "pid": std::process::id(),
+            "is_agent_pane": false,
+        }));
+
+        let (built_prompt, _source, _display_name, target_pane) =
+            build_prompt_text(8, 0.0, "check port 8000", false, true, &mgr, true, None).await;
+
+        assert!(built_prompt.contains("\"activeTarget\":\"real-pane-guid\""));
+        assert_eq!(target_pane.as_deref(), Some("real-pane-guid"));
+    }
+
+    #[tokio::test]
+    async fn build_prompt_text_planner_uses_submitted_source_after_focus_changes() {
+        let active = serde_json::json!({
+            "session_id": "newly-focused-pane",
+            "cwd": "C:\\other",
+            "pid": std::process::id(),
+            "is_agent_pane": false,
+        });
+        let source = serde_json::json!({
+            "session_id": "submitted-source-pane",
+            "cwd": "C:\\repo",
+            "pid": std::process::id(),
+            "is_agent_pane": false,
+        });
+        let mgr = shell_mgr_with_source_pane(active, source);
+        let pane_context = PaneContext {
+            source_pane_id: Some("submitted-source-pane".to_string()),
+            ..Default::default()
+        };
+
+        let (built_prompt, _source, _display_name, target_pane) = build_prompt_text(
+            9,
+            0.0,
+            "check port 8000",
+            false,
+            true,
+            &mgr,
+            true,
+            Some(&pane_context),
+        )
+        .await;
+
+        assert!(built_prompt.contains("\"activeTarget\":\"submitted-source-pane\""));
+        assert_eq!(target_pane.as_deref(), Some("submitted-source-pane"));
     }
 
     /// An autofix turn loads the *autofix* persona (not the planner), appends a

--- a/tools/wta/src/protocol/acp/prompt_context.rs
+++ b/tools/wta/src/protocol/acp/prompt_context.rs
@@ -292,12 +292,23 @@ async fn resolve_pane_by_session_id(
     None
 }
 
-async fn build_terminal_context_json(shell_mgr: &ShellManager) -> Option<String> {
+struct PlannerTerminalContext {
+    json: String,
+    target_pane_id: String,
+}
+
+async fn build_terminal_context(
+    shell_mgr: &ShellManager,
+    pane_context: Option<&PaneContext>,
+) -> Option<PlannerTerminalContext> {
     // WT's GetActivePane already resolves the agent pane to the user's working
     // pane (the "source"), so a single active-pane query gives us the right
     // target. Pane IDs are process-globally unique, so we only need the pane
     // id itself — tab/window aren't needed for addressing.
-    let active = shell_mgr.wt_get_active_pane().await.ok()?;
+    let active = match pane_context.and_then(|context| context.source_pane_id.as_deref()) {
+        Some(source) => resolve_pane_by_session_id(shell_mgr, source).await?,
+        None => shell_mgr.wt_get_active_pane().await.ok()?,
+    };
 
     let is_agent = active
         .get("is_agent_pane")
@@ -339,7 +350,7 @@ async fn build_terminal_context_json(shell_mgr: &ShellManager) -> Option<String>
     )
     .await;
 
-    serde_json::to_string(&serde_json::json!({
+    let json = serde_json::to_string(&serde_json::json!({
         "activeTarget": target_pane_id,
         "window_title": target_window_title,
         "cwd": target_cwd,
@@ -347,7 +358,12 @@ async fn build_terminal_context_json(shell_mgr: &ShellManager) -> Option<String>
         "locale": user_locale_tag(),
         "buffer": buffer,
     }))
-    .ok()
+    .ok()?;
+
+    Some(PlannerTerminalContext {
+        json,
+        target_pane_id,
+    })
 }
 
 /// User's UI locale as a BCP-47 tag, suitable for embedding in
@@ -367,6 +383,8 @@ pub(super) struct ResolvedProviderContext {
     pub(super) shell_exe: Option<String>,
     pub(super) terminal_output: Option<String>,
     pub(super) resolved_fix_pane: Option<String>,
+    pub(super) planner_terminal_context: Option<String>,
+    pub(super) resolved_planner_pane: Option<String>,
 }
 
 pub(super) async fn resolve_provider_context(
@@ -380,8 +398,17 @@ pub(super) async fn resolve_provider_context(
         shell_exe: None,
         terminal_output: None,
         resolved_fix_pane: None,
+        planner_terminal_context: None,
+        resolved_planner_pane: None,
     };
-    if !is_autofix || !wt_connected {
+    if !wt_connected {
+        return resolved;
+    }
+    if !is_autofix {
+        if let Some(context) = build_terminal_context(shell_mgr, pane_context).await {
+            resolved.planner_terminal_context = Some(context.json);
+            resolved.resolved_planner_pane = Some(context.target_pane_id);
+        }
         return resolved;
     }
 
@@ -478,6 +505,8 @@ pub(super) struct ContextRequest<'a> {
     pub(super) shell_exe: Option<&'a str>,
     /// Autofix only: the failing pane's last `[command + output]` buffer.
     pub(super) terminal_output: Option<&'a str>,
+    /// Planner only: terminal context assembled with its authoritative target.
+    pub(super) planner_terminal_context: Option<&'a str>,
 }
 
 /// One `### {heading}\n{body}` block to inject into the prompt. `heading` is
@@ -572,7 +601,7 @@ impl ContextProvider for TerminalContextProvider {
     }
 
     async fn provide(&self, req: &ContextRequest<'_>) -> Option<ContextSection> {
-        let json = build_terminal_context_json(req.shell_mgr).await?;
+        let json = req.planner_terminal_context?;
         Some(ContextSection {
             heading: "Terminal Context JSON",
             body: format!("```json\n{}\n```", json),
@@ -772,25 +801,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_terminal_context_json_none_without_wt_channel() {
+    async fn build_terminal_context_none_without_wt_channel() {
         let mgr = ShellManager::new();
-        assert!(build_terminal_context_json(&mgr).await.is_none());
+        assert!(build_terminal_context(&mgr, None).await.is_none());
     }
 
     #[tokio::test]
-    async fn build_terminal_context_json_skips_agent_pane() {
+    async fn build_terminal_context_skips_agent_pane() {
         let mgr = shell_mgr_with_pane(serde_json::json!({
             "session_id": "p1",
             "is_agent_pane": true,
         }));
         assert!(
-            build_terminal_context_json(&mgr).await.is_none(),
+            build_terminal_context(&mgr, None).await.is_none(),
             "an active agent pane has no terminal output to ship"
         );
     }
 
     #[tokio::test]
-    async fn build_terminal_context_json_assembles_fields_for_real_pane() {
+    async fn build_terminal_context_assembles_fields_for_real_pane() {
         let mgr = shell_mgr_with_pane(serde_json::json!({
             "session_id": "pane-9",
             "title": "My Tab",
@@ -798,11 +827,12 @@ mod tests {
             "pid": std::process::id(),
             "is_agent_pane": false,
         }));
-        let json = build_terminal_context_json(&mgr)
+        let context = build_terminal_context(&mgr, None)
             .await
             .expect("a non-agent active pane must yield context json");
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&context.json).unwrap();
         assert_eq!(v["activeTarget"], "pane-9");
+        assert_eq!(context.target_pane_id, "pane-9");
         assert_eq!(v["window_title"], "My Tab");
         assert_eq!(v["cwd"], "C:\\workspace");
         // The mock errors the buffer reads, so `buffer` is null.
@@ -863,6 +893,7 @@ mod tests {
             context_pane: None,
             shell_exe: None,
             terminal_output: None,
+            planner_terminal_context: None,
         }
     }
 

--- a/tools/wta/src/turn_context.rs
+++ b/tools/wta/src/turn_context.rs
@@ -1,0 +1,38 @@
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TurnContext {
+    /// Host-resolved pane whose terminal context was used for this turn.
+    pub target_pane_id: Option<String>,
+}
+
+impl TurnContext {
+    pub fn with_target_pane(target_pane_id: impl Into<String>) -> Self {
+        let target_pane_id = target_pane_id.into();
+        Self {
+            target_pane_id: (!target_pane_id.trim().is_empty()).then_some(target_pane_id),
+        }
+    }
+
+    pub fn target_pane_id(&self) -> Option<&str> {
+        self.target_pane_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|pane_id| !pane_id.is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_pane_treats_blank_values_as_unresolved() {
+        assert_eq!(TurnContext::with_target_pane("").target_pane_id(), None);
+        assert_eq!(
+            TurnContext {
+                target_pane_id: Some("  ".into()),
+            }
+            .target_pane_id(),
+            None
+        );
+    }
+}

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -1184,6 +1184,7 @@ mod tests {
                 id: 1,
                 text: "hi".into(),
                 submitted_at_unix_s: 0.0,
+                target_pane_id: None,
                 autofix: None,
             },
             buf: buf.to_string(),

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -1184,7 +1184,7 @@ mod tests {
                 id: 1,
                 text: "hi".into(),
                 submitted_at_unix_s: 0.0,
-                target_pane_id: None,
+                context: crate::app::TurnContext::default(),
                 autofix: None,
             },
             buf: buf.to_string(),


### PR DESCRIPTION
## Summary
- capture the authoritative source pane used to assemble each planner prompt
- bind send and panel actions to that host-owned target at the executor boundary
- remove model-owned pane IDs from the planner prompt and reject target-requiring actions when no host target exists
- preserve routing across focus changes, tab renames, autofix, and manual `/fix`

## Root cause
The planner prompt asked the model to return `parent`, and its JSON example hard-coded `"parent": "10"`. The parser accepted that non-empty value and passed it unchanged to `wtcli`, even though pane addressing requires a WT session GUID.

## Tests
- `cargo test --manifest-path tools\wta\Cargo.toml` (1221 passed)