### PR TITLE
Fix TerminalApp local tests after FRE deferral

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -227,6 +227,15 @@ namespace TerminalAppLocalTests
     void TabTests::_initializeTerminalPage(winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage>& page,
                                            CascadiaSettings initialSettings)
     {
+        // These tests exercise normal tab behavior, not the first-run
+        // experience, which intentionally defers tab creation until completion.
+        const auto applicationState = ApplicationState::SharedInstance();
+        const auto agentFreCompleted = applicationState.AgentFreCompleted();
+        applicationState.AgentFreCompleted(true);
+        const auto restoreAgentFreCompleted = wil::scope_exit([&]() {
+            applicationState.AgentFreCompleted(agentFreCompleted);
+        });
+
         // This is super wacky, but we can't just initialize the
         // com_ptr<impl::TerminalPage> in the lambda and assign it back out of
         // the lambda. We'll crash trying to get a weak_ref to the TerminalPage


### PR DESCRIPTION
## Summary

- run TerminalApp tab behavior tests in an explicit post-FRE state
- restore the previous `AgentFreCompleted` value after page initialization
- fix the 15 `TabTests` failures caused by FRE intentionally deferring initial tab creation

## Root cause

`TerminalPage` now defers startup actions while the first-run experience is active. The local tab tests waited for `Initialized` and then assumed the first tab existed, so `page->_tabs.GetAt(0)` threw `0x8000FFFF`. These tests exercise normal tab behavior rather than onboarding, so the helper now temporarily marks FRE complete while initializing the page.

## Validation

- `TerminalAppLocalTests::TabTests`: **21/21 passed**
- Main Release unit-test group: **7,043 passed, 0 failed, 2 skipped**
- SettingsModel Release unit-test group: **194/194 passed**

All executed unit tests pass. Please sign off on the fix.