### PR TITLE
Improve agent pane layout at compact heights

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -1,6 +1,7 @@
 aci
 adbea
 affordance
+agente
 agentic
 aiagents
 alacritty

--- a/src/cascadia/TerminalApp/AgentPaneContent.cpp
+++ b/src/cascadia/TerminalApp/AgentPaneContent.cpp
@@ -296,15 +296,17 @@ namespace winrt::TerminalApp::implementation
 
     winrt::Windows::Foundation::Size AgentPaneContent::MinimumSize()
     {
-        // Reserve 36px (top bar) on top of the inner control's minimum.
-        // The bottom bar is window-level chrome now, so it isn't part of
-        // this pane's minimum size.
+        // The responsive TUI's hard floor is seven rows: input(3),
+        // activity(1), chat(1), and a compact recommendation(2). Reserve
+        // six additional grid rows beyond TermControl's existing one-row
+        // minimum, plus the fixed 36px agent bar.
         if (const auto& impl = winrt::get_self<implementation::TerminalPaneContent>(_inner))
         {
             const auto inner = impl->MinimumSize();
-            return { inner.Width, inner.Height + 36.0f };
+            const auto rowHeight = std::max(1.0f, impl->GridUnitSize().Height);
+            return { inner.Width, inner.Height + (6.0f * rowHeight) + 36.0f };
         }
-        return { 1, 36.0f };
+        return { 1, 43.0f };
     }
 
     void AgentPaneContent::Focus(winrt::Windows::UI::Xaml::FocusState reason)

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -4926,9 +4926,12 @@ impl App {
             let card_h = ui::action_panel::recommendation_card_height(choice, panel_width);
             if idx == self.current_tab().selected_recommendation {
                 let offset = self.current_tab().rec_scroll.offset;
-                let card_bottom = line_top.saturating_add(card_h.saturating_sub(1));
+                // `card_h` includes the inter-card gap, so subtracting it
+                // yields the rendered card's exclusive bottom row.
+                let rendered_bottom_exclusive =
+                    line_top.saturating_add(card_h.saturating_sub(1));
                 let viewport_bottom = offset.saturating_add(viewport_height);
-                if line_top < offset || card_bottom > viewport_bottom {
+                if line_top < offset || rendered_bottom_exclusive > viewport_bottom {
                     self.current_tab_mut().rec_scroll.set(line_top);
                 }
                 return;

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -4233,7 +4233,7 @@ impl App {
         if self.agents_view_awaiting_snapshot() {
             return true; // agents-view "Loading" shimmer
         }
-        self.current_tab().turn.is_in_flight()
+        self.current_tab().should_show_thinking()
     }
 
     /// Get the most recent unacknowledged notification (for the banner).

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -4884,68 +4884,19 @@ impl App {
         }
     }
 
-    /// Height of the recommendations panel — grows to fit content, capped so
-    /// input and chat still have room, but floored at the tallest card's
-    /// height so any card is fully renderable when scrolled to. Using the
-    /// tallest (not just the recommended) means Down/Up navigation never
-    /// lands on a card too tall for the panel.
-    ///
-    /// `panel_width` is the actual render width (`main_area.width` after the
-    /// debug-panel split), not `terminal_cols` — passing the wrong one
-    /// under-counts wrap rows and clips the bottom card when the debug panel
-    /// is open.
-    pub fn rec_panel_height(&self, panel_width: u16) -> u16 {
-        let Some(recs) = self.current_tab().turn.recommendations() else {
-            return 0;
-        };
-        let card_heights = recs
-            .choices
-            .iter()
-            .map(|c| rec_card_height(c, panel_width) as u16);
-        let total = card_heights.clone().sum::<u16>();
-        let floor = card_heights.max().unwrap_or(ui::card::CARD_MIN_SIZE);
-        // Reserve: input(3) + chat_min(1) + rec_hint(1) = 5.
-        let ceiling = self.terminal_rows.saturating_sub(5);
-        total.min(ceiling).max(floor)
-    }
-
-    /// Height reserved for the embedded permission card. Returns 0 only when
-    /// no permission is pending — when one *is* pending, the user must be
-    /// able to see it (the agent flow is blocked until they answer), so we
-    /// fall back to a 1-row compact strip when the full card can't fit.
-    /// `permission::render` reads the actual reserved height and switches
-    /// between full and compact rendering.
-    ///
-    /// `panel_width` is the actual render width (`main_area.width` after the
-    /// debug-panel split), not `terminal_cols`.
-    pub fn permission_panel_height(&self, panel_width: u16) -> u16 {
-        let Some(perm) = self.current_tab().permission.front() else {
-            return 0;
-        };
-        let card_h = permission_card_height(perm, panel_width) as u16;
-        // Permission is modal — only hard-reserve input(3).
-        let ceiling = self.terminal_rows.saturating_sub(3);
-        let h = card_h.min(ceiling);
-        if h >= ui::card::CARD_MIN_SIZE {
-            h
-        } else {
-            1
-        }
-    }
-
     /// Recompute `rec_scroll.max` from the current card heights and the
     /// panel's available cards region. Called from layout.rs before
     /// `recommendations::render` so the renderer stays `&App` and any
     /// wheel-driven over-scroll is clamped before paint.
-    pub fn sync_rec_scroll_max(&mut self, panel_width: u16) {
-        let panel_cards_h = self.rec_panel_height(panel_width) as usize;
+    pub fn sync_rec_scroll_max(&mut self, panel_width: u16, panel_height: u16) {
+        let panel_cards_h = panel_height as usize;
         let Some(recs) = self.current_tab().turn.recommendations() else {
             return;
         };
         let total: usize = recs
             .choices
             .iter()
-            .map(|c| rec_card_height(c, panel_width))
+            .map(|c| ui::action_panel::recommendation_card_height(c, panel_width))
             .sum();
         self.current_tab_mut()
             .rec_scroll
@@ -4958,21 +4909,15 @@ impl App {
 
     /// Scroll the rec panel so the selected card's top sits at the panel top.
     fn scroll_rec_to_selected(&mut self, panel_width: u16) {
-        let panel_height = self.rec_panel_height(panel_width) as usize;
         let Some(recs) = self.current_tab().turn.recommendations().cloned() else {
             return;
         };
 
         let mut line_top = 0usize;
         for (idx, choice) in recs.choices.iter().enumerate() {
-            let card_h = rec_card_height(choice, panel_width);
+            let card_h = ui::action_panel::recommendation_card_height(choice, panel_width);
             if idx == self.current_tab().selected_recommendation {
-                let tab = self.current_tab_mut();
-                if line_top < tab.rec_scroll.offset
-                    || line_top + card_h > tab.rec_scroll.offset + panel_height
-                {
-                    tab.rec_scroll.set(line_top);
-                }
+                self.current_tab_mut().rec_scroll.set(line_top);
                 return;
             }
             line_top += card_h;
@@ -5491,97 +5436,6 @@ fn linux_cwd_arg(cwd: &std::path::Path) -> Option<String> {
 
 #[path = "app_turn.rs"]
 mod app_turn;
-
-/// Computes the rendered height (in terminal rows) of a recommendation card.
-/// Includes one trailing row used as the inter-card gap in the rec panel.
-pub(crate) fn rec_card_height(choice: &RecommendationChoice, panel_width: u16) -> usize {
-    use crate::coordinator::RecommendedAction;
-    let inner_width = ui::card::card_content_width(panel_width);
-
-    let text = choice
-        .actions
-        .iter()
-        .find_map(|action| match action {
-            RecommendedAction::Send { input, .. } => Some(input.clone()),
-            RecommendedAction::OpenAndSend { agent, input, .. } => {
-                let label = agent.as_deref().unwrap_or("agent");
-                Some(format!("{}: {}", label, input))
-            }
-            RecommendedAction::Open {
-                target, cwd, title, ..
-            } => {
-                use crate::coordinator::OpenTarget;
-                let kind = match target {
-                    OpenTarget::Tab => "tab",
-                    OpenTarget::Panel => "panel",
-                };
-                Some(match (title.as_deref(), cwd.as_deref()) {
-                    (Some(t), Some(c)) if !t.is_empty() && !c.is_empty() => {
-                        format!("New {} ({}) in {}", kind, t, c)
-                    }
-                    (Some(t), _) if !t.is_empty() => format!("New {} ({})", kind, t),
-                    (_, Some(c)) if !c.is_empty() => format!("New {} in {}", kind, c),
-                    _ => format!("New {} (empty)", kind),
-                })
-            }
-        })
-        .unwrap_or_else(|| choice.title.clone());
-
-    let content_lines: usize = text
-        .lines()
-        .map(|line| {
-            let chars = line.chars().count();
-            if chars == 0 {
-                1
-            } else {
-                chars.div_ceil(inner_width)
-            }
-        })
-        .sum::<usize>()
-        .max(1);
-
-    // CARD_MIN_SIZE counts 1 content row; add the wrap-extra rows + 1 gap.
-    ui::card::CARD_MIN_SIZE as usize + content_lines.saturating_sub(1) + 1
-}
-
-/// Computes the rendered height (in terminal rows) of the embedded
-/// permission card. Mirrors `ui/permission.rs::render`'s content exactly:
-/// a header line (`{kind_label} {title}` or just `title`) plus, for a
-/// path target, one wrapped line, or for a command target, one line per
-/// split statement (see `ui::command_format`) — NOT `description`, which
-/// is only the fallback text for the 1-row compact card. No inter-card
-/// gap — only one card is ever shown.
-pub(crate) fn permission_card_height(perm: &PermissionState, panel_width: u16) -> usize {
-    let inner_width = ui::card::card_content_width(panel_width);
-    let wrap_lines = |text: &str| -> usize {
-        text.lines()
-            .map(|line| {
-                let chars = line.chars().count();
-                if chars == 0 {
-                    1
-                } else {
-                    chars.div_ceil(inner_width)
-                }
-            })
-            .sum::<usize>()
-            .max(1)
-    };
-
-    let header = match &perm.kind_label {
-        Some(icon) => format!("{icon} {}", perm.title),
-        None => perm.title.clone(),
-    };
-    let mut content_lines = wrap_lines(&header);
-    if let Some(target) = &perm.target {
-        if perm.target_is_command {
-            content_lines += ui::command_format::command_display_lines(target).len();
-        } else {
-            content_lines += wrap_lines(target);
-        }
-    }
-    // CARD_MIN_SIZE counts 1 content row; add the wrap-extra rows.
-    ui::card::CARD_MIN_SIZE as usize + content_lines.saturating_sub(1)
-}
 
 /// Render a parsed `RecommendationSet` as the agent's "reply" text in chat.
 ///

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -4890,6 +4890,7 @@ impl App {
     /// wheel-driven over-scroll is clamped before paint.
     pub fn sync_rec_scroll_max(&mut self, panel_width: u16, panel_height: u16) {
         let panel_cards_h = panel_height as usize;
+        self.current_tab_mut().rec_viewport_height = panel_height;
         let Some(recs) = self.current_tab().turn.recommendations() else {
             return;
         };
@@ -4907,17 +4908,29 @@ impl App {
         self.current_tab_mut().clear_recommendations();
     }
 
-    /// Scroll the rec panel so the selected card's top sits at the panel top.
+    /// Keep the selected recommendation visible without moving a card that
+    /// already fits in the full panel viewport. Compact mode renders only the
+    /// selected card, so it never needs a canvas offset.
     fn scroll_rec_to_selected(&mut self, panel_width: u16) {
         let Some(recs) = self.current_tab().turn.recommendations().cloned() else {
             return;
         };
+        let viewport_height = self.current_tab().rec_viewport_height as usize;
+        if viewport_height < ui::card::CARD_MIN_SIZE as usize {
+            self.current_tab_mut().rec_scroll.set(0);
+            return;
+        }
 
         let mut line_top = 0usize;
         for (idx, choice) in recs.choices.iter().enumerate() {
             let card_h = ui::action_panel::recommendation_card_height(choice, panel_width);
             if idx == self.current_tab().selected_recommendation {
-                self.current_tab_mut().rec_scroll.set(line_top);
+                let offset = self.current_tab().rec_scroll.offset;
+                let card_bottom = line_top.saturating_add(card_h.saturating_sub(1));
+                let viewport_bottom = offset.saturating_add(viewport_height);
+                if line_top < offset || card_bottom > viewport_bottom {
+                    self.current_tab_mut().rec_scroll.set(line_top);
+                }
                 return;
             }
             line_top += card_h;

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -301,6 +301,7 @@ pub struct TabSession {
     pub selected_button: usize,
     pub recommendation_focus: RecommendationFocus,
     pub rec_scroll: Scroll,
+    pub rec_viewport_height: u16,
 
     /// Last value the helper published for this tab in a
     /// `set_agent_chip_target` event.
@@ -383,6 +384,7 @@ impl TabSession {
         self.selected_button = 0;
         self.recommendation_focus = RecommendationFocus::Button;
         self.rec_scroll.reset();
+        self.rec_viewport_height = 0;
     }
 
     /// The pane the "Agent" chip should be pinned to while this tab has a

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -363,6 +363,8 @@ impl TabSession {
 
     pub(crate) fn should_show_thinking(&self) -> bool {
         self.turn.is_in_flight()
+            && self.turn.recommendations().is_none()
+            && self.permission.is_empty()
     }
 
     /// Whether the input box is the live, enterable caret target.

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -5484,7 +5484,7 @@ fn perm_option_kind_matching_is_case_insensitive() {
 }
 
 #[test]
-fn permission_request_keeps_thinking_until_turn_ends() {
+fn permission_request_replaces_thinking_until_dismissed() {
     let mut app = test_app();
     let prompt = SubmittedPrompt {
         id: 1,
@@ -5522,7 +5522,10 @@ fn permission_request_keeps_thinking_until_turn_ends() {
         responder,
     });
 
-    assert!(app.current_tab().should_show_thinking());
+    assert!(
+        !app.current_tab().should_show_thinking(),
+        "an actionable permission replaces passive Thinking feedback"
+    );
     app.current_tab_mut().permission.pop_front();
     assert!(app.current_tab().should_show_thinking());
     let TurnState::Surfaced { end_pending, .. } = &mut app.current_tab_mut().turn else {
@@ -5530,6 +5533,35 @@ fn permission_request_keeps_thinking_until_turn_ends() {
     };
     *end_pending = false;
     assert!(!app.current_tab().should_show_thinking());
+}
+
+#[test]
+fn surfaced_recommendation_hides_thinking_before_turn_end() {
+    let mut app = test_app();
+    let prompt = SubmittedPrompt {
+        id: 1,
+        text: "test".into(),
+        submitted_at_unix_s: 0.0,
+        context: TurnContext::default(),
+        autofix: None,
+    };
+    app.tab_mut(DEFAULT_TAB_ID).turn = TurnState::Surfaced {
+        prompt,
+        outcome: TurnOutcome::Recommendation(RecommendationSet {
+            recommended_choice: None,
+            choices: Vec::new(),
+        }),
+        end_pending: true,
+    };
+
+    assert!(
+        app.current_tab().turn.is_in_flight(),
+        "end_pending must continue to gate new prompts"
+    );
+    assert!(
+        !app.current_tab().should_show_thinking(),
+        "the surfaced result replaces Thinking"
+    );
 }
 
 /// Tool-call card: when the mock proposes a command (a `ToolCall`

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -7886,6 +7886,36 @@ fn permission_card_height_treats_blank_lines_as_one_row() {
 }
 
 #[test]
+fn permission_card_height_counts_wrapped_formatted_command_rows() {
+    let mut perm = perm_with("Run command?");
+    perm.target = Some("a".repeat(150));
+    perm.target_is_command = true;
+
+    let inner_width = card_content_width(28);
+    // command_format truncates the statement to 100 chars plus an ellipsis,
+    // and permission rendering prepends "$ " before wrapping.
+    let rendered_command_width = 2_usize + 101;
+    assert_eq!(
+        permission_card_height(&perm, 28),
+        CARD_MIN_SIZE as usize + rendered_command_width.div_ceil(inner_width)
+    );
+}
+
+#[test]
+fn permission_card_height_counts_each_wrapped_split_command_line() {
+    let mut perm = perm_with("Run commands?");
+    perm.target = Some(format!("{}; {}", "a".repeat(45), "b".repeat(45)));
+    perm.target_is_command = true;
+
+    let inner_width = card_content_width(28);
+    let rows_per_command = (2_usize + 45).div_ceil(inner_width);
+    assert_eq!(
+        permission_card_height(&perm, 28),
+        CARD_MIN_SIZE as usize + rows_per_command * 2
+    );
+}
+
+#[test]
 fn rec_card_height_includes_inter_card_gap() {
     let h = recommendation_card_height(&rec_send("ls"), 80);
     assert_eq!(h as u16, CARD_MIN_SIZE + 1);

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -7893,6 +7893,8 @@ fn rec_card_height_includes_inter_card_gap() {
 
 #[test]
 fn rec_card_height_handles_open_action_synthesis() {
+    let _locale = crate::test_support::lock_locale();
+    rust_i18n::set_locale("en-US");
     let choice = RecommendationChoice {
         choice: 0,
         title: "t".into(),
@@ -7902,13 +7904,71 @@ fn rec_card_height_handles_open_action_synthesis() {
             parent: None,
             cwd: Some("C:/repo".into()),
             title: Some("logs".into()),
+            direction: Some("left".into()),
+            profile: None,
+        }],
+    };
+    // The rendered "New tab (logs) in C:/repo" fits on one row at width 72.
+    // Directions are ignored for tab targets.
+    assert_eq!(
+        recommendation_card_height(&choice, 80) as u16,
+        CARD_MIN_SIZE + 1
+    );
+}
+
+#[test]
+fn rec_card_height_uses_localized_open_panel_direction_display() {
+    let _locale = crate::test_support::lock_locale();
+    rust_i18n::set_locale("en-US");
+    let choice = RecommendationChoice {
+        choice: 0,
+        title: "t".into(),
+        rationale: String::new(),
+        actions: vec![RecommendedAction::Open {
+            target: OpenTarget::Panel,
+            parent: None,
+            cwd: Some("C:/repo".into()),
+            title: Some("logs".into()),
+            direction: Some("left".into()),
+            profile: None,
+        }],
+    };
+
+    // The renderer displays "New panel (left) (logs) in C:/repo", which wraps
+    // at the 32-cell content width. The old planner omitted "(left)".
+    assert_eq!(
+        recommendation_card_height(&choice, 40) as u16,
+        CARD_MIN_SIZE + 2
+    );
+}
+
+#[test]
+fn rec_card_height_uses_localized_open_and_send_fallback() {
+    let _locale = crate::test_support::lock_locale();
+    rust_i18n::set_locale("es-ES");
+    let choice = RecommendationChoice {
+        choice: 0,
+        title: "t".into(),
+        rationale: String::new(),
+        actions: vec![RecommendedAction::OpenAndSend {
+            target: OpenTarget::Tab,
+            parent: None,
+            input: "aaaaaaaa".into(),
+            agent: None,
+            cwd: None,
+            title: None,
             direction: None,
             profile: None,
         }],
     };
-    let h = recommendation_card_height(&choice, 80);
-    // "New tab (logs) in C:/repo" fits on one row at width 72.
-    assert_eq!(h as u16, CARD_MIN_SIZE + 1);
+
+    // The localized renderer text is "agente: aaaaaaaa" (16 chars), which
+    // wraps at the 15-character content width. The old hard-coded "agent"
+    // label fit on one row.
+    assert_eq!(
+        recommendation_card_height(&choice, 23) as u16,
+        CARD_MIN_SIZE + 2
+    );
 }
 
 #[test]

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -8032,6 +8032,80 @@ fn rec_card_height_matches_predict_and_render_paths() {
     );
 }
 
+#[test]
+fn recommendation_navigation_preserves_offset_for_fully_visible_card() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let mut app = test_app();
+    stage_surfaced_recommendation(
+        &mut app,
+        vec![
+            send_choice("pane-A", "a"),
+            send_choice("pane-B", "b"),
+            send_choice("pane-C", "c"),
+        ],
+        0,
+        None,
+    );
+    app.sync_rec_scroll_max(80, 12);
+    app.current_tab_mut().rec_scroll.set(2);
+
+    app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+
+    assert_eq!(app.current_tab().selected_recommendation, 1);
+    assert_eq!(app.current_tab().rec_scroll.offset, 2);
+}
+
+#[test]
+fn recommendation_navigation_scrolls_clipped_card_into_view() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let mut app = test_app();
+    stage_surfaced_recommendation(
+        &mut app,
+        vec![
+            send_choice("pane-A", "a"),
+            send_choice("pane-B", "b"),
+            send_choice("pane-C", "c"),
+        ],
+        0,
+        None,
+    );
+    app.sync_rec_scroll_max(80, 10);
+
+    app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+
+    assert_eq!(app.current_tab().selected_recommendation, 1);
+    assert_eq!(
+        app.current_tab().rec_scroll.offset,
+        recommendation_card_height(&rec_send("a"), 80)
+    );
+}
+
+#[test]
+fn compact_recommendation_navigation_keeps_canvas_unscrolled() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let mut app = test_app();
+    stage_surfaced_recommendation(
+        &mut app,
+        vec![
+            send_choice("pane-A", "a"),
+            send_choice("pane-B", "b"),
+            send_choice("pane-C", "c"),
+        ],
+        0,
+        None,
+    );
+    app.sync_rec_scroll_max(80, crate::ui::action_panel::COMPACT_RECOMMENDATION_HEIGHT);
+    app.current_tab_mut().rec_scroll.set(4);
+
+    app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+
+    assert_eq!(app.current_tab().selected_recommendation, 1);
+    assert_eq!(app.current_tab().rec_scroll.offset, 0);
+}
+
 // ─── Per-tab input history ──────────────────────────────────────────
 
 #[test]

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -7123,13 +7123,11 @@ fn fixed_activity_row_does_not_change_estimated_chat_height() {
 
 /// Render: when the pane is too short for a full permission card, the
 /// compact one-row fallback must paint the description and the `[Y/N]`
-/// hint. Lifts `render_compact` in `ui/permission.rs`. The compact path
-/// is gated on `terminal_rows - 3 < CARD_MIN_SIZE`.
+/// hint. Lifts `render_compact` in `ui/permission.rs`.
 #[test]
 fn render_permission_compact_shows_hint() {
     let mut app = test_app();
     app.state = ConnectionState::Connected;
-    app.terminal_rows = 7; // ceiling = 4 < CARD_MIN_SIZE(5) → compact fallback
     app.current_tab_mut().permission.push_back(PermissionState {
         tool_call_id: "tool".into(),
         description: "Run: echo PERM_COMPACT_XYZ".into(),
@@ -7153,7 +7151,7 @@ fn render_permission_compact_shows_hint() {
         responder: None,
     });
 
-    let text = render_to_text(&mut app, 80, 24);
+    let text = render_to_text(&mut app, 80, 7);
     assert!(
         text.contains("PERM_COMPACT_XYZ"),
         "the compact permission row must paint its description; rendered:\n{text}"
@@ -7161,6 +7159,33 @@ fn render_permission_compact_shows_hint() {
     assert!(
         text.contains("Y/N"),
         "the compact permission row must paint the [Y/N] hint; rendered:\n{text}"
+    );
+}
+
+#[test]
+fn render_recommendation_compact_keeps_summary_and_actions_visible() {
+    let _g = crate::test_support::lock_locale();
+    rust_i18n::set_locale("en-US");
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    install_recs(
+        &mut app,
+        vec![rec_send("echo COMPACT_RECOMMENDATION_XYZ")],
+    );
+
+    let text = render_to_text(&mut app, 80, 7);
+    assert!(
+        text.contains("COMPACT_RECOMMENDATION_XYZ"),
+        "compact recommendation must retain its selected summary; rendered:\n{text}"
+    );
+    let run_label = t!("recommendations.button_run_command").into_owned();
+    assert!(
+        text.contains(&run_label),
+        "compact recommendation must retain its primary action; rendered:\n{text}"
+    );
+    assert!(
+        text.contains('○') && !text.contains('✓'),
+        "compact recommendation must use the pending marker; rendered:\n{text}"
     );
 }
 
@@ -7728,6 +7753,9 @@ fn direct_proposal_cancel_before_commit_does_not_surface() {
 
 use crate::app::turn_state::{SubmittedPrompt, TurnOutcome, TurnState};
 use crate::coordinator::{OpenTarget, RecommendationChoice, RecommendationSet, RecommendedAction};
+use crate::ui::action_panel::{
+    permission_card_height, recommendation_card_height, recommendation_panel_height,
+};
 use crate::ui::card::{card_content_width, CARD_H_CHROME, CARD_MIN_SIZE};
 
 fn perm_with(desc: &str) -> PermissionState {
@@ -7827,7 +7855,7 @@ fn permission_card_height_treats_blank_lines_as_one_row() {
 
 #[test]
 fn rec_card_height_includes_inter_card_gap() {
-    let h = rec_card_height(&rec_send("ls"), 80);
+    let h = recommendation_card_height(&rec_send("ls"), 80);
     assert_eq!(h as u16, CARD_MIN_SIZE + 1);
 }
 
@@ -7846,63 +7874,19 @@ fn rec_card_height_handles_open_action_synthesis() {
             profile: None,
         }],
     };
-    let h = rec_card_height(&choice, 80);
+    let h = recommendation_card_height(&choice, 80);
     // "New tab (logs) in C:/repo" fits on one row at width 72.
     assert_eq!(h as u16, CARD_MIN_SIZE + 1);
 }
 
 #[test]
-fn permission_panel_height_zero_when_no_permission() {
+fn recommendation_panel_height_sums_card_canvases() {
     let mut app = test_app();
-    app.terminal_rows = 30;
-    assert_eq!(app.permission_panel_height(80), 0);
-}
-
-#[test]
-fn permission_panel_height_falls_back_to_compact_below_card_min() {
-    let mut app = test_app();
-    app.terminal_rows = 7; // ceiling = 7-3 = 4 < CARD_MIN_SIZE
-    app.current_tab_mut().permission.push_back(perm_with("ok"));
-    // Must stay visible — agent flow blocks on this prompt. 1-row strip
-    // is the compact fallback rendered by `ui::permission::render`.
-    assert_eq!(app.permission_panel_height(80), 1);
-}
-
-#[test]
-fn permission_panel_height_admits_at_card_min_ceiling() {
-    let mut app = test_app();
-    app.terminal_rows = 8; // ceiling = 5 == CARD_MIN_SIZE
-    app.current_tab_mut().permission.push_back(perm_with("ok"));
-    assert_eq!(app.permission_panel_height(80), CARD_MIN_SIZE);
-}
-
-#[test]
-fn rec_panel_height_floor_lets_tallest_card_render() {
-    let mut app = test_app();
-    app.terminal_rows = 20;
-    let tall = "x".repeat(500);
-    install_recs(&mut app, vec![rec_send(&tall)]);
-    let tall_h = rec_card_height(
-        &app.current_tab().turn.recommendations().unwrap().choices[0],
-        80,
-    ) as u16;
-    // ceiling = 20 - 5 = 15; tall card is much larger; floor wins.
-    assert_eq!(app.rec_panel_height(80), tall_h);
-}
-
-#[test]
-fn rec_panel_height_caps_at_ceiling_when_total_exceeds() {
-    let mut app = test_app();
-    app.terminal_rows = 30;
-    // Three short cards, each h=6 → total 18; ceiling 30-5=25.
     install_recs(&mut app, vec![rec_send("a"), rec_send("b"), rec_send("c")]);
-    assert_eq!(app.rec_panel_height(80), 18);
-}
-
-#[test]
-fn rec_panel_height_zero_when_no_recs() {
-    let app = test_app();
-    assert_eq!(app.rec_panel_height(80), 0);
+    assert_eq!(
+        recommendation_panel_height(app.current_tab().turn.recommendations().unwrap(), 80),
+        18
+    );
 }
 
 #[test]
@@ -7915,8 +7899,8 @@ fn main_area_width_reflects_debug_panel_split() {
 }
 
 /// Regression: `ui::recommendations::render` used `area.width` (= `h_rec[1]`
-/// = `main_area.width - 2`) when calling `rec_card_height`, while
-/// `rec_panel_height` / `sync_rec_scroll_max` used `main_area.width`. The
+/// = `main_area.width - 2`) when calling the card-height helper, while the
+/// panel planner / scroll bound used `main_area.width`. The
 /// 2-cell desync clipped the bottom card and undercounted scroll bounds
 /// whenever a card's wrap row count differed between the two widths.
 ///
@@ -7937,16 +7921,18 @@ fn rec_card_height_matches_predict_and_render_paths() {
     app.terminal_rows = 30;
     install_recs(&mut app, vec![choice.clone()]);
 
-    let predict = app.rec_panel_height(app.main_area_width()) as usize;
-    // Same width the renderer now uses (`app.main_area_width()`).
-    let render = rec_card_height(&choice, app.main_area_width());
+    let predict = recommendation_panel_height(
+        app.current_tab().turn.recommendations().unwrap(),
+        app.main_area_width(),
+    ) as usize;
+    let render = recommendation_card_height(&choice, app.main_area_width());
     assert_eq!(predict, render);
 
     // Sanity: confirm the chosen text *is* a sensitive input — i.e. the
     // old buggy basis (h_rec[1] width = W-2) would have produced a
     // different height. If this ever fails the test no longer guards
     // the regression.
-    let buggy = rec_card_height(&choice, app.main_area_width() - 2);
+    let buggy = recommendation_card_height(&choice, app.main_area_width() - 2);
     assert_ne!(
         render, buggy,
         "text length 42 should wrap differently at width 50 vs 48 — \

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -8113,7 +8113,7 @@ fn recommendation_navigation_scrolls_clipped_card_into_view() {
 }
 
 #[test]
-fn compact_recommendation_navigation_keeps_canvas_unscrolled() {
+fn compact_recommendation_navigation_resets_canvas_scroll() {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     let mut app = test_app();

--- a/tools/wta/src/ui/action_panel.rs
+++ b/tools/wta/src/ui/action_panel.rs
@@ -1,0 +1,303 @@
+use crate::app::PermissionState;
+use crate::coordinator::{OpenTarget, RecommendationChoice, RecommendationSet, RecommendedAction};
+
+use super::card::{card_content_width, CARD_MIN_SIZE};
+
+pub(crate) const COMPACT_RECOMMENDATION_HEIGHT: u16 = 2;
+const COMPACT_PERMISSION_HEIGHT: u16 = 1;
+const ACTIVITY_HEIGHT: u16 = 1;
+const CHAT_MIN_HEIGHT: u16 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PanelMode {
+    Hidden,
+    Compact,
+    Full,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ActionPanelLayout {
+    pub chat_height: u16,
+    pub recommendation_height: u16,
+    pub recommendation_mode: PanelMode,
+    pub permission_height: u16,
+    pub permission_mode: PanelMode,
+    pub hint_height: u16,
+    pub recommendation_hint_height: u16,
+    pub activity_height: u16,
+    pub input_height: u16,
+}
+
+pub(crate) struct LayoutRequest {
+    pub available_rows: u16,
+    pub input_height: u16,
+    pub chat_natural_height: u16,
+    pub hint_requested: bool,
+    pub recommendation_natural_height: Option<u16>,
+    pub permission_natural_height: Option<u16>,
+}
+
+/// Allocate vertical rows for the chat view.
+///
+/// Input and the active action form the hard interactive base. A pending
+/// permission is modal and suppresses recommendations. Recommendations use a
+/// two-row summary until a five-row card shell fits. Activity, chat, and
+/// optional hints yield first if the host reports fewer than seven rows.
+pub(crate) fn plan(request: LayoutRequest) -> ActionPanelLayout {
+    let mut result = ActionPanelLayout {
+        chat_height: 0,
+        recommendation_height: 0,
+        recommendation_mode: PanelMode::Hidden,
+        permission_height: 0,
+        permission_mode: PanelMode::Hidden,
+        hint_height: 0,
+        recommendation_hint_height: 0,
+        activity_height: 0,
+        input_height: super::input::INPUT_MIN_HEIGHT,
+    };
+
+    let preferred_base = super::input::INPUT_MIN_HEIGHT
+        .saturating_add(ACTIVITY_HEIGHT)
+        .saturating_add(CHAT_MIN_HEIGHT);
+    let preferred_action_budget = request.available_rows.saturating_sub(preferred_base);
+    let emergency_action_budget = request
+        .available_rows
+        .saturating_sub(super::input::INPUT_MIN_HEIGHT);
+
+    if let Some(natural_height) = request.permission_natural_height {
+        if preferred_action_budget >= natural_height {
+            result.permission_height = natural_height;
+            result.permission_mode = PanelMode::Full;
+        } else if emergency_action_budget >= COMPACT_PERMISSION_HEIGHT {
+            result.permission_height = COMPACT_PERMISSION_HEIGHT;
+            result.permission_mode = PanelMode::Compact;
+        }
+    } else if let Some(natural_height) = request.recommendation_natural_height {
+        if preferred_action_budget >= CARD_MIN_SIZE {
+            let reserve_hint = u16::from(preferred_action_budget > CARD_MIN_SIZE);
+            let panel_budget = preferred_action_budget.saturating_sub(reserve_hint);
+            result.recommendation_height = natural_height.min(panel_budget).max(CARD_MIN_SIZE);
+            result.recommendation_mode = PanelMode::Full;
+            result.recommendation_hint_height = reserve_hint;
+        } else if emergency_action_budget >= COMPACT_RECOMMENDATION_HEIGHT {
+            result.recommendation_height = COMPACT_RECOMMENDATION_HEIGHT;
+            result.recommendation_mode = PanelMode::Compact;
+        }
+    }
+
+    let action_rows = result
+        .permission_height
+        .saturating_add(result.recommendation_height)
+        .saturating_add(result.recommendation_hint_height);
+    let natural_content_without_hint = request
+        .input_height
+        .saturating_add(ACTIVITY_HEIGHT)
+        .saturating_add(action_rows)
+        .saturating_add(request.chat_natural_height.max(CHAT_MIN_HEIGHT));
+    let compact = result.permission_mode == PanelMode::Compact
+        || result.recommendation_mode == PanelMode::Compact;
+    if request.hint_requested && !compact && request.available_rows > natural_content_without_hint {
+        result.hint_height = 1;
+    }
+
+    let base_remaining = request
+        .available_rows
+        .saturating_sub(action_rows)
+        .saturating_sub(result.hint_height)
+        .saturating_sub(super::input::INPUT_MIN_HEIGHT);
+    result.chat_height = CHAT_MIN_HEIGHT.min(base_remaining);
+    result.activity_height = ACTIVITY_HEIGHT.min(base_remaining.saturating_sub(result.chat_height));
+
+    let input_capacity = request
+        .available_rows
+        .saturating_sub(result.activity_height)
+        .saturating_sub(action_rows)
+        .saturating_sub(result.hint_height)
+        .saturating_sub(result.chat_height)
+        .max(super::input::INPUT_MIN_HEIGHT);
+    result.input_height = request.input_height.min(input_capacity);
+
+    let chat_capacity = request
+        .available_rows
+        .saturating_sub(result.input_height)
+        .saturating_sub(result.activity_height)
+        .saturating_sub(action_rows)
+        .saturating_sub(result.hint_height);
+    result.chat_height = request.chat_natural_height.min(chat_capacity);
+    result
+}
+
+pub(crate) fn recommendation_panel_height(
+    recommendations: &RecommendationSet,
+    panel_width: u16,
+) -> u16 {
+    recommendations
+        .choices
+        .iter()
+        .map(|choice| recommendation_card_height(choice, panel_width))
+        .sum::<usize>()
+        .min(u16::MAX as usize) as u16
+}
+
+/// Rendered recommendation-card height, including one inter-card gap row.
+pub(crate) fn recommendation_card_height(choice: &RecommendationChoice, panel_width: u16) -> usize {
+    let inner_width = card_content_width(panel_width);
+    let text = choice
+        .actions
+        .iter()
+        .find_map(|action| match action {
+            RecommendedAction::Send { input, .. } => Some(input.clone()),
+            RecommendedAction::OpenAndSend { agent, input, .. } => {
+                let label = agent.as_deref().unwrap_or("agent");
+                Some(format!("{label}: {input}"))
+            }
+            RecommendedAction::Open {
+                target, cwd, title, ..
+            } => {
+                let kind = match target {
+                    OpenTarget::Tab => "tab",
+                    OpenTarget::Panel => "panel",
+                };
+                Some(match (title.as_deref(), cwd.as_deref()) {
+                    (Some(title), Some(cwd)) if !title.is_empty() && !cwd.is_empty() => {
+                        format!("New {kind} ({title}) in {cwd}")
+                    }
+                    (Some(title), _) if !title.is_empty() => format!("New {kind} ({title})"),
+                    (_, Some(cwd)) if !cwd.is_empty() => format!("New {kind} in {cwd}"),
+                    _ => format!("New {kind} (empty)"),
+                })
+            }
+        })
+        .unwrap_or_else(|| choice.title.clone());
+
+    let content_lines = wrapped_line_count(&text, inner_width);
+    CARD_MIN_SIZE as usize + content_lines.saturating_sub(1) + 1
+}
+
+/// Natural height of the blocking permission card.
+pub(crate) fn permission_card_height(permission: &PermissionState, panel_width: u16) -> usize {
+    let inner_width = card_content_width(panel_width);
+    let header = match &permission.kind_label {
+        Some(icon) => format!("{icon} {}", permission.title),
+        None => permission.title.clone(),
+    };
+    let mut content_lines = wrapped_line_count(&header, inner_width);
+    if let Some(target) = &permission.target {
+        if permission.target_is_command {
+            content_lines += super::command_format::command_display_lines(target).len();
+        } else {
+            content_lines += wrapped_line_count(target, inner_width);
+        }
+    }
+    CARD_MIN_SIZE as usize + content_lines.saturating_sub(1)
+}
+
+fn wrapped_line_count(text: &str, width: usize) -> usize {
+    text.lines()
+        .map(|line| {
+            let chars = line.chars().count();
+            if chars == 0 {
+                1
+            } else {
+                chars.div_ceil(width)
+            }
+        })
+        .sum::<usize>()
+        .max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn recommendation_request(rows: u16) -> LayoutRequest {
+        LayoutRequest {
+            available_rows: rows,
+            input_height: 3,
+            chat_natural_height: 4,
+            hint_requested: true,
+            recommendation_natural_height: Some(6),
+            permission_natural_height: None,
+        }
+    }
+
+    #[test]
+    fn recommendations_degrade_and_restore_between_seven_and_thirteen_rows() {
+        for rows in 7..=9 {
+            let layout = plan(recommendation_request(rows));
+            assert_eq!(layout.recommendation_mode, PanelMode::Compact);
+            assert_eq!(layout.recommendation_height, 2);
+            assert_eq!(layout.recommendation_hint_height, 0);
+            assert_eq!(layout.hint_height, 0);
+        }
+
+        let ten = plan(recommendation_request(10));
+        assert_eq!(ten.recommendation_mode, PanelMode::Full);
+        assert_eq!(ten.recommendation_height, 5);
+        assert_eq!(ten.recommendation_hint_height, 0);
+
+        let eleven = plan(recommendation_request(11));
+        assert_eq!(eleven.recommendation_height, 5);
+        assert_eq!(eleven.recommendation_hint_height, 1);
+
+        let twelve = plan(recommendation_request(12));
+        assert_eq!(twelve.recommendation_height, 6);
+        assert_eq!(twelve.recommendation_hint_height, 1);
+        assert_eq!(twelve.chat_height, 1);
+
+        let thirteen = plan(recommendation_request(13));
+        assert_eq!(thirteen.recommendation_height, 6);
+        assert_eq!(thirteen.recommendation_hint_height, 1);
+        assert_eq!(thirteen.chat_height, 2);
+    }
+
+    #[test]
+    fn permission_is_modal_and_uses_compact_until_full_card_fits() {
+        let request = |rows| LayoutRequest {
+            available_rows: rows,
+            input_height: 3,
+            chat_natural_height: 4,
+            hint_requested: true,
+            recommendation_natural_height: Some(6),
+            permission_natural_height: Some(5),
+        };
+
+        let short = plan(request(9));
+        assert_eq!(short.permission_mode, PanelMode::Compact);
+        assert_eq!(short.permission_height, 1);
+        assert_eq!(short.recommendation_mode, PanelMode::Hidden);
+
+        let full = plan(request(10));
+        assert_eq!(full.permission_mode, PanelMode::Full);
+        assert_eq!(full.permission_height, 5);
+        assert_eq!(full.recommendation_mode, PanelMode::Hidden);
+    }
+
+    #[test]
+    fn expanded_input_cannot_displace_a_compact_action() {
+        let layout = plan(LayoutRequest {
+            available_rows: 7,
+            input_height: 8,
+            chat_natural_height: 4,
+            hint_requested: false,
+            recommendation_natural_height: Some(6),
+            permission_natural_height: None,
+        });
+
+        assert_eq!(layout.recommendation_mode, PanelMode::Compact);
+        assert_eq!(layout.recommendation_height, 2);
+        assert_eq!(layout.input_height, 3);
+        assert_eq!(layout.chat_height, 1);
+    }
+
+    #[test]
+    fn compact_recommendation_survives_below_the_host_floor() {
+        let layout = plan(recommendation_request(6));
+
+        assert_eq!(layout.recommendation_mode, PanelMode::Compact);
+        assert_eq!(layout.recommendation_height, 2);
+        assert_eq!(layout.input_height, 3);
+        assert_eq!(layout.chat_height, 1);
+        assert_eq!(layout.activity_height, 0);
+    }
+}

--- a/tools/wta/src/ui/action_panel.rs
+++ b/tools/wta/src/ui/action_panel.rs
@@ -1,7 +1,9 @@
 use crate::app::PermissionState;
-use crate::coordinator::{OpenTarget, RecommendationChoice, RecommendationSet, RecommendedAction};
+use crate::coordinator::{RecommendationChoice, RecommendationSet};
+use unicode_width::UnicodeWidthStr;
 
 use super::card::{card_content_width, CARD_MIN_SIZE};
+use super::recommendations::recommendation_display_text;
 
 pub(crate) const COMPACT_RECOMMENDATION_HEIGHT: u16 = 2;
 const COMPACT_PERMISSION_HEIGHT: u16 = 1;
@@ -149,33 +151,7 @@ pub(crate) fn recommendation_panel_height(
 /// Rendered recommendation-card height, including one inter-card gap row.
 pub(crate) fn recommendation_card_height(choice: &RecommendationChoice, panel_width: u16) -> usize {
     let inner_width = card_content_width(panel_width);
-    let text = choice
-        .actions
-        .iter()
-        .find_map(|action| match action {
-            RecommendedAction::Send { input, .. } => Some(input.clone()),
-            RecommendedAction::OpenAndSend { agent, input, .. } => {
-                let label = agent.as_deref().unwrap_or("agent");
-                Some(format!("{label}: {input}"))
-            }
-            RecommendedAction::Open {
-                target, cwd, title, ..
-            } => {
-                let kind = match target {
-                    OpenTarget::Tab => "tab",
-                    OpenTarget::Panel => "panel",
-                };
-                Some(match (title.as_deref(), cwd.as_deref()) {
-                    (Some(title), Some(cwd)) if !title.is_empty() && !cwd.is_empty() => {
-                        format!("New {kind} ({title}) in {cwd}")
-                    }
-                    (Some(title), _) if !title.is_empty() => format!("New {kind} ({title})"),
-                    (_, Some(cwd)) if !cwd.is_empty() => format!("New {kind} in {cwd}"),
-                    _ => format!("New {kind} (empty)"),
-                })
-            }
-        })
-        .unwrap_or_else(|| choice.title.clone());
+    let text = recommendation_display_text(choice);
 
     let content_lines = wrapped_line_count(&text, inner_width);
     CARD_MIN_SIZE as usize + content_lines.saturating_sub(1) + 1
@@ -200,13 +176,14 @@ pub(crate) fn permission_card_height(permission: &PermissionState, panel_width: 
 }
 
 fn wrapped_line_count(text: &str, width: usize) -> usize {
+    let width = width.max(1);
     text.lines()
         .map(|line| {
-            let chars = line.chars().count();
-            if chars == 0 {
+            let display_width = UnicodeWidthStr::width(line);
+            if display_width == 0 {
                 1
             } else {
-                chars.div_ceil(width)
+                display_width.div_ceil(width)
             }
         })
         .sum::<usize>()
@@ -321,5 +298,20 @@ mod tests {
         assert_eq!(layout.input_height, 3);
         assert_eq!(layout.chat_height, 1);
         assert_eq!(layout.activity_height, 0);
+    }
+
+    #[test]
+    fn wrapped_line_count_uses_display_width_for_cjk() {
+        assert_eq!(wrapped_line_count("你好", 3), 2);
+    }
+
+    #[test]
+    fn wrapped_line_count_does_not_charge_combining_marks() {
+        assert_eq!(wrapped_line_count("e\u{301}e\u{301}", 1), 2);
+    }
+
+    #[test]
+    fn wrapped_line_count_handles_zero_width() {
+        assert_eq!(wrapped_line_count("abc", 0), 3);
     }
 }

--- a/tools/wta/src/ui/action_panel.rs
+++ b/tools/wta/src/ui/action_panel.rs
@@ -33,6 +33,7 @@ pub(crate) struct LayoutRequest {
     pub input_height: u16,
     pub chat_natural_height: u16,
     pub hint_requested: bool,
+    pub activity_requested: bool,
     pub recommendation_natural_height: Option<u16>,
     pub permission_natural_height: Option<u16>,
 }
@@ -41,8 +42,9 @@ pub(crate) struct LayoutRequest {
 ///
 /// Input and the active action form the hard interactive base. A pending
 /// permission is modal and suppresses recommendations. Recommendations use a
-/// two-row summary until a five-row card shell fits. Activity, chat, and
-/// optional hints yield first if the host reports fewer than seven rows.
+/// two-row summary until a five-row card shell fits. Activity and navigation
+/// hints share one status row, with activity taking precedence. Chat and the
+/// status row yield first if the host reports fewer than seven rows.
 pub(crate) fn plan(request: LayoutRequest) -> ActionPanelLayout {
     let mut result = ActionPanelLayout {
         chat_height: 0,
@@ -74,11 +76,9 @@ pub(crate) fn plan(request: LayoutRequest) -> ActionPanelLayout {
         }
     } else if let Some(natural_height) = request.recommendation_natural_height {
         if preferred_action_budget >= CARD_MIN_SIZE {
-            let reserve_hint = u16::from(preferred_action_budget > CARD_MIN_SIZE);
-            let panel_budget = preferred_action_budget.saturating_sub(reserve_hint);
-            result.recommendation_height = natural_height.min(panel_budget).max(CARD_MIN_SIZE);
+            result.recommendation_height =
+                natural_height.min(preferred_action_budget).max(CARD_MIN_SIZE);
             result.recommendation_mode = PanelMode::Full;
-            result.recommendation_hint_height = reserve_hint;
         } else if emergency_action_budget >= COMPACT_RECOMMENDATION_HEIGHT {
             result.recommendation_height = COMPACT_RECOMMENDATION_HEIGHT;
             result.recommendation_mode = PanelMode::Compact;
@@ -87,32 +87,40 @@ pub(crate) fn plan(request: LayoutRequest) -> ActionPanelLayout {
 
     let action_rows = result
         .permission_height
-        .saturating_add(result.recommendation_height)
-        .saturating_add(result.recommendation_hint_height);
+        .saturating_add(result.recommendation_height);
     let natural_content_without_hint = request
         .input_height
-        .saturating_add(ACTIVITY_HEIGHT)
         .saturating_add(action_rows)
         .saturating_add(request.chat_natural_height.max(CHAT_MIN_HEIGHT));
     let compact = result.permission_mode == PanelMode::Compact
         || result.recommendation_mode == PanelMode::Compact;
-    if request.hint_requested && !compact && request.available_rows > natural_content_without_hint {
-        result.hint_height = 1;
-    }
+    let generic_hint_requested = request.hint_requested
+        && !compact
+        && request.available_rows > natural_content_without_hint;
 
     let base_remaining = request
         .available_rows
         .saturating_sub(action_rows)
-        .saturating_sub(result.hint_height)
         .saturating_sub(super::input::INPUT_MIN_HEIGHT);
     result.chat_height = CHAT_MIN_HEIGHT.min(base_remaining);
-    result.activity_height = ACTIVITY_HEIGHT.min(base_remaining.saturating_sub(result.chat_height));
+    let status_height =
+        ACTIVITY_HEIGHT.min(base_remaining.saturating_sub(result.chat_height));
+    if request.activity_requested {
+        result.activity_height = status_height;
+    } else if result.recommendation_mode == PanelMode::Full {
+        result.recommendation_hint_height = status_height;
+    } else if generic_hint_requested {
+        result.hint_height = status_height;
+    }
+    let allocated_status_height = result
+        .activity_height
+        .saturating_add(result.recommendation_hint_height)
+        .saturating_add(result.hint_height);
 
     let input_capacity = request
         .available_rows
-        .saturating_sub(result.activity_height)
+        .saturating_sub(allocated_status_height)
         .saturating_sub(action_rows)
-        .saturating_sub(result.hint_height)
         .saturating_sub(result.chat_height)
         .max(super::input::INPUT_MIN_HEIGHT);
     result.input_height = request.input_height.min(input_capacity);
@@ -120,9 +128,8 @@ pub(crate) fn plan(request: LayoutRequest) -> ActionPanelLayout {
     let chat_capacity = request
         .available_rows
         .saturating_sub(result.input_height)
-        .saturating_sub(result.activity_height)
-        .saturating_sub(action_rows)
-        .saturating_sub(result.hint_height);
+        .saturating_sub(allocated_status_height)
+        .saturating_sub(action_rows);
     result.chat_height = request.chat_natural_height.min(chat_capacity);
     result
 }
@@ -216,6 +223,7 @@ mod tests {
             input_height: 3,
             chat_natural_height: 4,
             hint_requested: true,
+            activity_requested: false,
             recommendation_natural_height: Some(6),
             permission_natural_height: None,
         }
@@ -234,21 +242,33 @@ mod tests {
         let ten = plan(recommendation_request(10));
         assert_eq!(ten.recommendation_mode, PanelMode::Full);
         assert_eq!(ten.recommendation_height, 5);
-        assert_eq!(ten.recommendation_hint_height, 0);
+        assert_eq!(ten.recommendation_hint_height, 1);
 
         let eleven = plan(recommendation_request(11));
-        assert_eq!(eleven.recommendation_height, 5);
+        assert_eq!(eleven.recommendation_height, 6);
         assert_eq!(eleven.recommendation_hint_height, 1);
 
         let twelve = plan(recommendation_request(12));
         assert_eq!(twelve.recommendation_height, 6);
         assert_eq!(twelve.recommendation_hint_height, 1);
-        assert_eq!(twelve.chat_height, 1);
+        assert_eq!(twelve.chat_height, 2);
 
         let thirteen = plan(recommendation_request(13));
         assert_eq!(thirteen.recommendation_height, 6);
         assert_eq!(thirteen.recommendation_hint_height, 1);
-        assert_eq!(thirteen.chat_height, 2);
+        assert_eq!(thirteen.chat_height, 3);
+    }
+
+    #[test]
+    fn activity_replaces_navigation_and_generic_hints() {
+        let mut request = recommendation_request(13);
+        request.activity_requested = true;
+
+        let layout = plan(request);
+
+        assert_eq!(layout.activity_height, 1);
+        assert_eq!(layout.recommendation_hint_height, 0);
+        assert_eq!(layout.hint_height, 0);
     }
 
     #[test]
@@ -258,6 +278,7 @@ mod tests {
             input_height: 3,
             chat_natural_height: 4,
             hint_requested: true,
+            activity_requested: false,
             recommendation_natural_height: Some(6),
             permission_natural_height: Some(5),
         };
@@ -280,13 +301,14 @@ mod tests {
             input_height: 8,
             chat_natural_height: 4,
             hint_requested: false,
+            activity_requested: false,
             recommendation_natural_height: Some(6),
             permission_natural_height: None,
         });
 
         assert_eq!(layout.recommendation_mode, PanelMode::Compact);
         assert_eq!(layout.recommendation_height, 2);
-        assert_eq!(layout.input_height, 3);
+        assert_eq!(layout.input_height, 4);
         assert_eq!(layout.chat_height, 1);
     }
 

--- a/tools/wta/src/ui/action_panel.rs
+++ b/tools/wta/src/ui/action_panel.rs
@@ -166,7 +166,10 @@ pub(crate) fn permission_card_height(permission: &PermissionState, panel_width: 
     let mut content_lines = wrapped_line_count(&header, inner_width);
     if let Some(target) = &permission.target {
         if permission.target_is_command {
-            content_lines += super::command_format::command_display_lines(target).len();
+            content_lines += super::command_format::command_display_lines(target)
+                .iter()
+                .map(|line| wrapped_line_count(&line.rendered_text(""), inner_width))
+                .sum::<usize>();
         } else {
             content_lines += wrapped_line_count(target, inner_width);
         }

--- a/tools/wta/src/ui/action_panel.rs
+++ b/tools/wta/src/ui/action_panel.rs
@@ -123,8 +123,7 @@ pub(crate) fn plan(request: LayoutRequest) -> ActionPanelLayout {
         .available_rows
         .saturating_sub(allocated_status_height)
         .saturating_sub(action_rows)
-        .saturating_sub(result.chat_height)
-        .max(super::input::INPUT_MIN_HEIGHT);
+        .saturating_sub(result.chat_height);
     result.input_height = request.input_height.min(input_capacity);
 
     let chat_capacity = request
@@ -204,6 +203,69 @@ mod tests {
             recommendation_natural_height: Some(6),
             permission_natural_height: None,
         }
+    }
+
+    fn allocated_height(layout: ActionPanelLayout) -> u32 {
+        [
+            layout.chat_height,
+            layout.recommendation_height,
+            layout.permission_height,
+            layout.hint_height,
+            layout.recommendation_hint_height,
+            layout.activity_height,
+            layout.input_height,
+        ]
+        .into_iter()
+        .map(u32::from)
+        .sum()
+    }
+
+    #[test]
+    fn input_shrinks_to_fit_hosts_below_its_minimum_height() {
+        for rows in 0..super::super::input::INPUT_MIN_HEIGHT {
+            let layout = plan(recommendation_request(rows));
+
+            assert_eq!(layout.input_height, rows);
+            assert_eq!(allocated_height(layout), u32::from(rows));
+        }
+    }
+
+    #[test]
+    fn planned_heights_never_exceed_available_rows() {
+        for rows in 0..=32 {
+            let requests = [
+                recommendation_request(rows),
+                LayoutRequest {
+                    available_rows: rows,
+                    input_height: 8,
+                    chat_natural_height: 20,
+                    hint_requested: true,
+                    activity_requested: true,
+                    recommendation_natural_height: None,
+                    permission_natural_height: Some(12),
+                },
+                LayoutRequest {
+                    available_rows: rows,
+                    input_height: 8,
+                    chat_natural_height: 20,
+                    hint_requested: true,
+                    activity_requested: true,
+                    recommendation_natural_height: None,
+                    permission_natural_height: None,
+                },
+            ];
+
+            for request in requests {
+                let available_rows = request.available_rows;
+                let layout = plan(request);
+                assert!(allocated_height(layout) <= u32::from(available_rows));
+            }
+        }
+
+        let five = plan(recommendation_request(5));
+        assert_eq!(five.recommendation_mode, PanelMode::Compact);
+        assert_eq!(five.recommendation_height, COMPACT_RECOMMENDATION_HEIGHT);
+        assert_eq!(five.input_height, super::super::input::INPUT_MIN_HEIGHT);
     }
 
     #[test]

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -153,6 +153,11 @@ fn should_show_turn_activity(tab: &crate::app::TabSession) -> bool {
     tab.should_show_thinking()
 }
 
+pub(crate) fn should_show_activity(app: &App) -> bool {
+    matches!(app.state, crate::app::ConnectionState::Connecting(_))
+        || should_show_turn_activity(app.current_tab())
+}
+
 fn permission_tool_call_id(tab: &crate::app::TabSession) -> Option<&str> {
     tab.permission
         .front()

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -541,15 +541,10 @@ fn build_message_lines<'a>(
                 if let Some(command) = location {
                     for entry in crate::ui::command_format::command_display_lines(command) {
                         rendered_command = true;
-                        let text = match entry {
-                            crate::ui::command_format::CommandLine::Statement(s) => {
-                                format!("    $ {s}")
-                            }
-                            crate::ui::command_format::CommandLine::Folded { remaining } => {
-                                format!("    … (+{remaining} more)")
-                            }
-                        };
-                        lines.push(Line::from(Span::styled(text, theme::CARD_CODE)));
+                        lines.push(Line::from(Span::styled(
+                            entry.rendered_text("    "),
+                            theme::CARD_CODE,
+                        )));
                     }
                 }
             }

--- a/tools/wta/src/ui/command_format.rs
+++ b/tools/wta/src/ui/command_format.rs
@@ -95,6 +95,18 @@ pub(crate) enum CommandLine {
     Folded { remaining: usize },
 }
 
+impl CommandLine {
+    /// Formats this row exactly as command cards render it. `indent` lets
+    /// inline chat cards add their leading padding while permission cards
+    /// use the terminal-cell text directly.
+    pub(crate) fn rendered_text(&self, indent: &str) -> String {
+        match self {
+            Self::Statement(statement) => format!("{indent}$ {statement}"),
+            Self::Folded { remaining } => format!("{indent}… (+{remaining} more)"),
+        }
+    }
+}
+
 /// Formats a (possibly multi-statement) command into the display rows a
 /// card should show: one per top-level statement, each truncated
 /// individually, capped at `MAX_COMMAND_LINES` with any remainder folded
@@ -180,5 +192,17 @@ mod tests {
             }
             CommandLine::Folded { .. } => panic!("expected a Statement line"),
         }
+    }
+
+    #[test]
+    fn rendered_text_matches_card_prefixes() {
+        assert_eq!(
+            CommandLine::Statement("cargo test".into()).rendered_text(""),
+            "$ cargo test"
+        );
+        assert_eq!(
+            CommandLine::Folded { remaining: 2 }.rendered_text("    "),
+            "    … (+2 more)"
+        );
     }
 }

--- a/tools/wta/src/ui/input.rs
+++ b/tools/wta/src/ui/input.rs
@@ -48,7 +48,12 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     let text_width = area
         .width
         .saturating_sub(INPUT_LEFT_PAD + 2 + INPUT_PROMPT_WIDTH);
-    let viewport = input_viewport(&tab.input, tab.cursor_pos, text_width);
+    let viewport = input_viewport_with_max_rows(
+        &tab.input,
+        tab.cursor_pos,
+        text_width,
+        area.height.saturating_sub(2) as usize,
+    );
     let attachment_ranges = tab.attachments.token_ranges().collect::<Vec<_>>();
     let ghost_suffix = app.command_ghost_suffix();
 
@@ -256,12 +261,27 @@ fn push_styled_input(
 }
 
 pub(crate) fn input_viewport(input: &str, cursor_pos: usize, total_width: u16) -> InputViewport {
+    input_viewport_with_max_rows(
+        input,
+        cursor_pos,
+        total_width,
+        INPUT_MAX_INNER_ROWS,
+    )
+}
+
+fn input_viewport_with_max_rows(
+    input: &str,
+    cursor_pos: usize,
+    total_width: u16,
+    max_visible_rows: usize,
+) -> InputViewport {
     let inner_width = total_width.max(1) as usize;
     let wrapped = wrap_input(input, cursor_pos, inner_width);
+    let max_visible_rows = max_visible_rows.clamp(INPUT_MIN_INNER_ROWS, INPUT_MAX_INNER_ROWS);
     let visible_rows = wrapped
         .lines
         .len()
-        .clamp(INPUT_MIN_INNER_ROWS, INPUT_MAX_INNER_ROWS);
+        .clamp(INPUT_MIN_INNER_ROWS, max_visible_rows);
     let scroll_row = if wrapped.cursor_row + 1 > visible_rows {
         wrapped.cursor_row + 1 - visible_rows
     } else {

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -143,6 +143,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         input_height,
         chat_natural_height: chat_estimate,
         hint_requested,
+        activity_requested: chat::should_show_activity(app),
         recommendation_natural_height,
         permission_natural_height,
     });

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -2,8 +2,8 @@ use crate::app::{App, AppMode, View, DEFAULT_TAB_ID};
 use ratatui::prelude::*;
 
 use super::{
-    agent_popup, agents_view, auth, chat, command_popup, debug_panel, input, model_popup,
-    permission, recommendations, setup,
+    action_panel, agent_popup, agents_view, auth, chat, command_popup, debug_panel, input,
+    model_popup, permission, recommendations, setup,
 };
 
 pub fn render(frame: &mut Frame, app: &mut App) {
@@ -95,12 +95,6 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         (area, None)
     };
 
-    let rec_panel_h = if app.current_tab().turn.recommendations().is_some() {
-        app.rec_panel_height(main_area.width)
-    } else {
-        0
-    };
-    let perm_panel_h = app.permission_panel_height(main_area.width);
     let input_height = {
         let tab = app.current_tab();
         input::input_height(&tab.input, tab.cursor_pos, main_area.width)
@@ -119,45 +113,50 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     }
     let welcome_visible =
         app.show_welcome_hint && app.state == crate::app::ConnectionState::Connected;
-    let hint_visible = welcome_visible || transient_visible;
-    let hint_h: u16 = if hint_visible { 1 } else { 0 };
-    let rec_hint_h: u16 = if app.current_tab().turn.recommendations().is_some() {
-        1
-    } else {
-        0
-    };
+    let hint_requested = welcome_visible || transient_visible;
 
     // The host (Windows Terminal) renders the agent bar in XAML above this
     // pane, so wta uses the full pane area for chat / recommendations / input.
     //
-    // Layout: chat sized to its content, rec panel right below, blank
-    // filler, optional one-row transient hint, optional one-row rec nav
-    // hint, a permanently reserved activity row directly above the input,
-    // and input at the bottom. Cap chat at
-    // `pane_height - rec - permission - input - activity - hints`
-    // so the recommendation card always renders in full — chat_scroll lets
-    // the user reach older history if it overflows.
+    // A single planner owns every vertical degradation decision. This keeps
+    // height prediction and rendering in sync when a short pane switches
+    // permission/recommendation content between full and compact forms.
     let chat_content_width = main_area.width.saturating_sub(2); // h_chat 1+1 padding
     let chat_estimate = chat::estimated_block_height(app, chat_content_width);
-    let reserved_below = rec_panel_h
-        .saturating_add(perm_panel_h)
-        .saturating_add(input_height)
-        .saturating_add(hint_h)
-        .saturating_add(rec_hint_h)
-        .saturating_add(1);
-    let chat_max = main_area.height.saturating_sub(reserved_below).max(1);
-    let chat_height = chat_estimate.min(chat_max);
+    let recommendation_natural_height = app
+        .current_tab()
+        .turn
+        .recommendations()
+        .map(|recommendations| {
+            action_panel::recommendation_panel_height(recommendations, main_area.width)
+        });
+    let permission_natural_height = app
+        .current_tab()
+        .permission
+        .front()
+        .map(|permission| {
+            action_panel::permission_card_height(permission, main_area.width)
+                .min(u16::MAX as usize) as u16
+        });
+    let panel_layout = action_panel::plan(action_panel::LayoutRequest {
+        available_rows: main_area.height,
+        input_height,
+        chat_natural_height: chat_estimate,
+        hint_requested,
+        recommendation_natural_height,
+        permission_natural_height,
+    });
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(chat_height),
-            Constraint::Length(rec_panel_h),
-            Constraint::Length(perm_panel_h),
+            Constraint::Length(panel_layout.chat_height),
+            Constraint::Length(panel_layout.recommendation_height),
+            Constraint::Length(panel_layout.permission_height),
             Constraint::Min(0),
-            Constraint::Length(hint_h),
-            Constraint::Length(rec_hint_h),
-            Constraint::Length(1),
-            Constraint::Length(input_height),
+            Constraint::Length(panel_layout.hint_height),
+            Constraint::Length(panel_layout.recommendation_hint_height),
+            Constraint::Length(panel_layout.activity_height),
+            Constraint::Length(panel_layout.input_height),
         ])
         .split(main_area);
 
@@ -196,13 +195,18 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         .split(chunks[6]);
 
     chat::render(frame, app, h_chat[1]);
-    app.sync_rec_scroll_max(main_area.width);
-    recommendations::render(frame, app, h_rec[1]);
+    app.sync_rec_scroll_max(main_area.width, panel_layout.recommendation_height);
+    recommendations::render(
+        frame,
+        app,
+        h_rec[1],
+        panel_layout.recommendation_mode,
+    );
     if !app.current_tab().permission.is_empty() {
         permission::render(frame, app, h_perm[1]);
     }
 
-    if hint_visible {
+    if panel_layout.hint_height > 0 {
         // The hint is a single non-wrapping row; in a narrow pane the raw
         // string overruns the width and ratatui clips it mid-token. Truncate
         // with an ellipsis instead so it always reads as a deliberate, if
@@ -222,7 +226,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             frame.render_widget(line, chunks[4]);
         }
     }
-    if app.current_tab().turn.recommendations().is_some() {
+    if panel_layout.recommendation_hint_height > 0 {
         recommendations::render_hint(frame, chunks[5]);
     }
     chat::render_activity(frame, app, h_activity[1]);

--- a/tools/wta/src/ui/mod.rs
+++ b/tools/wta/src/ui/mod.rs
@@ -1,4 +1,5 @@
 mod agent_popup;
+pub(crate) mod action_panel;
 pub mod agents_view;
 mod auth;
 pub(crate) mod card;

--- a/tools/wta/src/ui/permission.rs
+++ b/tools/wta/src/ui/permission.rs
@@ -5,10 +5,9 @@ use crate::app::{App, PermissionState};
 use crate::theme;
 use crate::ui::card::{self, CARD_MIN_SIZE};
 
-/// Render the permission card. Embedded above the input box; `layout.rs`
-/// reserves the row budget via `App::permission_panel_height`, which is
-/// either ≥ `CARD_MIN_SIZE` (full card) or exactly 1 (compact fallback —
-/// the agent flow is blocked on this prompt, so we must remain visible).
+/// Render the permission card. The action-panel planner reserves either at
+/// least `CARD_MIN_SIZE` rows or a one-row compact fallback. The agent flow
+/// is blocked on this prompt, so it must remain visible.
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     let Some(perm) = app.current_tab().permission.front() else {
         return;

--- a/tools/wta/src/ui/permission.rs
+++ b/tools/wta/src/ui/permission.rs
@@ -46,13 +46,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 // card so it doesn't render as an unreadable wall of
                 // text (see `ui/command_format.rs`).
                 for entry in crate::ui::command_format::command_display_lines(target) {
-                    let text = match entry {
-                        crate::ui::command_format::CommandLine::Statement(s) => format!("$ {s}"),
-                        crate::ui::command_format::CommandLine::Folded { remaining } => {
-                            format!("… (+{remaining} more)")
-                        }
-                    };
-                    lines.push(Line::styled(text, theme::CARD_CODE));
+                    lines.push(Line::styled(entry.rendered_text(""), theme::CARD_CODE));
                 }
             } else {
                 // Paths are shown as-is — the code styling alone

--- a/tools/wta/src/ui/recommendations.rs
+++ b/tools/wta/src/ui/recommendations.rs
@@ -1,9 +1,11 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Paragraph, Wrap};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use crate::app::{rec_card_height, App};
+use crate::app::App;
 use crate::coordinator::{OpenTarget, RecommendationChoice, RecommendedAction};
 use crate::theme;
+use crate::ui::action_panel::{recommendation_card_height, PanelMode};
 use crate::ui::card::{self, CARD_MIN_SIZE};
 
 /// Render the recommendations panel. Pure: callers (layout.rs) must call
@@ -20,25 +22,29 @@ use crate::ui::card::{self, CARD_MIN_SIZE};
 /// area, so the user keeps the border, button, and as many content rows as
 /// fit. This avoids the previous "tall card in squashed pane → nothing
 /// renders" failure mode.
-pub fn render(frame: &mut Frame, app: &App, area: Rect) {
+pub fn render(frame: &mut Frame, app: &App, area: Rect, mode: PanelMode) {
     let Some(recs) = app.current_tab().turn.recommendations() else { return };
-    if area.width == 0 || area.height == 0 {
+    if mode == PanelMode::Hidden || area.width == 0 || area.height == 0 {
+        return;
+    }
+    if mode == PanelMode::Compact {
+        render_compact(frame, app, area);
         return;
     }
 
     let rec_scroll = app.current_tab().rec_scroll.offset;
     let cards_bottom = area.y.saturating_add(area.height);
 
-    // `area` is `h_rec[1]` (post-padding), but `rec_card_height` /
-    // `rec_panel_height` / `sync_rec_scroll_max` all root their wrap math at
-    // `main_area.width` (see `CARD_H_CHROME`). Use the same basis here or
+    // `area` is `h_rec[1]` (post-padding), but card-height prediction and
+    // scroll bounds both root their wrap math at `main_area.width` (see
+    // `CARD_H_CHROME`). Use the same basis here or
     // wrap rows go 2 cells narrower at render than at predict, clipping the
     // bottom card and undercounting `rec_scroll.max`.
     let panel_width = app.main_area_width();
 
     let mut canvas_top = 0usize;
     for (idx, choice) in recs.choices.iter().enumerate() {
-        let h = rec_card_height(choice, panel_width);
+        let h = recommendation_card_height(choice, panel_width);
         if canvas_top >= rec_scroll {
             let card_h = h.saturating_sub(1) as u16; // last canvas row is inter-card gap
             let y = area.y + (canvas_top - rec_scroll) as u16;
@@ -60,6 +66,78 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         }
         canvas_top += h;
     }
+}
+
+fn render_compact(frame: &mut Frame, app: &App, area: Rect) {
+    let Some(recommendations) = app.current_tab().turn.recommendations() else {
+        return;
+    };
+    let selected = app
+        .current_tab()
+        .selected_recommendation
+        .min(recommendations.choices.len().saturating_sub(1));
+    let Some(choice) = recommendations.choices.get(selected) else {
+        return;
+    };
+    let (summary, buttons, body_kind) = extract_card_content(choice, app, true);
+    let marker = "○";
+    let position = if recommendations.choices.len() > 1 {
+        format!(" ↑↓ {}/{} ", selected + 1, recommendations.choices.len())
+    } else {
+        " ".to_string()
+    };
+    let prefix = format!("{marker}{position}");
+    let summary_width =
+        (area.width as usize).saturating_sub(UnicodeWidthStr::width(prefix.as_str()));
+    let summary = truncate_compact(&summary.replace(['\r', '\n'], " "), summary_width);
+    let body_style = match body_kind {
+        CardBodyKind::Code => theme::CARD_CODE,
+        CardBodyKind::Description => theme::CARD_DESCRIPTION,
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(prefix, theme::TOOL_CALL_PENDING),
+            Span::styled(summary, body_style),
+        ])),
+        Rect {
+            height: 1,
+            ..area
+        },
+    );
+
+    if area.height > 1 {
+        let button_area = Rect {
+            y: area.y + 1,
+            height: 1,
+            ..area
+        };
+        let focused = (app.current_tab().recommendation_focus
+            == crate::app::RecommendationFocus::Button)
+            .then_some(app.current_tab().selected_button);
+        card::render_buttons(frame, button_area, &buttons, focused);
+    }
+}
+
+fn truncate_compact(text: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    if UnicodeWidthStr::width(text) <= width {
+        return text.to_string();
+    }
+    let content_width = width.saturating_sub(1);
+    let mut used = 0;
+    let mut result = String::new();
+    for character in text.chars() {
+        let character_width = UnicodeWidthChar::width(character).unwrap_or(0);
+        if used + character_width > content_width {
+            break;
+        }
+        result.push(character);
+        used += character_width;
+    }
+    result.push('…');
+    result
 }
 
 /// Render the recommendations navigation hint. Called by `layout.rs` to

--- a/tools/wta/src/ui/recommendations.rs
+++ b/tools/wta/src/ui/recommendations.rs
@@ -79,7 +79,7 @@ fn render_compact(frame: &mut Frame, app: &App, area: Rect) {
     let Some(choice) = recommendations.choices.get(selected) else {
         return;
     };
-    let (summary, buttons, body_kind) = extract_card_content(choice, app, true);
+    let (summary, buttons, body_kind) = extract_card_content(choice);
     let marker = "○";
     let position = if recommendations.choices.len() > 1 {
         format!(" ↑↓ {}/{} ", selected + 1, recommendations.choices.len())
@@ -181,7 +181,7 @@ fn render_card(
         return;
     };
 
-    let (command_text, buttons, body_kind) = extract_card_content(choice, app, is_selected);
+    let (command_text, buttons, body_kind) = extract_card_content(choice);
     let body_style = match body_kind {
         CardBodyKind::Code => theme::CARD_CODE,
         CardBodyKind::Description => theme::CARD_DESCRIPTION,
@@ -213,82 +213,92 @@ enum CardBodyKind {
     Description,
 }
 
-fn extract_card_content(
-    choice: &RecommendationChoice,
-    _app: &App,
-    _is_selected: bool,
-) -> (String, Vec<String>, CardBodyKind) {
-    for action in &choice.actions {
-        match action {
-            RecommendedAction::Send { input, .. } => {
-                return (
-                    input.clone(),
-                    vec![
-                        t!("recommendations.button_run_command").into_owned(),
-                        t!("recommendations.button_insert_in_terminal").into_owned(),
-                    ],
-                    CardBodyKind::Code,
-                );
-            }
-            RecommendedAction::OpenAndSend {
-                target,
-                input,
-                agent,
-                ..
-            } => {
-                let fallback = t!("recommendations.agent_fallback").into_owned();
-                let agent_label = agent.as_deref().unwrap_or(&fallback);
-                let display = t!("recommendations.open_and_send_display",
-                    agent = agent_label, input = input.as_str()).into_owned();
-                let target_label = match target {
-                    OpenTarget::Tab => t!("recommendations.button_open_in_new_tab").into_owned(),
-                    OpenTarget::Panel => t!("recommendations.button_open_in_new_panel").into_owned(),
-                };
-                return (display, vec![target_label], CardBodyKind::Code);
-            }
-            RecommendedAction::Open {
-                target,
-                cwd,
-                title,
-                direction,
-                ..
-            } => {
-                let kind = match target {
-                    OpenTarget::Tab => t!("recommendations.open_kind_tab").into_owned(),
-                    OpenTarget::Panel => match direction.as_deref() {
-                        Some(d) if !d.is_empty() => {
-                            t!("recommendations.open_kind_panel_direction", direction = d).into_owned()
-                        }
-                        _ => t!("recommendations.open_kind_panel").into_owned(),
-                    },
-                };
-                let display = match (title.as_deref(), cwd.as_deref()) {
-                    (Some(t), Some(c)) if !t.is_empty() && !c.is_empty() => {
-                        t!("recommendations.open_new_with_title_and_cwd",
-                            kind = kind.as_str(), title = t, cwd = c).into_owned()
-                    }
-                    (Some(t), _) if !t.is_empty() => {
-                        t!("recommendations.open_new_with_title",
-                            kind = kind.as_str(), title = t).into_owned()
-                    }
-                    (_, Some(c)) if !c.is_empty() => {
-                        t!("recommendations.open_new_with_cwd",
-                            kind = kind.as_str(), cwd = c).into_owned()
-                    }
-                    _ => t!("recommendations.open_new_empty", kind = kind.as_str()).into_owned(),
-                };
-                let button = match target {
-                    OpenTarget::Tab => t!("recommendations.button_open_tab").into_owned(),
-                    OpenTarget::Panel => t!("recommendations.button_open_panel").into_owned(),
-                };
-                return (display, vec![button], CardBodyKind::Description);
+fn extract_card_content(choice: &RecommendationChoice) -> (String, Vec<String>, CardBodyKind) {
+    let display = recommendation_display_text(choice);
+    let (buttons, body_kind) = match choice.actions.first() {
+        Some(RecommendedAction::Send { .. }) => (
+            vec![
+                t!("recommendations.button_run_command").into_owned(),
+                t!("recommendations.button_insert_in_terminal").into_owned(),
+            ],
+            CardBodyKind::Code,
+        ),
+        Some(RecommendedAction::OpenAndSend { target, .. }) => {
+            let target_label = match target {
+                OpenTarget::Tab => t!("recommendations.button_open_in_new_tab").into_owned(),
+                OpenTarget::Panel => t!("recommendations.button_open_in_new_panel").into_owned(),
+            };
+            (vec![target_label], CardBodyKind::Code)
+        }
+        Some(RecommendedAction::Open { target, .. }) => {
+            let button = match target {
+                OpenTarget::Tab => t!("recommendations.button_open_tab").into_owned(),
+                OpenTarget::Panel => t!("recommendations.button_open_panel").into_owned(),
+            };
+            (vec![button], CardBodyKind::Description)
+        }
+        None => (
+            vec![t!("recommendations.button_execute").into_owned()],
+            CardBodyKind::Description,
+        ),
+    };
+    (display, buttons, body_kind)
+}
+
+pub(super) fn recommendation_display_text(choice: &RecommendationChoice) -> String {
+    match choice.actions.first() {
+        Some(RecommendedAction::Send { input, .. }) => input.clone(),
+        Some(RecommendedAction::OpenAndSend { input, agent, .. }) => {
+            let fallback = t!("recommendations.agent_fallback").into_owned();
+            let agent_label = agent.as_deref().unwrap_or(&fallback);
+            t!(
+                "recommendations.open_and_send_display",
+                agent = agent_label,
+                input = input.as_str()
+            )
+            .into_owned()
+        }
+        Some(RecommendedAction::Open {
+            target,
+            cwd,
+            title,
+            direction,
+            ..
+        }) => {
+            let kind = match target {
+                OpenTarget::Tab => t!("recommendations.open_kind_tab").into_owned(),
+                OpenTarget::Panel => match direction.as_deref() {
+                    Some(direction) if !direction.is_empty() => t!(
+                        "recommendations.open_kind_panel_direction",
+                        direction = direction
+                    )
+                    .into_owned(),
+                    _ => t!("recommendations.open_kind_panel").into_owned(),
+                },
+            };
+            match (title.as_deref(), cwd.as_deref()) {
+                (Some(title), Some(cwd)) if !title.is_empty() && !cwd.is_empty() => t!(
+                    "recommendations.open_new_with_title_and_cwd",
+                    kind = kind.as_str(),
+                    title = title,
+                    cwd = cwd
+                )
+                .into_owned(),
+                (Some(title), _) if !title.is_empty() => t!(
+                    "recommendations.open_new_with_title",
+                    kind = kind.as_str(),
+                    title = title
+                )
+                .into_owned(),
+                (_, Some(cwd)) if !cwd.is_empty() => t!(
+                    "recommendations.open_new_with_cwd",
+                    kind = kind.as_str(),
+                    cwd = cwd
+                )
+                .into_owned(),
+                _ => t!("recommendations.open_new_empty", kind = kind.as_str()).into_owned(),
             }
         }
+        None => choice.title.clone(),
     }
-
-    (
-        choice.title.clone(),
-        vec![t!("recommendations.button_execute").into_owned()],
-        CardBodyKind::Description,
-    )
 }

--- a/tools/wta/src/ui/recommendations.rs
+++ b/tools/wta/src/ui/recommendations.rs
@@ -95,10 +95,13 @@ fn render_compact(frame: &mut Frame, app: &App, area: Rect) {
         CardBodyKind::Description => theme::CARD_DESCRIPTION,
     };
     frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled(prefix, theme::TOOL_CALL_PENDING),
-            Span::styled(summary, body_style),
-        ])),
+        compact_summary_paragraph(
+            Line::from(vec![
+                Span::styled(prefix, theme::TOOL_CALL_PENDING),
+                Span::styled(summary, body_style),
+            ]),
+            crate::rtl::text_alignment(),
+        ),
         Rect {
             height: 1,
             ..area
@@ -138,6 +141,10 @@ fn truncate_compact(text: &str, width: usize) -> String {
     }
     result.push('…');
     result
+}
+
+fn compact_summary_paragraph(line: Line<'static>, alignment: Alignment) -> Paragraph<'static> {
+    Paragraph::new(line).alignment(alignment)
 }
 
 /// Render the recommendations navigation hint. Called by `layout.rs` to
@@ -300,5 +307,27 @@ pub(super) fn recommendation_display_text(choice: &RecommendationChoice) -> Stri
             }
         }
         None => choice.title.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_summary_paragraph_right_aligns_for_rtl() {
+        let area = Rect::new(0, 0, 8, 1);
+        let mut buffer = Buffer::empty(area);
+
+        compact_summary_paragraph(
+            Line::from("RTL"),
+            crate::rtl::text_alignment_for_locale("qps-plocm"),
+        )
+        .render(area, &mut buffer);
+
+        assert_eq!(buffer[(4, 0)].symbol(), " ");
+        assert_eq!(buffer[(5, 0)].symbol(), "R");
+        assert_eq!(buffer[(6, 0)].symbol(), "T");
+        assert_eq!(buffer[(7, 0)].symbol(), "L");
     }
 }


### PR DESCRIPTION
## Summary
- centralize vertical placement and full/compact action-panel sizing in a dedicated UI planner
- preserve the selected recommendation and input at constrained heights, with a two-line compact recommendation and pending indicator
- raise the Agent Pane splitter minimum to seven terminal rows and keep input scrolling within its assigned viewport

## Validation
- cargo test --manifest-path tools/wta/Cargo.toml
- TerminalApp project build
- full Debug Terminal build and deployment

<img width="1145" height="237" alt="image" src="https://github.com/user-attachments/assets/f609b07b-1a8b-48a7-8025-1fcbb40e026c" />
<img width="1139" height="323" alt="image" src="https://github.com/user-attachments/assets/99cc7800-716a-4dd9-b0c0-a3402b7b1a97" />
<img width="1132" height="455" alt="image" src="https://github.com/user-attachments/assets/2f9a9cee-6ba5-44a6-b1ed-c93f1684546c" />
