### PR TITLE
Unify inline notice styling

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -60,7 +60,7 @@ pub use crate::turn_context::TurnContext;
 use input_edit::{next_word_boundary, prev_word_boundary, INPUT_HISTORY_MAX_ENTRIES};
 pub(crate) use tab_state::DEFAULT_TAB_ID;
 pub use tab_state::{
-    ChatMessage, CompletedTurn, PermissionState, RecommendationFocus, TabSession, View,
+    ChatMessage, CompletedTurn, NoticeKind, PermissionState, RecommendationFocus, TabSession, View,
 };
 pub use turn_state::{AutofixContext, ChunkKind, SubmittedPrompt, TurnOutcome, TurnState};
 
@@ -1987,7 +1987,7 @@ impl App {
             Some(agent) => self.apply_agent_pick(agent),
             None => {
                 let tab = self.current_tab_mut();
-                tab.messages.push(ChatMessage::System(
+                tab.messages.push(ChatMessage::error(
                     t!("system.agent_unknown", agent = arg).into_owned(),
                 ));
                 tab.scroll_to_bottom();
@@ -2050,7 +2050,7 @@ impl App {
 
     fn push_agent_switch_unavailable(&mut self) {
         let tab = self.current_tab_mut();
-        tab.messages.push(ChatMessage::System(
+        tab.messages.push(ChatMessage::warning(
             t!("system.agent_switch_unavailable").into_owned(),
         ));
         tab.scroll_to_bottom();
@@ -2071,7 +2071,7 @@ impl App {
         if self.model_picker_models.is_empty() {
             let tab = self.current_tab_mut();
             tab.messages
-                .push(ChatMessage::System(t!("system.no_models").into_owned()));
+                .push(ChatMessage::info(t!("system.no_models").into_owned()));
             tab.scroll_to_bottom();
             return;
         }
@@ -2095,7 +2095,7 @@ impl App {
             Some(_) => self.open_model_picker(),
             None => {
                 let tab = self.current_tab_mut();
-                tab.messages.push(ChatMessage::System(
+                tab.messages.push(ChatMessage::error(
                     t!("system.model_unknown", model = arg.as_str()).into_owned(),
                 ));
                 tab.scroll_to_bottom();
@@ -2195,7 +2195,7 @@ impl App {
         let session_id = {
             let tab = self.current_tab_mut();
             tab.model_override = Some(model_id.clone());
-            tab.messages.push(ChatMessage::System(
+            tab.messages.push(ChatMessage::success(
                 t!("system.model_set", model = name.as_str()).into_owned(),
             ));
             tab.scroll_to_bottom();
@@ -2427,7 +2427,7 @@ impl App {
                     "activate_agent_session_with_shift: not resumable",
                 );
                 let tab = self.current_tab_mut();
-                tab.messages.push(ChatMessage::System(msg));
+                tab.messages.push(ChatMessage::warning(msg));
                 tab.scroll_to_bottom();
                 #[cfg(test)]
                 {
@@ -2767,7 +2767,7 @@ impl App {
                 "dispatch_resume_in_agent_pane: agent does not support loadSession",
             );
             let tab = self.current_tab_mut();
-            tab.messages.push(ChatMessage::System(msg));
+            tab.messages.push(ChatMessage::warning(msg));
             tab.scroll_to_bottom();
             #[cfg(test)]
             {
@@ -4181,7 +4181,7 @@ impl App {
         }
         if !self.agent_supports_image {
             let tab = self.current_tab_mut();
-            tab.messages.push(ChatMessage::System(
+            tab.messages.push(ChatMessage::warning(
                 t!("system.image_not_supported").into_owned(),
             ));
             tab.scroll_to_bottom();
@@ -4194,7 +4194,7 @@ impl App {
             }
             None => {
                 let tab = self.current_tab_mut();
-                tab.messages.push(ChatMessage::System(
+                tab.messages.push(ChatMessage::info(
                     t!("system.image_clipboard_empty").into_owned(),
                 ));
                 tab.scroll_to_bottom();
@@ -4431,12 +4431,10 @@ impl App {
         if !tab.model_picker_open || self.model_picker_models.is_empty() {
             return None;
         }
-        let current_id = self.current_model_id_for_picker();
         Some(crate::ui::ModelPopupState {
             models: &self.model_picker_models,
             selected: tab.model_picker_selected,
             pane_focused: self.pane_focused,
-            current_id,
             disabled: self
                 .model_picker_models
                 .iter()
@@ -4553,7 +4551,7 @@ impl App {
                 // Warn but fall through: the raw line (leading `/` intact) is
                 // still sent so the user doesn't lose what they typed.
                 let tab = self.current_tab_mut();
-                tab.messages.push(ChatMessage::System(
+                tab.messages.push(ChatMessage::warning(
                     t!("system.unknown_command", command = name.as_str()).into_owned(),
                 ));
                 false
@@ -4570,7 +4568,7 @@ impl App {
         let msg = t!("connection.lost").into_owned();
         self.current_tab_mut()
             .messages
-            .push(ChatMessage::System(msg));
+            .push(ChatMessage::warning(msg));
     }
 
     /// Dispatch a parsed slash-command. The Enter handler is responsible
@@ -4639,11 +4637,11 @@ impl App {
             }
             let tab = self.current_tab_mut();
             tab.messages
-                .push(ChatMessage::System(t!("system.cancelled").into_owned()));
+                .push(ChatMessage::success(t!("system.cancelled").into_owned()));
             tab.scroll_to_bottom();
         } else {
             let tab = self.current_tab_mut();
-            tab.messages.push(ChatMessage::System(
+            tab.messages.push(ChatMessage::info(
                 t!("system.no_prompt_in_flight").into_owned(),
             ));
             tab.scroll_to_bottom();
@@ -4656,7 +4654,7 @@ impl App {
         if in_flight {
             let tab = self.current_tab_mut();
             tab.messages
-                .push(ChatMessage::System(t!("system.busy_use_stop").into_owned()));
+                .push(ChatMessage::warning(t!("system.busy_use_stop").into_owned()));
             tab.scroll_to_bottom();
             return;
         }
@@ -4702,7 +4700,7 @@ impl App {
         if in_flight {
             let tab = self.current_tab_mut();
             tab.messages
-                .push(ChatMessage::System(t!("system.busy_use_stop").into_owned()));
+                .push(ChatMessage::warning(t!("system.busy_use_stop").into_owned()));
             tab.scroll_to_bottom();
             return;
         }

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -10,11 +10,24 @@ use super::{TabAutofixState, TurnState};
 
 pub(crate) const DEFAULT_TAB_ID: &str = "0";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NoticeKind {
+    Success,
+    Info,
+    Warning,
+    Error,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum ChatMessage {
     User(String),
     Agent(String),
+    /// Legacy untyped system message retained for persisted chat compatibility.
     System(String),
+    Notice {
+        kind: NoticeKind,
+        text: String,
+    },
     ToolCall {
         id: String,
         title: String,
@@ -39,6 +52,36 @@ pub enum ChatMessage {
     /// no persistence gating — getting cleared by the next turn is fine,
     /// the next pane startup re-pushes it.
     Disclaimer,
+}
+
+impl ChatMessage {
+    pub fn success(text: impl Into<String>) -> Self {
+        Self::Notice {
+            kind: NoticeKind::Success,
+            text: text.into(),
+        }
+    }
+
+    pub fn info(text: impl Into<String>) -> Self {
+        Self::Notice {
+            kind: NoticeKind::Info,
+            text: text.into(),
+        }
+    }
+
+    pub fn warning(text: impl Into<String>) -> Self {
+        Self::Notice {
+            kind: NoticeKind::Warning,
+            text: text.into(),
+        }
+    }
+
+    pub fn error(text: impl Into<String>) -> Self {
+        Self::Notice {
+            kind: NoticeKind::Error,
+            text: text.into(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -373,7 +373,7 @@ impl App {
             }
             AppEvent::TabSystemMessage { tab_id, message } => {
                 let tab = self.tab_mut(&tab_id);
-                tab.messages.push(ChatMessage::System(message));
+                tab.messages.push(ChatMessage::info(message));
                 tab.scroll_to_bottom();
             }
             AppEvent::PromptTemplateLoaded { name } => {
@@ -389,7 +389,7 @@ impl App {
             AppEvent::AgentBusy { tab_id } => {
                 let tab = self.tab_mut(&tab_id);
                 tab.messages
-                    .push(ChatMessage::System(t!("system.agent_busy").into_owned()));
+                    .push(ChatMessage::warning(t!("system.agent_busy").into_owned()));
                 tab.scroll_to_bottom();
             }
             AppEvent::TabRenamed {
@@ -664,7 +664,7 @@ impl App {
                     SoftStopReason::Refusal => t!("system.stopped_refusal"),
                 };
                 let tab = self.session_tab_mut(&session_id);
-                tab.messages.push(ChatMessage::System(msg.into_owned()));
+                tab.messages.push(ChatMessage::warning(msg.into_owned()));
                 tab.scroll_to_bottom();
             }
             AppEvent::ExecutionInfo(message) => {
@@ -863,7 +863,7 @@ impl App {
             AppEvent::SystemMessage(message) => {
                 self.current_tab_mut()
                     .messages
-                    .push(ChatMessage::System(message));
+                    .push(ChatMessage::error(message));
                 self.scroll_to_bottom();
             }
             AppEvent::DebugPipeMessage(msg) => {
@@ -936,7 +936,7 @@ impl App {
                     if self.mode == AppMode::Chat {
                         self.current_tab_mut()
                             .messages
-                            .push(ChatMessage::System(t!("system.no_agents").into_owned()));
+                            .push(ChatMessage::warning(t!("system.no_agents").into_owned()));
                         self.scroll_to_bottom();
                     }
                 } else {

--- a/tools/wta/src/app_keys.rs
+++ b/tools/wta/src/app_keys.rs
@@ -599,7 +599,7 @@ impl App {
                     }
                     let tab = self.current_tab_mut();
                     tab.messages
-                        .push(ChatMessage::System(t!("system.cancelled").into_owned()));
+                        .push(ChatMessage::success(t!("system.cancelled").into_owned()));
                     tab.scroll_to_bottom();
                     self.close_pane_armed_at = None;
                 } else if !self.current_tab().input.is_empty()
@@ -783,7 +783,7 @@ impl App {
                     if !self.current_tab().turn.accepts_new_prompt() {
                         let tab = self.current_tab_mut();
                         tab.messages
-                            .push(ChatMessage::System(t!("system.agent_busy").into_owned()));
+                            .push(ChatMessage::warning(t!("system.agent_busy").into_owned()));
                         tab.scroll_to_bottom();
                         return;
                     }

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -2092,10 +2092,6 @@ fn model_config_update_refreshes_active_session_picker() {
         1,
         "the picker must highlight the model reported by the latest config update"
     );
-    assert_eq!(
-        app.model_popup_state().and_then(|state| state.current_id),
-        Some("gpt-5.6-sol")
-    );
 }
 
 #[test]
@@ -2230,6 +2226,13 @@ fn slash_model_hot_applies_cloud_model_to_live_session() {
         app.current_tab().model_override.as_deref(),
         Some("gpt-5.4")
     );
+    assert!(matches!(
+        app.current_tab().messages.last(),
+        Some(ChatMessage::Notice {
+            kind: NoticeKind::Success,
+            ..
+        })
+    ));
     match master_rx.try_recv().expect("live model switch request") {
         crate::protocol::acp::client::MasterExtRequest::SetSessionModel {
             session_id,
@@ -3946,9 +3949,12 @@ fn shift_enter_history_row_without_load_session_capability_shows_hint() {
     assert_eq!(cmd.kind, DispatchedCommandKind::NotResumable);
     let argv = cmd.argv.join(" ");
     assert!(argv.contains("LoadSessionNotSupported"), "argv: {}", argv);
-    // The current tab gets a System hint message.
+    // The current tab gets a warning notice.
     let has_hint = app.current_tab().messages.iter().any(|m| {
-        matches!(m, ChatMessage::System(text)
+        matches!(m, ChatMessage::Notice {
+            kind: NoticeKind::Warning,
+            text,
+        }
             if text.contains("loadSession")
                 && text.contains("Press Enter"))
     });
@@ -4620,8 +4626,11 @@ fn soft_stop_appends_system_line_without_changing_state() {
         app.current_tab()
             .messages
             .iter()
-            .any(|m| matches!(m, ChatMessage::System(s) if *s == expected)),
-        "a soft stop must append its localized System line"
+            .any(|m| matches!(m, ChatMessage::Notice {
+                kind: NoticeKind::Warning,
+                text,
+            } if *text == expected)),
+        "a soft stop must append its localized warning"
     );
     assert!(
         matches!(app.state, ConnectionState::Connected),
@@ -4664,7 +4673,10 @@ fn soft_stop_reasons_map_to_distinct_localized_lines() {
             app.current_tab()
                 .messages
                 .iter()
-                .any(|m| matches!(m, ChatMessage::System(s) if *s == expected)),
+                .any(|m| matches!(m, ChatMessage::Notice {
+                    kind: NoticeKind::Warning,
+                    text,
+                } if *text == expected)),
             "reason {reason:?} must render the {key} line"
         );
     }
@@ -6031,6 +6043,10 @@ fn render_model_picker_lists_models() {
         !text.contains("shared-model (BYOM)"),
         "the cloud-mode model picker must omit BYOM rows; rendered:\n{text}"
     );
+    assert!(
+        !text.contains('●'),
+        "the model picker must not prefix the current model with a circle; rendered:\n{text}"
+    );
 }
 
 #[test]
@@ -6693,7 +6709,10 @@ fn alt_v_without_image_capability_shows_not_supported_message() {
     assert!(
         tab.messages
             .iter()
-            .any(|m| matches!(m, ChatMessage::System(s) if *s == want)),
+            .any(|m| matches!(m, ChatMessage::Notice {
+                kind: NoticeKind::Warning,
+                text,
+            } if *text == want)),
         "Alt+V without image capability must push the not-supported message"
     );
     assert!(

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -29,6 +29,13 @@ fn custom_model(selection_id: &str, model_id: &str) -> CustomModelCatalogEntry {
     }
 }
 
+fn last_notice(app: &App) -> (NoticeKind, &str) {
+    match app.current_tab().messages.last() {
+        Some(ChatMessage::Notice { kind, text }) => (*kind, text),
+        other => panic!("expected an inline notice, got {other:?}"),
+    }
+}
+
 // ---- commands::classify — the pure input → intent mapping ----
 
 #[test]
@@ -114,10 +121,7 @@ fn slash_stop_when_idle_notes_nothing_to_stop() {
     run_slash(&mut app, "stop");
 
     assert_eq!(app.current_tab().messages.len(), 1);
-    assert!(matches!(
-        app.current_tab().messages.last(),
-        Some(ChatMessage::System(_))
-    ));
+    assert_eq!(last_notice(&app).0, NoticeKind::Info);
 }
 
 #[test]
@@ -226,10 +230,7 @@ fn slash_fix_while_busy_does_not_resubmit() {
         gen_after_first,
         "/fix while a turn is in flight must not bump generation / resubmit"
     );
-    assert!(matches!(
-        app.current_tab().messages.last(),
-        Some(ChatMessage::System(_))
-    ));
+    assert_eq!(last_notice(&app).0, NoticeKind::Warning);
 }
 
 #[test]
@@ -243,10 +244,7 @@ fn slash_model_without_models_notes_none() {
         !app.current_tab().model_picker_open,
         "/model must not open the picker when no models are available"
     );
-    assert!(matches!(
-        app.current_tab().messages.last(),
-        Some(ChatMessage::System(_))
-    ));
+    assert_eq!(last_notice(&app).0, NoticeKind::Info);
 }
 
 #[test]
@@ -499,10 +497,7 @@ fn slash_model_only_shows_cloud_choices_while_cloud_is_active() {
     run_slash_args(&mut app, "model", "custom:provider:local");
     assert_eq!(app.current_tab().model_override, None);
     assert!(!app.current_tab().model_picker_open);
-    assert!(matches!(
-        app.current_tab().messages.last(),
-        Some(ChatMessage::System(_))
-    ));
+    assert_eq!(last_notice(&app).0, NoticeKind::Error);
 }
 
 #[test]
@@ -524,7 +519,6 @@ fn slash_model_only_shows_selected_byok_while_byok_is_active() {
 
     app.open_model_picker();
     let state = app.model_popup_state().expect("picker state");
-    assert_eq!(state.current_id, Some(selected));
     assert_eq!(state.models.len(), 1);
     assert_eq!(state.models[0].id, selected);
     assert_eq!(state.disabled, vec![false]);
@@ -533,18 +527,12 @@ fn slash_model_only_shows_selected_byok_while_byok_is_active() {
     run_slash_args(&mut app, "model", "custom:provider:other");
     assert_eq!(app.current_tab().model_override, None);
     assert!(!app.current_tab().model_picker_open);
-    assert!(matches!(
-        app.current_tab().messages.last(),
-        Some(ChatMessage::System(_))
-    ));
+    assert_eq!(last_notice(&app).0, NoticeKind::Error);
 
     run_slash_args(&mut app, "model", "cloud");
     assert_eq!(app.current_tab().model_override, None);
     assert!(!app.current_tab().model_picker_open);
-    assert!(matches!(
-        app.current_tab().messages.last(),
-        Some(ChatMessage::System(_))
-    ));
+    assert_eq!(last_notice(&app).0, NoticeKind::Error);
 }
 
 #[test]
@@ -782,13 +770,12 @@ fn degraded_blocks_non_restart_command() {
     );
     // ...and the user is steered to /restart (the locked token is present in
     // every locale, so this holds regardless of the active language).
-    match app.current_tab().messages.last() {
-        Some(ChatMessage::System(msg)) => assert!(
-            msg.contains("/restart"),
-            "the degraded hint must point the user at /restart, got: {msg}"
-        ),
-        other => panic!("expected a System hint, got {other:?}"),
-    }
+    let (kind, message) = last_notice(&app);
+    assert_eq!(kind, NoticeKind::Warning);
+    assert!(
+        message.contains("/restart"),
+        "the degraded hint must point the user at /restart, got: {message}"
+    );
 }
 
 #[test]
@@ -807,10 +794,7 @@ fn degraded_blocks_model_command_too() {
         !app.current_tab().model_picker_open,
         "/model must be refused while the transport is lost"
     );
-    assert!(matches!(
-        app.current_tab().messages.last(),
-        Some(ChatMessage::System(_))
-    ));
+    assert_eq!(last_notice(&app).0, NoticeKind::Warning);
 }
 
 #[test]

--- a/tools/wta/src/theme.rs
+++ b/tools/wta/src/theme.rs
@@ -11,6 +11,10 @@ pub const ATTACHMENT_TOKEN: Style = Style::new().fg(Color::Cyan);
 // schemes. A hardcoded white was invisible on light color schemes (#234).
 pub const AGENT_TEXT: Style = Style::new().fg(Color::Reset);
 pub const SYSTEM_TEXT: Style = Style::new().fg(Color::Cyan);
+pub const NOTICE_SUCCESS: Style = Style::new().fg(Color::Green);
+pub const NOTICE_INFO: Style = Style::new().fg(Color::Cyan);
+pub const NOTICE_WARNING: Style = Style::new().fg(Color::Yellow);
+pub const NOTICE_ERROR: Style = Style::new().fg(Color::Red);
 pub const TOOL_CALL_TITLE: Style = Style::new().fg(Color::Reset).add_modifier(Modifier::DIM);
 pub const TOOL_CALL_PENDING: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
 pub const TOOL_CALL_RUNNING: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
-use crate::app::{App, ChatMessage, CompletedTurn, PlanEntryStatus};
+use crate::app::{App, ChatMessage, CompletedTurn, NoticeKind, PlanEntryStatus};
 use crate::theme;
 use crate::ui::shimmer;
 use crate::ui_trace;
@@ -74,6 +74,7 @@ fn message_height(msg: &ChatMessage, wrap_width: usize) -> usize {
         ChatMessage::Agent(t) | ChatMessage::Error(t) => dot_wrap_count(t, body_width) + 1,
         ChatMessage::User(t) => wrap_count(t, body_width) + 1,
         ChatMessage::System(t) | ChatMessage::AgentEvent(t) => wrap_count(t, wrap_width) + 1,
+        ChatMessage::Notice { text, .. } => dot_wrap_count(text, body_width) + 1,
         ChatMessage::ToolCall { location, location_is_command, .. } => {
             // Command targets render one line per split statement (see
             // the render arm below, and `command_format`) — must count
@@ -468,6 +469,16 @@ fn build_message_lines<'a>(
             }
             lines.push(Line::default());
         }
+        ChatMessage::Notice { kind, text } => {
+            let (marker, style) = match kind {
+                NoticeKind::Success => ("✓", theme::NOTICE_SUCCESS),
+                NoticeKind::Info => ("i", theme::NOTICE_INFO),
+                NoticeKind::Warning => ("!", theme::NOTICE_WARNING),
+                NoticeKind::Error => ("×", theme::NOTICE_ERROR),
+            };
+            push_prefixed_lines(&mut lines, marker, text, wrap_width, style);
+            lines.push(Line::default());
+        }
         ChatMessage::ToolCall {
             id,
             title,
@@ -643,6 +654,45 @@ fn push_dot_prefixed_lines<'a>(
     }
 }
 
+fn push_prefixed_lines<'a>(
+    lines: &mut Vec<Line<'a>>,
+    marker: &'static str,
+    text: &str,
+    wrap_width: usize,
+    style: Style,
+) {
+    let body_width = wrap_width.saturating_sub(2).max(1);
+    let mut first_row = true;
+
+    for paragraph in text.split('\n') {
+        if paragraph.is_empty() {
+            if first_row {
+                lines.push(Line::from(Span::styled(format!("{marker} "), style)));
+                first_row = false;
+            } else {
+                lines.push(Line::default());
+            }
+            continue;
+        }
+
+        for piece in textwrap::wrap(paragraph, body_width) {
+            let piece_str = truncate_render_text(&piece).into_owned();
+            if first_row {
+                lines.push(Line::from(vec![
+                    Span::styled(format!("{marker} "), style),
+                    Span::styled(piece_str, style),
+                ]));
+                first_row = false;
+            } else {
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled(piece_str, style),
+                ]));
+            }
+        }
+    }
+}
+
 /// Mirrors `push_dot_prefixed_lines`, but for the user's own submitted
 /// prompt: splits on embedded `\n` (from Shift+Enter multi-line input) and
 /// wraps each paragraph so every line is a real `ratatui::Line` — ratatui
@@ -742,6 +792,30 @@ mod tests {
 
     fn line_text(line: &Line) -> String {
         line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn notices_render_distinct_markers_and_hanging_indents() {
+        let cases = [
+            (NoticeKind::Success, "✓"),
+            (NoticeKind::Info, "i"),
+            (NoticeKind::Warning, "!"),
+            (NoticeKind::Error, "×"),
+        ];
+
+        for (kind, marker) in cases {
+            let message = ChatMessage::Notice {
+                kind,
+                text: "A notice that wraps onto another line".into(),
+            };
+            let lines = build_message_lines(&message, false, false, None, 0, 20);
+            assert!(line_text(&lines[0]).starts_with(&format!("{marker} ")));
+            assert!(
+                line_text(&lines[1]).starts_with("  "),
+                "continuation rows must align with the notice body"
+            );
+            assert!(line_text(lines.last().expect("trailing row")).is_empty());
+        }
     }
 
     fn assert_tool_call(

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -667,11 +667,9 @@ fn push_prefixed_lines<'a>(
     for paragraph in text.split('\n') {
         if paragraph.is_empty() {
             if first_row {
-                lines.push(Line::from(Span::styled(format!("{marker} "), style)));
-                first_row = false;
-            } else {
-                lines.push(Line::default());
+                continue;
             }
+            lines.push(Line::default());
             continue;
         }
 
@@ -816,6 +814,15 @@ mod tests {
             );
             assert!(line_text(lines.last().expect("trailing row")).is_empty());
         }
+    }
+
+    #[test]
+    fn notice_prefix_skips_leading_blank_lines() {
+        let message = ChatMessage::info("\n\nNotice text");
+        let lines = build_message_lines(&message, false, false, None, 0, 20);
+
+        assert_eq!(line_text(&lines[0]), "i Notice text");
+        assert_eq!(lines.len(), message_height(&message, 20));
     }
 
     fn assert_tool_call(

--- a/tools/wta/src/ui/model_popup.rs
+++ b/tools/wta/src/ui/model_popup.rs
@@ -17,18 +17,12 @@ use crate::app::AcpModelInfo;
 use crate::theme;
 
 const POPUP_MAX_VISIBLE: usize = 8;
-/// Marker drawn next to the model the pane is currently on.
-const CURRENT_MARKER: &str = "● ";
-const CURRENT_PAD: &str = "  ";
 
 /// Per-frame state captured from the [`App`](crate::app::App).
 pub struct ModelPopupState<'a> {
     pub models: &'a [AcpModelInfo],
     pub selected: usize,
     pub pane_focused: bool,
-    /// Id of the model the pane is currently effectively on, if any — drawn
-    /// with a leading marker so the user can see "where we are".
-    pub current_id: Option<&'a str>,
     /// Rows that require an agent restart and can only be changed in Settings.
     pub disabled: Vec<bool>,
 }
@@ -50,15 +44,9 @@ pub fn render_popup(frame: &mut Frame, state: ModelPopupState<'_>, input_area: R
         .iter()
         .enumerate()
         .map(|(index, m)| {
-            let is_current = state.current_id == Some(m.id.as_str());
             let disabled = state.disabled.get(index).copied().unwrap_or(false);
-            let marker = if is_current {
-                CURRENT_MARKER
-            } else {
-                CURRENT_PAD
-            };
             let spans = vec![Span::styled(
-                format!(" {marker}{}", m.name),
+                m.name.as_str(),
                 if disabled {
                     theme::DIM
                 } else {


### PR DESCRIPTION
## Summary of the Pull Request

Unifies inline feedback in the WTA chat UI and removes the current-model circle from the `/model` picker.

## References and Relevant Issues

N/A

## Detailed Description of the Pull Request / Additional comments

- Adds typed success, info, warning, and error notices with distinct accessible markers and colors.
- Uses consistent hanging indentation and spacing for multiline notices.
- Migrates slash-command and asynchronous system feedback to the shared notice renderer.
- Retains the legacy `System` message variant for persisted chat compatibility.
- Removes the redundant current-model circle while preserving picker preselection and the `>` cursor.

## Validation Steps Performed

- `cargo test --manifest-path tools/wta/Cargo.toml`
- `cargo build --manifest-path tools/wta/Cargo.toml`
- Hot-refreshed `wta.exe` in the Debug package and launched Intelligent Terminal.

## PR Checklist
- [ ] Closes #xxx
- [x] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)