### PR TITLE
Detect NVM-installed agents in WSL

### DIFF
--- a/tools/wta/src/agent_check.rs
+++ b/tools/wta/src/agent_check.rs
@@ -76,10 +76,11 @@ pub fn find_exe(agent_id: &str) -> Option<String> {
 
 /// Resolve a native Linux executable inside one WSL distro.
 ///
-/// A login shell is required for npm-global, snap, and `~/.local/bin`
-/// installations. Windows executables leaked through WSL's appended Windows
-/// PATH are rejected so a source is never advertised when it cannot run with
-/// Linux dependencies.
+/// An interactive login shell is required for npm-global, snap,
+/// `~/.local/bin`, and version managers such as nvm that initialize from
+/// `.bashrc`. Windows executables leaked through WSL's appended Windows PATH
+/// are rejected so a source is never advertised when it cannot run with Linux
+/// dependencies.
 pub async fn find_wsl_exe(distro: &str, executable: &str) -> Option<String> {
     if distro.trim().is_empty() || executable.trim().is_empty() {
         return None;
@@ -92,7 +93,7 @@ pub async fn find_wsl_exe(distro: &str, executable: &str) -> Option<String> {
             .arg(distro)
             .arg("--")
             .arg("bash")
-            .arg("-lc")
+            .arg("-lic")
             .arg(wsl_agent_probe_script(executable))
             .stdin(std::process::Stdio::null())
             .kill_on_drop(true);
@@ -182,14 +183,14 @@ pub async fn wsl_agent_available(distro: &str, agent_id: &str) -> bool {
 
 pub(crate) fn wsl_agent_probe_script(executable: &str) -> String {
     format!(
-        "printf '__WTA_PROBE_BEGIN__\\n'; command -v {} 2>/dev/null; \
+        "printf '__WTA_PROBE_BEGIN__\\n'; type -P {} 2>/dev/null; \
          printf '__WTA_PROBE_END__\\n'",
         crate::coordinator::sh_quote(executable)
     )
 }
 
 fn is_native_wsl_resolution(resolved: &str) -> bool {
-    !resolved.is_empty() && !resolved.starts_with("/mnt/")
+    resolved.starts_with('/') && !resolved.starts_with("/mnt/")
 }
 
 /// Build the login command for an agent, resolving the full executable path.
@@ -570,6 +571,19 @@ fn expand_env_vars(s: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn native_wsl_resolution_requires_absolute_non_windows_path() {
+        assert!(is_native_wsl_resolution(
+            "/home/user/.nvm/versions/node/v24/bin/copilot"
+        ));
+        assert!(is_native_wsl_resolution("/snap/bin/copilot"));
+        assert!(!is_native_wsl_resolution(""));
+        assert!(!is_native_wsl_resolution("copilot"));
+        assert!(!is_native_wsl_resolution(
+            "/mnt/c/Users/user/AppData/Roaming/npm/copilot"
+        ));
+    }
 
     #[test]
     fn merge_paths_prefers_fresh_and_removes_duplicates_case_insensitively() {

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2564,11 +2564,11 @@ impl App {
         //     `"Ubuntu"`. Distro names from `wsl -l` are space-free, so bare
         //     `-d <distro>` is safe. The `--cd` path keeps its quotes (it can
         //     contain spaces and quoting works fine there).
-        //   * The CLI is launched through a **login shell** (`bash -lc`) so the
-        //     user's PATH is set up — a snap-installed Copilot lives in
-        //     `/snap/bin`, which a bare `wsl -- copilot` misses ("command not
-        //     found"). A login shell sources the profile that adds it.
-        let login_invocation = format!("bash -lc \"{resume_invocation}\"");
+        //   * The CLI is launched through an **interactive login shell**
+        //     (`bash -lic`) so both login profiles and version managers such as
+        //     nvm set up PATH. A bare `wsl -- copilot` misses both snap and
+        //     nvm-installed CLIs.
+        let login_invocation = format!("bash -lic \"{resume_invocation}\"");
         let commandline = match &s.location {
             crate::agent_sessions::SessionLocation::Wsl { distro } => match linux_cwd_arg(&s.cwd) {
                 Some(cwd) => format!("wsl -d {distro} --cd \"{cwd}\" -- {login_invocation}"),

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -8629,7 +8629,7 @@ fn enter_on_wsl_history_row_resumes_inside_distro() {
     let argv = cmd.argv.join(" ");
     assert!(
         argv.contains(
-            "wsl -d Ubuntu --cd \"/home/u/proj\" -- bash -lc \"copilot --resume abc-123\""
+            "wsl -d Ubuntu --cd \"/home/u/proj\" -- bash -lic \"copilot --resume abc-123\""
         ),
         "expected in-distro resume; argv: {argv}"
     );

--- a/tools/wta/src/cli/delegate.rs
+++ b/tools/wta/src/cli/delegate.rs
@@ -73,13 +73,13 @@ pub(crate) async fn run(
 /// Whether the delegate agent CLI is actually available inside `distro`.
 ///
 /// Explicit WSL delegation launches the agent inside the selected distro
-/// (`wsl -d <distro> -- bash -lc "<agent> …"`). Re-probe immediately before
+/// (`wsl -d <distro> -- bash -lic "<agent> …"`). Re-probe immediately before
 /// launch because an agent discovered when settings were loaded may since
-/// have been removed. The probe uses a **login** shell because common CLI
-/// installs (npm-global, snap, `~/.local/bin`) only put the agent on the login
-/// PATH; a non-login `bash -c` would miss them. Only a native Linux install is
-/// accepted — a Windows CLI leaking in through `appendWindowsPath` and
-/// resolving under `/mnt/…` is rejected (see
+/// have been removed. The probe uses an **interactive login** shell because
+/// common CLI installs use either login profiles (npm-global, snap,
+/// `~/.local/bin`) or interactive startup files (nvm). Only a native Linux
+/// install is accepted — a Windows CLI leaking in through `appendWindowsPath`
+/// and resolving under `/mnt/…` is rejected (see
 /// [`crate::agent_check::wsl_agent_probe_script`]).
 /// This only gates an explicit `--delegate-source wsl` selection: an
 /// unavailable agent keeps WSL as the source (see
@@ -371,7 +371,7 @@ async fn delegate_with_context(
             pinned_session_id.as_deref(),
         )?;
         let escaped = crate::coordinator::quote_windows_commandline_arg(&wsl_agent_cmd);
-        let login_invocation = format!("bash -lc {}", escaped);
+        let login_invocation = format!("bash -lic {}", escaped);
         let distro_arg = crate::coordinator::quote_windows_commandline_arg(distro);
         let active_pane_cwd = active
             .as_ref()

--- a/tools/wta/src/cli_tests.rs
+++ b/tools/wta/src/cli_tests.rs
@@ -408,19 +408,19 @@ fn active_pane_wsl_distro_rejects_non_wsl_shells() {
 }
 
 #[test]
-fn wsl_agent_probe_script_prints_command_v_resolution() {
-    // Emits `command -v <exe>` straight to stdout (the caller captures it and
-    // rejects empty or /mnt results). Deliberately NOT wrapped in `$(…)`, which
-    // returns empty for snap apps. sh_quote single-quotes the exe.
+fn wsl_agent_probe_script_prints_executable_path_resolution() {
+    // `type -P` returns only executable paths, excluding aliases and functions
+    // loaded by the interactive shell. The caller rejects empty, relative, and
+    // /mnt results. sh_quote single-quotes the exe.
     assert_eq!(
         crate::agent_check::wsl_agent_probe_script("copilot"),
-        "printf '__WTA_PROBE_BEGIN__\\n'; command -v 'copilot' 2>/dev/null; \
+        "printf '__WTA_PROBE_BEGIN__\\n'; type -P 'copilot' 2>/dev/null; \
          printf '__WTA_PROBE_END__\\n'"
     );
     // An agent identity with shell metacharacters stays contained in the quotes.
     assert_eq!(
         crate::agent_check::wsl_agent_probe_script("my agent; rm -rf /"),
-        "printf '__WTA_PROBE_BEGIN__\\n'; command -v 'my agent; rm -rf /' 2>/dev/null; \
+        "printf '__WTA_PROBE_BEGIN__\\n'; type -P 'my agent; rm -rf /' 2>/dev/null; \
          printf '__WTA_PROBE_END__\\n'"
     );
 }

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -1312,7 +1312,7 @@ pub(crate) fn sh_quote(s: &str) -> String {
 ///   the prompt would be Windows-expanded — base64 has no `%`.
 /// * the `wsl.exe` interop performs one round of double-quote-context expansion
 ///   (`$(…)`, backtick, `$…`) — even inside single quotes — before the inner
-///   `bash -lc` runs. base64 triggers none of it.
+///   `bash -lic` runs. base64 triggers none of it.
 ///
 /// The agent invocation and the fixed decode wrapper are escaped for that
 /// `wsl.exe` expansion pass via [`escape_for_intermediate_shell`], so the inner
@@ -1321,7 +1321,7 @@ pub(crate) fn sh_quote(s: &str) -> String {
 /// `ExpandEnvironmentStringsW` + `CreateProcessW` probe (issue #404).
 ///
 /// Callers wrap the result with `quote_windows_commandline_arg`, embed in
-/// `bash -lc <escaped>`, then `wsl -d <distro> --cd "<cwd>" -- <full>` before
+/// `bash -lic <escaped>`, then `wsl -d <distro> --cd "<cwd>" -- <full>` before
 /// `CreateProcessW`.
 pub(crate) fn build_wsl_delegate_commandline(
     runtime: &DelegateAgentRuntime,
@@ -1386,7 +1386,7 @@ pub(crate) fn build_wsl_delegate_commandline(
 }
 
 /// Escape a bash command so it survives the single round of double-quote-context
-/// shell expansion the `wsl.exe` interop applies to `bash -lc "<cmd>"` before the
+/// shell expansion the `wsl.exe` interop applies to `bash -lic "<cmd>"` before the
 /// inner login bash sees it.
 ///
 /// That pass performs command substitution (`$(…)`, backtick) and parameter

--- a/tools/wta/src/protocol/acp/spawn.rs
+++ b/tools/wta/src/protocol/acp/spawn.rs
@@ -540,7 +540,7 @@ fn wsl_agent_launch_script(parts: &[String], environment_policy: ChildEnvironmen
         unset_names.join(" ")
     );
     format!(
-        "bash -lc {} 3>&1 >/dev/null",
+        "bash -lic {} 3>&1 >/dev/null",
         crate::coordinator::sh_quote(&inner)
     )
 }
@@ -688,7 +688,7 @@ mod tests {
         ];
         assert_eq!(
             wsl_agent_launch_script(&parts, ChildEnvironmentPolicy::ApplySharedProvider),
-            "bash -lc 'exec 1>&3 3>&-; unset CLAUDECODE; exec '\\''copilot'\\'' \
+            "bash -lic 'exec 1>&3 3>&-; unset CLAUDECODE; exec '\\''copilot'\\'' \
              '\\''--model'\\'' '\\''model; touch /tmp/nope'\\''' 3>&1 >/dev/null"
         );
     }

--- a/tools/wta/src/wsl_acp.rs
+++ b/tools/wta/src/wsl_acp.rs
@@ -1,7 +1,7 @@
 //! WSL historical agent-session discovery via ACP `session/list`.
 //!
 //! For each *running* WSL distro, spawns the distro's agent CLI in ACP
-//! mode through `wsl.exe` (`wsl -d <distro> -- bash -lc "<cli> --acp …"`)
+//! mode through `wsl.exe` (`wsl -d <distro> -- bash -lic "<cli> --acp …"`)
 //! and asks it for `session/list`. The CLI enumerates and parses its own
 //! on-disk transcripts inside the distro, so we get structured rows
 //! (id / title / cwd / updated_at) without reading distro files or parsing
@@ -184,21 +184,28 @@ fn acp_command_for(cli: &CliSource) -> Option<String> {
     Some(crate::agent_registry::build_acp_command(id, None))
 }
 
-/// Argv for `wsl -d <distro> -- bash -lc "<acp_cmd>"`.
+/// Argv for launching `<acp_cmd>` through an interactive login shell.
 ///
-/// A **login** shell (`bash -lc`) is required: `wsl.exe -- <cmd>` runs the
-/// command under a non-login `bash -c`, where a PATH-installed CLI
-/// (npm `~/.local/...`, snap `/snap/bin`) is not found. `acp_cmd` is a
-/// single argv element so its internal spaces survive intact (no quoting
-/// games).
+/// An **interactive login** shell (`bash -lic`) is required: `wsl.exe --
+/// <cmd>` runs the command under a non-login `bash -c`, where PATH-installed
+/// CLIs from login profiles or version managers such as nvm are not found.
+/// The non-interactive outer shell discards startup stdout until the inner
+/// shell execs the agent, preventing profile output from corrupting ACP.
 fn wsl_acp_argv(distro: &str, acp_cmd: &str) -> Vec<String> {
+    let inner = format!("exec 1>&3 3>&-; exec {acp_cmd}");
+    let script = format!(
+        "bash -lic {} 3>&1 >/dev/null",
+        crate::coordinator::sh_quote(&inner)
+    );
     vec![
         "-d".to_string(),
         distro.to_string(),
         "--".to_string(),
         "bash".to_string(),
-        "-lc".to_string(),
-        acp_cmd.to_string(),
+        "--noprofile".to_string(),
+        "--norc".to_string(),
+        "-c".to_string(),
+        script,
     ]
 }
 
@@ -305,16 +312,22 @@ mod tests {
     }
 
     #[test]
-    fn wsl_acp_argv_uses_login_shell_and_single_cmd_arg() {
+    fn wsl_acp_argv_uses_interactive_login_shell_and_preserves_acp_stdout() {
         let argv = wsl_acp_argv("Ubuntu", "copilot --acp --stdio");
         assert_eq!(
             argv,
-            vec!["-d", "Ubuntu", "--", "bash", "-lc", "copilot --acp --stdio"]
+            vec![
+                "-d",
+                "Ubuntu",
+                "--",
+                "bash",
+                "--noprofile",
+                "--norc",
+                "-c",
+                "bash -lic 'exec 1>&3 3>&-; exec copilot --acp --stdio' 3>&1 >/dev/null"
+            ]
         );
-        // The whole ACP command must be ONE argv element (login shell sees
-        // it as the script string), not split on spaces.
-        assert_eq!(argv.len(), 6);
-        assert_eq!(argv[5], "copilot --acp --stdio");
+        assert_eq!(argv.len(), 8);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Probe WSL agents through an interactive login shell so NVM and other `.bashrc`-initialized version managers contribute to `PATH`.
- Use `type -P` and require an absolute non-`/mnt` path, excluding aliases, functions, relative commands, and Windows interop executables.
- Launch WSL ACP agents, delegates, historical-session scans, and resumed sessions through the same interactive login environment while suppressing shell startup output before ACP begins.

## Root cause

PR #481 used `bash -lc`, which loads login profiles but is non-interactive. A standard NVM install initializes from `.bashrc`, so `/home/<user>/.nvm/versions/node/<version>/bin` was absent during both discovery and launch even though `command -v copilot` worked in an interactive WSL terminal.

## Validation

- `cargo test --manifest-path tools/wta/Cargo.toml` — 1422 passed.
- Reproduced with Copilot at `/home/yuazha/.nvm/versions/node/v24.19.0/bin/copilot` in `Ubuntu-22.04`.
- Verified the updated probe resolves the NVM path and the wrapped WSL launch runs `copilot --version` successfully.