### PR TITLE
Bump Intelligent Terminal to 0.2

### DIFF
--- a/build/pgo/Terminal.PGO.props
+++ b/build/pgo/Terminal.PGO.props
@@ -14,7 +14,7 @@
     <!-- Mandatory.  Name of the NuGet package which will contain PGO databases for consumption by build system. -->
     <PGOPackageName>Microsoft.Internal.Windows.Terminal.PGODatabase</PGOPackageName>
 
-    <!-- Pinned to upstream 1.26 instead of $(VersionMajor).$(VersionMinor): the fork's 0.1
+    <!-- Pinned to upstream 1.26 instead of $(VersionMajor).$(VersionMinor): the fork's 0.2
          product version has no matching PGODatabase on the TerminalDependencies feed. -->
     <PGOPackageVersionMajor>1</PGOPackageVersionMajor>
     <PGOPackageVersionMinor>26</PGOPackageVersionMinor>

--- a/custom.props
+++ b/custom.props
@@ -5,7 +5,7 @@
     <XesUseOneStoreVersioning>true</XesUseOneStoreVersioning>
     <XesBaseYearForStoreVersion>2026</XesBaseYearForStoreVersion>
     <VersionMajor>0</VersionMajor>
-    <VersionMinor>1</VersionMinor>
+    <VersionMinor>2</VersionMinor>
     <VersionInfoProductName>Intelligent Terminal</VersionInfoProductName>
     <VersionInfoCulture>1033</VersionInfoCulture>
     <!-- The default has a spacing problem -->

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -21,7 +21,7 @@
   <Identity
     Name="Microsoft.IntelligentTerminal"
     Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
-    Version="0.1.0.0" />
+    Version="0.2.0.0" />
 
   <Properties>
     <DisplayName>ms-resource:AppStoreName</DisplayName>


### PR DESCRIPTION
## Summary
- bump the Intelligent Terminal release version from 0.1 to 0.2
- update the Stable MSIX baseline to 0.2.0.0
- keep the pinned upstream PGO database documentation aligned

## Validation
- parsed the changed MSBuild and AppX XML files successfully
<img width="741" height="55" alt="image" src="https://github.com/user-attachments/assets/361ac939-ee56-4cee-b1e5-133bed648d14" />
