### PR TITLE
Stop protocol listeners when Terminal exits

### DIFF
--- a/doc/release-check-list.md
+++ b/doc/release-check-list.md
@@ -363,6 +363,8 @@ Net effect: UT shrinks the manual matrix to "did the wiring and UI connect", not
 - [ ] `C246` `[new]` `[E2E]` **Abandoned COM activation exits promptly:** A packaged protocol activation that receives no real window handoff exits after its bounded startup lease and releases package resources.
 - [ ] `C247` `[new]` `[E2E]` **Valid COM handoff survives the activation timeout:** A real window handoff cancels the startup lease and keeps the same Terminal process alive.
 - [ ] `C248` `[new]` `[E2E]` **Explicit headless mode survives the activation timeout:** `AllowHeadless` remains authoritative and keeps an intentionally headless Terminal process alive beyond the startup lease.
+- [ ] `C249` `[new]` `[E2E]` **`wtcli listen` exits when Terminal disconnects:** A listener exits promptly when its COM server closes so the packaged executable does not block servicing.
+- [ ] `C250` `[new]` `[E2E]` **`wta listen` exits when Terminal disconnects:** WTA propagates event-stream closure and terminates its child listener so both packaged executables release promptly.
 - [ ] `C185` `[E2E]` **WTA master starts:** One master process starts per Terminal process when needed.
 - [ ] `C186` `[E2E]` **WTA helper starts per tab/pane:** Agent pane helper starts and connects to master.
 - [ ] `C187` `[E2E]` **Master/helper crash recovery is acceptable:** Crashes or exits recover or surface an actionable error.

--- a/src/tools/wtcli/main.cpp
+++ b/src/tools/wtcli/main.cpp
@@ -869,8 +869,37 @@ int main()
             return;
         }
 
-        WaitForSingleObject(s_stopEvent, INFINITE);
-        server->Unsubscribe();
+        constexpr DWORD heartbeatIntervalMs = 1000;
+        bool serverConnected = true;
+        for (;;)
+        {
+            const auto waitResult = WaitForSingleObject(s_stopEvent, heartbeatIntervalMs);
+            if (waitResult == WAIT_OBJECT_0)
+            {
+                break;
+            }
+            if (waitResult != WAIT_TIMEOUT)
+            {
+                fprintf(stderr, "[wtcli] listen: stop wait failed (0x%08X)\n", GetLastError());
+                exitCode = 1;
+                break;
+            }
+
+            Json::Value capabilities;
+            hr = CallJson([&](BSTR* j) { return server->GetCapabilities(j); }, capabilities);
+            if (FAILED(hr))
+            {
+                serverConnected = false;
+                if (!jsonMode)
+                    fprintf(stderr, "Terminal disconnected; stopping listener.\n");
+                break;
+            }
+        }
+
+        if (serverConnected)
+        {
+            server->Unsubscribe();
+        }
         // s_stopEvent is intentionally NOT closed: it is static and still
         // referenced by the registered Ctrl-C handler (a non-capturing lambda
         // that can only reach it via the static), so closing it would leave the

--- a/test/e2e/ItE2E/Private/Paths.ps1
+++ b/test/e2e/ItE2E/Private/Paths.ps1
@@ -130,9 +130,11 @@ function Get-RunnableWtaPath {
 
     $runnable = $null
     if ($App.WtaPath -and (Test-Path $App.WtaPath) -and $App.WtaPath -like '*WindowsApps*') {
-        $dir = Join-Path $env:TEMP 'ite2e-wta'
+        $packageKey = $App.PackageFullName -replace '[^A-Za-z0-9._-]', '_'
+        $sourceHash = (Get-FileHash -LiteralPath $App.WtaPath -Algorithm SHA256).Hash
+        $dir = Join-Path $env:TEMP "ite2e-wta\$packageKey\$sourceHash"
         if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-        $dest = Join-Path $dir ("wta-{0}.exe" -f $App.Version)
+        $dest = Join-Path $dir 'wta.exe'
         if (-not (Test-Path $dest)) {
             try { Copy-Item -LiteralPath $App.WtaPath -Destination $dest -Force; Write-ItLog -Level INFO -Message "Staged runnable wta -> $dest" }
             catch { Write-ItLog -Level WARN -Message "Could not stage packaged wta: $_" }

--- a/test/e2e/ItE2E/Public/Observe.ps1
+++ b/test/e2e/ItE2E/Public/Observe.ps1
@@ -74,24 +74,29 @@ function Start-WtEventListener {
         [Parameter(Mandatory, ValueFromPipeline)]$App,
         [string]$EventFilter,
         [string]$SessionId,
-        [switch]$SkipAuthenticate
+        [switch]$SkipAuthenticate,
+        [switch]$ViaWta
     )
     process {
+        if ($ViaWta -and $SkipAuthenticate) {
+            throw 'Start-WtEventListener: -SkipAuthenticate is not supported with -ViaWta.'
+        }
         if (-not $App.ComClsid) { Resolve-WtComClsid -App $App | Out-Null }
         $args = @('--json')
         if ($SkipAuthenticate) { $args += '--skip-authenticate' }
         $args += 'listen'
         if ($SessionId) { $args += @('-t', $SessionId) }
-        if ($EventFilter) { $args += @('--event', $EventFilter) }
+        if ($EventFilter -and -not $ViaWta) { $args += @('--event', $EventFilter) }
 
         $psi = [System.Diagnostics.ProcessStartInfo]::new()
-        $psi.FileName = $App.WtcliPath
+        $psi.FileName = if ($ViaWta) { Get-RunnableWtaPath -App $App } else { $App.WtcliPath }
         foreach ($a in $args) { $psi.ArgumentList.Add([string]$a) }
         $psi.RedirectStandardOutput = $true
         $psi.RedirectStandardError = $true
         $psi.UseShellExecute = $false
         $psi.CreateNoWindow = $true
         $psi.Environment['WT_COM_CLSID'] = $App.ComClsid
+        if ($ViaWta) { $psi.Environment['WT_WTCLI_PATH'] = $App.WtcliPath }
 
         $events = [System.Collections.ArrayList]::Synchronized([System.Collections.ArrayList]::new())
         $p = [System.Diagnostics.Process]::new(); $p.StartInfo = $psi
@@ -105,7 +110,8 @@ function Start-WtEventListener {
         $sourceId = "ItE2E.WtEventListener.$([guid]::NewGuid())"
         $reg = Register-ObjectEvent -InputObject $p -EventName OutputDataReceived -Action $handler -MessageData $events -SourceIdentifier $sourceId
         [void]$p.Start(); $p.BeginOutputReadLine(); $p.BeginErrorReadLine()
-        Write-ItLog -Level INFO -Message "Event listener started (filter='$EventFilter' session='$SessionId')."
+        $transport = if ($ViaWta) { 'wta' } else { 'wtcli' }
+        Write-ItLog -Level INFO -Message "$transport event listener started (filter='$EventFilter' session='$SessionId')."
         [pscustomobject]@{ Process = $p; Events = $events; Reg = $reg; SourceId = $sourceId; App = $App }
     }
 }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -13,7 +13,7 @@ authenticated ACP agents. Current status (run on the Store package):
 
 | Suite (file) | Covers | Cases |
 |---|---|---|
-| `Feature.Packaging.Tests.ps1` | §9 packaging/protocol (incl. bounded COM activation lifetime and WT_COM_CLSID injection) + §10 logging + log retention/cleanup | 22 |
+| `Feature.Packaging.Tests.ps1` | §9 packaging/protocol (incl. bounded COM activation lifetime, wtcli/WTA listener disconnect cleanup, and WT_COM_CLSID injection) + §10 logging + log retention/cleanup | 24 |
 | `Feature.Settings.Tests.ps1` | §1 Settings>AI Agents + §0 FRE settings/positions/auto-error/session-mgmt | 18 |
 | `Feature.FreFlow.Tests.ps1` | §0 FRE overlay click-through (Next→Save, privacy link, close-safety) | 5 |
 | `Feature.FreExecutionPolicy.Tests.ps1` | §0 FRE execution-policy verdict (deterministic via registry; **Dev**, auto-skips) | 3 (1 conditional skip) |
@@ -32,11 +32,11 @@ authenticated ACP agents. Current status (run on the Store package):
 | `Feature.DelegateSource.Tests.ps1` | PR #488 profile-scoped delegate source: strict host/WSL `wta delegate` routing with no fallback in either direction | 2 (environment-gated) |
 | `Feature.AgentChat.Tests.ps1` / `Feature.AgentPopup.Tests.ps1` | agent chat + `/` popup/menu interaction | 1 + 3 |
 
-**Coverage: 108 of 110 automatable `[E2E]` checklist items are implemented.**
-**Test status: 102 baseline feature cases pass + 2 documented skips** (`wta sessions list` is
+**Coverage: 113 of 115 automatable `[E2E]` checklist items are implemented.**
+**Test status: 107 baseline feature cases pass + 2 documented skips** (`wta sessions list` is
 identity-gated — see `Feature.SessionList.Tests.ps1`), plus 2 PR #481 WSL-backend cases and 2
 PR #488 delegate-source cases that run only when a runnable distro (and, for the #481 chat
-case, an installed+authenticated native agent) is available. The 108 implemented checklist
+case, an installed+authenticated native agent) is available. The 113 implemented checklist
 items map to the baseline cases plus the deterministic settings/persistence assertions. The
 remaining new items are the two profile agent picker UIs; they stay explicit E2E work rather
 than being falsely credited by the JSON-level runtime tests. Other

--- a/test/e2e/tests/Feature.Packaging.Tests.ps1
+++ b/test/e2e/tests/Feature.Packaging.Tests.ps1
@@ -199,6 +199,58 @@ Describe 'Feature §9 Packaging + protocol' -Tag 'Feature' -Skip:(-not $script:R
     }
 }
 
+Describe 'Feature §9 listener lifecycle' -Tag 'Feature' -Skip:(-not $script:Ready) {
+    BeforeEach {
+        Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
+        $script:listenerApp = Start-Terminal -Package (Get-ItTestPackage) -PassFre $true
+        $script:listener = $null
+    }
+    AfterEach {
+        if ($script:listener) { Stop-WtEventListener -Listener $script:listener }
+        if ($script:listenerApp) { Stop-Terminal -App $script:listenerApp }
+    }
+
+    It 'wtcli listen exits when Terminal disconnects' {
+        $eventType = "protocol.disconnect_probe.$([guid]::NewGuid().ToString('N'))"
+        $script:listener = Start-WtEventListener -App $script:listenerApp -EventFilter $eventType
+        Wait-Until -TimeoutSec 10 -IntervalSec 0.25 -Because 'the wtcli listener subscription to become ready' -Condition {
+            Invoke-WtCli -App $script:listenerApp -Arguments @('send-event', '-e', $eventType, '{}') | Out-Null
+            Start-Sleep -Milliseconds 100
+            @(Get-WtEvents -Listener $script:listener -Predicate {
+                $_.method -eq 'agent_event' -and $_.params.event -eq $eventType
+            }).Count -gt 0
+        } | Out-Null
+
+        Stop-Terminal -App $script:listenerApp
+        $script:listenerApp = $null
+
+        Test-Until -TimeoutSec 5 -IntervalSec 0.1 -Condition {
+            $script:listener.Process.HasExited
+        } | Should -BeTrue -Because 'a listener must release its packaged executable after the COM server exits'
+        $script:listener.Process.ExitCode | Should -Be 0
+    }
+
+    It 'wta listen exits when Terminal disconnects' {
+        $eventType = "protocol.wta_disconnect_probe.$([guid]::NewGuid().ToString('N'))"
+        $script:listener = Start-WtEventListener -App $script:listenerApp -ViaWta
+        Wait-Until -TimeoutSec 10 -IntervalSec 0.25 -Because 'the WTA listener subscription to become ready' -Condition {
+            Invoke-WtCli -App $script:listenerApp -Arguments @('send-event', '-e', $eventType, '{}') | Out-Null
+            Start-Sleep -Milliseconds 100
+            @(Get-WtEvents -Listener $script:listener -Predicate {
+                $_.method -eq 'agent_event' -and $_.params.event -eq $eventType
+            }).Count -gt 0
+        } | Out-Null
+
+        Stop-Terminal -App $script:listenerApp
+        $script:listenerApp = $null
+
+        Test-Until -TimeoutSec 5 -IntervalSec 0.1 -Condition {
+            $script:listener.Process.HasExited
+        } | Should -BeTrue -Because 'WTA must close its event receiver and release packaged executables after the COM server exits'
+        $script:listener.Process.ExitCode | Should -Be 0
+    }
+}
+
 Describe 'Feature §10 Diagnostics + logging' -Tag 'Feature' -Skip:(-not $script:UiReady) {
     BeforeAll {
         Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force

--- a/tools/wta/src/cli/wt.rs
+++ b/tools/wta/src/cli/wt.rs
@@ -577,7 +577,10 @@ async fn run_listen(pane_filter: Option<&str>) -> Result<()> {
     let mut event_rx = arc_channel.subscribe_events();
     arc_channel.start_reader().await;
 
-    let _ = arc_channel.request("get_capabilities", json!({})).await;
+    arc_channel
+        .request("get_capabilities", json!({}))
+        .await
+        .context("Failed to verify the Terminal connection")?;
 
     eprintln!("Connected. Listening for events... (Ctrl+C to stop)");
     if let Some(pane) = pane_filter {
@@ -600,6 +603,10 @@ async fn run_listen(pane_filter: Option<&str>) -> Result<()> {
         }
 
         println!("{}", serde_json::to_string(&msg).unwrap_or_default());
+    }
+
+    if let Some(error) = arc_channel.take_event_error() {
+        bail!("Event stream failed: {error}");
     }
 
     eprintln!("Event stream closed.");

--- a/tools/wta/src/shell/wt_channel/cli_channel.rs
+++ b/tools/wta/src/shell/wt_channel/cli_channel.rs
@@ -348,6 +348,8 @@ pub struct CliChannel {
     available: AtomicBool,
     debug_tx: Option<mpsc::UnboundedSender<DebugMessage>>,
     event_tx: std::sync::Mutex<Option<mpsc::UnboundedSender<serde_json::Value>>>,
+    event_error: std::sync::Mutex<Option<String>>,
+    reader_task: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
     wtcli_path: String,
 }
 
@@ -362,6 +364,8 @@ impl CliChannel {
             available: AtomicBool::new(true),
             debug_tx: None,
             event_tx: std::sync::Mutex::new(None),
+            event_error: std::sync::Mutex::new(None),
+            reader_task: std::sync::Mutex::new(None),
             wtcli_path: resolve_wtcli_path(),
         })
     }
@@ -377,24 +381,52 @@ impl CliChannel {
         rx
     }
 
+    fn disconnect_event_stream(&self, error: Option<String>) {
+        if let Some(error) = error {
+            *self.event_error.lock().unwrap() = Some(error);
+        }
+        self.available.store(false, Ordering::Relaxed);
+        self.event_tx.lock().unwrap().take();
+    }
+
+    /// Take the terminal error that closed the event stream, if any.
+    pub fn take_event_error(&self) -> Option<String> {
+        self.event_error.lock().unwrap().take()
+    }
+
     /// Start background event listener (wraps `wtcli listen --json`).
     /// wtcli inherits WT_COM_CLSID from this process's env.
     pub async fn start_reader(self: &std::sync::Arc<Self>) {
+        let mut reader_task = self.reader_task.lock().unwrap();
+        if reader_task.is_some() {
+            return;
+        }
+
         let wtcli = self.wtcli_path.clone();
         let weak = std::sync::Arc::downgrade(self);
-        tokio::spawn(async move {
-            let Ok(mut child) = tokio::process::Command::new(&wtcli)
+        *reader_task = Some(tokio::spawn(async move {
+            let mut command = tokio::process::Command::new(&wtcli);
+            command
                 .args(["--json", "listen"])
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::null())
-                .spawn()
-            else {
-                return;
+                .kill_on_drop(true);
+            let mut child = match command.spawn() {
+                Ok(child) => child,
+                Err(error) => {
+                    if let Some(this) = weak.upgrade() {
+                        this.disconnect_event_stream(Some(format!(
+                            "failed to start wtcli listener: {error}"
+                        )));
+                    }
+                    return;
+                }
             };
 
             let stdout = child.stdout.take().unwrap();
             let mut reader = tokio::io::BufReader::new(stdout);
             let mut line = String::new();
+            let mut stream_error = None;
 
             loop {
                 line.clear();
@@ -410,10 +442,32 @@ impl CliChannel {
                             }
                         }
                     }
-                    Err(_) => break,
+                    Err(error) => {
+                        stream_error = Some(format!("failed to read wtcli event stream: {error}"));
+                        break;
+                    }
                 }
             }
-        });
+
+            drop(reader);
+            match child.wait().await {
+                Ok(status) if !status.success() => {
+                    stream_error = Some(format!(
+                        "wtcli listener exited with status {}",
+                        status
+                            .code()
+                            .map_or_else(|| "unknown".to_string(), |code| code.to_string())
+                    ));
+                }
+                Err(error) => {
+                    stream_error = Some(format!("failed to wait for wtcli listener: {error}"));
+                }
+                _ => {}
+            }
+            if let Some(this) = weak.upgrade() {
+                this.disconnect_event_stream(stream_error);
+            }
+        }));
     }
 
     /// Run a wtcli subcommand and return the parsed JSON output.
@@ -437,6 +491,14 @@ impl CliChannel {
         let val: serde_json::Value =
             serde_json::from_str(trimmed).context("Failed to parse wtcli JSON output")?;
         Ok(val)
+    }
+}
+
+impl Drop for CliChannel {
+    fn drop(&mut self) {
+        if let Some(reader_task) = self.reader_task.lock().unwrap().take() {
+            reader_task.abort();
+        }
     }
 }
 
@@ -521,7 +583,10 @@ impl WtChannel for CliChannel {
                     .unwrap_or("");
                 let title = params.get("title").and_then(|v| v.as_str()).unwrap_or("");
                 let cwd = params.get("cwd").and_then(|v| v.as_str()).unwrap_or("");
-                let profile = params.get("profile").and_then(|v| v.as_str()).unwrap_or("");
+                let profile = params
+                    .get("profile")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
                 let cmd_owned;
                 let title_owned;
                 let cwd_owned;
@@ -557,10 +622,7 @@ impl WtChannel for CliChannel {
                     .get("direction")
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
-                let profile = params
-                    .get("profile")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
+                let profile = params.get("profile").and_then(|v| v.as_str()).unwrap_or("");
                 let cmd_owned;
                 let dir_owned;
                 let profile_owned;
@@ -656,5 +718,51 @@ impl WtChannel for CliChannel {
 
     fn is_available(&self) -> bool {
         self.available.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disconnect_event_stream_closes_subscriber() {
+        let channel = CliChannel {
+            available: AtomicBool::new(true),
+            debug_tx: None,
+            event_tx: std::sync::Mutex::new(None),
+            event_error: std::sync::Mutex::new(None),
+            reader_task: std::sync::Mutex::new(None),
+            wtcli_path: "wtcli".to_string(),
+        };
+        let mut events = channel.subscribe_events();
+
+        channel.disconnect_event_stream(None);
+
+        assert!(!channel.is_available());
+        assert_eq!(
+            events.try_recv(),
+            Err(mpsc::error::TryRecvError::Disconnected)
+        );
+    }
+
+    #[test]
+    fn disconnect_event_stream_preserves_error() {
+        let channel = CliChannel {
+            available: AtomicBool::new(true),
+            debug_tx: None,
+            event_tx: std::sync::Mutex::new(None),
+            event_error: std::sync::Mutex::new(None),
+            reader_task: std::sync::Mutex::new(None),
+            wtcli_path: "wtcli".to_string(),
+        };
+
+        channel.disconnect_event_stream(Some("listener failed".to_string()));
+
+        assert_eq!(
+            channel.take_event_error().as_deref(),
+            Some("listener failed")
+        );
+        assert_eq!(channel.take_event_error(), None);
     }
 }


### PR DESCRIPTION
## Summary
- heartbeat the existing `ITerminalProtocol` proxy so `wtcli listen` exits promptly when Terminal closes without reactivating the COM server
- propagate listener EOF and abnormal spawn/read/exit failures through WTA, own the reader task, and terminate its child on channel teardown
- pin ItE2E WTA/wtcli binaries to the selected package with package/content-addressed Store staging
- add packaged disconnect coverage for direct `wtcli listen` and `wta listen` (C249-C250)

This is intentionally stacked on #549. The server-side handoff lease and client-side listener cleanup are separate reviewable changes; after #549 merges, this PR can be retargeted to `main`.

## Validation
- WindowsTerminal and wtcli x64 Debug builds
- WTA tests: 1,396 passed, 0 failed
- packaged combined lifecycle suite: 19 passed, 0 failed, 5 expected `winapp`-dependent skips
- release report: C246-C250 checked
- forced WTA listener spawn failure exits 1 in 238 ms with an actionable error
- Store staged/source WTA SHA-256 hashes match