### PR TITLE
Fix ACP model selection synchronization

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -4371,6 +4371,9 @@ impl App {
                 tab_id,
                 cwd: self.source_cwd.clone(),
             });
+        if let Some(session_id) = self.current_tab().session_id.clone() {
+            self.session_model_configs.remove(&session_id);
+        }
         let tab = self.current_tab_mut();
         tab.clear_chat_history();
         tab.completed_turns.clear();
@@ -4552,6 +4555,7 @@ impl App {
     fn cmd_restart(&mut self) {
         self.state = ConnectionState::Connecting("Restarting agent...".to_string());
         self.session_to_tab.clear();
+        self.session_model_configs.clear();
         self.session_id.clear();
         for (_, tab) in self.tab_sessions.iter_mut() {
             tab.clear_chat_history();
@@ -4711,20 +4715,15 @@ impl App {
         );
         self.tab_id = Some(new_tab_id);
 
-        if let Some((models, current)) = self
+        let (models, current) = self
             .current_tab()
             .session_id
             .as_deref()
             .and_then(|session_id| self.session_model_configs.get(session_id))
             .cloned()
-        {
-            if !models.is_empty() {
-                self.available_models = models;
-            }
-            if current.is_some() {
-                self.current_model_id = current;
-            }
-        }
+            .unwrap_or_default();
+        self.available_models = models;
+        self.current_model_id = current;
 
         // The new active tab's `current_view` (and autofix bar) is now
         // authoritative for the shared C++ agent pane. Re-emit so the bar
@@ -4759,6 +4758,9 @@ impl App {
             return;
         }
         let removed = self.tab_sessions.remove(closed_tab_id);
+        if let Some(session_id) = removed.as_ref().and_then(|tab| tab.session_id.as_ref()) {
+            self.session_model_configs.remove(session_id);
+        }
         self.session_to_tab.retain(|_, tab| tab != closed_tab_id);
 
         // Tell the ACP client to release the binding for this tab so
@@ -4961,15 +4963,19 @@ impl App {
     /// next tab_changed back into this tab finds an empty-but-present
     /// `TabSession` and just renders an empty chat.
     fn reset_tab_session_for(&mut self, tab_id: &str) {
+        let mut removed_session_id = None;
         // Same wipe as the `/clear` slash command: clear in-flight chat state
         // via `clear_chat_history` AND the completed-turn history that
         // `clear_chat_history` deliberately leaves alone.
         if let Some(tab) = self.tab_sessions.get_mut(tab_id) {
+            removed_session_id = tab.session_id.take();
             tab.clear_chat_history();
             tab.completed_turns.clear();
             tab.selected_completed_turn_idx = None;
             tab.scroll_to_bottom();
-            tab.session_id = None;
+        }
+        if let Some(session_id) = removed_session_id {
+            self.session_model_configs.remove(&session_id);
         }
 
         // Prune the reverse SessionId → tab routing so late ACP chunks for

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -872,6 +872,9 @@ pub struct App {
     /// `agent_status` event so the settings UI can render a dropdown.
     pub available_models: Vec<AcpModelInfo>,
     pub current_model_id: Option<String>,
+    /// Latest ACP model config for each session. Notifications can race ahead
+    /// of the event that attaches their session to a tab.
+    session_model_configs: HashMap<String, (Vec<AcpModelInfo>, Option<String>)>,
     pub prompt_name: Option<String>,
     pub session_id: String,
     #[allow(dead_code)]
@@ -1163,6 +1166,7 @@ impl App {
             agent_version: None,
             available_models: Vec::new(),
             current_model_id: None,
+            session_model_configs: HashMap::new(),
             prompt_name: None,
             session_id: String::new(),
             wt_connected,
@@ -3495,6 +3499,7 @@ impl App {
             AppEvent::ConnectionStage(_) => "connection_stage",
             AppEvent::AgentConnected { .. } => "agent_connected",
             AppEvent::SessionAttached { .. } => "session_attached",
+            AppEvent::ModelConfigUpdated { .. } => "model_config_updated",
             AppEvent::TabError { .. } => "tab_error",
             AppEvent::TabSystemMessage { .. } => "tab_system_message",
             AppEvent::AgentPasteTextReady { .. } => "agent_paste_text_ready",
@@ -4705,6 +4710,21 @@ impl App {
             "switch_tab_session"
         );
         self.tab_id = Some(new_tab_id);
+
+        if let Some((models, current)) = self
+            .current_tab()
+            .session_id
+            .as_deref()
+            .and_then(|session_id| self.session_model_configs.get(session_id))
+            .cloned()
+        {
+            if !models.is_empty() {
+                self.available_models = models;
+            }
+            if current.is_some() {
+                self.current_model_id = current;
+            }
+        }
 
         // The new active tab's `current_view` (and autofix bar) is now
         // authoritative for the shared C++ agent pane. Re-emit so the bar

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -26,6 +26,11 @@ pub enum AppEvent {
         available_models: Vec<AcpModelInfo>,
         current_model_id: Option<String>,
     },
+    ModelConfigUpdated {
+        session_id: String,
+        available_models: Vec<AcpModelInfo>,
+        current_model_id: Option<String>,
+    },
     TabError {
         tab_id: String,
         message: String,

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -220,6 +220,18 @@ impl App {
                 current_model_id,
             } => {
                 let is_active_tab = self.active_tab_key() == tab_id;
+                let replaced_session_ids: Vec<String> = self
+                    .session_to_tab
+                    .iter()
+                    .filter(|(known_session_id, known_tab_id)| {
+                        *known_tab_id == &tab_id && *known_session_id != &session_id
+                    })
+                    .map(|(known_session_id, _)| known_session_id.clone())
+                    .collect();
+                for replaced_session_id in replaced_session_ids {
+                    self.session_to_tab.remove(&replaced_session_id);
+                    self.session_model_configs.remove(&replaced_session_id);
+                }
                 self.session_to_tab
                     .insert(session_id.clone(), tab_id.clone());
                 let tab = self.tab_mut(&tab_id);
@@ -257,12 +269,8 @@ impl App {
                     .or_insert((available_models, current_model_id))
                     .clone();
                 if is_active_tab {
-                    if !available_models.is_empty() {
-                        self.available_models = available_models;
-                    }
-                    if current_model_id.is_some() {
-                        self.current_model_id = current_model_id;
-                    }
+                    self.available_models = available_models;
+                    self.current_model_id = current_model_id;
                 }
                 // Keep freshly-created sessions on the effective model for
                 // this tab — its per-pane `/model` override if set, else the
@@ -1323,7 +1331,6 @@ impl App {
                         tab.clear_chat_history();
                         tab.completed_turns.clear();
                         tab.selected_completed_turn_idx = None;
-                        tab.session_id = None;
                         // Open the replay window: chunk handlers will
                         // now accept session/update events for this
                         // tab even though `turn` stays Idle. Closed by

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -156,8 +156,13 @@ impl App {
                 self.agent_model = model;
                 self.agent_version = version;
                 self.session_id = session_id.clone();
-                self.available_models = available_models.clone();
-                self.current_model_id = current_model_id.clone();
+                let (available_models, current_model_id) = self
+                    .session_model_configs
+                    .entry(session_id.clone())
+                    .or_insert((available_models, current_model_id))
+                    .clone();
+                self.available_models = available_models;
+                self.current_model_id = current_model_id;
                 self.agent_supports_load_session = load_session_supported;
                 self.agent_supports_image = image_supported;
                 self.state = ConnectionState::Connected;
@@ -214,6 +219,7 @@ impl App {
                 available_models,
                 current_model_id,
             } => {
+                let is_active_tab = self.active_tab_key() == tab_id;
                 self.session_to_tab
                     .insert(session_id.clone(), tab_id.clone());
                 let tab = self.tab_mut(&tab_id);
@@ -245,11 +251,18 @@ impl App {
                 // this session in the future. For now we keep
                 // App.available_models pointing at the active session's
                 // models so the existing settings UI stays correct.
-                if !available_models.is_empty() {
-                    self.available_models = available_models;
-                }
-                if current_model_id.is_some() {
-                    self.current_model_id = current_model_id;
+                let (available_models, current_model_id) = self
+                    .session_model_configs
+                    .entry(session_id.clone())
+                    .or_insert((available_models, current_model_id))
+                    .clone();
+                if is_active_tab {
+                    if !available_models.is_empty() {
+                        self.available_models = available_models;
+                    }
+                    if current_model_id.is_some() {
+                        self.current_model_id = current_model_id;
+                    }
                 }
                 // Keep freshly-created sessions on the effective model for
                 // this tab — its per-pane `/model` override if set, else the
@@ -264,6 +277,21 @@ impl App {
                     }
                 }
                 self.publish_agent_status();
+            }
+            AppEvent::ModelConfigUpdated {
+                session_id,
+                available_models,
+                current_model_id,
+            } => {
+                self.session_model_configs.insert(
+                    session_id.clone(),
+                    (available_models.clone(), current_model_id.clone()),
+                );
+                if self.current_tab().session_id.as_deref() == Some(session_id.as_str()) {
+                    self.available_models = available_models;
+                    self.current_model_id = current_model_id;
+                    self.publish_agent_status();
+                }
             }
             AppEvent::TabError { tab_id, message } => {
                 // Scoped error for a specific tab. Bypasses the global

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -1957,6 +1957,84 @@ fn model_info(id: &str) -> AcpModelInfo {
     }
 }
 
+#[test]
+fn model_config_update_refreshes_active_session_picker() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("sid-1".into());
+    app.available_models = vec![model_info("claude-sonnet-5")];
+    app.current_model_id = Some("claude-sonnet-5".into());
+
+    app.handle_event(AppEvent::ModelConfigUpdated {
+        session_id: "sid-1".into(),
+        available_models: vec![
+            model_info("claude-sonnet-5"),
+            model_info("gpt-5.6-sol"),
+        ],
+        current_model_id: Some("gpt-5.6-sol".into()),
+    });
+
+    assert_eq!(app.current_model_id.as_deref(), Some("gpt-5.6-sol"));
+    assert_eq!(app.available_models.len(), 2);
+    app.open_model_picker();
+    assert_eq!(
+        app.current_tab().model_picker_selected,
+        1,
+        "the picker must highlight the model reported by the latest config update"
+    );
+    assert_eq!(
+        app.model_popup_state().and_then(|state| state.current_id),
+        Some("gpt-5.6-sol")
+    );
+}
+
+#[test]
+fn model_config_update_before_session_attach_is_applied_on_attach() {
+    let mut app = test_app();
+    app.available_models = vec![model_info("claude-sonnet-5")];
+    app.current_model_id = Some("claude-sonnet-5".into());
+
+    app.handle_event(AppEvent::ModelConfigUpdated {
+        session_id: "sid-later".into(),
+        available_models: vec![model_info("gpt-5.6-sol")],
+        current_model_id: Some("gpt-5.6-sol".into()),
+    });
+
+    assert_eq!(app.current_model_id.as_deref(), Some("claude-sonnet-5"));
+
+    app.handle_event(AppEvent::SessionAttached {
+        tab_id: DEFAULT_TAB_ID.into(),
+        session_id: "sid-later".into(),
+        available_models: vec![model_info("claude-sonnet-5")],
+        current_model_id: Some("claude-sonnet-5".into()),
+    });
+
+    assert_eq!(app.current_model_id.as_deref(), Some("gpt-5.6-sol"));
+    assert_eq!(app.available_models[0].id, "gpt-5.6-sol");
+}
+
+#[test]
+fn background_session_attach_waits_for_tab_switch_to_update_picker() {
+    let mut app = test_app();
+    app.available_models = vec![model_info("claude-sonnet-5")];
+    app.current_model_id = Some("claude-sonnet-5".into());
+    app.tab_sessions
+        .insert("background".into(), TabSession::default());
+
+    app.handle_event(AppEvent::SessionAttached {
+        tab_id: "background".into(),
+        session_id: "sid-background".into(),
+        available_models: vec![model_info("gpt-5.6-sol")],
+        current_model_id: Some("gpt-5.6-sol".into()),
+    });
+
+    assert_eq!(app.current_model_id.as_deref(), Some("claude-sonnet-5"));
+
+    app.switch_tab_session("background".into());
+
+    assert_eq!(app.current_model_id.as_deref(), Some("gpt-5.6-sol"));
+    assert_eq!(app.available_models[0].id, "gpt-5.6-sol");
+}
+
 /// `/model <id>` records a per-pane override and hot-applies it to *that*
 /// tab's live session (a targeted `SetSessionModel`, not a fan-out).
 #[test]

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -1227,6 +1227,14 @@ fn load_session_applied_when_target_tab_matches_owner() {
     app.owner_tab_id = Some("OWNER-TAB".to_string());
     app.tab_sessions
         .insert("OWNER-TAB".to_string(), TabSession::default());
+    app.tab_sessions
+        .get_mut("OWNER-TAB")
+        .unwrap()
+        .session_id = Some("old-session".into());
+    app.session_model_configs.insert(
+        "old-session".into(),
+        (vec![model_info("gpt-5.6-sol")], Some("gpt-5.6-sol".into())),
+    );
 
     app.handle_event(AppEvent::WtEvent {
         method: "load_session".to_string(),
@@ -1245,6 +1253,12 @@ fn load_session_applied_when_target_tab_matches_owner() {
     assert_eq!(req.tab_id, "OWNER-TAB");
     assert_eq!(req.session_id, "sess-abc");
     assert_eq!(req.cwd.as_deref(), Some("C:/foo"));
+    assert_eq!(
+        app.tab_sessions["OWNER-TAB"].session_id.as_deref(),
+        Some("old-session"),
+        "the previous session remains authoritative until load succeeds"
+    );
+    assert!(app.session_model_configs.contains_key("old-session"));
 }
 
 #[test]
@@ -1988,6 +2002,23 @@ fn model_config_update_refreshes_active_session_picker() {
 }
 
 #[test]
+fn model_config_update_without_model_clears_active_session_picker() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("sid-1".into());
+    app.available_models = vec![model_info("gpt-5.6-sol")];
+    app.current_model_id = Some("gpt-5.6-sol".into());
+
+    app.handle_event(AppEvent::ModelConfigUpdated {
+        session_id: "sid-1".into(),
+        available_models: Vec::new(),
+        current_model_id: None,
+    });
+
+    assert!(app.available_models.is_empty());
+    assert_eq!(app.current_model_id, None);
+}
+
+#[test]
 fn model_config_update_before_session_attach_is_applied_on_attach() {
     let mut app = test_app();
     app.available_models = vec![model_info("claude-sonnet-5")];
@@ -2013,6 +2044,28 @@ fn model_config_update_before_session_attach_is_applied_on_attach() {
 }
 
 #[test]
+fn session_attach_prunes_replaced_session_model_config() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("sid-old".into());
+    app.session_to_tab
+        .insert("sid-old".into(), DEFAULT_TAB_ID.into());
+    app.session_model_configs.insert(
+        "sid-old".into(),
+        (vec![model_info("claude-sonnet-5")], Some("claude-sonnet-5".into())),
+    );
+
+    app.handle_event(AppEvent::SessionAttached {
+        tab_id: DEFAULT_TAB_ID.into(),
+        session_id: "sid-new".into(),
+        available_models: vec![model_info("gpt-5.6-sol")],
+        current_model_id: Some("gpt-5.6-sol".into()),
+    });
+
+    assert!(!app.session_to_tab.contains_key("sid-old"));
+    assert!(!app.session_model_configs.contains_key("sid-old"));
+}
+
+#[test]
 fn background_session_attach_waits_for_tab_switch_to_update_picker() {
     let mut app = test_app();
     app.available_models = vec![model_info("claude-sonnet-5")];
@@ -2033,6 +2086,34 @@ fn background_session_attach_waits_for_tab_switch_to_update_picker() {
 
     assert_eq!(app.current_model_id.as_deref(), Some("gpt-5.6-sol"));
     assert_eq!(app.available_models[0].id, "gpt-5.6-sol");
+}
+
+#[test]
+fn switching_to_tab_without_session_clears_model_picker() {
+    let mut app = test_app();
+    app.available_models = vec![model_info("gpt-5.6-sol")];
+    app.current_model_id = Some("gpt-5.6-sol".into());
+    app.tab_sessions
+        .insert("without-session".into(), TabSession::default());
+
+    app.switch_tab_session("without-session".into());
+
+    assert!(app.available_models.is_empty());
+    assert_eq!(app.current_model_id, None);
+}
+
+#[test]
+fn new_session_prunes_previous_model_config() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("sid-old".into());
+    app.session_model_configs.insert(
+        "sid-old".into(),
+        (vec![model_info("gpt-5.6-sol")], Some("gpt-5.6-sol".into())),
+    );
+
+    app.cmd_new(false);
+
+    assert!(!app.session_model_configs.contains_key("sid-old"));
 }
 
 /// `/model <id>` records a per-pane override and hot-applies it to *that*

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -723,17 +723,17 @@ impl WtaClient {
                 });
             }
             acp::schema::v1::SessionUpdate::ConfigOptionUpdate(update) => {
-                if let Some((available_models, current_model_id)) =
+                let (available_models, current_model_id) =
                     crate::protocol::acp::model_select::models_from_config_options(
+                        &sid,
                         &update.config_options,
                     )
-                {
-                    let _ = self.state.event_tx.send(AppEvent::ModelConfigUpdated {
-                        session_id: sid,
-                        available_models,
-                        current_model_id,
-                    });
-                }
+                    .unwrap_or_default();
+                let _ = self.state.event_tx.send(AppEvent::ModelConfigUpdated {
+                    session_id: sid,
+                    available_models,
+                    current_model_id,
+                });
             }
             _ => {} // Ignore other update types for now
         }
@@ -2158,7 +2158,7 @@ fn dispatch_load_session(
         let load_result = tokio::time::timeout(timeout, conn.load_session(load_req)).await;
 
         match load_result {
-            Ok(Ok(_resp)) => {
+            Ok(Ok(resp)) => {
                 tracing::info!(
                     target: "acp_load_session",
                     tab = %req.tab_id,
@@ -2169,12 +2169,20 @@ fn dispatch_load_session(
                     let mut g = tab_to_session.lock().await;
                     g.insert(req.tab_id.clone(), session_id.clone());
                 }
+                if let Some(old) = old_sid
+                    .as_ref()
+                    .filter(|old| old.0.as_ref() != session_id.0.as_ref())
+                {
+                    crate::protocol::acp::model_select::forget_session(old.0.as_ref());
+                }
                 // The agent replays past content via session/update
                 // notifications that route through the existing
                 // session_to_tab map. SessionAttached primes that mapping.
-                // load_session/LoadSessionResponse does not carry the
-                // per-session model list (only modes); leave the
-                // previously-published list alone.
+                let (available_models, current_model_id) =
+                    crate::protocol::acp::model_select::models_from_load_session(
+                        session_id.0.as_ref(),
+                        &resp,
+                    );
                 //
                 // Resume is intentionally silent: no "Session loaded" note
                 // and no "Resuming…" marker (see the `load_session` handler),
@@ -2182,8 +2190,8 @@ fn dispatch_load_session(
                 let _ = event_tx.send(AppEvent::SessionAttached {
                     tab_id: req.tab_id.clone(),
                     session_id: session_id.to_string(),
-                    available_models: Vec::new(),
-                    current_model_id: None,
+                    available_models,
+                    current_model_id,
                 });
             }
             Ok(Err(e)) => {
@@ -2329,6 +2337,7 @@ fn dispatch_new_session(
 
         if let Some(ref old) = old_sid {
             let old_str = old.to_string();
+            crate::protocol::acp::model_select::forget_session(&old_str);
             template_memo.forget(&old_str).await;
             if let Some(sig) = cancel_signals.lock().unwrap().remove(&old_str) {
                 let _ = sig.send(());
@@ -2428,6 +2437,7 @@ fn dispatch_drop_session(
             // to the agent. Mirrors the new_session cancel path, minus the
             // new_session round-trip.
             let old_str = old.to_string();
+            crate::protocol::acp::model_select::forget_session(&old_str);
             template_memo.forget(&old_str).await;
             if let Some(sig) = cancel_signals.lock().unwrap().remove(&old_str) {
                 let _ = sig.send(());

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -722,6 +722,19 @@ impl WtaClient {
                     entries,
                 });
             }
+            acp::schema::v1::SessionUpdate::ConfigOptionUpdate(update) => {
+                if let Some((available_models, current_model_id)) =
+                    crate::protocol::acp::model_select::models_from_config_options(
+                        &update.config_options,
+                    )
+                {
+                    let _ = self.state.event_tx.send(AppEvent::ModelConfigUpdated {
+                        session_id: sid,
+                        available_models,
+                        current_model_id,
+                    });
+                }
+            }
             _ => {} // Ignore other update types for now
         }
         Ok(())

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -1601,6 +1601,50 @@ async fn session_notification_routes_user_message_replay_chunk() {
     }
 }
 
+#[tokio::test]
+async fn session_notification_routes_model_config_update() {
+    let (client, mut rx) = bare_client();
+    let update: acp::schema::v1::SessionUpdate = serde_json::from_value(serde_json::json!({
+        "sessionUpdate": "config_option_update",
+        "configOptions": [{
+            "id": "model",
+            "name": "Model",
+            "category": "model",
+            "type": "select",
+            "currentValue": "gpt-5.6-sol",
+            "options": [
+                {"value": "claude-sonnet-5", "name": "Claude Sonnet 5"},
+                {"value": "gpt-5.6-sol", "name": "GPT-5.6 Sol"}
+            ]
+        }]
+    }))
+    .unwrap();
+
+    client
+        .session_notification(notif("s1", update))
+        .await
+        .unwrap();
+
+    match rx.try_recv() {
+        Ok(AppEvent::ModelConfigUpdated {
+            session_id,
+            available_models,
+            current_model_id,
+        }) => {
+            assert_eq!(session_id, "s1");
+            assert_eq!(current_model_id.as_deref(), Some("gpt-5.6-sol"));
+            assert_eq!(
+                available_models
+                    .iter()
+                    .map(|model| model.id.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["claude-sonnet-5", "gpt-5.6-sol"]
+            );
+        }
+        _ => panic!("expected ModelConfigUpdated"),
+    }
+}
+
 /// A `ToolCall` update becomes a `ToolCall` event with the tool id and title.
 #[tokio::test]
 async fn session_notification_routes_tool_call() {

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -1645,6 +1645,41 @@ async fn session_notification_routes_model_config_update() {
     }
 }
 
+#[tokio::test]
+async fn session_notification_clears_removed_model_config() {
+    let (client, mut rx) = bare_client();
+    let update: acp::schema::v1::SessionUpdate = serde_json::from_value(serde_json::json!({
+        "sessionUpdate": "config_option_update",
+        "configOptions": [{
+            "id": "mode",
+            "name": "Mode",
+            "category": "mode",
+            "type": "select",
+            "currentValue": "auto",
+            "options": [{"value": "auto", "name": "Auto"}]
+        }]
+    }))
+    .unwrap();
+
+    client
+        .session_notification(notif("s1", update))
+        .await
+        .unwrap();
+
+    match rx.try_recv() {
+        Ok(AppEvent::ModelConfigUpdated {
+            session_id,
+            available_models,
+            current_model_id,
+        }) => {
+            assert_eq!(session_id, "s1");
+            assert!(available_models.is_empty());
+            assert_eq!(current_model_id, None);
+        }
+        _ => panic!("expected ModelConfigUpdated"),
+    }
+}
+
 /// A `ToolCall` update becomes a `ToolCall` event with the tool id and title.
 #[tokio::test]
 async fn session_notification_routes_tool_call() {

--- a/tools/wta/src/protocol/acp/model_select.rs
+++ b/tools/wta/src/protocol/acp/model_select.rs
@@ -55,13 +55,22 @@ pub(crate) fn models_from_new_session(
     resp: &acp::schema::v1::NewSessionResponse,
 ) -> (Vec<AcpModelInfo>, Option<String>) {
     if let Some(opts) = &resp.config_options {
-        if let Some((config_id, models, current)) = model_option_from_config(opts) {
-            record_channel_config(&config_id);
+        if let Some((models, current)) = models_from_config_options(opts) {
             return (models, current);
         }
     }
 
     (Vec::new(), None)
+}
+
+/// Extract the model selector from a full config-options snapshot delivered by
+/// either `session/new` or a later `config_option_update`.
+pub(crate) fn models_from_config_options(
+    opts: &[acp::schema::v1::SessionConfigOption],
+) -> Option<(Vec<AcpModelInfo>, Option<String>)> {
+    let (config_id, models, current) = model_option_from_config(opts)?;
+    record_channel_config(&config_id);
+    Some((models, current))
 }
 
 /// Find the model selector among a session's config options and flatten it

--- a/tools/wta/src/protocol/acp/model_select.rs
+++ b/tools/wta/src/protocol/acp/model_select.rs
@@ -10,39 +10,60 @@
 //!   `@agentclientprotocol/claude-agent-acp` adapter (>= 0.24), which returns
 //!   `Method not found` for `session/set_model`.
 //!
-//! A single `wta` process drives exactly one agent CLI, so the channel is
-//! uniform for the whole process: [`models_from_new_session`] records it the
-//! first time a `new_session` response is parsed and [`apply_session_model`]
-//! reads it back when the user hot-swaps the model from a decoupled call site.
+//! Channels are cached per session because the shared agent CLI can host
+//! concurrent sessions with different config-option IDs. Extraction records
+//! the channel for that session and [`apply_session_model`] reads it back when
+//! the user hot-swaps the model from a decoupled call site.
 
-use std::sync::RwLock;
+use std::collections::HashMap;
+use std::sync::{LazyLock, RwLock};
 
 use agent_client_protocol as acp;
 
 use crate::app_contracts::AcpModelInfo;
 
-/// How the current agent expects a model switch to be delivered. Refreshed on
-/// every `new_session` parse (see [`models_from_new_session`]) so an in-process
-/// agent restart — or a session whose model selector advertises a different
-/// config-option id — is always reflected, rather than frozen at first write.
+/// How one session expects a model switch to be delivered.
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum ModelSwitchChannel {
     /// Legacy `session/set_model`.
     Legacy,
+    /// Legacy after the agent rejected `session/set_config_option`.
+    LegacyFallback,
     /// `session/set_config_option` carrying this config id (e.g. `"model"`).
     Config { config_id: String },
 }
 
-/// The switch channel for this process's currently-connected agent. One `wta`
-/// process drives one agent CLI, but the agent can restart in-process and a
-/// later `new_session` may advertise a different channel/id — so this is a
-/// mutable cell overwritten on every extraction, not a write-once latch.
-static MODEL_SWITCH: RwLock<ModelSwitchChannel> = RwLock::new(ModelSwitchChannel::Legacy);
+/// Switch channels are session-scoped because one shared agent can advertise
+/// different config-option IDs for concurrent sessions.
+static MODEL_SWITCHES: LazyLock<RwLock<HashMap<String, ModelSwitchChannel>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
 
-fn record_channel_config(config_id: &str) {
-    *MODEL_SWITCH.write().unwrap() = ModelSwitchChannel::Config {
-        config_id: config_id.to_string(),
-    };
+fn record_channel_config(session_id: &str, config_id: &str) {
+    MODEL_SWITCHES.write().unwrap().insert(
+        session_id.to_string(),
+        ModelSwitchChannel::Config {
+            config_id: config_id.to_string(),
+        },
+    );
+}
+
+fn record_loaded_channel_config(session_id: &str, config_id: &str) {
+    let mut channels = MODEL_SWITCHES.write().unwrap();
+    if !matches!(
+        channels.get(session_id),
+        Some(ModelSwitchChannel::LegacyFallback)
+    ) {
+        channels.insert(
+            session_id.to_string(),
+            ModelSwitchChannel::Config {
+                config_id: config_id.to_string(),
+            },
+        );
+    }
+}
+
+pub(crate) fn forget_session(session_id: &str) {
+    MODEL_SWITCHES.write().unwrap().remove(session_id);
 }
 
 /// Extract the model list and current model id from a `new_session` response.
@@ -54,8 +75,33 @@ fn record_channel_config(config_id: &str) {
 pub(crate) fn models_from_new_session(
     resp: &acp::schema::v1::NewSessionResponse,
 ) -> (Vec<AcpModelInfo>, Option<String>) {
+    forget_session(resp.session_id.0.as_ref());
     if let Some(opts) = &resp.config_options {
-        if let Some((models, current)) = models_from_config_options(opts) {
+        if let Some((config_id, models, current)) = model_option_from_config(opts) {
+            record_channel_config(resp.session_id.0.as_ref(), &config_id);
+            return (models, current);
+        }
+    }
+
+    (Vec::new(), None)
+}
+
+/// Extract the model selector from a `session/load` response and record the
+/// switch channel advertised for the loaded session.
+pub(crate) fn models_from_load_session(
+    session_id: &str,
+    resp: &acp::schema::v1::LoadSessionResponse,
+) -> (Vec<AcpModelInfo>, Option<String>) {
+    let had_confirmed_fallback = matches!(
+        MODEL_SWITCHES.read().unwrap().get(session_id),
+        Some(ModelSwitchChannel::LegacyFallback)
+    );
+    if !had_confirmed_fallback {
+        forget_session(session_id);
+    }
+    if let Some(opts) = &resp.config_options {
+        if let Some((config_id, models, current)) = model_option_from_config(opts) {
+            record_loaded_channel_config(session_id, &config_id);
             return (models, current);
         }
     }
@@ -64,12 +110,18 @@ pub(crate) fn models_from_new_session(
 }
 
 /// Extract the model selector from a full config-options snapshot delivered by
-/// either `session/new` or a later `config_option_update`.
+/// a `config_option_update`. This is intentionally side-effect free: an update
+/// for a background session must not change the switch channel used by the
+/// active session.
 pub(crate) fn models_from_config_options(
+    session_id: &str,
     opts: &[acp::schema::v1::SessionConfigOption],
 ) -> Option<(Vec<AcpModelInfo>, Option<String>)> {
-    let (config_id, models, current) = model_option_from_config(opts)?;
-    record_channel_config(&config_id);
+    let Some((config_id, models, current)) = model_option_from_config(opts) else {
+        forget_session(session_id);
+        return None;
+    };
+    record_loaded_channel_config(session_id, &config_id);
     Some((models, current))
 }
 
@@ -135,7 +187,13 @@ pub(crate) async fn apply_session_model(
 ) -> acp::Result<()> {
     // Snapshot under the read lock and release it before the await — the lock
     // guard isn't Send and must not be held across the suspension point.
-    let channel = MODEL_SWITCH.read().unwrap().clone();
+    let session_key = session_id.to_string();
+    let channel = MODEL_SWITCHES
+        .read()
+        .unwrap()
+        .get(&session_key)
+        .cloned()
+        .unwrap_or(ModelSwitchChannel::Legacy);
     match channel {
         ModelSwitchChannel::Config { config_id } => {
             match conn
@@ -148,13 +206,18 @@ pub(crate) async fn apply_session_model(
             {
                 Ok(_) => Ok(()),
                 Err(e) if e.code == acp::ErrorCode::MethodNotFound => {
-                    *MODEL_SWITCH.write().unwrap() = ModelSwitchChannel::Legacy;
+                    MODEL_SWITCHES
+                        .write()
+                        .unwrap()
+                        .insert(session_key, ModelSwitchChannel::LegacyFallback);
                     apply_legacy_set_model(conn, session_id, model_id).await
                 }
                 Err(e) => Err(e),
             }
         }
-        ModelSwitchChannel::Legacy => apply_legacy_set_model(conn, session_id, model_id).await,
+        ModelSwitchChannel::Legacy | ModelSwitchChannel::LegacyFallback => {
+            apply_legacy_set_model(conn, session_id, model_id).await
+        }
     }
 }
 
@@ -179,9 +242,18 @@ mod tests {
     use std::sync::Arc;
     use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
-    // `MODEL_SWITCH` is a process global; every test that reads or writes it
+    // The channel map is process-global; every test that reads or writes it
     // serializes on this lock so parallel test execution can't interleave.
     static SWITCH_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn channel_for(session_id: &str) -> ModelSwitchChannel {
+        MODEL_SWITCHES
+            .read()
+            .unwrap()
+            .get(session_id)
+            .cloned()
+            .unwrap_or(ModelSwitchChannel::Legacy)
+    }
 
     // Real `session/new` wire shape from @agentclientprotocol/claude-agent-acp
     // (v0.44): no legacy `models` field — the model selector lives in
@@ -223,6 +295,7 @@ mod tests {
     #[test]
     fn model_extraction_across_channels() {
         let _guard = SWITCH_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        MODEL_SWITCHES.write().unwrap().clear();
         // Run sequentially in one test: the recorded switch channel is a
         // process-global, so splitting these into parallel #[test]s would race.
 
@@ -237,9 +310,42 @@ mod tests {
         // The model selector — not the "mode" selector — must win.
         assert_eq!(models[0].name, "Default (recommended)");
         assert_eq!(
-            *MODEL_SWITCH.read().unwrap(),
+            channel_for("dac14599-682e-4a94-b48d-828101d22c05"),
             ModelSwitchChannel::Config {
                 config_id: "model".to_string()
+            }
+        );
+
+        // Notifications are session-scoped and must not overwrite the channel
+        // selected for the active session.
+        let update: acp::schema::v1::ConfigOptionUpdate = serde_json::from_value(
+            serde_json::json!({
+                "configOptions": [{
+                    "id": "background-model",
+                    "name": "Model",
+                    "category": "model",
+                    "type": "select",
+                    "currentValue": "haiku",
+                    "options": [{"value": "haiku", "name": "Haiku"}]
+                }]
+            }),
+        )
+        .expect("valid config option update");
+        let (models, current) =
+            models_from_config_options("background", &update.config_options)
+                .expect("model selector");
+        assert_eq!(models[0].id, "haiku");
+        assert_eq!(current.as_deref(), Some("haiku"));
+        assert_eq!(
+            channel_for("dac14599-682e-4a94-b48d-828101d22c05"),
+            ModelSwitchChannel::Config {
+                config_id: "model".to_string()
+            }
+        );
+        assert_eq!(
+            channel_for("background"),
+            ModelSwitchChannel::Config {
+                config_id: "background-model".to_string()
             }
         );
 
@@ -286,7 +392,7 @@ mod tests {
         // proving it is no longer frozen at the first-seen "model" id — the
         // exact regression the OnceLock version had.
         assert_eq!(
-            *MODEL_SWITCH.read().unwrap(),
+            channel_for("cat-1"),
             ModelSwitchChannel::Config {
                 config_id: "llm".to_string()
             }
@@ -373,6 +479,7 @@ mod tests {
     #[test]
     fn config_channel_falls_back_to_set_model_on_method_not_found() {
         let _guard = SWITCH_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        MODEL_SWITCHES.write().unwrap().clear();
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -382,7 +489,7 @@ mod tests {
             let hit = Arc::new(AtomicBool::new(false));
             let client = spawn_switch_mock(true, hit.clone());
 
-            record_channel_config("model");
+            record_channel_config("s-fallback", "model");
             let r = apply_session_model(&client, "s-fallback".into(), "haiku".to_string()).await;
 
             assert!(r.is_ok(), "fall back to set_model must succeed, got {r:?}");
@@ -391,9 +498,29 @@ mod tests {
                 "set_model must be invoked as the fallback"
             );
             assert_eq!(
-                *MODEL_SWITCH.read().unwrap(),
-                ModelSwitchChannel::Legacy,
+                channel_for("s-fallback"),
+                ModelSwitchChannel::LegacyFallback,
                 "MethodNotFound on set_config_option must flip the channel to Legacy"
+            );
+
+            let loaded: acp::schema::v1::LoadSessionResponse = serde_json::from_value(
+                serde_json::json!({
+                    "configOptions": [{
+                        "id": "model",
+                        "name": "Model",
+                        "category": "model",
+                        "type": "select",
+                        "currentValue": "haiku",
+                        "options": [{"value": "haiku", "name": "Haiku"}]
+                    }]
+                }),
+            )
+            .expect("valid load_session response");
+            let _ = models_from_load_session("s-fallback", &loaded);
+            assert_eq!(
+                channel_for("s-fallback"),
+                ModelSwitchChannel::LegacyFallback,
+                "loading a session must preserve a confirmed Legacy fallback"
             );
         });
     }
@@ -401,6 +528,7 @@ mod tests {
     #[test]
     fn config_channel_does_not_fall_back_on_other_errors() {
         let _guard = SWITCH_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        MODEL_SWITCHES.write().unwrap().clear();
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -410,7 +538,7 @@ mod tests {
             let hit = Arc::new(AtomicBool::new(false));
             let client = spawn_switch_mock(false, hit.clone());
 
-            record_channel_config("model");
+            record_channel_config("s-other", "model");
             let r = apply_session_model(&client, "s-other".into(), "haiku".to_string()).await;
 
             assert!(r.is_err(), "a non-MethodNotFound error must propagate");
@@ -419,7 +547,7 @@ mod tests {
                 "set_model must NOT be called for a non-MethodNotFound error"
             );
             assert!(
-                matches!(*MODEL_SWITCH.read().unwrap(), ModelSwitchChannel::Config { .. }),
+                matches!(channel_for("s-other"), ModelSwitchChannel::Config { .. }),
                 "a non-MethodNotFound error must leave the channel on Config"
             );
         });


### PR DESCRIPTION
## Summary
- consume ACP `config_option_update` notifications for model selectors
- cache model state per session so early and background-session updates cannot stale or overwrite the active picker
- restore the correct model state when switching tabs

## Root cause
Copilot initially returned `claude-sonnet-5` from `session/new`, then reported the effective `gpt-5.6-sol` model in a later config-option update. WTA ignored that update, so `/model` retained the initial value.

## Tests
- `cargo test --manifest-path tools/wta/Cargo.toml` (1261 passed)