### PR TITLE
fix(sync-545): correct localized help command quoting

### DIFF
--- a/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
@@ -1281,7 +1281,7 @@
   <data name="Usage_ContextWindowLabel" xml:space="preserve"><value>Kontextfenster</value><comment>Label for the AI agent context-window usage percentage shown in the terminal bottom bar.</comment></data>
   <data name="CmdAppHelpFooter" xml:space="preserve">
     <value>Hinweis: Nicht erkannte Argumente werden automatisch an den Unterbefehl „new-tab“ übergeben.
-Beispielsweise entspricht 'wt -p "Ubuntu" -d C:\' wt new-tab -p "Ubuntu" -d C:\'.
+Beispielsweise entspricht 'wt -p "Ubuntu" -d C:\' 'wt new-tab -p "Ubuntu" -d C:\'.
 Für alle verfügbaren Optionen führen Sie 'wt new-tab --help' aus.</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>

--- a/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
@@ -1279,7 +1279,7 @@
   <data name="Usage_ContextWindowLabel" xml:space="preserve"><value>Fenêtre de contexte</value><comment>Label for the AI agent context-window usage percentage shown in the terminal bottom bar.</comment></data>
   <data name="CmdAppHelpFooter" xml:space="preserve">
     <value>Remarque : les arguments non reconnus sont automatiquement passés à la sous-commande « new-tab ».
-Par exemple, « wt -p "Ubuntu" -d C:\' » est équivalent à « wt new-tab -p "Ubuntu" -d C:\' ».
+Par exemple, « wt -p "Ubuntu" -d C:\ » est équivalent à « wt new-tab -p "Ubuntu" -d C:\ ».
 Pour toutes les options disponibles, exécutez « wt new-tab --help ».</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>

--- a/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
@@ -1313,7 +1313,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="Usage_ContextWindowLabel" xml:space="preserve"><value>Контекстное окно</value><comment>Label for the AI agent context-window usage percentage shown in the terminal bottom bar.</comment></data>
   <data name="CmdAppHelpFooter" xml:space="preserve">
     <value>Примечание. Нераспознанные аргументы автоматически передаются в подкоманду "new-tab".
-Например, "wt -p "Ubuntu" -d C:\" эквивалентно "wt new-tab -p "Ubuntu" -d C:\".
+Например, 'wt -p "Ubuntu" -d C:\' эквивалентно 'wt new-tab -p "Ubuntu" -d C:\'.
 Для просмотра всех доступных параметров выполните команду "wt new-tab --help".</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>

--- a/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
@@ -1320,7 +1320,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="Usage_ContextWindowLabel" xml:space="preserve"><value>上下文窗口</value><comment>Label for the AI agent context-window usage percentage shown in the terminal bottom bar.</comment></data>
   <data name="CmdAppHelpFooter" xml:space="preserve">
     <value>注意: 无法识别的参数会自动传递给 "new-tab" 子命令。
-例如，"wt -p "Ubuntu" -d C:\" 等同于 "wt new-tab -p "Ubuntu" -d C:\"。
+例如，'wt -p "Ubuntu" -d C:\' 等同于 'wt new-tab -p "Ubuntu" -d C:\'。
 如需了解所有可用选项，请运行 "wt new-tab --help"。</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>


### PR DESCRIPTION
Addresses four Copilot localization findings on #545 without modifying the upstream-sync commits.

- Fixes the missing opening quote in the German second command example.
- Removes stray apostrophes from the French `C:\` paths.
- Uses single-quoted command examples in Russian and Simplified Chinese to avoid nested double quotes.
- Preserves XML validity, UTF-8 BOMs, translations, and locked command tokens.

The remaining `LCMapStringEx` finding on #545 is declined: the call passes positive `cchSrc` (1 or 2), so the return count excludes a terminator that was not included in the source count; only null-terminated input includes it.

Validation: all four RESW files parse successfully and retain UTF-8 BOMs.