### PR TITLE
Add integration coverage for mid-turn tab closure

### DIFF
--- a/doc/release-check-list.md
+++ b/doc/release-check-list.md
@@ -134,6 +134,7 @@ Net effect: UT shrinks the manual matrix to "did the wiring and UI connect", not
 - [ ] `C054` `[E2E]` **Different positions work:** Open/hide/focus works for bottom, right, left, and top pane positions.
 - [ ] `C055` `[E2E]` **Stash preserves chat:** Hiding and restoring the pane preserves helper process, connection state, and chat history.
 - [ ] `C056` `[E2E]` **Tab close cleans up:** Closing the owning tab cleans up the helper and does not leave a broken pane.
+- [ ] `C247` `[new]` `[E2E]` **Closing a tab mid-turn leaves sibling agent tabs working:** When one tab closes with a prompt in flight, its orphaned result is discarded without terminating the shared agent CLI, and another tab can continue chatting without a restart. _(#419/#425; E2E: `Feature.SharedAgentLifecycle`.)_
 - [ ] `C215` `[new]` `[E2E]` **Agent panes are not persisted into saved layout:** Saving and restoring a window layout does not resurrect a previously-open agent pane; restored windows come back without an unexpected agent pane. _(#360/#275.)_
 
 ### Built-in agent chat matrix

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -28,16 +28,17 @@ authenticated ACP agents. Current status (run on the Store package):
 | `Feature.ShellIntegration.Tests.ps1` | §3 shell-integration OSC 133 marks (success/failure, ParserError dedup, handled errors, WinPS 5.1 errors) + non-integrated cmd.exe safety | 6 |
 | `Feature.AgentProposedCommand.Tests.ps1` | §2 Direct Helper Proposal Insert/Run into the shell pane | 2 |
 | `Feature.AgentMatrix.Tests.ps1` | §2 non-Copilot built-in agents (Claude/Codex/Gemini) connect+chat through the ACP adapter — ONE consolidated case (Copilot is the in-depth suite); skips when none installed+authed | 1 |
+| `Feature.SharedAgentLifecycle.Tests.ps1` | PR #425: closing a tab mid-turn does not terminate the shared agent CLI or break sibling tabs | 1 |
 | `Feature.PerTabAgent.Tests.ps1` | C225-C228 + PR #487: `/agent` picker/direct selection, invalid-id safety, per-tab isolation/shared-master reuse, and global-default/override behavior | 7 |
 | `Feature.WslAgentBackend.Tests.ps1` | PR #481 profile-scoped WSL agent backend: settings hot reload, helper/master source routing, and authenticated chat | 2 (environment-gated) |
 | `Feature.DelegateSource.Tests.ps1` | PR #488 profile-scoped delegate source: strict host/WSL `wta delegate` routing with no fallback in either direction | 2 (environment-gated) |
 | `Feature.AgentChat.Tests.ps1` / `Feature.AgentPopup.Tests.ps1` | agent chat + `/` popup/menu interaction | 1 + 3 |
 
-**Coverage: 109 of 111 automatable `[E2E]` checklist items are implemented.**
-**Test status: 103 baseline feature cases pass + 2 documented skips** (`wta sessions list` is
+**Coverage: 110 of 112 automatable `[E2E]` checklist items are implemented.**
+**Test status: 104 baseline feature cases pass + 2 documented skips** (`wta sessions list` is
 identity-gated — see `Feature.SessionList.Tests.ps1`), plus 2 PR #481 WSL-backend cases and 2
 PR #488 delegate-source cases that run only when a runnable distro (and, for the #481 chat
-case, an installed+authenticated native agent) is available. The 109 implemented checklist
+case, an installed+authenticated native agent) is available. The 110 implemented checklist
 items map to the baseline cases plus the deterministic settings/persistence assertions. The
 remaining new items are the two profile agent picker UIs; they stay explicit E2E work rather
 than being falsely credited by the JSON-level runtime tests. Other

--- a/test/e2e/tests/Feature.SharedAgentLifecycle.Tests.ps1
+++ b/test/e2e/tests/Feature.SharedAgentLifecycle.Tests.ps1
@@ -1,0 +1,100 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+# PR #425 / issue #419: all Copilot tabs share one agent CLI through wta-master.
+# Closing one tab while its prompt is in flight must not tear down that shared
+# connection and break a sibling tab.
+
+BeforeDiscovery {
+    Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
+    $script:Ready = $false
+    try {
+        $null = Resolve-ItApp -Package Dev -ErrorAction Stop
+        $script:Ready = [bool](
+            (Get-Command copilot -ErrorAction SilentlyContinue) -and
+            (Test-WinAppAvailable)
+        )
+    }
+    catch {
+        $script:Ready = $false
+    }
+}
+
+Describe 'Feature: shared agent CLI lifecycle' -Tag 'Feature' -Skip:(-not $script:Ready) {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
+        $script:app = Start-Terminal -Package Dev -PassFre $true -Settings @{ acpAgent = 'copilot' }
+
+        $script:GetMaster = {
+            @(Get-CimInstance Win32_Process -Filter "Name='wta.exe'" -ErrorAction SilentlyContinue |
+                Where-Object {
+                    $_.ParentProcessId -eq $script:app.Pid -and
+                    $_.CommandLine -match '--master(\s|$|")' -and
+                    $_.CommandLine -notmatch '--connect-master'
+                }) | Select-Object -First 1
+        }
+    }
+
+    AfterAll {
+        if ($script:app) {
+            Stop-Terminal -App $script:app
+        }
+    }
+
+    It 'Closing a tab mid-turn leaves sibling agent tabs working' {
+        # Establish the survivor first and pin its exact helper pane.
+        $survivorShell = Get-ActivePane -App $script:app
+        Open-AgentPane -App $script:app | Out-Null
+        $survivorAgent = (Wait-NewAgentPaneSession -App $script:app -OwnerPaneSessionId $survivorShell.session_id -TimeoutSec 30).PaneSessionId
+        Wait-AgentReady -App $script:app -PaneSessionId $survivorAgent -TimeoutSec 90 |
+            Should -BeTrue -Because 'the sibling agent tab must connect before the victim tab is closed'
+
+        # A second tab shares the same master and underlying Copilot CLI.
+        $victimShell = New-WtTab -App $script:app -Title 'mid-turn-close-victim'
+        Set-WtPaneFocus -App $script:app -SessionId $victimShell.session_id
+        Open-AgentPane -App $script:app | Out-Null
+        $victimAgent = (Wait-NewAgentPaneSession -App $script:app -OwnerPaneSessionId $victimShell.session_id -TimeoutSec 30).PaneSessionId
+        Wait-AgentReady -App $script:app -PaneSessionId $victimAgent -TimeoutSec 90 |
+            Should -BeTrue -Because 'the victim agent tab must connect through the shared master'
+
+        $masterReady = Test-Until -TimeoutSec 20 -IntervalSec 0.5 -Condition $script:GetMaster
+        $masterReady | Should -BeTrue -Because 'the two helpers must share a running master'
+        $masterBefore = & $script:GetMaster
+        $masterBefore | Should -Not -BeNullOrEmpty
+        Initialize-LogOffsets -App $script:app | Out-Null
+
+        # Request enough output that the helper can be closed after forwarding but
+        # before the turn completes. The master log is the deterministic in-flight
+        # signal; no model text is used to decide when to close.
+        Send-AgentPrompt -App $script:app -PaneSessionId $victimAgent -Text `
+            'Write the integers from 1 through 500, one per line, without abbreviating or using a tool.' | Out-Null
+        $forwarded = Test-Until -TimeoutSec 20 -IntervalSec 0.1 -Condition {
+            (Get-ItLogText -App $script:app -Name 'wta-main_master.log' -SinceStart) -match
+                'forwarding prompt to agent CLI \(non-blocking\)'
+        }
+        $forwarded | Should -BeTrue -Because 'the victim prompt must be in flight before its tab closes'
+
+        Close-WtPane -App $script:app -SessionId $victimShell.session_id
+
+        # This is the fixed #425 branch: the shared CLI finishes the orphaned turn,
+        # and master drops only its undeliverable result instead of propagating the
+        # responder error and tearing down every tab's connection.
+        $orphanDropped = Test-Until -TimeoutSec 120 -IntervalSec 0.5 -Condition {
+            (Get-ItLogText -App $script:app -Name 'wta-main_master.log' -SinceStart) -match
+                'dropping orphan prompt result \(helper gone\)'
+        }
+        $orphanDropped | Should -BeTrue -Because 'the closed tab must exercise the orphan-result path'
+
+        $masterAfter = & $script:GetMaster
+        $masterAfter.ProcessId | Should -Be $masterBefore.ProcessId -Because 'closing one tab must not restart the shared master'
+        (Get-ItLogText -App $script:app -Name 'wta-main_master.log' -SinceStart) |
+            Should -Not -Match 'agent CLI exited' -Because 'the orphan result must not tear down the shared agent CLI'
+
+        # Final user-visible contract: the original sibling helper is still connected
+        # and can complete a fresh turn without /restart or rebuilding its pane.
+        Set-WtPaneFocus -App $script:app -SessionId $survivorShell.session_id
+        Wait-AgentReady -App $script:app -PaneSessionId $survivorAgent -TimeoutSec 30 |
+            Should -BeTrue -Because 'the original sibling helper must remain connected'
+        Send-AgentPrompt -App $script:app -PaneSessionId $survivorAgent -Text `
+            'What is 6 plus 7? Reply with only the number.' | Out-Null
+        Assert-AgentPaneText -App $script:app -PaneSessionId $survivorAgent -Pattern '\b13\b' -TimeoutSec 60
+    }
+}


### PR DESCRIPTION
## Summary

- add deployed Dev-package regression coverage for #425 / #419
- create a survivor agent tab and a victim tab that share one `wta-master`
- close the victim only after its prompt has been forwarded and is still in flight
- observe the fixed orphan-result branch, assert the shared CLI did not exit, then prove the original sibling pane answers without `/restart`
- track the behavior as release checklist item C247

## Integration boundary

Agent pane A -> helper A -> shared `wta-master` / Copilot CLI -> helper disconnect during prompt completion -> agent pane B remains connected and completes a new turn.

## Validation

- `Feature.SharedAgentLifecycle.Tests.ps1`: 1 passed, 0 failed, 0 skipped
- incremental release report marks C247 `[x]`
- package: Dev `IntelligentTerminal_rd9vj3e6a2mbr` 0.8.0.2

## Stack

This PR is stacked on #576 so each integration-test PR has an isolated diff and checklist IDs remain stable. It should target `main` after #576 merges.

Follow-up integration coverage for #425.