### PR TITLE
Fix per-tab agent pane position routing

### DIFF
--- a/src/cascadia/TerminalApp/AgentPaneContent.cpp
+++ b/src/cascadia/TerminalApp/AgentPaneContent.cpp
@@ -292,8 +292,6 @@ namespace winrt::TerminalApp::implementation
         {
             impl->UpdateSettings(settings);
         }
-        // Re-pick up the pane position in case settings changed it.
-        SetAgentPanePosition(settings.GlobalSettings().AgentPanePosition());
     }
 
     winrt::Windows::Foundation::Size AgentPaneContent::MinimumSize()

--- a/src/cascadia/TerminalApp/AgentPaneContent.h
+++ b/src/cascadia/TerminalApp/AgentPaneContent.h
@@ -165,8 +165,9 @@ namespace winrt::TerminalApp::implementation
         winrt::hstring _suggestionTitle{};
         winrt::hstring _detectedSummary{};
         std::vector<::TerminalApp::AgentUsage::Item> _agentUsage;
-        // Current AgentPanePosition for icon orientation. Set by
-        // TerminalPage on creation + on settings change.
+        // Effective per-tab AgentPanePosition for icon orientation.
+        // TerminalPage updates it from the Tab runtime override or global
+        // fallback; generic settings propagation must not overwrite it.
         winrt::hstring _agentPanePosition{ L"bottom" };
 
         // Source-tab StableId stashed during a cross-window agent-pane drag

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -122,6 +122,15 @@ namespace winrt::TerminalApp::implementation
         bool RestoreStashedAgentPane(winrt::Microsoft::Terminal::Settings::Model::SplitDirection direction);
         bool HasStashedAgentPane() const;
 
+        // Runtime-only position selected by `/move`. A missing override means
+        // this tab follows the global AgentPanePosition setting.
+        void AgentPanePositionOverride(std::optional<winrt::hstring> value) { _agentPanePositionOverride = std::move(value); }
+        const std::optional<winrt::hstring>& AgentPanePositionOverride() const noexcept { return _agentPanePositionOverride; }
+        winrt::hstring EffectiveAgentPanePosition(const winrt::hstring& globalPosition) const
+        {
+            return _agentPanePositionOverride.value_or(globalPosition);
+        }
+
         // Override which pane in this tab shows the blue "Agent" chip. Pass
         // a session GUID to pin the chip onto that pane (e.g. while a Send
         // recommendation is selected). Pass std::nullopt to revert to the
@@ -248,6 +257,8 @@ namespace winrt::TerminalApp::implementation
         // a Send-card selected in the agent pane). When unset, the chip
         // falls back to following each pane's IsSourceOfAgentPane() flag.
         std::optional<winrt::guid> _agentChipOverride{};
+
+        std::optional<winrt::hstring> _agentPanePositionOverride{};
 
         // Per-tab agent override (runtime-only). Empty id = follow global.
         winrt::hstring _agentIdOverride{};

--- a/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
@@ -798,7 +798,8 @@ namespace winrt::TerminalApp::implementation
             // actually receives focus.
             if (foundPane->IsHidden())
             {
-                const auto splitDir = _AgentPanePositionToSplitDirection(_settings.GlobalSettings().AgentPanePosition());
+                const auto splitDir = _AgentPanePositionToSplitDirection(
+                    tabImpl->EffectiveAgentPanePosition(_settings.GlobalSettings().AgentPanePosition()));
                 if (tabImpl->RestoreStashedAgentPane(splitDir))
                 {
                     // Mirror the unstash to wta so wta's tab.pane_open

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -919,6 +919,11 @@ namespace winrt::TerminalApp::implementation
         return SplitDirection::Right;
     }
 
+    winrt::hstring TerminalPage::_AgentPanePositionToContentPosition(const winrt::hstring& position)
+    {
+        return position == L"up" ? winrt::hstring{ L"top" } : position;
+    }
+
     // ── First-run experience ──────────────────────────────────────────────
 
     bool TerminalPage::_IsFreRequired() const
@@ -1046,7 +1051,7 @@ namespace winrt::TerminalApp::implementation
                 }
                 if (const auto agentContent = tabImpl->FindAgentPaneContent())
                 {
-                    agentContent.SetAgentPanePosition(position);
+                    agentContent.SetAgentPanePosition(_AgentPanePositionToContentPosition(position));
                 }
             }
         }
@@ -2456,8 +2461,7 @@ namespace winrt::TerminalApp::implementation
         if (const auto agentContent = newPane->GetContent().try_as<winrt::TerminalApp::AgentPaneContent>())
         {
             _WireAgentPaneEvents(agentContent, tab);
-            agentContent.SetAgentPanePosition(
-                panePosition == L"up" ? winrt::hstring{ L"top" } : panePosition);
+            agentContent.SetAgentPanePosition(_AgentPanePositionToContentPosition(panePosition));
         }
 
         {
@@ -5184,11 +5188,7 @@ namespace winrt::TerminalApp::implementation
             }
             if (const auto agentContent = targetTab->FindAgentPaneContent())
             {
-                // AgentPaneContent uses the settings spelling "top" for Up.
-                const auto contentPosition = panePosition == L"up" ?
-                                                 winrt::hstring{ L"top" } :
-                                                 panePosition;
-                agentContent.SetAgentPanePosition(contentPosition);
+                agentContent.SetAgentPanePosition(_AgentPanePositionToContentPosition(panePosition));
 
                 // RepositionAgentPane rebuilds the split's XAML visual tree,
                 // which clears focus. `/move` originates in this TermControl,

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1029,17 +1029,17 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
-    // Repositions agent panes (one per tab) to match the current
-    // AgentPanePosition setting. Walks every tab in this window.
+    // Repositions agent panes (one per tab) to match each tab's runtime
+    // override or the global AgentPanePosition fallback.
     void TerminalPage::_RepositionAgentPanes()
     {
-        const auto splitDirection = _AgentPanePositionToSplitDirection(
-            _settings.GlobalSettings().AgentPanePosition());
-        const auto position = _settings.GlobalSettings().AgentPanePosition();
+        const auto globalPosition = _settings.GlobalSettings().AgentPanePosition();
         for (const auto& tab : _tabs)
         {
             if (auto tabImpl = _GetTabImpl(tab))
             {
+                const auto position = tabImpl->EffectiveAgentPanePosition(globalPosition);
+                const auto splitDirection = _AgentPanePositionToSplitDirection(position);
                 if (const auto rootPane = tabImpl->GetRootPane())
                 {
                     rootPane->RepositionAgentPane(splitDirection);
@@ -2448,6 +2448,7 @@ namespace winrt::TerminalApp::implementation
         }
         auto newPane = _WrapInAgentPaneContent(rawPane);
         newPane->IsAgentPane(true);
+        const auto panePosition = tab->EffectiveAgentPanePosition(globals.AgentPanePosition());
 
         // Wire the AgentPaneContent's bottom-bar click events to the page
         // so toolbar buttons drive the per-tab logic. We need the tab
@@ -2455,7 +2456,8 @@ namespace winrt::TerminalApp::implementation
         if (const auto agentContent = newPane->GetContent().try_as<winrt::TerminalApp::AgentPaneContent>())
         {
             _WireAgentPaneEvents(agentContent, tab);
-            agentContent.SetAgentPanePosition(globals.AgentPanePosition());
+            agentContent.SetAgentPanePosition(
+                panePosition == L"up" ? winrt::hstring{ L"top" } : panePosition);
         }
 
         {
@@ -2473,7 +2475,7 @@ namespace winrt::TerminalApp::implementation
         // scope_exit so a successful return doesn't double-release.
         sharedAcquired.release();
 
-        const auto splitDirection = _AgentPanePositionToSplitDirection(globals.AgentPanePosition());
+        const auto splitDirection = _AgentPanePositionToSplitDirection(panePosition);
         tab->SplitPaneAtRoot(splitDirection, newPane);
 
         if (autoStash)
@@ -2861,7 +2863,10 @@ namespace winrt::TerminalApp::implementation
 
         // Swap the toggle icon to match the current pane position.
         {
-            const auto position = _settings ? _settings.GlobalSettings().AgentPanePosition() : winrt::hstring{ L"bottom" };
+            const auto globalPosition = _settings ? _settings.GlobalSettings().AgentPanePosition() : winrt::hstring{ L"bottom" };
+            const auto position = focusedTabImpl ?
+                                      focusedTabImpl->EffectiveAgentPanePosition(globalPosition) :
+                                      globalPosition;
             const bool isVertical = (position == L"right" || position == L"left");
             if (auto iconBottom = AgentToggleIconBottom())
                 iconBottom.Visibility(isVertical ? Visibility::Collapsed : Visibility::Visible);
@@ -3411,7 +3416,8 @@ namespace winrt::TerminalApp::implementation
             if (existingPane->IsHidden())
             {
                 _agentPaneLog("found stashed agent pane on focused tab — unstashing locally + notifying wta");
-                const auto splitDir = _AgentPanePositionToSplitDirection(_settings.GlobalSettings().AgentPanePosition());
+                const auto splitDir = _AgentPanePositionToSplitDirection(
+                    focusedTab->EffectiveAgentPanePosition(_settings.GlobalSettings().AgentPanePosition()));
                 focusedTab->RestoreStashedAgentPane(splitDir);
                 // ALWAYS specify view on unstash. If we left it `nullopt`,
                 // wta would echo back its stored view (which is whatever
@@ -5049,7 +5055,8 @@ namespace winrt::TerminalApp::implementation
             view = params["view"].asString();
             logSuffix += " view=" + *view;
         }
-        std::optional<winrt::hstring> panePosition;
+        bool panePositionSpecified = false;
+        std::optional<winrt::hstring> panePositionOverride;
         if (params.isMember("pane_position"))
         {
             if (params["pane_position"].isString())
@@ -5058,14 +5065,14 @@ namespace winrt::TerminalApp::implementation
                 if (requested == L"left" || requested == L"right" ||
                     requested == L"up" || requested == L"bottom")
                 {
-                    panePosition = requested;
+                    panePositionSpecified = true;
+                    panePositionOverride = requested;
                     logSuffix += " pane_position=" + winrt::to_string(requested);
                 }
             }
             else if (params["pane_position"].isNull())
             {
-                panePosition = _settings.GlobalSettings().AgentPanePosition();
-                logSuffix += " pane_position=global";
+                logSuffix += " pane_position=unchanged";
             }
         }
         std::optional<Json::Value> usage;
@@ -5078,6 +5085,14 @@ namespace winrt::TerminalApp::implementation
                                             " usage=invalid";
         }
         _agentPaneLog(std::string{ "OnAgentStateChanged:" } + logSuffix);
+
+        // Cache the WTA-owned runtime override on the Tab before applying
+        // pane_open. Creation and restoration below must use the position
+        // carried by this same snapshot, not the global fallback.
+        if (panePositionSpecified)
+        {
+            targetTab->AgentPanePositionOverride(panePositionOverride);
+        }
 
         // Apply view to the existing AgentPaneContent if any.
         if (view.has_value())
@@ -5104,7 +5119,8 @@ namespace winrt::TerminalApp::implementation
             {
                 if (targetTab->HasStashedAgentPane())
                 {
-                    const auto splitDir = _AgentPanePositionToSplitDirection(_settings.GlobalSettings().AgentPanePosition());
+                    const auto splitDir = _AgentPanePositionToSplitDirection(
+                        targetTab->EffectiveAgentPanePosition(_settings.GlobalSettings().AgentPanePosition()));
                     targetTab->RestoreStashedAgentPane(splitDir);
                 }
                 else if (!targetTab->FindAgentPane())
@@ -5147,11 +5163,13 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        // Apply the per-tab `/move` override, or reset this tab to the global
-        // position when WTA explicitly sends null. Never mutate GlobalSettings
-        // or walk the other tabs.
-        if (panePosition.has_value())
+        // Apply a per-tab `/move` override. A null projection means WTA has no
+        // override to contribute; it must not erase the Tab's runtime mirror
+        // after a helper restart. Never mutate GlobalSettings or other tabs.
+        if (panePositionSpecified)
         {
+            const auto panePosition = targetTab->EffectiveAgentPanePosition(
+                _settings.GlobalSettings().AgentPanePosition());
             const auto agentPane = targetTab->FindAgentPane();
             const auto focusedTab = _GetFocusedTabImpl();
             const bool restoreAgentFocus = agentPane &&
@@ -5162,14 +5180,14 @@ namespace winrt::TerminalApp::implementation
             bool repositioned = false;
             if (const auto rootPane = targetTab->GetRootPane())
             {
-                repositioned = rootPane->RepositionAgentPane(_AgentPanePositionToSplitDirection(*panePosition));
+                repositioned = rootPane->RepositionAgentPane(_AgentPanePositionToSplitDirection(panePosition));
             }
             if (const auto agentContent = targetTab->FindAgentPaneContent())
             {
                 // AgentPaneContent uses the settings spelling "top" for Up.
-                const auto contentPosition = *panePosition == L"up" ?
+                const auto contentPosition = panePosition == L"up" ?
                                                  winrt::hstring{ L"top" } :
-                                                 *panePosition;
+                                                 panePosition;
                 agentContent.SetAgentPanePosition(contentPosition);
 
                 // RepositionAgentPane rebuilds the split's XAML visual tree,

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -813,6 +813,7 @@ namespace winrt::TerminalApp::implementation
         void _FocusAgentPane();
         void _RepositionAgentPanes();
         static winrt::Microsoft::Terminal::Settings::Model::SplitDirection _AgentPanePositionToSplitDirection(const winrt::hstring& position);
+        static winrt::hstring _AgentPanePositionToContentPosition(const winrt::hstring& position);
 
         // First-run experience
         bool _IsFreRequired() const;

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -1612,6 +1612,23 @@ impl App {
                         .map(|s| s.to_string())
                         .unwrap_or_else(|| self.active_tab_key().to_string());
 
+                    // WT protocol events are window broadcasts, while each
+                    // helper owns exactly one tab. A non-owner must not
+                    // materialize a default TabSession for the target and
+                    // project it back: that races the owner's real snapshot
+                    // (notably pane_position=left vs. default null/global).
+                    if let Some(owner) = self.owner_tab_id.as_deref() {
+                        if owner != target_tab {
+                            tracing::debug!(
+                                target: "set_agent_state",
+                                owner,
+                                target_tab,
+                                "ignoring set_agent_state for non-owner tab"
+                            );
+                            return;
+                        }
+                    }
+
                     // Apply `view` if present.
                     if let Some(view_str) = params.get("view").and_then(|v| v.as_str()) {
                         tracing::info!(

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -1379,6 +1379,63 @@ fn session_attached_for_bootstrap_does_not_close_load_replay_window() {
     );
 }
 
+#[test]
+fn set_agent_state_ignored_when_target_tab_differs_from_owner() {
+    let mut app = test_app();
+    app.window_id = Some("window-1".into());
+    app.owner_tab_id = Some("owner-tab".into());
+    app.tab_id = Some("owner-tab".into());
+    app.tab_mut("owner-tab").agent_pane_position = Some("left");
+
+    app.handle_event(AppEvent::WtEvent {
+        method: "set_agent_state".into(),
+        pane_id: String::new(),
+        tab_id: None,
+        params: json!({
+            "window_id": "window-1",
+            "tab_id": "other-tab",
+            "pane_open": true,
+        }),
+    });
+
+    assert!(
+        !app.tab_sessions.contains_key("other-tab"),
+        "a non-owner helper must not create or project a default TabSession"
+    );
+    assert_eq!(
+        app.tab_sessions["owner-tab"].agent_pane_position,
+        Some("left")
+    );
+}
+
+#[test]
+fn set_agent_state_preserves_owner_pane_position() {
+    let mut app = test_app();
+    app.window_id = Some("window-1".into());
+    app.owner_tab_id = Some("owner-tab".into());
+    app.tab_id = Some("owner-tab".into());
+    {
+        let tab = app.tab_mut("owner-tab");
+        tab.agent_pane_position = Some("left");
+        tab.pane_open = false;
+    }
+
+    app.handle_event(AppEvent::WtEvent {
+        method: "set_agent_state".into(),
+        pane_id: String::new(),
+        tab_id: None,
+        params: json!({
+            "window_id": "window-1",
+            "tab_id": "owner-tab",
+            "pane_open": true,
+        }),
+    });
+
+    let tab = &app.tab_sessions["owner-tab"];
+    assert!(tab.pane_open);
+    assert_eq!(tab.agent_pane_position, Some("left"));
+}
+
 /// SessionAttached for the actual load target DOES close the window
 /// (the normal happy path — keep working).
 #[test]


### PR DESCRIPTION
## Summary
- ignore cross-tab `set_agent_state` broadcasts in non-owner helpers
- preserve `/move` as a runtime per-tab pane-position override across toggles, settings reloads, and pane recreation
- update the bottom-bar toggle icon from the active tab's effective pane position

## Testing
- `cargo test --manifest-path tools\wta\Cargo.toml`
- `tools\razzle.cmd && cd src\cascadia\TerminalApp && bx`