### PR TITLE
test(e2e): cover per-tab agent pane moves

### DIFF
--- a/doc/release-check-list.md
+++ b/doc/release-check-list.md
@@ -132,6 +132,7 @@ Net effect: UT shrinks the manual matrix to "did the wiring and UI connect", not
 - [ ] `C052` `[E2E]` **Hotkey hides pane:** `Ctrl+Shift+.` hides/stashes the agent pane without killing the session.
 - [ ] `C053` `[UT✓]` `[E2E]` **Focus hotkey works:** `Ctrl+Shift+I` focuses the agent pane when available. _(UT: `DefaultAgentKeybindings` binding; focus behavior E2E.)_
 - [ ] `C054` `[E2E]` **Different positions work:** Open/hide/focus works for bottom, right, left, and top pane positions.
+- [ ] `C252` `[new]` `[E2E]` **Agent pane move is isolated per tab and preserves input focus:** `/move` changes only the current tab's runtime pane position, leaves the global setting and sibling tabs unchanged, and returns keyboard focus to the moved agent input. _(#429; E2E: `Feature.AgentPaneMove`.)_
 - [ ] `C055` `[E2E]` **Stash preserves chat:** Hiding and restoring the pane preserves helper process, connection state, and chat history.
 - [ ] `C056` `[E2E]` **Tab close cleans up:** Closing the owning tab cleans up the helper and does not leave a broken pane.
 - [ ] `C247` `[new]` `[E2E]` **Closing a tab mid-turn leaves sibling agent tabs working:** When one tab closes with a prompt in flight, its orphaned result is discarded without terminating the shared agent CLI, and another tab can continue chatting without a restart. _(#419/#425; E2E: `Feature.SharedAgentLifecycle`.)_

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -37,12 +37,13 @@ authenticated ACP agents. Current status (run on the Store package):
 | `Feature.WslAgentBackend.Tests.ps1` | PR #481 profile-scoped WSL agent backend: settings hot reload, helper/master source routing, and authenticated chat | 2 (environment-gated) |
 | `Feature.DelegateSource.Tests.ps1` | PR #488 profile-scoped delegate source: strict host/WSL `wta delegate` routing with no fallback in either direction | 2 (environment-gated) |
 | `Feature.AgentChat.Tests.ps1` / `Feature.AgentPopup.Tests.ps1` | agent chat + `/` popup/menu interaction | 1 + 3 |
+| `Feature.AgentPaneMove.Tests.ps1` | PR #429: `/move` stays per-tab, preserves global position, and restores agent input focus | 1 |
 
-**Coverage: 114 of 116 automatable `[E2E]` checklist items are implemented.**
-**Test status: 108 baseline feature cases pass + 2 documented skips** (`wta sessions list` is
+**Coverage: 115 of 117 automatable `[E2E]` checklist items are implemented.**
+**Test status: 109 baseline feature cases pass + 2 documented skips** (`wta sessions list` is
 identity-gated — see `Feature.SessionList.Tests.ps1`), plus 2 PR #481 WSL-backend cases and 2
 PR #488 delegate-source cases that run only when a runnable distro (and, for the #481 chat
-case, an installed+authenticated native agent) is available. The 114 implemented checklist
+case, an installed+authenticated native agent) is available. The 115 implemented checklist
 items map to the baseline cases plus the deterministic settings/persistence assertions. The
 remaining new items are the two profile agent picker UIs; they stay explicit E2E work rather
 than being falsely credited by the JSON-level runtime tests. Other

--- a/test/e2e/tests/Feature.AgentPaneMove.Tests.ps1
+++ b/test/e2e/tests/Feature.AgentPaneMove.Tests.ps1
@@ -1,0 +1,87 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+# PR #429: /move is a transient per-tab override and must restore agent input
+# focus after rebuilding the split layout.
+
+BeforeDiscovery {
+    $script:Ready = [bool](
+        (Get-AppxPackage | Where-Object { $_.PackageFamilyName -like 'IntelligentTerminal_*' }) -and
+        (Get-Command copilot -ErrorAction SilentlyContinue) -and
+        (Get-Command winapp -ErrorAction SilentlyContinue)
+    )
+}
+
+Describe 'Feature: per-tab agent pane move' -Tag 'Feature' -Skip:(-not $script:Ready) {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
+        $script:app = Start-Terminal -Package Dev -PassFre $true -Settings @{
+            acpAgent         = 'copilot'
+            agentPanePosition = 'bottom'
+        }
+    }
+
+    AfterAll {
+        if ($script:app) {
+            Stop-Terminal -App $script:app
+        }
+    }
+
+    It 'Agent pane move is isolated per tab and preserves input focus' {
+        $resolveTabId = {
+            param([string]$OwnerPaneSessionId)
+            $listener = Start-WtEventListener -App $script:app
+            try {
+                Start-Sleep -Milliseconds 500
+                Invoke-RunCommand -App $script:app -SessionId $OwnerPaneSessionId -Command 'echo ite2e-move-tab-probe' | Out-Null
+                $event = Wait-WtEvent -Listener $listener -TimeoutSec 15 -Predicate {
+                    $_.method -eq 'vt_sequence' -and
+                    "$($_.params.pane_id)" -eq $OwnerPaneSessionId -and
+                    $_.params.tab_id
+                }
+                [string]$event.params.tab_id
+            }
+            finally {
+                Stop-WtEventListener -Listener $listener
+            }
+        }
+
+        $shellA = Get-ActivePane -App $script:app
+        Open-AgentPane -App $script:app | Out-Null
+        $agentA = Wait-NewAgentPaneSession -App $script:app -OwnerPaneSessionId $shellA.session_id -TimeoutSec 30
+        Wait-AgentReady -App $script:app -PaneSessionId $agentA.PaneSessionId -TimeoutSec 90 |
+            Should -BeTrue
+        $tabA = & $resolveTabId $shellA.session_id
+
+        $shellB = New-WtTab -App $script:app -Title 'move-isolation-b'
+        Open-AgentPane -App $script:app | Out-Null
+        $agentB = Wait-NewAgentPaneSession -App $script:app -OwnerPaneSessionId $shellB.session_id -ExcludePaneSessionId $agentA.PaneSessionId -TimeoutSec 30
+        Wait-AgentReady -App $script:app -PaneSessionId $agentB.PaneSessionId -TimeoutSec 90 |
+            Should -BeTrue
+        $tabB = & $resolveTabId $shellB.session_id
+        $tabA | Should -Not -Be $tabB
+
+        Set-WtWindowForeground -App $script:app | Should -BeTrue
+        Set-AgentPaneFocus -App $script:app | Out-Null
+        Start-Sleep -Seconds 1
+        Clear-AgentInput -App $script:app -PaneSessionId $agentB.PaneSessionId | Out-Null
+        Initialize-LogOffsets -App $script:app | Out-Null
+        Send-AgentPrompt -App $script:app -PaneSessionId $agentB.PaneSessionId -Text '/move right' | Out-Null
+
+        Assert-Log -App $script:app -Name 'terminal-agent-pane.log' `
+            -Pattern "OnAgentStateChanged: tab_id=$([regex]::Escape($tabB)).*pane_position=right" -TimeoutSec 15
+        Send-WtWindowKey -App $script:app -Vk 0xBF -RequireForeground | Out-Null
+        Assert-AgentPaneText -App $script:app -PaneSessionId $agentB.PaneSessionId `
+            -Pattern '(?i)/help' -TimeoutSec 10
+        Clear-AgentInput -App $script:app -PaneSessionId $agentB.PaneSessionId | Out-Null
+
+        Set-WtPaneFocus -App $script:app -SessionId $shellA.session_id
+        Assert-Log -App $script:app -Name 'terminal-agent-pane.log' `
+            -Pattern "OnAgentStateChanged: tab_id=$([regex]::Escape($tabA)).*pane_position=global" -TimeoutSec 15
+        (Get-WtSetting -App $script:app -Key 'agentPanePosition') |
+            Should -Be 'bottom' -Because '/move must not mutate the global setting'
+
+        Initialize-LogOffsets -App $script:app | Out-Null
+        Set-WtPaneFocus -App $script:app -SessionId $shellB.session_id
+        Assert-Log -App $script:app -Name 'terminal-agent-pane.log' `
+            -Pattern "OnAgentStateChanged: tab_id=$([regex]::Escape($tabB)).*pane_position=right" -TimeoutSec 15
+    }
+}


### PR DESCRIPTION
## Summary
- add a real Dev-package E2E for PR #429 `/move` behavior
- verify the runtime position override stays on the current tab and does not change `agentPanePosition`
- verify the rebuilt pane restores keyboard focus by opening the slash-command menu with window-level input
- add checklist case C252 and update ItE2E coverage counts

## Validation
- `Feature.AgentPaneMove.Tests.ps1`: 1 passed
- `Feature.AgentPaneMove.Tests.ps1` + `Feature.AgentPaneInteraction.Tests.ps1`: 15 passed
- C252 is marked `[x]` in the generated release report