### PR TITLE
Skip WTA hooks in Copilot ACP sessions

### DIFF
--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -26,7 +26,7 @@
 //         .claude-plugin/plugin.json
 //         hooks/{hooks.json,send-event.ps1}
 //     copilot/                             <- passed to `copilot plugin marketplace add`
-//       (same shape; only hooks.json differs from claude/ — `-CliSource copilot`)
+//       (adds send-event.cmd to bypass the bridge in WTA-owned ACP sessions)
 //     gemini-extension/                    <- passed to `gemini extensions install`
 //       gemini-extension.json
 //       hooks/{hooks.json,send-event.ps1}

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -541,6 +541,7 @@ fn bundle_files_are_well_formed() {
     assert!(!CLAUDE_SEND_EVENT_PS1.is_empty());
     assert!(!COPILOT_SEND_EVENT_PS1.is_empty());
     assert!(COPILOT_SEND_EVENT_CMD.contains("WTA_COPILOT_ACP"));
+    assert!(COPILOT_SEND_EVENT_CMD.contains("exit /b %ERRORLEVEL%"));
     assert!(!GEMINI_SEND_EVENT_PS1.is_empty());
 }
 

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -517,6 +517,8 @@ const CLAUDE_SEND_EVENT_PS1: &str =
     include_str!("../wt-agent-hooks/claude/wt-agent-hooks/hooks/send-event.ps1");
 const COPILOT_SEND_EVENT_PS1: &str =
     include_str!("../wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.ps1");
+const COPILOT_SEND_EVENT_CMD: &str =
+    include_str!("../wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.cmd");
 const CODEX_SEND_EVENT_PS1: &str =
     include_str!("../wt-agent-hooks/codex/wt-agent-hooks/hooks/send-event.ps1");
 const GEMINI_SEND_EVENT_PS1: &str =
@@ -538,6 +540,7 @@ fn bundle_files_are_well_formed() {
 
     assert!(!CLAUDE_SEND_EVENT_PS1.is_empty());
     assert!(!COPILOT_SEND_EVENT_PS1.is_empty());
+    assert!(COPILOT_SEND_EVENT_CMD.contains("WTA_COPILOT_ACP"));
     assert!(!GEMINI_SEND_EVENT_PS1.is_empty());
 }
 
@@ -601,8 +604,12 @@ fn claude_and_copilot_hooks_json_are_parity_identical() {
     let normalized_claude = CLAUDE_HOOKS_JSON.replace("-CliSource claude", "-CliSource <CLI>");
     // Strip the copilot-only tool-use hook blocks before comparing.
     // Each block is a top-level key with its JSON array value + trailing comma.
-    let mut normalized_copilot =
-        COPILOT_HOOKS_JSON.replace("-CliSource copilot", "-CliSource <CLI>");
+    let mut normalized_copilot = COPILOT_HOOKS_JSON
+        .replace(
+            r#"cmd.exe /d /c call \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.cmd\""#,
+            r#"powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.ps1\""#,
+        )
+        .replace("-CliSource copilot", "-CliSource <CLI>");
     for event in ["PreToolUse", "PostToolUse", "PostToolUseFailure"] {
         // Remove the block: `"<Event>": [ ... ],\r\n` (with possible \r\n or \n)
         if let Some(start) = normalized_copilot.find(&format!("\"{event}\"")) {
@@ -630,18 +637,42 @@ fn claude_and_copilot_hooks_json_are_parity_identical() {
     );
 }
 
-/// Claude and Copilot share the same `plugin.json`, `marketplace.json`,
-/// and `send-event.ps1` content; assert byte-equality so future edits
-/// stay in sync.
+/// Claude and Copilot share static manifests modulo independently bumped
+/// bundle versions, and keep the PowerShell bridge byte-identical.
 #[test]
 fn claude_and_copilot_share_static_manifests() {
+    fn without_versions(json: &str) -> serde_json::Value {
+        fn strip(value: &mut serde_json::Value) {
+            match value {
+                serde_json::Value::Object(object) => {
+                    object.remove("version");
+                    for child in object.values_mut() {
+                        strip(child);
+                    }
+                }
+                serde_json::Value::Array(array) => {
+                    for child in array {
+                        strip(child);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let mut value: serde_json::Value = serde_json::from_str(json).unwrap();
+        strip(&mut value);
+        value
+    }
+
     assert_eq!(
-        CLAUDE_PLUGIN_JSON, COPILOT_PLUGIN_JSON,
-        "claude/ and copilot/ plugin.json must match byte-for-byte"
+        without_versions(CLAUDE_PLUGIN_JSON),
+        without_versions(COPILOT_PLUGIN_JSON),
+        "claude/ and copilot/ plugin.json must match modulo version"
     );
     assert_eq!(
-        CLAUDE_MARKETPLACE_JSON, COPILOT_MARKETPLACE_JSON,
-        "claude/ and copilot/ marketplace.json must match byte-for-byte"
+        without_versions(CLAUDE_MARKETPLACE_JSON),
+        without_versions(COPILOT_MARKETPLACE_JSON),
+        "claude/ and copilot/ marketplace.json must match modulo version"
     );
     assert_eq!(
         CLAUDE_SEND_EVENT_PS1, COPILOT_SEND_EVENT_PS1,

--- a/tools/wta/src/protocol/acp/spawn.rs
+++ b/tools/wta/src/protocol/acp/spawn.rs
@@ -17,6 +17,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 const STARTUP_STDERR_MAX_LINES: usize = 32;
 const STARTUP_STDERR_MAX_CHARS_PER_LINE: usize = 1024;
 const STARTUP_STDERR_DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
+const COPILOT_ACP_HOOK_GATE_ENV: &str = "WTA_COPILOT_ACP";
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
@@ -250,6 +251,7 @@ pub(crate) fn spawn_agent_process(
     // ACP host. Scrub unconditionally; other agents don't care.
     cmd.env_remove("CLAUDECODE");
     configure_child_environment(&mut cmd, agent_cmd, agent_id, environment_policy)?;
+    configure_copilot_acp_hook_gate(&mut cmd, agent_cmd, agent_id, environment_policy);
 
     // Give the agent CLI a fresh PATH and make this package's `wta.exe`
     // App Execution Alias the first match. The package-specific alias directory
@@ -410,6 +412,24 @@ fn configure_child_environment(
             crate::custom_model_provider::scrub_child_for_cloud_discovery(command);
             Ok(None)
         }
+    }
+}
+
+fn configure_copilot_acp_hook_gate(
+    command: &mut tokio::process::Command,
+    agent_cmd: &str,
+    agent_id: Option<&str>,
+    environment_policy: ChildEnvironmentPolicy,
+) {
+    command.env_remove(COPILOT_ACP_HOOK_GATE_ENV);
+    if environment_policy == ChildEnvironmentPolicy::ApplySharedProvider
+        && resolve_spawn_profile(agent_cmd, agent_id).id == "copilot"
+    {
+        // Copilot runs command hooks synchronously, including Stop and
+        // SessionEnd. The WTA bridge is redundant for an ACP-owned session
+        // and delays the session/prompt response, so let its lightweight
+        // command wrapper exit before starting PowerShell.
+        command.env(COPILOT_ACP_HOOK_GATE_ENV, "1");
     }
 }
 
@@ -635,6 +655,51 @@ mod tests {
                 configured_env.get(std::ffi::OsStr::new(key)),
                 Some(&None),
                 "cloud policy must scrub {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn normal_copilot_acp_launch_suppresses_wta_hook_bridge() {
+        let mut command = tokio::process::Command::new("copilot");
+        configure_copilot_acp_hook_gate(
+            &mut command,
+            "copilot --acp --stdio",
+            Some("copilot"),
+            ChildEnvironmentPolicy::ApplySharedProvider,
+        );
+
+        let configured_env: std::collections::HashMap<_, _> =
+            command.as_std().get_envs().collect();
+        assert_eq!(
+            configured_env.get(std::ffi::OsStr::new(COPILOT_ACP_HOOK_GATE_ENV)),
+            Some(&Some(std::ffi::OsStr::new("1")))
+        );
+    }
+
+    #[test]
+    fn non_copilot_and_probe_launches_do_not_suppress_hooks() {
+        for (agent_cmd, agent_id, policy) in [
+            (
+                "claude",
+                Some("claude"),
+                ChildEnvironmentPolicy::ApplySharedProvider,
+            ),
+            (
+                "copilot --acp --stdio",
+                Some("copilot"),
+                ChildEnvironmentPolicy::CleanCloudDiscovery,
+            ),
+        ] {
+            let mut command = tokio::process::Command::new("agent");
+            command.env(COPILOT_ACP_HOOK_GATE_ENV, "inherited");
+            configure_copilot_acp_hook_gate(&mut command, agent_cmd, agent_id, policy);
+
+            let configured_env: std::collections::HashMap<_, _> =
+                command.as_std().get_envs().collect();
+            assert_eq!(
+                configured_env.get(std::ffi::OsStr::new(COPILOT_ACP_HOOK_GATE_ENV)),
+                Some(&None)
             );
         }
     }

--- a/tools/wta/wt-agent-hooks/README.md
+++ b/tools/wta/wt-agent-hooks/README.md
@@ -23,7 +23,7 @@ wt-agent-hooks/
 │           ├── hooks.json                  # 10 events, -CliSource claude
 │           └── send-event.ps1
 ├── copilot/                                # passed to `copilot plugin marketplace add`
-│   └── (identical layout to claude/, only -CliSource differs)
+│   └── (adds send-event.cmd to skip the bridge for WTA-owned ACP sessions)
 ├── gemini-extension/                       # passed to `gemini extensions install`
 │   ├── gemini-extension.json
 │   └── hooks/

--- a/tools/wta/wt-agent-hooks/copilot/.claude-plugin/marketplace.json
+++ b/tools/wta/wt-agent-hooks/copilot/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "wt-agent-hooks",
       "description": "Forward CLI agent hook events to Windows Terminal for WTA display",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "source": "./wt-agent-hooks"
     }
   ]

--- a/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/.claude-plugin/plugin.json
+++ b/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wt-agent-hooks",
   "description": "Forward CLI agent hook events to Windows Terminal for WTA display",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": {
     "name": "Agentic Terminal"
   },

--- a/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/hooks.json
+++ b/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/hooks.json
@@ -5,7 +5,7 @@
         "matcher": ".*",
         "hooks": [{
           "type": "command",
-          "command": "powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.ps1\" -CliSource copilot agent.session.start"
+          "command": "cmd.exe /d /c call \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.cmd\" -CliSource copilot agent.session.start"
         }]
       }
     ],
@@ -14,7 +14,7 @@
         "matcher": ".*",
         "hooks": [{
           "type": "command",
-          "command": "powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.ps1\" -CliSource copilot agent.session.end"
+          "command": "cmd.exe /d /c call \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.cmd\" -CliSource copilot agent.session.end"
         }]
       }
     ],
@@ -23,7 +23,7 @@
         "matcher": ".*",
         "hooks": [{
           "type": "command",
-          "command": "powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.ps1\" -CliSource copilot agent.notification"
+          "command": "cmd.exe /d /c call \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.cmd\" -CliSource copilot agent.notification"
         }]
       }
     ],
@@ -32,7 +32,7 @@
         "matcher": ".*",
         "hooks": [{
           "type": "command",
-          "command": "powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.ps1\" -CliSource copilot agent.prompt.submit"
+          "command": "cmd.exe /d /c call \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.cmd\" -CliSource copilot agent.prompt.submit"
         }]
       }
     ],
@@ -41,7 +41,7 @@
         "matcher": ".*",
         "hooks": [{
           "type": "command",
-          "command": "powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.ps1\" -CliSource copilot agent.tool.starting"
+          "command": "cmd.exe /d /c call \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.cmd\" -CliSource copilot agent.tool.starting"
         }]
       }
     ],
@@ -50,7 +50,7 @@
         "matcher": ".*",
         "hooks": [{
           "type": "command",
-          "command": "powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.ps1\" -CliSource copilot agent.tool.finished"
+          "command": "cmd.exe /d /c call \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.cmd\" -CliSource copilot agent.tool.finished"
         }]
       }
     ],
@@ -59,7 +59,7 @@
         "matcher": ".*",
         "hooks": [{
           "type": "command",
-          "command": "powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.ps1\" -CliSource copilot agent.tool.failed"
+          "command": "cmd.exe /d /c call \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.cmd\" -CliSource copilot agent.tool.failed"
         }]
       }
     ],
@@ -68,7 +68,7 @@
         "matcher": ".*",
         "hooks": [{
           "type": "command",
-          "command": "powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.ps1\" -CliSource copilot agent.error"
+          "command": "cmd.exe /d /c call \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.cmd\" -CliSource copilot agent.error"
         }]
       }
     ],
@@ -77,7 +77,7 @@
         "matcher": ".*",
         "hooks": [{
           "type": "command",
-          "command": "powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.ps1\" -CliSource copilot agent.stop"
+          "command": "cmd.exe /d /c call \"${CLAUDE_PLUGIN_ROOT}/hooks/send-event.cmd\" -CliSource copilot agent.stop"
         }]
       }
     ]

--- a/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.cmd
+++ b/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.cmd
@@ -1,0 +1,4 @@
+@echo off
+if "%WTA_COPILOT_ACP%"=="1" exit /b 0
+powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "%~dp0send-event.ps1" %*
+exit /b 0

--- a/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.cmd
+++ b/tools/wta/wt-agent-hooks/copilot/wt-agent-hooks/hooks/send-event.cmd
@@ -1,4 +1,4 @@
 @echo off
 if "%WTA_COPILOT_ACP%"=="1" exit /b 0
 powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "%~dp0send-event.ps1" %*
-exit /b 0
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
## Summary

- mark WTA-owned Copilot ACP processes with `WTA_COPILOT_ACP=1`
- route the bundled Copilot hooks through a lightweight `cmd.exe` wrapper that exits immediately in ACP mode
- preserve the existing PowerShell/`wtcli` hook bridge for normal interactive Copilot sessions
- bump the Copilot hook bundle to `0.1.5` so installed plugins upgrade

## Why

Copilot runs lifecycle hooks synchronously. In an agent-pane ACP session, WTA already owns and tracks the session through helper/master ACP routing, so the bundled hooks are redundant. Starting PowerShell and forwarding `Stop`/`SessionEnd` delayed the authoritative `session/prompt` response and kept Thinking plus the next-turn gate active after visible output had finished.

## Validation

- `cargo test --manifest-path tools\wta\Cargo.toml`
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools\wta\Cargo.toml`
- `cmd.exe /c "tools\razzle.cmd && bcz no_clean"`
- deployed the Debug package and exercised consecutive Copilot ACP turns
- confirmed `hook-trace.log` receives no new Copilot events from ACP sessions
- observed plain-response first-text-to-close latency improve from about 3.06s to 1.68s; ACP EndTurn-to-close remains about 50-60ms
- confirmed normal hook forwarding remains available when `WTA_COPILOT_ACP` is absent