### PR TITLE
Add integration coverage for profile-defined command aliases

### DIFF
--- a/doc/release-check-list.md
+++ b/doc/release-check-list.md
@@ -224,6 +224,7 @@ Net effect: UT shrinks the manual matrix to "did the wiring and UI connect", not
 - [ ] `C103` `[E2E]` `[MANUAL]` **Autofix with Copilot works:** Copilot submits a valid Direct Helper Proposal and the card presents a useful suggestion.
 - [ ] `C104` `[E2E]` **Autofix with non-Copilot agents works:** A non-Copilot built-in agent (Claude/Codex/Gemini) and a custom ACP agent each execute the canonical command, complete permission arming, and submit a usable Direct Helper Proposal through the same path.
 - [ ] `C221` `[new]` `[E2E]` `[MANUAL]` **Environment-aware answers/fixes:** For a failed or "how do I use X" prompt, the agent investigates the live environment first — checks whether the command actually exists on PATH and surfaces local scripts / near-matches for a mistyped command — instead of giving generic advice or fixing a nonexistent command. _(#306.)_
+- [ ] `C246` `[new]` `[E2E]` **Profile-defined PowerShell aliases resolve through packaged WTA:** A command defined only in the current user's PowerShell profile is reported as an alias with its real target by the shipped `wta resolve-command` CLI. _(#286/#418; E2E: `Feature.CommandResolution`.)_
 
 ### Autofix across layout changes
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -22,6 +22,7 @@ authenticated ACP agents. Current status (run on the Store package):
 | `Feature.PromptHistory.Tests.ps1` | PR #478: per-tab Up/Down prompt recall, draft restoration, and multiline preservation | 3 |
 | `Feature.AutofixPane.Tests.ps1` | Direct Helper Autofix proposal card render/insert/run/reject/target/stashed + across layout | 10 |
 | `Feature.AutofixParser.Tests.ps1` | issue #474: PowerShell ParserError-to-Autofix pipeline + success/handled-error/blank-input negative controls | 4 |
+| `Feature.CommandResolution.Tests.ps1` | PR #418: packaged WTA resolves PowerShell profile-only aliases to their real targets | 1 |
 | `Feature.SessionList.Tests.ps1` | session view (button + `/sessions` slash), session states, view switching (incl. draft-preservation), focus/restore | 13 (+1 skip) |
 | `Feature.AgentRestart.Tests.ps1` | agent restart after a settings change (/restart reconnects and answers) | 1 |
 | `Feature.ShellIntegration.Tests.ps1` | §3 shell-integration OSC 133 marks (success/failure, ParserError dedup, handled errors, WinPS 5.1 errors) + non-integrated cmd.exe safety | 6 |
@@ -32,11 +33,11 @@ authenticated ACP agents. Current status (run on the Store package):
 | `Feature.DelegateSource.Tests.ps1` | PR #488 profile-scoped delegate source: strict host/WSL `wta delegate` routing with no fallback in either direction | 2 (environment-gated) |
 | `Feature.AgentChat.Tests.ps1` / `Feature.AgentPopup.Tests.ps1` | agent chat + `/` popup/menu interaction | 1 + 3 |
 
-**Coverage: 108 of 110 automatable `[E2E]` checklist items are implemented.**
-**Test status: 102 baseline feature cases pass + 2 documented skips** (`wta sessions list` is
+**Coverage: 109 of 111 automatable `[E2E]` checklist items are implemented.**
+**Test status: 103 baseline feature cases pass + 2 documented skips** (`wta sessions list` is
 identity-gated — see `Feature.SessionList.Tests.ps1`), plus 2 PR #481 WSL-backend cases and 2
 PR #488 delegate-source cases that run only when a runnable distro (and, for the #481 chat
-case, an installed+authenticated native agent) is available. The 108 implemented checklist
+case, an installed+authenticated native agent) is available. The 109 implemented checklist
 items map to the baseline cases plus the deterministic settings/persistence assertions. The
 remaining new items are the two profile agent picker UIs; they stay explicit E2E work rather
 than being falsely credited by the JSON-level runtime tests. Other

--- a/test/e2e/tests/Feature.CommandResolution.Tests.ps1
+++ b/test/e2e/tests/Feature.CommandResolution.Tests.ps1
@@ -1,0 +1,92 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+# PR #418 / issue #286: packaged WTA must resolve aliases defined only in the
+# user's PowerShell profile, not just commands visible to a -NoProfile probe.
+#
+# The test temporarily replaces the current-host profile with one unique alias,
+# invokes the exact wta.exe shipped in the Dev package, and restores the original
+# profile bytes in finally/AfterAll.
+
+BeforeDiscovery {
+    Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
+    $script:Ready = $false
+    try {
+        $null = Resolve-ItApp -Package Dev -ErrorAction Stop
+        $script:Ready = $null -ne (Get-Command pwsh.exe -ErrorAction Stop)
+    }
+    catch {
+        $script:Ready = $false
+    }
+}
+
+Describe 'Feature: packaged WTA command resolution' -Tag 'Feature' -Skip:(-not $script:Ready) {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
+        $script:app = Resolve-ItApp -Package Dev
+        $script:pwsh = (Get-Command pwsh.exe -ErrorAction Stop).Source
+        $script:profileState = $null
+
+        $script:RestoreProfile = {
+            if (-not $script:profileState) {
+                return
+            }
+
+            if ($script:profileState.Existed) {
+                [System.IO.File]::WriteAllBytes($script:profileState.Path, $script:profileState.Bytes)
+            }
+            elseif (Test-Path -LiteralPath $script:profileState.Path) {
+                Remove-Item -LiteralPath $script:profileState.Path -Force
+            }
+            $script:profileState = $null
+        }
+    }
+
+    AfterAll {
+        & $script:RestoreProfile
+    }
+
+    It 'Profile-defined PowerShell aliases resolve through packaged WTA' {
+        $profilePath = (& $script:pwsh -NoProfile -NonInteractive -Command '$PROFILE.CurrentUserCurrentHost').Trim()
+        $profilePath | Should -Not -BeNullOrEmpty -Because 'pwsh must expose its current-user profile path'
+
+        $profileExisted = Test-Path -LiteralPath $profilePath
+        $script:profileState = [pscustomobject]@{
+            Path = $profilePath
+            Existed = $profileExisted
+            Bytes = if ($profileExisted) { [System.IO.File]::ReadAllBytes($profilePath) } else { $null }
+        }
+
+        $aliasName = "ite2e-profile-alias-$([guid]::NewGuid().ToString('N'))"
+        try {
+            $profileDirectory = Split-Path -Parent $profilePath
+            if (-not (Test-Path -LiteralPath $profileDirectory)) {
+                New-Item -ItemType Directory -Path $profileDirectory -Force | Out-Null
+            }
+            Set-Content -LiteralPath $profilePath -Encoding utf8 -Value "Set-Alias -Name '$aliasName' -Value 'Get-ChildItem' -Scope Global"
+
+            $withoutProfile = & $script:pwsh -NoProfile -NonInteractive -Command "Get-Command -Name '$aliasName' -ErrorAction SilentlyContinue"
+            $withoutProfile | Should -BeNullOrEmpty -Because 'the fixture must exist only in the PowerShell profile'
+
+            $result = Invoke-Wta -App $script:app -Arguments @(
+                'resolve-command',
+                $aliasName,
+                '--shell',
+                $script:pwsh,
+                '--json'
+            ) -TimeoutSec 15 -Raw
+
+            $result.ExitCode | Should -Be 0 -Because "packaged wta resolve-command failed: $($result.StdErr)"
+            $resolved = $result.StdOut | ConvertFrom-Json
+            $resolved.status | Should -Be 'exists'
+
+            $profileAlias = @($resolved.resolutions | Where-Object {
+                    $_.type -eq 'Alias' -and
+                    $_.name -eq $aliasName
+                })
+            $profileAlias | Should -HaveCount 1
+            $profileAlias[0].target | Should -Be 'Get-ChildItem'
+        }
+        finally {
+            & $script:RestoreProfile
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add deployed Dev-package integration coverage for profile-defined PowerShell aliases from #418 / #286
- prove the fixture is invisible to `pwsh -NoProfile`, then invoke the shipped `wta resolve-command` binary and assert the alias type, name, and target
- restore the user's original profile bytes on every test exit path
- track the behavior as release checklist item C246

## Integration boundary

PowerShell current-user profile -> packaged `wta.exe` -> profile-loading PowerShell resolver subprocess -> stable JSON command-resolution contract.

## Validation

- `test/e2e/bootstrap.ps1 -Check`
- `Feature.CommandResolution.Tests.ps1`: 1 passed, 0 failed, 0 skipped
- incremental release report marks C246 `[x]`
- package: Dev `IntelligentTerminal_rd9vj3e6a2mbr` 0.8.0.2

Follow-up integration coverage for #418.