### PR TITLE
Add E2E coverage for profile delegate source

### DIFF
--- a/doc/release-check-list.md
+++ b/doc/release-check-list.md
@@ -102,6 +102,11 @@ Net effect: UT shrinks the manual matrix to "did the wiring and UI connect", not
 - [ ] `C237` `[new]` `[UT~]` `[E2E]` **Profile Agent pane agent picker works:** Each profile's Agent pane agent picker lists installed, policy-allowed Windows agents plus agents installed natively in that profile's WSL distro; saving persists `agentPaneBackend`, while an unconfigured profile inherits the global Windows agent. _(#481; UT: `ProfileTests::AgentPaneBackendDefaultsAndInherits`.)_
 - [ ] `C238` `[new]` `[E2E]` **Profile WSL agent routing is strict:** Changing a profile to a WSL backend rebuilds its helper, routes the exact selected agent through `wsl:<distro>`, and does not fall back to a Windows-hosted agent. _(#481; E2E: `Feature.WslAgentBackend`.)_
 
+### Profile command palette agent
+
+- [ ] `C244` `[new]` `[UT~]` `[E2E]` **Profile Command palette agent picker works:** Each profile's Command palette agent picker offers Host and WSL-distro delegate agents; saving persists `commandPaletteAgent`, while an unconfigured profile follows the global delegate agent. _(#488; UT: `ProfileTests::AgentPaneBackendDefaultsAndInherits`.)_
+- [ ] `C245` `[new]` `[E2E]` **Command palette agent source is strict:** A profile's Command palette agent selects the exact delegate execution source — an explicit WSL selection stays in its distro and surfaces the real in-distro error, and a host selection is never diverted to WSL. _(#488; E2E: `Feature.DelegateSource`.)_
+
 ## 2. Agent pane chat
 
 **Feature definition:** The agent pane is a per-tab AI chat pane backed by WTA helper/master and an ACP-capable agent. It should be reusable, able to be hidden, and stable across tab/window operations.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -28,16 +28,17 @@ environment. Current status (run on the Store package):
 | `Feature.AgentMatrix.Tests.ps1` | §2 non-Copilot built-in agents (Claude/Codex/Gemini) connect+chat through the ACP adapter — ONE consolidated case (Copilot is the in-depth suite); skips when none installed+authed | 1 |
 | `Feature.PerTabAgent.Tests.ps1` | C225-C228 + PR #487: `/agent` picker/prefix completion/direct selection, invalid-id safety, per-tab isolation/shared-master reuse, and global-default/override behavior | 8 |
 | `Feature.WslAgentBackend.Tests.ps1` | PR #481 profile-scoped WSL agent backend: settings hot reload, helper/master source routing, and authenticated chat | 2 (environment-gated) |
+| `Feature.DelegateSource.Tests.ps1` | PR #488 profile-scoped delegate source: strict host/WSL `wta delegate` routing with no fallback in either direction | 2 (environment-gated) |
 | `Feature.AgentChat.Tests.ps1` / `Feature.AgentPopup.Tests.ps1` | agent chat + `/` popup/menu interaction | 1 + 3 |
 
-**Coverage: 107 of 108 automatable `[E2E]` checklist items are implemented.**
+**Coverage: 108 of 110 automatable `[E2E]` checklist items are implemented.**
 **Test status: 102 baseline feature cases pass + 2 documented skips** (`wta sessions list` is
-identity-gated — see `Feature.SessionList.Tests.ps1`), plus 2 PR #481 WSL-backend cases that
-run only when a dev package, runnable distro, and native supported agent are available; the
-chat case also requires authentication. The 107 implemented checklist items map to the
-baseline cases plus the deterministic settings/persistence assertions. The remaining new
-item is the profile Agent pane agent picker UI; it stays explicit E2E work rather than being
-falsely credited by the JSON-level runtime tests. Other
+identity-gated — see `Feature.SessionList.Tests.ps1`), plus 2 PR #481 WSL-backend cases and 2
+PR #488 delegate-source cases that run only when a runnable distro (and, for the #481 chat
+case, an installed+authenticated native agent) is available. The 108 implemented checklist
+items map to the baseline cases plus the deterministic settings/persistence assertions. The
+remaining new items are the two profile agent picker UIs; they stay explicit E2E work rather
+than being falsely credited by the JSON-level runtime tests. Other
 environment-dependent items are tracked and auto-skipped when their prerequisite is absent:
 **other agent CLIs** (`Feature.AgentMatrix.Tests.ps1` now covers Claude/Codex/Gemini chat,
 auth-gated per CLI — each Context runs only when that CLI is installed *and* authenticated,

--- a/test/e2e/release-coverage-map.psd1
+++ b/test/e2e/release-coverage-map.psd1
@@ -42,6 +42,11 @@
     'Profile WSL agent routing is strict' = 'Hot reload routes the profile agent through its WSL distro without host fallback'
     'Profile WSL agent chat works'        = 'profile-selected WSL agent connects and answers a chat round trip'
 
+    # PR #488 profile-scoped delegate source routing. The profile picker UI is
+    # deliberately NOT mapped, same as #481's above: Feature.DelegateSource drives
+    # `wta delegate` directly and cannot prove the Settings picker renders or saves.
+    'Command palette agent source is strict' = 'never falls back to the Windows host|never diverted to WSL'
+
     # §0 FRE auto-error (on/off both covered by the single off/on test)
     'Automatic error detection on'      = 'Automatic error detection off/on'
     'Automatic error suggestion on'     = 'Automatic error suggestion off/on'

--- a/test/e2e/tests/Feature.DelegateSource.Tests.ps1
+++ b/test/e2e/tests/Feature.DelegateSource.Tests.ps1
@@ -1,0 +1,94 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+# PR #488: a profile can pin the command palette (delegate) agent to an exact
+# execution source, so `wta delegate` always gets an explicit `--delegate-source
+# host|wsl` and never re-routes itself. Both assertions are deterministic once a
+# runnable WSL distro is present.
+#
+# The C++ half (TerminalPage.cpp turning a profile's `commandPaletteAgent` into
+# those flags) is only reachable via non-injectable UI — Alt+Shift+B, the
+# Alt+Shift+/ palette, `?<prompt>` — so, exactly like Feature.Delegate, these
+# cases drive the delegate ENGINE directly with the flags it now always passes.
+# The oracle is the rendered pane, not wta-delegate.log: `Invoke-Wta` runs an
+# unpackaged copy of wta.exe, which logs to the bare fallback dir rather than the
+# packaged one `Assert-Log` reads.
+
+BeforeDiscovery {
+    $script:Ready = [bool](
+        (Get-AppxPackage | Where-Object { $_.Name -like '*IntelligentTerminal*' }) -and
+        (Get-Command winapp -ErrorAction SilentlyContinue) -and
+        (Get-Command wsl.exe -ErrorAction SilentlyContinue)
+    )
+}
+
+Describe 'Feature profile-scoped delegate source' -Tag 'Feature' -Skip:(-not $script:Ready) {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
+
+        $script:app = $null
+        $script:skipReason = $null
+
+        $distroProbe = Invoke-Native -FilePath 'wsl.exe' -Arguments @(
+            '-e', 'sh', '-lc', 'printf "%s" "${WSL_DISTRO_NAME:-}"'
+        ) -TimeoutSec 45
+        $script:distro = $distroProbe.StdOut.Trim()
+        if ($distroProbe.ExitCode -ne 0 -or -not $script:distro) {
+            $script:skipReason = 'no runnable default WSL distro is available'
+        }
+        elseif ($script:distro -match '["\r\n]') {
+            $script:skipReason = 'the default WSL distro name cannot be represented safely in a test command line'
+        }
+
+        $script:app = Start-Terminal -Package (Get-ItTestPackage) -PassFre $true `
+            -Settings @{ acpAgent = 'copilot'; delegateAgent = 'copilot' }
+
+        # A random, never-installed name is absent from BOTH the Windows PATH and every
+        # distro's PATH, so the "agent unavailable" branch fires deterministically.
+        $script:bogusAgent = "ite2e-bogus-delegate-$(Get-Random -Maximum 999999)"
+
+        # Launch a delegate and return the NEW tab created in this window.
+        $script:RunDelegate = {
+            param([string[]]$ExtraArgs = @())
+            $wid = [string]$script:app.WindowId
+            $before = @((Get-WtTabs -App $script:app -WindowId $wid).tab_id)
+            Invoke-Wta -App $script:app -TimeoutSec 40 -Raw -Arguments (@(
+                    'delegate', 'hi', '--agent', 'copilot --acp --stdio',
+                    '--delegate-agent', $script:bogusAgent) + $ExtraArgs) | Out-Null
+            $newTab = $null
+            for ($i = 0; $i -lt 30 -and -not $newTab; $i++) {
+                $newTab = @(Get-WtTabs -App $script:app -WindowId $wid) | Where-Object { $_.tab_id -notin $before } | Select-Object -First 1
+                if (-not $newTab) { Start-Sleep -Milliseconds 500 }
+            }
+            $panes = if ($newTab) { @(Get-WtPanes -App $script:app -WindowId $wid -TabId ([string]$newTab.tab_id)) } else { @() }
+            @{ Tab = $newTab; Panes = $panes }
+        }
+    }
+    AfterAll { if ($script:app) { Stop-Terminal -App $script:app } }
+
+    It 'An explicit WSL delegate source never falls back to the Windows host' {
+        if ($script:skipReason) { Set-ItResult -Skipped -Because $script:skipReason; return }
+
+        $d = & $script:RunDelegate -ExtraArgs @('--delegate-source', 'wsl', '--delegate-wsl-distro', $script:distro)
+        $d.Tab | Should -Not -BeNullOrEmpty -Because 'even a doomed WSL launch must open a tab so the real error stays visible'
+
+        # bash's own "not found" (the launch wraps the command in `exec`) proves it really
+        # ran in the distro; Windows would say "cannot find the file specified".
+        $sid = $d.Panes[0].session_id
+        (Test-Until -TimeoutSec 20 -IntervalSec 1 -Condition {
+                (Get-WtCapture -App $script:app -SessionId $sid -MaxLines 40) -match '(?i)bash:.*not found'
+            }) | Should -BeTrue -Because 'a missing WSL delegate agent must surface the real in-distro error, not silently switch to the host'
+    }
+
+    It 'The default delegate source is never diverted to WSL' {
+        if ($script:skipReason) { Set-ItResult -Skipped -Because $script:skipReason; return }
+
+        # No --delegate-source => host. A runnable distro on this machine (proven by the
+        # probe above) must not tempt the CLI into routing there.
+        $d = & $script:RunDelegate
+        $d.Tab | Should -Not -BeNullOrEmpty -Because 'the host delegate launch must still open a tab'
+
+        $sid = $d.Panes[0].session_id
+        (Test-Until -TimeoutSec 20 -IntervalSec 1 -Condition {
+                (Get-WtCapture -App $script:app -SessionId $sid -MaxLines 40) -match '(?i)cannot find the file specified|is not recognized'
+            }) | Should -BeTrue -Because 'the default launch must fail with the real Windows error, proving it never ran inside WSL bash'
+    }
+}


### PR DESCRIPTION
## Summary

Adds `test/e2e/tests/Feature.DelegateSource.Tests.ps1` covering PR #488's strict delegate source routing — the direct counterpart to #486 for #481.

#488 is now merged, so this branch is rebased onto `main` and its diff is test-only.

## Cases (environment-gated: needs a runnable default WSL distro)

1. **An explicit WSL delegate source never falls back to the Windows host** — the regression #488 fixes. A random never-installed agent name deterministically forces the "agent unavailable in WSL" branch; the pane must show bash's own `not found`.
2. **The default delegate source is never diverted to WSL** — guards the removed active-pane WSL inference; the pane must show the real Windows spawn failure.

`TerminalPage.cpp`'s profile resolution (`commandPaletteAgent` → `--delegate-source`/`--delegate-wsl-distro`) is only reachable via non-injectable UI (`Alt+Shift+B`, the `Alt+Shift+/` palette, `?<prompt>`), so — exactly like `Feature.Delegate` — these cases drive the delegate engine directly with the flags it now always passes.

## Validation

- Post-merge `main` build → both cases pass; `Invoke-ItE2EReport.ps1 -UpdateReport` credits `C245` as `[x]`, `C244` stays manual.
- Pre-fix proof: run against a `wta.exe` built before #488 (no `--delegate-source` flag), case 1 fails with `AUTOMATION FAILED` rather than passing vacuously — confirmed twice, once deliberately on a `main`-built binary and once accidentally against a stale deployment.

## Checklist

New **Profile command palette agent** section in `doc/release-check-list.md`, mirroring #481's entries:
- `C244` **Profile Command palette agent picker works** — manual (picker UI isn't harness-drivable, same rationale as `C237`).
- `C245` **Command palette agent source is strict** — mapped to this suite in `release-coverage-map.psd1`.

The `--delegate-source` argument-validation branches (`parse_delegate_source`, `require_delegate_agent_for_explicit_source`) are already covered by `cli/delegate.rs`'s own unit tests, so they are not duplicated here.
