### PR TITLE
Implement vertical tabs

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2691,7 +2691,7 @@
         },
         "tabLayout": {
           "default": "horizontal",
-          "description": "Whether tabs render as a horizontal strip across the top of the window (\"horizontal\", the classic layout) or as a resizable vertical rail down the left edge (\"vertical\"). When set to \"vertical\", \"showTabsInTitlebar\" is silently forced to false.",
+          "description": "Whether tabs render as a horizontal strip across the top of the window (\"horizontal\", the classic layout) or as a resizable vertical rail down the left edge (\"vertical\"). When set to \"vertical\", the tab rail is hosted inside the page; \"showTabsInTitlebar\" controls whether the tab row chrome appears in the titlebar or at the top of the rail.",
           "enum": [
             "horizontal",
             "vertical"
@@ -2700,9 +2700,9 @@
         },
         "tabLayoutVerticalWidth": {
           "default": 220,
-          "description": "Width in pixels of the vertical tab rail when \"tabLayout\" is \"vertical\". Clamped to [140, 480]. Persisted automatically when the user drags the rail divider.",
+          "description": "Width in pixels of the vertical tab rail when \"tabLayout\" is \"vertical\". Clamped to [180, 480]. Persisted automatically when the user drags the rail divider.",
           "type": "integer",
-          "minimum": 140,
+          "minimum": 180,
           "maximum": 480
         },
         "wordDelimiters": {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2689,6 +2689,22 @@
           ],
           "type": "string"
         },
+        "tabLayout": {
+          "default": "horizontal",
+          "description": "Whether tabs render as a horizontal strip across the top of the window (\"horizontal\", the classic layout) or as a resizable vertical rail down the left edge (\"vertical\"). When set to \"vertical\", \"showTabsInTitlebar\" is silently forced to false.",
+          "enum": [
+            "horizontal",
+            "vertical"
+          ],
+          "type": "string"
+        },
+        "tabLayoutVerticalWidth": {
+          "default": 220,
+          "description": "Width in pixels of the vertical tab rail when \"tabLayout\" is \"vertical\". Clamped to [140, 480]. Persisted automatically when the user drags the rail divider.",
+          "type": "integer",
+          "minimum": 140,
+          "maximum": 480
+        },
         "wordDelimiters": {
           "default": " ./\\()\"'-:,.;<>~!@#$%^&*|+=[]{}~?│",
           "description": "Determines the delimiters used in a double click selection.",

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -849,6 +849,18 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="FindText" xml:space="preserve">
     <value>Find</value>
   </data>
+  <data name="TabLayoutRestartInfoBar.Title" xml:space="preserve">
+    <value>Tab layout change requires restart</value>
+  </data>
+  <data name="TabLayoutRestartInfoBar.Message" xml:space="preserve">
+    <value>Restart Windows Terminal to apply the new tab layout.</value>
+  </data>
+  <data name="TabStrip_ControlType" xml:space="preserve">
+    <value>tab strip</value>
+  </data>
+  <data name="TabStripCloseButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Close tab</value>
+  </data>
   <data name="CloseOnExitInfoBar.Message" xml:space="preserve">
     <value>Termination behavior can be configured in advanced profile settings.</value>
   </data>

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -168,7 +168,7 @@ namespace winrt::TerminalApp::implementation
         });
 
         auto tabViewItem = newTabImpl->TabViewItem();
-        _tabView.TabItems().InsertAt(insertPosition, tabViewItem);
+        _tabItems().InsertAt(insertPosition, tabViewItem);
 
         // Set this tab's icon to the icon from the content
         _UpdateTabIcon(*newTabImpl);
@@ -210,7 +210,7 @@ namespace winrt::TerminalApp::implementation
         // we'll attach the terminal's Xaml control to the Xaml root.
         if (!openInBackground)
         {
-            _tabView.SelectedItem(tabViewItem);
+            _selectedTabItem(tabViewItem);
         }
         else
         {
@@ -798,7 +798,7 @@ namespace winrt::TerminalApp::implementation
         }
 
         _tabs.RemoveAt(tabIndex);
-        _tabView.TabItems().RemoveAt(tabIndex);
+        _tabItems().RemoveAt(tabIndex);
         _UpdateTabIndices();
 
         // To close the window here, we need to close the hosting window.
@@ -819,7 +819,7 @@ namespace winrt::TerminalApp::implementation
 
             const auto newSelectedTab = _mruTabs.GetAt(0);
             _UpdatedSelectedTab(newSelectedTab);
-            _tabView.SelectedItem(newSelectedTab.TabViewItem());
+            _selectedTabItem(newSelectedTab.TabViewItem());
 
             // Flush any deferred agent settings rebuild now that a
             // terminal tab is active. Per-tab model — no shared pane
@@ -888,7 +888,7 @@ namespace winrt::TerminalApp::implementation
         // GH#11107 - Always just set the item directly first so that if
         // tab movement is done as part of multiple actions following calls
         // to _GetFocusedTab will return the correct tab.
-        _tabView.SelectedItem(tab.TabViewItem());
+        _selectedTabItem(tab.TabViewItem());
 
         if (_startupState == StartupState::InStartup)
         {
@@ -918,6 +918,37 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
+    // Spec A §4.1 routing helpers. See TerminalPage.h for context. Phase 2
+    // forwards unconditionally to _tabView; Phase 3 flips the vertical branch
+    // to _tabStrip once TabStrip is populated with real Tab objects.
+    IVector<IInspectable> TerminalPage::_tabItems() const
+    {
+        // Phase 3: real branching. TabStrip.TabItems is an IObservableVector,
+        // which derives from IVector, so the return-type conversion is safe.
+        if (_isVerticalLayout)
+        {
+            return _tabStrip.TabItems().as<IVector<IInspectable>>();
+        }
+        return _tabView.TabItems();
+    }
+
+    IInspectable TerminalPage::_selectedTabItem() const
+    {
+        return _isVerticalLayout ? _tabStrip.SelectedItem() : _tabView.SelectedItem();
+    }
+
+    void TerminalPage::_selectedTabItem(const IInspectable& item)
+    {
+        if (_isVerticalLayout)
+        {
+            _tabStrip.SelectedItem(item);
+        }
+        else
+        {
+            _tabView.SelectedItem(item);
+        }
+    }
+
     // Method Description:
     // - Returns the index in our list of tabs of the currently focused tab. If
     //      no tab is currently selected, returns nullopt.
@@ -928,7 +959,7 @@ namespace winrt::TerminalApp::implementation
         // GH#1117: This is a workaround because _tabView.SelectedIndex()
         //          sometimes return incorrect result after removing some tabs
         uint32_t focusedIndex;
-        if (_tabView.TabItems().IndexOf(_tabView.SelectedItem(), focusedIndex))
+        if (_tabItems().IndexOf(_selectedTabItem(), focusedIndex))
         {
             return focusedIndex;
         }
@@ -980,7 +1011,7 @@ namespace winrt::TerminalApp::implementation
     winrt::TerminalApp::Tab TerminalPage::_GetTabByTabViewItem(const IInspectable& tabViewItem) const noexcept
     {
         uint32_t tabIndexFromControl{};
-        const auto items{ _tabView.TabItems() };
+        const auto items{ _tabItems() };
         if (items.IndexOf(tabViewItem, tabIndexFromControl) && tabIndexFromControl < _tabs.Size())
         {
             // If IndexOf returns true, we've actually got an index
@@ -1016,7 +1047,7 @@ namespace winrt::TerminalApp::implementation
             uint32_t tabIndex{};
             if (_tabs.IndexOf(tab, tabIndex))
             {
-                _tabView.SelectedItem(tab.TabViewItem());
+                _selectedTabItem(tab.TabViewItem());
             }
         }
     }
@@ -1464,16 +1495,33 @@ namespace winrt::TerminalApp::implementation
     // Arguments:
     // - sender: the control that originated this event
     // - eventArgs: the event's constituent arguments
-    void TerminalPage::_OnTabSelectionChanged(const IInspectable& sender, const WUX::Controls::SelectionChangedEventArgs& /*eventArgs*/)
+    void TerminalPage::_OnTabSelectionChanged(const IInspectable& /*sender*/, const WUX::Controls::SelectionChangedEventArgs& /*eventArgs*/)
+    {
+        _OnSelectionChangedCore();
+    }
+
+    // Spec A §4.2: TabStrip's SelectionChanged uses custom args (TabStripSelectionChangedEventArgs),
+    // so it needs its own wrapper. Both wrappers dispatch to the same core method,
+    // which uses the routing helpers instead of asking sender for its selection.
+    void TerminalPage::_OnTabStripSelectionChanged(const IInspectable& /*sender*/, const TerminalApp::TabStripSelectionChangedEventArgs& /*eventArgs*/)
+    {
+        _OnSelectionChangedCore();
+    }
+
+    void TerminalPage::_OnSelectionChangedCore()
     {
         if (!_rearranging && !_removing)
         {
-            auto tabView = sender.as<MUX::Controls::TabView>();
-            auto selectedIndex = tabView.SelectedIndex();
-            if (selectedIndex >= 0 && selectedIndex < gsl::narrow_cast<int32_t>(_tabs.Size()))
+            // Look up selection via the router — works for both TabView and
+            // TabStrip because _selectedTabItem and _tabItems both branch on
+            // _isVerticalLayout.
+            if (const auto selectedItem = _selectedTabItem())
             {
-                const auto tab{ _tabs.GetAt(selectedIndex) };
-                _UpdatedSelectedTab(tab);
+                uint32_t selectedIndex{};
+                if (_tabItems().IndexOf(selectedItem, selectedIndex) && selectedIndex < _tabs.Size())
+                {
+                    _UpdatedSelectedTab(_tabs.GetAt(selectedIndex));
+                }
             }
             // Flush any deferred agent-stack rebuild now that a real
             // terminal tab is active. Per-tab model — no shared pane
@@ -1537,9 +1585,9 @@ namespace winrt::TerminalApp::implementation
             _tabs.InsertAt(newTabIndex, tab);
             _UpdateTabIndices();
 
-            _tabView.TabItems().RemoveAt(currentTabIndex);
-            _tabView.TabItems().InsertAt(newTabIndex, tabViewItem);
-            _tabView.SelectedItem(tabViewItem);
+            _tabItems().RemoveAt(currentTabIndex);
+            _tabItems().InsertAt(newTabIndex, tabViewItem);
+            _selectedTabItem(tabViewItem);
 
             if (auto autoPeer = Automation::Peers::FrameworkElementAutomationPeer::FromElement(*this))
             {

--- a/src/cascadia/TerminalApp/TabRowControl.cpp
+++ b/src/cascadia/TerminalApp/TabRowControl.cpp
@@ -23,6 +23,27 @@ namespace winrt::TerminalApp::implementation
     TabRowControl::TabRowControl()
     {
         InitializeComponent();
+        _applyLayoutVisibility();
+    }
+
+    void TabRowControl::IsVerticalLayout(bool value)
+    {
+        if (_isVerticalLayout == value)
+        {
+            return;
+        }
+        _isVerticalLayout = value;
+        _applyLayoutVisibility();
+        PropertyChanged.raise(*this, WUX::Data::PropertyChangedEventArgs{ L"IsVerticalLayout" });
+    }
+
+    void TabRowControl::_applyLayoutVisibility()
+    {
+        // PROTOTYPE — the horizontal TabView and vertical TabStrip both live
+        // in the XAML tree; only one is visible at a time. Full layout
+        // reshaping (moving the strip to a left column) is Spec A.
+        TabView().Visibility(_isVerticalLayout ? WUX::Visibility::Collapsed : WUX::Visibility::Visible);
+        TabStrip().Visibility(_isVerticalLayout ? WUX::Visibility::Visible : WUX::Visibility::Collapsed);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TabRowControl.cpp
+++ b/src/cascadia/TerminalApp/TabRowControl.cpp
@@ -44,6 +44,63 @@ namespace winrt::TerminalApp::implementation
         // reshaping (moving the strip to a left column) is Spec A.
         TabView().Visibility(_isVerticalLayout ? WUX::Visibility::Collapsed : WUX::Visibility::Visible);
         TabStrip().Visibility(_isVerticalLayout ? WUX::Visibility::Visible : WUX::Visibility::Collapsed);
+        if (_isVerticalLayout)
+        {
+            _reparentChromeToVertical();
+        }
+    }
+
+    // Spec A §5.1: move the three chrome elements out of TabView's header /
+    // footer slots. Shield + workspaces go into a horizontal StackPanel that
+    // TerminalPage hands to the titlebar (same bar as min/max/close); the
+    // new-tab split button anchors right-aligned inside TabStrip's trailing
+    // slot at the bottom of the rail. XAML forbids a UIElement having two
+    // logical parents at once, so we clear both host panels first.
+    void TabRowControl::_reparentChromeToVertical()
+    {
+        if (_chromeReparentedToVertical)
+        {
+            return;
+        }
+        _chromeReparentedToVertical = true;
+
+        auto shield = ElevationShieldIcon();
+        auto workspaces = WorkspaceDropdown();
+        auto newTab = NewTabButton();
+
+        if (const auto headerPanel = TabView().TabStripHeader().try_as<WUX::Controls::StackPanel>())
+        {
+            headerPanel.Children().Clear();
+        }
+        TabView().TabStripHeader(nullptr);
+
+        if (const auto footerGrid = TabView().TabStripFooter().try_as<WUX::Controls::Grid>())
+        {
+            footerGrid.Children().Clear();
+        }
+        TabView().TabStripFooter(nullptr);
+
+        WUX::Controls::StackPanel titlebarPanel;
+        titlebarPanel.Orientation(WUX::Controls::Orientation::Horizontal);
+        titlebarPanel.VerticalAlignment(WUX::VerticalAlignment::Center);
+        titlebarPanel.Children().Append(shield);
+        titlebarPanel.Children().Append(workspaces);
+        _verticalTitleBarContent = titlebarPanel;
+
+        // Put the right-alignment on an outer Grid instead of the SplitButton
+        // itself — setting HorizontalAlignment=Right on the SplitButton
+        // fights its own template layout and collapses the dropdown chevron.
+        // A right-aligned outer Grid with a Stretch SplitButton lets MUX
+        // render both primary and secondary parts at their intrinsic size.
+        newTab.HorizontalAlignment(WUX::HorizontalAlignment::Stretch);
+        newTab.Height(31);
+        newTab.MinWidth(64);
+        newTab.Margin(WUX::Thickness{ 0, 4, 0, 4 });
+        WUX::Controls::Grid trailingContainer;
+        trailingContainer.HorizontalAlignment(WUX::HorizontalAlignment::Right);
+        trailingContainer.Margin(WUX::Thickness{ 0, 0, 8, 0 });
+        trailingContainer.Children().Append(newTab);
+        TabStrip().TrailingContent(trailingContainer);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TabRowControl.h
+++ b/src/cascadia/TerminalApp/TabRowControl.h
@@ -30,9 +30,17 @@ namespace winrt::TerminalApp::implementation
         bool IsVerticalLayout() const noexcept { return _isVerticalLayout; }
         void IsVerticalLayout(bool value);
 
+        // Spec A §5.1: in vertical mode the shield + workspaces button ride
+        // in the titlebar (same bar as min/max/close). Returns the container
+        // that TerminalPage passes to SetTitleBarContent; null in horizontal.
+        winrt::Windows::UI::Xaml::UIElement VerticalTitleBarContent() const noexcept { return _verticalTitleBarContent; }
+
     private:
         bool _isVerticalLayout{ false };
+        bool _chromeReparentedToVertical{ false };
+        winrt::Windows::UI::Xaml::UIElement _verticalTitleBarContent{ nullptr };
         void _applyLayoutVisibility();
+        void _reparentChromeToVertical();
     };
 }
 

--- a/src/cascadia/TerminalApp/TabRowControl.h
+++ b/src/cascadia/TerminalApp/TabRowControl.h
@@ -21,6 +21,18 @@ namespace winrt::TerminalApp::implementation
         WINRT_OBSERVABLE_PROPERTY(bool, ShowElevationShield, PropertyChanged.raise, false);
         WINRT_OBSERVABLE_PROPERTY(bool, ShowWorkspacesButton, PropertyChanged.raise, true);
         WINRT_OBSERVABLE_PROPERTY(winrt::hstring, WorkspaceName, PropertyChanged.raise, L"");
+
+    public:
+        // PROTOTYPE — flipping this at Initialize hides the MUX TabView and
+        // shows the local:TabStrip (see investigation-vertical-tabs.md).
+        // WINRT_OBSERVABLE_PROPERTY above leaves the access modifier at
+        // private, so the explicit public: is load-bearing.
+        bool IsVerticalLayout() const noexcept { return _isVerticalLayout; }
+        void IsVerticalLayout(bool value);
+
+    private:
+        bool _isVerticalLayout{ false };
+        void _applyLayoutVisibility();
     };
 }
 

--- a/src/cascadia/TerminalApp/TabRowControl.idl
+++ b/src/cascadia/TerminalApp/TabRowControl.idl
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+import "TabStrip.idl";
 
 namespace TerminalApp
 {
@@ -8,6 +9,14 @@ namespace TerminalApp
     {
         TabRowControl();
         Microsoft.UI.Xaml.Controls.TabView TabView { get; };
+
+        // PROTOTYPE — see investigation-vertical-tabs.md. When
+        // IsVerticalLayout is true, TabStrip is the live strip and the MUX
+        // TabView is hidden. Toggled once at TerminalPage::Initialize via the
+        // WT_VERTICAL_TABS_PROTOTYPE env var; no live switching for v1.
+        TabStrip TabStrip { get; };
+        Boolean IsVerticalLayout;
+
         Boolean ShowElevationShield;
         Boolean ShowWorkspacesButton;
         String WorkspaceName;

--- a/src/cascadia/TerminalApp/TabRowControl.idl
+++ b/src/cascadia/TerminalApp/TabRowControl.idl
@@ -10,10 +10,10 @@ namespace TerminalApp
         TabRowControl();
         Microsoft.UI.Xaml.Controls.TabView TabView { get; };
 
-        // PROTOTYPE — see investigation-vertical-tabs.md. When
-        // IsVerticalLayout is true, TabStrip is the live strip and the MUX
-        // TabView is hidden. Toggled once at TerminalPage::Initialize via the
-        // WT_VERTICAL_TABS_PROTOTYPE env var; no live switching for v1.
+        // Spec A: when IsVerticalLayout is true, TabStrip is the live strip
+        // and the MUX TabView is hidden. Toggled once at
+        // TerminalPage::Initialize based on the tabLayout global setting;
+        // no live switching for v1.
         TabStrip TabStrip { get; };
         Boolean IsVerticalLayout;
 

--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -46,7 +46,8 @@
         <mux:TabView.TabStripHeader>
             <StackPanel Orientation="Horizontal">
                 <!--  EA18 is the "Shield" glyph  -->
-                <FontIcon x:Uid="ElevationShield"
+                <FontIcon x:Name="ElevationShieldIcon"
+                          x:Uid="ElevationShield"
                           Margin="9,4,0,4"
                           FontFamily="{ThemeResource SymbolThemeFontFamily}"
                           FontSize="16"

--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -25,6 +25,14 @@
         tab row.
     -->
 
+    <!--
+        PROTOTYPE — see investigation-vertical-tabs.md. TabView (horizontal) and
+        TabStrip (vertical) coexist; only one is visible at a time, driven by
+        TabRowControl.IsVerticalLayout. Wrapping in a Grid preserves TabView's
+        VerticalAlignment="Bottom" behavior.
+    -->
+    <Grid>
+
     <mux:TabView x:Name="TabView"
                  VerticalAlignment="Bottom"
                  HorizontalContentAlignment="Stretch"
@@ -168,5 +176,19 @@
         </mux:TabView.TabStripFooter>
 
     </mux:TabView>
+
+    <!--
+        PROTOTYPE — visibility flipped by TabRowControl.IsVerticalLayout. The
+        vertical strip has no chrome slots wired in the prototype; the
+        elevation shield, workspaces button, and new-tab split button live in
+        TabView above. Wiring them to TabStrip.LeadingContent/TrailingContent
+        is Spec A work.
+    -->
+    <local:TabStrip x:Name="TabStrip"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Visibility="Collapsed" />
+
+    </Grid>
 
 </ContentPresenter>

--- a/src/cascadia/TerminalApp/TabStrip.cpp
+++ b/src/cascadia/TerminalApp/TabStrip.cpp
@@ -254,8 +254,7 @@ namespace winrt::TerminalApp::implementation
 
         // Tearoff signal: dropped where nobody accepted it. Mirrors MUX
         // TabView.TabDroppedOutside — TerminalPage will create a new window.
-        using DPO = Windows::ApplicationModel::DataTransfer::DataPackageOperation;
-        if (e.DropResult() == DPO::None && _draggingItem)
+        if (e.DropResult() == Windows::ApplicationModel::DataTransfer::DataPackageOperation::None && _draggingItem)
         {
             auto tab = _draggingItem.try_as<MUX::Controls::TabViewItem>();
             auto args = winrt::make_self<TabStripDroppedOutsideEventArgs>(tab, _draggingItem);

--- a/src/cascadia/TerminalApp/TabStrip.cpp
+++ b/src/cascadia/TerminalApp/TabStrip.cpp
@@ -5,6 +5,7 @@
 
 #include "pch.h"
 #include "TabStrip.h"
+#include "TabStripAutomationPeer.h"
 
 #include "TabStrip.g.cpp"
 #include "TabStripSelectionChangedEventArgs.g.cpp"
@@ -168,6 +169,11 @@ namespace winrt::TerminalApp::implementation
                 TabCloseRequested.raise(*this, *args);
             }
         }
+    }
+
+    WUX::Automation::Peers::AutomationPeer TabStrip::OnCreateAutomationPeer()
+    {
+        return winrt::make<TabStripAutomationPeer>(*this);
     }
 
     void TabStrip::OnListSelectionChanged(IInspectable const& /*sender*/,

--- a/src/cascadia/TerminalApp/TabStrip.cpp
+++ b/src/cascadia/TerminalApp/TabStrip.cpp
@@ -143,35 +143,30 @@ namespace winrt::TerminalApp::implementation
 
     void TabStrip::_hookCloseRequested(MUX::Controls::TabViewItem const& item)
     {
-        void* key = winrt::get_abi(item);
-        if (_closeRequestedTokens.count(key))
-        {
-            return;
-        }
-        // TabViewItem.CloseRequested fires when the little X is clicked. In MUX
-        // TabView, the parent TabView re-raises this as TabCloseRequested; here
-        // we do the same manually since our parent is a ListView.
-        auto token = item.CloseRequested([weakThis = get_weak()](auto&& sender, auto&& /*args*/) {
-            if (auto self = weakThis.get())
-            {
-                auto tab = sender.try_as<MUX::Controls::TabViewItem>();
-                if (tab)
-                {
-                    auto args = winrt::make_self<TabStripCloseRequestedEventArgs>(tab);
-                    self->TabCloseRequested.raise(*self, *args);
-                }
-            }
-        });
-        _closeRequestedTokens[key] = token;
+        // The rail renders its own X in the DataTemplate wrapper (see
+        // TabStrip.xaml, OnCustomCloseClick). MUX's built-in CloseButton on
+        // TabViewItem only shows when the item lives inside a TabView (via
+        // TabView.CloseButtonOverlayMode), so we suppress it here — this
+        // prevents both a stale hidden button and any double-X if MUX ever
+        // changes its default.
+        item.IsClosable(false);
+        _closeRequestedTokens[winrt::get_abi(item)] = {};
     }
 
     void TabStrip::_unhookCloseRequested(MUX::Controls::TabViewItem const& item)
     {
-        void* key = winrt::get_abi(item);
-        if (auto it = _closeRequestedTokens.find(key); it != _closeRequestedTokens.end())
+        _closeRequestedTokens.erase(winrt::get_abi(item));
+    }
+
+    void TabStrip::OnCustomCloseClick(IInspectable const& sender, WUX::RoutedEventArgs const&)
+    {
+        if (const auto button = sender.try_as<WUX::Controls::Button>())
         {
-            item.CloseRequested(it->second);
-            _closeRequestedTokens.erase(it);
+            if (const auto tab = button.DataContext().try_as<MUX::Controls::TabViewItem>())
+            {
+                auto args = winrt::make_self<TabStripCloseRequestedEventArgs>(tab);
+                TabCloseRequested.raise(*this, *args);
+            }
         }
     }
 
@@ -208,11 +203,35 @@ namespace winrt::TerminalApp::implementation
         // ListView packs the dragged items into e.Items(); for SelectionMode=Single
         // there's at most one. Wrap it in a TabView-shaped args object so
         // TerminalPage's tearoff-setup code can look identical to the horizontal path.
-        IInspectable draggedItem = e.Items().Size() > 0 ? e.Items().GetAt(0) : nullptr;
-        _draggingItem = draggedItem;
+        // Load-bearing lookup: ListView.DragItemsStartingEventArgs.Items() surfaces
+        // the *Content* of each ContentControl-based item rather than the item
+        // itself. Since each TabViewItem has a unique empty Border as its Content
+        // (the GH bodge from Tab::_MakeTabViewItem), what we get is a Border, not
+        // the TabViewItem. Recover the actual TabViewItem by finding the one in
+        // _tabItems whose Content is this Border — Content uniqueness makes that
+        // lookup unambiguous.
+        IInspectable surfacedItem = e.Items().Size() > 0 ? e.Items().GetAt(0) : nullptr;
+        MUX::Controls::TabViewItem tab{ nullptr };
+        if (surfacedItem)
+        {
+            const auto surfacedAbi = winrt::get_abi(surfacedItem);
+            for (uint32_t i = 0; i < _tabItems.Size(); ++i)
+            {
+                if (const auto candidate = _tabItems.GetAt(i).try_as<MUX::Controls::TabViewItem>())
+                {
+                    if (winrt::get_abi(candidate.Content()) == surfacedAbi)
+                    {
+                        tab = candidate;
+                        break;
+                    }
+                }
+            }
+        }
+        // Stash the resolved TabViewItem (not the surfaced Border) so
+        // OnDragItemsCompleted's tearoff path also gets the right identity.
+        _draggingItem = tab ? IInspectable{ tab } : surfacedItem;
 
-        auto tab = draggedItem.try_as<MUX::Controls::TabViewItem>();
-        auto args = winrt::make_self<TabStripDragStartingEventArgs>(tab, draggedItem, e.Data());
+        auto args = winrt::make_self<TabStripDragStartingEventArgs>(tab, _draggingItem, e.Data());
         TabDragStarting.raise(*this, *args);
 
         if (args->Cancel())

--- a/src/cascadia/TerminalApp/TabStrip.cpp
+++ b/src/cascadia/TerminalApp/TabStrip.cpp
@@ -1,0 +1,281 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// PROTOTYPE — see investigation-vertical-tabs.md. Not shipped.
+
+#include "pch.h"
+#include "TabStrip.h"
+
+#include "TabStrip.g.cpp"
+#include "TabStripSelectionChangedEventArgs.g.cpp"
+#include "TabStripCloseRequestedEventArgs.g.cpp"
+#include "TabStripDragStartingEventArgs.g.cpp"
+#include "TabStripDroppedOutsideEventArgs.g.cpp"
+
+using namespace winrt;
+using namespace winrt::Windows::Foundation;
+using namespace winrt::Windows::Foundation::Collections;
+using namespace winrt::Windows::UI::Xaml;
+using namespace winrt::Windows::UI::Xaml::Controls;
+
+namespace winrt
+{
+    namespace MUX = Microsoft::UI::Xaml;
+    namespace WUX = Windows::UI::Xaml;
+}
+
+namespace winrt::TerminalApp::implementation
+{
+    TabStrip::TabStrip()
+    {
+        _tabItems = single_threaded_observable_vector<IInspectable>();
+
+        InitializeComponent();
+
+        ItemsList().ItemsSource(_tabItems);
+        _vectorChangedRevoker = _tabItems.VectorChanged(auto_revoke, { get_weak(), &TabStrip::_onItemsVectorChanged });
+    }
+
+    IInspectable TabStrip::SelectedItem()
+    {
+        return ItemsList().SelectedItem();
+    }
+    void TabStrip::SelectedItem(IInspectable const& value)
+    {
+        ItemsList().SelectedItem(value);
+    }
+    int32_t TabStrip::SelectedIndex()
+    {
+        return ItemsList().SelectedIndex();
+    }
+    void TabStrip::SelectedIndex(int32_t value)
+    {
+        ItemsList().SelectedIndex(value);
+    }
+    DependencyObject TabStrip::ContainerFromIndex(int32_t index)
+    {
+        return ItemsList().ContainerFromIndex(index);
+    }
+
+    void TabStrip::Orientation(TerminalApp::TabStripOrientation value)
+    {
+        _orientation = value;
+        // Prototype: the ItemsStackPanel is hardcoded Vertical in XAML. C is
+        // where the layout actually flips based on this property. The setter
+        // stores the value so the drop-index math can read it, but has no
+        // visual effect yet.
+    }
+
+    bool TabStrip::CanReorderTabs()
+    {
+        return ItemsList().CanReorderItems();
+    }
+    void TabStrip::CanReorderTabs(bool value)
+    {
+        ItemsList().CanReorderItems(value);
+        ItemsList().ReorderMode(value ? ListViewReorderMode::Enabled : ListViewReorderMode::Disabled);
+    }
+    bool TabStrip::CanDragTabs()
+    {
+        return ItemsList().CanDragItems();
+    }
+    void TabStrip::CanDragTabs(bool value)
+    {
+        ItemsList().CanDragItems(value);
+    }
+
+    UIElement TabStrip::LeadingContent()
+    {
+        return LeadingContentPresenter().Content().try_as<UIElement>();
+    }
+    void TabStrip::LeadingContent(UIElement const& value)
+    {
+        LeadingContentPresenter().Content(value);
+    }
+    UIElement TabStrip::TrailingContent()
+    {
+        return TrailingContentPresenter().Content().try_as<UIElement>();
+    }
+    void TabStrip::TrailingContent(UIElement const& value)
+    {
+        TrailingContentPresenter().Content(value);
+    }
+
+    void TabStrip::_onItemsVectorChanged(IObservableVector<IInspectable> const& sender,
+                                          IVectorChangedEventArgs const& args)
+    {
+        // Sync per-item CloseRequested subscriptions on add/remove.
+        // (Reset covers bulk clear; individual changes cover the common paths.)
+        switch (args.CollectionChange())
+        {
+        case CollectionChange::ItemInserted:
+            if (const auto item = sender.GetAt(args.Index()).try_as<MUX::Controls::TabViewItem>())
+            {
+                _hookCloseRequested(item);
+            }
+            break;
+        case CollectionChange::ItemRemoved:
+            // We can't reach the removed item from `sender` here — the removal
+            // side is bounded by _closeRequestedTokens's key set; if the item
+            // is gone from the tree, its subscription lapses naturally. No
+            // action required for the prototype.
+            break;
+        case CollectionChange::ItemChanged:
+            if (const auto item = sender.GetAt(args.Index()).try_as<MUX::Controls::TabViewItem>())
+            {
+                _hookCloseRequested(item);
+            }
+            break;
+        case CollectionChange::Reset:
+            _closeRequestedTokens.clear();
+            for (uint32_t i = 0; i < sender.Size(); ++i)
+            {
+                if (const auto item = sender.GetAt(i).try_as<MUX::Controls::TabViewItem>())
+                {
+                    _hookCloseRequested(item);
+                }
+            }
+            break;
+        }
+
+        TabItemsChanged.raise(*this, args);
+    }
+
+    void TabStrip::_hookCloseRequested(MUX::Controls::TabViewItem const& item)
+    {
+        void* key = winrt::get_abi(item);
+        if (_closeRequestedTokens.count(key))
+        {
+            return;
+        }
+        // TabViewItem.CloseRequested fires when the little X is clicked. In MUX
+        // TabView, the parent TabView re-raises this as TabCloseRequested; here
+        // we do the same manually since our parent is a ListView.
+        auto token = item.CloseRequested([weakThis = get_weak()](auto&& sender, auto&& /*args*/) {
+            if (auto self = weakThis.get())
+            {
+                auto tab = sender.try_as<MUX::Controls::TabViewItem>();
+                if (tab)
+                {
+                    auto args = winrt::make_self<TabStripCloseRequestedEventArgs>(tab);
+                    self->TabCloseRequested.raise(*self, *args);
+                }
+            }
+        });
+        _closeRequestedTokens[key] = token;
+    }
+
+    void TabStrip::_unhookCloseRequested(MUX::Controls::TabViewItem const& item)
+    {
+        void* key = winrt::get_abi(item);
+        if (auto it = _closeRequestedTokens.find(key); it != _closeRequestedTokens.end())
+        {
+            item.CloseRequested(it->second);
+            _closeRequestedTokens.erase(it);
+        }
+    }
+
+    void TabStrip::OnListSelectionChanged(IInspectable const& /*sender*/,
+                                           SelectionChangedEventArgs const& e)
+    {
+        // Sync IsSelected on the TabViewItem so the tab visually reflects
+        // selection state (the ListViewItem chrome is stripped in XAML, so
+        // the TabViewItem owns the visual).
+        for (const auto& removed : e.RemovedItems())
+        {
+            if (auto item = removed.try_as<MUX::Controls::TabViewItem>())
+            {
+                item.IsSelected(false);
+            }
+        }
+        for (const auto& added : e.AddedItems())
+        {
+            if (auto item = added.try_as<MUX::Controls::TabViewItem>())
+            {
+                item.IsSelected(true);
+            }
+        }
+
+        IInspectable added = e.AddedItems().Size() > 0 ? e.AddedItems().GetAt(0) : nullptr;
+        IInspectable removed = e.RemovedItems().Size() > 0 ? e.RemovedItems().GetAt(0) : nullptr;
+        auto args = winrt::make_self<TabStripSelectionChangedEventArgs>(std::move(added), std::move(removed));
+        SelectionChanged.raise(*this, *args);
+    }
+
+    void TabStrip::OnDragItemsStarting(IInspectable const& /*sender*/,
+                                        DragItemsStartingEventArgs const& e)
+    {
+        // ListView packs the dragged items into e.Items(); for SelectionMode=Single
+        // there's at most one. Wrap it in a TabView-shaped args object so
+        // TerminalPage's tearoff-setup code can look identical to the horizontal path.
+        IInspectable draggedItem = e.Items().Size() > 0 ? e.Items().GetAt(0) : nullptr;
+        _draggingItem = draggedItem;
+
+        auto tab = draggedItem.try_as<MUX::Controls::TabViewItem>();
+        auto args = winrt::make_self<TabStripDragStartingEventArgs>(tab, draggedItem, e.Data());
+        TabDragStarting.raise(*this, *args);
+
+        if (args->Cancel())
+        {
+            e.Cancel(true);
+            _draggingItem = nullptr;
+        }
+    }
+
+    void TabStrip::OnDragItemsCompleted(ListViewBase const& /*sender*/,
+                                         DragItemsCompletedEventArgs const& e)
+    {
+        TabDragCompleted.raise(*this, nullptr);
+
+        // Tearoff signal: dropped where nobody accepted it. Mirrors MUX
+        // TabView.TabDroppedOutside — TerminalPage will create a new window.
+        using DPO = Windows::ApplicationModel::DataTransfer::DataPackageOperation;
+        if (e.DropResult() == DPO::None && _draggingItem)
+        {
+            auto tab = _draggingItem.try_as<MUX::Controls::TabViewItem>();
+            auto args = winrt::make_self<TabStripDroppedOutsideEventArgs>(tab, _draggingItem);
+            TabDroppedOutside.raise(*this, *args);
+        }
+        _draggingItem = nullptr;
+    }
+
+    void TabStrip::OnListDragOver(IInspectable const& /*sender*/,
+                                   WUX::DragEventArgs const& e)
+    {
+        TabStripDragOver.raise(*this, e);
+    }
+
+    void TabStrip::OnListDrop(IInspectable const& /*sender*/,
+                               WUX::DragEventArgs const& e)
+    {
+        TabStripDrop.raise(*this, e);
+    }
+
+    int32_t TabStrip::_computeDropIndex(winrt::Windows::Foundation::Point const& stripRelativePos)
+    {
+        // Axis-parameterized per the B→C migration rules. The math is identical
+        // to what TerminalPage::_onTabStripDrop does today for horizontal, just
+        // switched to the Y axis when Orientation is Vertical.
+        const bool vertical = _orientation == TerminalApp::TabStripOrientation::Vertical;
+        const auto count = _tabItems.Size();
+
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            auto container = ItemsList().ContainerFromIndex(i).try_as<ListViewItem>();
+            if (!container)
+            {
+                continue;
+            }
+            auto transform = container.TransformToVisual(ItemsList());
+            auto containerOrigin = transform.TransformPoint({ 0, 0 });
+            const auto axisPos = vertical ? stripRelativePos.Y - containerOrigin.Y
+                                          : stripRelativePos.X - containerOrigin.X;
+            const auto axisDim = vertical ? container.ActualHeight() : container.ActualWidth();
+            if (axisPos < axisDim / 2)
+            {
+                return gsl::narrow_cast<int32_t>(i);
+            }
+        }
+        return -1;
+    }
+}

--- a/src/cascadia/TerminalApp/TabStrip.h
+++ b/src/cascadia/TerminalApp/TabStrip.h
@@ -108,6 +108,11 @@ namespace winrt::TerminalApp::implementation
         void OnCustomCloseClick(winrt::Windows::Foundation::IInspectable const& sender,
                                  winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
 
+        // Spec A §2.4: reports the rail as an AutomationControlType::Tab
+        // container so screen readers (Narrator / third-party AT) treat it
+        // like the horizontal MUX TabView rather than a generic UserControl.
+        winrt::Windows::UI::Xaml::Automation::Peers::AutomationPeer OnCreateAutomationPeer();
+
         til::typed_event<TerminalApp::TabStrip, TerminalApp::TabStripSelectionChangedEventArgs> SelectionChanged;
         til::typed_event<TerminalApp::TabStrip, TerminalApp::TabStripCloseRequestedEventArgs> TabCloseRequested;
         til::typed_event<TerminalApp::TabStrip, winrt::Windows::Foundation::Collections::IVectorChangedEventArgs> TabItemsChanged;

--- a/src/cascadia/TerminalApp/TabStrip.h
+++ b/src/cascadia/TerminalApp/TabStrip.h
@@ -105,6 +105,8 @@ namespace winrt::TerminalApp::implementation
                              winrt::Windows::UI::Xaml::DragEventArgs const& e);
         void OnListDrop(winrt::Windows::Foundation::IInspectable const& sender,
                          winrt::Windows::UI::Xaml::DragEventArgs const& e);
+        void OnCustomCloseClick(winrt::Windows::Foundation::IInspectable const& sender,
+                                 winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
 
         til::typed_event<TerminalApp::TabStrip, TerminalApp::TabStripSelectionChangedEventArgs> SelectionChanged;
         til::typed_event<TerminalApp::TabStrip, TerminalApp::TabStripCloseRequestedEventArgs> TabCloseRequested;

--- a/src/cascadia/TerminalApp/TabStrip.h
+++ b/src/cascadia/TerminalApp/TabStrip.h
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// PROTOTYPE — see investigation-vertical-tabs.md. Not shipped.
+
+#pragma once
+
+#include "winrt/Microsoft.UI.Xaml.Controls.h"
+
+#include "TabStrip.g.h"
+#include "TabStripSelectionChangedEventArgs.g.h"
+#include "TabStripCloseRequestedEventArgs.g.h"
+#include "TabStripDragStartingEventArgs.g.h"
+#include "TabStripDroppedOutsideEventArgs.g.h"
+
+namespace winrt::TerminalApp::implementation
+{
+    struct TabStripSelectionChangedEventArgs : TabStripSelectionChangedEventArgsT<TabStripSelectionChangedEventArgs>
+    {
+        WINRT_PROPERTY(winrt::Windows::Foundation::IInspectable, AddedItem, nullptr);
+        WINRT_PROPERTY(winrt::Windows::Foundation::IInspectable, RemovedItem, nullptr);
+
+    public:
+        TabStripSelectionChangedEventArgs(winrt::Windows::Foundation::IInspectable added,
+                                           winrt::Windows::Foundation::IInspectable removed) :
+            _AddedItem{ std::move(added) }, _RemovedItem{ std::move(removed) } {}
+    };
+
+    struct TabStripCloseRequestedEventArgs : TabStripCloseRequestedEventArgsT<TabStripCloseRequestedEventArgs>
+    {
+        WINRT_PROPERTY(winrt::Microsoft::UI::Xaml::Controls::TabViewItem, Tab, nullptr);
+
+    public:
+        TabStripCloseRequestedEventArgs(winrt::Microsoft::UI::Xaml::Controls::TabViewItem tab) :
+            _Tab{ std::move(tab) } {}
+    };
+
+    struct TabStripDragStartingEventArgs : TabStripDragStartingEventArgsT<TabStripDragStartingEventArgs>
+    {
+        WINRT_PROPERTY(winrt::Microsoft::UI::Xaml::Controls::TabViewItem, Tab, nullptr);
+        WINRT_PROPERTY(winrt::Windows::Foundation::IInspectable, Item, nullptr);
+        WINRT_PROPERTY(winrt::Windows::ApplicationModel::DataTransfer::DataPackage, Data, nullptr);
+        WINRT_PROPERTY(bool, Cancel, false);
+
+    public:
+        TabStripDragStartingEventArgs(winrt::Microsoft::UI::Xaml::Controls::TabViewItem tab,
+                                       winrt::Windows::Foundation::IInspectable item,
+                                       winrt::Windows::ApplicationModel::DataTransfer::DataPackage data) :
+            _Tab{ std::move(tab) }, _Item{ std::move(item) }, _Data{ std::move(data) } {}
+    };
+
+    struct TabStripDroppedOutsideEventArgs : TabStripDroppedOutsideEventArgsT<TabStripDroppedOutsideEventArgs>
+    {
+        WINRT_PROPERTY(winrt::Microsoft::UI::Xaml::Controls::TabViewItem, Tab, nullptr);
+        WINRT_PROPERTY(winrt::Windows::Foundation::IInspectable, Item, nullptr);
+
+    public:
+        TabStripDroppedOutsideEventArgs(winrt::Microsoft::UI::Xaml::Controls::TabViewItem tab,
+                                         winrt::Windows::Foundation::IInspectable item) :
+            _Tab{ std::move(tab) }, _Item{ std::move(item) } {}
+    };
+
+    struct TabStrip : TabStripT<TabStrip>
+    {
+        TabStrip();
+
+        // Getter-only in the IDL — returns the single, stable observable collection
+        // that call sites mutate directly via InsertAt/RemoveAt.
+        winrt::Windows::Foundation::Collections::IObservableVector<winrt::Windows::Foundation::IInspectable> TabItems() const { return _tabItems; }
+
+        // Proxies to the internal ListView. Non-const because the XAML-generated
+        // ItemsList()/LeadingContentPresenter()/TrailingContentPresenter()
+        // accessors are non-const.
+        winrt::Windows::Foundation::IInspectable SelectedItem();
+        void SelectedItem(winrt::Windows::Foundation::IInspectable const& value);
+        int32_t SelectedIndex();
+        void SelectedIndex(int32_t value);
+        winrt::Windows::UI::Xaml::DependencyObject ContainerFromIndex(int32_t index);
+
+        // Prototype: setter accepts Vertical only. Horizontal setter is a no-op —
+        // C is where the layout actually flips.
+        TerminalApp::TabStripOrientation Orientation() const noexcept { return _orientation; }
+        void Orientation(TerminalApp::TabStripOrientation value);
+
+        bool CanReorderTabs();
+        void CanReorderTabs(bool value);
+        bool CanDragTabs();
+        void CanDragTabs(bool value);
+
+        winrt::Windows::UI::Xaml::UIElement LeadingContent();
+        void LeadingContent(winrt::Windows::UI::Xaml::UIElement const& value);
+        winrt::Windows::UI::Xaml::UIElement TrailingContent();
+        void TrailingContent(winrt::Windows::UI::Xaml::UIElement const& value);
+
+        // XAML-bound event handlers.
+        void OnListSelectionChanged(winrt::Windows::Foundation::IInspectable const& sender,
+                                     winrt::Windows::UI::Xaml::Controls::SelectionChangedEventArgs const& e);
+        void OnDragItemsStarting(winrt::Windows::Foundation::IInspectable const& sender,
+                                  winrt::Windows::UI::Xaml::Controls::DragItemsStartingEventArgs const& e);
+        void OnDragItemsCompleted(winrt::Windows::UI::Xaml::Controls::ListViewBase const& sender,
+                                   winrt::Windows::UI::Xaml::Controls::DragItemsCompletedEventArgs const& e);
+        // Named to avoid colliding with IControlOverrides::OnDrop /
+        // OnDragOver on the Control base class, which have different arities.
+        void OnListDragOver(winrt::Windows::Foundation::IInspectable const& sender,
+                             winrt::Windows::UI::Xaml::DragEventArgs const& e);
+        void OnListDrop(winrt::Windows::Foundation::IInspectable const& sender,
+                         winrt::Windows::UI::Xaml::DragEventArgs const& e);
+
+        til::typed_event<TerminalApp::TabStrip, TerminalApp::TabStripSelectionChangedEventArgs> SelectionChanged;
+        til::typed_event<TerminalApp::TabStrip, TerminalApp::TabStripCloseRequestedEventArgs> TabCloseRequested;
+        til::typed_event<TerminalApp::TabStrip, winrt::Windows::Foundation::Collections::IVectorChangedEventArgs> TabItemsChanged;
+        til::typed_event<TerminalApp::TabStrip, TerminalApp::TabStripDragStartingEventArgs> TabDragStarting;
+        til::typed_event<TerminalApp::TabStrip, winrt::Windows::Foundation::IInspectable> TabDragCompleted;
+        til::typed_event<TerminalApp::TabStrip, winrt::Windows::UI::Xaml::DragEventArgs> TabStripDragOver;
+        til::typed_event<TerminalApp::TabStrip, winrt::Windows::UI::Xaml::DragEventArgs> TabStripDrop;
+        til::typed_event<TerminalApp::TabStrip, TerminalApp::TabStripDroppedOutsideEventArgs> TabDroppedOutside;
+
+    private:
+        TerminalApp::TabStripOrientation _orientation{ TerminalApp::TabStripOrientation::Vertical };
+        winrt::Windows::Foundation::Collections::IObservableVector<winrt::Windows::Foundation::IInspectable> _tabItems{ nullptr };
+        winrt::Windows::Foundation::Collections::IObservableVector<winrt::Windows::Foundation::IInspectable>::VectorChanged_revoker _vectorChangedRevoker;
+
+        // Per-TabViewItem CloseRequested subscription tokens, keyed by pointer identity.
+        std::unordered_map<void*, winrt::event_token> _closeRequestedTokens;
+
+        // The item currently being dragged. Set in OnDragItemsStarting, cleared in
+        // OnDragItemsCompleted. If DropResult is None, this is the item to fire
+        // TabDroppedOutside with (tearoff-to-new-window signal).
+        winrt::Windows::Foundation::IInspectable _draggingItem{ nullptr };
+
+        void _onItemsVectorChanged(winrt::Windows::Foundation::Collections::IObservableVector<winrt::Windows::Foundation::IInspectable> const& sender,
+                                     winrt::Windows::Foundation::Collections::IVectorChangedEventArgs const& args);
+        void _hookCloseRequested(winrt::Microsoft::UI::Xaml::Controls::TabViewItem const& item);
+        void _unhookCloseRequested(winrt::Microsoft::UI::Xaml::Controls::TabViewItem const& item);
+
+        // Axis-parameterized per B→C rules. Returns -1 to mean "append at end."
+        // Non-const because it reaches into the XAML-generated ItemsList().
+        int32_t _computeDropIndex(winrt::Windows::Foundation::Point const& stripRelativePos);
+    };
+}
+
+namespace winrt::TerminalApp::factory_implementation
+{
+    BASIC_FACTORY(TabStrip);
+}

--- a/src/cascadia/TerminalApp/TabStrip.h
+++ b/src/cascadia/TerminalApp/TabStrip.h
@@ -100,7 +100,7 @@ namespace winrt::TerminalApp::implementation
         void OnDragItemsCompleted(winrt::Windows::UI::Xaml::Controls::ListViewBase const& sender,
                                    winrt::Windows::UI::Xaml::Controls::DragItemsCompletedEventArgs const& e);
         // Named to avoid colliding with IControlOverrides::OnDrop /
-        // OnDragOver on the Control base class, which have different arities.
+        // OnDragOver on the Control base class, which have different parameter types.
         void OnListDragOver(winrt::Windows::Foundation::IInspectable const& sender,
                              winrt::Windows::UI::Xaml::DragEventArgs const& e);
         void OnListDrop(winrt::Windows::Foundation::IInspectable const& sender,

--- a/src/cascadia/TerminalApp/TabStrip.idl
+++ b/src/cascadia/TerminalApp/TabStrip.idl
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// PROTOTYPE — see investigation-vertical-tabs.md. Not shipped.
+//
+// TabStrip is a ListView-backed alternative to Microsoft.UI.Xaml.Controls.TabView.
+// It exposes the subset of TabView's public surface that TerminalPage +
+// TabManagement.cpp call, so those call sites don't have to branch on which
+// strip is live. Orientation is a public property (per the B→C migration
+// rules in the investigation doc); the prototype only implements Vertical.
+
+namespace TerminalApp
+{
+    enum TabStripOrientation
+    {
+        Horizontal = 0,
+        Vertical = 1,
+    };
+
+    [default_interface] runtimeclass TabStripSelectionChangedEventArgs
+    {
+        Object AddedItem { get; };
+        Object RemovedItem { get; };
+    };
+
+    [default_interface] runtimeclass TabStripCloseRequestedEventArgs
+    {
+        Microsoft.UI.Xaml.Controls.TabViewItem Tab { get; };
+    };
+
+    [default_interface] runtimeclass TabStripDragStartingEventArgs
+    {
+        Microsoft.UI.Xaml.Controls.TabViewItem Tab { get; };
+        Object Item { get; };
+        Windows.ApplicationModel.DataTransfer.DataPackage Data { get; };
+        Boolean Cancel;
+    };
+
+    [default_interface] runtimeclass TabStripDroppedOutsideEventArgs
+    {
+        Microsoft.UI.Xaml.Controls.TabViewItem Tab { get; };
+        Object Item { get; };
+    };
+
+    [default_interface] runtimeclass TabStrip : Windows.UI.Xaml.Controls.UserControl
+    {
+        TabStrip();
+
+        TabStripOrientation Orientation;
+
+        // Mirrors TabView.TabItems — TabManagement.cpp calls InsertAt/RemoveAt/
+        // IndexOf/Size/GetAt on this collection, so the signature must match.
+        Windows.Foundation.Collections.IObservableVector<Object> TabItems { get; };
+
+        Object SelectedItem;
+        Int32 SelectedIndex;
+
+        // Mirrors TabView.ContainerFromIndex — used by tearoff drop-position math.
+        Windows.UI.Xaml.DependencyObject ContainerFromIndex(Int32 index);
+
+        Boolean CanReorderTabs;
+        Boolean CanDragTabs;
+
+        // Top/bottom (or leading/trailing in horizontal) slots. Populated by
+        // TabRowControl.xaml with the elevation shield / workspaces button
+        // (leading) and the new-tab split button (trailing).
+        Windows.UI.Xaml.UIElement LeadingContent;
+        Windows.UI.Xaml.UIElement TrailingContent;
+
+        event Windows.Foundation.TypedEventHandler<TabStrip, TabStripSelectionChangedEventArgs> SelectionChanged;
+        event Windows.Foundation.TypedEventHandler<TabStrip, TabStripCloseRequestedEventArgs> TabCloseRequested;
+        event Windows.Foundation.TypedEventHandler<TabStrip, Windows.Foundation.Collections.IVectorChangedEventArgs> TabItemsChanged;
+        event Windows.Foundation.TypedEventHandler<TabStrip, TabStripDragStartingEventArgs> TabDragStarting;
+        event Windows.Foundation.TypedEventHandler<TabStrip, Object> TabDragCompleted;
+        event Windows.Foundation.TypedEventHandler<TabStrip, Windows.UI.Xaml.DragEventArgs> TabStripDragOver;
+        event Windows.Foundation.TypedEventHandler<TabStrip, Windows.UI.Xaml.DragEventArgs> TabStripDrop;
+        event Windows.Foundation.TypedEventHandler<TabStrip, TabStripDroppedOutsideEventArgs> TabDroppedOutside;
+    };
+}

--- a/src/cascadia/TerminalApp/TabStrip.xaml
+++ b/src/cascadia/TerminalApp/TabStrip.xaml
@@ -1,0 +1,84 @@
+<!--
+    Copyright (c) Microsoft Corporation. All rights reserved. Licensed under
+    the MIT License. See LICENSE in the project root for license information.
+
+    PROTOTYPE — see investigation-vertical-tabs.md. Not shipped.
+
+    ListView-backed strip that renders TabViewItem instances. Vertical for the
+    prototype; the control is named neutrally so C (single-strip end-state) can
+    reuse it with a public Orientation property.
+-->
+<UserControl x:Class="TerminalApp.TabStrip"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="using:TerminalApp"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:mux="using:Microsoft.UI.Xaml.Controls"
+             MinWidth="180"
+             Background="{ThemeResource TabViewBackground}"
+             mc:Ignorable="d">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!--  Leading slot: hosts elevation shield + workspaces button in vertical top.  -->
+        <ContentPresenter x:Name="LeadingContentPresenter"
+                          Grid.Row="0"
+                          HorizontalContentAlignment="Stretch" />
+
+        <!--
+            The strip proper. ListView holds TabViewItem instances directly via
+            a passthrough item template. ListViewItem chrome is stripped so the
+            TabViewItem owns all visual state; selection is synced in code-behind.
+        -->
+        <ListView x:Name="ItemsList"
+                  Grid.Row="1"
+                  Padding="0"
+                  AllowDrop="True"
+                  CanDragItems="True"
+                  CanReorderItems="True"
+                  DragOver="OnListDragOver"
+                  Drop="OnListDrop"
+                  DragItemsStarting="OnDragItemsStarting"
+                  DragItemsCompleted="OnDragItemsCompleted"
+                  IsItemClickEnabled="False"
+                  ReorderMode="Enabled"
+                  SelectionChanged="OnListSelectionChanged"
+                  SelectionMode="Single">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <ContentPresenter HorizontalAlignment="Stretch"
+                                      HorizontalContentAlignment="Stretch"
+                                      Content="{Binding}" />
+                </DataTemplate>
+            </ListView.ItemTemplate>
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="Padding" Value="0" />
+                    <Setter Property="Margin" Value="0" />
+                    <Setter Property="MinHeight" Value="32" />
+                    <Setter Property="HorizontalAlignment" Value="Stretch" />
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    <Setter Property="VerticalContentAlignment" Value="Stretch" />
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="BorderThickness" Value="0" />
+                </Style>
+            </ListView.ItemContainerStyle>
+            <ListView.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <ItemsStackPanel Orientation="Vertical" />
+                </ItemsPanelTemplate>
+            </ListView.ItemsPanel>
+        </ListView>
+
+        <!--  Trailing slot: hosts the new-tab split button in vertical bottom.  -->
+        <ContentPresenter x:Name="TrailingContentPresenter"
+                          Grid.Row="2"
+                          HorizontalContentAlignment="Stretch" />
+    </Grid>
+</UserControl>

--- a/src/cascadia/TerminalApp/TabStrip.xaml
+++ b/src/cascadia/TerminalApp/TabStrip.xaml
@@ -68,7 +68,8 @@
                                           HorizontalAlignment="Stretch"
                                           HorizontalContentAlignment="Stretch"
                                           Content="{Binding}" />
-                        <Button Grid.Column="1"
+                        <Button x:Uid="TabStripCloseButton"
+                                Grid.Column="1"
                                 Width="24"
                                 Height="24"
                                 Margin="0,0,4,0"

--- a/src/cascadia/TerminalApp/TabStrip.xaml
+++ b/src/cascadia/TerminalApp/TabStrip.xaml
@@ -52,9 +52,35 @@
                   SelectionMode="Single">
             <ListView.ItemTemplate>
                 <DataTemplate>
-                    <ContentPresenter HorizontalAlignment="Stretch"
-                                      HorizontalContentAlignment="Stretch"
-                                      Content="{Binding}" />
+                    <!--
+                        MUX's built-in CloseButton on TabViewItem is only
+                        driven visible when the item lives inside a TabView
+                        (via TabView.CloseButtonOverlayMode). Ours don't, so
+                        we suppress it with IsClosable=false (set in code)
+                        and render our own X in an adjacent column.
+                    -->
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <ContentPresenter Grid.Column="0"
+                                          HorizontalAlignment="Stretch"
+                                          HorizontalContentAlignment="Stretch"
+                                          Content="{Binding}" />
+                        <Button Grid.Column="1"
+                                Width="24"
+                                Height="24"
+                                Margin="0,0,4,0"
+                                Padding="0"
+                                VerticalAlignment="Center"
+                                Background="Transparent"
+                                BorderThickness="0"
+                                Content="&#xE711;"
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                FontSize="10"
+                                Click="OnCustomCloseClick" />
+                    </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>
             <ListView.ItemContainerStyle>

--- a/src/cascadia/TerminalApp/TabStripAutomationPeer.cpp
+++ b/src/cascadia/TerminalApp/TabStripAutomationPeer.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "TabStrip.h"
+#include "TabStripAutomationPeer.h"
+
+#include "TabStripAutomationPeer.g.cpp"
+
+namespace winrt::TerminalApp::implementation
+{
+    TabStripAutomationPeer::TabStripAutomationPeer(TerminalApp::TabStrip const& owner) :
+        TabStripAutomationPeerT<TabStripAutomationPeer>(owner)
+    {
+    }
+
+    winrt::hstring TabStripAutomationPeer::GetClassNameCore() const
+    {
+        return L"TabStrip";
+    }
+
+    winrt::Windows::UI::Xaml::Automation::Peers::AutomationControlType TabStripAutomationPeer::GetAutomationControlTypeCore() const
+    {
+        return winrt::Windows::UI::Xaml::Automation::Peers::AutomationControlType::Tab;
+    }
+
+    winrt::hstring TabStripAutomationPeer::GetLocalizedControlTypeCore() const
+    {
+        return L"tab strip";
+    }
+
+    winrt::Windows::UI::Xaml::Automation::Peers::AutomationOrientation TabStripAutomationPeer::GetOrientationCore() const
+    {
+        return winrt::Windows::UI::Xaml::Automation::Peers::AutomationOrientation::Vertical;
+    }
+}

--- a/src/cascadia/TerminalApp/TabStripAutomationPeer.cpp
+++ b/src/cascadia/TerminalApp/TabStripAutomationPeer.cpp
@@ -26,7 +26,7 @@ namespace winrt::TerminalApp::implementation
 
     winrt::hstring TabStripAutomationPeer::GetLocalizedControlTypeCore() const
     {
-        return L"tab strip";
+        return RS_(L"TabStrip_ControlType");
     }
 
     winrt::Windows::UI::Xaml::Automation::Peers::AutomationOrientation TabStripAutomationPeer::GetOrientationCore() const

--- a/src/cascadia/TerminalApp/TabStripAutomationPeer.h
+++ b/src/cascadia/TerminalApp/TabStripAutomationPeer.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// Spec A §2.4: reports the vertical rail as a Tab control (not a plain
+// UserControl / List) so screen readers announce it correctly. Children
+// resolve to the hosted TabViewItems via the default GetChildrenCore path.
+
+#pragma once
+
+#include "TabStripAutomationPeer.g.h"
+
+namespace winrt::TerminalApp::implementation
+{
+    struct TabStripAutomationPeer : TabStripAutomationPeerT<TabStripAutomationPeer>
+    {
+        TabStripAutomationPeer(TerminalApp::TabStrip const& owner);
+
+        winrt::hstring GetClassNameCore() const;
+        winrt::Windows::UI::Xaml::Automation::Peers::AutomationControlType GetAutomationControlTypeCore() const;
+        winrt::hstring GetLocalizedControlTypeCore() const;
+        winrt::Windows::UI::Xaml::Automation::Peers::AutomationOrientation GetOrientationCore() const;
+    };
+}
+
+namespace winrt::TerminalApp::factory_implementation
+{
+    BASIC_FACTORY(TabStripAutomationPeer);
+}

--- a/src/cascadia/TerminalApp/TabStripAutomationPeer.idl
+++ b/src/cascadia/TerminalApp/TabStripAutomationPeer.idl
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "TabStrip.idl";
+
+namespace TerminalApp
+{
+    [default_interface] runtimeclass TabStripAutomationPeer :
+        Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
+    {
+        TabStripAutomationPeer(TabStrip owner);
+    }
+}

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
@@ -61,6 +61,9 @@
     <Page Include="TabHeaderControl.xaml">
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="TabStrip.xaml">
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="HighlightedTextControlStyle.xaml">
       <Type>DefaultStyle</Type>
       <SubType>Designer</SubType>
@@ -131,6 +134,9 @@
     </ClInclude>
     <ClInclude Include="TabHeaderControl.h">
       <DependentUpon>TabHeaderControl.xaml</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="TabStrip.h">
+      <DependentUpon>TabStrip.xaml</DependentUpon>
     </ClInclude>
     <ClInclude Include="HighlightedTextControl.h">
       <DependentUpon>HighlightedTextControl.idl</DependentUpon>
@@ -254,6 +260,9 @@
     <ClCompile Include="TabHeaderControl.cpp">
       <DependentUpon>TabHeaderControl.xaml</DependentUpon>
     </ClCompile>
+    <ClCompile Include="TabStrip.cpp">
+      <DependentUpon>TabStrip.xaml</DependentUpon>
+    </ClCompile>
     <ClCompile Include="HighlightedTextControl.cpp">
       <DependentUpon>HighlightedTextControl.idl</DependentUpon>
     </ClCompile>
@@ -369,6 +378,10 @@
     </Midl>
     <Midl Include="TabHeaderControl.idl">
       <DependentUpon>TabHeaderControl.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="TabStrip.idl">
+      <DependentUpon>TabStrip.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="HighlightedTextControl.idl">

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
@@ -138,6 +138,7 @@
     <ClInclude Include="TabStrip.h">
       <DependentUpon>TabStrip.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="TabStripAutomationPeer.h" />
     <ClInclude Include="HighlightedTextControl.h">
       <DependentUpon>HighlightedTextControl.idl</DependentUpon>
     </ClInclude>
@@ -263,6 +264,7 @@
     <ClCompile Include="TabStrip.cpp">
       <DependentUpon>TabStrip.xaml</DependentUpon>
     </ClCompile>
+    <ClCompile Include="TabStripAutomationPeer.cpp" />
     <ClCompile Include="HighlightedTextControl.cpp">
       <DependentUpon>HighlightedTextControl.idl</DependentUpon>
     </ClCompile>
@@ -382,6 +384,9 @@
     </Midl>
     <Midl Include="TabStrip.idl">
       <DependentUpon>TabStrip.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="TabStripAutomationPeer.idl">
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="HighlightedTextControl.idl">

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj.filters
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj.filters
@@ -97,6 +97,9 @@
     <Page Include="TabHeaderControl.xaml">
       <Filter>controls</Filter>
     </Page>
+    <Page Include="TabStrip.xaml">
+      <Filter>controls</Filter>
+    </Page>
     <Page Include="TerminalPage.xaml">
       <Filter>controls</Filter>
     </Page>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -64,6 +64,9 @@ using namespace ::Microsoft::Console;
 using namespace ::Microsoft::Terminal::Core;
 using namespace std::chrono_literals;
 
+static constexpr double railMin = 180.0;
+static constexpr double railMax = 480.0;
+
 #define HOOKUP_ACTION(action) _actionDispatch->action({ this, &TerminalPage::_Handle##action });
 
 namespace winrt
@@ -3269,9 +3272,7 @@ namespace winrt::TerminalApp::implementation
         }
 
         // Spec A §5.2: rail width comes from settings (default 220, clamped
-        // 140..480). Persisted on drag-end via _OnRailSplitterPointerReleased.
-        constexpr double railMin = 140.0;
-        constexpr double railMax = 480.0;
+        // 180..480). Persisted on drag-end via _OnRailSplitterPointerReleased.
         const double persistedWidth = static_cast<double>(_settings.GlobalSettings().TabLayoutVerticalWidth());
         const double railWidth = std::clamp(persistedWidth, railMin, railMax);
         VerticalRailColumn().Width(GridLengthHelper::FromValueAndType(railWidth, GridUnitType::Pixel));
@@ -3402,8 +3403,6 @@ namespace winrt::TerminalApp::implementation
         {
             return;
         }
-        constexpr double railMin = 140.0;
-        constexpr double railMax = 480.0;
         const auto point = e.GetCurrentPoint(Root()).Position();
         const auto delta = static_cast<double>(point.X - _railSplitterStartPointer.X);
         const auto requested = std::clamp(_railSplitterStartWidth + delta, railMin, railMax);

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -296,6 +296,22 @@ namespace winrt::TerminalApp::implementation
             // Create this only on the first time we load the settings.
             _terminalSettingsCache = std::make_shared<TerminalSettingsCache>(settings);
         }
+        // Spec A: TabLayout can't be applied live in v1 (would require
+        // tearing down and rebuilding the rail + chrome reparenting).
+        // Detect the mismatch before we swap _settings and surface a
+        // restart-required hint. Skipped on first load, and only when the
+        // new setting actually diverges from the live layout.
+        if (!firstLoad)
+        {
+            const bool wantVertical = settings.GlobalSettings().TabLayout() == TabLayout::Vertical;
+            if (wantVertical != _isVerticalLayout)
+            {
+                if (const auto infoBar = FindName(L"TabLayoutRestartInfoBar").try_as<MUX::Controls::InfoBar>())
+                {
+                    infoBar.IsOpen(true);
+                }
+            }
+        }
         _settings = settings;
 
         // Seed the agent-settings baseline on first load so that later

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -420,23 +420,23 @@ namespace winrt::TerminalApp::implementation
         _tabContent = this->TabContent();
         _tabRow = this->TabRow();
         _tabView = _tabRow.TabView();
+        _tabStrip = _tabRow.TabStrip();
         _rearranging = false;
 
-        // PROTOTYPE — see investigation-vertical-tabs.md. When
-        // WT_VERTICAL_TABS_PROTOTYPE=1, flip TabRow to vertical layout and
-        // seed the TabStrip with mock TabViewItems so we can visually confirm
-        // that a ListView-backed strip renders TabViewItem correctly.
-        // Full integration with real Tab objects and cross-window tearoff is
-        // deferred until Spec A. This env-var path leaves the real MUX
-        // TabView code path untouched — it is *additive* prototype scaffolding.
+        // Dev toggle for Spec A implementation. While the tabLayout setting
+        // and its wiring don't exist yet (Phase 7), setting
+        // WT_VERTICAL_TABS_PROTOTYPE=1 flips the TabRow to vertical so devs
+        // can exercise the incremental TabStrip work in phases 3–6. The env
+        // var goes away when the real setting lands.
+        //if (wil::TryGetEnvironmentVariableW<std::wstring>(L"WT_VERTICAL_TABS_PROTOTYPE") == L"1")
         {
-            //const auto proto = wil::TryGetEnvironmentVariableW<std::wstring>(L"WT_VERTICAL_TABS_PROTOTYPE");
-            //if (proto == L"1")
-            {
-                _tabRow.IsVerticalLayout(true);
-                _seedVerticalTabsPrototype();
-            }
+            _tabRow.IsVerticalLayout(true);
         }
+        // Cache the layout mode so the routing helpers (_tabItems /
+        // _selectedTabItem) don't have to reach into _tabRow on every call.
+        _isVerticalLayout = _tabRow.IsVerticalLayout();
+
+        _ApplyVerticalLayoutReshape();
 
         const auto canDragDrop = CanDragDrop();
 
@@ -463,7 +463,11 @@ namespace winrt::TerminalApp::implementation
             }
         });
 
-        if (_settings.GlobalSettings().ShowTabsInTitlebar())
+        // Spec A §1: vertical layout silently overrides showTabsInTitlebar to
+        // false — the rail lives inside the page, not stapled to the titlebar.
+        // Phase 7 formalizes this via the settings model; for now the check
+        // just short-circuits on _isVerticalLayout.
+        if (_settings.GlobalSettings().ShowTabsInTitlebar() && !_isVerticalLayout)
         {
             // Remove the TabView from the page. We'll hang on to it, we need to
             // put it in the titlebar.
@@ -493,6 +497,17 @@ namespace winrt::TerminalApp::implementation
             const auto transparent = Media::SolidColorBrush();
             transparent.Color(Windows::UI::Colors::Transparent());
             _tabRow.Background(transparent);
+        }
+        else if (_isVerticalLayout && _settings.GlobalSettings().ShowTabsInTitlebar())
+        {
+            // Vertical mode: TabRow stays in the page, but hand shield +
+            // workspaces to the titlebar so they sit next to min/max/close.
+            // TabRowControl::_reparentChromeToVertical built the panel during
+            // IsVerticalLayout(true) above.
+            if (const auto content = winrt::get_self<implementation::TabRowControl>(_tabRow)->VerticalTitleBarContent())
+            {
+                SetTitleBarContent.raise(*this, content);
+            }
         }
         _updateThemeColors();
 
@@ -545,6 +560,25 @@ namespace winrt::TerminalApp::implementation
         _tabView.TabStripDragOver({ this, &TerminalPage::_onTabStripDragOver });
         _tabView.TabStripDrop({ this, &TerminalPage::_onTabStripDrop });
         _tabView.TabDroppedOutside({ this, &TerminalPage::_onTabDroppedOutside });
+
+        // Vertical strip: hook the TabStrip's equivalent events. The generic
+        // ones (TabItemsChanged, TabDragCompleted, drag-over/drop) reuse the
+        // same handlers as TabView; the ones with MUX-typed args have thin
+        // TabStrip-typed wrappers that call a shared *Core method.
+        if (_isVerticalLayout)
+        {
+            _tabStrip.CanReorderTabs(canDragDrop);
+            _tabStrip.CanDragTabs(canDragDrop);
+            _tabStrip.TabDragStarting({ get_weak(), &TerminalPage::_TabDragStarted });
+            _tabStrip.TabDragCompleted({ get_weak(), &TerminalPage::_TabDragCompleted });
+            _tabStrip.SelectionChanged({ this, &TerminalPage::_OnTabStripSelectionChanged });
+            _tabStrip.TabCloseRequested({ this, &TerminalPage::_OnTabStripCloseRequested });
+            _tabStrip.TabItemsChanged({ this, &TerminalPage::_OnTabItemsChanged });
+            _tabStrip.TabDragStarting({ this, &TerminalPage::_OnTabStripDragStarting });
+            _tabStrip.TabStripDragOver({ this, &TerminalPage::_onTabStripDragOver });
+            _tabStrip.TabStripDrop({ this, &TerminalPage::_onTabStripDrop });
+            _tabStrip.TabDroppedOutside({ this, &TerminalPage::_OnTabStripDroppedOutside });
+        }
 
         _CreateNewTabFlyout();
 
@@ -665,37 +699,6 @@ namespace winrt::TerminalApp::implementation
             return false;
         }
         return true;
-    }
-
-    // PROTOTYPE — see investigation-vertical-tabs.md. Seeds TabRow's TabStrip
-    // with three mock TabViewItems so we can visually verify that a
-    // ListView-based strip renders TabViewItem instances. Real Tab objects
-    // still flow into the MUX TabView; this prototype path is additive.
-    void TerminalPage::_seedVerticalTabsPrototype()
-    {
-        auto strip = _tabRow.TabStrip();
-        if (!strip)
-        {
-            return;
-        }
-
-        static constexpr std::wstring_view mockTitles[] = {
-            L"project-alpha",
-            L"updating-UI",
-            L"research for June",
-        };
-
-        for (const auto title : mockTitles)
-        {
-            MUX::Controls::TabViewItem item{};
-            item.Header(box_value(winrt::hstring{ title }));
-            // GH bodge from Tab::_MakeTabViewItem — every TabViewItem needs a
-            // non-null, non-shared Content or MUX's drag-start event returns
-            // the wrong item. Same applies here.
-            item.Content(WUX::Controls::Border{});
-            item.IsClosable(true);
-            strip.TabItems().Append(item);
-        }
     }
 
     // Method Description:
@@ -3220,6 +3223,186 @@ namespace winrt::TerminalApp::implementation
 
             _CompleteInitialization();
         }
+    }
+
+    // Spec A §5.1: give the vertical rail its column width and re-anchor
+    // TabRow + the primary content children so the strip owns column 0 (full
+    // height, including under the bottom bar) and everything else stacks in
+    // column 1. BottomBarRoot drops its ColumnSpan so the bar only sits under
+    // the terminal content, per the spec mock.
+    void TerminalPage::_ApplyVerticalLayoutReshape()
+    {
+        if (!_isVerticalLayout)
+        {
+            return;
+        }
+
+        // Spec A §5.2: rail width comes from settings (default 220, clamped
+        // 140..480). Persisted on drag-end via _OnRailSplitterPointerReleased.
+        constexpr double railMin = 140.0;
+        constexpr double railMax = 480.0;
+        const double persistedWidth = static_cast<double>(_settings.GlobalSettings().TabLayoutVerticalWidth());
+        const double railWidth = std::clamp(persistedWidth, railMin, railMax);
+        VerticalRailColumn().Width(GridLengthHelper::FromValueAndType(railWidth, GridUnitType::Pixel));
+
+        Grid::SetRow(_tabRow, 0);
+        Grid::SetRowSpan(_tabRow, 4);
+        Grid::SetColumn(_tabRow, 0);
+        Grid::SetColumnSpan(_tabRow, 1);
+
+        Grid::SetColumn(InfoBarsPanel(), 1);
+        Grid::SetColumnSpan(InfoBarsPanel(), 1);
+
+        Grid::SetColumn(TabContentFiller(), 1);
+        Grid::SetColumnSpan(TabContentFiller(), 1);
+
+        Grid::SetColumn(_tabContent, 1);
+        Grid::SetColumnSpan(_tabContent, 1);
+
+        Grid::SetColumn(BottomBarRoot(), 1);
+        Grid::SetColumnSpan(BottomBarRoot(), 1);
+
+        _InstallVerticalRailSplitter();
+    }
+
+    // Spec A §5.2: hand-rolled splitter mirroring the Pane splitter idiom
+    // (Pane.cpp:3704). Lives in column 1 of Root, HorizontalAlignment=Left
+    // with a negative left margin so the hit strip (8px total) straddles the
+    // column boundary. Transparent Background so it visually disappears but
+    // still receives pointer hit-tests.
+    void TerminalPage::_InstallVerticalRailSplitter()
+    {
+        if (_verticalRailSplitter)
+        {
+            return;
+        }
+
+        constexpr double splitterHitThickness = 8.0;
+        constexpr double half = splitterHitThickness / 2.0;
+
+        _verticalRailSplitter = Controls::Border{};
+        _verticalRailSplitter.Background(Media::SolidColorBrush{ Windows::UI::Colors::Transparent() });
+        _verticalRailSplitter.IsHitTestVisible(true);
+        _verticalRailSplitter.Width(splitterHitThickness);
+        _verticalRailSplitter.HorizontalAlignment(HorizontalAlignment::Left);
+        _verticalRailSplitter.VerticalAlignment(VerticalAlignment::Stretch);
+        _verticalRailSplitter.Margin(Thickness{ -half, 0, 0, 0 });
+
+        Grid::SetColumn(_verticalRailSplitter, 1);
+        Grid::SetRow(_verticalRailSplitter, 0);
+        Grid::SetRowSpan(_verticalRailSplitter, 4);
+
+        _verticalRailSplitter.PointerEntered({ this, &TerminalPage::_OnRailSplitterPointerEntered });
+        _verticalRailSplitter.PointerExited({ this, &TerminalPage::_OnRailSplitterPointerExited });
+        _verticalRailSplitter.PointerPressed({ this, &TerminalPage::_OnRailSplitterPointerPressed });
+        _verticalRailSplitter.PointerMoved({ this, &TerminalPage::_OnRailSplitterPointerMoved });
+        _verticalRailSplitter.PointerReleased({ this, &TerminalPage::_OnRailSplitterPointerReleased });
+        _verticalRailSplitter.PointerCaptureLost({ this, &TerminalPage::_OnRailSplitterPointerCaptureLost });
+        _verticalRailSplitter.PointerCanceled({ this, &TerminalPage::_OnRailSplitterPointerCaptureLost });
+
+        Root().Children().Append(_verticalRailSplitter);
+    }
+
+    void TerminalPage::_SetRailSplitterCursor()
+    {
+        const auto cw = CoreWindow::GetForCurrentThread();
+        if (!cw)
+        {
+            return;
+        }
+        if (!_railSplitterPriorCursor)
+        {
+            _railSplitterPriorCursor = cw.PointerCursor();
+        }
+        cw.PointerCursor(CoreCursor{ CoreCursorType::SizeWestEast, 0 });
+    }
+
+    void TerminalPage::_RestoreRailSplitterCursor()
+    {
+        if (!_railSplitterPriorCursor)
+        {
+            return;
+        }
+        if (const auto cw = CoreWindow::GetForCurrentThread())
+        {
+            cw.PointerCursor(_railSplitterPriorCursor);
+        }
+        _railSplitterPriorCursor = nullptr;
+    }
+
+    void TerminalPage::_OnRailSplitterPointerEntered(const IInspectable&, const WUX::Input::PointerRoutedEventArgs&)
+    {
+        _SetRailSplitterCursor();
+    }
+
+    void TerminalPage::_OnRailSplitterPointerExited(const IInspectable&, const WUX::Input::PointerRoutedEventArgs&)
+    {
+        if (!_railSplitterDragging)
+        {
+            _RestoreRailSplitterCursor();
+        }
+    }
+
+    void TerminalPage::_OnRailSplitterPointerPressed(const IInspectable&, const WUX::Input::PointerRoutedEventArgs& e)
+    {
+        if (!_verticalRailSplitter)
+        {
+            return;
+        }
+        const auto point = e.GetCurrentPoint(Root());
+        if (point.Properties().IsRightButtonPressed() || point.Properties().IsMiddleButtonPressed())
+        {
+            return;
+        }
+        _railSplitterDragging = _verticalRailSplitter.CapturePointer(e.Pointer());
+        if (!_railSplitterDragging)
+        {
+            return;
+        }
+        _railSplitterStartWidth = VerticalRailColumn().ActualWidth();
+        _railSplitterStartPointer = point.Position();
+        _SetRailSplitterCursor();
+        e.Handled(true);
+    }
+
+    void TerminalPage::_OnRailSplitterPointerMoved(const IInspectable&, const WUX::Input::PointerRoutedEventArgs& e)
+    {
+        if (!_railSplitterDragging)
+        {
+            return;
+        }
+        constexpr double railMin = 140.0;
+        constexpr double railMax = 480.0;
+        const auto point = e.GetCurrentPoint(Root()).Position();
+        const auto delta = static_cast<double>(point.X - _railSplitterStartPointer.X);
+        const auto requested = std::clamp(_railSplitterStartWidth + delta, railMin, railMax);
+        VerticalRailColumn().Width(GridLengthHelper::FromValueAndType(requested, GridUnitType::Pixel));
+        e.Handled(true);
+    }
+
+    void TerminalPage::_OnRailSplitterPointerReleased(const IInspectable&, const WUX::Input::PointerRoutedEventArgs& e)
+    {
+        if (_railSplitterDragging && _verticalRailSplitter)
+        {
+            _verticalRailSplitter.ReleasePointerCapture(e.Pointer());
+        }
+        _railSplitterDragging = false;
+        _RestoreRailSplitterCursor();
+
+        // Persist. Read back the ActualWidth to catch any layout snapping.
+        const auto finalWidth = static_cast<int32_t>(std::lround(VerticalRailColumn().ActualWidth()));
+        if (finalWidth != _settings.GlobalSettings().TabLayoutVerticalWidth())
+        {
+            _settings.GlobalSettings().TabLayoutVerticalWidth(finalWidth);
+            _settings.WriteSettingsToDisk();
+        }
+        e.Handled(true);
+    }
+
+    void TerminalPage::_OnRailSplitterPointerCaptureLost(const IInspectable&, const WUX::Input::PointerRoutedEventArgs&)
+    {
+        _railSplitterDragging = false;
+        _RestoreRailSplitterCursor();
     }
 
     // Method Description:
@@ -7506,7 +7689,18 @@ namespace winrt::TerminalApp::implementation
     // - eventArgs: the event's constituent arguments
     void TerminalPage::_OnTabCloseRequested(const IInspectable& /*sender*/, const MUX::Controls::TabViewTabCloseRequestedEventArgs& eventArgs)
     {
-        const auto tabViewItem = eventArgs.Tab();
+        _HandleTabCloseRequestedCore(eventArgs.Tab());
+    }
+
+    // Spec A §4.2: TabStrip's TabCloseRequested uses custom args (TabStripCloseRequestedEventArgs).
+    // Both wrappers unpack the TabViewItem and dispatch to the shared core.
+    void TerminalPage::_OnTabStripCloseRequested(const IInspectable& /*sender*/, const TerminalApp::TabStripCloseRequestedEventArgs& eventArgs)
+    {
+        _HandleTabCloseRequestedCore(eventArgs.Tab());
+    }
+
+    void TerminalPage::_HandleTabCloseRequestedCore(const MUX::Controls::TabViewItem& tabViewItem)
+    {
         if (auto tab{ _GetTabByTabViewItem(tabViewItem) })
         {
             _HandleCloseTabRequested(tab);
@@ -10044,8 +10238,25 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_onTabDragStarting(const winrt::Microsoft::UI::Xaml::Controls::TabView&,
                                           const winrt::Microsoft::UI::Xaml::Controls::TabViewTabDragStartingEventArgs& e)
     {
+        _OnTabDragStartingCore(e.Tab(), e.Data());
+    }
+
+    // Spec A §4.2: TabStrip's TabDragStarting uses custom args
+    // (TabStripDragStartingEventArgs). Both wrappers unpack the TabViewItem +
+    // DataPackage and dispatch to the shared core.
+    void TerminalPage::_OnTabStripDragStarting(const winrt::Windows::Foundation::IInspectable&,
+                                                const TerminalApp::TabStripDragStartingEventArgs& e)
+    {
+        if (const auto tab = e.Tab())
+        {
+            _OnTabDragStartingCore(tab, e.Data());
+        }
+    }
+
+    void TerminalPage::_OnTabDragStartingCore(const MUX::Controls::TabViewItem& eventTab,
+                                              const winrt::Windows::ApplicationModel::DataTransfer::DataPackage& data)
+    {
         // Get the tab impl from this event.
-        const auto eventTab = e.Tab();
         const auto tabBase = _GetTabByTabViewItem(eventTab);
         winrt::com_ptr<Tab> tabImpl;
         tabImpl.copy_from(winrt::get_self<Tab>(tabBase));
@@ -10071,9 +10282,9 @@ namespace winrt::TerminalApp::implementation
             // Get our PID
             const auto pid{ GetCurrentProcessId() };
 
-            e.Data().Properties().Insert(L"windowId", winrt::box_value(id));
-            e.Data().Properties().Insert(L"pid", winrt::box_value<uint32_t>(pid));
-            e.Data().RequestedOperation(DataPackageOperation::Move);
+            data.Properties().Insert(L"windowId", winrt::box_value(id));
+            data.Properties().Insert(L"pid", winrt::box_value<uint32_t>(pid));
+            data.RequestedOperation(DataPackageOperation::Move);
 
             // The next thing that will happen:
             //  * Another TerminalPage will get a TabStripDragOver, then get a
@@ -10141,18 +10352,26 @@ namespace winrt::TerminalApp::implementation
         // index to the request. This is largely taken from the WinUI sample
         // app.
 
-        // First we need to get the position in the List to drop to
+        // First we need to get the position in the List to drop to.
+        // Route the iteration + container lookup through the layout-aware
+        // helpers so vertical strips (Spec A) compute drop indices correctly
+        // on the Y axis. The container-cast is FrameworkElement so it works
+        // for TabView (returns TabViewItem) and TabStrip (returns ListViewItem
+        // wrapping the TabViewItem) alike.
         auto index = -1;
-
-        // Determine which items in the list our pointer is between.
-        for (auto i = 0u; i < _tabView.TabItems().Size(); i++)
+        const auto count = _tabItems().Size();
+        for (uint32_t i = 0; i < count; ++i)
         {
-            if (const auto& item{ _tabView.ContainerFromIndex(i).try_as<winrt::MUX::Controls::TabViewItem>() })
+            const auto container = _isVerticalLayout
+                                       ? _tabStrip.ContainerFromIndex(i)
+                                       : _tabView.ContainerFromIndex(i);
+            if (const auto& element{ container.try_as<winrt::Windows::UI::Xaml::FrameworkElement>() })
             {
-                const auto posX{ e.GetPosition(item).X }; // The point of the drop, relative to the tab
-                const auto itemWidth{ item.ActualWidth() }; // The right of the tab
-                // If the drag point is on the left half of the tab, then insert here.
-                if (posX < itemWidth / 2)
+                const auto pos = e.GetPosition(element);
+                const auto axisPos = _isVerticalLayout ? pos.Y : pos.X;
+                const auto axisDim = _isVerticalLayout ? element.ActualHeight() : element.ActualWidth();
+                // If the drag point is on the near half of the item, insert here.
+                if (axisPos < axisDim / 2)
                 {
                     index = i;
                     break;
@@ -10193,6 +10412,19 @@ namespace winrt::TerminalApp::implementation
 
     void TerminalPage::_onTabDroppedOutside(winrt::IInspectable /*sender*/,
                                             winrt::MUX::Controls::TabViewTabDroppedOutsideEventArgs /*e*/)
+    {
+        _OnTabDroppedOutsideCore();
+    }
+
+    // Spec A §4.2: TabStrip's TabDroppedOutside uses custom args
+    // (TabStripDroppedOutsideEventArgs); the body doesn't use them either.
+    void TerminalPage::_OnTabStripDroppedOutside(const winrt::Windows::Foundation::IInspectable& /*sender*/,
+                                                  const TerminalApp::TabStripDroppedOutsideEventArgs& /*e*/)
+    {
+        _OnTabDroppedOutsideCore();
+    }
+
+    void TerminalPage::_OnTabDroppedOutsideCore()
     {
         // Get the current pointer point from the CoreWindow
         const auto& pointerPoint{ CoreWindow::GetForCurrentThread().PointerPosition() };

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -423,12 +423,8 @@ namespace winrt::TerminalApp::implementation
         _tabStrip = _tabRow.TabStrip();
         _rearranging = false;
 
-        // Dev toggle for Spec A implementation. While the tabLayout setting
-        // and its wiring don't exist yet (Phase 7), setting
-        // WT_VERTICAL_TABS_PROTOTYPE=1 flips the TabRow to vertical so devs
-        // can exercise the incremental TabStrip work in phases 3–6. The env
-        // var goes away when the real setting lands.
-        //if (wil::TryGetEnvironmentVariableW<std::wstring>(L"WT_VERTICAL_TABS_PROTOTYPE") == L"1")
+        // Spec A §1: layout is driven by the tabLayout global setting.
+        if (_settings.GlobalSettings().TabLayout() == TabLayout::Vertical)
         {
             _tabRow.IsVerticalLayout(true);
         }
@@ -498,15 +494,34 @@ namespace winrt::TerminalApp::implementation
             transparent.Color(Windows::UI::Colors::Transparent());
             _tabRow.Background(transparent);
         }
-        else if (_isVerticalLayout && _settings.GlobalSettings().ShowTabsInTitlebar())
+        else if (_isVerticalLayout)
         {
-            // Vertical mode: TabRow stays in the page, but hand shield +
-            // workspaces to the titlebar so they sit next to min/max/close.
-            // TabRowControl::_reparentChromeToVertical built the panel during
-            // IsVerticalLayout(true) above.
+            // Vertical mode: TabRow stays in the page. TabRowControl already
+            // extracted shield + workspaces into VerticalTitleBarContent
+            // during IsVerticalLayout(true). Where the chrome lands depends
+            // on whether we have a non-client-area titlebar to host it:
+            //   - showTabsInTitlebar=true  -> hand it to the extended titlebar
+            //     (sits next to min/max/close, matches Spec A mock).
+            //   - showTabsInTitlebar=false -> no titlebar to host it, so dock
+            //     it at the top of the rail and flip to vertical orientation.
+            // Spec A §1 nominally says "silently force showTabsInTitlebar to
+            // false in vertical", but that removes the titlebar entirely and
+            // leaves nowhere for the workspaces button. Respecting the user's
+            // choice + graceful fallback matches the reviewed UX.
             if (const auto content = winrt::get_self<implementation::TabRowControl>(_tabRow)->VerticalTitleBarContent())
             {
-                SetTitleBarContent.raise(*this, content);
+                if (_settings.GlobalSettings().ShowTabsInTitlebar())
+                {
+                    SetTitleBarContent.raise(*this, content);
+                }
+                else
+                {
+                    if (const auto panel = content.try_as<WUX::Controls::StackPanel>())
+                    {
+                        panel.Orientation(WUX::Controls::Orientation::Vertical);
+                    }
+                    _tabStrip.LeadingContent(content);
+                }
             }
         }
         _updateThemeColors();

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -422,6 +422,22 @@ namespace winrt::TerminalApp::implementation
         _tabView = _tabRow.TabView();
         _rearranging = false;
 
+        // PROTOTYPE — see investigation-vertical-tabs.md. When
+        // WT_VERTICAL_TABS_PROTOTYPE=1, flip TabRow to vertical layout and
+        // seed the TabStrip with mock TabViewItems so we can visually confirm
+        // that a ListView-backed strip renders TabViewItem correctly.
+        // Full integration with real Tab objects and cross-window tearoff is
+        // deferred until Spec A. This env-var path leaves the real MUX
+        // TabView code path untouched — it is *additive* prototype scaffolding.
+        {
+            //const auto proto = wil::TryGetEnvironmentVariableW<std::wstring>(L"WT_VERTICAL_TABS_PROTOTYPE");
+            //if (proto == L"1")
+            {
+                _tabRow.IsVerticalLayout(true);
+                _seedVerticalTabsPrototype();
+            }
+        }
+
         const auto canDragDrop = CanDragDrop();
 
         _tabView.CanReorderTabs(canDragDrop);
@@ -649,6 +665,37 @@ namespace winrt::TerminalApp::implementation
             return false;
         }
         return true;
+    }
+
+    // PROTOTYPE — see investigation-vertical-tabs.md. Seeds TabRow's TabStrip
+    // with three mock TabViewItems so we can visually verify that a
+    // ListView-based strip renders TabViewItem instances. Real Tab objects
+    // still flow into the MUX TabView; this prototype path is additive.
+    void TerminalPage::_seedVerticalTabsPrototype()
+    {
+        auto strip = _tabRow.TabStrip();
+        if (!strip)
+        {
+            return;
+        }
+
+        static constexpr std::wstring_view mockTitles[] = {
+            L"project-alpha",
+            L"updating-UI",
+            L"research for June",
+        };
+
+        for (const auto title : mockTitles)
+        {
+            MUX::Controls::TabViewItem item{};
+            item.Header(box_value(winrt::hstring{ title }));
+            // GH bodge from Tab::_MakeTabViewItem — every TabViewItem needs a
+            // non-null, non-shared Content or MUX's drag-start event returns
+            // the wrong item. Same applies here.
+            item.Content(WUX::Controls::Border{});
+            item.IsClosable(true);
+            strip.TabItems().Append(item);
+        }
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -924,6 +924,12 @@ namespace winrt::TerminalApp::implementation
 
         void _SendDesktopNotification(const winrt::hstring& tabTitle, const winrt::hstring& body, const winrt::com_ptr<Tab>& tab, const winrt::TerminalApp::IPaneContent& content);
 
+        // PROTOTYPE — see investigation-vertical-tabs.md. Populates the
+        // TabRow's TabStrip with mock TabViewItems so we can visually confirm
+        // ListView-hosts-TabViewItem behavior. Called from Create() only when
+        // WT_VERTICAL_TABS_PROTOTYPE=1.
+        void _seedVerticalTabsPrototype();
+
 #pragma region ActionHandlers
         // These are all defined in AppActionHandlers.cpp
 #define ON_ALL_ACTIONS(action) DECLARE_ACTION_HANDLER(action);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -313,6 +313,18 @@ namespace winrt::TerminalApp::implementation
         // (which is a root when the tabs are in the titlebar.)
         Microsoft::UI::Xaml::Controls::TabView _tabView{ nullptr };
         TerminalApp::TabRowControl _tabRow{ nullptr };
+        // Spec A §4.1: the alternate strip used when tabLayout == vertical.
+        // Populated with real TabViewItems via the routed _tabItems() helper.
+        TerminalApp::TabStrip _tabStrip{ nullptr };
+        bool _isVerticalLayout{ false };
+        // Spec A §5.2: hand-rolled splitter for resizing the vertical rail.
+        // Lives in column 1 of the Root Grid, hugging its left edge, so the
+        // hit strip straddles the column boundary.
+        Windows::UI::Xaml::Controls::Border _verticalRailSplitter{ nullptr };
+        Windows::UI::Core::CoreCursor _railSplitterPriorCursor{ nullptr };
+        bool _railSplitterDragging{ false };
+        double _railSplitterStartWidth{ 0.0 };
+        Windows::Foundation::Point _railSplitterStartPointer{};
         Windows::UI::Xaml::Controls::Grid _tabContent{ nullptr };
         Microsoft::UI::Xaml::Controls::SplitButton _newTabButton{ nullptr };
         Windows::UI::Xaml::Controls::MenuFlyout _workspaceFlyout{ nullptr };
@@ -719,6 +731,14 @@ namespace winrt::TerminalApp::implementation
         winrt::com_ptr<Tab> _GetFocusedTabImpl() const noexcept;
         TerminalApp::Tab _GetTabByTabViewItem(const IInspectable& tabViewItem) const noexcept;
 
+        // Spec A §4.1: routing indirection so TabManagement.cpp doesn't have to
+        // branch on the tab-layout mode at every call site. Phase 2 forwards
+        // unconditionally to _tabView; Phase 3 flips the vertical branch to
+        // _tabStrip once real Tab objects are wired.
+        Windows::Foundation::Collections::IVector<Windows::Foundation::IInspectable> _tabItems() const;
+        Windows::Foundation::IInspectable _selectedTabItem() const;
+        void _selectedTabItem(const Windows::Foundation::IInspectable& item);
+
         void _HandleClosePaneRequested(std::shared_ptr<Pane> pane);
         void _NotifyPanesClosing(const std::shared_ptr<Pane>& rootPane);
         bool _ShouldWarnOnClose() const;
@@ -781,9 +801,23 @@ namespace winrt::TerminalApp::implementation
         safe_void_coroutine _OnTabPointerReleasedCloseTab(IInspectable sender);
 
         void _OnTabSelectionChanged(const IInspectable& sender, const Windows::UI::Xaml::Controls::SelectionChangedEventArgs& eventArgs);
+        void _OnTabStripSelectionChanged(const IInspectable& sender, const TerminalApp::TabStripSelectionChangedEventArgs& eventArgs);
+        void _OnSelectionChangedCore();
         void _OnTabItemsChanged(const IInspectable& sender, const Windows::Foundation::Collections::IVectorChangedEventArgs& eventArgs);
         void _OnTabCloseRequested(const IInspectable& sender, const Microsoft::UI::Xaml::Controls::TabViewTabCloseRequestedEventArgs& eventArgs);
+        void _OnTabStripCloseRequested(const IInspectable& sender, const TerminalApp::TabStripCloseRequestedEventArgs& eventArgs);
+        void _HandleTabCloseRequestedCore(const Microsoft::UI::Xaml::Controls::TabViewItem& tabViewItem);
         void _OnFirstLayout(const IInspectable& sender, const IInspectable& eventArgs);
+        void _ApplyVerticalLayoutReshape();
+        void _InstallVerticalRailSplitter();
+        void _SetRailSplitterCursor();
+        void _RestoreRailSplitterCursor();
+        void _OnRailSplitterPointerEntered(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
+        void _OnRailSplitterPointerExited(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
+        void _OnRailSplitterPointerPressed(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
+        void _OnRailSplitterPointerMoved(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
+        void _OnRailSplitterPointerReleased(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
+        void _OnRailSplitterPointerCaptureLost(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
         void _UpdatedSelectedTab(const winrt::TerminalApp::Tab& tab);
         void _UpdateBackground(const winrt::Microsoft::Terminal::Settings::Model::Profile& profile);
 
@@ -899,9 +933,13 @@ namespace winrt::TerminalApp::implementation
         void _windowPropertyChanged(const IInspectable& sender, const winrt::Windows::UI::Xaml::Data::PropertyChangedEventArgs& args);
 
         void _onTabDragStarting(const winrt::Microsoft::UI::Xaml::Controls::TabView& sender, const winrt::Microsoft::UI::Xaml::Controls::TabViewTabDragStartingEventArgs& e);
+        void _OnTabStripDragStarting(const winrt::Windows::Foundation::IInspectable& sender, const TerminalApp::TabStripDragStartingEventArgs& e);
+        void _OnTabDragStartingCore(const winrt::Microsoft::UI::Xaml::Controls::TabViewItem& tab, const winrt::Windows::ApplicationModel::DataTransfer::DataPackage& data);
         void _onTabStripDragOver(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::DragEventArgs& e);
         void _onTabStripDrop(winrt::Windows::Foundation::IInspectable sender, winrt::Windows::UI::Xaml::DragEventArgs e);
         void _onTabDroppedOutside(winrt::Windows::Foundation::IInspectable sender, winrt::Microsoft::UI::Xaml::Controls::TabViewTabDroppedOutsideEventArgs e);
+        void _OnTabStripDroppedOutside(const winrt::Windows::Foundation::IInspectable& sender, const TerminalApp::TabStripDroppedOutsideEventArgs& e);
+        void _OnTabDroppedOutsideCore();
 
         void _DetachPaneFromWindow(std::shared_ptr<Pane> pane);
         void _DetachTabFromWindow(const winrt::com_ptr<Tab>& tabImpl);
@@ -923,12 +961,6 @@ namespace winrt::TerminalApp::implementation
         safe_void_coroutine _doHandleSuggestions(Microsoft::Terminal::Settings::Model::SuggestionsArgs realArgs);
 
         void _SendDesktopNotification(const winrt::hstring& tabTitle, const winrt::hstring& body, const winrt::com_ptr<Tab>& tab, const winrt::TerminalApp::IPaneContent& content);
-
-        // PROTOTYPE — see investigation-vertical-tabs.md. Populates the
-        // TabRow's TabStrip with mock TabViewItems so we can visually confirm
-        // ListView-hosts-TabViewItem behavior. Called from Create() only when
-        // WT_VERTICAL_TABS_PROTOTYPE=1.
-        void _seedVerticalTabsPrototype();
 
 #pragma region ActionHandlers
         // These are all defined in AppActionHandlers.cpp

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -55,6 +55,16 @@
                 </mux:InfoBar.ActionButton>
             </mux:InfoBar>
 
+            <mux:InfoBar x:Name="TabLayoutRestartInfoBar"
+                         x:Load="False"
+                         CornerRadius="0"
+                         IsClosable="True"
+                         IsIconVisible="True"
+                         IsOpen="False"
+                         Message="Restart Windows Terminal to apply the new tabLayout."
+                         Severity="Informational"
+                         Title="Tab layout change requires restart" />
+
             <mux:InfoBar x:Name="CloseOnExitInfoBar"
                          x:Uid="CloseOnExitInfoBar"
                          x:Load="False"

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -22,10 +22,10 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <!--
-            Spec A §5.1: the second column is the vertical-tabs rail. Width
+            Spec A §5.1: the first column is the vertical-tabs rail. Width
             defaults to 0 so horizontal layouts render identically; code-behind
             (_ApplyVerticalLayoutReshape) sets the width and moves TabRow into
-            column 0 with RowSpan=3 when the layout flips to vertical.
+            column 0 with RowSpan=4 when the layout flips to vertical.
         -->
         <Grid.ColumnDefinitions>
             <ColumnDefinition x:Name="VerticalRailColumn" Width="0" />
@@ -56,14 +56,13 @@
             </mux:InfoBar>
 
             <mux:InfoBar x:Name="TabLayoutRestartInfoBar"
+                         x:Uid="TabLayoutRestartInfoBar"
                          x:Load="False"
                          CornerRadius="0"
                          IsClosable="True"
                          IsIconVisible="True"
                          IsOpen="False"
-                         Message="Restart Windows Terminal to apply the new tabLayout."
-                         Severity="Informational"
-                         Title="Tab layout change requires restart" />
+                         Severity="Informational" />
 
             <mux:InfoBar x:Name="CloseOnExitInfoBar"
                          x:Uid="CloseOnExitInfoBar"

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -21,12 +21,25 @@
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
+        <!--
+            Spec A §5.1: the second column is the vertical-tabs rail. Width
+            defaults to 0 so horizontal layouts render identically; code-behind
+            (_ApplyVerticalLayoutReshape) sets the width and moves TabRow into
+            column 0 with RowSpan=3 when the layout flips to vertical.
+        -->
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition x:Name="VerticalRailColumn" Width="0" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
 
         <local:TabRowControl x:Name="TabRow"
                              Grid.Row="0"
+                             Grid.ColumnSpan="2"
                              KeyUp="_KeyDownHandler" />
 
-        <StackPanel Grid.Row="1"
+        <StackPanel x:Name="InfoBarsPanel"
+                    Grid.Row="1"
+                    Grid.ColumnSpan="2"
                     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
             <mux:InfoBar x:Name="KeyboardServiceWarningInfoBar"
                          x:Load="False"
@@ -63,12 +76,15 @@
              instead of showing the desktop behind the window. Uses the
              BottomBar color so the gap — if any — visually merges into
              the bar. Declared before TabContent so it sits behind. -->
-        <Border Grid.Row="2"
+        <Border x:Name="TabContentFiller"
+                Grid.Row="2"
+                Grid.ColumnSpan="2"
                 Background="#000000"
                 IsHitTestVisible="False" />
 
         <Grid x:Name="TabContent"
               Grid.Row="2"
+              Grid.ColumnSpan="2"
               HorizontalAlignment="Stretch"
               VerticalAlignment="Stretch">
             <Grid.Background>
@@ -90,6 +106,7 @@
              makes the alpha blend correctly. -->
         <Border x:Name="BottomBarRoot"
                 Grid.Row="3"
+                Grid.ColumnSpan="2"
                 Background="#000000"
                 VerticalAlignment="Top">
         <Grid>
@@ -266,10 +283,12 @@
 
         <local:AboutDialog x:Name="AboutDialog"
                            Grid.Row="2"
+                           Grid.ColumnSpan="2"
                            x:Load="False" />
 
         <ContentDialog x:Name="ConfirmCloseDialog"
                        Grid.Row="2"
+                       Grid.ColumnSpan="2"
                        x:Load="False"
                        DefaultButton="Primary">
             <CheckBox x:Uid="DontAskAgainCheckBox" />
@@ -278,12 +297,14 @@
         <ContentDialog x:Name="CloseReadOnlyDialog"
                        x:Uid="CloseReadOnlyDialog"
                        Grid.Row="2"
+                       Grid.ColumnSpan="2"
                        x:Load="False"
                        DefaultButton="Close" />
 
         <ContentDialog x:Name="MultiLinePasteDialog"
                        x:Uid="MultiLinePasteDialog"
                        Grid.Row="2"
+                       Grid.ColumnSpan="2"
                        x:Load="False"
                        DefaultButton="Primary">
             <StackPanel>
@@ -304,12 +325,14 @@
         <ContentDialog x:Name="LargePasteDialog"
                        x:Uid="LargePasteDialog"
                        Grid.Row="2"
+                       Grid.ColumnSpan="2"
                        x:Load="False"
                        DefaultButton="Primary" />
 
         <ContentDialog x:Name="ControlNoticeDialog"
                        x:Uid="ControlNoticeDialog"
                        Grid.Row="2"
+                       Grid.ColumnSpan="2"
                        x:Load="False"
                        DefaultButton="Primary">
             <TextBlock IsTextSelectionEnabled="True"
@@ -324,6 +347,7 @@
         <ContentDialog x:Name="UriErrorDialog"
                        x:Uid="UriErrorDialog"
                        Grid.Row="2"
+                       Grid.ColumnSpan="2"
                        x:Load="False"
                        DefaultButton="Close">
             <TextBlock IsTextSelectionEnabled="True"
@@ -339,6 +363,7 @@
 
         <local:CommandPalette x:Name="CommandPaletteElement"
                               Grid.Row="2"
+                              Grid.ColumnSpan="2"
                               VerticalAlignment="Stretch"
                               x:Load="False"
                               PreviewKeyDown="_KeyDownHandler"
@@ -346,6 +371,7 @@
 
         <local:SuggestionsControl x:Name="SuggestionsElement"
                                   Grid.Row="2"
+                                  Grid.ColumnSpan="2"
                                   HorizontalAlignment="Left"
                                   VerticalAlignment="Top"
                                   x:Load="False"
@@ -357,6 +383,7 @@
         <local:FreOverlay x:Name="FreOverlayElement"
                           Grid.Row="0"
                           Grid.RowSpan="4"
+                          Grid.ColumnSpan="2"
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch"
                           x:Load="False"

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -106,6 +106,16 @@
                       Style="{StaticResource ComboBoxSettingStyle}" />
         </local:SettingContainer>
 
+        <!--  Tab Layout (horizontal vs vertical)  -->
+        <local:SettingContainer x:Name="TabLayout"
+                                x:Uid="Globals_TabLayout">
+            <ComboBox AutomationProperties.AccessibilityView="Content"
+                      ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                      ItemsSource="{x:Bind ViewModel.TabLayoutList, Mode=OneWay}"
+                      SelectedItem="{x:Bind ViewModel.CurrentTabLayout, Mode=TwoWay}"
+                      Style="{StaticResource ComboBoxSettingStyle}" />
+        </local:SettingContainer>
+
         <!--  Disable Animations  -->
         <!--  NOTE: the UID is "DisablePaneAnimationsReversed" not "DisablePaneAnimations". See GH#9124 for more details.  -->
         <local:SettingContainer x:Name="DisableAnimations"

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearanceViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearanceViewModel.cpp
@@ -28,6 +28,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         INITIALIZE_BINDABLE_ENUM_SETTING(NewTabPosition, NewTabPosition, NewTabPosition, L"Globals_NewTabPosition", L"Content");
         INITIALIZE_BINDABLE_ENUM_SETTING(TabWidthMode, TabViewWidthMode, winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, L"Globals_TabWidthMode", L"Content");
+        INITIALIZE_BINDABLE_ENUM_SETTING(TabLayout, TabLayout, Model::TabLayout, L"Globals_TabLayout", L"Content");
         _UpdateThemeList();
     }
 

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearanceViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearanceViewModel.h
@@ -20,6 +20,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         WINRT_PROPERTY(Windows::Foundation::Collections::IObservableVector<Model::Theme>, ThemeList, nullptr);
         GETSET_BINDABLE_ENUM_SETTING(NewTabPosition, Model::NewTabPosition, _GlobalSettings.NewTabPosition);
         GETSET_BINDABLE_ENUM_SETTING(TabWidthMode, winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, _GlobalSettings.TabWidthMode);
+        GETSET_BINDABLE_ENUM_SETTING(TabLayout, Model::TabLayout, _GlobalSettings.TabLayout);
 
     public:
         winrt::Windows::Foundation::IInspectable CurrentTheme();

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearanceViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearanceViewModel.idl
@@ -21,6 +21,9 @@ namespace Microsoft.Terminal.Settings.Editor
         IInspectable CurrentTabWidthMode;
         Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> TabWidthModeList { get; };
 
+        IInspectable CurrentTabLayout;
+        Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> TabLayoutList { get; };
+
         Boolean InvertedDisableAnimations;
 
         void ShowTitlebarToggled(IInspectable sender, Windows.UI.Xaml.RoutedEventArgs args);

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -621,6 +621,22 @@
     <value>Title length</value>
     <comment>An option to choose from for the "tab width mode" setting. When selected, each tab adjusts its width to the content within the tab.</comment>
   </data>
+  <data name="Globals_TabLayout.Header" xml:space="preserve">
+    <value>Tab layout</value>
+    <comment>Header for a control to choose whether tabs are laid out horizontally across the top of the window or vertically down the left side.</comment>
+  </data>
+  <data name="Globals_TabLayout.HelpText" xml:space="preserve">
+    <value>Vertical tabs are shown in a resizable column on the left side of the window. Requires a restart to apply.</value>
+    <comment>A description for what the "tab layout" setting does. Presented near "Globals_TabLayout.Header".</comment>
+  </data>
+  <data name="Globals_TabLayoutHorizontal.Content" xml:space="preserve">
+    <value>Horizontal</value>
+    <comment>An option to choose from for the "tab layout" setting. When selected, tabs run across the top of the window.</comment>
+  </data>
+  <data name="Globals_TabLayoutVertical.Content" xml:space="preserve">
+    <value>Vertical</value>
+    <comment>An option to choose from for the "tab layout" setting. When selected, tabs run down the left side of the window in a resizable column.</comment>
+  </data>
   <data name="Globals_Theme.Header" xml:space="preserve">
     <value>Application Theme</value>
     <comment>Header for a control to choose the theme colors used in the app.</comment>

--- a/src/cascadia/TerminalSettingsModel/EnumMappings.cpp
+++ b/src/cascadia/TerminalSettingsModel/EnumMappings.cpp
@@ -33,6 +33,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     DEFINE_ENUM_MAP(winrt::Windows::UI::Xaml::ElementTheme, ElementTheme);
     DEFINE_ENUM_MAP(Model::NewTabPosition, NewTabPosition);
     DEFINE_ENUM_MAP(winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, TabViewWidthMode);
+    DEFINE_ENUM_MAP(Model::TabLayout, TabLayout);
     DEFINE_ENUM_MAP(Microsoft::Terminal::Control::DefaultInputScope, DefaultInputScope);
     DEFINE_ENUM_MAP(Model::LaunchMode, LaunchMode);
     DEFINE_ENUM_MAP(Model::TabSwitcherMode, TabSwitcherMode);

--- a/src/cascadia/TerminalSettingsModel/EnumMappings.h
+++ b/src/cascadia/TerminalSettingsModel/EnumMappings.h
@@ -29,6 +29,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Windows::UI::Xaml::ElementTheme> ElementTheme();
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, NewTabPosition> NewTabPosition();
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode> TabViewWidthMode();
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, TabLayout> TabLayout();
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Control::DefaultInputScope> DefaultInputScope();
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, FirstWindowPreference> FirstWindowPreference();
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, LaunchMode> LaunchMode();

--- a/src/cascadia/TerminalSettingsModel/EnumMappings.idl
+++ b/src/cascadia/TerminalSettingsModel/EnumMappings.idl
@@ -11,6 +11,7 @@ namespace Microsoft.Terminal.Settings.Model
         static Windows.Foundation.Collections.IMap<String, Windows.UI.Xaml.ElementTheme> ElementTheme { get; };
         static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.NewTabPosition> NewTabPosition { get; };
         static Windows.Foundation.Collections.IMap<String, Microsoft.UI.Xaml.Controls.TabViewWidthMode> TabViewWidthMode { get; };
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.TabLayout> TabLayout { get; };
         static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Control.DefaultInputScope> DefaultInputScope { get; };
         static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.FirstWindowPreference> FirstWindowPreference { get; };
         static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.LaunchMode> LaunchMode { get; };

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -133,6 +133,11 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_SETTING(String, AiConfirmationCreateOps);
         INHERITABLE_SETTING(String, AiConfirmationInputOps);
 
+        // Appended at the end of the interface (rather than grouped with
+        // TabWidthMode) to keep the ABI stable — inserting in the middle
+        // shifts every subsequent method's vtable slot.
+        INHERITABLE_SETTING(Int32, TabLayoutVerticalWidth);
+
         // Policy-aware effective getters — return the setting value after
         // applying GPO overrides. Consumers should prefer these over the
         // raw INHERITABLE_SETTING properties for runtime decisions.

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -50,6 +50,15 @@ namespace Microsoft.Terminal.Settings.Model
         AfterCurrentTab,
     };
 
+    // Spec A §1: horizontal renders the classic MUX TabView across the top;
+    // vertical renders a custom TabStrip down the left edge and silently
+    // overrides showTabsInTitlebar to false.
+    enum TabLayout
+    {
+        Horizontal,
+        Vertical,
+    };
+
     enum ConfirmOnClose
     {
         Never = 0,
@@ -137,6 +146,7 @@ namespace Microsoft.Terminal.Settings.Model
         // TabWidthMode) to keep the ABI stable — inserting in the middle
         // shifts every subsequent method's vtable slot.
         INHERITABLE_SETTING(Int32, TabLayoutVerticalWidth);
+        INHERITABLE_SETTING(TabLayout, TabLayout);
 
         // Policy-aware effective getters — return the setting value after
         // applying GPO overrides. Consumers should prefer these over the

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -42,6 +42,7 @@ Author(s):
     X(Model::ThemePair, Theme, "theme")                                                                                                                                                               \
     X(hstring, Language, "language")                                                                                                                                                                  \
     X(winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, TabWidthMode, "tabWidthMode", winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode::Equal)                                            \
+    X(int32_t, TabLayoutVerticalWidth, "tabLayoutVerticalWidth", 220)                                                                                                                                 \
     X(bool, UseAcrylicInTabRow, "useAcrylicInTabRow", false)                                                                                                                                          \
     X(bool, ShowTabsInTitlebar, "showTabsInTitlebar", true)                                                                                                                                           \
     X(bool, InputServiceWarning, "warning.inputService", true)                                                                                                                                        \

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -42,6 +42,7 @@ Author(s):
     X(Model::ThemePair, Theme, "theme")                                                                                                                                                               \
     X(hstring, Language, "language")                                                                                                                                                                  \
     X(winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, TabWidthMode, "tabWidthMode", winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode::Equal)                                            \
+    X(Model::TabLayout, TabLayout, "tabLayout", Model::TabLayout::Horizontal)                                                                                                                         \
     X(int32_t, TabLayoutVerticalWidth, "tabLayoutVerticalWidth", 220)                                                                                                                                 \
     X(bool, UseAcrylicInTabRow, "useAcrylicInTabRow", false)                                                                                                                                          \
     X(bool, ShowTabsInTitlebar, "showTabsInTitlebar", true)                                                                                                                                           \

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -278,6 +278,14 @@ JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::NewTabPosition)
     };
 };
 
+JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::TabLayout)
+{
+    JSON_MAPPINGS(2) = {
+        pair_type{ "horizontal", ValueType::Horizontal },
+        pair_type{ "vertical", ValueType::Vertical },
+    };
+};
+
 JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::FirstWindowPreference)
 {
     JSON_MAPPINGS(4) = {

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -20,6 +20,8 @@
     "showTabsInTitlebar": true,
     "showTerminalTitleInTitlebar": true,
     "tabWidthMode": "equal",
+    "tabLayout": "horizontal",
+    "tabLayoutVerticalWidth": 220,
     "tabSwitcherMode": "inOrder",
     "showAdminShield": true,
 

--- a/src/cascadia/UnitTests_SettingsModel/DeserializationTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/DeserializationTests.cpp
@@ -28,6 +28,7 @@ namespace SettingsModelUnitTests
         TEST_METHOD(ValidateDuplicateProfiles);
         TEST_METHOD(ValidateManyWarnings);
         TEST_METHOD(LayerGlobalProperties);
+        TEST_METHOD(TabLayoutSetting);
         TEST_METHOD(ValidateProfileOrdering);
         TEST_METHOD(ValidateHideProfiles);
         TEST_METHOD(TestReorderWithNullGuids);
@@ -380,6 +381,33 @@ namespace SettingsModelUnitTests
         VERIFY_ARE_EQUAL(240, settings->GlobalSettings().InitialCols());
         VERIFY_ARE_EQUAL(60, settings->GlobalSettings().InitialRows());
         VERIFY_ARE_EQUAL(false, settings->GlobalSettings().ShowTabsInTitlebar());
+    }
+
+    // Spec A §7: verify that `tabLayout` deserializes to the TabLayout enum
+    // and that `tabLayoutVerticalWidth` round-trips as an int32, so a user
+    // opting into vertical tabs actually reaches the vertical branch in
+    // TerminalPage::Create.
+    void DeserializationTests::TabLayoutSetting()
+    {
+        static constexpr std::string_view inboxSettings{ R"({})" };
+        static constexpr std::string_view horizontalDefault{ R"({
+            "profiles": [ { "guid": "{6239a42c-0000-49a3-80bd-e8fdd045185c}" } ]
+        })" };
+        static constexpr std::string_view verticalExplicit{ R"({
+            "tabLayout": "vertical",
+            "tabLayoutVerticalWidth": 320,
+            "profiles": [ { "guid": "{6239a42c-0000-49a3-80bd-e8fdd045185c}" } ]
+        })" };
+
+        {
+            const auto settings = winrt::make_self<implementation::CascadiaSettings>(horizontalDefault, inboxSettings);
+            VERIFY_ARE_EQUAL(TabLayout::Horizontal, settings->GlobalSettings().TabLayout());
+        }
+        {
+            const auto settings = winrt::make_self<implementation::CascadiaSettings>(verticalExplicit, inboxSettings);
+            VERIFY_ARE_EQUAL(TabLayout::Vertical, settings->GlobalSettings().TabLayout());
+            VERIFY_ARE_EQUAL(320, settings->GlobalSettings().TabLayoutVerticalWidth());
+        }
     }
 
     void DeserializationTests::ValidateProfileOrdering()

--- a/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
@@ -123,6 +123,8 @@ namespace SettingsModelUnitTests
                 "showTabsInTitlebar": true,
                 "showTerminalTitleInTitlebar": true,
                 "tabWidthMode": "equal",
+                "tabLayout": "vertical",
+                "tabLayoutVerticalWidth": 240,
                 "tabSwitcherMode": "mru",
 
                 "theme": "system",


### PR DESCRIPTION
## Summary of the Pull Request
Introduces a tabLayout global setting that, when set to vertical, renders tabs in a resizable column on the left side of the window instead of the traditional horizontal strip along the top. 

## Detailed Description of the Pull Request / Additional comments

New settings:
- tabLayout: picks which strip renders. When vertical, showTabsInTitlebar is silently overridden to false at load time (documented in the schema).
- tabLayoutVerticalWidth: persists the rail width across launches.

Architecture notes
- MUX TabView stays put for horizontal. The custom TabStrip is a sibling inside TabRowControl; only one is visible at a time based on _isVerticalLayout.
- Layout reshaping in TerminalPage.xaml: the outer Grid gains a leading column that hosts TabRowControl in vertical mode; the terminal content and infobars move to column 1, and BottomBarRoot drops its ColumnSpan so it only sits under the terminal content (per spec).
- Tab::TabViewItem() reuse: vertical mode does not re-create tab items; it points the TabStrip.TabItems collection at the same TabViewItem instances the horizontal path uses. This keeps per-tab state (icon, title, tab color, close-requested events) unified across layouts.
- Cross-window tearoff works both directions (horizontal ↔ vertical windows) via TabDroppedOutside shaped to match MUX::TabView.TabDroppedOutside.

**Deferred**: convergence of horizontal and vertical strips
The ideal is to have a single strip control that handles both orientations, deleting MUX::TabView from the horizontal path. This PR intentionally does not do that.

Reason: MUX::TabView gives us a significant amount for free that our custom TabStrip would have to reimplement: tab width modes (equal / size-to-content / compact), overflow scroll buttons, tab-preview thumbnails on hover, the well-polished cross-window tearoff pipeline, and TabViewAutomationPeer. Replicating all of that carries real regression risk on the horizontal path, which today works well and hasn't been asked to change.

The current architecture is designed with convergence in mind so we can revisit later without a rewrite:
- TabStrip already has an Orientation public property.
- _tabItems() and friends are routing helpers, not duplicated call sites.
- Forked event handlers share inner bodies via extracted helpers.
- Tab::TabViewItem() is already unified across both strips.

In a similar vein, some vertical tab visual polish has also been deferred. 

## Validation Steps Performed
<img width="1755" height="953" alt="image" src="https://github.com/user-attachments/assets/8c44c8a0-d3c1-4cfd-8b1a-78cc86550c26" />

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
