### PR TITLE
Remove action proposal arming requirement

### DIFF
--- a/doc/specs/WTA-CLI-terminal-action-proposals.md
+++ b/doc/specs/WTA-CLI-terminal-action-proposals.md
@@ -37,7 +37,7 @@ payloads, correlate proposal results, or acknowledge cards.
 - Have the agent session execute one canonical command directly.
 - Route the short-lived CLI directly to the owning Helper.
 - Keep session, Helper, tab, window, and pane identifiers out of proposal JSON.
-- Reject wrong-Helper, stale-turn, unapproved, modified, and replayed requests.
+- Reject wrong-Helper, stale-turn, already-consumed, and replayed requests.
 - Give the agent immediate validation feedback and final user-decision feedback.
 - Preserve the existing Run, Insert, Open, Split, and Delegate card UI.
 - Preserve exactly one visible user confirmation before terminal mutation.
@@ -59,20 +59,20 @@ payloads, correlate proposal results, or acknowledge cards.
 1. Helper starts a turn and creates one opaque channel.
 2. Helper injects the channel and canonical invocation contract into the prompt.
 3. Agent emits the exact canonical WTA command with inline proposal JSON.
-4. Before executing it, the Agent CLI sends session/request_permission over ACP.
-5. Master routes that request by trusted ACP session ownership to the Helper.
-6. Helper parses the command before creating a Permission AppEvent.
-7. For an exact current-channel invocation, Helper records the payload digest,
-   moves the channel from Issued to Armed, and silently selects AllowOnce.
-8. Agent runs the short-lived WTA CLI.
-9. The CLI derives the per-Helper pipe from the opaque channel and connects
+4. If the Agent CLI sends session/request_permission before executing it,
+   master routes that request by trusted ACP session ownership to the Helper.
+5. Helper parses an exact current-channel invocation and silently selects
+   AllowOnce. Agents that execute without a permission callback use the same
+   proposal path without this optional preflight.
+6. Agent runs the short-lived WTA CLI.
+7. The CLI derives the per-Helper pipe from the opaque channel and connects
    directly to it.
-10. Helper verifies channel state, lease, turn freshness, and payload digest,
-    then atomically consumes the armed attempt.
-11. Helper validates the typed proposal and stages the existing card.
-12. CLI receives a validation response. If accepted, it remains connected.
-13. User confirms or cancels the card, or lifecycle invalidation ends the turn.
-14. CLI receives the final response and exits.
+8. Helper verifies channel ownership and turn freshness, then atomically
+   consumes the issued attempt.
+9. Helper validates the typed proposal and stages the existing card.
+10. CLI receives a validation response. If accepted, it remains connected.
+11. User confirms or cancels the card, or lifecycle invalidation ends the turn.
+12. CLI receives the final response and exits.
 ```
 
 The permission request still crosses master because that is part of the ACP
@@ -125,23 +125,22 @@ title.
 
 The permission request must describe one execute operation with a `command`
 field and a single-entry `commands` array containing the same canonical command.
-Agent adapters that emit another permission envelope fail arming and therefore
-surface their integration gap instead of falling back to Assistant text.
+Agent adapters that emit another permission envelope are silently cancelled,
+but adapters that execute without a permission callback can submit directly.
 
 Permission policy has three outcomes:
 
 | Input | Outcome |
 |---|---|
-| Exact canonical command for the current channel and compact JSON payload, with successful arming | Silently `AllowOnce` |
+| Exact canonical command for the current channel and compact JSON payload | Silently `AllowOnce` without changing proposal state |
 | Recognizable proposal command with unsafe or non-canonical syntax | Silently cancel |
 | Any unrelated command | Use the existing Permission UI |
 
-Returning `AllowOnce` and transitioning the channel to `Armed` are one
-indivisible permission outcome. If arming fails for any reason, including a
-different or stale channel, the Helper silently cancels the permission request
-and the Agent must not launch the CLI.
-`AllowAlways` is never selected because every proposal must pass through
-per-turn arming.
+If current-channel validation fails for any reason, including a different or
+stale channel, the Helper silently cancels the permission request. The
+permission callback is an optional compatibility preflight, not a prerequisite
+for proposal submission: some agents execute tool commands without emitting
+`request_permission`. `AllowAlways` is never selected.
 
 ## CLI contract
 
@@ -196,11 +195,8 @@ Validation statuses:
 - `accepted`
 - `unknown_channel`
 - `helper_mismatch`
-- `not_armed`
 - `stale`
 - `superseded`
-- `expired`
-- `digest_mismatch`
 - `already_consumed`
 - `invalid_schema`
 - `rejected`
@@ -211,7 +207,6 @@ Final statuses:
 - `confirmed`
 - `cancelled`
 - `superseded`
-- `session_replaced`
 - `timed_out`
 - `unavailable`
 
@@ -222,11 +217,9 @@ executor. It does not claim that a target shell command finished successfully.
 
 ```text
 Issued
-  -> Armed
   -> Validating
   -> AwaitingUser
-  -> Confirmed | Cancelled | Superseded | SessionReplaced
-                  | TimedOut | Unavailable
+  -> Confirmed | Cancelled | Superseded | TimedOut | Unavailable
 ```
 
 The Helper stores:
@@ -234,32 +227,28 @@ The Helper stores:
 ```text
 ProposalChannelManager
   helper_instance_id
-  session_epoch
   active_channel
   bounded_tombstones
 ```
 
-An active channel contains its nonce, session epoch, Helper-local prompt
-identity, state, retry count, optional digest, lease deadline, and optional
-pending final responder. It does not contain model-authored target identity.
+An active channel contains its nonce, trusted Helper-local binding, state,
+retry count, and optional pending final responder. The binding records the ACP
+session, prompt, active pane target, and autofix origin. None of these values
+come from the proposal payload.
 
 Before accepting a pipe request, the Helper checks in order:
 
 1. protocol version and frame limits;
 2. Helper instance encoded in the channel;
 3. active channel or bounded tombstone;
-4. channel state is `Armed`;
-5. 30-second armed lease has not expired;
-6. session epoch and prompt identity are still current;
-7. SHA-256 of the exact payload bytes matches the armed digest;
-8. atomic one-use transition to `Validating`;
-9. strict proposal schema and origin policy;
-10. trusted active target injection by App.
+4. channel state is `Issued`;
+5. atomic one-use transition to `Validating`;
+6. strict proposal schema and origin policy;
+7. trusted active target injection by App.
 
-After schema rejection, the channel returns to `Issued` and clears its digest.
-The agent may correct the payload, request permission again, and retry up to
-two times. An accepted proposal is one-use. Lifecycle and user-decision
-terminal states are not retryable.
+After a retryable schema rejection, the channel returns to `Issued`. The agent
+may correct the payload and retry up to two times. An accepted proposal is
+one-use. Lifecycle and user-decision terminal states are not retryable.
 
 ## Proposal schema and trusted target
 
@@ -288,44 +277,41 @@ The ownership hierarchy is:
 
 ```text
 Helper process
-  -> ACP session epoch
-     -> active turn channel
+  -> active turn channel
 ```
 
-Lifecycle transitions invalidate the channel before replacing the owning
-session or process:
+Implemented lifecycle transitions are:
 
 | Event | Result |
 |---|---|
 | New prompt in same session | Previous channel becomes `superseded`; issue a new channel |
-| `/stop` | In-flight channel becomes `cancelled` |
-| `/new` or load another session | Increment epoch; old channel becomes `session_replaced`; pipe remains |
-| `/restart` | Helper and pipe are destroyed; waiting clients become unavailable |
-| Pane stash/restore | Preserve Helper, pipe, session, channel, and card |
 | Card confirm | Atomically claim the live proposal, dispatch through the existing executor, then send `confirmed` |
 | Card cancel/dismiss | Send `cancelled` |
 | User-decision timeout | Send `timed_out` after 10 minutes |
 | ACP transport lost | Send `unavailable` and refuse new channels |
-| Tab/window close or Ctrl+C twice | Destroy Helper and pipe |
+| Helper pipe shutdown | Send `unavailable` and refuse new channels |
 
 The Helper retains at most four terminal tombstones for three minutes.
 Tombstones contain only a channel hash, terminal status, and timestamp. They
-improve errors for late clients without retaining payload, digest, or target
-data. They are not persisted.
+improve errors for late clients without retaining payload or target data. They
+are not persisted.
 
 ## Security model
 
-The channel is an unguessable, short-lived bearer handle. The per-user named
-pipe ACL, Helper-instance routing, per-turn nonce, ACP-session permission
-routing, payload digest, short armed lease, and one-use transition prevent
-normal cross-tab mistakes, stale turns, payload changes, and replay.
+The channel is an unguessable, per-turn bearer handle. The per-user named pipe
+ACL, Helper-instance routing, per-turn nonce, trusted Helper-local turn
+binding, and one-use transition prevent normal cross-tab mistakes, stale turns,
+and replay.
 
-The Helper-side permission decision is essential: knowing an issued channel is
-not enough to submit a proposal; the exact payload must first be armed through
-the owning ACP session.
+The Helper-side permission decision is optional. When present it confirms that
+the canonical command references the current channel owned by the requesting
+ACP session, but agents that do not emit a permission callback can submit the
+same one-use channel directly. The channel only proposes a visible card; it
+cannot mutate the terminal.
 
-A malicious process that can read the complete armed channel and exact payload
-from the agent process and race that process can still use the bearer handle.
+A malicious process that can read the complete issued channel from the agent
+process and race that process can still use the bearer handle to choose a
+schema-valid payload.
 The direct-pipe design does not claim process attestation. This residual risk
 is bounded because the CLI only proposes a visible card and user confirmation
 is still required before mutation.
@@ -339,13 +325,12 @@ proposal path.
 
 Automated and live coverage must include:
 
-- channel parsing, uniqueness, one-use, lease, retries, tombstones, and epochs;
+- channel parsing, uniqueness, one-use, retries, and tombstones;
 - canonical rendering/parsing, quoting, extra-token rejection, and auto-policy;
 - pipe framing, size limits, disconnects, and two-phase responses;
-- wrong Helper, wrong turn, stale, unarmed, digest mismatch, and replay;
+- wrong Helper, wrong turn, stale, direct submission without permission, and replay;
 - schema and origin policy validation with trusted target injection;
 - card confirm, cancel, supersede, timeout, and Helper shutdown;
-- `/stop`, `/new`, session load, `/restart`, stash/restore, tab/window close;
 - multi-tab and multi-window isolation;
 - no Permission UI for an exact canonical proposal;
 - Assistant JSON remains visible chat text and never surfaces a card;

--- a/tools/wta/src/agent_tools/action_proposal/channel.rs
+++ b/tools/wta/src/agent_tools/action_proposal/channel.rs
@@ -10,25 +10,9 @@ use uuid::Uuid;
 
 pub const CHANNEL_VERSION: &str = "v1";
 pub const PIPE_PREFIX: &str = r"\\.\pipe\IntelligentTerminal.Proposal.";
-
-#[derive(Debug, Clone, Copy)]
-pub struct ProposalChannelConfig {
-    pub armed_lease: Duration,
-    pub max_validation_retries: u8,
-    pub max_tombstones: usize,
-    pub tombstone_ttl: Duration,
-}
-
-impl Default for ProposalChannelConfig {
-    fn default() -> Self {
-        Self {
-            armed_lease: Duration::from_secs(30),
-            max_validation_retries: 2,
-            max_tombstones: 4,
-            tombstone_ttl: Duration::from_secs(3 * 60),
-        }
-    }
-}
+const MAX_VALIDATION_RETRIES: u8 = 2;
+const MAX_TOMBSTONES: usize = 4;
+const TOMBSTONE_TTL: Duration = Duration::from_secs(3 * 60);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ProposalChannel {
@@ -103,7 +87,6 @@ impl std::error::Error for ChannelParseError {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProposalBinding {
     pub session_id: String,
-    pub session_epoch: u64,
     pub prompt_id: u64,
     pub active_target: Option<String>,
     pub is_autofix: bool,
@@ -112,7 +95,6 @@ pub struct ProposalBinding {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProposalChannelState {
     Issued,
-    Armed,
     Validating,
     AwaitingUser,
 }
@@ -123,11 +105,8 @@ pub enum ProposalValidationStatus {
     Accepted,
     UnknownChannel,
     HelperMismatch,
-    NotArmed,
     Stale,
     Superseded,
-    Expired,
-    DigestMismatch,
     AlreadyConsumed,
     InvalidSchema,
     Rejected,
@@ -140,7 +119,6 @@ pub enum ProposalFinalStatus {
     Confirmed,
     Cancelled,
     Superseded,
-    SessionReplaced,
     TimedOut,
     Unavailable,
 }
@@ -155,7 +133,6 @@ pub struct ChannelFailure {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidationContext {
     pub proposal_id: String,
-    pub channel: ProposalChannel,
     pub binding: ProposalBinding,
 }
 
@@ -164,8 +141,6 @@ struct ActiveChannel {
     binding: ProposalBinding,
     state: ProposalChannelState,
     validation_retries: u8,
-    payload_digest: Option<[u8; 32]>,
-    armed_until: Option<Instant>,
     proposal_id: Option<String>,
     final_responder: Option<oneshot::Sender<ProposalFinalStatus>>,
 }
@@ -183,7 +158,6 @@ pub struct ConfirmationClaim {
 }
 
 struct ChannelState {
-    session_epoch: u64,
     pipe_available: bool,
     agent_transport_available: bool,
     active: Option<ActiveChannel>,
@@ -192,21 +166,14 @@ struct ChannelState {
 
 pub struct ProposalChannelManager {
     helper_instance_id: Uuid,
-    config: ProposalChannelConfig,
     state: Mutex<ChannelState>,
 }
 
 impl ProposalChannelManager {
     pub fn new() -> Self {
-        Self::with_config(ProposalChannelConfig::default())
-    }
-
-    fn with_config(config: ProposalChannelConfig) -> Self {
         Self {
             helper_instance_id: Uuid::new_v4(),
-            config,
             state: Mutex::new(ChannelState {
-                session_epoch: 0,
                 pipe_available: true,
                 agent_transport_available: true,
                 active: None,
@@ -241,26 +208,22 @@ impl ProposalChannelManager {
             channel: channel.clone(),
             binding: ProposalBinding {
                 session_id,
-                session_epoch: state.session_epoch,
                 prompt_id,
                 active_target,
                 is_autofix,
             },
             state: ProposalChannelState::Issued,
             validation_retries: 0,
-            payload_digest: None,
-            armed_until: None,
             proposal_id: None,
             final_responder: None,
         });
         Ok(channel)
     }
 
-    pub fn arm(
+    pub fn validate_permission(
         &self,
         session_id: &str,
         channel: &ProposalChannel,
-        payload: &[u8],
     ) -> Result<(), ChannelFailure> {
         let mut state = self.lock_state();
         self.prune_tombstones(&mut state);
@@ -272,15 +235,13 @@ impl ProposalChannelManager {
                 false,
             ));
         }
-        let session_epoch = state.session_epoch;
         let Some(active) = state.active.as_mut() else {
             return Err(self.inactive_failure(&state, channel));
         };
         if active.channel != *channel {
             return Err(self.inactive_failure(&state, channel));
         }
-        if active.binding.session_epoch != session_epoch || active.binding.session_id != session_id
-        {
+        if active.binding.session_id != session_id {
             return Err(failure(
                 ProposalValidationStatus::Stale,
                 "channel does not belong to the requesting ACP session",
@@ -290,25 +251,20 @@ impl ProposalChannelManager {
         if active.state != ProposalChannelState::Issued {
             return Err(failure(
                 ProposalValidationStatus::AlreadyConsumed,
-                "channel is already armed or consumed",
+                "channel is already being validated or awaiting the user",
                 false,
             ));
         }
-        active.payload_digest = Some(payload_digest(payload));
-        active.armed_until = Some(Instant::now() + self.config.armed_lease);
-        active.state = ProposalChannelState::Armed;
         Ok(())
     }
 
     pub fn begin_validation(
         &self,
         channel: &ProposalChannel,
-        payload: &[u8],
     ) -> Result<ValidationContext, ChannelFailure> {
         let mut state = self.lock_state();
         self.prune_tombstones(&mut state);
         self.ensure_local_channel(channel)?;
-        let session_epoch = state.session_epoch;
         let transport_available = state.pipe_available && state.agent_transport_available;
         let Some(active) = state.active.as_mut() else {
             return Err(self.inactive_failure(&state, channel));
@@ -323,54 +279,11 @@ impl ProposalChannelManager {
                 false,
             ));
         }
-        if active.binding.session_epoch != session_epoch {
+        if active.state != ProposalChannelState::Issued {
             return Err(failure(
-                ProposalValidationStatus::Stale,
-                "channel belongs to a replaced session",
+                ProposalValidationStatus::AlreadyConsumed,
+                "channel is already being validated or awaiting the user",
                 false,
-            ));
-        }
-        if active.state != ProposalChannelState::Armed {
-            let (status, reason) = if active.state == ProposalChannelState::Issued {
-                (
-                    ProposalValidationStatus::NotArmed,
-                    "channel was not approved for this payload",
-                )
-            } else {
-                (
-                    ProposalValidationStatus::AlreadyConsumed,
-                    "channel is already being validated or awaiting the user",
-                )
-            };
-            return Err(failure(status, reason, false));
-        }
-        if active
-            .armed_until
-            .is_none_or(|deadline| deadline <= Instant::now())
-        {
-            active.state = ProposalChannelState::Issued;
-            active.payload_digest = None;
-            active.armed_until = None;
-            return Err(failure(
-                ProposalValidationStatus::Expired,
-                "channel approval lease expired",
-                true,
-            ));
-        }
-        if active.payload_digest != Some(payload_digest(payload)) {
-            active.validation_retries = active.validation_retries.saturating_add(1);
-            let can_retry = active.validation_retries <= self.config.max_validation_retries;
-            if can_retry {
-                active.state = ProposalChannelState::Issued;
-                active.payload_digest = None;
-                active.armed_until = None;
-            } else {
-                self.invalidate_active(&mut state, ProposalFinalStatus::Cancelled);
-            }
-            return Err(failure(
-                ProposalValidationStatus::DigestMismatch,
-                "payload differs from the approved command",
-                can_retry,
             ));
         }
         let proposal_id = Uuid::new_v4().to_string();
@@ -378,7 +291,6 @@ impl ProposalChannelManager {
         active.proposal_id = Some(proposal_id.clone());
         Ok(ValidationContext {
             proposal_id,
-            channel: active.channel.clone(),
             binding: active.binding.clone(),
         })
     }
@@ -413,12 +325,9 @@ impl ProposalChannelManager {
             return false;
         }
         active.validation_retries = active.validation_retries.saturating_add(1);
-        let can_retry =
-            retryable && active.validation_retries <= self.config.max_validation_retries;
+        let can_retry = retryable && active.validation_retries <= MAX_VALIDATION_RETRIES;
         if can_retry {
             active.state = ProposalChannelState::Issued;
-            active.payload_digest = None;
-            active.armed_until = None;
             active.proposal_id = None;
         } else {
             self.invalidate_active(&mut state, ProposalFinalStatus::Cancelled);
@@ -485,17 +394,6 @@ impl ProposalChannelManager {
         true
     }
 
-    pub fn replace_session(&self) {
-        let mut state = self.lock_state();
-        self.invalidate_active(&mut state, ProposalFinalStatus::SessionReplaced);
-        state.session_epoch = state.session_epoch.wrapping_add(1);
-    }
-
-    pub fn cancel_active(&self) {
-        let mut state = self.lock_state();
-        self.invalidate_active(&mut state, ProposalFinalStatus::Cancelled);
-    }
-
     pub fn set_pipe_available(&self, available: bool) {
         let mut state = self.lock_state();
         if !available {
@@ -541,10 +439,6 @@ impl ProposalChannelManager {
                     ProposalValidationStatus::Superseded,
                     "channel was superseded by a newer turn",
                 ),
-                Some(ProposalFinalStatus::SessionReplaced) => (
-                    ProposalValidationStatus::Stale,
-                    "channel belongs to a replaced session",
-                ),
                 None | Some(ProposalFinalStatus::Unavailable) => (
                     ProposalValidationStatus::Unavailable,
                     "owning Helper became unavailable",
@@ -581,11 +475,11 @@ impl ProposalChannelManager {
     fn prune_tombstones(&self, state: &mut ChannelState) {
         let now = Instant::now();
         while state.tombstones.front().is_some_and(|item| {
-            now.saturating_duration_since(item.created_at) >= self.config.tombstone_ttl
+            now.saturating_duration_since(item.created_at) >= TOMBSTONE_TTL
         }) {
             state.tombstones.pop_front();
         }
-        while state.tombstones.len() > self.config.max_tombstones {
+        while state.tombstones.len() > MAX_TOMBSTONES {
             state.tombstones.pop_front();
         }
     }
@@ -603,12 +497,8 @@ impl Default for ProposalChannelManager {
     }
 }
 
-fn payload_digest(payload: &[u8]) -> [u8; 32] {
-    Sha256::digest(payload).into()
-}
-
 fn channel_hash(channel: &ProposalChannel) -> [u8; 32] {
-    payload_digest(channel.to_string().as_bytes())
+    Sha256::digest(channel.to_string().as_bytes()).into()
 }
 
 fn failure(
@@ -627,18 +517,9 @@ fn failure(
 mod tests {
     use super::*;
 
-    fn manager() -> ProposalChannelManager {
-        ProposalChannelManager::with_config(ProposalChannelConfig {
-            armed_lease: Duration::from_secs(30),
-            max_validation_retries: 2,
-            max_tombstones: 4,
-            tombstone_ttl: Duration::from_secs(180),
-        })
-    }
-
     #[test]
     fn channel_round_trips_and_derives_pipe() {
-        let manager = manager();
+        let manager = ProposalChannelManager::new();
         let channel = manager
             .issue("session".into(), 7, Some("pane".into()), false)
             .unwrap();
@@ -650,7 +531,7 @@ mod tests {
 
     #[test]
     fn channel_parser_rejects_noncanonical_forms() {
-        let manager = manager();
+        let manager = ProposalChannelManager::new();
         let channel = manager
             .issue("session".into(), 1, None, false)
             .unwrap()
@@ -669,20 +550,10 @@ mod tests {
     }
 
     #[test]
-    fn validation_requires_matching_permission_digest() {
-        let manager = manager();
+    fn validation_accepts_current_channel_without_permission() {
+        let manager = ProposalChannelManager::new();
         let channel = manager.issue("session".into(), 1, None, false).unwrap();
-        let unarmed = manager.begin_validation(&channel, b"payload").unwrap_err();
-        assert_eq!(unarmed.status, ProposalValidationStatus::NotArmed);
-
-        manager.arm("session", &channel, b"payload").unwrap();
-        let mismatch = manager.begin_validation(&channel, b"changed").unwrap_err();
-        assert_eq!(mismatch.status, ProposalValidationStatus::DigestMismatch);
-        assert!(mismatch.retryable);
-        assert_eq!(manager.active_state(), Some(ProposalChannelState::Issued));
-
-        manager.arm("session", &channel, b"payload").unwrap();
-        let context = manager.begin_validation(&channel, b"payload").unwrap();
+        let context = manager.begin_validation(&channel).unwrap();
         assert_eq!(context.binding.prompt_id, 1);
         assert_eq!(
             manager.active_state(),
@@ -692,10 +563,9 @@ mod tests {
 
     #[test]
     fn accepted_proposal_resolves_waiting_cli() {
-        let manager = manager();
+        let manager = ProposalChannelManager::new();
         let channel = manager.issue("session".into(), 1, None, false).unwrap();
-        manager.arm("session", &channel, b"payload").unwrap();
-        let context = manager.begin_validation(&channel, b"payload").unwrap();
+        let context = manager.begin_validation(&channel).unwrap();
         let (tx, rx) = oneshot::channel();
         assert!(manager.accept_validation(&context.proposal_id, tx));
         assert!(manager.resolve_final(&context.proposal_id, ProposalFinalStatus::Confirmed));
@@ -704,51 +574,35 @@ mod tests {
 
     #[test]
     fn newer_turn_supersedes_old_channel() {
-        let manager = manager();
+        let manager = ProposalChannelManager::new();
         let old = manager.issue("session".into(), 1, None, false).unwrap();
         let _new = manager.issue("session".into(), 2, None, false).unwrap();
-        let failure = manager.begin_validation(&old, b"payload").unwrap_err();
+        let failure = manager.begin_validation(&old).unwrap_err();
         assert_eq!(failure.status, ProposalValidationStatus::Superseded);
     }
 
     #[test]
     fn schema_retry_returns_channel_to_issued() {
-        let manager = manager();
+        let manager = ProposalChannelManager::new();
         let channel = manager.issue("session".into(), 1, None, false).unwrap();
-        manager.arm("session", &channel, b"bad").unwrap();
-        let context = manager.begin_validation(&channel, b"bad").unwrap();
+        let context = manager.begin_validation(&channel).unwrap();
         assert!(manager.reject_validation(&context.proposal_id, true));
         assert_eq!(manager.active_state(), Some(ProposalChannelState::Issued));
-        manager.arm("session", &channel, b"fixed").unwrap();
-        assert!(manager.begin_validation(&channel, b"fixed").is_ok());
+        assert!(manager.begin_validation(&channel).is_ok());
     }
 
     #[test]
-    fn session_replacement_returns_stale_tombstone() {
-        let manager = manager();
+    fn permission_validation_does_not_gate_or_consume_submission() {
+        let manager = ProposalChannelManager::new();
         let channel = manager.issue("session".into(), 1, None, false).unwrap();
-        manager.replace_session();
-        let failure = manager.begin_validation(&channel, b"payload").unwrap_err();
-        assert_eq!(failure.status, ProposalValidationStatus::Stale);
-    }
-
-    #[test]
-    fn expired_arm_can_be_approved_again() {
-        let manager = ProposalChannelManager::with_config(ProposalChannelConfig {
-            armed_lease: Duration::ZERO,
-            ..ProposalChannelConfig::default()
-        });
-        let channel = manager.issue("session".into(), 1, None, false).unwrap();
-        manager.arm("session", &channel, b"payload").unwrap();
-        let failure = manager.begin_validation(&channel, b"payload").unwrap_err();
-        assert_eq!(failure.status, ProposalValidationStatus::Expired);
-        assert!(failure.retryable);
+        manager.validate_permission("session", &channel).unwrap();
         assert_eq!(manager.active_state(), Some(ProposalChannelState::Issued));
+        assert!(manager.begin_validation(&channel).is_ok());
     }
 
     #[test]
     fn agent_reconnect_does_not_revive_failed_pipe() {
-        let manager = manager();
+        let manager = ProposalChannelManager::new();
         manager.set_pipe_available(false);
         manager.set_agent_transport_available(false);
         manager.set_agent_transport_available(true);
@@ -759,7 +613,7 @@ mod tests {
 
     #[test]
     fn agent_reconnect_restores_channels_when_pipe_is_live() {
-        let manager = manager();
+        let manager = ProposalChannelManager::new();
         manager.set_agent_transport_available(false);
         assert!(manager.issue("session".into(), 1, None, false).is_err());
 

--- a/tools/wta/src/agent_tools/action_proposal/pipe.rs
+++ b/tools/wta/src/agent_tools/action_proposal/pipe.rs
@@ -177,7 +177,7 @@ async fn serve_connection(
             .await;
         }
     };
-    let context = match manager.begin_validation(&channel, request.payload.as_bytes()) {
+    let context = match manager.begin_validation(&channel) {
         Ok(context) => context,
         Err(failure) => {
             return write_validation_failure(
@@ -432,14 +432,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn named_pipe_round_trip_returns_validation_then_final_status() {
+    async fn named_pipe_round_trip_without_permission_returns_both_phases() {
         let manager = Arc::new(ProposalChannelManager::new());
         let payload = r#"{"schema_version":1,"origin":"terminal_agent","choices":[{"choice":1,"title":"run","rationale":"","actions":[{"type":"send","input":"echo ok"}]}]}"#;
         let channel = manager
             .issue("session".to_string(), 1, None, false)
-            .unwrap();
-        manager
-            .arm("session", &channel, payload.as_bytes())
             .unwrap();
         let pipe_name = manager.pipe_name();
         let security = super::super::pipe_security::build_required().unwrap();

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -7578,16 +7578,7 @@ fn stage_direct_proposal(
             false,
         )
         .unwrap();
-    manager
-        .arm(
-            session_id,
-            &channel,
-            TERMINAL_AGENT_PROPOSAL_PAYLOAD.as_bytes(),
-        )
-        .unwrap();
-    let context = manager
-        .begin_validation(&channel, TERMINAL_AGENT_PROPOSAL_PAYLOAD.as_bytes())
-        .unwrap();
+    let context = manager.begin_validation(&channel).unwrap();
     let proposal_id = context.proposal_id.clone();
     let (decision_tx, decision_rx) = tokio::sync::oneshot::channel();
     app.handle_event(AppEvent::DirectTerminalActionProposal {

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -733,22 +733,21 @@ impl WtaClient {
                             acp::schema::v1::RequestPermissionOutcome::Cancelled,
                         ));
                     };
-                    let arm_result = self.state.proposal_channels.arm(
-                        &session_id,
-                        &invocation.channel,
-                        invocation.payload.as_bytes(),
-                    );
+                    let permission_result = self
+                        .state
+                        .proposal_channels
+                        .validate_permission(&session_id, &invocation.channel);
                     tracing::info!(
                         target: "proposal_permission",
                         session_id = %session_id,
-                        armed = arm_result.is_ok(),
-                        status = ?arm_result.as_ref().err().map(|failure| failure.status),
+                        approved = permission_result.is_ok(),
+                        status = ?permission_result.as_ref().err().map(|failure| failure.status),
                         "silently resolving canonical proposal permission"
                     );
-                    if arm_result.is_err() {
+                    if permission_result.is_err() {
                         self.state
                             .prompt_timing
-                            .permission_resolved(&session_id, "proposal_arm_failed");
+                            .permission_resolved(&session_id, "proposal_permission_rejected");
                         return Ok(acp::schema::v1::RequestPermissionResponse::new(
                             acp::schema::v1::RequestPermissionOutcome::Cancelled,
                         ));
@@ -3472,7 +3471,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn canonical_proposal_permission_is_silent_and_arms_payload() {
+    async fn canonical_proposal_permission_is_silent_and_does_not_gate_submission() {
         let manager =
             Arc::new(crate::agent_tools::action_proposal::channel::ProposalChannelManager::new());
         let payload = r#"{"schema_version":1,"origin":"terminal_agent","choices":[{"choice":1,"title":"run test","rationale":"","actions":[{"type":"send","input":"cargo test"}]}]}"#;
@@ -3497,13 +3496,11 @@ mod tests {
             Ok(AppEvent::HideToolCall { session_id, id })
                 if session_id == "proposal-session" && id == "proposal-tool"
         ));
-        assert!(manager
-            .begin_validation(&channel, payload.as_bytes())
-            .is_ok());
+        assert!(manager.begin_validation(&channel).is_ok());
     }
 
     #[tokio::test]
-    async fn canonical_proposal_permission_is_cancelled_when_arming_fails() {
+    async fn canonical_proposal_permission_is_cancelled_for_another_session() {
         let manager =
             Arc::new(crate::agent_tools::action_proposal::channel::ProposalChannelManager::new());
         let payload = r#"{"schema_version":1,"origin":"terminal_agent","choices":[{"choice":1,"title":"run test","rationale":"","actions":[{"type":"send","input":"cargo test"}]}]}"#;
@@ -3527,13 +3524,7 @@ mod tests {
             event_rx.try_recv(),
             Ok(AppEvent::HideToolCall { .. })
         ));
-        assert_eq!(
-            manager
-                .begin_validation(&channel, payload.as_bytes())
-                .unwrap_err()
-                .status,
-            crate::agent_tools::action_proposal::channel::ProposalValidationStatus::NotArmed
-        );
+        assert!(manager.begin_validation(&channel).is_ok());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- allow action proposals to move directly from `Issued` to validation without an ACP permission callback
- preserve silent canonical permission validation when an agent emits `request_permission`
- remove obsolete arming, payload digest, lease, session epoch, and session replacement state
- align tests and the action proposal specification with the simplified lifecycle

## Testing
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools\wta\Cargo.toml`
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools\wta\Cargo.toml --quiet`