### PR TITLE
test(e2e): cover ACP model synchronization

### DIFF
--- a/doc/release-check-list.md
+++ b/doc/release-check-list.md
@@ -182,6 +182,7 @@ Net effect: UT shrinks the manual matrix to "did the wiring and UI connect", not
 - [x] `C078` `[UT✓]` **`/stop` works:** Stops/cancels an in-progress turn.
 - [x] `C079` `[UT✓]` **`/sessions` works:** Switches to session-management view. _(UT: `slash_sessions_opens_agents_view`.)_
 - [ ] `C080` `[UT✓]` `[E2E]` **`/model` works:** Opens/selects model where supported; unsupported agents fail gracefully. _(UT: `slash_model_*`; picker render covered by `render_model_picker_lists_models`, full UI flow still E2E.)_
+- [ ] `C255` `[new]` `[UT✓]` `[E2E]` **ACP model updates refresh the active picker:** A model reported by a later ACP `config_option_update` replaces stale `session/new` selection state in the active session's `/model` picker. _(UT: `session_notification_routes_model_config_update`, `model_config_update_refreshes_active_session_picker`; #538; E2E: `Feature.AgentModelSync`.)_
 - [x] `C081` `[UT✓]` **Unknown slash command is safe:** Unknown `/command` does not lose user input or crash.
 - [ ] `C225` `[E2E]` **`/agent` picker works:** `/agent` opens a keyboard-operable picker containing the current installed/allowed agents, and selecting the current agent is a safe no-op.
 - [ ] `C241` `[new]` `[E2E]` **`/agent` completion selection is safe:** Enter activates the highlighted matching agent without rebuilding the pane or changing the global default when it is already selected. _(#487; E2E: `Feature.PerTabAgent`.)_

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -19,6 +19,7 @@ authenticated ACP agents. Current status (run on the Store package):
 | `Feature.FreExecutionPolicy.Tests.ps1` | §0 FRE execution-policy verdict (deterministic via registry; **Dev**, auto-skips) | 3 (1 conditional skip) |
 | `Feature.AgentPaneInteraction.Tests.ps1` | open/hide/focus, input/rendering, slash, Copilot chat | 14 |
 | `Feature.AgentImageAttachmentEditing.Tests.ps1` | PR #536: inline image tokens move and delete atomically while preserving adjacent prompt text | 1 |
+| `Feature.AgentModelSync.Tests.ps1` | PR #538: ACP config-option updates replace stale session model state in the active picker | 1 |
 | `Feature.AgentMouse.Tests.ps1` | PR #506: chat wheel scrolling, draft preservation, text selection/copy, and stale-selection suppression | 2 |
 | `Feature.PromptHistory.Tests.ps1` | PR #478: per-tab Up/Down prompt recall, draft restoration, and multiline preservation | 3 |
 | `Feature.AutofixPane.Tests.ps1` | Direct Helper Autofix proposal card render/insert/run/reject/target/stashed + across layout | 10 |
@@ -41,11 +42,11 @@ authenticated ACP agents. Current status (run on the Store package):
 | `Feature.AgentChat.Tests.ps1` / `Feature.AgentPopup.Tests.ps1` | agent chat + `/` popup/menu interaction | 1 + 3 |
 | `Feature.AgentPaneMove.Tests.ps1` | PR #429: `/move` stays per-tab, preserves global position, and restores agent input focus | 1 |
 
-**Coverage: 117 of 119 automatable `[E2E]` checklist items are implemented.**
-**Test status: 111 baseline feature cases pass + 2 documented skips** (`wta sessions list` is
+**Coverage: 118 of 120 automatable `[E2E]` checklist items are implemented.**
+**Test status: 112 baseline feature cases pass + 2 documented skips** (`wta sessions list` is
 identity-gated — see `Feature.SessionList.Tests.ps1`), plus 2 PR #481 WSL-backend cases and 2
 PR #488 delegate-source cases that run only when a runnable distro (and, for the #481 chat
-case, an installed+authenticated native agent) is available. The 117 implemented checklist
+case, an installed+authenticated native agent) is available. The 118 implemented checklist
 items map to the baseline cases plus the deterministic settings/persistence assertions. The
 remaining new items are the two profile agent picker UIs; they stay explicit E2E work rather
 than being falsely credited by the JSON-level runtime tests. Other

--- a/test/e2e/fixtures/Mock-AcpModelUpdateAgent.ps1
+++ b/test/e2e/fixtures/Mock-AcpModelUpdateAgent.ps1
@@ -1,0 +1,83 @@
+$ErrorActionPreference = 'Stop'
+
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+
+function Send-AcpMessage {
+    param([Parameter(Mandatory)][hashtable]$Message)
+
+    [Console]::Out.WriteLine(($Message | ConvertTo-Json -Depth 20 -Compress))
+    [Console]::Out.Flush()
+}
+
+$models = @(
+    @{ value = 'initial-model'; name = 'Initial Model' }
+    @{ value = 'effective-model'; name = 'Effective Model' }
+)
+
+while ($null -ne ($line = [Console]::In.ReadLine())) {
+    $request = $line | ConvertFrom-Json
+    switch ($request.method) {
+        'initialize' {
+            Send-AcpMessage @{
+                jsonrpc = '2.0'
+                id = $request.id
+                result = @{
+                    protocolVersion = 1
+                    agentCapabilities = @{}
+                    agentInfo = @{
+                        name = 'Model Update Fixture'
+                        version = '1.0.0'
+                    }
+                }
+            }
+        }
+        'session/new' {
+            Send-AcpMessage @{
+                jsonrpc = '2.0'
+                id = $request.id
+                result = @{
+                    sessionId = 'model-update-session'
+                    models = @{
+                        currentModelId = 'initial-model'
+                        availableModels = @(
+                            @{ modelId = 'initial-model'; name = 'Initial Model' }
+                            @{ modelId = 'effective-model'; name = 'Effective Model' }
+                        )
+                    }
+                    configOptions = @(
+                        @{
+                            id = 'model'
+                            name = 'Model'
+                            category = 'model'
+                            type = 'select'
+                            currentValue = 'initial-model'
+                            options = $models
+                        }
+                    )
+                }
+            }
+
+            Start-Sleep -Milliseconds 500
+            Send-AcpMessage @{
+                jsonrpc = '2.0'
+                method = 'session/update'
+                params = @{
+                    sessionId = 'model-update-session'
+                    update = @{
+                        sessionUpdate = 'config_option_update'
+                        configOptions = @(
+                            @{
+                                id = 'model'
+                                name = 'Model'
+                                category = 'model'
+                                type = 'select'
+                                currentValue = 'effective-model'
+                                options = $models
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/e2e/tests/Feature.AgentModelSync.Tests.ps1
+++ b/test/e2e/tests/Feature.AgentModelSync.Tests.ps1
@@ -1,0 +1,46 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+# PR #538: ACP config-option updates replace stale session/new model state.
+#
+# The fixture is a real ACP stdio child process. It returns Initial Model from
+# session/new, then reports Effective Model through session/update. The test
+# observes the final state through the deployed agent pane's /model picker.
+#
+#   Invoke-Pester test/e2e/tests/Feature.AgentModelSync.Tests.ps1 -Tag Feature
+
+BeforeDiscovery {
+    $script:Ready = [bool](
+        (Get-AppxPackage | Where-Object { $_.Name -like '*IntelligentTerminal*' }) -and
+        (Get-Command pwsh -ErrorAction SilentlyContinue) -and
+        (Get-Command winapp -ErrorAction SilentlyContinue)
+    )
+}
+
+Describe 'Feature: ACP model synchronization' -Tag 'Feature' -Skip:(-not $script:Ready) {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
+        $fixture = (Resolve-Path (Join-Path $PSScriptRoot '..\fixtures\Mock-AcpModelUpdateAgent.ps1')).Path
+        $command = "pwsh -NoProfile -File $fixture"
+        $script:app = Start-Terminal -Package (Get-ItTestPackage) -PassFre $true -Settings @{
+            acpAgent = 'custom:model-update-fixture'
+            acpCustomCommand = $command
+        }
+        Open-AgentPane -App $script:app | Out-Null
+        Wait-AgentReady -App $script:app -TimeoutSec 30 | Should -BeTrue -Because 'the ACP model-update fixture must connect'
+    }
+    AfterAll { if ($script:app) { Stop-Terminal -App $script:app } }
+
+    It 'ACP model updates refresh the active picker' {
+        Start-Sleep -Seconds 1
+        Clear-AgentInput -App $script:app | Out-Null
+        Invoke-AgentMenuItem -App $script:app -Name '/model'
+
+        $titleRe = Get-WtaLocalizedTextRegex -Key 'model_picker.title'
+        if (-not $titleRe) { $titleRe = '(?i)Select model' }
+        Assert-AgentPaneText -App $script:app -Pattern $titleRe -TimeoutSec 10
+
+        $picker = Get-AgentPaneText -App $script:app -MaxLines 40
+        $picker | Should -Match '(?m)^\s*[│║|]\s*>\s+Effective Model\s*[│║|]\s*$' -Because 'the config_option_update model must replace the stale session/new selection'
+        $picker | Should -Match '(?m)^\s*[│║|]\s+Initial Model\s*[│║|]\s*$' -Because 'the initial model must remain available without staying selected'
+        $picker | Should -Not -Match '(?m)^\s*[│║|]\s*>\s+Initial Model\s*[│║|]\s*$'
+    }
+}


### PR DESCRIPTION
## Summary
- add deployed-package E2E coverage for #538's asynchronous ACP model synchronization
- launch a deterministic ACP stdio fixture that returns `Initial Model` from `session/new`, then sends `session/update` with a `config_option_update` selecting `Effective Model`
- verify the real WTA master/helper and agent-pane `/model` picker consume the update, retain both choices, and move the highlight off the stale model
- add release checklist coverage C255 and update the E2E inventory

## Integration boundary
The Rust unit tests cover event parsing and state replacement in-process. This case adds the missing external ACP child process -> JSON-RPC stdio -> shared master -> helper event -> rendered TUI picker boundary.

## Validation
- `Feature.AgentModelSync.Tests.ps1`: 1 passed, 0 failed, 0 skipped (run twice, including the report driver)
- `Feature.AgentPaneInteraction.Tests.ps1`: 14 passed, 0 failed, 0 skipped
- release report: C255 marked `[x]`
- bootstrap prerequisite check passed against Dev package `IntelligentTerminal_rd9vj3e6a2mbr` v0.8.0.2

Stacked on #587. Covers #538.