### PR TITLE
Prevent duplicate blank windows during packaged startup

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1321,6 +1321,7 @@ safe_void_coroutine AppHost::_WindowInitializedHandler(const winrt::Windows::Fou
     // In AppHost::_WindowMoved, we'll make sure we're at least initialized
     // before dismissing open dialogs.
     _isWindowInitialized = WindowInitializedState::Initialized;
+    _windowManager->NotifyWindowInitialized();
 }
 
 winrt::TerminalApp::TerminalWindow AppHost::Logic()

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -656,6 +656,7 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
     const auto args = commandlineToArgArray(GetCommandLineW());
     const auto isEmbedding = args.size() == 2 && args[1] == L"-Embedding";
     _deferPersistedLayoutRestore = isEmbedding;
+    _ignoreBareHandoffsDuringInitialWindowCreation = !isEmbedding && args.size() == 1;
 
     _createMessageWindow(windowClassName.c_str());
     _setupGlobalHotkeys();
@@ -874,6 +875,11 @@ void WindowEmperor::_dispatchSpecialKey(const MSG& msg) const
     const auto scanCode = gsl::narrow_cast<uint8_t>(msg.lParam >> 16);
     const bool keyDown = (msg.message & 1) == 0;
     window->OnDirectKeyEvent(vkey, scanCode, keyDown);
+}
+
+void WindowEmperor::NotifyWindowInitialized() noexcept
+{
+    LOG_IF_WIN32_BOOL_FALSE(PostMessageW(_window.get(), WM_INITIAL_WINDOW_INITIALIZED, 0, 0));
 }
 
 void WindowEmperor::_dispatchCommandline(winrt::TerminalApp::CommandlineArgs args)
@@ -1269,6 +1275,9 @@ LRESULT WindowEmperor::_messageHandler(HWND window, UINT const message, WPARAM c
     {
         switch (message)
         {
+        case WM_INITIAL_WINDOW_INITIALIZED:
+            _ignoreBareHandoffsDuringInitialWindowCreation = false;
+            return 0;
         case WM_CLOSE_TERMINAL_WINDOW:
         {
             const auto globalSettings = _app.Logic().Settings().GlobalSettings();
@@ -1565,6 +1574,15 @@ LRESULT WindowEmperor::_messageHandler(HWND window, UINT const message, WPARAM c
                 // toast's Activated event, so just ignore this handoff.
                 if (argv.size() != 2 || argv[1] != L"--from-toast")
                 {
+                    // Packaged debuggers can issue the same bare activation
+                    // twice while the first process is still restoring its
+                    // initial window. The second process hands off here; the
+                    // in-flight initial launch already owns that request.
+                    if (_ignoreBareHandoffsDuringInitialWindowCreation && argv.size() == 1)
+                    {
+                        return 0;
+                    }
+
                     // Coming back from the headless state that keep-running put
                     // us in. A bare launch means "give me my terminal back", so
                     // restore what was open when the last window closed rather

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -38,6 +38,7 @@ public:
         WM_GET_DETACHED_SESSIONS_FOR_PROTOCOL,
         WM_KILL_DETACHED_SESSION_FOR_PROTOCOL,
         WM_GET_SHELL_SESSIONS_FOR_PROTOCOL,
+        WM_INITIAL_WINDOW_INITIALIZED,
     };
 
     // Used by WM_GET_WINDOW_LIST.  Callers allocate a vector on their
@@ -92,6 +93,7 @@ public:
     // CreateNewWindow is used for creating a new window from existing Content
     void CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs args);
     void HandleCommandlineArgs(int nCmdShow);
+    void NotifyWindowInitialized() noexcept;
     void FocusTabInAnyWindow(const winrt::TerminalApp::Tab& tab) const;
     // OpenWindow is used for opening a new window or summoning an existing window by name.
     void OpenWindow(const winrt::hstring& name);
@@ -164,6 +166,7 @@ private:
     bool _skipPersistence = false;
     bool _needsPersistenceCleanup = false;
     bool _deferPersistedLayoutRestore = false;
+    bool _ignoreBareHandoffsDuringInitialWindowCreation = false;
     SafeDispatcherTimer _persistStateTimer;
     std::wstring _startupCurrentDirectory;
     std::wstring _startupEnvironment;


### PR DESCRIPTION
## Summary
- ignore a duplicate bare single-instance handoff while the initial packaged window is still initializing
- clear the startup guard through the emperor message loop after `AppHost` reports the first window initialized
- preserve normal later launches, which still open a new window

## Validation
- `cargo build --manifest-path tools\wta\Cargo.toml --target x86_64-pc-windows-msvc`
- `tools\razzle.cmd && bcz no_clean`
- manually verified two package activations restore one window instead of adding a blank tab