### PR TITLE
Make keep-running sessions tab-scoped

### DIFF
--- a/doc/specs/keep-running-sessions.md
+++ b/doc/specs/keep-running-sessions.md
@@ -11,7 +11,7 @@ issue id: durable-sessions (bucket 2)
 
 Durable Sessions combines saving sessions for restore with keeping their shells
 running. Users opt in a whole tab from its context menu; the tab header then
-shows a pin. Closing that tab detaches all of its non-agent shell panes so the
+shows a keep-running indicator. Closing that tab detaches all of its non-agent shell panes so the
 terminal process can stay alive with nothing on screen. When "When Terminal
 starts" is set to either restore option, the tab also persists its layout, cwd,
 shell sessions, and agent sessions. "Restore window layout and content"
@@ -190,7 +190,7 @@ request in flight at a time.
 ## Opt-in and settings
 
 Right-click a tab and select **Add tab to keep-running**. The item changes to
-**Remove tab from keep-running** after selection, and a pin in the tab header
+**Remove tab from keep-running** after selection, and a stopwatch in the tab header
 shows which tabs are selected. There is no pane-level opt-in or default keyboard
 shortcut.
 

--- a/doc/specs/keep-running-sessions.md
+++ b/doc/specs/keep-running-sessions.md
@@ -1,7 +1,7 @@
 ---
 author: Intelligent Terminal
 created on: 2026-08-04
-last updated: 2026-08-04
+last updated: 2026-08-10
 issue id: durable-sessions (bucket 2)
 ---
 
@@ -10,13 +10,14 @@ issue id: durable-sessions (bucket 2)
 ## Abstract
 
 Durable Sessions combines saving sessions for restore with keeping their shells
-running. When "When Terminal starts" is set to either restore option, closing a
-tab persists its layout and cwd, preserves its shell and agent sessions, and
-detaches the live shell content so the terminal process can stay alive with
-nothing on screen. "Restore window layout and content" additionally persists
-scrollback for fallback restoration after the live session is unavailable.
-A build that was halfway through when the last window closed is still halfway
-through when the terminal comes back.
+running. Users opt in a whole tab from its context menu; the tab header then
+shows a pin. Closing that tab detaches all of its non-agent shell panes so the
+terminal process can stay alive with nothing on screen. When "When Terminal
+starts" is set to either restore option, the tab also persists its layout, cwd,
+shell sessions, and agent sessions. "Restore window layout and content"
+additionally persists scrollback for fallback restoration after the live
+session is unavailable. A build that was halfway through when the last window
+closed is still halfway through when the terminal comes back.
 
 ## Background: what the terminal already does with ConPTYs
 
@@ -122,12 +123,14 @@ any pane unconfirmed.
 
 ### Ordering with bucket 1
 
-Saving the session metadata and keeping a process alive are both enabled by
-either restore value of `firstWindowPreference`. A successful save supplies the
-durable database id and revision stored beside the detached group. Only
-`PersistedLayoutAndContent` writes scrollback into the snapshot;
-`PersistedLayout` restores the same shell sessions, agent panes, and agent
-sessions without replaying saved terminal content.
+Keeping a process alive is controlled by the tab's explicit keep-running
+selection. Saving fallback metadata remains controlled by
+`firstWindowPreference`. A successful save supplies the durable database id and
+revision stored beside the detached group. Only `PersistedLayoutAndContent`
+writes scrollback into the snapshot; `PersistedLayout` restores the same shell
+sessions, agent panes, and agent sessions without replaying saved terminal
+content. With `DefaultProfile`, an opted-in tab still stays live in the current
+process but has no persisted fallback after that process exits.
 
 `_PersistShellSession` is normally reached from `_HandleCloseTabRequested`, which
 a window close never goes through. Since "close the terminal" is the whole point
@@ -177,15 +180,19 @@ Groups from several former windows may be restored into one available window.
 The original window topology and pane split ratios are not retained; panes in a
 multi-pane group are currently rebuilt with equal splits.
 
-## Settings
+## Opt-in and settings
+
+Right-click a tab and select **Add tab to keep-running**. The item changes to
+**Remove tab from keep-running** after selection, and a pin in the tab header
+shows which tabs are selected. There is no pane-level opt-in or default keyboard
+shortcut.
 
 The existing `firstWindowPreference` setting under Settings → Startup → "When
-Terminal starts" controls durable sessions. Both "Restore window layout" and
-"Restore window layout and content" restore shell sessions, agent panes, and
-agent sessions and keep running commands alive while detached. The latter also
-restores persisted scrollback. "Open a new tab with the default profile"
-disables future save-and-detach decisions but does not prevent an
-already-detached live session from being reattached.
+Terminal starts" controls the persisted fallback. Both "Restore window layout"
+and "Restore window layout and content" restore shell sessions, agent panes, and
+agent sessions; the latter also restores persisted scrollback. "Open a new tab
+with the default profile" does not prevent an opted-in tab from staying live or
+an already-detached live tab from being reattached.
 
 ## Capabilities and limitations
 
@@ -199,9 +206,10 @@ already-detached live session from being reattached.
 * Detached sessions hold their whole `ControlCore` and buffer in memory. That is
   heavier than a raw output ring, and is what buys full scrollback, marks and
   search on reattach.
-* Only qualifying sessions are detached: a shell must have received user input
-  or already belong to a durable record. Blank or accidental tabs remain
-  excluded.
+* Keep-running is a tab-level opt-in. Closing an opted-in tab detaches all of
+  its shell panes into one group, so the notification-area menu shows one row
+  for that tab. Closing an individual pane while its tab remains open ends that
+  pane normally.
 * Restoring several detached tabs can coalesce them into one window. Multi-pane
   tabs retain their live panes but currently use equal split sizes.
 * Agent panes are excluded — their durability is the agent CLI's own resume
@@ -209,9 +217,5 @@ already-detached live session from being reattached.
 
 ## Future considerations
 
-* **Per-session opt-in.** The Durable Sessions spec asks for marking an
-  individual session to keep running, with a badge on the pane. Today the setting
-  is global. The plumbing is per-pane already, so this is a UI change plus a flag
-  consulted in `_DetachShellPanesForKeepRunning`.
 * **Releasing the renderer while detached.** Detached content does not need its
   renderer; dropping it would cut the memory cost of a long-detached session.

--- a/doc/specs/keep-running-sessions.md
+++ b/doc/specs/keep-running-sessions.md
@@ -119,7 +119,8 @@ reattaches every live group directly from the process-wide `ContentManager`.
 The notification-area menu also lists each detached tab separately, with
 **Restore** and **Close** actions. A group is hidden while its restore is
 pending, preventing a second restore request; it reappears if dispatch leaves
-any pane unconfirmed.
+any pane unconfirmed. When a durable database id is available, it is also the
+group identity, so the same saved shell session can only occupy one row.
 
 ### Ordering with bucket 1
 
@@ -179,6 +180,12 @@ unconfirmed panes. This deliberately does not use
 Groups from several former windows may be restored into one available window.
 The original window topology and pane split ratios are not retained; panes in a
 multi-pane group are currently rebuilt with equal splits.
+
+Opening a saved shell session is idempotent across windows. The protocol first
+looks for a tab whose durable shell-session id matches the database primary key;
+if found, it summons that window and focuses the existing tab instead of
+starting another copy. The shell-session picker also allows only one Enter
+request in flight at a time.
 
 ## Opt-in and settings
 

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -530,9 +530,12 @@ namespace TerminalAppLocalTests
 
             NewTerminalArgs args{};
             args.SessionId(sessionId);
-            const auto reattachedPane = page->_MakeTerminalPane(args);
-            VERIFY_IS_NOT_NULL(reattachedPane);
-            VERIFY_ARE_EQUAL(content.Id(), reattachedPane->GetTerminalControl().ContentId());
+            VERIFY_SUCCEEDED(page->_OpenNewTab(args));
+            const auto reattachedTab = page->_GetTabImpl(page->_tabs.GetAt(page->_tabs.Size() - 1));
+            VERIFY_IS_NOT_NULL(reattachedTab);
+            VERIFY_IS_TRUE(reattachedTab->KeepRunning());
+            VERIFY_IS_TRUE(reattachedTab->TabStatus().IsKeepRunning());
+            VERIFY_ARE_EQUAL(content.Id(), reattachedTab->GetActiveTerminalControl().ContentId());
             VERIFY_ARE_EQUAL(0ull, _contentManager->TryReattachKeptSession(sessionId));
         });
     }
@@ -1277,14 +1280,17 @@ namespace TerminalAppLocalTests
             page->_DetachShellPanesForKeepRunning(tab.get(), shellSessionId, shellSessionRevision);
             VERIFY_ARE_EQUAL(0u, _contentManager->KeptGroups().Size());
 
-            const auto activePane = tab->GetActivePane();
-            VERIFY_IS_FALSE(!!activePane->_keepRunningButton);
-            activePane->KeepRunning(true);
-            VERIFY_IS_TRUE(!!activePane->_keepRunningButton);
+            page->_SplitPane(nullptr, SplitDirection::Right, 0.5f, page->_MakePane(nullptr, page->_GetFocusedTab(), nullptr));
+            VERIFY_ARE_EQUAL(2, tab->GetLeafPaneCount());
+
+            tab->KeepRunning(true);
+            VERIFY_IS_TRUE(tab->KeepRunning());
+            VERIFY_IS_TRUE(tab->TabStatus().IsKeepRunning());
             page->_DetachShellPanesForKeepRunning(tab.get(), shellSessionId, shellSessionRevision);
 
             const auto keptGroups = _contentManager->KeptGroups();
             VERIFY_ARE_EQUAL(1u, keptGroups.Size());
+            VERIFY_ARE_EQUAL(2u, _contentManager->DetachedSessions().Size());
 
             winrt::guid groupId{};
             for (const auto& group : keptGroups)
@@ -1297,15 +1303,15 @@ namespace TerminalAppLocalTests
 
             auto restored = _contentManager->BeginReattachKeptGroup(groupId);
             VERIFY_IS_TRUE(!!restored);
-            VERIFY_ARE_EQUAL(1u, restored.ContentIds().Size());
-            VERIFY_ARE_EQUAL(1u, restored.RestoreArgs().Size());
+            VERIFY_ARE_EQUAL(2u, restored.ContentIds().Size());
+            VERIFY_ARE_EQUAL(2u, restored.RestoreArgs().Size());
             VERIFY_IS_TRUE(restored.ShellSessionId() == shellSessionId);
             VERIFY_ARE_EQUAL(shellSessionRevision, restored.ShellSessionRevision());
             VERIFY_IS_TRUE(_contentManager->HasKeptSessions());
             VERIFY_ARE_EQUAL(0u, _contentManager->DetachedSessions().Size());
             VERIFY_ARE_EQUAL(0u, _contentManager->KeptGroups().Size());
             _contentManager->CancelKeptGroupReattach(groupId);
-            VERIFY_ARE_EQUAL(1u, _contentManager->DetachedSessions().Size());
+            VERIFY_ARE_EQUAL(2u, _contentManager->DetachedSessions().Size());
             VERIFY_ARE_EQUAL(1u, _contentManager->KeptGroups().Size());
 
             restored = _contentManager->BeginReattachKeptGroup(groupId);
@@ -2496,7 +2502,7 @@ namespace TerminalAppLocalTests
             expectedPaneId = _formatPaneId(sessionId);
             connection->TransitionTo(winrt::Microsoft::Terminal::TerminalConnection::ConnectionState::Failed);
 
-            tab->GetActivePane()->KeepRunning(true);
+            tab->KeepRunning(true);
             page->_DetachShellPanesForKeepRunning(tab.get(), winrt::hstring{}, 0);
 
             VERIFY_IS_FALSE(_contentManager->HasKeptSessions());
@@ -2560,7 +2566,7 @@ namespace TerminalAppLocalTests
                 endedSessions.push_back({ endedSession.SessionId(), endedSession.State() });
             });
 
-            tab->GetActivePane()->KeepRunning(true);
+            tab->KeepRunning(true);
             page->_DetachShellPanesForKeepRunning(tab.get(), shellSessionId, 41);
 
             VERIFY_IS_TRUE(_contentManager->HasKeptSessions());
@@ -2625,7 +2631,7 @@ namespace TerminalAppLocalTests
             const auto tab = page->_GetTabImpl(page->_tabs.GetAt(page->_tabs.Size() - 1));
             VERIFY_IS_NOT_NULL(tab);
             tab->SetDurableShellSession(L"existing-session", 8);
-            tab->GetActivePane()->KeepRunning(true);
+            tab->KeepRunning(true);
             page->_settings.GlobalSettings().FirstWindowPreference(FirstWindowPreference::PersistedLayout);
         });
 
@@ -2657,6 +2663,7 @@ namespace TerminalAppLocalTests
         TestOnUIThread([&]() {
             const auto tab = page->_GetFocusedTabImpl();
             VERIFY_IS_NOT_NULL(tab);
+            tab->KeepRunning(true);
 
             page->_SplitPane(nullptr, SplitDirection::Right, 0.5f, page->_MakePane(nullptr, page->_GetFocusedTab(), nullptr));
             VERIFY_ARE_EQUAL(2, tab->GetLeafPaneCount());

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -1487,6 +1487,20 @@ namespace TerminalAppLocalTests
         VERIFY_IS_NOT_NULL(renameAction);
         VERIFY_ARE_EQUAL(winrt::hstring{ L"Detached tab name" }, renameAction.Title());
 
+        // Restoring a detached tab hands these actions to the target window as
+        // JSON, so the keep-running opt-in has to survive a round trip.
+        const auto serialized = ActionAndArgs::Serialize(winrt::single_threaded_vector<ActionAndArgs>(std::vector<ActionAndArgs>{ actions }));
+        const auto deserialized = ActionAndArgs::Deserialize(serialized);
+        VERIFY_ARE_EQUAL(3u, deserialized.Size());
+        const auto roundTrippedTab = deserialized.GetAt(0).Args().try_as<NewTabArgs>();
+        VERIFY_IS_NOT_NULL(roundTrippedTab);
+        const auto roundTrippedArgs = roundTrippedTab.ContentArgs().try_as<NewTerminalArgs>();
+        VERIFY_IS_NOT_NULL(roundTrippedArgs);
+        VERIFY_IS_TRUE(roundTrippedArgs.KeepRunning());
+        const auto roundTrippedRename = deserialized.GetAt(2).Args().try_as<RenameTabArgs>();
+        VERIFY_IS_NOT_NULL(roundTrippedRename);
+        VERIFY_ARE_EQUAL(winrt::hstring{ L"Detached tab name" }, roundTrippedRename.Title());
+
         const auto untitled = winrt::make<winrt::TerminalApp::implementation::KeptGroupRestoreResult>(
             std::vector<NewTerminalArgs>{ firstRestoreArgs },
             winrt::hstring{},

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -773,6 +773,7 @@ namespace TerminalAppLocalTests
             auto restored = _contentManager->BeginReattachKeptGroup(firstGroupId);
             VERIFY_IS_NOT_NULL(restored);
             VERIFY_ARE_EQUAL(1u, restored.RestoreArgs().Size());
+            VERIFY_IS_TRUE(restored.Title() == L"Renamed tab");
             VERIFY_IS_TRUE(restored.ShellSessionId() == shellSessionId);
             VERIFY_ARE_EQUAL(2LL, restored.ShellSessionRevision());
             _contentManager->CancelKeptGroupReattach(firstGroupId);
@@ -1474,11 +1475,24 @@ namespace TerminalAppLocalTests
 
         const auto restored = winrt::make<winrt::TerminalApp::implementation::KeptGroupRestoreResult>(
             std::vector<NewTerminalArgs>{ firstRestoreArgs, secondRestoreArgs },
+            winrt::hstring{ L"Detached tab name" },
             winrt::hstring{ L"shell-session-restored" },
             55);
 
         const auto actions = winrt::TerminalApp::implementation::BuildKeptGroupRestoreActions(restored);
-        VERIFY_ARE_EQUAL(2u, static_cast<unsigned int>(actions.size()));
+        VERIFY_ARE_EQUAL(3u, static_cast<unsigned int>(actions.size()));
+
+        VERIFY_ARE_EQUAL(ShortcutAction::RenameTab, actions.at(2).Action());
+        const auto renameAction = actions.at(2).Args().try_as<RenameTabArgs>();
+        VERIFY_IS_NOT_NULL(renameAction);
+        VERIFY_ARE_EQUAL(winrt::hstring{ L"Detached tab name" }, renameAction.Title());
+
+        const auto untitled = winrt::make<winrt::TerminalApp::implementation::KeptGroupRestoreResult>(
+            std::vector<NewTerminalArgs>{ firstRestoreArgs },
+            winrt::hstring{},
+            winrt::hstring{ L"shell-session-restored" },
+            55);
+        VERIFY_ARE_EQUAL(1u, static_cast<unsigned int>(winrt::TerminalApp::implementation::BuildKeptGroupRestoreActions(untitled).size()));
 
         VERIFY_ARE_EQUAL(ShortcutAction::NewTab, actions.at(0).Action());
         const auto firstAction = actions.at(0).Args().try_as<NewTabArgs>();

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -208,6 +208,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(ContentIdHandoffEndClearsAgentBinding);
         TEST_METHOD(WindowCloseAcceptanceIsOneShot);
         TEST_METHOD(ContentMapOperationsUseOwnerThread);
+        TEST_METHOD(RepeatedKeepRunningDetachKeepsOneGroup);
         TEST_METHOD(ContentAttachRejectsDeadConnections);
         TEST_METHOD(ReattachEndEventOwnershipHandoff);
         TEST_METHOD(DetachedReapUsesConfiguredOwnerScheduler);
@@ -711,6 +712,55 @@ namespace TerminalAppLocalTests
         content.Close();
 
         VERIFY_IS_NULL(_contentManager->TryLookupCore(contentId));
+    }
+
+    void TabTests::RepeatedKeepRunningDetachKeepsOneGroup()
+    {
+        BEGIN_TEST_METHOD_PROPERTIES()
+            TEST_METHOD_PROPERTY(L"IsolationLevel", L"Method")
+        END_TEST_METHOD_PROPERTIES()
+
+        _createContentManager();
+
+        const auto firstGroupId = ::Microsoft::Console::Utils::GuidFromString(L"{61616161-1111-2222-3333-444444444444}");
+        const auto secondGroupId = ::Microsoft::Console::Utils::GuidFromString(L"{61616161-5555-6666-7777-888888888888}");
+        const auto sessionId = ::Microsoft::Console::Utils::GuidFromString(L"{61616161-aaaa-bbbb-cccc-dddddddddddd}");
+
+        TestOnUIThread([&]() {
+            auto settings = winrt::make_self<ControlUnitTests::MockControlSettings>();
+            std::vector<winrt::Microsoft::Terminal::Control::ControlInteractivity> contents;
+            const auto makeControl = [&]() {
+                auto connection = winrt::make_self<TestConnection>(
+                    sessionId,
+                    winrt::Microsoft::Terminal::TerminalConnection::ConnectionState::Connected);
+                auto content = _contentManager->CreateCore(*settings, *settings, *connection);
+                contents.emplace_back(content);
+                return winrt::Microsoft::Terminal::Control::TermControl{ content };
+            };
+
+            const auto firstControl = makeControl();
+            const auto replacementControl = makeControl();
+            VERIFY_IS_TRUE(_contentManager->DetachForKeepRunning(firstGroupId, sessionId, L"Tab", L"", 0, NewTerminalArgs{}, firstControl));
+            VERIFY_IS_TRUE(_contentManager->DetachForKeepRunning(firstGroupId, sessionId, L"Tab", L"", 0, NewTerminalArgs{}, replacementControl));
+            VERIFY_ARE_EQUAL(1u, _contentManager->DetachedSessions().Size());
+            VERIFY_ARE_EQUAL(1u, _contentManager->KeptGroups().Size());
+
+            auto restored = _contentManager->BeginReattachKeptGroup(firstGroupId);
+            VERIFY_IS_NOT_NULL(restored);
+            VERIFY_ARE_EQUAL(1u, restored.RestoreArgs().Size());
+            _contentManager->CancelKeptGroupReattach(firstGroupId);
+
+            const auto movedControl = makeControl();
+            VERIFY_IS_TRUE(_contentManager->DetachForKeepRunning(secondGroupId, sessionId, L"Tab", L"", 0, NewTerminalArgs{}, movedControl));
+            const auto groups = _contentManager->KeptGroups();
+            VERIFY_ARE_EQUAL(1u, groups.Size());
+            VERIFY_IS_FALSE(groups.HasKey(firstGroupId));
+            VERIFY_IS_TRUE(groups.HasKey(secondGroupId));
+
+            _contentManager->DiscardKeptGroup(secondGroupId);
+            contents.at(0).Close();
+            contents.at(1).Close();
+        });
     }
 
     void TabTests::ContentAttachRejectsDeadConnections()
@@ -1300,6 +1350,7 @@ namespace TerminalAppLocalTests
             }
 
             VERIFY_IS_TRUE(groupId != winrt::guid{});
+            VERIFY_IS_TRUE(!!::IsEqualGUID(groupId, ::Microsoft::Console::Utils::GuidFromString(tab->StableId().c_str())));
 
             auto restored = _contentManager->BeginReattachKeptGroup(groupId);
             VERIFY_IS_TRUE(!!restored);

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -553,6 +553,15 @@ namespace TerminalAppLocalTests
             VERIFY_IS_TRUE(reattachedTab->TabStatus().IsKeepRunning());
             VERIFY_ARE_EQUAL(content.Id(), reattachedTab->GetActiveTerminalControl().ContentId());
             VERIFY_ARE_EQUAL(0ull, _contentManager->TryReattachKeptSession(sessionId));
+
+            NewTerminalArgs fallbackArgs{};
+            fallbackArgs.KeptSessionId(::Microsoft::Console::Utils::GuidFromString(L"{42a75f00-eeee-ffff-1111-222222222222}"));
+            VERIFY_SUCCEEDED(page->_OpenNewTab(fallbackArgs));
+            const auto fallbackTab = page->_GetTabImpl(page->_tabs.GetAt(page->_tabs.Size() - 1));
+            VERIFY_IS_NOT_NULL(fallbackTab);
+            VERIFY_IS_FALSE(fallbackTab->KeepRunning());
+            VERIFY_IS_FALSE(fallbackTab->TabStatus().IsKeepRunning());
+            VERIFY_IS_TRUE(fallbackArgs.KeptSessionId() == winrt::guid{});
         });
     }
 

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -740,6 +740,7 @@ namespace TerminalAppLocalTests
         const auto firstGroupId = ::Microsoft::Console::Utils::GuidFromString(L"{61616161-1111-2222-3333-444444444444}");
         const auto secondGroupId = ::Microsoft::Console::Utils::GuidFromString(L"{61616161-5555-6666-7777-888888888888}");
         const auto sessionId = ::Microsoft::Console::Utils::GuidFromString(L"{61616161-aaaa-bbbb-cccc-dddddddddddd}");
+        const winrt::hstring shellSessionId{ L"61616161-9999-aaaa-bbbb-cccccccccccc" };
 
         TestOnUIThread([&]() {
             auto settings = winrt::make_self<ControlUnitTests::MockControlSettings>();
@@ -755,18 +756,20 @@ namespace TerminalAppLocalTests
 
             const auto firstControl = makeControl();
             const auto replacementControl = makeControl();
-            VERIFY_IS_TRUE(_contentManager->DetachForKeepRunning(firstGroupId, sessionId, L"Tab", L"", 0, NewTerminalArgs{}, firstControl));
-            VERIFY_IS_TRUE(_contentManager->DetachForKeepRunning(firstGroupId, sessionId, L"Tab", L"", 0, NewTerminalArgs{}, replacementControl));
+            VERIFY_IS_TRUE(_contentManager->DetachForKeepRunning(firstGroupId, sessionId, L"Tab", shellSessionId, 1, NewTerminalArgs{}, firstControl));
+            VERIFY_IS_TRUE(_contentManager->DetachForKeepRunning(firstGroupId, sessionId, L"Renamed tab", shellSessionId, 2, NewTerminalArgs{}, replacementControl));
             VERIFY_ARE_EQUAL(1u, _contentManager->DetachedSessions().Size());
             VERIFY_ARE_EQUAL(1u, _contentManager->KeptGroups().Size());
 
             auto restored = _contentManager->BeginReattachKeptGroup(firstGroupId);
             VERIFY_IS_NOT_NULL(restored);
             VERIFY_ARE_EQUAL(1u, restored.RestoreArgs().Size());
+            VERIFY_IS_TRUE(restored.ShellSessionId() == shellSessionId);
+            VERIFY_ARE_EQUAL(2LL, restored.ShellSessionRevision());
             _contentManager->CancelKeptGroupReattach(firstGroupId);
 
             const auto movedControl = makeControl();
-            VERIFY_IS_TRUE(_contentManager->DetachForKeepRunning(secondGroupId, sessionId, L"Tab", L"", 0, NewTerminalArgs{}, movedControl));
+            VERIFY_IS_TRUE(_contentManager->DetachForKeepRunning(secondGroupId, sessionId, L"Renamed tab", shellSessionId, 3, NewTerminalArgs{}, movedControl));
             const auto groups = _contentManager->KeptGroups();
             VERIFY_ARE_EQUAL(1u, groups.Size());
             VERIFY_IS_FALSE(groups.HasKey(firstGroupId));

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -239,6 +239,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(SuccessfulDetachedCloseDefersEndEventToContentManager);
         TEST_METHOD(CloseProtocolLastPaneKeepsRunningWithoutEmittingEndState);
         TEST_METHOD(CloseNonLastPaneEmitsOneEndStateWithoutKeepingTheTab);
+        TEST_METHOD(FocusProtocolShellSessionUsesDurableId);
         TEST_METHOD(ParseShellSessionSaveResponse);
 
         TEST_METHOD(TryDuplicateBadTab);
@@ -379,6 +380,20 @@ namespace TerminalAppLocalTests
 
     void TabTests::ShellSessionCloseActionsFollowStartupPreference()
     {
+        const auto tabId = ::Microsoft::Console::Utils::GuidFromString(L"{aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee}");
+        const auto durableId = ::Microsoft::Console::Utils::GuidFromString(L"{11111111-2222-3333-4444-555555555555}");
+        const winrt::hstring tabIdString{ ::Microsoft::Console::Utils::GuidToString(tabId) };
+        VERIFY_IS_TRUE(!!::IsEqualGUID(
+            durableId,
+            winrt::TerminalApp::implementation::GetKeepRunningGroupId(
+                tabIdString,
+                L"11111111-2222-3333-4444-555555555555")));
+        VERIFY_IS_TRUE(!!::IsEqualGUID(
+            tabId,
+            winrt::TerminalApp::implementation::GetKeepRunningGroupId(
+                tabIdString,
+                L"not-a-durable-uuid")));
+
         const auto disabled = winrt::TerminalApp::implementation::GetShellSessionCloseActions(FirstWindowPreference::DefaultProfile, false);
         VERIFY_IS_FALSE(disabled.save);
         VERIFY_IS_FALSE(disabled.detach);
@@ -1320,7 +1335,7 @@ namespace TerminalAppLocalTests
         auto page = _commonSetup();
         VERIFY_IS_NOT_NULL(page);
 
-        const winrt::hstring shellSessionId{ L"shell-session-detach-metadata" };
+        const winrt::hstring shellSessionId{ L"12345678-1234-5678-9abc-def012345678" };
         constexpr int64_t shellSessionRevision{ 19 };
 
         TestOnUIThread([&]() {
@@ -1350,7 +1365,7 @@ namespace TerminalAppLocalTests
             }
 
             VERIFY_IS_TRUE(groupId != winrt::guid{});
-            VERIFY_IS_TRUE(!!::IsEqualGUID(groupId, ::Microsoft::Console::Utils::GuidFromString(tab->StableId().c_str())));
+            VERIFY_IS_TRUE(!!::IsEqualGUID(groupId, ::Microsoft::Console::Utils::GuidFromPlainString(shellSessionId.c_str())));
 
             auto restored = _contentManager->BeginReattachKeptGroup(groupId);
             VERIFY_IS_TRUE(!!restored);
@@ -2734,6 +2749,22 @@ namespace TerminalAppLocalTests
         const auto states = _statesForPane(connectionStates, closedPaneId);
         VERIFY_ARE_EQUAL(1u, static_cast<unsigned int>(states.size()));
         VERIFY_ARE_EQUAL(std::string{ "closed" }, states.at(0));
+    }
+
+    void TabTests::FocusProtocolShellSessionUsesDurableId()
+    {
+        auto page = _commonSetup();
+        VERIFY_IS_NOT_NULL(page);
+
+        const winrt::hstring durableId{ L"11111111-2222-3333-4444-555555555555" };
+        TestOnUIThread([&]() {
+            const auto tab = page->_GetFocusedTabImpl();
+            VERIFY_IS_NOT_NULL(tab);
+            tab->SetDurableShellSession(durableId, 1);
+        });
+
+        VERIFY_IS_TRUE(page->FocusProtocolShellSession(durableId).get());
+        VERIFY_IS_FALSE(page->FocusProtocolShellSession(L"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").get());
     }
 
     void TabTests::ParseShellSessionSaveResponse()

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -356,20 +356,6 @@ namespace winrt::TerminalApp::implementation
         args.Handled(true);
     }
 
-    void TerminalPage::_HandleTogglePaneKeepRunning(const IInspectable& sender,
-                                                    const ActionEventArgs& args)
-    {
-        if (const auto activeTab{ _senderOrFocusedTab(sender) })
-        {
-            if (const auto pane = activeTab->GetActivePane(); pane && !pane->IsAgentPane())
-            {
-                pane->ToggleKeepRunning();
-            }
-        }
-
-        args.Handled(true);
-    }
-
     void TerminalPage::_HandleEnablePaneReadOnly(const IInspectable& sender,
                                                  const ActionEventArgs& args)
     {

--- a/src/cascadia/TerminalApp/ContentManager.cpp
+++ b/src/cascadia/TerminalApp/ContentManager.cpp
@@ -27,8 +27,10 @@ using namespace winrt::Microsoft::Terminal::Settings::Model;
 namespace winrt::TerminalApp::implementation
 {
     KeptGroupRestoreResult::KeptGroupRestoreResult(std::vector<NewTerminalArgs> restoreArgs,
+                                                   winrt::hstring title,
                                                    winrt::hstring shellSessionId,
                                                    const int64_t shellSessionRevision) :
+        _title{ std::move(title) },
         _shellSessionId{ std::move(shellSessionId) },
         _shellSessionRevision{ shellSessionRevision }
     {
@@ -691,6 +693,7 @@ namespace winrt::TerminalApp::implementation
         std::vector<NewTerminalArgs> restoreArgs;
         auto changed = false;
 
+        const auto title = it->second.title;
         const auto shellSessionId = it->second.shellSessionId;
         const auto shellSessionRevision = it->second.shellSessionRevision;
 
@@ -757,6 +760,7 @@ namespace winrt::TerminalApp::implementation
 
             return winrt::make<winrt::TerminalApp::implementation::KeptGroupRestoreResult>(
                 std::move(restoreArgs),
+                title,
                 shellSessionId,
                 shellSessionRevision);
     }

--- a/src/cascadia/TerminalApp/ContentManager.cpp
+++ b/src/cascadia/TerminalApp/ContentManager.cpp
@@ -392,6 +392,11 @@ namespace winrt::TerminalApp::implementation
                 });
         }
 
+        if (const auto existing = _keptSessions.find(sessionId);
+            existing != _keptSessions.end() && existing->second.groupId != groupId)
+        {
+            _dropKeptSession(sessionId);
+        }
         _keptSessions.insert_or_assign(sessionId, std::move(kept));
 
         auto& group = _keptGroups[groupId];
@@ -415,7 +420,10 @@ namespace winrt::TerminalApp::implementation
         {
             WI_ASSERT(group.shellSessionRevision == shellSessionRevision || shellSessionRevision == 0);
         }
-        group.sessionIds.push_back(sessionId);
+        if (std::find(group.sessionIds.begin(), group.sessionIds.end(), sessionId) == group.sessionIds.end())
+        {
+            group.sessionIds.push_back(sessionId);
+        }
 
         // The connection may already have transitioned to Closed/Failed before
         // we finished recording the detached session, or a queued callback may

--- a/src/cascadia/TerminalApp/ContentManager.cpp
+++ b/src/cascadia/TerminalApp/ContentManager.cpp
@@ -400,25 +400,17 @@ namespace winrt::TerminalApp::implementation
         _keptSessions.insert_or_assign(sessionId, std::move(kept));
 
         auto& group = _keptGroups[groupId];
-        if (group.title.empty())
+        if (!title.empty())
         {
             group.title = title;
         }
-        if (group.shellSessionId.empty())
+        if (!shellSessionId.empty())
         {
             group.shellSessionId = shellSessionId;
         }
-        else
-        {
-            WI_ASSERT(group.shellSessionId == shellSessionId || shellSessionId.empty());
-        }
-        if (group.shellSessionRevision == 0)
+        if (shellSessionRevision > group.shellSessionRevision)
         {
             group.shellSessionRevision = shellSessionRevision;
-        }
-        else
-        {
-            WI_ASSERT(group.shellSessionRevision == shellSessionRevision || shellSessionRevision == 0);
         }
         if (std::find(group.sessionIds.begin(), group.sessionIds.end(), sessionId) == group.sessionIds.end())
         {

--- a/src/cascadia/TerminalApp/ContentManager.h
+++ b/src/cascadia/TerminalApp/ContentManager.h
@@ -95,17 +95,20 @@ namespace winrt::TerminalApp::implementation
     {
     public:
         KeptGroupRestoreResult(std::vector<winrt::Microsoft::Terminal::Settings::Model::NewTerminalArgs> restoreArgs,
+                               winrt::hstring title,
                                winrt::hstring shellSessionId,
                                const int64_t shellSessionRevision);
 
         winrt::Windows::Foundation::Collections::IVectorView<uint64_t> ContentIds() const noexcept { return _contentIds; }
         winrt::Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Settings::Model::NewTerminalArgs> RestoreArgs() const noexcept { return _restoreArgs; }
+        winrt::hstring Title() const noexcept { return _title; }
         winrt::hstring ShellSessionId() const noexcept { return _shellSessionId; }
         int64_t ShellSessionRevision() const noexcept { return _shellSessionRevision; }
 
     private:
         winrt::Windows::Foundation::Collections::IVectorView<uint64_t> _contentIds{ nullptr };
         winrt::Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Settings::Model::NewTerminalArgs> _restoreArgs{ nullptr };
+        winrt::hstring _title;
         winrt::hstring _shellSessionId;
         int64_t _shellSessionRevision{ 0 };
     };

--- a/src/cascadia/TerminalApp/KeepRunningSessionHelpers.h
+++ b/src/cascadia/TerminalApp/KeepRunningSessionHelpers.h
@@ -215,6 +215,10 @@ namespace winrt::TerminalApp::implementation
             terminalArgs.DurableShellSessionId(L"");
             terminalArgs.DurableShellSessionRevision(0);
             terminalArgs.KeptSessionId(terminalArgs.SessionId());
+            // Survives the JSON hop into the target window, unlike
+            // KeptSessionId. The tab was explicitly opted into keep-running
+            // before it was detached, so restoring it keeps that opt-in.
+            terminalArgs.KeepRunning(true);
 
             if (actions.empty())
             {

--- a/src/cascadia/TerminalApp/KeepRunningSessionHelpers.h
+++ b/src/cascadia/TerminalApp/KeepRunningSessionHelpers.h
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <string>
 #include <vector>
 
 namespace winrt::TerminalApp::implementation
@@ -41,6 +42,31 @@ namespace winrt::TerminalApp::implementation
         const bool hasAgentSession) noexcept
     {
         return hasUserInput || hasDurableId || keepRunning || hasAgentSession;
+    }
+
+    inline winrt::guid GetKeepRunningGroupId(
+        const winrt::hstring& tabStableId,
+        const winrt::hstring& durableShellSessionId)
+    {
+        if (!durableShellSessionId.empty())
+        {
+            std::wstring text{ durableShellSessionId };
+            if (text.front() != L'{')
+            {
+                text.insert(text.begin(), L'{');
+                text.push_back(L'}');
+            }
+
+            GUID durableId{};
+            if (SUCCEEDED(IIDFromString(text.c_str(), &durableId)))
+            {
+                return winrt::guid{ durableId };
+            }
+        }
+
+        GUID tabId{};
+        winrt::check_hresult(IIDFromString(tabStableId.c_str(), &tabId));
+        return winrt::guid{ tabId };
     }
 
     inline constexpr bool ShouldResumeAgentSession(

--- a/src/cascadia/TerminalApp/KeepRunningSessionHelpers.h
+++ b/src/cascadia/TerminalApp/KeepRunningSessionHelpers.h
@@ -37,10 +37,10 @@ namespace winrt::TerminalApp::implementation
     inline constexpr bool ShouldPersistShellSession(
         const bool hasUserInput,
         const bool hasDurableId,
-        const bool hasKeepRunningPane,
+        const bool keepRunning,
         const bool hasAgentSession) noexcept
     {
-        return hasUserInput || hasDurableId || hasKeepRunningPane || hasAgentSession;
+        return hasUserInput || hasDurableId || keepRunning || hasAgentSession;
     }
 
     inline constexpr bool ShouldResumeAgentSession(

--- a/src/cascadia/TerminalApp/KeepRunningSessionHelpers.h
+++ b/src/cascadia/TerminalApp/KeepRunningSessionHelpers.h
@@ -232,6 +232,15 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
+        // The tray row the user clicked is labeled with the detached tab's
+        // title. Reattaching only rebuilds panes, so without this the tab comes
+        // back labeled from its profile instead of the name it was closed under.
+        if (const auto title = restoredGroup.Title();
+            !actions.empty() && !title.empty())
+        {
+            actions.emplace_back(ShortcutAction::RenameTab, RenameTabArgs{ title });
+        }
+
         return actions;
     }
 }

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1609,7 +1609,6 @@ void Pane::_CloseChild(const bool closeFirst)
         // we pass the child's contentId to _setPaneContent so it transfers with
         // the content automatically.
         auto remainingContentId = remainingChild->_contentId;
-        const auto remainingKeepRunning = remainingChild->_keepRunning;
         _setPaneContent(remainingChild->_takePaneContent(), remainingContentId);
         if (!_content)
         {
@@ -1654,7 +1653,6 @@ void Pane::_CloseChild(const bool closeFirst)
         // what our active control is, we won't technically be a "leaf", and
         // GetTerminalControl will return null.
         _splitState = SplitState::None;
-        KeepRunning(remainingKeepRunning);
 
         // re-attach our handler for the control's GotFocus event.
         if (control)
@@ -2534,11 +2532,8 @@ std::pair<std::shared_ptr<Pane>, std::shared_ptr<Pane>> Pane::_Split(SplitDirect
     {
         //   Move our content and content ID into the first child.
         auto originalContentId = _contentId;
-        const auto originalKeepRunning = _keepRunning;
         _firstChild = std::make_shared<Pane>(_takePaneContent());
         _firstChild->_broadcastEnabled = _broadcastEnabled;
-        _firstChild->KeepRunning(originalKeepRunning);
-        _keepRunning = false;
         // Overwrite the fresh content ID with the original so protocol
         // lookups continue to find this content after the split.
         _firstChild->_contentId = originalContentId;
@@ -3475,59 +3470,6 @@ void Pane::_EnsureAgentChip()
     _agentChip.IsHitTestVisible(false);
     _agentChip.Visibility(Visibility::Collapsed);
     _UpdateAgentChipBackground();
-}
-
-void Pane::_EnsureKeepRunningButton()
-{
-    if (!_keepRunningButton)
-    {
-        Controls::FontIcon icon{};
-        icon.Glyph(L"\xE718");
-
-        _keepRunningButton = Controls::Button{};
-        _keepRunningButton.Content(icon);
-        _keepRunningButton.Width(32);
-        _keepRunningButton.Height(32);
-        _keepRunningButton.Padding({ 0, 0, 0, 0 });
-        _keepRunningButton.HorizontalAlignment(HorizontalAlignment::Right);
-        _keepRunningButton.VerticalAlignment(VerticalAlignment::Top);
-        _keepRunningButton.Margin({ 0, 8, 8, 0 });
-        _keepRunningButton.Visibility(Visibility::Collapsed);
-        const auto label = RS_(L"PaneKeepRunningButton/ToolTip");
-        Controls::ToolTipService::SetToolTip(_keepRunningButton, box_value(label));
-        Automation::AutomationProperties::SetName(_keepRunningButton, label);
-        const auto weakThis = weak_from_this();
-        _keepRunningButton.Click([weakThis](const auto&, const auto&) {
-            if (const auto pane = weakThis.lock())
-            {
-                pane->KeepRunning(false);
-            }
-        });
-    }
-
-    if (!_keepRunningButton.Parent())
-    {
-        _root.Children().Append(_keepRunningButton);
-    }
-}
-
-void Pane::KeepRunning(const bool value)
-{
-    _keepRunning = value && _IsLeaf() && !_isAgentPane;
-    if (_keepRunning)
-    {
-        _EnsureKeepRunningButton();
-        _keepRunningButton.Visibility(Visibility::Visible);
-    }
-    else if (_keepRunningButton)
-    {
-        _keepRunningButton.Visibility(Visibility::Collapsed);
-    }
-}
-
-void Pane::ToggleKeepRunning()
-{
-    KeepRunning(!_keepRunning);
 }
 
 // Apply the theme-tracking background brush to the chip. Reuses the

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -172,9 +172,6 @@ public:
 
     bool IsAgentPane() const noexcept;
     void IsAgentPane(bool value) noexcept;
-    bool KeepRunning() const noexcept { return _keepRunning; }
-    void KeepRunning(bool value);
-    void ToggleKeepRunning();
     bool IsSourceOfAgentPane() const noexcept;
     void SetSourceOfAgentPane(bool value) noexcept;
     void SetAgentChipVisible(bool value);
@@ -309,8 +306,6 @@ private:
     bool _broadcastEnabled{ false };
     bool _isAgentPane{ false };
     bool _isSourceOfAgentPane{ false };
-    bool _keepRunning{ false };
-    winrt::Windows::UI::Xaml::Controls::Button _keepRunningButton{ nullptr };
 
     // Mouse drag-to-resize state on the splitter.
     bool _splitterDragging{ false };
@@ -336,7 +331,6 @@ private:
     void _UpdateBorders();
     void _EnsureAgentChip();
     void _UpdateAgentChipBackground();
-    void _EnsureKeepRunningButton();
     Borders _GetCommonBorders();
     winrt::Windows::UI::Xaml::Media::SolidColorBrush _ComputeBorderColor();
 

--- a/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
@@ -1307,10 +1307,10 @@ Für alle verfügbaren Optionen führen Sie 'wt new-tab --help' aus.</value>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Diese Registerkarte wird nach dem Schließen weiter ausgeführt.</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Diese Registerkarte wird nach dem Schließen weiter ausgeführt.</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
@@ -1297,8 +1297,20 @@ Beispielsweise entspricht 'wt -p "Ubuntu" -d C:\' 'wt new-tab -p "Ubuntu" -d C:\
 Für alle verfügbaren Optionen führen Sie 'wt new-tab --help' aus.</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>Diesen Bereich nach dem Schließen nicht weiter ausführen</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>Registerkarte nach dem Schließen weiter ausführen</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>Registerkarte nicht mehr nach dem Schließen weiter ausführen</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Diese Registerkarte wird nach dem Schließen weiter ausgeführt.</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Diese Registerkarte wird nach dem Schließen weiter ausgeführt.</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1353,8 +1353,20 @@ For example, 'wt -p "Ubuntu" -d C:\' is equivalent to 'wt new-tab -p "Ubuntu" -d
 For all available options, run 'wt new-tab --help'.</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>Stop keeping this pane running</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>Add tab to keep-running</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>Remove tab from keep-running</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>This tab will keep running after it is closed.</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>This tab will keep running after it is closed.</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1363,10 +1363,10 @@ For all available options, run 'wt new-tab --help'.</value>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>This tab will keep running after it is closed.</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>This tab will keep running after it is closed.</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
@@ -1294,8 +1294,20 @@ Por ejemplo, 'wt -p "Ubuntu" -d C:\' equivale a 'wt new-tab -p "Ubuntu" -d C:\'.
 Para todas las opciones disponibles, ejecute 'wt new-tab --help'.</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>Dejar de ejecutar este panel después de cerrarlo</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>Mantener la pestaña en ejecución después de cerrarla</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>Dejar de mantener la pestaña en ejecución después de cerrarla</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Esta pestaña seguirá ejecutándose después de cerrarla.</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Esta pestaña seguirá ejecutándose después de cerrarla.</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
@@ -1304,10 +1304,10 @@ Para todas las opciones disponibles, ejecute 'wt new-tab --help'.</value>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Esta pestaña seguirá ejecutándose después de cerrarla.</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Esta pestaña seguirá ejecutándose después de cerrarla.</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
@@ -1305,10 +1305,10 @@ Pour toutes les options disponibles, exécutez « wt new-tab --help ».</value
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Cet onglet continuera de s’exécuter après sa fermeture.</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Cet onglet continuera de s’exécuter après sa fermeture.</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
@@ -1295,8 +1295,20 @@ Par exemple, « wt -p "Ubuntu" -d C:\ » est équivalent à « wt new-tab -p 
 Pour toutes les options disponibles, exécutez « wt new-tab --help ».</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>Ne plus exécuter ce volet après sa fermeture</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>Maintenir l’onglet en cours d’exécution après sa fermeture</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>Ne plus maintenir l’onglet en cours d’exécution après sa fermeture</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Cet onglet continuera de s’exécuter après sa fermeture.</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Cet onglet continuera de s’exécuter après sa fermeture.</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
@@ -1294,8 +1294,20 @@ Ad esempio, 'wt -p "Ubuntu" -d C:\' equivale a 'wt new-tab -p "Ubuntu" -d C:\'.
 Per tutte le opzioni disponibili, esegui 'wt new-tab --help'.</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>Interrompi l'esecuzione del riquadro dopo la chiusura</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>Mantieni la scheda in esecuzione dopo la chiusura</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>Interrompi l’esecuzione della scheda dopo la chiusura</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Questa scheda continuerà a essere eseguita dopo la chiusura.</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Questa scheda continuerà a essere eseguita dopo la chiusura.</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
@@ -1304,10 +1304,10 @@ Per tutte le opzioni disponibili, esegui 'wt new-tab --help'.</value>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Questa scheda continuerà a essere eseguita dopo la chiusura.</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Questa scheda continuerà a essere eseguita dopo la chiusura.</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
@@ -1313,10 +1313,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>このタブは閉じた後も実行され続けます。</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>このタブは閉じた後も実行され続けます。</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
@@ -1303,8 +1303,20 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
 使用できるすべてのオプションについては、'wt new-tab --help' を実行します。</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>このペインを閉じた後も実行し続ける設定を解除する</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>タブを閉じた後も実行し続ける</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>タブを閉じた後も実行し続ける設定を解除する</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>このタブは閉じた後も実行され続けます。</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>このタブは閉じた後も実行され続けます。</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
@@ -1344,10 +1344,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>이 탭은 닫은 후에도 계속 실행됩니다.</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>이 탭은 닫은 후에도 계속 실행됩니다.</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
@@ -1334,8 +1334,20 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
 사용 가능한 모든 옵션에 대해 'wt new-tab --help'를 실행합니다.</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>이 창을 닫은 후에도 계속 실행하는 설정 해제</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>탭을 닫은 후에도 계속 실행</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>탭을 닫은 후에도 계속 실행하는 설정 해제</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>이 탭은 닫은 후에도 계속 실행됩니다.</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>이 탭은 닫은 후에도 계속 실행됩니다.</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
@@ -1322,8 +1322,20 @@ Por exemplo, 'wt -p "Ubuntu" -d C:\' é equivalente a 'wt new-tab -p "Ubuntu" -d
 Para todas as opções disponíveis, execute 'wt new-tab --help'.</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>Parar de manter este painel em execução após fechá-lo</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>Manter a guia em execução após fechá-la</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>Parar de manter a guia em execução após fechá-la</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Esta guia continuará em execução após ser fechada.</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Esta guia continuará em execução após ser fechada.</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
@@ -1332,10 +1332,10 @@ Para todas as opções disponíveis, execute 'wt new-tab --help'.</value>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Esta guia continuará em execução após ser fechada.</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Esta guia continuará em execução após ser fechada.</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
@@ -1301,10 +1301,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>This tab will keep running after it is closed.</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>This tab will keep running after it is closed.</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
@@ -1291,8 +1291,20 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
 ₣òŕ ăłļ åνãϊłάвļê ôφŧιôņş, ґùη 'wt new-tab --help'. !!! !!! !!! !!! !!!</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>Stop keeping this pane running</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>Add tab to keep-running</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>Remove tab from keep-running</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>This tab will keep running after it is closed.</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>This tab will keep running after it is closed.</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
@@ -1301,10 +1301,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>This tab will keep running after it is closed.</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>This tab will keep running after it is closed.</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
@@ -1291,8 +1291,20 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
 ₣òŕ ăłļ åνãϊłάвļê ôφŧιôņş, ґùη 'wt new-tab --help'. !!! !!! !!! !!! !!!</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>Stop keeping this pane running</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>Add tab to keep-running</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>Remove tab from keep-running</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>This tab will keep running after it is closed.</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>This tab will keep running after it is closed.</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
@@ -1301,10 +1301,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>This tab will keep running after it is closed.</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>This tab will keep running after it is closed.</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
@@ -1291,8 +1291,20 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
 ₣òŕ ăłļ åνãϊłάвļê ôφŧιôņş, ґùη 'wt new-tab --help'. !!! !!! !!! !!! !!!</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>Stop keeping this pane running</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>Add tab to keep-running</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>Remove tab from keep-running</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>This tab will keep running after it is closed.</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>This tab will keep running after it is closed.</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
@@ -1339,10 +1339,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Эта вкладка продолжит работу после закрытия.</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Эта вкладка продолжит работу после закрытия.</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
@@ -1329,8 +1329,20 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
 Для просмотра всех доступных параметров выполните команду "wt new-tab --help".</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>Не оставлять эту панель запущенной после закрытия</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>Оставить вкладку запущенной после закрытия</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>Не оставлять вкладку запущенной после закрытия</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Эта вкладка продолжит работу после закрытия.</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Эта вкладка продолжит работу после закрытия.</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
@@ -1303,8 +1303,20 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Употреба</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>
   <data name="Usage_TokensUnit" xml:space="preserve"><value>токени</value><comment>Unit label for AI context-window token counts. Translate this term using the established AI/LLM terminology for the locale.</comment></data>
   <data name="Usage_ContextWindowLabel" xml:space="preserve"><value>Контекстни прозор</value><comment>Label for the AI agent context-window usage percentage shown in the terminal bottom bar.</comment></data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>Не остављај овај панел покренутим након затварања</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>Остави картицу покренутом након затварања</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>Не остављај картицу покренутом након затварања</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Ова картица ће наставити да ради након затварања.</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Ова картица ће наставити да ради након затварања.</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
@@ -1313,10 +1313,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ова картица ће наставити да ради након затварања.</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Ова картица ће наставити да ради након затварања.</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
@@ -1288,8 +1288,20 @@
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Використання</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>
   <data name="Usage_TokensUnit" xml:space="preserve"><value>токени</value><comment>Unit label for AI context-window token counts. Translate this term using the established AI/LLM terminology for the locale.</comment></data>
   <data name="Usage_ContextWindowLabel" xml:space="preserve"><value>Контекстне вікно</value><comment>Label for the AI agent context-window usage percentage shown in the terminal bottom bar.</comment></data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>Не залишати цю панель запущеною після закриття</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>Залишати вкладку запущеною після закриття</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>Не залишати вкладку запущеною після закриття</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Ця вкладка продовжить працювати після закриття.</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Ця вкладка продовжить працювати після закриття.</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
@@ -1298,10 +1298,10 @@
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ця вкладка продовжить працювати після закриття.</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Ця вкладка продовжить працювати після закриття.</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
@@ -1346,10 +1346,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>此标签页关闭后将继续运行。</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>此标签页关闭后将继续运行。</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
@@ -1336,8 +1336,20 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
 如需了解所有可用选项，请运行 "wt new-tab --help"。</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>停止让此窗格在关闭后继续运行</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>关闭后继续运行此标签页</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>关闭后不再继续运行此标签页</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>此标签页关闭后将继续运行。</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>此标签页关闭后将继续运行。</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
@@ -1312,10 +1312,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>此索引標籤關閉後將繼續執行。</value>
-    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Tooltip for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
   <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>此索引標籤關閉後將繼續執行。</value>
-    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+    <comment>Accessible name for the stopwatch icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
@@ -1302,8 +1302,20 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
 如需所有可用選項，請執行 'wt new-tab --help'。</value>
     <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
   </data>
-  <data name="PaneKeepRunningButton.ToolTip" xml:space="preserve">
-    <value>停止讓此窗格在關閉後繼續執行</value>
-    <comment>Tooltip and accessible name for the pin button that opts the pane out of remaining alive after it is closed.</comment>
+  <data name="TabKeepRunningAdd" xml:space="preserve">
+    <value>讓此索引標籤在關閉後繼續執行</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab into remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningRemove" xml:space="preserve">
+    <value>停止讓此索引標籤在關閉後繼續執行</value>
+    <comment>Tab context menu item that opts every non-agent pane in this tab out of remaining alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>此索引標籤關閉後將繼續執行。</value>
+    <comment>Tooltip for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
+  </data>
+  <data name="TabKeepRunningIndicator.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>此索引標籤關閉後將繼續執行。</value>
+    <comment>Accessible name for the pin icon shown on a tab whose non-agent panes will remain alive after the tab is closed.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -2051,7 +2051,7 @@ namespace winrt::TerminalApp::implementation
         {
             Controls::FontIcon keepRunningSymbol;
             keepRunningSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
-            keepRunningSymbol.Glyph(L"\xE718");
+            keepRunningSymbol.Glyph(L"\xE916"); // Stopwatch
 
             _keepRunningMenuItem.Click([weakThis](auto&&, auto&&) {
                 if (auto tab{ weakThis.get() })

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -471,6 +471,28 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
+    void Tab::_UpdateKeepRunningVisuals()
+    {
+        const auto label = _keepRunning ? RS_(L"TabKeepRunningRemove") : RS_(L"TabKeepRunningAdd");
+        _keepRunningMenuItem.Text(label);
+        WUX::Controls::ToolTipService::SetToolTip(_keepRunningMenuItem, box_value(label));
+        Automation::AutomationProperties::SetHelpText(_keepRunningMenuItem, label);
+        _tabStatus.IsKeepRunning(_keepRunning);
+    }
+
+    void Tab::KeepRunning(const bool value)
+    {
+        ASSERT_UI_THREAD();
+
+        _keepRunning = value;
+        _UpdateKeepRunningVisuals();
+    }
+
+    void Tab::ToggleKeepRunning()
+    {
+        KeepRunning(!_keepRunning);
+    }
+
     // Method Description:
     // - Hide or show the bell indicator in the tab header
     // Arguments:
@@ -1619,6 +1641,11 @@ namespace winrt::TerminalApp::implementation
         _findMenuItem.IsEnabled(isTerm);
         _restartConnectionMenuItem.IsEnabled(isTerm);
 
+        const auto hasShellPane = _rootPane && _rootPane->WalkTree([](const auto& pane) {
+            return !pane->IsAgentPane() && pane->GetTerminalControl() != nullptr;
+        });
+        _keepRunningMenuItem.IsEnabled(hasShellPane || _keepRunning);
+
         // Snippets Pane can technically be split
         _splitTabMenuItem.IsEnabled(isTerm || (content && content.try_as<winrt::TerminalApp::SnippetsPaneContent>() != nullptr));
     }
@@ -2021,6 +2048,21 @@ namespace winrt::TerminalApp::implementation
             Automation::AutomationProperties::SetHelpText(_restartConnectionMenuItem, restartConnectionToolTip);
         }
 
+        {
+            Controls::FontIcon keepRunningSymbol;
+            keepRunningSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
+            keepRunningSymbol.Glyph(L"\xE718");
+
+            _keepRunningMenuItem.Click([weakThis](auto&&, auto&&) {
+                if (auto tab{ weakThis.get() })
+                {
+                    tab->ToggleKeepRunning();
+                }
+            });
+            _keepRunningMenuItem.Icon(keepRunningSymbol);
+            _UpdateKeepRunningVisuals();
+        }
+
         // Build the menu
         Controls::MenuFlyout contextMenuFlyout;
         Controls::MenuFlyoutSeparator menuSeparator;
@@ -2032,6 +2074,7 @@ namespace winrt::TerminalApp::implementation
         contextMenuFlyout.Items().Append(_exportTabMenuItem);
         contextMenuFlyout.Items().Append(_findMenuItem);
         contextMenuFlyout.Items().Append(_restartConnectionMenuItem);
+        contextMenuFlyout.Items().Append(_keepRunningMenuItem);
         contextMenuFlyout.Items().Append(menuSeparator);
 
         auto closeSubMenu = _AppendCloseMenuItems(contextMenuFlyout);

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -95,6 +95,9 @@ namespace winrt::TerminalApp::implementation
         void TogglePaneReadOnly();
         void SetPaneReadOnly(const bool readOnlyState);
         void ToggleBroadcastInput();
+        bool KeepRunning() const noexcept { return _keepRunning; }
+        void KeepRunning(bool value);
+        void ToggleKeepRunning();
 
         std::shared_ptr<Pane> GetActivePane() const;
         winrt::TerminalApp::TaskbarState GetCombinedTaskbarState() const;
@@ -242,6 +245,7 @@ namespace winrt::TerminalApp::implementation
         winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _exportTabMenuItem{};
         winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _findMenuItem{};
         winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _restartConnectionMenuItem{};
+        winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _keepRunningMenuItem{};
         winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _closeOtherTabsMenuItem{};
         winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _closeTabsAfterMenuItem{};
         winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _closePaneMenuItem{};
@@ -315,6 +319,7 @@ namespace winrt::TerminalApp::implementation
         bool _receivedKeyDown{ false };
         bool _iconHidden{ false };
         bool _changingActivePane{ false };
+        bool _keepRunning{ false };
 
         winrt::hstring _stableId{};
         winrt::hstring _durableShellSessionId{};
@@ -341,6 +346,7 @@ namespace winrt::TerminalApp::implementation
         void _UpdateActivePane(std::shared_ptr<Pane> pane);
         void _UpdateMenuItemStates();
         void _UpdateAgentChipVisibility();
+        void _UpdateKeepRunningVisuals();
 
         winrt::hstring _GetActiveTitle() const;
 

--- a/src/cascadia/TerminalApp/TabHeaderControl.xaml
+++ b/src/cascadia/TerminalApp/TabHeaderControl.xaml
@@ -56,6 +56,13 @@
                   FontSize="12"
                   Glyph="&#xEC05;"
                   Visibility="{x:Bind TabStatus.IsInputBroadcastActive, Mode=OneWay}" />
+        <FontIcon x:Name="HeaderKeepRunningIcon"
+                  x:Uid="TabKeepRunningIndicator"
+                  Margin="0,0,8,0"
+                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                  FontSize="12"
+                  Glyph="&#xE718;"
+                  Visibility="{x:Bind TabStatus.IsKeepRunning, Mode=OneWay}" />
         <TextBlock x:Name="HeaderTextBlock"
                    Text="{x:Bind Title, Mode=OneWay}"
                    Visibility="Visible" />

--- a/src/cascadia/TerminalApp/TabHeaderControl.xaml
+++ b/src/cascadia/TerminalApp/TabHeaderControl.xaml
@@ -61,7 +61,7 @@
                   Margin="0,0,8,0"
                   FontFamily="{ThemeResource SymbolThemeFontFamily}"
                   FontSize="12"
-                  Glyph="&#xE718;"
+                  Glyph="&#xE916;"
                   Visibility="{x:Bind TabStatus.IsKeepRunning, Mode=OneWay}" />
         <TextBlock x:Name="HeaderTextBlock"
                    Text="{x:Bind Title, Mode=OneWay}"

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -969,7 +969,7 @@ namespace winrt::TerminalApp::implementation
 
         // One group per tab, so a multi-pane tab is offered back as the one
         // thing the user closed rather than as N indistinguishable panes.
-        const auto groupId = ::Microsoft::Console::Utils::CreateGuid();
+        const auto groupId = ::Microsoft::Console::Utils::GuidFromString(tab->StableId().c_str());
         const auto title = tab->Title();
         auto detached = 0;
 

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -99,7 +99,7 @@ namespace winrt::TerminalApp::implementation
         {
             if (const auto tabImpl = _GetTabImpl(newTab))
             {
-                if (newTerminalArgs.KeptSessionId() != winrt::guid{})
+                if (newTerminalArgs.KeepRunning() || newTerminalArgs.KeptSessionId() != winrt::guid{})
                 {
                     tabImpl->KeepRunning(true);
                 }

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -969,7 +969,7 @@ namespace winrt::TerminalApp::implementation
 
         // One group per tab, so a multi-pane tab is offered back as the one
         // thing the user closed rather than as N indistinguishable panes.
-        const auto groupId = ::Microsoft::Console::Utils::GuidFromString(tab->StableId().c_str());
+        const auto groupId = GetKeepRunningGroupId(tab->StableId(), shellSessionId);
         const auto title = tab->Title();
         auto detached = 0;
 

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -95,21 +95,27 @@ namespace winrt::TerminalApp::implementation
         // This call to _MakePane won't return nullptr, we already checked that
         // case above with the _maybeElevate call.
         const auto newTab = _CreateNewTabFromPane(_MakePane(newContentArgs, nullptr), -1, openInBackground);
-        if (const auto newTerminalArgs{ newContentArgs.try_as<NewTerminalArgs>() };
-            newTerminalArgs && !newTerminalArgs.AgentPaneSessionId().empty())
+        if (const auto newTerminalArgs{ newContentArgs.try_as<NewTerminalArgs>() })
         {
             if (const auto tabImpl = _GetTabImpl(newTab))
             {
-                _pendingDurableAgentPaneRestores.insert_or_assign(
-                    tabImpl->StableId(),
-                    _PendingDurableAgentPaneRestore{
-                        _currentStartupActionBatchId,
-                        winrt::to_string(newTerminalArgs.AgentPaneSessionId()),
-                        newTerminalArgs.AgentPaneAgent(),
-                        winrt::to_string(newTerminalArgs.StartingDirectory()),
-                        winrt::to_string(newTerminalArgs.AgentPaneView()),
-                        newTerminalArgs.AgentPaneOpen(),
-                        newTerminalArgs.AgentPanePosition() });
+                if (newTerminalArgs.KeptSessionId() != winrt::guid{})
+                {
+                    tabImpl->KeepRunning(true);
+                }
+                if (!newTerminalArgs.AgentPaneSessionId().empty())
+                {
+                    _pendingDurableAgentPaneRestores.insert_or_assign(
+                        tabImpl->StableId(),
+                        _PendingDurableAgentPaneRestore{
+                            _currentStartupActionBatchId,
+                            winrt::to_string(newTerminalArgs.AgentPaneSessionId()),
+                            newTerminalArgs.AgentPaneAgent(),
+                            winrt::to_string(newTerminalArgs.StartingDirectory()),
+                            winrt::to_string(newTerminalArgs.AgentPaneView()),
+                            newTerminalArgs.AgentPaneOpen(),
+                            newTerminalArgs.AgentPanePosition() });
+                }
             }
         }
         return S_OK;
@@ -742,11 +748,8 @@ namespace winrt::TerminalApp::implementation
 
     void TerminalPage::_PersistShellSession(Tab* const tab)
     {
-        bool hasKeepRunningPane = false;
-        tab->GetRootPane()->WalkTree([&](const auto& pane) {
-            hasKeepRunningPane = hasKeepRunningPane || pane->KeepRunning();
-        });
-        const auto closeActions = GetShellSessionCloseActions(_settings.GlobalSettings().FirstWindowPreference(), hasKeepRunningPane);
+        const auto keepRunning = tab->KeepRunning();
+        const auto closeActions = GetShellSessionCloseActions(_settings.GlobalSettings().FirstWindowPreference(), keepRunning);
         if (!closeActions.save && !closeActions.detach)
         {
             _agentPaneLog("_PersistShellSession: skipped — saving and keep-running are off");
@@ -768,11 +771,11 @@ namespace winrt::TerminalApp::implementation
                 }
             }
         });
-        if (!ShouldPersistShellSession(hasUserInput, !tab->DurableShellSessionId().empty(), hasKeepRunningPane, hasAgentSession))
+        if (!ShouldPersistShellSession(hasUserInput, !tab->DurableShellSessionId().empty(), keepRunning, hasAgentSession))
         {
             // Profile startup commands alone do not qualify until the user
             // sends input or a resumable agent session binds to the pane.
-            _agentPaneLog("_PersistShellSession: skipped — no user input, durable id, keep-running pane, or agent session");
+            _agentPaneLog("_PersistShellSession: skipped — no user input, durable id, keep-running tab, or agent session");
             return;
         }
 
@@ -955,21 +958,23 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
-    // Detaches opted-in shell panes so the commands they are running survive
-    // closing. The content keeps its connection and buffer; only the
-    // TermControl is severed. Restoring the session reattaches to the same
-    // content.
-    void TerminalPage::_DetachShellPanesForKeepRunning(Tab* const tab, const winrt::hstring& shellSessionId, const int64_t shellSessionRevision, const std::shared_ptr<Pane>& subtree)
+    // Detaches every shell pane in an opted-in tab so its commands survive the
+    // tab closing. Agent panes use their own resume mechanism and are excluded.
+    void TerminalPage::_DetachShellPanesForKeepRunning(Tab* const tab, const winrt::hstring& shellSessionId, const int64_t shellSessionRevision)
     {
+        if (!tab->KeepRunning())
+        {
+            return;
+        }
+
         // One group per tab, so a multi-pane tab is offered back as the one
         // thing the user closed rather than as N indistinguishable panes.
         const auto groupId = ::Microsoft::Console::Utils::CreateGuid();
         const auto title = tab->Title();
         auto detached = 0;
 
-        const auto root = subtree ? subtree : tab->GetRootPane();
-        root->WalkTree([&](const auto& pane) {
-            if (pane->IsAgentPane() || !pane->KeepRunning())
+        tab->GetRootPane()->WalkTree([&](const auto& pane) {
+            if (pane->IsAgentPane())
             {
                 return;
             }
@@ -1542,11 +1547,6 @@ namespace winrt::TerminalApp::implementation
             }
             CATCH_LOG()
         }
-        else if (owningTab && pane->KeepRunning())
-        {
-            _DetachShellPanesForKeepRunning(owningTab.get(), owningTab->DurableShellSessionId(), owningTab->DurableShellSessionRevision(), pane);
-        }
-
         // If this is the last pane on the last tab of a named window, persist
         // the workspace after the shell-session save has updated the tab's
         // durable id and revision, while the pane content is still alive.

--- a/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
@@ -193,6 +193,8 @@ namespace winrt::TerminalApp::implementation
                 });
             }
             info.PaneCount = terminalPaneCount;
+            info.DurableShellSessionId = tabImpl->DurableShellSessionId();
+            info.KeepRunning = tabImpl->KeepRunning();
             tabs.Append(info);
         }
 

--- a/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
@@ -860,6 +860,24 @@ namespace winrt::TerminalApp::implementation
             extraArgs);
     }
 
+    IAsyncOperation<bool> TerminalPage::FocusProtocolShellSession(hstring id)
+    {
+        co_await wil::resume_foreground(Dispatcher());
+
+        for (uint32_t index = 0; index < _tabs.Size(); ++index)
+        {
+            if (const auto tab = _GetTabImpl(_tabs.GetAt(index));
+                tab && tab->DurableShellSessionId() == id)
+            {
+                SummonWindowRequested.raise(*this, nullptr);
+                _SelectTab(index);
+                co_return true;
+            }
+        }
+
+        co_return false;
+    }
+
     IAsyncOperation<bool> TerminalPage::RestoreProtocolShellSession(hstring id)
     {
         co_await wil::resume_foreground(Dispatcher());
@@ -979,7 +997,10 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        ProcessStartupActions(std::move(actions));
+        // Publish the first tab before returning to the protocol caller. COM
+        // serializes restores, so the next request can now find and focus this
+        // durable id instead of racing a deferred first action.
+        ProcessStartupActions(std::move(actions), {}, {}, true);
         co_return true;
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -8613,6 +8613,7 @@ namespace winrt::TerminalApp::implementation
                 std::optional<winrt::guid> ignoredSourceProfileGuid;
                 winrt::TerminalApp::implementation::AgentPaneDragStash::Take(contentId, ignoredOldTabId, ignoredSourceProfileGuid);
                 newTerminalArgs.ContentId(0);
+                newTerminalArgs.KeptSessionId({});
                 return _MakeTerminalPane(newTerminalArgs, sourceTab, existingConnection);
             }
             auto paneContent{ winrt::make<TerminalPaneContent>(profile, _terminalSettingsCache, control) };
@@ -8875,6 +8876,15 @@ namespace winrt::TerminalApp::implementation
                     }
                 }
             }
+        }
+
+        // KeptSessionId identifies the live content we attempted to claim; it
+        // is not a persisted keep-running preference. Reaching the fresh-shell
+        // path means no live reattach succeeded, so do not show a pin on the
+        // snapshot fallback tab.
+        if (newTerminalArgs)
+        {
+            newTerminalArgs.KeptSessionId({});
         }
 
         if (hasSessionId &&

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -7619,7 +7619,14 @@ namespace winrt::TerminalApp::implementation
         }
         const auto contentWidth = static_cast<float>(_tabContent.ActualWidth());
         const auto contentHeight = static_cast<float>(_tabContent.ActualHeight());
-        const winrt::Windows::Foundation::Size availableSpace{ contentWidth, contentHeight };
+        // A tab created moments ago in the same synchronous batch (a durable
+        // session restore, a multi-pane tab dropped in from another window) has
+        // not been measured yet. Falling back to the window's own size keeps the
+        // split from being silently dropped for want of a layout pass.
+        const winrt::Windows::Foundation::Size availableSpace{
+            contentWidth > 0 ? contentWidth : static_cast<float>(ActualWidth()),
+            contentHeight > 0 ? contentHeight : static_cast<float>(ActualHeight())
+        };
 
         const auto realSplitType = activeTab->PreCalculateCanSplit(splitDirection, splitSize, availableSpace);
         if (!realSplitType)

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -8614,10 +8614,6 @@ namespace winrt::TerminalApp::implementation
             }
             auto paneContent{ winrt::make<TerminalPaneContent>(profile, _terminalSettingsCache, control) };
             auto resultPane = std::make_shared<Pane>(paneContent);
-            if (newTerminalArgs.KeptSessionId() != winrt::guid{})
-            {
-                resultPane->KeepRunning(true);
-            }
 
             // Cross-window agent-pane drag: if the source tab stashed an
             // original StableId for this ContentId, the migrating pane was
@@ -8867,10 +8863,12 @@ namespace winrt::TerminalApp::implementation
                     if (const auto keptControl = _AttachControlToContent(keptContentId, newTerminalArgs))
                     {
                         cancelReattach.release();
+                        if (newTerminalArgs)
+                        {
+                            newTerminalArgs.KeptSessionId(keptId);
+                        }
                         auto keptContent{ winrt::make<TerminalPaneContent>(profile, _terminalSettingsCache, keptControl) };
-                        auto keptPane = std::make_shared<Pane>(keptContent);
-                        keptPane->KeepRunning(true);
-                        return keptPane;
+                        return std::make_shared<Pane>(keptContent);
                     }
                 }
             }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3675,7 +3675,10 @@ namespace winrt::TerminalApp::implementation
     //   nt -d .` from inside another directory to work as expected.
     // Return Value:
     // - <none>
-    safe_void_coroutine TerminalPage::ProcessStartupActions(std::vector<ActionAndArgs> actions, const winrt::hstring cwd, const winrt::hstring env)
+    safe_void_coroutine TerminalPage::ProcessStartupActions(std::vector<ActionAndArgs> actions,
+                                                            const winrt::hstring cwd,
+                                                            const winrt::hstring env,
+                                                            const bool forceFirstActionSynchronous)
     {
         const auto strong = get_strong();
 
@@ -3714,7 +3717,7 @@ namespace winrt::TerminalApp::implementation
         // This same logic is also applied to CreateTabFromConnection.
         //
         // See GH#13136.
-        auto suspend = _tabs.Size() > 0;
+        auto suspend = _tabs.Size() > 0 && !forceFirstActionSynchronous;
         const auto startupActionBatchId = ++_nextStartupActionBatchId;
 
         for (size_t i = 0; i < actions.size(); ++i)

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -8880,8 +8880,9 @@ namespace winrt::TerminalApp::implementation
 
         // KeptSessionId identifies the live content we attempted to claim; it
         // is not a persisted keep-running preference. Reaching the fresh-shell
-        // path means no live reattach succeeded, so do not show a pin on the
-        // snapshot fallback tab.
+        // path means no live reattach succeeded, so a snapshot restore must not
+        // pin the tab. The explicit `KeepRunning` opt-in (set only when
+        // restoring a detached tab) is deliberately left alone.
         if (newTerminalArgs)
         {
             newTerminalArgs.KeptSessionId({});

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -217,7 +217,8 @@ namespace winrt::TerminalApp::implementation
 
         safe_void_coroutine ProcessStartupActions(std::vector<Microsoft::Terminal::Settings::Model::ActionAndArgs> actions,
                                                   const winrt::hstring cwd = winrt::hstring{},
-                                                  const winrt::hstring env = winrt::hstring{});
+                                                  const winrt::hstring env = winrt::hstring{},
+                                                  bool forceFirstActionSynchronous = false);
         safe_void_coroutine CreateTabFromConnection(winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection connection);
 
         TerminalApp::WindowProperties WindowProperties() const noexcept { return _WindowProperties; };
@@ -252,6 +253,7 @@ namespace winrt::TerminalApp::implementation
         Windows::Foundation::IAsyncOperation<bool> SendProtocolInput(winrt::guid sessionId, hstring text);
         Windows::Foundation::IAsyncOperation<bool> FocusProtocolPane(winrt::guid sessionId);
         Windows::Foundation::IAsyncOperation<hstring> ListProtocolShellSessions();
+        Windows::Foundation::IAsyncOperation<bool> FocusProtocolShellSession(hstring id);
         Windows::Foundation::IAsyncOperation<bool> RestoreProtocolShellSession(hstring id);
         void OnAutofixStateChanged(hstring eventJson);
         void OnAgentStatusChanged(hstring eventJson);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -711,7 +711,7 @@ namespace winrt::TerminalApp::implementation
         static void _ApplyShellSessionSaveResult(Tab* tab, const _ShellSessionSaveResult& save);
         void _AddDurableSessionMetadata(Tab* tab, std::vector<winrt::Microsoft::Terminal::Settings::Model::ActionAndArgs>& actions);
         void _PersistShellSession(Tab* tab);
-        void _DetachShellPanesForKeepRunning(Tab* tab, const winrt::hstring& shellSessionId, int64_t shellSessionRevision, const std::shared_ptr<Pane>& subtree = nullptr);
+        void _DetachShellPanesForKeepRunning(Tab* tab, const winrt::hstring& shellSessionId, int64_t shellSessionRevision);
         // Session ids of panes detached for keep-running during the tab close
         // that is currently in flight, so _NotifyPanesClosing can tell them
         // apart from panes that really are going away.

--- a/src/cascadia/TerminalApp/TerminalPage.idl
+++ b/src/cascadia/TerminalApp/TerminalPage.idl
@@ -25,6 +25,7 @@ namespace TerminalApp
     {
         Windows.Foundation.Collections.IVectorView<UInt64> ContentIds { get; };
         Windows.Foundation.Collections.IVectorView<Microsoft.Terminal.Settings.Model.NewTerminalArgs> RestoreArgs { get; };
+        String Title { get; };
         String ShellSessionId { get; };
         Int64 ShellSessionRevision { get; };
     }

--- a/src/cascadia/TerminalApp/TerminalPage.idl
+++ b/src/cascadia/TerminalApp/TerminalPage.idl
@@ -214,6 +214,7 @@ namespace TerminalApp
         Windows.Foundation.IAsyncOperation<Boolean> SendProtocolInput(Guid sessionId, String text);
         Windows.Foundation.IAsyncOperation<Boolean> FocusProtocolPane(Guid sessionId);
         Windows.Foundation.IAsyncOperation<String> ListProtocolShellSessions();
+        Windows.Foundation.IAsyncOperation<Boolean> FocusProtocolShellSession(String id);
         Windows.Foundation.IAsyncOperation<Boolean> RestoreProtocolShellSession(String id);
         event Windows.Foundation.TypedEventHandler<Object, String> ProtocolVtSequenceReceived;
 

--- a/src/cascadia/TerminalApp/TerminalTabStatus.h
+++ b/src/cascadia/TerminalApp/TerminalTabStatus.h
@@ -20,6 +20,7 @@ namespace winrt::TerminalApp::implementation
         WINRT_OBSERVABLE_PROPERTY(bool, IsReadOnlyActive, PropertyChanged.raise);
         WINRT_OBSERVABLE_PROPERTY(uint32_t, ProgressValue, PropertyChanged.raise);
         WINRT_OBSERVABLE_PROPERTY(bool, IsInputBroadcastActive, PropertyChanged.raise);
+        WINRT_OBSERVABLE_PROPERTY(bool, IsKeepRunning, PropertyChanged.raise);
         WINRT_OBSERVABLE_PROPERTY(winrt::Windows::UI::Color, TabColorIndicator, PropertyChanged.raise);
     };
 }

--- a/src/cascadia/TerminalApp/TerminalTabStatus.idl
+++ b/src/cascadia/TerminalApp/TerminalTabStatus.idl
@@ -15,6 +15,7 @@ namespace TerminalApp
         UInt32 ProgressValue { get; set; };
         Boolean IsReadOnlyActive { get; set; };
         Boolean IsInputBroadcastActive { get; set; };
+        Boolean IsKeepRunning { get; set; };
         Windows.UI.Color TabColorIndicator { get; set; };
     }
 }

--- a/src/cascadia/TerminalProtocol/TerminalProtocol.idl
+++ b/src/cascadia/TerminalProtocol/TerminalProtocol.idl
@@ -20,6 +20,10 @@ namespace Microsoft.Terminal.Protocol
         String Title;
         Boolean IsActive;
         UInt32 PaneCount;
+        // Durable shell-session id this tab is bound to, empty when the tab has
+        // never been saved, plus whether the user opted it into keep-running.
+        String DurableShellSessionId;
+        Boolean KeepRunning;
     };
 
     struct PaneInfo

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -68,7 +68,6 @@ static constexpr std::string_view MoveTabKey{ "moveTab" };
 static constexpr std::string_view BreakIntoDebuggerKey{ "breakIntoDebugger" };
 static constexpr std::string_view FindMatchKey{ "findMatch" };
 static constexpr std::string_view TogglePaneReadOnlyKey{ "toggleReadOnlyMode" };
-static constexpr std::string_view TogglePaneKeepRunningKey{ "togglePaneKeepRunning" };
 static constexpr std::string_view EnablePaneReadOnlyKey{ "enableReadOnlyMode" };
 static constexpr std::string_view DisablePaneReadOnlyKey{ "disableReadOnlyMode" };
 static constexpr std::string_view NewWindowKey{ "newWindow" };

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -402,6 +402,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         ACTION_ARG(int64_t, DurableShellSessionRevision, 0);
         // Transient, restore-only, never serialized. See ActionArgs.idl.
         ACTION_ARG(winrt::guid, KeptSessionId, winrt::guid{});
+        ACTION_ARG(bool, KeepRunning, false);
         ACTION_ARG(bool, AppendCommandLine, false);
         ACTION_ARG(uint64_t, ContentId);
 
@@ -421,6 +422,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static constexpr std::string_view PositionKey{ "position" };
         static constexpr std::string_view DurableShellSessionIdKey{ "durableShellSessionId" };
         static constexpr std::string_view DurableShellSessionRevisionKey{ "durableShellSessionRevision" };
+        static constexpr std::string_view KeepRunningKey{ "keepRunning" };
         static constexpr std::string_view AppendCommandLineKey{ "appendCommandLine" };
         static constexpr std::string_view ContentKey{ "__content" };
 
@@ -508,6 +510,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             {
                 args->_DurableShellSessionRevision = durableShellSessionRevision.asInt64();
             }
+            JsonUtils::GetValueForKey(json, KeepRunningKey, args->_KeepRunning);
             JsonUtils::GetValueForKey(json, ContentKey, args->_ContentId);
             return *args;
         }
@@ -568,6 +571,10 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 JsonUtils::SetValueForKey(json, DurableShellSessionIdKey, durableShellSessionId);
                 json[DurableShellSessionRevisionKey.data()] = Json::Int64{ args->DurableShellSessionRevision() };
             }
+            if (args->_KeepRunning)
+            {
+                JsonUtils::SetValueForKey(json, KeepRunningKey, args->_KeepRunning);
+            }
             JsonUtils::SetValueForKey(json, ContentKey, args->_ContentId);
             return json;
         }
@@ -593,6 +600,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             copy->_DurableShellSessionId = _DurableShellSessionId;
             copy->_DurableShellSessionRevision = _DurableShellSessionRevision;
             copy->_KeptSessionId = _KeptSessionId;
+            copy->_KeepRunning = _KeepRunning;
             copy->_SuppressApplicationTitle = _SuppressApplicationTitle;
             copy->_ColorScheme = _ColorScheme;
             copy->_Elevate = _Elevate;

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -213,6 +213,11 @@ namespace Microsoft.Terminal.Settings.Model
         // of a session that may still be detached and running. SessionId always
         // carries a fresh identity for the shell we would create if it isn't.
         Guid KeptSessionId;
+
+        // Set when restoring a tab the user had opted into keep-running.
+        // Unlike KeptSessionId this IS serialized, because restoring a
+        // detached tab hands the actions to the target window as JSON.
+        Boolean KeepRunning;
     };
 
     [default_interface] runtimeclass ActionEventArgs : IActionEventArgs

--- a/src/cascadia/TerminalSettingsModel/ActionMap.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.cpp
@@ -167,7 +167,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 { ShortcutAction::ToggleFocusMode, USES_RESOURCE(L"ToggleFocusModeCommandKey") },
                 { ShortcutAction::ToggleFullscreen, USES_RESOURCE(L"ToggleFullscreenCommandKey") },
                 { ShortcutAction::TogglePaneReadOnly, USES_RESOURCE(L"TogglePaneReadOnlyCommandKey") },
-                { ShortcutAction::TogglePaneKeepRunning, USES_RESOURCE(L"TogglePaneKeepRunningCommandKey") },
                 { ShortcutAction::TogglePaneVisibility, USES_RESOURCE(L"TogglePaneVisibilityCommandKey") },
                 { ShortcutAction::TogglePaneZoom, USES_RESOURCE(L"TogglePaneZoomCommandKey") },
                 { ShortcutAction::ToggleShaderEffects, USES_RESOURCE(L"ToggleShaderEffectsCommandKey") },

--- a/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
+++ b/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
@@ -78,7 +78,6 @@
     ON_ALL_ACTIONS(MoveTab)                 \
     ON_ALL_ACTIONS(BreakIntoDebugger)       \
     ON_ALL_ACTIONS(TogglePaneReadOnly)      \
-    ON_ALL_ACTIONS(TogglePaneKeepRunning)   \
     ON_ALL_ACTIONS(EnablePaneReadOnly)      \
     ON_ALL_ACTIONS(DisablePaneReadOnly)     \
     ON_ALL_ACTIONS(FindMatch)               \

--- a/src/cascadia/TerminalSettingsModel/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/de-DE/Resources.resw
@@ -997,8 +997,4 @@
   <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>Hintergrund-Agent in neuer Registerkarte öffnen</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>Bereich nach dem Schließen weiter ausführen ein-/ausschalten</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -1018,8 +1018,4 @@
   <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>Open background agent in a new tab</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>Toggle keep running for pane</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/es-ES/Resources.resw
@@ -997,8 +997,4 @@
   <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>Abrir agente en segundo plano en una pestaña nueva</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>Alternar la ejecución del panel después de cerrarlo</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/fr-FR/Resources.resw
@@ -998,8 +998,4 @@
   <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>Ouvrir l'agent en arrière-plan dans un nouvel onglet</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>Activer/désactiver l’exécution du volet après sa fermeture</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/it-IT/Resources.resw
@@ -997,8 +997,4 @@
   <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>Apri agente in background in una nuova scheda</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>Attiva/disattiva l'esecuzione del riquadro dopo la chiusura</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/ja-JP/Resources.resw
@@ -997,8 +997,4 @@
   <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>バックグラウンド エージェントを新しいタブで開く</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>ペインを閉じた後も実行し続ける設定を切り替える</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/ko-KR/Resources.resw
@@ -1014,8 +1014,4 @@
   <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>새 탭에서 백그라운드 에이전트 열기</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>창을 닫은 후에도 계속 실행하는 설정 전환</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/pt-BR/Resources.resw
@@ -1014,8 +1014,4 @@
   <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>Abrir agente em segundo plano em uma nova guia</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>Alternar a execução do painel após fechá-lo</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-ploc/Resources.resw
@@ -992,8 +992,4 @@
 <data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data>  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>Open background agent in a new tab</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>Toggle keep running for pane</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-ploca/Resources.resw
@@ -992,8 +992,4 @@
 <data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data>  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>Open background agent in a new tab</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>Toggle keep running for pane</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-plocm/Resources.resw
@@ -992,8 +992,4 @@
 <data name="TogglePaneVisibilityCommandKey" xml:space="preserve"><value>Toggle pane visibility</value></data><data name="ShowProtocolInfoCommandKey" xml:space="preserve"><value>Show Terminal Protocol Info</value></data><data name="OpenAgentSessionsCommandKey" xml:space="preserve"><value>Open AI assistant sessions list</value></data><data name="PromptActionArgumentLocalized" xml:space="preserve"><value>Prompt</value></data><data name="FocusAgentPaneCommandKey" xml:space="preserve"><value>Focus AI assistant pane</value></data><data name="TriggerAutofixCommandKey" xml:space="preserve"><value>Trigger autofix</value></data><data name="OpenAgentPaneCommandKey" xml:space="preserve"><value>Toggle AI assistant</value></data><data name="BugReportCommandKey" xml:space="preserve"><value>Report a bug (collect logs)</value></data>  <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>Open background agent in a new tab</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>Toggle keep running for pane</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/ru-RU/Resources.resw
@@ -1014,8 +1014,4 @@
   <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>Открыть фонового агента в новой вкладке</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>Переключить сохранение работы панели после закрытия</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/sr-Cyrl-RS/Resources.resw
@@ -1004,8 +1004,4 @@
   <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>Отвори позадинског агента у новој картици</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>Укључи/искључи рад панела након затварања</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/uk-UA/Resources.resw
@@ -987,8 +987,4 @@
   <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>Відкрити фоновий агент у новій вкладці</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>Перемкнути роботу панелі після закриття</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/zh-CN/Resources.resw
@@ -1014,8 +1014,4 @@
   <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>在新标签页中打开后台智能体</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>切换窗格关闭后继续运行</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/zh-TW/Resources.resw
@@ -997,8 +997,4 @@
   <data name="OpenBackgroundAgentCommandKey" xml:space="preserve">
     <value>在新索引標籤中開啟背景代理</value>
   <comment>In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment></data>
-  <data name="TogglePaneKeepRunningCommandKey" xml:space="preserve">
-    <value>切換窗格關閉後繼續執行</value>
-    <comment>Command name for opting the active terminal pane in or out of remaining alive after it is closed.</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -633,7 +633,6 @@
         { "command": "togglePaneVisibility", "id": "Terminal.TogglePaneVisibility" },
         { "command": "toggleSplitOrientation", "id": "Terminal.ToggleSplitOrientation" },
         { "command": "toggleReadOnlyMode", "id": "Terminal.ToggleReadOnlyMode" },
-        { "command": "togglePaneKeepRunning", "id": "Terminal.TogglePaneKeepRunning" },
         { "command": "enableReadOnlyMode", "id": "Terminal.EnableReadOnlyMode" },
         { "command": "disableReadOnlyMode", "id": "Terminal.DisableReadOnlyMode" },
         { "command": { "action": "movePane", "index": 0 }, "id": "Terminal.MovePaneToTab0" },
@@ -820,7 +819,6 @@
         { "keys": "ctrl+shift+home", "id": "Terminal.ScrollToTop" },
         { "keys": "ctrl+shift+end", "id": "Terminal.ScrollToBottom" },
         { "keys": "ctrl+shift+k", "id": "Terminal.ClearBuffer" },
-        { "keys": "ctrl+alt+k", "id": "Terminal.TogglePaneKeepRunning" },
 
         // Visual Adjustments
         { "keys": "ctrl+plus", "id": "Terminal.IncreaseFontSize" },

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
@@ -31,6 +31,7 @@ WindowEmperor* TerminalProtocolComServer::s_emperor = nullptr;
 static DWORD g_comRegistration = 0;
 static DWORD g_activeObjectRegistration = 0;
 static std::shared_mutex g_mtx;
+static std::mutex g_shellSessionRestoreMutex;
 static std::thread g_comMtaThread;
 static wil::unique_event g_comMtaStop;
 
@@ -1041,6 +1042,19 @@ try
     RETURN_HR_IF(E_NOT_VALID_STATE, !s_emperor);
     const auto idH = _hstr(id);
     RETURN_HR_IF(E_INVALIDARG, idH.empty());
+
+    // Keep the active-tab lookup and first synchronous NewTab action atomic
+    // across concurrent wtcli/helper requests for the same database row.
+    std::scoped_lock restoreLock{ g_shellSessionRestoreMutex };
+
+    for (const auto& host : s_emperor->GetWindows())
+    {
+        const auto page = _getPage(host.get());
+        if (page && page.FocusProtocolShellSession(idH).get())
+        {
+            return S_OK;
+        }
+    }
 
     const auto targetHost = s_emperor->GetWindowForProtocol(windowId);
     RETURN_HR_IF(E_FAIL, !targetHost);

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
@@ -272,6 +272,8 @@ static Json::Value _toJson(const Protocol::TabInfo& t)
     v["title"] = winrt::to_string(t.Title);
     v["is_active"] = static_cast<bool>(t.IsActive);
     v["pane_count"] = static_cast<Json::UInt>(t.PaneCount);
+    v["durable_shell_session_id"] = winrt::to_string(t.DurableShellSessionId);
+    v["keep_running"] = static_cast<bool>(t.KeepRunning);
     return v;
 }
 

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -2042,30 +2042,27 @@ try
     {
         if (_windows.empty())
         {
-            // Startup action processing suspends between actions after the
-            // first one. Create the tab with its first pane, then attach the
-            // remaining splits synchronously so every kept pane either
-            // confirms reattach before this transaction ends or is cancelled.
-            std::vector<ActionAndArgs> firstAction;
-            firstAction.emplace_back(actions.front());
-            const auto firstContent = ActionAndArgs::Serialize(winrt::single_threaded_vector<ActionAndArgs>(std::move(firstAction)));
-            CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs{ winrt::hstring{}, firstContent, nullptr });
-
-            if (actions.size() > 1)
-            {
-                std::vector<ActionAndArgs> remainingActions{ actions.begin() + 1, actions.end() };
-                const auto remainingContent = ActionAndArgs::Serialize(winrt::single_threaded_vector<ActionAndArgs>(std::move(remainingActions)));
-                _windows.back()->Logic().AttachContent(remainingContent, 0);
-            }
-        }
-        else
-        {
+            // A brand new window has not been laid out yet, so its tab content
+            // still measures 0x0 and `_SplitPane` would silently drop every
+            // split. Hand the whole restore to startup-action processing, which
+            // suspends between actions precisely so WinUI can size each new
+            // pane first. Those later panes therefore confirm their reattach
+            // after this call returns.
             const auto content = ActionAndArgs::Serialize(winrt::single_threaded_vector<ActionAndArgs>(std::move(actions)));
-            // -1 means "wherever a new tab normally goes". Passing a real index
-            // here would move the restored tab there — 0 dragged every restore
-            // to the front of the tab row.
-            _windows.front()->Logic().AttachContent(content, -1);
+            CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs{ winrt::hstring{}, content, nullptr });
+
+            // Releasing the pending claim is still right: the panes are already
+            // spoken for by ContentId, and leaving them pending would hide a
+            // group that never finished restoring.
+            manager.CancelKeptGroupReattach(groupId);
+            return true;
         }
+
+        const auto content = ActionAndArgs::Serialize(winrt::single_threaded_vector<ActionAndArgs>(std::move(actions)));
+        // -1 means "wherever a new tab normally goes". Passing a real index
+        // here would move the restored tab there — 0 dragged every restore
+        // to the front of the tab row.
+        _windows.front()->Logic().AttachContent(content, -1);
     }
     catch (...)
     {

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -2061,7 +2061,10 @@ try
         else
         {
             const auto content = ActionAndArgs::Serialize(winrt::single_threaded_vector<ActionAndArgs>(std::move(actions)));
-            _windows.front()->Logic().AttachContent(content, 0);
+            // -1 means "wherever a new tab normally goes". Passing a real index
+            // here would move the restored tab there — 0 dragged every restore
+            // to the front of the tab row.
+            _windows.front()->Logic().AttachContent(content, -1);
         }
     }
     catch (...)

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2947,6 +2947,7 @@ impl App {
         tab.current_view = View::Chat;
         tab.shell_sessions_loading = false;
         tab.shell_sessions_error = None;
+        tab.shell_session_restore_in_flight = false;
         tab.shell_session_delete_confirmation = None;
         tab.shell_session_delete_in_flight = false;
         tab.shell_sessions_search_focused = false;
@@ -2966,14 +2967,23 @@ impl App {
     }
 
     fn restore_shell_session(&mut self, tab_id: String, id: String) {
-        self.tab_mut(&tab_id).shell_sessions_error = None;
+        {
+            let tab = self.tab_mut(&tab_id);
+            if tab.shell_session_restore_in_flight {
+                return;
+            }
+            tab.shell_sessions_error = None;
+            tab.shell_session_restore_in_flight = true;
+        }
         let request = crate::protocol::acp::client::MasterExtRequest::ShellSessionRestore {
             tab_id: tab_id.clone(),
             id,
             window_id: self.window_id.clone(),
         };
         if self.master_request_tx.send(request).is_err() {
-            self.tab_mut(&tab_id).shell_sessions_error =
+            let tab = self.tab_mut(&tab_id);
+            tab.shell_session_restore_in_flight = false;
+            tab.shell_sessions_error =
                 Some("Shell-session master connection is unavailable".to_string());
         }
     }

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -363,6 +363,8 @@ pub struct TabSession {
     pub agents_list_state: ratatui::widgets::ListState,
     pub agents_view: AgentsViewState,
     pub shell_sessions: Vec<crate::shell_session_store::ShellSessionSummary>,
+    /// Durable ids whose shell is still detached and running.
+    pub shell_sessions_keep_running: std::collections::HashSet<String>,
     pub shell_sessions_query: String,
     pub shell_sessions_search_focused: bool,
     pub shell_sessions_list_state: ratatui::widgets::ListState,

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -368,6 +368,7 @@ pub struct TabSession {
     pub shell_sessions_list_state: ratatui::widgets::ListState,
     pub shell_sessions_loading: bool,
     pub shell_sessions_error: Option<String>,
+    pub shell_session_restore_in_flight: bool,
     pub shell_session_delete_confirmation: Option<String>,
     pub shell_session_delete_in_flight: bool,
 

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -365,6 +365,8 @@ pub struct TabSession {
     pub shell_sessions: Vec<crate::shell_session_store::ShellSessionSummary>,
     /// Durable ids whose shell is still detached and running.
     pub shell_sessions_keep_running: std::collections::HashSet<String>,
+    /// Durable ids that are already open in a tab.
+    pub shell_sessions_open: std::collections::HashSet<String>,
     pub shell_sessions_query: String,
     pub shell_sessions_search_focused: bool,
     pub shell_sessions_list_state: ratatui::widgets::ListState,

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -219,9 +219,11 @@ pub enum AppEvent {
     ShellSessionsLoaded {
         tab_id: String,
         sessions: Vec<crate::shell_session_store::ShellSessionSummary>,
-        /// Durable ids whose shell is still detached and running, so the row
-        /// can be marked as keep-running.
+        /// Durable ids whose shell is still detached and running, or whose tab
+        /// is open and opted into keep-running.
         keep_running: std::collections::HashSet<String>,
+        /// Durable ids that are already open in a tab.
+        open: std::collections::HashSet<String>,
         error: Option<String>,
     },
     ShellSessionRestored {

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -219,6 +219,9 @@ pub enum AppEvent {
     ShellSessionsLoaded {
         tab_id: String,
         sessions: Vec<crate::shell_session_store::ShellSessionSummary>,
+        /// Durable ids whose shell is still detached and running, so the row
+        /// can be marked as keep-running.
+        keep_running: std::collections::HashSet<String>,
         error: Option<String>,
     },
     ShellSessionRestored {

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -1118,7 +1118,9 @@ impl App {
             }
             AppEvent::ShellSessionRestored { tab_id, id, error } => {
                 tracing::debug!(target: "shell_sessions", %id, restored = error.is_none(), "shell-session restore completed");
-                self.tab_mut(&tab_id).shell_sessions_error = error;
+                let tab = self.tab_mut(&tab_id);
+                tab.shell_session_restore_in_flight = false;
+                tab.shell_sessions_error = error;
             }
             AppEvent::ShellSessionDeleted {
                 tab_id,

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -1099,11 +1099,13 @@ impl App {
                 tab_id,
                 sessions,
                 keep_running,
+                open,
                 error,
             } => {
                 let tab = self.tab_mut(&tab_id);
                 tab.shell_sessions = sessions;
                 tab.shell_sessions_keep_running = keep_running;
+                tab.shell_sessions_open = open;
                 tab.shell_sessions_loading = false;
                 tab.shell_sessions_error = error;
                 let matching_count = tab.matching_shell_session_count();

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -1098,10 +1098,12 @@ impl App {
             AppEvent::ShellSessionsLoaded {
                 tab_id,
                 sessions,
+                keep_running,
                 error,
             } => {
                 let tab = self.tab_mut(&tab_id);
                 tab.shell_sessions = sessions;
+                tab.shell_sessions_keep_running = keep_running;
                 tab.shell_sessions_loading = false;
                 tab.shell_sessions_error = error;
                 let matching_count = tab.matching_shell_session_count();

--- a/tools/wta/src/app_keys.rs
+++ b/tools/wta/src/app_keys.rs
@@ -243,7 +243,9 @@ impl App {
             let tab_id = self.active_tab_key().to_string();
             let count = self.current_tab().matching_shell_session_count();
 
-            if self.current_tab().shell_session_delete_in_flight {
+            if self.current_tab().shell_session_restore_in_flight
+                || self.current_tab().shell_session_delete_in_flight
+            {
                 return;
             }
             if let Some(id) = self.current_tab().shell_session_delete_confirmation.clone() {

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -9398,6 +9398,8 @@ fn shell_session_search_filters_navigation_and_restore() {
     app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
     app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
     app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+    assert!(app.current_tab().shell_session_restore_in_flight);
     assert!(matches!(
         master_rx.try_recv(),
         Ok(crate::protocol::acp::client::MasterExtRequest::ShellSessionRestore {
@@ -9405,6 +9407,14 @@ fn shell_session_search_filters_navigation_and_restore() {
             ..
         }) if id == cwd_id
     ));
+    assert!(master_rx.try_recv().is_err());
+
+    app.handle_event(AppEvent::ShellSessionRestored {
+        tab_id: DEFAULT_TAB_ID.to_string(),
+        id: cwd_id.to_string(),
+        error: None,
+    });
+    assert!(!app.current_tab().shell_session_restore_in_flight);
 
     app.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE));
     app.handle_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -2875,14 +2875,15 @@ fn dispatch_master_ext_request(
                     Ok(response) => (response.sessions, None),
                     Err(error) => (Vec::new(), Some(error.to_string())),
                 };
-                // Which of those durable rows still has a live detached shell
-                // is only known to Windows Terminal, not to the store. A
-                // failure here just means no row is marked.
-                let keep_running = fetch_keep_running_shell_session_ids().await;
+                // Which of those durable rows still has a live detached shell,
+                // and which are already open in a tab, is only known to Windows
+                // Terminal. A failure here just means no row is marked.
+                let marks = fetch_shell_session_marks().await;
                 let _ = event_tx.send(AppEvent::ShellSessionsLoaded {
                     tab_id,
                     sessions,
-                    keep_running,
+                    keep_running: marks.keep_running,
+                    open: marks.open,
                     error,
                 });
             }
@@ -3830,36 +3831,66 @@ fn parse_keep_running_tab_shell_session_ids(
         .unwrap_or_default()
 }
 
-async fn fetch_keep_running_shell_session_ids() -> std::collections::HashSet<String> {
+/// Durable ids of tabs that are open right now, whatever their keep-running
+/// state, so the list can show which saved sessions are already on screen.
+fn parse_open_tab_shell_session_ids(
+    payload: &serde_json::Value,
+) -> std::collections::HashSet<String> {
+    payload
+        .get("tabs")
+        .and_then(|tabs| tabs.as_array())
+        .map(|tabs| {
+            tabs.iter()
+                .filter_map(|tab| tab.get("durable_shell_session_id")?.as_str())
+                .filter(|id| !id.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// How the shell-session list should annotate each saved row.
+#[derive(Default)]
+struct ShellSessionMarks {
+    keep_running: std::collections::HashSet<String>,
+    open: std::collections::HashSet<String>,
+}
+
+async fn fetch_shell_session_marks() -> ShellSessionMarks {
     use crate::shell::wt_channel::WtChannel;
 
     let channel = match crate::shell::wt_channel::CliChannel::connect().await {
         Ok(channel) => channel,
         Err(error) => {
-            tracing::debug!(target: "shell_sessions", %error, "no wt channel for keep-running marks");
-            return std::collections::HashSet::new();
+            tracing::debug!(target: "shell_sessions", %error, "no wt channel for shell-session marks");
+            return ShellSessionMarks::default();
         }
     };
 
-    let mut ids = match channel
+    let mut marks = ShellSessionMarks::default();
+    match channel
         .request("list_detached_sessions", serde_json::Value::Null)
         .await
     {
-        Ok(payload) => parse_detached_shell_session_ids(&payload),
+        Ok(payload) => marks.keep_running = parse_detached_shell_session_ids(&payload),
         Err(error) => {
             tracing::debug!(target: "shell_sessions", %error, "could not list detached sessions");
-            std::collections::HashSet::new()
         }
-    };
+    }
 
     match channel.request("list_tabs", serde_json::Value::Null).await {
-        Ok(payload) => ids.extend(parse_keep_running_tab_shell_session_ids(&payload)),
+        Ok(payload) => {
+            marks
+                .keep_running
+                .extend(parse_keep_running_tab_shell_session_ids(&payload));
+            marks.open = parse_open_tab_shell_session_ids(&payload);
+        }
         Err(error) => {
             tracing::debug!(target: "shell_sessions", %error, "could not list tabs");
         }
     }
 
-    ids
+    marks
 }
 
 #[cfg(test)]
@@ -3869,8 +3900,9 @@ mod tests {
         acp_result_failure_fields, complete_prompt_request, inject_wta_pane_meta,
         is_proposal_mcp_tool_title, is_redundant_startup_model_error,
         parse_detached_shell_session_ids, parse_keep_running_tab_shell_session_ids,
-        post_login_authenticate_error, timeout_result_failure_fields, tool_call_kind_label,
-        ClientState, PromptTimingState, PromptUsageIdentity, SoftStopReason, WtaClient,
+        parse_open_tab_shell_session_ids, post_login_authenticate_error,
+        timeout_result_failure_fields, tool_call_kind_label, ClientState, PromptTimingState,
+        PromptUsageIdentity, SoftStopReason, WtaClient,
     };
     use crate::app_contracts::AppEvent;
     use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
@@ -3916,6 +3948,25 @@ mod tests {
         assert!(ids.contains("durable-3"));
 
         assert!(parse_keep_running_tab_shell_session_ids(&serde_json::json!({})).is_empty());
+    }
+
+    #[test]
+    fn open_ids_cover_every_tab_with_a_durable_session() {
+        let payload = serde_json::json!({
+            "tabs": [
+                { "tab_id": 0, "keep_running": true, "durable_shell_session_id": "durable-3" },
+                { "tab_id": 1, "keep_running": false, "durable_shell_session_id": "durable-4" },
+                { "tab_id": 2, "keep_running": false, "durable_shell_session_id": "" },
+                { "tab_id": 3 }
+            ]
+        });
+
+        let ids = parse_open_tab_shell_session_ids(&payload);
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains("durable-3"));
+        assert!(ids.contains("durable-4"));
+
+        assert!(parse_open_tab_shell_session_ids(&serde_json::json!({})).is_empty());
     }
 
     fn proposal_permission_request(command: &str) -> acp::schema::v1::RequestPermissionRequest {

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -3789,7 +3789,7 @@ async fn dispatch_prompt_body(
 /// Durable ids from a `wtcli list-detached-sessions` payload. A detached
 /// session is a shell that Windows Terminal is keeping alive with no window,
 /// so its durable row is "keep running" rather than merely saved.
-fn parse_keep_running_shell_session_ids(
+fn parse_detached_shell_session_ids(
     payload: &serde_json::Value,
 ) -> std::collections::HashSet<String> {
     payload
@@ -3806,24 +3806,60 @@ fn parse_keep_running_shell_session_ids(
         .unwrap_or_default()
 }
 
+/// Durable ids of tabs that are open right now and opted into keep-running.
+/// Without these, a row would only be marked while its tab is closed, so the
+/// indicator would vanish the moment the session is restored.
+fn parse_keep_running_tab_shell_session_ids(
+    payload: &serde_json::Value,
+) -> std::collections::HashSet<String> {
+    payload
+        .get("tabs")
+        .and_then(|tabs| tabs.as_array())
+        .map(|tabs| {
+            tabs.iter()
+                .filter(|tab| {
+                    tab.get("keep_running")
+                        .and_then(serde_json::Value::as_bool)
+                        .unwrap_or(false)
+                })
+                .filter_map(|tab| tab.get("durable_shell_session_id")?.as_str())
+                .filter(|id| !id.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 async fn fetch_keep_running_shell_session_ids() -> std::collections::HashSet<String> {
     use crate::shell::wt_channel::WtChannel;
 
-    let result = async {
-        let channel = crate::shell::wt_channel::CliChannel::connect().await?;
-        channel
-            .request("list_detached_sessions", serde_json::Value::Null)
-            .await
-    }
-    .await;
+    let channel = match crate::shell::wt_channel::CliChannel::connect().await {
+        Ok(channel) => channel,
+        Err(error) => {
+            tracing::debug!(target: "shell_sessions", %error, "no wt channel for keep-running marks");
+            return std::collections::HashSet::new();
+        }
+    };
 
-    match result {
-        Ok(payload) => parse_keep_running_shell_session_ids(&payload),
+    let mut ids = match channel
+        .request("list_detached_sessions", serde_json::Value::Null)
+        .await
+    {
+        Ok(payload) => parse_detached_shell_session_ids(&payload),
         Err(error) => {
             tracing::debug!(target: "shell_sessions", %error, "could not list detached sessions");
             std::collections::HashSet::new()
         }
+    };
+
+    match channel.request("list_tabs", serde_json::Value::Null).await {
+        Ok(payload) => ids.extend(parse_keep_running_tab_shell_session_ids(&payload)),
+        Err(error) => {
+            tracing::debug!(target: "shell_sessions", %error, "could not list tabs");
+        }
     }
+
+    ids
 }
 
 #[cfg(test)]
@@ -3832,9 +3868,9 @@ mod tests {
     use super::{
         acp_result_failure_fields, complete_prompt_request, inject_wta_pane_meta,
         is_proposal_mcp_tool_title, is_redundant_startup_model_error,
-        parse_keep_running_shell_session_ids, post_login_authenticate_error,
-        timeout_result_failure_fields, tool_call_kind_label, ClientState, PromptTimingState,
-        PromptUsageIdentity, SoftStopReason, WtaClient,
+        parse_detached_shell_session_ids, parse_keep_running_tab_shell_session_ids,
+        post_login_authenticate_error, timeout_result_failure_fields, tool_call_kind_label,
+        ClientState, PromptTimingState, PromptUsageIdentity, SoftStopReason, WtaClient,
     };
     use crate::app_contracts::AppEvent;
     use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
@@ -3855,13 +3891,31 @@ mod tests {
             ]
         });
 
-        let ids = parse_keep_running_shell_session_ids(&payload);
+        let ids = parse_detached_shell_session_ids(&payload);
         assert_eq!(ids.len(), 2);
         assert!(ids.contains("durable-1"));
         assert!(ids.contains("durable-2"));
 
-        assert!(parse_keep_running_shell_session_ids(&serde_json::json!({})).is_empty());
-        assert!(parse_keep_running_shell_session_ids(&serde_json::Value::Null).is_empty());
+        assert!(parse_detached_shell_session_ids(&serde_json::json!({})).is_empty());
+        assert!(parse_detached_shell_session_ids(&serde_json::Value::Null).is_empty());
+    }
+
+    #[test]
+    fn keep_running_ids_include_opted_in_open_tabs() {
+        let payload = serde_json::json!({
+            "tabs": [
+                { "tab_id": 0, "keep_running": true, "durable_shell_session_id": "durable-3" },
+                { "tab_id": 1, "keep_running": false, "durable_shell_session_id": "durable-4" },
+                { "tab_id": 2, "keep_running": true, "durable_shell_session_id": "" },
+                { "tab_id": 3, "keep_running": true }
+            ]
+        });
+
+        let ids = parse_keep_running_tab_shell_session_ids(&payload);
+        assert_eq!(ids.len(), 1);
+        assert!(ids.contains("durable-3"));
+
+        assert!(parse_keep_running_tab_shell_session_ids(&serde_json::json!({})).is_empty());
     }
 
     fn proposal_permission_request(command: &str) -> acp::schema::v1::RequestPermissionRequest {

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -2875,9 +2875,14 @@ fn dispatch_master_ext_request(
                     Ok(response) => (response.sessions, None),
                     Err(error) => (Vec::new(), Some(error.to_string())),
                 };
+                // Which of those durable rows still has a live detached shell
+                // is only known to Windows Terminal, not to the store. A
+                // failure here just means no row is marked.
+                let keep_running = fetch_keep_running_shell_session_ids().await;
                 let _ = event_tx.send(AppEvent::ShellSessionsLoaded {
                     tab_id,
                     sessions,
+                    keep_running,
                     error,
                 });
             }
@@ -3781,14 +3786,55 @@ async fn dispatch_prompt_body(
     in_flight_tabs_task.lock().unwrap().remove(&tab_key_task);
 }
 
+/// Durable ids from a `wtcli list-detached-sessions` payload. A detached
+/// session is a shell that Windows Terminal is keeping alive with no window,
+/// so its durable row is "keep running" rather than merely saved.
+fn parse_keep_running_shell_session_ids(
+    payload: &serde_json::Value,
+) -> std::collections::HashSet<String> {
+    payload
+        .get("detached_sessions")
+        .and_then(|sessions| sessions.as_array())
+        .map(|sessions| {
+            sessions
+                .iter()
+                .filter_map(|session| session.get("shell_session_id")?.as_str())
+                .filter(|id| !id.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+async fn fetch_keep_running_shell_session_ids() -> std::collections::HashSet<String> {
+    use crate::shell::wt_channel::WtChannel;
+
+    let result = async {
+        let channel = crate::shell::wt_channel::CliChannel::connect().await?;
+        channel
+            .request("list_detached_sessions", serde_json::Value::Null)
+            .await
+    }
+    .await;
+
+    match result {
+        Ok(payload) => parse_keep_running_shell_session_ids(&payload),
+        Err(error) => {
+            tracing::debug!(target: "shell_sessions", %error, "could not list detached sessions");
+            std::collections::HashSet::new()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::acp;
     use super::{
         acp_result_failure_fields, complete_prompt_request, inject_wta_pane_meta,
         is_proposal_mcp_tool_title, is_redundant_startup_model_error,
-        post_login_authenticate_error, timeout_result_failure_fields, tool_call_kind_label,
-        ClientState, PromptTimingState, PromptUsageIdentity, SoftStopReason, WtaClient,
+        parse_keep_running_shell_session_ids, post_login_authenticate_error,
+        timeout_result_failure_fields, tool_call_kind_label, ClientState, PromptTimingState,
+        PromptUsageIdentity, SoftStopReason, WtaClient,
     };
     use crate::app_contracts::AppEvent;
     use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
@@ -3796,6 +3842,27 @@ mod tests {
     use std::collections::HashSet;
     use std::sync::{Arc, Mutex};
     use tokio::sync::mpsc;
+
+    #[test]
+    fn keep_running_ids_come_from_detached_sessions() {
+        let payload = serde_json::json!({
+            "detached_sessions": [
+                { "session_id": "a", "shell_session_id": "durable-1" },
+                { "session_id": "b", "shell_session_id": "" },
+                { "session_id": "c" },
+                { "session_id": "d", "shell_session_id": "durable-2" },
+                { "session_id": "e", "shell_session_id": "durable-1" }
+            ]
+        });
+
+        let ids = parse_keep_running_shell_session_ids(&payload);
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains("durable-1"));
+        assert!(ids.contains("durable-2"));
+
+        assert!(parse_keep_running_shell_session_ids(&serde_json::json!({})).is_empty());
+        assert!(parse_keep_running_shell_session_ids(&serde_json::Value::Null).is_empty());
+    }
 
     fn proposal_permission_request(command: &str) -> acp::schema::v1::RequestPermissionRequest {
         use acp::schema::v1::{

--- a/tools/wta/src/shell/wt_channel/cli_channel.rs
+++ b/tools/wta/src/shell/wt_channel/cli_channel.rs
@@ -450,6 +450,7 @@ impl WtChannel for CliChannel {
         // Map protocol method names to wtcli subcommands + args.
         match method {
             "list_shell_sessions" => self.run_wtcli(&["list-shell-sessions"]).await,
+            "list_detached_sessions" => self.run_wtcli(&["list-detached-sessions"]).await,
             "restore_shell_session" => {
                 let id = params
                     .get("id")

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -92,6 +92,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             area,
             &tab.shell_sessions,
             &tab.shell_sessions_keep_running,
+            &tab.shell_sessions_open,
             &tab.shell_sessions_query,
             tab.shell_sessions_search_focused,
             &mut tab.shell_sessions_list_state,

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -96,6 +96,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             &mut tab.shell_sessions_list_state,
             tab.shell_sessions_loading,
             tab.shell_sessions_error.as_deref(),
+            tab.shell_session_restore_in_flight,
             tab.shell_session_delete_confirmation.as_deref(),
             tab.shell_session_delete_in_flight,
         );

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -91,6 +91,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             frame,
             area,
             &tab.shell_sessions,
+            &tab.shell_sessions_keep_running,
             &tab.shell_sessions_query,
             tab.shell_sessions_search_focused,
             &mut tab.shell_sessions_list_state,

--- a/tools/wta/src/ui/shell_sessions_view.rs
+++ b/tools/wta/src/ui/shell_sessions_view.rs
@@ -17,6 +17,7 @@ pub fn render(
     list_state: &mut ListState,
     loading: bool,
     error: Option<&str>,
+    restore_in_flight: bool,
     delete_confirmation: Option<&str>,
     delete_in_flight: bool,
 ) {
@@ -142,7 +143,12 @@ pub fn render(
             width: area.width,
             height: 1,
         };
-        let (hint, style) = if delete_in_flight {
+        let (hint, style) = if restore_in_flight {
+            (
+                "Opening or focusing shell session...".to_string(),
+                Style::default().fg(Color::Yellow),
+            )
+        } else if delete_in_flight {
             (
                 "Deleting shell session...".to_string(),
                 Style::default().fg(Color::Yellow),
@@ -161,7 +167,8 @@ pub fn render(
             )
         } else {
             (
-                "(↑ ↓ Navigate • Enter Restore • Esc Back • D Delete • F5 Refresh)".to_string(),
+                "(↑ ↓ Navigate • Enter Open/Focus • Esc Back • D Delete • F5 Refresh)"
+                    .to_string(),
                 Style::default().fg(Color::DarkGray),
             )
         };

--- a/tools/wta/src/ui/shell_sessions_view.rs
+++ b/tools/wta/src/ui/shell_sessions_view.rs
@@ -12,6 +12,7 @@ pub fn render(
     frame: &mut Frame,
     area: Rect,
     sessions: &[crate::shell_session_store::ShellSessionSummary],
+    keep_running: &std::collections::HashSet<String>,
     query: &str,
     search_focused: bool,
     list_state: &mut ListState,
@@ -104,7 +105,7 @@ pub fn render(
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_or(0, |duration| duration.as_secs() as i64);
-        let row_width = list_area.width.saturating_sub(2) as usize;
+        let row_width = list_area.width.saturating_sub(4) as usize;
         let rows = visible_sessions
             .into_iter()
             .enumerate()
@@ -118,8 +119,15 @@ pub fn render(
                 } else {
                     Style::default()
                 };
+                // Reserved for every row so the name column stays aligned
+                // whether or not the session is still running.
+                let keep_running_marker = if keep_running.contains(&session.id) {
+                    Span::styled("● ", Style::default().fg(Color::Green))
+                } else {
+                    Span::raw("  ")
+                };
                 let row = format_row(session, row_width, now);
-                let mut spans = vec![Span::styled(marker, style)];
+                let mut spans = vec![Span::styled(marker, style), keep_running_marker];
                 spans.extend(highlight_matches(&row.name, query, style));
                 if !row.cwd.is_empty() {
                     spans.push(Span::raw("  "));
@@ -167,8 +175,7 @@ pub fn render(
             )
         } else {
             (
-                "(↑ ↓ Navigate • Enter Open/Focus • Esc Back • D Delete • F5 Refresh)"
-                    .to_string(),
+                "(↑ ↓ Navigate • Enter Open/Focus • Esc Back • D Delete • F5 Refresh)".to_string(),
                 Style::default().fg(Color::DarkGray),
             )
         };

--- a/tools/wta/src/ui/shell_sessions_view.rs
+++ b/tools/wta/src/ui/shell_sessions_view.rs
@@ -255,9 +255,10 @@ struct FormattedRow {
     age: String,
 }
 
-/// Width reserved for the open column on every row, so the age column stays
-/// right-aligned whether or not a session is currently open in a tab.
-const OPEN_COLUMN_WIDTH: usize = 6;
+/// Width reserved for the opened column on every row, so the age column stays
+/// right-aligned whether or not a session is currently open in a tab. The
+/// label itself is left-aligned inside that column.
+const OPEN_COLUMN_WIDTH: usize = 8;
 
 fn format_row(
     session: &crate::shell_session_store::ShellSessionSummary,
@@ -297,7 +298,7 @@ fn format_row(
         padding: " ".repeat(gap),
         open: format!(
             "{:<width$}",
-            if is_open { "open" } else { "" },
+            if is_open { "opened" } else { "" },
             width = OPEN_COLUMN_WIDTH
         ),
         age,
@@ -422,7 +423,9 @@ mod tests {
         let closed = format_row(&summary(), 50, 172_800, false);
         let open = format_row(&summary(), 50, 172_800, true);
 
-        assert_eq!(open.open.trim(), "open");
+        assert_eq!(open.open.trim(), "opened");
+        // Left-aligned inside a fixed-width column.
+        assert!(open.open.starts_with("opened"));
         assert!(closed.open.trim().is_empty());
         // Same reserved width either way, so the age column does not shift.
         assert_eq!(

--- a/tools/wta/src/ui/shell_sessions_view.rs
+++ b/tools/wta/src/ui/shell_sessions_view.rs
@@ -13,6 +13,7 @@ pub fn render(
     area: Rect,
     sessions: &[crate::shell_session_store::ShellSessionSummary],
     keep_running: &std::collections::HashSet<String>,
+    open: &std::collections::HashSet<String>,
     query: &str,
     search_focused: bool,
     list_state: &mut ListState,
@@ -126,7 +127,7 @@ pub fn render(
                 } else {
                     Span::raw("  ")
                 };
-                let row = format_row(session, row_width, now);
+                let row = format_row(session, row_width, now, open.contains(&session.id));
                 let mut spans = vec![Span::styled(marker, style), keep_running_marker];
                 spans.extend(highlight_matches(&row.name, query, style));
                 if !row.cwd.is_empty() {
@@ -138,6 +139,7 @@ pub fn render(
                     ));
                 }
                 spans.push(Span::raw(row.padding));
+                spans.push(Span::styled(row.open, Style::default().fg(Color::Cyan)));
                 spans.push(Span::styled(row.age, style));
                 ListItem::new(Line::from(spans))
             });
@@ -249,26 +251,34 @@ struct FormattedRow {
     name: String,
     cwd: String,
     padding: String,
+    open: String,
     age: String,
 }
+
+/// Width reserved for the open column on every row, so the age column stays
+/// right-aligned whether or not a session is currently open in a tab.
+const OPEN_COLUMN_WIDTH: usize = 6;
 
 fn format_row(
     session: &crate::shell_session_store::ShellSessionSummary,
     width: usize,
     now: i64,
+    is_open: bool,
 ) -> FormattedRow {
     let age = format_relative_age(session.last_used_at, now);
     let age_width = UnicodeWidthStr::width(age.as_str());
-    if width <= age_width + 2 {
+    let right_width = age_width + OPEN_COLUMN_WIDTH;
+    if width <= right_width + 2 {
         return FormattedRow {
             name: super::layout::truncate_to_width(&session.name, width),
             cwd: String::new(),
             padding: String::new(),
+            open: String::new(),
             age: String::new(),
         };
     }
 
-    let left_width = width - age_width - 2;
+    let left_width = width - right_width - 2;
     let name = super::layout::truncate_to_width(&session.name, left_width);
     let name_width = UnicodeWidthStr::width(name.as_str());
     let cwd = if session.active_pane_cwd.is_empty() || name_width + 2 >= left_width {
@@ -280,11 +290,16 @@ fn format_row(
     let content_width = name_width + separator_width + UnicodeWidthStr::width(cwd.as_str());
     let gap = width
         .saturating_sub(content_width)
-        .saturating_sub(age_width);
+        .saturating_sub(right_width);
     FormattedRow {
         name,
         cwd,
         padding: " ".repeat(gap),
+        open: format!(
+            "{:<width$}",
+            if is_open { "open" } else { "" },
+            width = OPEN_COLUMN_WIDTH
+        ),
         age,
     }
 }
@@ -387,7 +402,7 @@ mod tests {
 
     #[test]
     fn row_places_age_at_right_edge() {
-        let row = format_row(&summary(), 50, 172_800);
+        let row = format_row(&summary(), 50, 172_800, false);
         assert_eq!(row.name, "2panes");
         assert_eq!(row.cwd, r"C:\Windows\system32");
         assert_eq!(row.age, "1 day ago");
@@ -396,16 +411,33 @@ mod tests {
                 + 2
                 + UnicodeWidthStr::width(row.cwd.as_str())
                 + row.padding.len()
+                + UnicodeWidthStr::width(row.open.as_str())
                 + UnicodeWidthStr::width(row.age.as_str()),
             50
         );
     }
 
     #[test]
+    fn open_column_keeps_the_age_aligned() {
+        let closed = format_row(&summary(), 50, 172_800, false);
+        let open = format_row(&summary(), 50, 172_800, true);
+
+        assert_eq!(open.open.trim(), "open");
+        assert!(closed.open.trim().is_empty());
+        // Same reserved width either way, so the age column does not shift.
+        assert_eq!(
+            UnicodeWidthStr::width(open.open.as_str()),
+            UnicodeWidthStr::width(closed.open.as_str())
+        );
+        assert_eq!(open.padding.len(), closed.padding.len());
+    }
+
+    #[test]
     fn narrow_row_truncates_without_overflowing() {
-        let row = format_row(&summary(), 10, 172_800);
+        let row = format_row(&summary(), 10, 172_800, false);
         assert!(UnicodeWidthStr::width(row.name.as_str()) <= 10);
         assert!(row.cwd.is_empty());
+        assert!(row.open.is_empty());
         assert!(row.age.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Move keep-running opt-in from individual panes to the tab context menu and show a pin in the tab header.
- Keep every non-agent pane in an opted-in tab alive as one detached tab group, so the notification-area menu shows one entry per tab.
- Remove the pane-level keep-running action, `Ctrl+Alt+K` binding, pane state, and pane pin button.
- Restore the tab-level opt-in when a live detached tab is reattached and update localized resources and the durable-session spec.

## Validation

- Built `TerminalApp_LocalTests` and `TestHostApp` in Release.
- Built `SettingsModel_UnitTests` in Release.
- Passed all 8 `SettingsModelUnitTests::CommandTests` tests.
- Passed the 2 shell-session close/persistence helper tests.
- Page-backed TerminalApp LocalTests remain blocked by the branch's existing `TryInitializePage` `E_UNEXPECTED`; the same failure reproduces with the pre-change Debug test binary.