### PR TITLE
Fix session management mouse wheel navigation

### DIFF
--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -41,6 +41,18 @@ impl App {
             AppEvent::Mouse(mouse) => match mouse.kind {
                 crossterm::event::MouseEventKind::ScrollUp
                 | crossterm::event::MouseEventKind::ScrollDown
+                    if self.current_tab().current_view == View::Agents =>
+                {
+                    self.text_selection.clear();
+                    let code = if matches!(mouse.kind, crossterm::event::MouseEventKind::ScrollUp) {
+                        KeyCode::Up
+                    } else {
+                        KeyCode::Down
+                    };
+                    self.handle_key(KeyEvent::new(code, mouse.modifiers));
+                }
+                crossterm::event::MouseEventKind::ScrollUp
+                | crossterm::event::MouseEventKind::ScrollDown
                     if self.mode == AppMode::Chat
                         && self.current_tab().current_view == View::Chat =>
                 {

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -7942,6 +7942,43 @@ fn mouse_wheel_does_not_scroll_hidden_chat() {
 }
 
 #[test]
+fn mouse_wheel_moves_session_management_selection() {
+    use crate::agent_sessions::SessionOrigin;
+    use crossterm::event::{KeyModifiers, MouseEvent, MouseEventKind};
+
+    let mut app = test_app();
+    let mut first = session_info_for_test("first");
+    first.origin = Some(SessionOrigin::Unknown);
+    first.last_activity_at_ms = Some(300);
+    let mut second = session_info_for_test("second");
+    second.origin = Some(SessionOrigin::Unknown);
+    second.last_activity_at_ms = Some(200);
+    let mut third = session_info_for_test("third");
+    third.origin = Some(SessionOrigin::Unknown);
+    third.last_activity_at_ms = Some(100);
+
+    app.current_tab_mut().current_view = View::Agents;
+    app.current_tab_mut().agents_view.snapshot = Some(vec![first, second, third]);
+    app.current_tab_mut().agents_list_state.select(Some(1));
+
+    app.handle_event(AppEvent::Mouse(MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    }));
+    assert_eq!(app.current_tab().agents_list_state.selected(), Some(2));
+
+    app.handle_event(AppEvent::Mouse(MouseEvent {
+        kind: MouseEventKind::ScrollUp,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    }));
+    assert_eq!(app.current_tab().agents_list_state.selected(), Some(1));
+}
+
+#[test]
 fn input_history_navigates_newest_first_and_restores_draft() {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     let mut app = test_app();


### PR DESCRIPTION
## Summary
- route mouse wheel events in Session Management through the existing Up/Down navigation path
- preserve filtering, selection bounds, and focus synchronization behavior
- add regression coverage for scrolling the session selection in both directions

## Root cause
PR #478 disabled alternate-scroll so wheel input no longer became Up/Down keys. PR #506 later enabled explicit mouse capture, but only routed wheel events to the Chat view, leaving Session Management unhandled.

## Testing
- `cargo test --manifest-path tools/wta/Cargo.toml`
- `cargo test --manifest-path tools/wta/Cargo.toml mouse_wheel_moves_session_management_selection`

Fixes #513