### PR TITLE
Fix agent model switching lifecycle

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -364,15 +364,15 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        // Hot-reload of runtime agent config (autofix gate, acp-model,
-        // delegate agent/model). When any of these change between settings
+        // Hot-reload of runtime agent config (autofix gate and delegate
+        // agent/model). When any of these change between settings
         // reloads we push a single consolidated `agent_config_changed`
         // event to the running wta-helper(s) so they update in place,
         // WITHOUT tearing down and restarting the agent pane. This is the
         // unified dispatch for every hot-updatable agent setting — adding a
         // new one means adding a field to AgentRuntimeConfigSnapshot, not a
-        // bespoke diff/emit block here. (Agent *identity* changes still go
-        // through _RebuildAgentStack in _RefreshUIForSettingsReload.)
+        // bespoke diff/emit block here. Agent identity and model changes go
+        // through _RebuildAgentStack in _RefreshUIForSettingsReload.
         _EmitAgentRuntimeConfigIfChanged();
 
         // Make sure to call SetCommands before _RefreshUIForSettingsReload.
@@ -1566,6 +1566,9 @@ namespace winrt::TerminalApp::implementation
         AgentSettingsSnapshot snapshot{
             std::wstring{ globals.AcpAgent() },
             std::wstring{ globals.AcpCustomCommand() },
+            _IsAgentByokConfigured(globals.EffectiveAcpAgent(), globals) ?
+                std::wstring{} :
+                std::wstring{ globals.AcpModel() },
             _CaptureCustomModelLaunchConfiguration(globals),
         };
         for (const auto& profile : _settings.AllProfiles())
@@ -1582,15 +1585,14 @@ namespace winrt::TerminalApp::implementation
 
     bool TerminalPage::_AgentSettingsChanged(const AgentSettingsSnapshot& a, const AgentSettingsSnapshot& b)
     {
-        // Agent identity changes rebuild helpers. acp-model and delegate-*
-        // fields are hot-updated over the protocol and must not trigger a
-        // teardown. A profile backend is part of identity because it changes
-        // both the agent id and the execution source for that profile. Only
-        // selected-provider fields consumed by the master launch environment
-        // participate in identity. The helper-safe full catalog is hot-updated
-        // separately.
+        // Agent identity and effective model changes rebuild helpers. A profile
+        // backend is part of identity because it changes both the agent id and
+        // the execution source for that profile. Only selected-provider fields
+        // consumed by the master launch environment participate in identity.
+        // The helper-safe full catalog is hot-updated separately.
         return a.acpAgent != b.acpAgent ||
                a.acpCustomCommand != b.acpCustomCommand ||
+               a.acpModel != b.acpModel ||
                a.customModelLaunch != b.customModelLaunch ||
                a.profileBackends != b.profileBackends;
     }
@@ -1598,10 +1600,8 @@ namespace winrt::TerminalApp::implementation
     TerminalPage::AgentRuntimeConfigSnapshot TerminalPage::_CaptureAgentRuntimeConfig() const
     {
         const auto& globals = _settings.GlobalSettings();
-        const bool providerConfigured = _IsAgentByokConfigured(globals.EffectiveAcpAgent(), globals);
         const auto customModelLaunch = _CaptureCustomModelLaunchConfiguration(globals);
         return AgentRuntimeConfigSnapshot{
-            providerConfigured ? std::wstring{} : std::wstring{ globals.AcpModel() },
             std::wstring{ _ResolveEffectiveDelegateAgent(globals) },
             std::wstring{ globals.DelegateModel() },
             customModelLaunch ? customModelLaunch->selectionId : std::wstring{},
@@ -1610,13 +1610,12 @@ namespace winrt::TerminalApp::implementation
         };
     }
 
-    // Hot-propagate runtime agent config to the running wta-helper(s) over
-    // the protocol event channel. Unlike agent *identity* changes (which
+    // Hot-propagate runtime agent config to the running wta-helper(s) over the
+    // protocol event channel. Unlike agent identity/model changes (which
     // require a master respawn via _RebuildAgentStack), these take effect
     // without tearing down the agent pane. A single consolidated
     // `agent_config_changed` event carries only the fields that changed:
     //   - autofix_enabled : the auto-suggest gate (was its own event)
-    //   - acp_model + target_agent_id : the global ACP agent's scoped model
     //   - delegate_agent + delegate_model : the delegate-tab agent identity
     //   - cloud_models + custom_models + custom_model_selection :
     //     credential-free picker metadata and its restart-required selection.
@@ -1637,14 +1636,13 @@ namespace winrt::TerminalApp::implementation
 
         const auto& last = _lastAgentRuntimeConfig;
         const bool autofixChanged = last.autofixEnabled != current.autofixEnabled;
-        const bool acpModelChanged = last.acpModel != current.acpModel;
         const bool delegateChanged = last.delegateAgent != current.delegateAgent ||
                                      last.delegateModel != current.delegateModel;
         const bool customModelsChanged =
             last.customModelSelection != current.customModelSelection ||
             last.customModels != current.customModels;
 
-        if (!autofixChanged && !acpModelChanged && !delegateChanged && !customModelsChanged)
+        if (!autofixChanged && !delegateChanged && !customModelsChanged)
         {
             return;
         }
@@ -1653,12 +1651,6 @@ namespace winrt::TerminalApp::implementation
         if (autofixChanged)
         {
             params["autofix_enabled"] = current.autofixEnabled;
-        }
-        if (acpModelChanged)
-        {
-            params["acp_model"] = winrt::to_string(current.acpModel);
-            params["target_agent_id"] =
-                winrt::to_string(_settings.GlobalSettings().EffectiveAcpAgent());
         }
         if (delegateChanged)
         {
@@ -3128,8 +3120,11 @@ namespace winrt::TerminalApp::implementation
              _lastAgentSettings.acpCustomCommand != current.acpCustomCommand);
         const bool customModelLaunchChanged =
             _lastAgentSettings.customModelLaunch != current.customModelLaunch;
+        const bool cloudModelChanged =
+            _lastAgentSettings.acpModel != current.acpModel;
         const bool masterConfigurationChanged =
             customMasterArgsChanged ||
+            cloudModelChanged ||
             customModelLaunchChanged;
         const bool globalAgentChanged =
             _lastAgentSettings.acpAgent != current.acpAgent ||
@@ -3258,7 +3253,7 @@ namespace winrt::TerminalApp::implementation
             _TeardownAgentPane(tabImpl);
         }
 
-        // Built-in agent changes do not restart the master. It is now a
+        // Built-in agent identity changes do not restart the master. It is now a
         // multi-agent broker — it spawns/reuses one agent CLI per distinct
         // agent command line, driven by each helper's `initialize`
         // handshake (which carries the tab's agent). The master's own
@@ -3268,10 +3263,10 @@ namespace winrt::TerminalApp::implementation
         // affected (non-override) tabs' helpers is enough: each fresh
         // helper declares the new global agent and the master lazily
         // spawns/reuses the matching CLI, leaving overridden tabs' CLIs
-        // (and other windows) untouched. Custom commands and selected provider
-        // launch fields are the exceptions: both are supplied only on the
-        // master's trusted launch configuration, so refresh it after affected
-        // helpers are down.
+        // (and other windows) untouched. Custom commands and model selections
+        // are exceptions: model/provider launch state is supplied on the
+        // master's trusted launch configuration, and a model change requires a
+        // fresh agent CLI rather than mutating the existing ACP session.
         if (masterConfigurationChanged)
         {
             const auto wtaPath = _DetectWtaPath();

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -415,14 +415,16 @@ namespace winrt::TerminalApp::implementation
         // SetSettings and after every rebuild; a diff drives teardown/rebuild
         // of the agent pane.
         //
-        // Agent identity changes (global acpAgent/acpCustomCommand or an
-        // effective per-profile backend) rebuild affected helpers. A custom
-        // global command or selected provider launch configuration forces a
-        // master respawn; unselected provider catalog changes are hot-updated.
+        // Agent identity changes (global acpAgent/acpCustomCommand, the
+        // effective model selection, or an effective per-profile backend)
+        // rebuild affected helpers. Model changes force a master respawn so
+        // the agent CLI starts with a clean model-provider environment;
+        // unselected provider catalog changes are hot-updated.
         struct AgentSettingsSnapshot
         {
             std::wstring acpAgent;
             std::wstring acpCustomCommand;
+            std::wstring acpModel;
             std::optional<::Microsoft::Terminal::CustomModels::LaunchConfiguration> customModelLaunch;
             std::vector<std::pair<winrt::guid, std::wstring>> profileBackends;
         };
@@ -432,13 +434,12 @@ namespace winrt::TerminalApp::implementation
         // push a single consolidated `agent_config_changed` event to the
         // running wta-helper(s) so they update in place — no agent-pane
         // teardown/restart. This is the unified dispatch point for every
-        // agent setting that can be hot-reloaded (autofix gate, scoped
-        // acp-model, delegate agent/model, credential-free model catalogs).
+        // agent setting that can be hot-reloaded (autofix gate, delegate
+        // agent/model, credential-free model catalogs).
         // `delegateAgent` holds the resolved effective value (custom-command
         // ids already expanded).
         struct AgentRuntimeConfigSnapshot
         {
-            std::wstring acpModel;
             std::wstring delegateAgent;
             std::wstring delegateModel;
             std::wstring customModelSelection;

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -172,7 +172,7 @@
             <local:SettingContainer x:Name="CustomModelProvidersExpander"
                                     x:Uid="AIAgents_CustomModels"
                                     StartExpanded="{x:Bind ViewModel.IsCustomModelProvidersExpanded, Mode=TwoWay}"
-                                    Style="{StaticResource ExpanderSettingContainerStyle}">
+                                    Style="{StaticResource ExpanderSettingContainerStyleWithComplexPreview}">
                 <local:SettingContainer.CurrentValue>
                     <Button x:Uid="AIAgents_CustomProviderAdd"
                             VerticalAlignment="Center"
@@ -181,12 +181,6 @@
                             Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(ViewModel.IsAddingCustomModelProvider), Mode=OneWay}" />
                 </local:SettingContainer.CurrentValue>
                 <StackPanel>
-                    <Button x:Uid="AIAgents_CustomProviderAdd"
-                            Margin="0,12,0,12"
-                            HorizontalAlignment="Right"
-                            Click="{x:Bind ViewModel.AddCustomModelProvider}"
-                            Style="{StaticResource AccentButtonStyle}"
-                            Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(ViewModel.IsAddingCustomModelProvider), Mode=OneWay}" />
                     <TextBlock Margin="0,12,0,0"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Text="{x:Bind ViewModel.CustomModelProviderUnsupportedMessage, Mode=OneWay}"

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -177,8 +177,7 @@
                     <Button x:Uid="AIAgents_CustomProviderAdd"
                             VerticalAlignment="Center"
                             Click="{x:Bind ViewModel.AddCustomModelProvider}"
-                            Style="{StaticResource AccentButtonStyle}"
-                            Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(ViewModel.IsAddingCustomModelProvider), Mode=OneWay}" />
+                            Style="{StaticResource AccentButtonStyle}" />
                 </local:SettingContainer.CurrentValue>
                 <StackPanel>
                     <TextBlock Margin="0,12,0,0"

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -181,6 +181,12 @@
                             Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(ViewModel.IsAddingCustomModelProvider), Mode=OneWay}" />
                 </local:SettingContainer.CurrentValue>
                 <StackPanel>
+                    <Button x:Uid="AIAgents_CustomProviderAdd"
+                            Margin="0,12,0,12"
+                            HorizontalAlignment="Right"
+                            Click="{x:Bind ViewModel.AddCustomModelProvider}"
+                            Style="{StaticResource AccentButtonStyle}"
+                            Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(ViewModel.IsAddingCustomModelProvider), Mode=OneWay}" />
                     <TextBlock Margin="0,12,0,0"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Text="{x:Bind ViewModel.CustomModelProviderUnsupportedMessage, Mode=OneWay}"

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.h
@@ -228,7 +228,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         bool _isAddingCustomAcpAgent{ false };
         bool _isAddingCustomDelegateAgent{ false };
-        bool _isCustomModelProvidersExpanded{ true };
+        bool _isCustomModelProvidersExpanded{ false };
         bool _isAddingCustomModelProvider{ false };
         winrt::hstring _customAcpCommand;
         winrt::hstring _customDelegateCommand;

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -3020,7 +3020,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","%LOCALAPPDATA%","IntelligentTerminal","logs","wta-install-hooks.log"}</comment>
   </data>
   <data name="AIAgents_CustomModels.Header" xml:space="preserve">
-    <value>BYOM providers</value>
+    <value>BYOM (bring your own model) providers</value>
     <comment>Section header for user-configured model providers. {Locked="BYOM"}</comment>
   </data>
   <data name="AIAgents_CustomModels.HelpText" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -2921,7 +2921,7 @@
     <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
   </data>
   <data name="AIAgents_CustomModels.Header" xml:space="preserve">
-    <value>BYOM providers</value>
+    <value>BYOM (bring your own model) providers</value>
     <comment>Section header for user-configured model providers. {Locked="BYOM"}</comment>
   </data>
   <data name="AIAgents_CustomModels.HelpText" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -2921,7 +2921,7 @@
     <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
   </data>
   <data name="AIAgents_CustomModels.Header" xml:space="preserve">
-    <value>BYOM providers</value>
+    <value>BYOM (bring your own model) providers</value>
     <comment>Section header for user-configured model providers. {Locked="BYOM"}</comment>
   </data>
   <data name="AIAgents_CustomModels.HelpText" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -2921,7 +2921,7 @@
     <value>Give Intelligent Terminal permission to send errors to your agent to automatically suggest fixes.</value>
   </data>
   <data name="AIAgents_CustomModels.Header" xml:space="preserve">
-    <value>BYOM providers</value>
+    <value>BYOM (bring your own model) providers</value>
     <comment>Section header for user-configured model providers. {Locked="BYOM"}</comment>
   </data>
   <data name="AIAgents_CustomModels.HelpText" xml:space="preserve">

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1776,11 +1776,17 @@ impl App {
     fn rebuild_model_catalog(&mut self) {
         let old_selected_ids = self.capture_model_picker_selections();
         self.available_models = self.merge_custom_models(self.agent_models.clone());
-        let local_mode = self.selected_custom_model_id().is_some();
+        let selected_custom = self.selected_custom_model_id().map(str::to_owned);
         self.model_picker_models = self
             .available_models
             .iter()
-            .filter(|model| self.is_custom_model(&model.id) == local_mode)
+            .filter(|model| match selected_custom.as_deref() {
+                Some(selected) => model.id == selected,
+                None => !self
+                    .custom_model_catalog
+                    .iter()
+                    .any(|custom| custom.selection_id == model.id),
+            })
             .cloned()
             .collect();
         self.recompute_current_model_id();
@@ -2162,12 +2168,6 @@ impl App {
             .or_else(|| self.selected_custom_model_id())
             .or(self.current_model_id.as_deref())
             .or(self.acp_model.as_deref())
-    }
-
-    fn is_custom_model(&self, model_id: &str) -> bool {
-        self.custom_model_catalog
-            .iter()
-            .any(|model| model.selection_id == model_id)
     }
 
     fn model_pick_enabled(&self, _model_id: &str) -> bool {

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1776,13 +1776,13 @@ impl App {
     fn rebuild_model_catalog(&mut self) {
         let old_selected_ids = self.capture_model_picker_selections();
         self.available_models = self.merge_custom_models(self.agent_models.clone());
-        let model_picker_models = self
+        let local_mode = self.selected_custom_model_id().is_some();
+        self.model_picker_models = self
             .available_models
             .iter()
-            .filter(|model| self.is_custom_model(&model.id))
+            .filter(|model| self.is_custom_model(&model.id) == local_mode)
             .cloned()
             .collect();
-        self.model_picker_models = model_picker_models;
         self.recompute_current_model_id();
         self.reconcile_model_picker_selections(old_selected_ids);
     }
@@ -2057,8 +2057,9 @@ impl App {
         self.current_tab().model_picker_open
     }
 
-    /// `/model [id]` — show the pane's configured BYOM models. Cloud/native
-    /// models are intentionally available only through Settings.
+    /// `/model [id]` — show models from the mode selected in Settings. Cloud
+    /// mode shows only agent/cloud models; local mode shows only BYOM models.
+    /// Crossing modes requires changing Settings and restarting the agent.
     fn cmd_model(&mut self, arg: String) {
         let arg = arg.trim().to_string();
         if self.model_picker_models.is_empty() {
@@ -2169,17 +2170,14 @@ impl App {
             .any(|model| model.selection_id == model_id)
     }
 
-    /// `/model` only exposes BYOM rows. A selected BYOM model is visible as the
-    /// current row, but entering or changing BYOM still requires Settings.
-    fn model_pick_enabled(&self, model_id: &str) -> bool {
-        self.current_model_id_for_picker() == Some(model_id)
+    fn model_pick_enabled(&self, _model_id: &str) -> bool {
+        true
     }
 
-    /// Pin the active pane to `model_id`: record the per-pane override, mirror
-    /// it into the status projection (title bar / settings dropdown), and
-    /// hot-apply it to the tab's live session. Shared by the picker (Enter)
-    /// and `/model <id>`. If no session is live yet, the override is stored
-    /// and `SessionAttached` applies it via `effective_model_for_tab`.
+    /// Pin the active pane to `model_id` and hot-apply it to the live ACP
+    /// session. The picker is already scoped to the local/cloud mode selected
+    /// in Settings, so slash-command changes never cross modes or restart the
+    /// agent CLI.
     fn apply_model_pick(&mut self, model_id: String) {
         if self.current_model_id_for_picker() == Some(model_id.as_str()) {
             return;
@@ -2205,8 +2203,8 @@ impl App {
         };
         self.current_model_id = Some(model_id.clone());
         self.agent_current_model_id = Some(model_id.clone());
-        if let Some(sid) = session_id {
-            self.send_session_model(Some(sid), model_id);
+        if let Some(session_id) = session_id {
+            self.send_session_model(Some(session_id), model_id);
         }
         self.publish_agent_status();
     }

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -2007,27 +2007,12 @@ fn model_info(id: &str) -> AcpModelInfo {
     }
 }
 
-fn custom_model_info(id: &str) -> CustomModelCatalogEntry {
-    CustomModelCatalogEntry {
-        selection_id: id.to_string(),
-        model_id: id.to_string(),
-        ..Default::default()
-    }
-}
-
 #[test]
 fn model_config_update_refreshes_active_session_picker() {
     let mut app = test_app();
     app.current_tab_mut().session_id = Some("sid-1".into());
     app.available_models = vec![model_info("claude-sonnet-5")];
     app.current_model_id = Some("claude-sonnet-5".into());
-    app.set_custom_model_config(
-        vec![
-            custom_model_info("claude-sonnet-5"),
-            custom_model_info("gpt-5.6-sol"),
-        ],
-        None,
-    );
 
     app.handle_event(AppEvent::ModelConfigUpdated {
         session_id: "sid-1".into(),
@@ -2167,26 +2152,30 @@ fn new_session_prunes_previous_model_config() {
     assert!(!app.session_model_configs.contains_key("sid-old"));
 }
 
-/// `/model <id>` records a per-pane override and hot-applies it to *that*
-/// tab's live session (a targeted `SetSessionModel`, not a fan-out).
-/// Cloud/native models remain available to Settings but are not exposed
-/// through `/model`, so the command cannot create a live pane override.
+/// `/model <id>` hot-applies a model within the current Settings-selected mode
+/// and does not restart the agent CLI.
 #[test]
-fn slash_model_does_not_apply_cloud_model_to_live_session() {
+fn slash_model_hot_applies_cloud_model_to_live_session() {
     let (mut app, mut master_rx) = test_app_with_master_rx();
     app.set_cloud_models(vec![model_info("gpt-5.5"), model_info("gpt-5.4")]);
     app.current_tab_mut().session_id = Some("sid-1".into());
 
     app.cmd_model("gpt-5.4".into());
 
-    assert!(
-        app.current_tab().model_override.is_none(),
-        "cloud models must not create a pane-local override"
+    assert_eq!(
+        app.current_tab().model_override.as_deref(),
+        Some("gpt-5.4")
     );
-    assert!(
-        master_rx.try_recv().is_err(),
-        "the command must not send SetSessionModel for a hidden cloud model"
-    );
+    match master_rx.try_recv().expect("live model switch request") {
+        crate::protocol::acp::client::MasterExtRequest::SetSessionModel {
+            session_id,
+            model,
+        } => {
+            assert_eq!(session_id.expect("target session").0.as_ref(), "sid-1");
+            assert_eq!(model, "gpt-5.4");
+        }
+        other => panic!("expected SetSessionModel, got {other:?}"),
+    }
 }
 
 /// A pane-local `/model` pick remains authoritative when the matching global
@@ -5939,8 +5928,8 @@ fn render_help_overlay_lists_commands() {
     );
 }
 
-/// Render: the `/model` picker must list BYOM model IDs and omit cloud models. Lifts
-/// `ui/model_popup.rs`.
+/// Render: cloud mode lists cloud models and omits BYOM rows. Lifts
+/// `ui/model_popup.rs`; local-mode filtering is covered by slash-command tests.
 #[test]
 fn render_model_picker_lists_models() {
     let mut app = test_app();
@@ -5971,14 +5960,12 @@ fn render_model_picker_lists_models() {
 
     let text = render_to_text(&mut app, 120, 24);
     assert!(
-        !text.contains("PickModelXYZ"),
-        "the model picker must omit cloud models; rendered:\n{text}"
+        text.contains("PickModelXYZ"),
+        "the cloud-mode model picker must show cloud models; rendered:\n{text}"
     );
     assert!(
-        text.contains("shared-model (BYOM)")
-            && !text.contains("custom:provider-one")
-            && !text.contains("custom:provider-two"),
-        "custom models must show only modelId (BYOM); rendered:\n{text}"
+        !text.contains("shared-model (BYOM)"),
+        "the cloud-mode model picker must omit BYOM rows; rendered:\n{text}"
     );
 }
 

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -252,7 +252,11 @@ fn slash_model_without_models_notes_none() {
 #[test]
 fn slash_model_bare_opens_picker_when_models_present() {
     let mut app = test_app();
-    app.set_custom_model_config(vec![custom_model("custom:provider:local", "local")], None);
+    let selected = "custom:provider:local";
+    app.set_custom_model_config(
+        vec![custom_model(selected, "local")],
+        Some(selected.into()),
+    );
 
     run_slash(&mut app, "model");
 
@@ -263,7 +267,7 @@ fn slash_model_bare_opens_picker_when_models_present() {
 }
 
 #[test]
-fn slash_model_hides_cloud_models() {
+fn slash_model_shows_cloud_models() {
     let mut app = test_app();
     app.set_cloud_models(vec![AcpModelInfo {
         id: "cloud".into(),
@@ -273,11 +277,8 @@ fn slash_model_hides_cloud_models() {
 
     run_slash(&mut app, "model");
 
-    assert!(!app.current_tab().model_picker_open);
-    assert!(matches!(
-        app.current_tab().messages.last(),
-        Some(ChatMessage::System(_))
-    ));
+    assert!(app.current_tab().model_picker_open);
+    assert_eq!(app.model_picker_models[0].id, "cloud");
 }
 
 #[test]
@@ -391,11 +392,11 @@ fn helper_status_catalog_combines_cloud_agent_and_byok_models() {
         .iter()
         .any(|model| model.id == "custom:provider-one:shared-model"
             && model.name == "shared-model (BYOM)"));
-    assert_eq!(app.model_picker_models.len(), 1);
-    assert_eq!(
-        app.model_picker_models[0].id,
-        "custom:provider-one:shared-model"
-    );
+    assert_eq!(app.model_picker_models.len(), 2);
+    assert!(app
+        .model_picker_models
+        .iter()
+        .all(|model| !model.id.starts_with("custom:")));
 }
 
 #[test]
@@ -437,7 +438,11 @@ fn private_cloud_catalog_survives_bare_agent_model_response() {
 #[test]
 fn agent_and_model_pickers_are_mutually_exclusive() {
     let mut app = test_app();
-    app.set_custom_model_config(vec![custom_model("custom:provider:local", "local")], None);
+    let selected = "custom:provider:local";
+    app.set_custom_model_config(
+        vec![custom_model(selected, "local")],
+        Some(selected.into()),
+    );
 
     app.open_model_picker();
     assert!(app.current_tab().model_picker_open);
@@ -472,7 +477,7 @@ fn slash_model_direct_current_byok_is_a_noop() {
 }
 
 #[test]
-fn slash_model_only_shows_disabled_byok_choices_while_cloud_is_active() {
+fn slash_model_only_shows_cloud_choices_while_cloud_is_active() {
     let mut app = test_app();
     app.set_cloud_models(vec![AcpModelInfo {
         id: "cloud".into(),
@@ -487,16 +492,21 @@ fn slash_model_only_shows_disabled_byok_choices_while_cloud_is_active() {
         app.model_popup_state().expect("picker state")
     };
     assert_eq!(state.models.len(), 1);
-    assert_eq!(state.models[0].id, "custom:provider:local");
-    assert_eq!(state.disabled, vec![true]);
+    assert_eq!(state.models[0].id, "cloud");
+    assert_eq!(state.disabled, vec![false]);
 
+    app.close_model_picker();
     run_slash_args(&mut app, "model", "custom:provider:local");
     assert_eq!(app.current_tab().model_override, None);
-    assert!(app.current_tab().model_picker_open);
+    assert!(!app.current_tab().model_picker_open);
+    assert!(matches!(
+        app.current_tab().messages.last(),
+        Some(ChatMessage::System(_))
+    ));
 }
 
 #[test]
-fn slash_model_locks_non_current_choices_while_byok_is_active() {
+fn slash_model_only_shows_byok_choices_while_byok_is_active() {
     let mut app = test_app();
     let selected = "custom:provider:local";
     app.set_cloud_models(vec![AcpModelInfo {
@@ -516,7 +526,11 @@ fn slash_model_locks_non_current_choices_while_byok_is_active() {
     let state = app.model_popup_state().expect("picker state");
     assert_eq!(state.current_id, Some(selected));
     assert_eq!(state.models.len(), 2);
-    assert_eq!(state.disabled, vec![false, true]);
+    assert!(state
+        .models
+        .iter()
+        .all(|model| model.id.starts_with("custom:")));
+    assert_eq!(state.disabled, vec![false, false]);
 
     app.close_model_picker();
     run_slash_args(&mut app, "model", "cloud");

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -506,7 +506,7 @@ fn slash_model_only_shows_cloud_choices_while_cloud_is_active() {
 }
 
 #[test]
-fn slash_model_only_shows_byok_choices_while_byok_is_active() {
+fn slash_model_only_shows_selected_byok_while_byok_is_active() {
     let mut app = test_app();
     let selected = "custom:provider:local";
     app.set_cloud_models(vec![AcpModelInfo {
@@ -525,14 +525,19 @@ fn slash_model_only_shows_byok_choices_while_byok_is_active() {
     app.open_model_picker();
     let state = app.model_popup_state().expect("picker state");
     assert_eq!(state.current_id, Some(selected));
-    assert_eq!(state.models.len(), 2);
-    assert!(state
-        .models
-        .iter()
-        .all(|model| model.id.starts_with("custom:")));
-    assert_eq!(state.disabled, vec![false, false]);
+    assert_eq!(state.models.len(), 1);
+    assert_eq!(state.models[0].id, selected);
+    assert_eq!(state.disabled, vec![false]);
 
     app.close_model_picker();
+    run_slash_args(&mut app, "model", "custom:provider:other");
+    assert_eq!(app.current_tab().model_override, None);
+    assert!(!app.current_tab().model_picker_open);
+    assert!(matches!(
+        app.current_tab().messages.last(),
+        Some(ChatMessage::System(_))
+    ));
+
     run_slash_args(&mut app, "model", "cloud");
     assert_eq!(app.current_tab().model_override, None);
     assert!(!app.current_tab().model_picker_open);


### PR DESCRIPTION
## Summary
- restart the shared agent stack when Settings changes between local and cloud mode or changes the configured cloud model
- scope `/model` choices to the active local/cloud mode
- keep `/model` selection session-local and hot-apply it through ACP without restarting the agent CLI

## Validation
- full WTA test suite (1,395 tests)
- explicit-target WTA Debug build
- Terminal Debug package build and deployment
- verified packaged `wta.exe` matches the explicit-target build