### PR TITLE
Fix abandoned COM activation lifetime

### DIFF
--- a/doc/release-check-list.md
+++ b/doc/release-check-list.md
@@ -360,6 +360,9 @@ Net effect: UT shrinks the manual matrix to "did the wiring and UI connect", not
 - [ ] `C182` `[E2E]` **`wtcli capture-pane` works:** Pane output capture succeeds.
 - [ ] `C183` `[E2E]` **`wtcli send-keys`/send input path works:** Insert/run operations can send input to the target pane.
 - [ ] `C184` `[E2E]` **`wtcli listen` works:** Event subscription receives shell/agent events.
+- [ ] `C246` `[new]` `[E2E]` **Abandoned COM activation exits promptly:** A packaged protocol activation that receives no real window handoff exits after its bounded startup lease and releases package resources.
+- [ ] `C247` `[new]` `[E2E]` **Valid COM handoff survives the activation timeout:** A real window handoff cancels the startup lease and keeps the same Terminal process alive.
+- [ ] `C248` `[new]` `[E2E]` **Explicit headless mode survives the activation timeout:** `AllowHeadless` remains authoritative and keeps an intentionally headless Terminal process alive beyond the startup lease.
 - [ ] `C185` `[E2E]` **WTA master starts:** One master process starts per Terminal process when needed.
 - [ ] `C186` `[E2E]` **WTA helper starts per tab/pane:** Agent pane helper starts and connects to master.
 - [ ] `C187` `[E2E]` **Master/helper crash recovery is acceptable:** Crashes or exits recover or surface an actionable error.

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -262,6 +262,15 @@ void WindowEmperor::CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs args
 {
     _assertIsMainThread();
 
+    // AppHost initialization can pump messages. Mark the handoff first so a
+    // timeout already queued before KillTimer cannot quit during initialization.
+    _handoffWindowCreationCount += 1;
+    KillTimer(_window.get(), HandoffTimeoutTimerId);
+    auto resetHandoff = wil::scope_exit([this]() noexcept {
+        _handoffWindowCreationCount -= 1;
+        _postQuitMessageIfNeeded();
+    });
+
     uint64_t id = args.Id();
     bool needsNewId = id == 0;
     uint64_t newId = 0;
@@ -283,6 +292,8 @@ void WindowEmperor::CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs args
 
     _windowCount += 1;
     _windows.emplace_back(std::move(host));
+    _handoffWindowCreationCount -= 1;
+    resetHandoff.release();
 
     // Wire the new window's TerminalPage::ProtocolVtSequenceReceived
     // into the COM fan-out so events emitted by panes in this window
@@ -622,10 +633,18 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
 
         if (args.size() == 2 && args[1] == L"-Embedding")
         {
-            // We were launched for ConPTY handoff. We have no windows and also don't want to exit.
-            //
-            // TODO: Here we could start a timer and exit after, say, 5 seconds
-            // if no windows are created. But that's a minor concern.
+            // DCOM may activate us for a ConPTY handoff that never arrives.
+            // Give the client a short lease to create a window, then apply the
+            // normal quit policy so AllowHeadless (and other explicit
+            // headless reasons) remain authoritative.
+            if (_windows.empty())
+            {
+                if (!SetTimer(_window.get(), HandoffTimeoutTimerId, 5000, nullptr))
+                {
+                    LOG_LAST_ERROR();
+                    _postQuitMessageIfNeeded();
+                }
+            }
         }
         else
         {
@@ -1096,6 +1115,7 @@ void WindowEmperor::_postQuitMessageIfNeeded() const
     if (
         _messageBoxCount <= 0 &&
         _windowCount <= 0 &&
+        _handoffWindowCreationCount <= 0 &&
         !_app.Logic().Settings().GlobalSettings().AllowHeadless())
     {
         PostQuitMessage(0);
@@ -1208,6 +1228,17 @@ LRESULT WindowEmperor::_messageHandler(HWND window, UINT const message, WPARAM c
             _messageBoxCount -= 1;
             _postQuitMessageIfNeeded();
             return 0;
+        case WM_TIMER:
+            if (wParam == HandoffTimeoutTimerId)
+            {
+                KillTimer(window, HandoffTimeoutTimerId);
+                if (_handoffWindowCreationCount <= 0)
+                {
+                    _postQuitMessageIfNeeded();
+                }
+                return 0;
+            }
+            break;
         case WM_IDENTIFY_ALL_WINDOWS:
             for (const auto& host : _windows)
             {

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -95,6 +95,8 @@ private:
     void _checkWindowsForNotificationIcon();
     void _setupAumid(const std::wstring& aumid);
 
+    static constexpr UINT_PTR HandoffTimeoutTimerId = 1;
+
     wil::unique_hwnd _window;
     winrt::TerminalApp::App _app{ nullptr };
     std::vector<std::shared_ptr<::AppHost>> _windows;
@@ -113,6 +115,7 @@ private:
     std::optional<bool> _currentSystemThemeIsDark;
     int32_t _windowCount = 0;
     int32_t _messageBoxCount = 0;
+    int32_t _handoffWindowCreationCount = 0;
     std::wstring _pendingAumidLnkPath;
     std::wstring _pendingAumid;
 

--- a/test/e2e/ItE2E/ItE2E.psm1
+++ b/test/e2e/ItE2E/ItE2E.psm1
@@ -14,7 +14,7 @@ foreach ($scope in @('Private', 'Public')) {
 # Export every function defined by the Public files (and the few private ones tests use).
 $publicFns = @(
     # Harness
-    'Resolve-ItApp', 'Resolve-WtComClsid', 'Get-ItTestPackage', 'Start-Terminal', 'Start-TerminalClean', 'Stop-Terminal',
+    'Resolve-ItApp', 'Get-ItProtocolComClsid', 'Resolve-WtComClsid', 'Get-ItTestPackage', 'Start-Terminal', 'Start-TerminalClean', 'Stop-Terminal',
     'Reset-TerminalState', 'Backup-WtConfig', 'Restore-WtConfig', 'Clear-WtConfig', 'Get-WtProcessesForApp', 'Stop-AppInstances', 'Stop-StaleItInstances', 'Start-TerminalFre', 'Get-DescendantWtaIds',
     # Core (useful in tests)
     'Wait-Until', 'Test-Until', 'Invoke-Native', 'Write-ItLog', 'ConvertFrom-JsonSafe',

--- a/test/e2e/ItE2E/Private/Paths.ps1
+++ b/test/e2e/ItE2E/Private/Paths.ps1
@@ -145,6 +145,31 @@ function Get-RunnableWtaPath {
     $runnable
 }
 
+function Get-ItProtocolComClsid {
+    <#
+    .SYNOPSIS
+        Read the protocol server CLSID registered by the package under test.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory, ValueFromPipeline)]$App)
+
+    $manifestPath = Join-Path $App.InstallLocation 'AppxManifest.xml'
+    $manifest = [xml](Get-Content -Raw $manifestPath)
+    $registeredClasses = @(
+        $manifest.SelectNodes(
+            "//*[local-name()='Extension' and @Category='windows.comServer']//*[local-name()='Class']/@Id"
+        ) | ForEach-Object Value
+    )
+
+    foreach ($clsid in $script:ItBrandClsids.Values) {
+        if ($registeredClasses -contains $clsid.Trim('{}')) {
+            return $clsid
+        }
+    }
+
+    throw "No known Terminal protocol COM server class found in $manifestPath."
+}
+
 function Resolve-WtComClsid {
     <#
     .SYNOPSIS

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -13,7 +13,7 @@ authenticated ACP agents. Current status (run on the Store package):
 
 | Suite (file) | Covers | Cases |
 |---|---|---|
-| `Feature.Packaging.Tests.ps1` | §9 packaging/protocol (incl. WT_COM_CLSID injected into pane shells) + §10 logging + log retention/cleanup | 18 |
+| `Feature.Packaging.Tests.ps1` | §9 packaging/protocol (incl. bounded COM activation lifetime and WT_COM_CLSID injection) + §10 logging + log retention/cleanup | 22 |
 | `Feature.Settings.Tests.ps1` | §1 Settings>AI Agents + §0 FRE settings/positions/auto-error/session-mgmt | 18 |
 | `Feature.FreFlow.Tests.ps1` | §0 FRE overlay click-through (Next→Save, privacy link, close-safety) | 5 |
 | `Feature.FreExecutionPolicy.Tests.ps1` | §0 FRE execution-policy verdict (deterministic via registry; **Dev**, auto-skips) | 3 (1 conditional skip) |

--- a/test/e2e/tests/Feature.Packaging.Tests.ps1
+++ b/test/e2e/tests/Feature.Packaging.Tests.ps1
@@ -11,6 +11,94 @@ BeforeDiscovery {
     $script:UiReady = $script:Ready -and [bool](Get-Command winapp -ErrorAction SilentlyContinue)
 }
 
+Describe 'Feature §9 COM activation lifecycle' -Tag 'Feature' -Skip:(-not $script:Ready) {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
+        $script:activationApp = Resolve-ItApp -Package (Get-ItTestPackage)
+        $script:activationClsid = Get-ItProtocolComClsid -App $script:activationApp
+        Stop-AppInstances -App $script:activationApp
+        Backup-WtConfig -App $script:activationApp
+        Set-WtSettings -App $script:activationApp -Settings @{ 'compatibility.allowHeadless' = $false } | Out-Null
+    }
+    BeforeEach {
+        Stop-AppInstances -App $script:activationApp
+    }
+    AfterAll {
+        if ($script:activationApp) {
+            Stop-AppInstances -App $script:activationApp
+            Restore-WtConfig -App $script:activationApp
+        }
+    }
+
+    It 'Abandoned COM activation exits promptly' {
+        $started = Get-Date
+        $probe = Invoke-Native -FilePath $script:activationApp.WtcliPath -Arguments @('info') `
+            -TimeoutSec 15 -Environment @{ WT_COM_CLSID = $script:activationClsid }
+        $probe.ExitCode | Should -Be 0
+        $probe.StdOut | Should -Match 'Connection:\s+OK'
+
+        $server = Wait-Until -TimeoutSec 5 -IntervalSec 0.1 -Because 'the DCOM-activated Terminal server process' -Condition {
+            Get-WtProcessesForApp -App $script:activationApp | Select-Object -First 1
+        }
+        $commandLine = (Get-CimInstance Win32_Process -Filter "ProcessId=$($server.Id)").CommandLine
+        $commandLine | Should -Match '(?i)\s-Embedding(?:\s|$)'
+        $server.MainWindowHandle | Should -Be 0
+
+        Test-Until -TimeoutSec 10 -IntervalSec 0.1 -Condition {
+            $null -eq (Get-Process -Id $server.Id -ErrorAction SilentlyContinue)
+        } | Should -BeTrue -Because 'an unused packaged COM server must release package files after its five-second handoff lease'
+        ((Get-Date) - $started).TotalSeconds | Should -BeLessThan 10
+    }
+
+    It 'Valid COM handoff survives the activation timeout' {
+        $probe = Invoke-Native -FilePath $script:activationApp.WtcliPath -Arguments @('info') `
+            -TimeoutSec 15 -Environment @{ WT_COM_CLSID = $script:activationClsid }
+        $probe.ExitCode | Should -Be 0
+
+        $server = Wait-Until -TimeoutSec 5 -IntervalSec 0.1 -Because 'the DCOM-activated Terminal server process' -Condition {
+            Get-WtProcessesForApp -App $script:activationApp | Select-Object -First 1
+        }
+        Start-Process -FilePath 'explorer.exe' -ArgumentList "shell:AppsFolder\$($script:activationApp.AppUserModelId)" | Out-Null
+
+        Wait-Until -TimeoutSec 8 -IntervalSec 0.2 -Because 'a real window handed off to the activated server' -Condition {
+            $windows = Invoke-Native -FilePath $script:activationApp.WtcliPath -Arguments @('--json', 'list-windows') `
+                -TimeoutSec 5 -Environment @{ WT_COM_CLSID = $script:activationClsid }
+            if ($windows.ExitCode -ne 0) { return $false }
+            $json = $windows.StdOut | ConvertFrom-JsonSafe
+            $null -ne $json -and @($json.windows).Count -gt 0
+        } | Out-Null
+
+        Test-Until -TimeoutSec 7 -IntervalSec 0.2 -Condition {
+            $null -eq (Get-Process -Id $server.Id -ErrorAction SilentlyContinue)
+        } | Should -BeFalse -Because 'a real handoff must cancel the startup timeout'
+        (Get-WtProcessesForApp -App $script:activationApp | Select-Object -ExpandProperty Id) | Should -Contain $server.Id
+    }
+
+    It 'Explicit headless mode survives the activation timeout' {
+        Set-WtSettings -App $script:activationApp -Settings @{ 'compatibility.allowHeadless' = $true } | Out-Null
+        try {
+            $probe = Invoke-Native -FilePath $script:activationApp.WtcliPath -Arguments @('info') `
+                -TimeoutSec 15 -Environment @{ WT_COM_CLSID = $script:activationClsid }
+            $probe.ExitCode | Should -Be 0
+
+            $server = Wait-Until -TimeoutSec 5 -IntervalSec 0.1 -Because 'the explicitly headless Terminal server process' -Condition {
+                Get-WtProcessesForApp -App $script:activationApp | Select-Object -First 1
+            }
+            $windows = Invoke-Native -FilePath $script:activationApp.WtcliPath -Arguments @('--json', 'list-windows') `
+                -TimeoutSec 5 -Environment @{ WT_COM_CLSID = $script:activationClsid }
+            $windows.ExitCode | Should -Be 0
+            @((($windows.StdOut | ConvertFrom-JsonSafe).windows)).Count | Should -Be 0
+            Test-Until -TimeoutSec 7 -IntervalSec 0.2 -Condition {
+                $null -eq (Get-Process -Id $server.Id -ErrorAction SilentlyContinue)
+            } | Should -BeFalse -Because 'AllowHeadless remains the authoritative opt-in lifetime policy'
+        }
+        finally {
+            Stop-AppInstances -App $script:activationApp
+            Set-WtSettings -App $script:activationApp -Settings @{ 'compatibility.allowHeadless' = $false } | Out-Null
+        }
+    }
+}
+
 Describe 'Feature §9 Packaging + protocol' -Tag 'Feature' -Skip:(-not $script:Ready) {
     BeforeAll {
         Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force


### PR DESCRIPTION
## Summary
- give exact `-Embedding` startup a bounded five-second window-handoff lease
- cancel the lease for restored or newly created windows, including reentrant initialization and queued `WM_TIMER` races
- preserve normal final-window exit and explicit `AllowHeadless` behavior without coupling lifetime to COM object counts
- add packaged COM/process lifecycle coverage and release-checklist mappings C246-C248

This replaces #22 with a fix aligned to the current classic COM architecture. Orphaned `wtcli listen` client cleanup remains a separate focused follow-up because subscriptions intentionally do not own Terminal process lifetime.

## Validation
- `cmd.exe /c "tools\razzle.cmd && cd src\cascadia\WindowsTerminal && bx"`
- x64 Debug `CascadiaPackage` build and deployment
- `Feature.Packaging.Tests.ps1` against the deployed Dev package: 17 passed, 0 failed, 5 expected `winapp`-dependent skips
- release report: C246, C247, and C248 checked