### PR TITLE
fix(wta): isolate agent state updates by tab

### DIFF
--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -1580,8 +1580,8 @@ impl App {
                 // so multi-window setups don't cross-talk. When window_id
                 // is unknown on either side we apply (best-effort fallback).
                 //
-                // Processed BEFORE the own-pane skip below: this is a
-                // global UI command, not a per-pane signal.
+                // Processed BEFORE the own-pane skip below: this command
+                // is routed by the target tab rather than the source pane.
                 if method == "set_agent_state" {
                     let target_window = params
                         .get("window_id")
@@ -1611,6 +1611,18 @@ impl App {
                         .and_then(|v| v.as_str())
                         .map(|s| s.to_string())
                         .unwrap_or_else(|| self.active_tab_key().to_string());
+
+                    if let Some(owner) = self.owner_tab_id.as_deref() {
+                        if owner != target_tab {
+                            tracing::debug!(
+                                target: "set_agent_state",
+                                owner,
+                                tab = %target_tab,
+                                "ignoring set_agent_state for non-owner tab"
+                            );
+                            return;
+                        }
+                    }
 
                     // Apply `view` if present.
                     if let Some(view_str) = params.get("view").and_then(|v| v.as_str()) {

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -1317,6 +1317,33 @@ fn load_session_passes_through_when_owner_tab_id_unset() {
     assert_eq!(req.session_id, "sess-legacy");
 }
 
+#[test]
+fn set_agent_state_ignored_when_target_tab_differs_from_owner() {
+    let mut app = test_app();
+    app.owner_tab_id = Some("OWNER-TAB".to_string());
+    app.tab_id = Some("OWNER-TAB".to_string());
+    app.tab_sessions
+        .insert("OWNER-TAB".to_string(), TabSession::default());
+
+    app.handle_event(AppEvent::WtEvent {
+        method: "set_agent_state".to_string(),
+        pane_id: String::new(),
+        tab_id: None,
+        params: json!({
+            "tab_id": "OTHER-TAB",
+            "view": "sessions",
+            "pane_open": true,
+        }),
+    });
+
+    assert!(
+        !app.tab_sessions.contains_key("OTHER-TAB"),
+        "non-owner helper must not create state or echo usage for another tab"
+    );
+    assert_eq!(app.tab_sessions["OWNER-TAB"].current_view, View::Chat);
+    assert!(!app.tab_sessions["OWNER-TAB"].pane_open);
+}
+
 // ─── SessionAttached load-target gating (Plan-C race fix) ───────────────
 
 /// After a load_session sets the replay window open, an unrelated


### PR DESCRIPTION
## Summary of the Pull Request
This is a fix regarding the issue where the display of usage/cost were messed up after switching to another terminal tab then switching back.

## Repro steps
1. Enable **Show context usage and session cost**.
1. In Tab A, send a prompt and wait for usage to appear.
1. Open and switch to Tab B.
1. Return to Tab A.
1. Move to **Show sessions**, then back to open **Toggle agent chat pane**.
1. Usage may disappear.

## Detailed Description of the Pull Request / Additional comments
Root cause: Filters `set_agent_state` by `owner_tab_id` before mutating or projecting tab state. This prevents non-owner helpers from overwriting another tab’s view, pane visibility, position, or usage/cost.

## Validation Steps Performed
- Added a regression test.
- Manually verified the fix

## PR Checklist
- [ ] Closes #xxx
- [x] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
