### PR TITLE
Keep wtcli COM activation headless

### DIFF
--- a/doc/release-check-list.md
+++ b/doc/release-check-list.md
@@ -360,6 +360,7 @@ Net effect: UT shrinks the manual matrix to "did the wiring and UI connect", not
 - [ ] `C183` `[E2E]` **`wtcli send-keys`/send input path works:** Insert/run operations can send input to the target pane.
 - [ ] `C184` `[E2E]` **`wtcli listen` works:** Event subscription receives shell/agent events.
 - [ ] `C246` `[new]` `[E2E]` **Event-only protocol commands do not relaunch Terminal:** Late hook and WTA events are dropped after shutdown instead of activating a new Terminal process.
+- [ ] `C247` `[new]` `[E2E]` **COM activation stays headless and defers saved-layout restore:** Regular external `wtcli` queries may start the protocol server, but do not show a window or consume the saved layout; the next genuine UI activation restores it without an extra default window. _(E2E: `Feature.Packaging`.)_
 - [ ] `C185` `[E2E]` **WTA master starts:** One master process starts per Terminal process when needed.
 - [ ] `C186` `[E2E]` **WTA helper starts per tab/pane:** Agent pane helper starts and connects to master.
 - [ ] `C187` `[E2E]` **Master/helper crash recovery is acceptable:** Crashes or exits recover or surface an actionable error.

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -356,6 +356,7 @@ void WindowEmperor::CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs args
     _windowCount += 1;
     _windows.emplace_back(std::move(host));
 
+    _deferPersistedLayoutRestore = false;
     _skipPersistence = false;
 
     // Wire the new window's TerminalPage::ProtocolVtSequenceReceived
@@ -402,6 +403,8 @@ void WindowEmperor::OpenWindow(const winrt::hstring& name)
     {
         return;
     }
+
+    _restoreDeferredPersistedLayouts(_startupCurrentDirectory, _startupEnvironment, _startupShowWindowCommand);
 
     // If a window with this name is already live, just summon it.
     // This mirrors the summon behavior in AppHost::DispatchCommandline (which is
@@ -670,6 +673,10 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
     _app = winrt::TerminalApp::App{};
     _app.Logic().ReloadSettings();
 
+    const auto args = commandlineToArgArray(GetCommandLineW());
+    const auto isEmbedding = args.size() == 2 && args[1] == L"-Embedding";
+    _deferPersistedLayoutRestore = isEmbedding;
+
     _createMessageWindow(windowClassName.c_str());
     _setupGlobalHotkeys();
     _setupKeptSessionTracking();
@@ -693,32 +700,18 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
 
     {
         const wil::unique_environstrings_ptr envMem{ GetEnvironmentStringsW() };
-        const auto env = stringFromDoubleNullTerminated(envMem.get());
-        const auto cwd = wil::GetCurrentDirectoryW<std::wstring>();
-        const auto showCmd = gsl::narrow_cast<uint32_t>(nCmdShow);
+        _startupEnvironment = stringFromDoubleNullTerminated(envMem.get());
+        _startupCurrentDirectory = wil::GetCurrentDirectoryW<std::wstring>();
+        _startupShowWindowCommand = gsl::narrow_cast<uint32_t>(nCmdShow);
 
-        // Restore persisted windows.
-        const auto state = ApplicationState::SharedInstance();
-        const auto layouts = state.PersistedWindowLayouts();
-        if (layouts && layouts.Size() > 0)
+        if (!isEmbedding)
         {
-            _needsPersistenceCleanup = true;
-
-            uint32_t startIdx = 0;
-            for (const auto layout : layouts)
-            {
-                hstring args[] = { L"wt", L"-w", L"new", L"-s", winrt::to_hstring(startIdx) };
-                _dispatchCommandlineCommon(args, cwd, env, showCmd);
-                startIdx += 1;
-            }
+            _restorePersistedLayouts(_startupCurrentDirectory, _startupEnvironment, _startupShowWindowCommand);
         }
 
-
-        const auto args = commandlineToArgArray(GetCommandLineW());
-
-        if (args.size() == 2 && args[1] == L"-Embedding")
+        if (isEmbedding)
         {
-            // We were launched for ConPTY handoff. We have no windows and also don't want to exit.
+            // We were launched as a COM server. We have no windows and also don't want to exit.
             //
             // TODO: Here we could start a timer and exit after, say, 5 seconds
             // if no windows are created. But that's a minor concern.
@@ -728,7 +721,7 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
             // Create another window if needed: There aren't any yet, OR we got an explicit command line.
             if (_windows.empty() || args.size() != 1)
             {
-                _dispatchCommandlineCommon(args, cwd, env, showCmd);
+                _dispatchCommandlineCommon(args, _startupCurrentDirectory, _startupEnvironment, _startupShowWindowCommand);
             }
 
             // If we created no windows, e.g. because the args are "/?" we can just exit now.
@@ -745,6 +738,8 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
 
     {
         TerminalConnection::ConptyConnection::NewConnection([this](TerminalConnection::ConptyConnection conn) {
+            _restoreDeferredPersistedLayouts(_startupCurrentDirectory, _startupEnvironment, _startupShowWindowCommand);
+
             TerminalApp::CommandlineArgs args;
             args.ShowWindowCommand(conn.ShowWindow());
             args.Connection(std::move(conn));
@@ -1216,11 +1211,10 @@ bool WindowEmperor::_hasKeptSessions() const
     return false;
 }
 
-// Re-runs the startup layout restore for a process that never restarted. Used
-// when a bare launch arrives while we are headless with kept sessions: the
-// layout was written when the last window closed, and restoring it is what
-// reattaches those sessions. Returns false if there is nothing to restore, so
-// the caller can fall back to an ordinary new window.
+// Runs the startup layout restore, including when a process stayed headless
+// after COM activation or after its last window closed with kept sessions.
+// Returns false if no window was restored, so callers can fall back to an
+// ordinary new window.
 bool WindowEmperor::_restorePersistedLayouts(wil::zwstring_view cwd, wil::zwstring_view env, uint32_t showCmd)
 try
 {
@@ -1232,15 +1226,15 @@ try
     }
 
     _needsPersistenceCleanup = true;
+    const auto previousWindowCount = _windows.size();
 
-    uint32_t startIdx = 0;
-    for (const auto layout : layouts)
+    for (uint32_t index = 0; index < layouts.Size(); ++index)
     {
-        winrt::hstring args[] = { L"wt", L"-w", L"new", L"-s", winrt::to_hstring(startIdx) };
+        winrt::hstring args[] = { L"wt", L"-w", L"new", L"-s", winrt::to_hstring(index) };
         _dispatchCommandlineCommon(args, cwd, env, showCmd);
-        startIdx += 1;
     }
-    return true;
+
+    return _windows.size() > previousWindowCount;
 }
 catch (...)
 {
@@ -1591,6 +1585,11 @@ LRESULT WindowEmperor::_messageHandler(HWND window, UINT const message, WPARAM c
                     // kept sessions stranded with no way to reach them. The
                     // startup path does this too, but it only runs once, when
                     // the process starts — and this process never left.
+                    const auto restoredDeferredLayouts = _restoreDeferredPersistedLayouts(handoff.cwd, handoff.env, handoff.show);
+                    if (restoredDeferredLayouts && argv.size() == 1)
+                    {
+                        return 0;
+                    }
                     if (_windows.empty() && _hasKeptSessions() && argv.size() == 1 &&
                         _restoreAllKeptSessions())
                     {
@@ -1636,6 +1635,17 @@ LRESULT WindowEmperor::_messageHandler(HWND window, UINT const message, WPARAM c
     return DefWindowProcW(window, message, wParam, lParam);
 }
 
+bool WindowEmperor::_restoreDeferredPersistedLayouts(wil::zwstring_view cwd, wil::zwstring_view env, uint32_t showCmd)
+{
+    if (!_deferPersistedLayoutRestore)
+    {
+        return false;
+    }
+
+    _deferPersistedLayoutRestore = false;
+    return _restorePersistedLayouts(cwd, env, showCmd);
+}
+
 void WindowEmperor::_setupSessionPersistence(bool enabled)
 {
     if (!enabled)
@@ -1652,6 +1662,11 @@ void WindowEmperor::_setupSessionPersistence(bool enabled)
 
 void WindowEmperor::_persistState(const ApplicationState& state) const
 {
+    if (_deferPersistedLayoutRestore)
+    {
+        return;
+    }
+
     // Calling an `ApplicationState` setter triggers a write to state.json.
     // With this if condition we avoid an unnecessary write when persistence is disabled.
     if (state.PersistedWindowLayouts())
@@ -1674,6 +1689,11 @@ void WindowEmperor::_persistState(const ApplicationState& state) const
 void WindowEmperor::_finalizeSessionPersistence() const
 {
     using namespace std::string_view_literals;
+
+    if (_deferPersistedLayoutRestore)
+    {
+        return;
+    }
 
     if (_skipPersistence)
     {

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -134,6 +134,7 @@ private:
     void _registerHotKey(int index, const winrt::Microsoft::Terminal::Control::KeyChord& hotkey) noexcept;
     void _unregisterHotKey(int index) noexcept;
     void _setupGlobalHotkeys();
+    bool _restoreDeferredPersistedLayouts(wil::zwstring_view cwd, wil::zwstring_view env, uint32_t showCmd);
     void _setupSessionPersistence(bool enabled);
     void _persistState(const winrt::Microsoft::Terminal::Settings::Model::ApplicationState& state) const;
     void _finalizeSessionPersistence() const;
@@ -162,7 +163,11 @@ private:
     bool _notificationIconShown = false;
     bool _skipPersistence = false;
     bool _needsPersistenceCleanup = false;
+    bool _deferPersistedLayoutRestore = false;
     SafeDispatcherTimer _persistStateTimer;
+    std::wstring _startupCurrentDirectory;
+    std::wstring _startupEnvironment;
+    uint32_t _startupShowWindowCommand = SW_SHOWDEFAULT;
     std::optional<bool> _currentSystemThemeIsDark;
     int32_t _windowCount = 0;
     int32_t _messageBoxCount = 0;

--- a/test/e2e/tests/Feature.Packaging.Tests.ps1
+++ b/test/e2e/tests/Feature.Packaging.Tests.ps1
@@ -181,6 +181,84 @@ Describe 'Feature §9 event-only protocol lifecycle' -Tag 'Feature','ConnectOnly
     }
 }
 
+Describe 'Feature §9 headless COM activation' -Tag 'Feature','Packaging' -Skip:(-not $script:UiReady) {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
+    }
+
+    It 'COM activation stays headless and defers saved-layout restore' {
+        $app = Resolve-ItApp -Package (Get-ItTestPackage)
+        Stop-AppInstances -App $app
+        Backup-WtConfig -App $app
+
+        try {
+            Invoke-FrePass -App $app | Out-Null
+            Set-WtSetting -App $app -Key 'firstWindowPreference' -Value 'persistedLayout' | Out-Null
+            Set-WtState -App $app -Key 'persistedWindowLayouts' -Value $null | Out-Null
+
+            $app.AppUserModelId | Should -Not -BeNullOrEmpty
+            Start-Process -FilePath 'explorer.exe' -ArgumentList "shell:AppsFolder\$($app.AppUserModelId)" | Out-Null
+
+            $initialProcess = Wait-Until -TimeoutSec 30 -IntervalSec 0.5 -Because 'initial Terminal process' -Condition {
+                Get-WtProcessesForApp -App $app | Select-Object -First 1
+            }
+            $app.Pid = $initialProcess.Id
+            Resolve-WtComClsid -App $app -TimeoutSec 30 | Out-Null
+
+            (Test-Until -TimeoutSec 20 -IntervalSec 0.5 -Condition {
+                @(Get-WtWindows -App $app).Count -eq 1
+            }) | Should -BeTrue
+            (Test-Until -TimeoutSec 20 -IntervalSec 0.5 -Condition {
+                @(Get-WtWindowHwnds -App $app | Where-Object { $_.pid -eq $app.Pid }).Count -gt 0
+            }) | Should -BeTrue
+
+            Stop-Terminal -App $app -RestoreSettings $false
+            (Test-Until -TimeoutSec 15 -IntervalSec 0.5 -Condition {
+                @(Get-WtProcessesForApp -App $app).Count -eq 0
+            }) | Should -BeTrue
+
+            $savedLayoutCount = Wait-Until -TimeoutSec 10 -IntervalSec 0.5 -Because 'persisted window layout' -Condition {
+                $count = @((Get-WtStateObject -App $app).persistedWindowLayouts).Count
+                if ($count -gt 0) { $count }
+            }
+            $savedLayoutCount | Should -Be 1
+
+            $activation = Invoke-Native -FilePath $app.WtcliPath -Arguments @('--json', 'list-windows') `
+                -TimeoutSec 20 -Environment @{ WT_COM_CLSID = $app.ComClsid }
+            $activation.ExitCode | Should -Be 0
+            $activationResult = $activation.StdOut | ConvertFrom-JsonSafe
+            $activationResult | Should -Not -BeNullOrEmpty
+            $activationResult.PSObject.Properties.Name | Should -Contain 'windows'
+            @($activationResult.windows).Count | Should -Be 0
+
+            $headlessProcess = Wait-Until -TimeoutSec 15 -IntervalSec 0.5 -Because 'COM-activated Terminal process' -Condition {
+                Get-WtProcessesForApp -App $app | Select-Object -First 1
+            }
+            $app.Pid = $headlessProcess.Id
+            $unexpectedWindow = Test-Until -TimeoutSec 3 -IntervalSec 0.25 -Condition {
+                $process = Get-Process -Id $app.Pid -ErrorAction SilentlyContinue
+                ($process -and $process.MainWindowHandle -ne 0) -or
+                    @(Get-WtWindows -App $app).Count -gt 0 -or
+                    @(Get-WtWindowHwnds -App $app | Where-Object { $_.pid -eq $app.Pid }).Count -gt 0
+            }
+            $unexpectedWindow | Should -BeFalse
+            @((Get-WtStateObject -App $app).persistedWindowLayouts).Count | Should -Be $savedLayoutCount
+
+            Start-Process -FilePath 'explorer.exe' -ArgumentList "shell:AppsFolder\$($app.AppUserModelId)" | Out-Null
+            (Test-Until -TimeoutSec 30 -IntervalSec 0.5 -Condition {
+                try { @(Get-WtWindows -App $app).Count -eq $savedLayoutCount } catch { $false }
+            }) | Should -BeTrue
+            (Test-Until -TimeoutSec 20 -IntervalSec 0.5 -Condition {
+                @(Get-WtWindowHwnds -App $app | Where-Object { $_.pid -eq $app.Pid }).Count -eq $savedLayoutCount
+            }) | Should -BeTrue
+        }
+        finally {
+            Stop-AppInstances -App $app
+            Restore-WtConfig -App $app
+        }
+    }
+}
+
 Describe 'Feature §10 Diagnostics + logging' -Tag 'Feature' -Skip:(-not $script:UiReady) {
     BeforeAll {
         Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force


### PR DESCRIPTION
## Summary
- treat exact `-Embedding` startup as protocol-only and defer persisted-layout restoration
- restore pending layouts on command-line, named-window, and inbound ConPTY UI activation while preserving durable-session re-restore behavior
- suppress protocol-only persistence and add packaged regression coverage (`C247`)

## Validation
- `cmd.exe /c "tools\razzle.cmd && cd src\cascadia\WindowsTerminal && bx"` (passed; 0 errors, 77 existing PRI warnings)
- PowerShell parser and `git diff --check` (passed)
- `pwsh -NoProfile -File test\e2e\bootstrap.ps1 -Check` (passed; Windows App CLI unavailable)
- Packaging-tag Pester discovery (1 regression test discovered, skipped because `winapp` is unavailable)

Live E2E was not run because the changed package was not deployed.