### PR TITLE
Use ACP session/close for durable agent resume

### DIFF
--- a/doc/specs/WTA-terminal-action-proposals.md
+++ b/doc/specs/WTA-terminal-action-proposals.md
@@ -67,15 +67,19 @@ Before creating or loading a session:
 4. master discards the pending capability on failure.
 
 Helper disconnect preserves the committed capability while the same Agent CLI
-still owns an orphaned ACP session, allowing direct rebind without
-`session/load`. When that Agent CLI instance dies, master revokes every
-capability owned by that exact instance. Reapers compare the pool cell identity
-before removal, so a late reaper from an old process cannot revoke or remove a
-replacement process using the same command.
+still owns an orphaned ACP session. On resume, agents that advertise
+`sessionCapabilities.close` close that resident session and reload it on the
+same ACP connection so the new Helper receives history replay. A successful
+close retires the old capability; a successful load binds its replacement.
+Agents without `session/close` retain the legacy direct rebind and its existing
+capability.
 
-A failed replacement leaves the prior session capability valid. A successful
-replacement retires it. Orphan Helper rebinds preserve the existing capability
-because the Agent CLI session and MCP client are still alive.
+When an Agent CLI instance dies, master revokes every capability owned by that
+exact instance. Reapers compare the pool cell identity before removal, so a
+late reaper from an old process cannot revoke or remove a replacement process
+using the same command. A failed close leaves the prior session capability
+valid; after close succeeds, the prior capability stays retired even if the
+subsequent load fails.
 
 The model never receives or supplies a Helper, session, prompt, tab, window,
 pane, channel, capability, origin, schema version, or choice ID. The Helper

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -308,15 +308,15 @@ struct MasterStateInner {
     /// and Gemini in another, and reaping one must not affect the other.
     ///
     /// When a helper resumes such a session (`--initial-load-session-id`
-    /// re-warm or `/restart`), `load_session` re-binds routing to the new
-    /// helper *directly* — no fresh `session/load` — because the CLI already
-    /// has it (a re-load would be rejected "already loaded", or, if the
-    /// orphan turn is still running, wedge behind it and hang the pane on
-    /// "Resuming…"). Only recorded while the owning CLI *instance* is still
-    /// the live pool entry (checked via `Arc::ptr_eq`), and `reap_agent`
-    /// drops just that agent's set on CLI death, so a crashed-and-respawned
-    /// CLI under the same command line never re-binds to a session it never
-    /// had — such a resume falls back to a real `session/load` from disk.
+    /// re-warm or `/restart`), `load_session` uses `session/close` followed
+    /// by a real `session/load` on the same ACP connection so the replacement
+    /// helper receives the history replay. Agents without the close capability
+    /// retain the legacy route-only re-bind. Only recorded while the owning
+    /// CLI *instance* is still the live pool entry (checked via `Arc::ptr_eq`),
+    /// and `reap_agent` drops just that agent's set on CLI death, so a
+    /// crashed-and-respawned CLI under the same command line never re-binds
+    /// to a session it never had — such a resume falls back to a real
+    /// `session/load` from disk.
     orphaned_sessions: Mutex<HashMap<AgentCmdKey, HashSet<acp::schema::v1::SessionId>>>,
     /// #266 born-bound sessions (WTA-launched delegate/resume — copilot/claude/
     /// gemini). **Binding-only**: unlike `hook_owned`, the file watcher may
@@ -360,6 +360,20 @@ async fn bind_session_route(
     pending_usage.remove(&session_id);
     routes.insert(session_id, route);
     routes.len()
+}
+
+async fn remove_session_route_if_owned(
+    state: &MasterStateInner,
+    session_id: &acp::schema::v1::SessionId,
+    helper_id: HelperId,
+) {
+    let mut routes = state.session_to_helper.lock().await;
+    if routes
+        .get(session_id)
+        .is_some_and(|route| route.helper_id == helper_id)
+    {
+        routes.remove(session_id);
+    }
 }
 
 /// Canonical key for the agent-CLI pool: authoritative agent identity,
@@ -409,6 +423,16 @@ struct AgentCli {
     /// eventual clean-probe result without leaking one agent/source catalog to
     /// unrelated helpers in the same master.
     bound_helpers: Mutex<HashSet<HelperId>>,
+}
+
+impl AgentCli {
+    fn supports_session_close(&self) -> bool {
+        self.cached_init_resp
+            .agent_capabilities
+            .session_capabilities
+            .close
+            .is_some()
+    }
 }
 
 fn update_model_switch_channel_from_load(
@@ -692,7 +716,8 @@ impl MasterClient {
 /// already live inside the CLI (not missing). Copilot reports this as a
 /// "… is already loaded" message under `-32602`; we match that stable
 /// substring (in message or data) rather than the code. `load_session`
-/// uses it to re-bind an orphan session instead of failing the resume.
+/// uses it to close and retry when supported, or to retain the legacy
+/// route-only re-bind for agents without `session/close`.
 fn is_already_loaded_error(err: &acp::Error) -> bool {
     let msg = err.message.to_ascii_lowercase();
     if msg.contains("already loaded") {
@@ -1622,34 +1647,31 @@ impl HelperHandler {
             },
         )
         .await;
-        // Orphan re-bind fast path: this session's previous helper
-        // disconnected but the shared CLI still has it loaded (tracked in
-        // `orphaned_sessions` under this agent's key). Re-attach onto the
-        // routing pre-registered above WITHOUT a `session/load` round-trip —
-        // the CLI already has the session, and forwarding a load would be
-        // rejected "already loaded", or (if the orphan turn is still running)
-        // wedge behind it and hang the pane on "Resuming…". Any in-flight
-        // turn now streams its `session/update`s to this new helper. Scoped
-        // to `agent.cmd_key` so we only re-bind sessions this exact CLI still
-        // holds (a crashed+respawned CLI's set was dropped by `reap_agent`).
-        let is_orphan_rebind = {
+        // Claim an orphan owned by this exact live CLI instance. Agents that
+        // support session/close can release it and perform a real load on the
+        // same connection, which replays history to the replacement helper.
+        // Legacy agents retain the route-only re-bind because loading a
+        // resident session is rejected as "already loaded".
+        let is_orphan = {
             let mut orphans = self.state.orphaned_sessions.lock().await;
             orphans
                 .get_mut(&agent.cmd_key)
                 .is_some_and(|set| set.remove(&session_id))
         };
+        let supports_session_close = agent.supports_session_close();
+        let close_before_load = is_orphan && supports_session_close;
 
-        // Both a re-bind and a real `session/load` resume the session; only a
-        // genuine load failure rolls back. Resolve the response, then register
-        // the resumed row once for either success path.
-        let resp = if is_orphan_rebind {
+        // Both a legacy re-bind and a real `session/load` resume the session;
+        // close/load failures roll back the route. Resolve the response, then
+        // register the resumed row once for either success path.
+        let resp = if is_orphan && !close_before_load {
             tracing::info!(
                 target: "master",
                 step = "helper→agent",
                 op = "load_session",
                 helper_id = ?self.helper_id,
                 session_id = ?session_id,
-                "re-binding orphan session without a session/load round-trip"
+                "re-binding orphan session because agent does not support session/close"
             );
             acp::schema::v1::LoadSessionResponse::new()
         } else {
@@ -1659,11 +1681,7 @@ impl HelperHandler {
             {
                 Ok(endpoint) => endpoint,
                 Err(error) => {
-                    self.state
-                        .session_to_helper
-                        .lock()
-                        .await
-                        .remove(&session_id);
+                    remove_session_route_if_owned(&self.state, &session_id, self.helper_id).await;
                     return Err(error);
                 }
             };
@@ -1679,7 +1697,84 @@ impl HelperHandler {
             } else {
                 None
             };
-            match agent.conn.load_session(args).await {
+            if close_before_load {
+                tracing::info!(
+                    target: "master",
+                    step = "helper→agent",
+                    op = "close_session",
+                    helper_id = ?self.helper_id,
+                    session_id = ?session_id,
+                    "closing orphan session before reloading history on the existing ACP connection"
+                );
+                if let Err(error) = agent
+                    .conn
+                    .close_session(acp::schema::v1::CloseSessionRequest::new(
+                        session_id.clone(),
+                    ))
+                    .await
+                {
+                    if let Some(pending) = proposal_mcp.as_ref() {
+                        self.state.proposal_mcp_capabilities.cancel(pending).await;
+                    }
+                    remove_session_route_if_owned(&self.state, &session_id, self.helper_id).await;
+                    tracing::warn!(
+                        target: "master",
+                        helper_id = ?self.helper_id,
+                        session_id = ?session_id,
+                        error = %error,
+                        "session/close failed before durable resume; rolled back routing entry"
+                    );
+                    return Err(error);
+                }
+                self.state
+                    .proposal_mcp_capabilities
+                    .remove_session(&session_id)
+                    .await;
+            }
+
+            let mut load_result = agent.conn.load_session(args.clone()).await;
+            if !close_before_load
+                && supports_session_close
+                && load_result
+                    .as_ref()
+                    .is_err_and(|error| is_already_loaded_error(error))
+            {
+                tracing::info!(
+                    target: "master",
+                    step = "helper→agent",
+                    op = "close_session",
+                    helper_id = ?self.helper_id,
+                    session_id = ?session_id,
+                    "session was already loaded; closing it before retrying on the existing ACP connection"
+                );
+                load_result = match agent
+                    .conn
+                    .close_session(acp::schema::v1::CloseSessionRequest::new(
+                        session_id.clone(),
+                    ))
+                    .await
+                {
+                    Ok(_) => {
+                        self.state
+                            .proposal_mcp_capabilities
+                            .remove_session(&session_id)
+                            .await;
+                        agent.conn.load_session(args).await
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            target: "master",
+                            helper_id = ?self.helper_id,
+                            session_id = ?session_id,
+                            error = %error,
+                            "session/close failed after session/load reported already loaded"
+                        );
+                        Err(error)
+                    }
+                };
+            }
+
+            match load_result {
                 Ok(resp) => {
                     if let Some(pending) = proposal_mcp.as_ref() {
                         if !self
@@ -1697,10 +1792,9 @@ impl HelperHandler {
                     }
                     resp
                 }
-                // Fallback for an orphan we didn't track (e.g. it predates
-                // this master): the CLI reports "already loaded", so re-bind
-                // onto the pre-registered routing just like the fast path.
-                Err(err) if is_already_loaded_error(&err) => {
+                // Compatibility fallback for an orphan we did not track when
+                // the agent cannot close resident sessions.
+                Err(err) if !supports_session_close && is_already_loaded_error(&err) => {
                     if let Some(pending) = proposal_mcp.as_ref() {
                         self.state.proposal_mcp_capabilities.cancel(pending).await;
                     }
@@ -1710,7 +1804,7 @@ impl HelperHandler {
                         op = "load_session",
                         helper_id = ?self.helper_id,
                         session_id = ?session_id,
-                        "re-binding session already loaded in the shared CLI"
+                        "re-binding already-loaded session because agent does not support session/close"
                     );
                     acp::schema::v1::LoadSessionResponse::new()
                 }
@@ -1722,10 +1816,7 @@ impl HelperHandler {
                     // needs touching — we never wrote to `registry` and we
                     // never broadcast `session_added`, so peers never saw
                     // this row.
-                    {
-                        let mut map = self.state.session_to_helper.lock().await;
-                        map.remove(&session_id);
-                    }
+                    remove_session_route_if_owned(&self.state, &session_id, self.helper_id).await;
                     tracing::warn!(
                         target: "master",
                         helper_id = ?self.helper_id,
@@ -1754,7 +1845,7 @@ impl HelperHandler {
         }
 
         // Register the resumed row (Live + tagged) — shared by the real-load
-        // and orphan-re-bind paths.
+        // and legacy orphan-re-bind paths.
         let mut info =
             crate::session_registry::SessionInfo::new(session_id.clone(), cwd_for_registry);
         info.pane_session_id = wta_meta.pane_session_id;
@@ -3525,14 +3616,14 @@ async fn serve_helper(
     let victims = drop_sessions_for_helper(&state, helper_id).await;
 
     // The dropped sessions are still loaded on the shared CLI — they're now
-    // orphans. Record them under the owning agent's key so a later resume
-    // re-binds directly instead of forwarding a `session/load` that the CLI
-    // rejects "already loaded" (or, mid-turn, wedges behind the running
-    // turn). Guard on `Arc::ptr_eq`: only record if the helper's bound CLI
-    // is STILL the live pool instance for its key. If that CLI already died
-    // (reaped, possibly respawned under the same command line), these
-    // sessions are gone — recording them would make a later resume skip the
-    // `session/load` the new CLI needs, binding to a session it never had.
+    // orphans. Record them under the owning agent's key so a later resume can
+    // close and reload them on the same ACP connection (or use the legacy
+    // route-only re-bind when the agent lacks session/close). Guard on
+    // `Arc::ptr_eq`: only record if the helper's bound CLI is STILL the live
+    // pool instance for its key. If that CLI already died (reaped, possibly
+    // respawned under the same command line), these sessions are gone —
+    // recording them would make a later resume skip the `session/load` the
+    // new CLI needs, binding to a session it never had.
     if !victims.is_empty() {
         if let Some(agent) = handler.agent.get() {
             let key = agent.cmd_key.clone();

--- a/tools/wta/src/master/proposal_mcp.rs
+++ b/tools/wta/src/master/proposal_mcp.rs
@@ -289,6 +289,13 @@ impl CapabilityRegistry {
         Self::remove_capability(&mut routes, &pending.hash);
     }
 
+    pub(super) async fn remove_session(&self, session_id: &acp::schema::v1::SessionId) {
+        let mut routes = self.routes.lock().await;
+        if let Some(hash) = routes.by_session.get(session_id).copied() {
+            Self::remove_capability(&mut routes, &hash);
+        }
+    }
+
     pub(super) async fn remove_owner(&self, owner: AgentInstanceId) -> usize {
         let mut routes = self.routes.lock().await;
         let Some(hashes) = routes.by_owner.remove(&owner) else {
@@ -1081,6 +1088,27 @@ mod tests {
         assert!(matches!(
             registry.resolve(&replacement.secret).await,
             CapabilityResolution::Unknown
+        ));
+    }
+
+    #[tokio::test]
+    async fn closing_session_revokes_committed_capability_but_not_replacement() {
+        let registry = CapabilityRegistry::default();
+        let owner = AgentInstanceId::new_v4();
+        let session_id = acp::schema::v1::SessionId::new("session");
+        let committed = registry.prepare(owner, None).await;
+        assert!(registry.bind(&committed, session_id.clone()).await);
+        let replacement = registry.prepare(owner, Some(session_id.clone())).await;
+
+        registry.remove_session(&session_id).await;
+
+        assert!(matches!(
+            registry.resolve(&committed.secret).await,
+            CapabilityResolution::Unknown
+        ));
+        assert!(matches!(
+            registry.resolve(&replacement.secret).await,
+            CapabilityResolution::Bound(found) if found == session_id
         ));
     }
 

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -748,6 +748,145 @@ fn client_connection_to_model_agent(
     client_conn
 }
 
+fn client_connection_to_resume_agent(
+    events: Arc<std::sync::Mutex<Vec<&'static str>>>,
+    first_load_already_loaded: bool,
+    close_fails: bool,
+) -> conn::ClientLink {
+    let (client_pipe, agent_pipe) = tokio::io::duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_pipe);
+    let (agent_read, agent_write) = tokio::io::split(agent_pipe);
+    let load_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    let close_events = Arc::clone(&events);
+    let load_events = events;
+    let agent_builder = acp::Agent
+        .builder()
+        .name("resume-agent")
+        .on_receive_request(
+            move |_req: acp::schema::v1::CloseSessionRequest,
+                  responder: acp::Responder<acp::schema::v1::CloseSessionResponse>,
+                  _cx| {
+                let events = Arc::clone(&close_events);
+                async move {
+                    events
+                        .lock()
+                        .expect("resume events lock poisoned")
+                        .push("close");
+                    if close_fails {
+                        responder.respond_with_error(
+                            acp::Error::internal_error().data("mock session/close failure"),
+                        )
+                    } else {
+                        responder.respond(acp::schema::v1::CloseSessionResponse::new())
+                    }
+                }
+            },
+            acp::on_receive_request!(),
+        )
+        .on_receive_request(
+            move |_req: acp::schema::v1::LoadSessionRequest,
+                  responder: acp::Responder<acp::schema::v1::LoadSessionResponse>,
+                  _cx| {
+                let events = Arc::clone(&load_events);
+                let load_count = Arc::clone(&load_count);
+                async move {
+                    events
+                        .lock()
+                        .expect("resume events lock poisoned")
+                        .push("load");
+                    let attempt = load_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    if first_load_already_loaded && attempt == 0 {
+                        responder.respond_with_error(acp::Error::new(
+                            -32602,
+                            "Session is already loaded",
+                        ))
+                    } else {
+                        responder.respond(acp::schema::v1::LoadSessionResponse::new())
+                    }
+                }
+            },
+            acp::on_receive_request!(),
+        );
+    let (_agent_conn, agent_io) = conn::spawn_agent(
+        agent_builder,
+        conn::byte_streams(agent_write.compat_write(), agent_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = agent_io.await;
+    });
+
+    let (client_conn, client_io) = conn::spawn_client(
+        acp::Client.builder().name("resume-client"),
+        conn::byte_streams(client_write.compat_write(), client_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = client_io.await;
+    });
+
+    client_conn
+}
+
+fn agent_link_to_noop_helper() -> conn::AgentLink {
+    let (master_pipe, helper_pipe) = tokio::io::duplex(4096);
+    let (master_read, master_write) = tokio::io::split(master_pipe);
+    let (helper_read, helper_write) = tokio::io::split(helper_pipe);
+
+    let (agent_link, agent_io) = conn::spawn_agent(
+        acp::Agent.builder().name("master-helper-side"),
+        conn::byte_streams(master_write.compat_write(), master_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = agent_io.await;
+    });
+
+    let (_helper_link, helper_io) = conn::spawn_client(
+        acp::Client.builder().name("noop-helper"),
+        conn::byte_streams(helper_write.compat_write(), helper_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = helper_io.await;
+    });
+
+    agent_link
+}
+
+fn resume_handler(
+    state: Arc<MasterStateInner>,
+    connection: conn::ClientLink,
+    supports_session_close: bool,
+) -> HelperHandler {
+    let mut init_response =
+        acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+    if supports_session_close {
+        init_response.agent_capabilities.session_capabilities.close =
+            Some(acp::schema::v1::SessionCloseCapabilities::new());
+    }
+    let agent = Arc::new(AgentCli {
+        instance_id: AgentInstanceId::new_v4(),
+        conn: connection,
+        cached_init_resp: init_response,
+        cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+        source: crate::agent_source::AgentSource::Host,
+        cmd_key: "resume-agent".to_string(),
+        cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+        bound_helpers: Mutex::new(HashSet::new()),
+    });
+    let agent_slot = Arc::new(OnceLock::new());
+    let _ = agent_slot.set(agent);
+    let agent_side_slot = Arc::new(OnceLock::new());
+    let _ = agent_side_slot.set(agent_link_to_noop_helper());
+    let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+    HelperHandler {
+        helper_id: HelperId(1),
+        client_elevated: false,
+        agent: agent_slot,
+        state,
+        notif_tx,
+        agent_side_slot,
+    }
+}
+
 fn model_handler(agent: Arc<AgentCli>, helper_id: u64) -> HelperHandler {
     let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
     let slot = Arc::new(OnceLock::new());
@@ -893,6 +1032,154 @@ async fn direct_resume_updates_model_switch_channel_from_load_response() {
 
             assert!(config_hit.load(Ordering::SeqCst));
             assert!(!legacy_hit.load(Ordering::SeqCst));
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn orphan_resume_closes_then_loads_on_existing_connection() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let session_id = SessionId::new("orphan-session");
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry("resume-agent".to_string())
+                .or_default()
+                .insert(session_id.clone());
+            let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let handler = resume_handler(
+                Arc::clone(&state),
+                client_connection_to_resume_agent(Arc::clone(&events), false, false),
+                true,
+            );
+
+            handler
+                .load_session(acp::schema::v1::LoadSessionRequest::new(
+                    session_id,
+                    PathBuf::from(r"C:\repo"),
+                ))
+                .await
+                .expect("orphan resume should close and reload");
+
+            assert_eq!(
+                *events.lock().expect("resume events lock poisoned"),
+                ["close", "load"],
+                "resume must reuse the ACP connection and reload history after close"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn untracked_loaded_session_closes_then_retries_load() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let handler = resume_handler(
+                state,
+                client_connection_to_resume_agent(Arc::clone(&events), true, false),
+                true,
+            );
+
+            handler
+                .load_session(acp::schema::v1::LoadSessionRequest::new(
+                    SessionId::new("untracked-session"),
+                    PathBuf::from(r"C:\repo"),
+                ))
+                .await
+                .expect("already-loaded resume should close and retry");
+
+            assert_eq!(
+                *events.lock().expect("resume events lock poisoned"),
+                ["load", "close", "load"]
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn orphan_resume_without_close_capability_keeps_legacy_rebind() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let session_id = SessionId::new("legacy-orphan-session");
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry("resume-agent".to_string())
+                .or_default()
+                .insert(session_id.clone());
+            let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let handler = resume_handler(
+                state,
+                client_connection_to_resume_agent(Arc::clone(&events), false, false),
+                false,
+            );
+
+            handler
+                .load_session(acp::schema::v1::LoadSessionRequest::new(
+                    session_id,
+                    PathBuf::from(r"C:\repo"),
+                ))
+                .await
+                .expect("legacy agent should retain route-only rebind");
+
+            assert!(
+                events
+                    .lock()
+                    .expect("resume events lock poisoned")
+                    .is_empty(),
+                "legacy rebind must not call unsupported lifecycle methods"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn orphan_resume_close_failure_rolls_back_route() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let session_id = SessionId::new("close-failure-session");
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry("resume-agent".to_string())
+                .or_default()
+                .insert(session_id.clone());
+            let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let handler = resume_handler(
+                Arc::clone(&state),
+                client_connection_to_resume_agent(Arc::clone(&events), false, true),
+                true,
+            );
+
+            handler
+                .load_session(acp::schema::v1::LoadSessionRequest::new(
+                    session_id.clone(),
+                    PathBuf::from(r"C:\repo"),
+                ))
+                .await
+                .expect_err("session/close failure must fail resume");
+
+            assert_eq!(
+                *events.lock().expect("resume events lock poisoned"),
+                ["close"]
+            );
+            assert!(
+                !state
+                    .session_to_helper
+                    .lock()
+                    .await
+                    .contains_key(&session_id),
+                "failed close must remove the tentative helper route"
+            );
         })
         .await;
 }

--- a/tools/wta/src/protocol/acp/conn.rs
+++ b/tools/wta/src/protocol/acp/conn.rs
@@ -28,9 +28,9 @@ use std::future::Future;
 
 use agent_client_protocol as acp;
 use acp::schema::v1::{
-    self, AuthenticateRequest, AuthenticateResponse, CancelNotification, CreateTerminalRequest,
-    CreateTerminalResponse, ExtNotification, ExtRequest, ExtResponse, InitializeRequest,
-    InitializeResponse,
+    self, AuthenticateRequest, AuthenticateResponse, CancelNotification, CloseSessionRequest,
+    CloseSessionResponse, CreateTerminalRequest, CreateTerminalResponse, ExtNotification,
+    ExtRequest, ExtResponse, InitializeRequest, InitializeResponse,
     KillTerminalRequest, KillTerminalResponse, ListSessionsRequest, ListSessionsResponse,
     LoadSessionRequest, LoadSessionResponse, NewSessionRequest, NewSessionResponse,
     PromptRequest, PromptResponse, ReadTextFileRequest, ReadTextFileResponse,
@@ -127,6 +127,13 @@ impl ClientLink {
     }
 
     pub async fn load_session(&self, req: LoadSessionRequest) -> acp::Result<LoadSessionResponse> {
+        self.cx().await?.send_request(req).block_task().await
+    }
+
+    pub async fn close_session(
+        &self,
+        req: CloseSessionRequest,
+    ) -> acp::Result<CloseSessionResponse> {
         self.cx().await?.send_request(req).block_task().await
     }
 


### PR DESCRIPTION
## Summary

- Close resident orphan agent sessions with ACP `session/close`, then reload them on the existing shared ACP connection so the replacement Helper receives history replay without rotating the agent process.
- Retry untracked `already loaded` sessions with the same close-then-load sequence; retain route-only rebind for agents that do not advertise `sessionCapabilities.close`.
- Roll back tentative routing on lifecycle failures and retire the old proposal-MCP capability after a successful close.
- Add coverage for close/load ordering, retry, legacy fallback, route rollback, and capability replacement.

## Verification

- `cargo test --manifest-path tools/wta/Cargo.toml`: 1467 passed.
- Copilot CLI 1.0.79-6 advertises `loadSession: true` and `sessionCapabilities.close: {}`.

Targets the branch behind #442.