### PR TITLE
Allow direction hints on tab actions

### DIFF
--- a/tools/wta/src/agent_tools/action_proposal/schema.rs
+++ b/tools/wta/src/agent_tools/action_proposal/schema.rs
@@ -705,6 +705,27 @@ mod tests {
     }
 
     #[test]
+    fn flat_mcp_open_and_send_tab_accepts_direction() {
+        let payload = br#"{
+            "type": "open_and_send",
+            "title": "Project walkthrough",
+            "input": "Walk through this project",
+            "target": "tab",
+            "direction": "auto"
+        }"#;
+        let wire = parse_mcp_proposal_payload(payload, false).unwrap();
+        let set = build_recommendation_set(&wire, false, None, None, None).unwrap();
+        assert!(matches!(
+            &set.choices[0].actions[0],
+            RecommendedAction::OpenAndSend {
+                target: OpenTarget::Tab,
+                direction: Some(direction),
+                ..
+            } if direction == "auto"
+        ));
+    }
+
+    #[test]
     fn flat_mcp_rejects_nested_legacy_payload() {
         let payload = br#"{
             "recommended_choice": 1,

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -715,7 +715,6 @@ fn validate_action(action: &RecommendedAction) -> Result<()> {
             ensure_non_empty("input", input)?;
         }
         RecommendedAction::OpenAndSend {
-            target,
             parent,
             input,
             agent,
@@ -729,10 +728,9 @@ fn validate_action(action: &RecommendedAction) -> Result<()> {
             if let Some(agent) = agent.as_deref() {
                 ensure_non_empty("agent", agent)?;
             }
-            validate_direction(direction.as_deref(), target)?;
+            validate_direction(direction.as_deref())?;
         }
         RecommendedAction::Open {
-            target,
             parent,
             direction,
             ..
@@ -740,22 +738,19 @@ fn validate_action(action: &RecommendedAction) -> Result<()> {
             if let Some(parent) = parent.as_deref() {
                 ensure_non_empty("parent", parent)?;
             }
-            validate_direction(direction.as_deref(), target)?;
+            validate_direction(direction.as_deref())?;
         }
     }
 
     Ok(())
 }
 
-fn validate_direction(direction: Option<&str>, target: &OpenTarget) -> Result<()> {
+fn validate_direction(direction: Option<&str>) -> Result<()> {
     let Some(value) = direction else {
         return Ok(());
     };
     if value.is_empty() {
         bail!("field 'direction' must not be empty");
-    }
-    if matches!(target, OpenTarget::Tab) {
-        bail!("field 'direction' is only valid when target is 'panel'");
     }
     match value {
         "right" | "left" | "up" | "down" | "auto" | "automatic" => Ok(()),
@@ -2615,7 +2610,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_open_tab_with_direction() {
+    fn accepts_open_tab_with_direction() {
         let text = r#"```json
 {
   "recommended_choice": 1,
@@ -2635,7 +2630,7 @@ mod tests {
 }
 ```"#;
 
-        assert!(parse_recommendation_set(text).is_err());
+        assert!(parse_recommendation_set(text).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- accept `direction` on both tab and panel open actions
- continue validating direction values without coupling them to the target type
- update the tab-direction regression test to assert acceptance

Tab execution already ignores direction, so this keeps the proposal schema permissive without adding conditional schema complexity.

## Validation

- `cargo test --manifest-path tools\wta\Cargo.toml`