### PR TITLE
Add agent user input action

### DIFF
--- a/doc/specs/WTA-terminal-action-proposals.md
+++ b/doc/specs/WTA-terminal-action-proposals.md
@@ -17,18 +17,18 @@ ACP session
   -> wta-master capability -> ACP SessionId
   -> session_to_helper -> existing master/helper ACP pipe
   -> owning Helper
-  -> existing recommendation card
-  -> user confirmation
-  -> existing wtcli/COM executor
+       -> request_terminal_actions -> recommendation card -> wtcli/COM executor
+       -> request_user_input -> blocking choice/freeform modal -> structured answer
 ```
 
 The endpoint presents typed terminal actions for review and blocking
 clarification questions. It cannot read or mutate Windows Terminal. The
 existing card confirmation is the sole mutation boundary.
 
-The MCP call returns as soon as the Helper commits the card. User confirmation
-or cancellation happens independently, so an agent turn never waits on a
-human-held tool call.
+`request_terminal_actions` returns as soon as the Helper commits its card;
+confirmation or cancellation then happens independently. `request_user_input`
+deliberately keeps the MCP call open until the user answers, cancels, the
+caller disconnects, or the ten-minute timeout expires.
 
 ## Ownership and routing
 
@@ -60,7 +60,8 @@ sessions.
 
 Before creating or loading a session:
 
-1. the Helper marks the private ACP request as proposal-MCP eligible;
+1. the Helper marks the private ACP request as session-MCP eligible using the
+   legacy `_meta.wta.proposal_mcp` compatibility field;
 2. master generates an opaque capability and sends the HTTP MCP configuration
    to the Agent CLI;
 3. master binds the capability to the returned ACP SessionId on success; or
@@ -144,8 +145,11 @@ and an optional freeform answer. Master routes the request through the same
 session capability and `session_to_helper` ownership lookup, then waits for
 the owning Helper's modal response. Enter submits the selected choice or a
 non-empty freeform answer; Esc returns `cancelled`. The request times out
-after ten minutes. It does not inspect, intercept, or translate an Agent's
-provider-specific `ask_user` implementation.
+after ten minutes. Each session may have only one outstanding user-input
+request. A request ID removes the exact modal when its HTTP caller disconnects,
+the Helper connection drops, the turn is cancelled, or master times out. It
+does not inspect, intercept, or translate an Agent's provider-specific
+`ask_user` implementation.
 
 ## Helper validation
 
@@ -160,7 +164,7 @@ The Helper's `ProposalChannelManager` owns:
 - one active turn binding;
 - bounded CLI channel tombstones.
 
-An MCP request is accepted only when:
+An MCP terminal-action request is accepted only when:
 
 1. master recognizes its bearer capability;
 2. that capability is committed to an ACP SessionId;
@@ -196,8 +200,10 @@ When an adapter requests permission for either the current
 3. does not consume or arm proposal state.
 
 Unrelated MCP and shell permissions continue through the normal permission UI.
-The proposal MCP tool-call row is hidden because the recommendation card is the
-user-facing representation.
+Permission preflights for `request_user_input` are also resolved with
+`AllowOnce`: the blocking modal itself is the user-facing decision point.
+Session MCP tool-call rows are hidden because the recommendation card or
+user-input modal is the user-facing representation.
 
 ## HTTP and ACP boundaries
 
@@ -206,7 +212,10 @@ relays bind only to ephemeral loopback ports inside their distro and rewrite
 loopback Host/Origin authorities to the upstream loopback authority before
 byte-forwarding. A relay limits concurrent handlers, applies a request read
 timeout and the same header/body size ceilings, and returns explicit HTTP
-errors when request parsing or the Windows bridge fails. The master server requires the session bearer capability,
+errors when request parsing or the Windows bridge fails. Long-held user-input
+requests use a separate connection pool from short MCP requests, and duplicate
+user-input requests for one ACP session are rejected. The master server
+requires the session bearer capability,
 validates Host and any Origin header, rejects duplicate or oversized headers,
 rejects transfer encoding, and caps request bodies. Capabilities are stored
 hashed and are never logged.

--- a/doc/specs/WTA-terminal-action-proposals.md
+++ b/doc/specs/WTA-terminal-action-proposals.md
@@ -7,13 +7,13 @@ remains as a fallback transport.
 
 ## Summary
 
-`wta-master` owns one Windows-loopback proposal MCP endpoint. Host ACP
+`wta-master` owns one Windows-loopback session MCP endpoint. Host ACP
 sessions use it directly. Each WSL distro gets an on-demand loopback relay,
 and every eligible ACP session receives a distinct bearer capability:
 
 ```text
 ACP session
-  -> HTTP MCP: intellterm_<public-id>/request_terminal_actions
+  -> HTTP MCP: intellterm_<public-id>/{request_terminal_actions,request_user_input}
   -> wta-master capability -> ACP SessionId
   -> session_to_helper -> existing master/helper ACP pipe
   -> owning Helper
@@ -22,9 +22,9 @@ ACP session
   -> existing wtcli/COM executor
 ```
 
-The tool can only present typed actions for review. It cannot read or mutate
-Windows Terminal. The existing card confirmation is the sole mutation
-boundary.
+The endpoint presents typed terminal actions for review and blocking
+clarification questions. It cannot read or mutate Windows Terminal. The
+existing card confirmation is the sole mutation boundary.
 
 The MCP call returns as soon as the Helper commits the card. User confirmation
 or cancellation happens independently, so an agent turn never waits on a
@@ -49,7 +49,7 @@ distro with `wsl.exe`; the relay invokes a fixed, encoded Windows PowerShell
 byte forwarder for each HTTP request, which reaches master's Windows-loopback
 endpoint. The bearer header remains in the forwarded bytes and never enters a
 process command line. If Python 3 or Windows interop is unavailable in a
-distro, master does not advertise proposal MCP to that Helper. The relay is
+distro, master does not advertise session MCP to that Helper. The relay is
 cached for that master's lifetime, but its stdin remains connected to an
 ownership pipe: normal child cleanup or unexpected master termination closes
 the pipe and makes the Python relay exit. Each distro has an independent
@@ -89,10 +89,11 @@ Server name:
 intellterm_<public-id>
 ```
 
-Tool:
+Tools:
 
 ```text
 request_terminal_actions
+request_user_input
 ```
 
 The server supports MCP `initialize`, `ping`, `tools/list`, and `tools/call`
@@ -137,6 +138,14 @@ Tool result statuses:
 
 `accepted` means the handoff completed. The agent ends its turn after
 this result.
+
+`request_user_input` accepts one question, up to eight single-line choices,
+and an optional freeform answer. Master routes the request through the same
+session capability and `session_to_helper` ownership lookup, then waits for
+the owning Helper's modal response. Enter submits the selected choice or a
+non-empty freeform answer; Esc returns `cancelled`. The request times out
+after ten minutes. It does not inspect, intercept, or translate an Agent's
+provider-specific `ask_user` implementation.
 
 ## Helper validation
 
@@ -227,6 +236,6 @@ future agents that work better through shell commands.
 
 ## Scope
 
-The MCP server is attached only for host agents that advertise ACP HTTP MCP
+The MCP server is attached only for agents that advertise ACP HTTP MCP
 support. Assistant text remains ordinary chat content and is never parsed into
 terminal actions.

--- a/doc/specs/WTA-terminal-action-proposals.md
+++ b/doc/specs/WTA-terminal-action-proposals.md
@@ -200,7 +200,7 @@ When an adapter requests permission for either the current
 3. does not consume or arm proposal state.
 
 Unrelated MCP and shell permissions continue through the normal permission UI.
-Permission preflights for `request_user_input` are also resolved with
+Permission preflight requests for `request_user_input` are also resolved with
 `AllowOnce`: the blocking modal itself is the user-facing decision point.
 Session MCP tool-call rows are hidden because the recommendation card or
 user-input modal is the user-facing representation.

--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -23,9 +23,9 @@ bare `wta` with neither a role flag nor a subcommand exits with an error.
   `delegate`, `hooks`, `sessions`, …) -- one-shot WT-control commands for humans
   and for agents that can shell out. Direct keystroke injection is not exposed by
   the CLI. Dispatched in `src/main.rs`.
-- **Proposal MCP endpoint** (one ephemeral Windows-loopback Streamable HTTP
+- **Session MCP endpoint** (one ephemeral Windows-loopback Streamable HTTP
   listener owned by `wta-master`, plus an on-demand loopback relay per WSL
-  distro) -- exposes only `request_terminal_actions`. Each session receives an
+  distro) -- exposes `request_terminal_actions` and `request_user_input`. Each session receives an
   independent public server name plus a bearer capability, preventing
   name-keyed Agent caches from overwriting another session's header. The
   capability resolves to ACP SessionId, then `session_to_helper` routes the
@@ -213,7 +213,7 @@ subfolder keyed by the package version:
 Per-process logs in the helper+master architecture:
 
 - `wta-main_master.log` -- `wta-master`: agent CLI spawn, pipe accept loop,
-  per-helper routing, `session_to_helper` updates, proposal MCP call
+  per-helper routing, `session_to_helper` updates, session MCP call
   receipt/routing/validation results, agent CLI exit detection
 - `wta-main_helper-{pid}.log` -- each `wta-helper` (one file per PID): pipe
   connect, ACP initialize, `session/new`, prompts, agent responses, TUI lifecycle

--- a/tools/wta/OVERVIEW.md
+++ b/tools/wta/OVERVIEW.md
@@ -28,11 +28,11 @@ WTA runs as a **helper + master** pair, never as a standalone process: Windows
 Terminal spawns one **`wta-master`** singleton that owns the single connection to
 the agent CLI, and one **`wta-helper`** per agent pane that renders the TUI and
 talks ACP to master over a named pipe. Stateless **CLI helpers** provide one-shot
-WT control, and the master-owned **proposal MCP endpoint** accepts typed terminal
-action requests with per-session capabilities.
+WT control, and the master-owned **session MCP endpoint** accepts typed terminal
+action and user-input requests with per-session capabilities.
 
 > There is no standalone agent / TUI mode. Bare `wta` with neither a role flag
-> nor a subcommand exits with an error (`main.rs`). The proposal MCP endpoint is
+> nor a subcommand exits with an error (`main.rs`). The session MCP endpoint is
 > not a general WT-control server and exposes no read or execution tools.
 
 ---
@@ -91,7 +91,7 @@ Stateless, short-lived commands dispatched in `src/main.rs`. They talk directly
 to Windows Terminal via `CliChannel` → `wtcli.exe` → COM and exit, except local
 helpers such as `resolve-command`, which inspect cwd and machine state directly. Used by
 humans debugging WTA and by agents that can shell out. (The agent CLI reaches WT
-this way too — by shelling out to `wta` / `wtcli`. The proposal MCP endpoint
+this way too — by shelling out to `wta` / `wtcli`. The session MCP endpoint
 is separate and cannot perform these operations.)
 
 Packaged builds register `wta.exe` as an App Execution Alias. WTA prepends the
@@ -100,7 +100,7 @@ current package family's alias directory to the agent process `PATH`, so a short
 even when multiple variants are installed. Unpackaged builds prepend the
 running executable's directory instead.
 
-### 4. Proposal MCP endpoint — master-owned
+### 4. Session MCP endpoint — master-owned
 
 `wta-master` owns one stateless Streamable HTTP endpoint on Windows loopback.
 Host Agents use it directly; WSL Agents use an on-demand loopback relay inside
@@ -113,9 +113,11 @@ name and a distinct bearer capability, so name-keyed Agent caches cannot
 overwrite another session's header. Master maps the capability to SessionId,
 resolves the current Helper through `session_to_helper`, and forwards the typed
 input over the existing ACP pipe.
-The endpoint exposes only `request_terminal_actions` and returns after the
-Helper confirms that the recommendation card was presented. The user confirms
-or cancels independently.
+The endpoint exposes `request_terminal_actions`, which returns after the Helper
+confirms that the recommendation card was presented, and `request_user_input`,
+which blocks until the user answers, cancels, disconnects, or the request times
+out. The latter is a WTA-owned fallback and does not intercept provider-native
+question tools.
 
 ---
 

--- a/tools/wta/prompts/terminal-agent.md
+++ b/tools/wta/prompts/terminal-agent.md
@@ -18,6 +18,8 @@ Your own shell, bash, and other execution tools are Agent-owned work. Intelligen
 
 `request_terminal_actions` is the separate user-owned path for changing the user's terminal workflow. Use it only when the intended result should run, open, split, or otherwise mutate a terminal pane. Internal investigation remains an Agent-owned tool call and must not be proposed as a pane action.
 
+When a missing user decision prevents you from continuing, use the session's `request_user_input` tool to ask one focused question. Supply concise choices when the decision has a bounded set of answers and enable freeform input only when needed. Wait for the tool result before continuing. This is a WTA-provided interaction; do not claim that it intercepts or replaces the Agent implementation's own input tools.
+
 ## Grounding unfamiliar commands
 
 Use the exact structured invocation from the runtime **Command Resolver Invocation** section when an unfamiliar command's identity or availability matters. Do not substitute another WTA path or executable spelling. The resolver checks the active pane's working directory and host PATH; for PowerShell it also loads the user's profile so aliases and functions are visible.

--- a/tools/wta/prompts/terminal-agent.md
+++ b/tools/wta/prompts/terminal-agent.md
@@ -18,7 +18,7 @@ Your own shell, bash, and other execution tools are Agent-owned work. Intelligen
 
 `request_terminal_actions` is the separate user-owned path for changing the user's terminal workflow. Use it only when the intended result should run, open, split, or otherwise mutate a terminal pane. Internal investigation remains an Agent-owned tool call and must not be proposed as a pane action.
 
-When a missing user decision prevents you from continuing, use the session's `request_user_input` tool to ask one focused question. Supply concise choices when the decision has a bounded set of answers and enable freeform input only when needed. Wait for the tool result before continuing. This is a WTA-provided interaction; do not claim that it intercepts or replaces the Agent implementation's own input tools.
+When the user's intent or a material requirement is unclear and clarification could change what you do, use the session's `request_user_input` tool to ask one focused question before continuing instead of guessing. Supply concise choices when the decision has a bounded set of answers and enable freeform input only when needed. Do not ask when the answer is already available in context or a safe, reversible default is clear. Wait for the tool result before continuing. This is a WTA-provided interaction; do not claim that it intercepts or replaces the Agent implementation's own input tools.
 
 ## Grounding unfamiliar commands
 

--- a/tools/wta/src/agent_tools/action_proposal/mcp.rs
+++ b/tools/wta/src/agent_tools/action_proposal/mcp.rs
@@ -5,14 +5,17 @@ use serde_json::{json, Value};
 
 use super::channel::ProposalValidationStatus;
 use super::pipe::ProposalValidationResponse;
+use crate::agent_tools::user_input::UserInputResponse;
 
 const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
 const SUPPORTED_MCP_PROTOCOL_VERSIONS: &[&str] =
     &["2024-11-05", "2025-03-26", MCP_PROTOCOL_VERSION];
-const TOOL_NAME: &str = "request_terminal_actions";
+const TERMINAL_ACTION_TOOL_NAME: &str = "request_terminal_actions";
+const USER_INPUT_TOOL_NAME: &str = "request_user_input";
 pub const SERVER_NAME_PREFIX: &str = "intellterm_";
 pub const SERVER_ID_HEX_LEN: usize = 20;
 pub const HELPER_REQUEST_METHOD: &str = "_intellterm.wta/request_terminal_actions";
+pub const USER_INPUT_HELPER_REQUEST_METHOD: &str = "_intellterm.wta/request_user_input";
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -23,6 +26,10 @@ pub struct HelperRequest {
 
 pub fn helper_method_matches(method: &str) -> bool {
     method.trim_start_matches('_') == HELPER_REQUEST_METHOD.trim_start_matches('_')
+}
+
+pub fn user_input_helper_method_matches(method: &str) -> bool {
+    method.trim_start_matches('_') == USER_INPUT_HELPER_REQUEST_METHOD.trim_start_matches('_')
 }
 
 pub fn server_name_matches(name: &str) -> bool {
@@ -38,10 +45,16 @@ pub fn server_name_matches(name: &str) -> bool {
         })
 }
 
-pub async fn dispatch<F, Fut>(request: Value, submit: F) -> Option<Value>
+pub async fn dispatch<A, AFut, U, UFut>(
+    request: Value,
+    submit_action: A,
+    request_user_input: U,
+) -> Option<Value>
 where
-    F: FnOnce(Value) -> Fut,
-    Fut: Future<Output = anyhow::Result<ProposalValidationResponse>>,
+    A: FnOnce(Value) -> AFut,
+    AFut: Future<Output = anyhow::Result<ProposalValidationResponse>>,
+    U: FnOnce(Value) -> UFut,
+    UFut: Future<Output = anyhow::Result<UserInputResponse>>,
 {
     let id = request.get("id").cloned();
     let method = request.get("method").and_then(Value::as_str).unwrap_or("");
@@ -67,74 +80,142 @@ where
         }
         "ping" => json!({}),
         "tools/list" => json!({
-            "tools": [{
-                "name": TOOL_NAME,
-                "description": "Request one terminal action in Intelligent Terminal. Use send for a simple bounded action in the current pane, open for a new empty tab or panel, and open_and_send for a new destination with input. Prefer a panel for related parallel work and a tab for independent work, a different environment, or a long-running task. Routing is automatic. Call at most once per turn, then end without assistant prose.",
-                "inputSchema": super::schema::mcp_input_schema()
-            }]
+            "tools": [
+                {
+                    "name": TERMINAL_ACTION_TOOL_NAME,
+                    "description": "Request one terminal action in Intelligent Terminal. Use send for a simple bounded action in the current pane, open for a new empty tab or panel, and open_and_send for a new destination with input. Prefer a panel for related parallel work and a tab for independent work, a different environment, or a long-running task. Routing is automatic. Call at most once per turn, then end without assistant prose.",
+                    "inputSchema": super::schema::mcp_input_schema()
+                },
+                {
+                    "name": USER_INPUT_TOOL_NAME,
+                    "description": "Ask the user a blocking clarification question in Intelligent Terminal. Supply up to 8 choices, allow freeform input, or both. Use only when the answer is required to continue the current task.",
+                    "inputSchema": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["question"],
+                        "properties": {
+                            "question": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 2000
+                            },
+                            "choices": {
+                                "type": "array",
+                                "maxItems": 8,
+                                "items": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 200
+                                }
+                            },
+                            "allow_freeform": {
+                                "type": "boolean",
+                                "default": false
+                            }
+                        }
+                    }
+                }
+            ]
         }),
         "tools/call" => {
             let name = request.pointer("/params/name").and_then(Value::as_str);
-            if name != Some(TOOL_NAME) {
-                return Some(error_response(id, -32602, "unknown tool"));
-            }
             let arguments = request
                 .pointer("/params/arguments")
                 .cloned()
                 .unwrap_or_else(|| json!({}));
-            match submit(arguments).await {
-                Ok(response) => {
-                    let status = response.status;
-                    let status_text = match status {
-                        ProposalValidationStatus::Accepted => "accepted",
-                        ProposalValidationStatus::AlreadyConsumed => "duplicate",
-                        ProposalValidationStatus::Stale
-                        | ProposalValidationStatus::UnknownChannel
-                        | ProposalValidationStatus::HelperMismatch
-                        | ProposalValidationStatus::Superseded => "stale",
-                        ProposalValidationStatus::InvalidSchema
-                        | ProposalValidationStatus::Rejected => "rejected",
-                        ProposalValidationStatus::Unavailable => "unavailable",
-                    };
-                    let structured = json!({
-                        "status": status_text,
-                        "reason": response.reason,
-                        "retryable": response.retryable
-                    });
-                    let text = if status == ProposalValidationStatus::Accepted {
-                        "Terminal actions accepted. End the turn without additional text."
-                            .to_string()
-                    } else {
-                        format!(
-                            "Terminal action request {status_text}: {}",
-                            structured["reason"]
-                                .as_str()
-                                .unwrap_or("no reason provided")
-                        )
-                    };
-                    json!({
-                        "content": [{ "type": "text", "text": text }],
-                        "structuredContent": structured,
-                        "isError": status != ProposalValidationStatus::Accepted
-                    })
+            match name {
+                Some(TERMINAL_ACTION_TOOL_NAME) => {
+                    terminal_action_result(submit_action(arguments).await)
                 }
-                Err(error) => json!({
-                    "content": [{
-                        "type": "text",
-                        "text": format!("Terminal action request unavailable: {error:#}")
-                    }],
-                    "structuredContent": {
-                        "status": "unavailable",
-                        "reason": format!("{error:#}"),
-                        "retryable": false
-                    },
-                    "isError": true
-                }),
+                Some(USER_INPUT_TOOL_NAME) => user_input_result(request_user_input(arguments).await),
+                _ => return Some(error_response(id, -32602, "unknown tool")),
             }
         }
         _ => return Some(error_response(id, -32601, "method not found")),
     };
     Some(json!({ "jsonrpc": "2.0", "id": id, "result": result }))
+}
+
+fn terminal_action_result(response: anyhow::Result<ProposalValidationResponse>) -> Value {
+    match response {
+        Ok(response) => {
+            let status = response.status;
+            let status_text = match status {
+                ProposalValidationStatus::Accepted => "accepted",
+                ProposalValidationStatus::AlreadyConsumed => "duplicate",
+                ProposalValidationStatus::Stale
+                | ProposalValidationStatus::UnknownChannel
+                | ProposalValidationStatus::HelperMismatch
+                | ProposalValidationStatus::Superseded => "stale",
+                ProposalValidationStatus::InvalidSchema
+                | ProposalValidationStatus::Rejected => "rejected",
+                ProposalValidationStatus::Unavailable => "unavailable",
+            };
+            let structured = json!({
+                "status": status_text,
+                "reason": response.reason,
+                "retryable": response.retryable
+            });
+            let text = if status == ProposalValidationStatus::Accepted {
+                "Terminal actions accepted. End the turn without additional text.".to_string()
+            } else {
+                format!(
+                    "Terminal action request {status_text}: {}",
+                    structured["reason"].as_str().unwrap_or("no reason provided")
+                )
+            };
+            json!({
+                "content": [{ "type": "text", "text": text }],
+                "structuredContent": structured,
+                "isError": status != ProposalValidationStatus::Accepted
+            })
+        }
+        Err(error) => json!({
+            "content": [{
+                "type": "text",
+                "text": format!("Terminal action request unavailable: {error:#}")
+            }],
+            "structuredContent": {
+                "status": "unavailable",
+                "reason": format!("{error:#}"),
+                "retryable": false
+            },
+            "isError": true
+        }),
+    }
+}
+
+fn user_input_result(response: anyhow::Result<UserInputResponse>) -> Value {
+    match response {
+        Ok(UserInputResponse::Answered {
+            answer,
+            selected_index,
+        }) => json!({
+            "content": [{ "type": "text", "text": answer }],
+            "structuredContent": {
+                "outcome": "answered",
+                "answer": answer,
+                "selected_index": selected_index
+            },
+            "isError": false
+        }),
+        Ok(UserInputResponse::Cancelled) => json!({
+            "content": [{ "type": "text", "text": "The user cancelled the question." }],
+            "structuredContent": { "outcome": "cancelled" },
+            "isError": false
+        }),
+        Err(error) => json!({
+            "content": [{
+                "type": "text",
+                "text": format!("User input request unavailable: {error:#}")
+            }],
+            "structuredContent": {
+                "outcome": "unavailable",
+                "reason": format!("{error:#}")
+            },
+            "isError": true
+        }),
+    }
 }
 
 pub fn error_response(id: Value, code: i64, message: &str) -> Value {
@@ -150,9 +231,10 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn lists_only_the_proposal_tool() {
+    async fn lists_session_tools() {
         let response = dispatch(
             json!({"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}),
+            |_| async { unreachable!() },
             |_| async { unreachable!() },
         )
         .await
@@ -161,14 +243,14 @@ mod tests {
             response
                 .pointer("/result/tools/0/name")
                 .and_then(Value::as_str),
-            Some(TOOL_NAME)
+            Some(TERMINAL_ACTION_TOOL_NAME)
         );
         assert_eq!(
             response
                 .pointer("/result/tools")
                 .and_then(Value::as_array)
                 .map(Vec::len),
-            Some(1)
+            Some(2)
         );
     }
 
@@ -180,15 +262,56 @@ mod tests {
             "method": "initialize",
             "params": { "protocolVersion": "unsupported" }
         });
-        let response = dispatch(request, |_| async { unreachable!() })
-            .await
-            .unwrap();
+        let response = dispatch(
+            request,
+            |_| async { unreachable!() },
+            |_| async { unreachable!() },
+        )
+        .await
+        .unwrap();
 
         assert_eq!(
             response
                 .pointer("/result/protocolVersion")
                 .and_then(Value::as_str),
             Some(MCP_PROTOCOL_VERSION)
+        );
+    }
+
+    #[tokio::test]
+    async fn returns_structured_user_answer() {
+        let response = dispatch(
+            json!({
+                "jsonrpc":"2.0",
+                "id":1,
+                "method":"tools/call",
+                "params":{
+                    "name":"request_user_input",
+                    "arguments":{"question":"Choose","choices":["A","B"]}
+                }
+            }),
+            |_| async { unreachable!() },
+            |_| async {
+                Ok(UserInputResponse::Answered {
+                    answer: "B".into(),
+                    selected_index: Some(1),
+                })
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            response
+                .pointer("/result/structuredContent/answer")
+                .and_then(Value::as_str),
+            Some("B")
+        );
+        assert_eq!(
+            response
+                .pointer("/result/structuredContent/selected_index")
+                .and_then(Value::as_u64),
+            Some(1)
         );
     }
 }

--- a/tools/wta/src/agent_tools/action_proposal/mod.rs
+++ b/tools/wta/src/agent_tools/action_proposal/mod.rs
@@ -1,6 +1,5 @@
 pub(crate) mod channel;
 pub(crate) mod invocation;
-pub(crate) mod mcp;
 pub(crate) mod pipe;
 mod pipe_security;
 pub(crate) mod schema;

--- a/tools/wta/src/agent_tools/mod.rs
+++ b/tools/wta/src/agent_tools/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod action_proposal;
 pub(crate) mod command_resolution;
+pub(crate) mod user_input;

--- a/tools/wta/src/agent_tools/mod.rs
+++ b/tools/wta/src/agent_tools/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod action_proposal;
 pub(crate) mod command_resolution;
+pub(crate) mod session_mcp;
 pub(crate) mod user_input;

--- a/tools/wta/src/agent_tools/session_mcp.rs
+++ b/tools/wta/src/agent_tools/session_mcp.rs
@@ -66,16 +66,16 @@ pub fn server_name_matches(name: &str) -> bool {
         })
 }
 
-pub async fn dispatch<A, AFut, U, UFut>(
+pub async fn dispatch<A, ActionFuture, U, UserInputFuture>(
     request: Value,
     submit_action: A,
     request_user_input: U,
 ) -> Option<Value>
 where
-    A: FnOnce(Value) -> AFut,
-    AFut: Future<Output = anyhow::Result<ProposalValidationResponse>>,
-    U: FnOnce(Value) -> UFut,
-    UFut: Future<Output = anyhow::Result<UserInputResponse>>,
+    A: FnOnce(Value) -> ActionFuture,
+    ActionFuture: Future<Output = anyhow::Result<ProposalValidationResponse>>,
+    U: FnOnce(Value) -> UserInputFuture,
+    UserInputFuture: Future<Output = anyhow::Result<UserInputResponse>>,
 {
     let id = request.get("id").cloned();
     let method = request.get("method").and_then(Value::as_str).unwrap_or("");

--- a/tools/wta/src/agent_tools/session_mcp.rs
+++ b/tools/wta/src/agent_tools/session_mcp.rs
@@ -3,8 +3,8 @@ use std::future::Future;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use super::channel::ProposalValidationStatus;
-use super::pipe::ProposalValidationResponse;
+use super::action_proposal::channel::ProposalValidationStatus;
+use super::action_proposal::pipe::ProposalValidationResponse;
 use crate::agent_tools::user_input::UserInputResponse;
 
 const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
@@ -16,6 +16,7 @@ pub const SERVER_NAME_PREFIX: &str = "intellterm_";
 pub const SERVER_ID_HEX_LEN: usize = 20;
 pub const HELPER_REQUEST_METHOD: &str = "_intellterm.wta/request_terminal_actions";
 pub const USER_INPUT_HELPER_REQUEST_METHOD: &str = "_intellterm.wta/request_user_input";
+pub const CANCEL_USER_INPUT_HELPER_REQUEST_METHOD: &str = "_intellterm.wta/cancel_user_input";
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -24,12 +25,32 @@ pub struct HelperRequest {
     pub arguments: Value,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UserInputHelperRequest {
+    pub request_id: String,
+    pub session_id: String,
+    pub request: crate::agent_tools::user_input::UserInputRequest,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CancelUserInputHelperRequest {
+    pub request_id: String,
+    pub session_id: String,
+}
+
 pub fn helper_method_matches(method: &str) -> bool {
     method.trim_start_matches('_') == HELPER_REQUEST_METHOD.trim_start_matches('_')
 }
 
 pub fn user_input_helper_method_matches(method: &str) -> bool {
     method.trim_start_matches('_') == USER_INPUT_HELPER_REQUEST_METHOD.trim_start_matches('_')
+}
+
+pub fn cancel_user_input_helper_method_matches(method: &str) -> bool {
+    method.trim_start_matches('_')
+        == CANCEL_USER_INPUT_HELPER_REQUEST_METHOD.trim_start_matches('_')
 }
 
 pub fn server_name_matches(name: &str) -> bool {
@@ -84,7 +105,7 @@ where
                 {
                     "name": TERMINAL_ACTION_TOOL_NAME,
                     "description": "Request one terminal action in Intelligent Terminal. Use send for a simple bounded action in the current pane, open for a new empty tab or panel, and open_and_send for a new destination with input. Prefer a panel for related parallel work and a tab for independent work, a different environment, or a long-running task. Routing is automatic. Call at most once per turn, then end without assistant prose.",
-                    "inputSchema": super::schema::mcp_input_schema()
+                    "inputSchema": super::action_proposal::schema::mcp_input_schema()
                 },
                 {
                     "name": USER_INPUT_TOOL_NAME,
@@ -112,7 +133,21 @@ where
                                 "type": "boolean",
                                 "default": false
                             }
-                        }
+                        },
+                        "anyOf": [
+                            {
+                                "required": ["choices"],
+                                "properties": {
+                                    "choices": { "minItems": 1 }
+                                }
+                            },
+                            {
+                                "required": ["allow_freeform"],
+                                "properties": {
+                                    "allow_freeform": { "const": true }
+                                }
+                            }
+                        ]
                     }
                 }
             ]
@@ -127,7 +162,9 @@ where
                 Some(TERMINAL_ACTION_TOOL_NAME) => {
                     terminal_action_result(submit_action(arguments).await)
                 }
-                Some(USER_INPUT_TOOL_NAME) => user_input_result(request_user_input(arguments).await),
+                Some(USER_INPUT_TOOL_NAME) => {
+                    user_input_result(request_user_input(arguments).await)
+                }
                 _ => return Some(error_response(id, -32602, "unknown tool")),
             }
         }
@@ -147,8 +184,9 @@ fn terminal_action_result(response: anyhow::Result<ProposalValidationResponse>) 
                 | ProposalValidationStatus::UnknownChannel
                 | ProposalValidationStatus::HelperMismatch
                 | ProposalValidationStatus::Superseded => "stale",
-                ProposalValidationStatus::InvalidSchema
-                | ProposalValidationStatus::Rejected => "rejected",
+                ProposalValidationStatus::InvalidSchema | ProposalValidationStatus::Rejected => {
+                    "rejected"
+                }
                 ProposalValidationStatus::Unavailable => "unavailable",
             };
             let structured = json!({
@@ -161,7 +199,9 @@ fn terminal_action_result(response: anyhow::Result<ProposalValidationResponse>) 
             } else {
                 format!(
                     "Terminal action request {status_text}: {}",
-                    structured["reason"].as_str().unwrap_or("no reason provided")
+                    structured["reason"]
+                        .as_str()
+                        .unwrap_or("no reason provided")
                 )
             };
             json!({
@@ -248,6 +288,19 @@ mod tests {
         assert_eq!(
             response
                 .pointer("/result/tools")
+                .and_then(Value::as_array)
+                .map(Vec::len),
+            Some(2)
+        );
+        assert_eq!(
+            response
+                .pointer("/result/tools/1/name")
+                .and_then(Value::as_str),
+            Some(USER_INPUT_TOOL_NAME)
+        );
+        assert_eq!(
+            response
+                .pointer("/result/tools/1/inputSchema/anyOf")
                 .and_then(Value::as_array)
                 .map(Vec::len),
             Some(2)

--- a/tools/wta/src/agent_tools/user_input.rs
+++ b/tools/wta/src/agent_tools/user_input.rs
@@ -99,7 +99,7 @@ mod tests {
         .is_err());
         assert!(UserInputRequest {
             question: "Choose".into(),
-            choices: vec!["bad\nchoice".into()],
+            choices: vec![format!("bad{}choice", '\n')],
             allow_freeform: false,
         }
         .validate()

--- a/tools/wta/src/agent_tools/user_input.rs
+++ b/tools/wta/src/agent_tools/user_input.rs
@@ -34,15 +34,11 @@ impl UserInputRequest {
         if self.choices.len() > MAX_CHOICES {
             bail!("too many choices");
         }
-        if self
-            .choices
-            .iter()
-            .any(|choice| {
-                choice.trim().is_empty()
-                    || choice.chars().count() > MAX_CHOICE_CHARS
-                    || choice.chars().any(char::is_control)
-            })
-        {
+        if self.choices.iter().any(|choice| {
+            choice.trim().is_empty()
+                || choice.chars().count() > MAX_CHOICE_CHARS
+                || choice.chars().any(char::is_control)
+        }) {
             bail!("choices must be non-empty and within the character limit");
         }
         if self.choices.is_empty() && !self.allow_freeform {

--- a/tools/wta/src/agent_tools/user_input.rs
+++ b/tools/wta/src/agent_tools/user_input.rs
@@ -1,0 +1,112 @@
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+
+pub const MAX_QUESTION_CHARS: usize = 2_000;
+pub const MAX_CHOICES: usize = 8;
+pub const MAX_CHOICE_CHARS: usize = 200;
+pub const MAX_ANSWER_CHARS: usize = 4_000;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UserInputRequest {
+    pub question: String,
+    #[serde(default)]
+    pub choices: Vec<String>,
+    #[serde(default)]
+    pub allow_freeform: bool,
+}
+
+impl UserInputRequest {
+    pub fn validate(self) -> Result<Self> {
+        if self.question.trim().is_empty() {
+            bail!("question must not be empty");
+        }
+        if self.question.chars().count() > MAX_QUESTION_CHARS {
+            bail!("question exceeds the character limit");
+        }
+        if self
+            .question
+            .chars()
+            .any(|character| character.is_control() && !matches!(character, '\n' | '\t'))
+        {
+            bail!("question contains unsupported control characters");
+        }
+        if self.choices.len() > MAX_CHOICES {
+            bail!("too many choices");
+        }
+        if self
+            .choices
+            .iter()
+            .any(|choice| {
+                choice.trim().is_empty()
+                    || choice.chars().count() > MAX_CHOICE_CHARS
+                    || choice.chars().any(char::is_control)
+            })
+        {
+            bail!("choices must be non-empty and within the character limit");
+        }
+        if self.choices.is_empty() && !self.allow_freeform {
+            bail!("at least one choice or freeform input is required");
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum UserInputResponse {
+    Answered {
+        answer: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        selected_index: Option<usize>,
+    },
+    Cancelled,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_choices_or_freeform() {
+        assert!(UserInputRequest {
+            question: "Choose".into(),
+            choices: vec!["A".into(), "B".into()],
+            allow_freeform: false,
+        }
+        .validate()
+        .is_ok());
+        assert!(UserInputRequest {
+            question: "Explain".into(),
+            choices: vec![],
+            allow_freeform: true,
+        }
+        .validate()
+        .is_ok());
+        assert!(UserInputRequest {
+            question: "Blocked".into(),
+            choices: vec![],
+            allow_freeform: false,
+        }
+        .validate()
+        .is_err());
+    }
+
+    #[test]
+    fn rejects_oversized_and_empty_values() {
+        assert!(UserInputRequest {
+            question: "q".repeat(MAX_QUESTION_CHARS + 1),
+            choices: vec!["A".into()],
+            allow_freeform: false,
+        }
+        .validate()
+        .is_err());
+        assert!(UserInputRequest {
+            question: "Choose".into(),
+            choices: vec!["bad\nchoice".into()],
+            allow_freeform: false,
+        }
+        .validate()
+        .is_err());
+    }
+}

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -3818,6 +3818,7 @@ impl App {
             AppEvent::Plan { .. } => "plan",
             AppEvent::PermissionRequest { .. } => "permission_request",
             AppEvent::UserInputRequest { .. } => "user_input_request",
+            AppEvent::CancelUserInputRequest { .. } => "cancel_user_input_request",
             AppEvent::SystemMessage(_) => "system_message",
             AppEvent::DebugPipeMessage(_) => "debug_pipe_message",
             AppEvent::WtEvent { .. } => "wt_event",

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -61,7 +61,7 @@ use input_edit::{next_word_boundary, prev_word_boundary, INPUT_HISTORY_MAX_ENTRI
 pub(crate) use tab_state::DEFAULT_TAB_ID;
 pub use tab_state::{
     ChatMessage, CompletedTurn, NoticeKind, PermissionState, RecommendationFocus, TabSession,
-    ToolCallKind, ToolCallOutput, View,
+    ToolCallKind, ToolCallOutput, UserInputState, View,
 };
 pub use turn_state::{AutofixContext, ChunkKind, SubmittedPrompt, TurnOutcome, TurnState};
 
@@ -3817,6 +3817,7 @@ impl App {
             AppEvent::HideToolCall { .. } => "hide_tool_call",
             AppEvent::Plan { .. } => "plan",
             AppEvent::PermissionRequest { .. } => "permission_request",
+            AppEvent::UserInputRequest { .. } => "user_input_request",
             AppEvent::SystemMessage(_) => "system_message",
             AppEvent::DebugPipeMessage(_) => "debug_pipe_message",
             AppEvent::WtEvent { .. } => "wt_event",

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -188,6 +188,7 @@ pub struct PermissionState {
 }
 
 pub struct UserInputState {
+    pub request_id: String,
     pub request: crate::agent_tools::user_input::UserInputRequest,
     pub selected: usize,
     pub input: String,
@@ -419,6 +420,7 @@ impl TabSession {
         self.turn.is_in_flight()
             && self.turn.recommendations().is_none()
             && self.permission.is_empty()
+            && self.user_input.is_empty()
     }
 
     /// Whether the input box is the live, enterable caret target.
@@ -427,6 +429,7 @@ impl TabSession {
             && (self.turn.recommendations().is_none()
                 || self.recommendation_focus == RecommendationFocus::Input)
             && self.permission.is_empty()
+            && self.user_input.is_empty()
             && !self.paste_pending
             && !self.model_picker_open
             && !self.agent_picker_open

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -187,6 +187,24 @@ pub struct PermissionState {
     pub responder: Option<tokio::sync::oneshot::Sender<String>>,
 }
 
+pub struct UserInputState {
+    pub request: crate::agent_tools::user_input::UserInputRequest,
+    pub selected: usize,
+    pub input: String,
+    pub responder:
+        Option<tokio::sync::oneshot::Sender<crate::agent_tools::user_input::UserInputResponse>>,
+}
+
+impl UserInputState {
+    pub fn selection_count(&self) -> usize {
+        self.request.choices.len() + usize::from(self.request.allow_freeform)
+    }
+
+    pub fn freeform_selected(&self) -> bool {
+        self.request.allow_freeform && self.selected == self.request.choices.len()
+    }
+}
+
 impl PermissionState {
     /// Index of the first "allow" option, used by the `y` quick-key and the
     /// `[Y]` button label.
@@ -328,6 +346,8 @@ pub struct TabSession {
     /// entry is the one currently rendered and accepting keys; the rest
     /// queue up.
     pub permission: VecDeque<PermissionState>,
+    /// FIFO of blocking clarification requests from the session MCP tool.
+    pub user_input: VecDeque<UserInputState>,
     // Recommendation card UI focus (the set itself lives on
     // `turn.recommendations()`).
     pub selected_recommendation: usize,
@@ -445,6 +465,7 @@ impl TabSession {
         self.messages.clear();
         self.tool_calls.clear();
         self.permission.clear();
+        self.user_input.clear();
         self.activity_frame = 0;
         self.pending_agent_response.clear();
         self.pending_user_replay.clear();

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -163,10 +163,14 @@ pub enum AppEvent {
         responder: tokio::sync::oneshot::Sender<String>,
     },
     UserInputRequest {
+        request_id: String,
         session_id: String,
         request: crate::agent_tools::user_input::UserInputRequest,
-        responder:
-            tokio::sync::oneshot::Sender<crate::agent_tools::user_input::UserInputResponse>,
+        responder: tokio::sync::oneshot::Sender<crate::agent_tools::user_input::UserInputResponse>,
+    },
+    CancelUserInputRequest {
+        request_id: String,
+        session_id: String,
     },
     SystemMessage(String),
     DebugPipeMessage(DebugMessage),

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -162,6 +162,12 @@ pub enum AppEvent {
         options: Vec<PermOption>,
         responder: tokio::sync::oneshot::Sender<String>,
     },
+    UserInputRequest {
+        session_id: String,
+        request: crate::agent_tools::user_input::UserInputRequest,
+        responder:
+            tokio::sync::oneshot::Sender<crate::agent_tools::user_input::UserInputResponse>,
+    },
     SystemMessage(String),
     DebugPipeMessage(DebugMessage),
     WtEvent {

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -901,6 +901,7 @@ impl App {
                 });
             }
             AppEvent::UserInputRequest {
+                request_id,
                 session_id,
                 request,
                 responder,
@@ -910,11 +911,25 @@ impl App {
                     return;
                 }
                 tab.user_input.push_back(UserInputState {
+                    request_id,
                     request,
                     selected: 0,
                     input: String::new(),
                     responder: Some(responder),
                 });
+            }
+            AppEvent::CancelUserInputRequest {
+                request_id,
+                session_id,
+            } => {
+                let tab = self.session_tab_mut(&session_id);
+                if let Some(index) = tab
+                    .user_input
+                    .iter()
+                    .position(|pending| pending.request_id == request_id)
+                {
+                    tab.user_input.remove(index);
+                }
             }
             AppEvent::SystemMessage(message) => {
                 self.current_tab_mut()

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -900,6 +900,22 @@ impl App {
                     responder: Some(responder),
                 });
             }
+            AppEvent::UserInputRequest {
+                session_id,
+                request,
+                responder,
+            } => {
+                let tab = self.session_tab_mut(&session_id);
+                if !tab.turn.is_in_flight() {
+                    return;
+                }
+                tab.user_input.push_back(UserInputState {
+                    request,
+                    selected: 0,
+                    input: String::new(),
+                    responder: Some(responder),
+                });
+            }
             AppEvent::SystemMessage(message) => {
                 self.current_tab_mut()
                     .messages

--- a/tools/wta/src/app_keys.rs
+++ b/tools/wta/src/app_keys.rs
@@ -372,6 +372,72 @@ impl App {
             return;
         }
 
+        // A session MCP clarification blocks the Agent's current tool call.
+        // Keep all editing inside the modal so keys never leak into the normal
+        // prompt input behind it.
+        if !self.current_tab().user_input.is_empty() {
+            use crate::agent_tools::user_input::{UserInputResponse, MAX_ANSWER_CHARS};
+
+            let mut resolved = None;
+            {
+                let Some(request) = self.current_tab_mut().user_input.front_mut() else {
+                    return;
+                };
+                match key.code {
+                    KeyCode::Up => {
+                        request.selected = request.selected.saturating_sub(1);
+                    }
+                    KeyCode::Down => {
+                        request.selected = (request.selected + 1)
+                            .min(request.selection_count().saturating_sub(1));
+                    }
+                    KeyCode::Char(character)
+                        if request.request.allow_freeform
+                            && !key
+                                .modifiers
+                                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+                            && request.input.chars().count() < MAX_ANSWER_CHARS =>
+                    {
+                        request.selected = request.request.choices.len();
+                        request.input.push(character);
+                    }
+                    KeyCode::Backspace if request.freeform_selected() => {
+                        request.input.pop();
+                    }
+                    KeyCode::Enter => {
+                        if request.freeform_selected() {
+                            let answer = request.input.trim();
+                            if !answer.is_empty() {
+                                resolved = Some(UserInputResponse::Answered {
+                                    answer: answer.to_string(),
+                                    selected_index: None,
+                                });
+                            }
+                        } else if let Some(answer) =
+                            request.request.choices.get(request.selected)
+                        {
+                            resolved = Some(UserInputResponse::Answered {
+                                answer: answer.clone(),
+                                selected_index: Some(request.selected),
+                            });
+                        }
+                    }
+                    KeyCode::Esc => {
+                        resolved = Some(UserInputResponse::Cancelled);
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(response) = resolved {
+                if let Some(mut request) = self.current_tab_mut().user_input.pop_front() {
+                    if let Some(responder) = request.responder.take() {
+                        let _ = responder.send(response);
+                    }
+                }
+            }
+            return;
+        }
+
         // If permission card is showing, route keys there. Buttons are
         // rendered horizontally inside the embedded card (same chrome as
         // recommendations), so Left/Right move the focus; Up/Down kept as

--- a/tools/wta/src/app_keys.rs
+++ b/tools/wta/src/app_keys.rs
@@ -372,6 +372,13 @@ impl App {
             return;
         }
 
+        // Help is rendered above every other modal, so Esc must dismiss it
+        // before interacting with the modal underneath.
+        if self.help_overlay_visible && key.code == KeyCode::Esc {
+            self.help_overlay_visible = false;
+            return;
+        }
+
         // A session MCP clarification blocks the Agent's current tool call.
         // Keep all editing inside the modal so keys never leak into the normal
         // prompt input behind it.

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -5555,6 +5555,7 @@ fn user_input_choice_returns_selected_index() {
     begin_user_input_test(&mut app);
     let (responder, mut response) = tokio::sync::oneshot::channel();
     app.handle_event(AppEvent::UserInputRequest {
+        request_id: "choice".into(),
         session_id: DEFAULT_TAB_ID.into(),
         request: crate::agent_tools::user_input::UserInputRequest {
             question: "Which approach?".into(),
@@ -5583,6 +5584,7 @@ fn user_input_accepts_freeform_and_escape_cancels() {
     begin_user_input_test(&mut app);
     let (responder, mut response) = tokio::sync::oneshot::channel();
     app.handle_event(AppEvent::UserInputRequest {
+        request_id: "freeform".into(),
         session_id: DEFAULT_TAB_ID.into(),
         request: crate::agent_tools::user_input::UserInputRequest {
             question: "Name it".into(),
@@ -5603,6 +5605,7 @@ fn user_input_accepts_freeform_and_escape_cancels() {
 
     let (responder, mut response) = tokio::sync::oneshot::channel();
     app.handle_event(AppEvent::UserInputRequest {
+        request_id: "cancel".into(),
         session_id: DEFAULT_TAB_ID.into(),
         request: crate::agent_tools::user_input::UserInputRequest {
             question: "Continue?".into(),
@@ -5616,6 +5619,72 @@ fn user_input_accepts_freeform_and_escape_cancels() {
         response.try_recv().unwrap(),
         crate::agent_tools::user_input::UserInputResponse::Cancelled
     );
+}
+
+#[test]
+fn user_input_owns_focus_and_cancellation_removes_only_its_request() {
+    let mut app = test_app();
+    begin_user_input_test(&mut app);
+    let (first_responder, mut first_response) = tokio::sync::oneshot::channel();
+    let (second_responder, mut second_response) = tokio::sync::oneshot::channel();
+    for (request_id, responder) in [("first", first_responder), ("second", second_responder)] {
+        app.handle_event(AppEvent::UserInputRequest {
+            request_id: request_id.into(),
+            session_id: DEFAULT_TAB_ID.into(),
+            request: crate::agent_tools::user_input::UserInputRequest {
+                question: "Choose".into(),
+                choices: vec!["A".into()],
+                allow_freeform: false,
+            },
+            responder,
+        });
+    }
+
+    assert!(!app.current_tab().input_has_nav_focus());
+    assert!(!app.current_tab().should_show_thinking());
+    app.handle_event(AppEvent::CancelUserInputRequest {
+        request_id: "second".into(),
+        session_id: DEFAULT_TAB_ID.into(),
+    });
+
+    assert_eq!(app.current_tab().user_input.len(), 1);
+    assert_eq!(
+        app.current_tab().user_input.front().unwrap().request_id,
+        "first"
+    );
+    assert!(matches!(
+        second_response.try_recv(),
+        Err(tokio::sync::oneshot::error::TryRecvError::Closed)
+    ));
+    assert!(matches!(
+        first_response.try_recv(),
+        Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+    ));
+}
+
+#[test]
+fn cancelling_turn_drops_pending_user_input() {
+    let mut app = test_app();
+    begin_user_input_test(&mut app);
+    let (responder, mut response) = tokio::sync::oneshot::channel();
+    app.handle_event(AppEvent::UserInputRequest {
+        request_id: "turn-cancel".into(),
+        session_id: DEFAULT_TAB_ID.into(),
+        request: crate::agent_tools::user_input::UserInputRequest {
+            question: "Continue?".into(),
+            choices: vec!["Yes".into()],
+            allow_freeform: false,
+        },
+        responder,
+    });
+
+    app.turn_cancel(DEFAULT_TAB_ID);
+
+    assert!(app.current_tab().user_input.is_empty());
+    assert!(matches!(
+        response.try_recv(),
+        Err(tokio::sync::oneshot::error::TryRecvError::Closed)
+    ));
 }
 
 #[test]

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -5622,6 +5622,39 @@ fn user_input_accepts_freeform_and_escape_cancels() {
 }
 
 #[test]
+fn help_overlay_dismisses_before_user_input() {
+    let mut app = test_app();
+    begin_user_input_test(&mut app);
+    let (responder, mut response) = tokio::sync::oneshot::channel();
+    app.handle_event(AppEvent::UserInputRequest {
+        request_id: "behind-help".into(),
+        session_id: DEFAULT_TAB_ID.into(),
+        request: crate::agent_tools::user_input::UserInputRequest {
+            question: "Continue?".into(),
+            choices: vec!["Yes".into()],
+            allow_freeform: false,
+        },
+        responder,
+    });
+    app.help_overlay_visible = true;
+
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+    assert!(!app.help_overlay_visible);
+    assert_eq!(app.current_tab().user_input.len(), 1);
+    assert!(matches!(
+        response.try_recv(),
+        Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+    ));
+
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+    assert_eq!(
+        response.try_recv().unwrap(),
+        crate::agent_tools::user_input::UserInputResponse::Cancelled
+    );
+}
+
+#[test]
 fn user_input_owns_focus_and_cancellation_removes_only_its_request() {
     let mut app = test_app();
     begin_user_input_test(&mut app);

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -5539,6 +5539,85 @@ fn permission_request_replaces_thinking_until_dismissed() {
     assert!(!app.current_tab().should_show_thinking());
 }
 
+fn begin_user_input_test(app: &mut App) {
+    app.tab_mut(DEFAULT_TAB_ID).turn = TurnState::Submitted(SubmittedPrompt {
+        id: 1,
+        text: "test".into(),
+        submitted_at_unix_s: 0.0,
+        context: TurnContext::default(),
+        autofix: None,
+    });
+}
+
+#[test]
+fn user_input_choice_returns_selected_index() {
+    let mut app = test_app();
+    begin_user_input_test(&mut app);
+    let (responder, mut response) = tokio::sync::oneshot::channel();
+    app.handle_event(AppEvent::UserInputRequest {
+        session_id: DEFAULT_TAB_ID.into(),
+        request: crate::agent_tools::user_input::UserInputRequest {
+            question: "Which approach?".into(),
+            choices: vec!["A".into(), "B".into()],
+            allow_freeform: true,
+        },
+        responder,
+    });
+
+    app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert_eq!(
+        response.try_recv().unwrap(),
+        crate::agent_tools::user_input::UserInputResponse::Answered {
+            answer: "B".into(),
+            selected_index: Some(1),
+        }
+    );
+    assert!(app.current_tab().user_input.is_empty());
+}
+
+#[test]
+fn user_input_accepts_freeform_and_escape_cancels() {
+    let mut app = test_app();
+    begin_user_input_test(&mut app);
+    let (responder, mut response) = tokio::sync::oneshot::channel();
+    app.handle_event(AppEvent::UserInputRequest {
+        session_id: DEFAULT_TAB_ID.into(),
+        request: crate::agent_tools::user_input::UserInputRequest {
+            question: "Name it".into(),
+            choices: Vec::new(),
+            allow_freeform: true,
+        },
+        responder,
+    });
+    app.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+    assert_eq!(
+        response.try_recv().unwrap(),
+        crate::agent_tools::user_input::UserInputResponse::Answered {
+            answer: "x".into(),
+            selected_index: None,
+        }
+    );
+
+    let (responder, mut response) = tokio::sync::oneshot::channel();
+    app.handle_event(AppEvent::UserInputRequest {
+        session_id: DEFAULT_TAB_ID.into(),
+        request: crate::agent_tools::user_input::UserInputRequest {
+            question: "Continue?".into(),
+            choices: vec!["Yes".into()],
+            allow_freeform: false,
+        },
+        responder,
+    });
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+    assert_eq!(
+        response.try_recv().unwrap(),
+        crate::agent_tools::user_input::UserInputResponse::Cancelled
+    );
+}
+
 #[test]
 fn surfaced_recommendation_hides_thinking_before_turn_end() {
     let mut app = test_app();

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -757,6 +757,7 @@ impl App {
         tab.recommendation_focus = RecommendationFocus::Button;
         tab.rec_scroll.reset();
         tab.activity_frame = 0;
+        tab.user_input.clear();
         tab.turn = TurnState::Idle;
         tab.pending_terminal_action_proposal = None;
         tab.active_direct_proposal_id = None;

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -62,6 +62,7 @@ impl App {
         // Dropping any in-flight responders signals Cancelled back to
         // the agent — appropriate when the user starts a new turn.
         tab.permission.clear();
+        tab.user_input.clear();
         tab.chat_scroll.reset();
         tab.selection_visible_pending = false;
         // Any leftover card from the previous turn's

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -65,7 +65,7 @@ use crate::protocol::acp::spawn::{
 };
 
 pub(crate) mod config;
-mod proposal_mcp;
+mod session_mcp;
 
 use config::MasterConfig;
 
@@ -149,8 +149,8 @@ struct MasterStateInner {
     /// blocking would freeze notification delivery for every other
     /// helper sharing this master.
     session_to_helper: Mutex<HashMap<acp::schema::v1::SessionId, HelperRoute>>,
-    proposal_mcp_endpoints: proposal_mcp::Endpoints,
-    proposal_mcp_capabilities: proposal_mcp::CapabilityRegistry,
+    session_mcp_endpoints: session_mcp::Endpoints,
+    session_mcp_capabilities: session_mcp::CapabilityRegistry,
     /// Latest Usage waiting for its owning helper. Context is replaced by
     /// SessionId while an omitted optional cost is retained from an
     /// undelivered prior update.
@@ -512,11 +512,11 @@ async fn inject_ready_cloud_catalog(
 
 async fn initialize_response_for_agent(
     agent: &AgentCli,
-    proposal_mcp_available: bool,
+    session_mcp_available: bool,
 ) -> Result<acp::schema::v1::InitializeResponse, serde_json::Error> {
     let mut response = agent.cached_init_resp.clone();
     inject_ready_cloud_catalog(agent, &mut response.meta).await?;
-    if proposal_mcp_available {
+    if session_mcp_available {
         crate::session_registry::inject_wta_meta(
             &mut response.meta,
             &crate::session_registry::WtaMeta {
@@ -1215,7 +1215,7 @@ impl HelperHandler {
 }
 
 impl HelperHandler {
-    async fn proposal_endpoint_for_session(
+    async fn session_mcp_endpoint_for_session(
         &self,
         agent: &AgentCli,
         wta_meta: &crate::session_registry::WtaMeta,
@@ -1231,31 +1231,31 @@ impl HelperHandler {
             .http
         {
             tracing::error!(
-                target: "proposal_mcp",
+                target: "session_mcp",
                 helper_id = ?self.helper_id,
                 op = operation,
                 source = %agent.source,
-                "helper requested proposal MCP after agent HTTP support disappeared"
+                "helper requested session MCP after agent HTTP support disappeared"
             );
             return Err(acp::Error::internal_error().data(serde_json::json!(
-                "proposal MCP is unavailable because the agent does not support HTTP MCP"
+                "session MCP is unavailable because the agent does not support HTTP MCP"
             )));
         }
-        proposal_mcp::endpoint_for(&self.state, &agent.source)
+        session_mcp::endpoint_for(&self.state, &agent.source)
             .await
             .map(Some)
             .map_err(|error| {
                 let error_chain = format!("{error:#}");
                 tracing::error!(
-                    target: "proposal_mcp",
+                    target: "session_mcp",
                     helper_id = ?self.helper_id,
                     op = operation,
                     source = %agent.source,
                     error = %error_chain,
-                    "proposal MCP endpoint became unavailable after initialize"
+                    "session MCP endpoint became unavailable after initialize"
                 );
                 acp::Error::internal_error().data(serde_json::json!(format!(
-                    "proposal MCP endpoint unavailable: {error_chain}"
+                    "session MCP endpoint unavailable: {error_chain}"
                 )))
             })
     }
@@ -1356,21 +1356,21 @@ impl HelperHandler {
             .get()
             .expect("helper agent binding is set before initialize response");
         agent.bound_helpers.lock().await.insert(self.helper_id);
-        let proposal_mcp_available = if agent
+        let session_mcp_available = if agent
             .cached_init_resp
             .agent_capabilities
             .mcp_capabilities
             .http
         {
-            match proposal_mcp::endpoint_for(&self.state, &agent.source).await {
+            match session_mcp::endpoint_for(&self.state, &agent.source).await {
                 Ok(_) => true,
                 Err(error) => {
                     tracing::warn!(
-                        target: "proposal_mcp",
+                        target: "session_mcp",
                         helper_id = ?self.helper_id,
                         source = %agent.source,
                         error = %format!("{error:#}"),
-                        "proposal MCP is unavailable for helper source"
+                        "session MCP is unavailable for helper source"
                     );
                     false
                 }
@@ -1383,7 +1383,7 @@ impl HelperHandler {
         // empty `agent_info` on most backends, blanking the agent bar), adding
         // only our private helper-facing cloud catalog metadata. The original
         // third-party response capabilities remain untouched.
-        match initialize_response_for_agent(agent, proposal_mcp_available).await {
+        match initialize_response_for_agent(agent, session_mcp_available).await {
             Ok(response) => Ok(response),
             Err(error) => {
                 tracing::warn!(
@@ -1430,17 +1430,17 @@ impl HelperHandler {
         let wta_meta = crate::session_registry::extract_wta_meta(&mut args.meta);
         let cwd_for_registry = args.cwd.clone();
         let agent = self.resolved_agent("new_session")?;
-        let proposal_endpoint = self
-            .proposal_endpoint_for_session(&agent, &wta_meta, "new_session")
+        let session_mcp_endpoint = self
+            .session_mcp_endpoint_for_session(&agent, &wta_meta, "new_session")
             .await?;
-        let proposal_mcp = if let Some(endpoint) = proposal_endpoint {
+        let session_mcp = if let Some(endpoint) = session_mcp_endpoint {
             let pending = self
                 .state
-                .proposal_mcp_capabilities
+                .session_mcp_capabilities
                 .prepare(agent.instance_id, None)
                 .await;
             args.mcp_servers
-                .push(proposal_mcp::server_config(&endpoint, &pending));
+                .push(session_mcp::server_config(&endpoint, &pending));
             Some(pending)
         } else {
             None
@@ -1463,23 +1463,23 @@ impl HelperHandler {
         {
             Ok(response) => response,
             Err(error) => {
-                if let Some(pending) = proposal_mcp.as_ref() {
-                    self.state.proposal_mcp_capabilities.cancel(pending).await;
+                if let Some(pending) = session_mcp.as_ref() {
+                    self.state.session_mcp_capabilities.cancel(pending).await;
                 }
                 return Err(error);
             }
         };
-        if let Some(pending) = proposal_mcp.as_ref() {
+        if let Some(pending) = session_mcp.as_ref() {
             if !self
                 .state
-                .proposal_mcp_capabilities
+                .session_mcp_capabilities
                 .bind(pending, resp.session_id.clone())
                 .await
             {
                 tracing::warn!(
-                    target: "proposal_mcp",
+                    target: "session_mcp",
                     session_id = %resp.session_id,
-                    "proposal MCP capability disappeared before session binding"
+                    "session MCP capability disappeared before session binding"
                 );
             }
         }
@@ -1650,8 +1650,8 @@ impl HelperHandler {
             );
             acp::schema::v1::LoadSessionResponse::new()
         } else {
-            let proposal_endpoint = match self
-                .proposal_endpoint_for_session(&agent, &wta_meta, "load_session")
+            let session_mcp_endpoint = match self
+                .session_mcp_endpoint_for_session(&agent, &wta_meta, "load_session")
                 .await
             {
                 Ok(endpoint) => endpoint,
@@ -1664,31 +1664,31 @@ impl HelperHandler {
                     return Err(error);
                 }
             };
-            let proposal_mcp = if let Some(endpoint) = proposal_endpoint {
+            let session_mcp = if let Some(endpoint) = session_mcp_endpoint {
                 let pending = self
                     .state
-                    .proposal_mcp_capabilities
+                    .session_mcp_capabilities
                     .prepare(agent.instance_id, Some(session_id.clone()))
                     .await;
                 args.mcp_servers
-                    .push(proposal_mcp::server_config(&endpoint, &pending));
+                    .push(session_mcp::server_config(&endpoint, &pending));
                 Some(pending)
             } else {
                 None
             };
             match agent.conn.load_session(args).await {
                 Ok(resp) => {
-                    if let Some(pending) = proposal_mcp.as_ref() {
+                    if let Some(pending) = session_mcp.as_ref() {
                         if !self
                             .state
-                            .proposal_mcp_capabilities
+                            .session_mcp_capabilities
                             .bind(pending, session_id.clone())
                             .await
                         {
                             tracing::warn!(
-                                target: "proposal_mcp",
+                                target: "session_mcp",
                                 session_id = %session_id,
-                                "proposal MCP capability disappeared before load binding"
+                                "session MCP capability disappeared before load binding"
                             );
                         }
                     }
@@ -1698,8 +1698,8 @@ impl HelperHandler {
                 // this master): the CLI reports "already loaded", so re-bind
                 // onto the pre-registered routing just like the fast path.
                 Err(err) if is_already_loaded_error(&err) => {
-                    if let Some(pending) = proposal_mcp.as_ref() {
-                        self.state.proposal_mcp_capabilities.cancel(pending).await;
+                    if let Some(pending) = session_mcp.as_ref() {
+                        self.state.session_mcp_capabilities.cancel(pending).await;
                     }
                     tracing::info!(
                         target: "master",
@@ -1712,8 +1712,8 @@ impl HelperHandler {
                     acp::schema::v1::LoadSessionResponse::new()
                 }
                 Err(err) => {
-                    if let Some(pending) = proposal_mcp.as_ref() {
-                        self.state.proposal_mcp_capabilities.cancel(pending).await;
+                    if let Some(pending) = session_mcp.as_ref() {
+                        self.state.session_mcp_capabilities.cancel(pending).await;
                     }
                     // Roll back the pre-registration. Only `session_to_helper`
                     // needs touching — we never wrote to `registry` and we
@@ -2381,22 +2381,19 @@ async fn run_master_loop(config: MasterConfig, pipe_name: String) -> Result<()> 
         "agent allowlist resolved"
     );
 
-    let proposal_mcp_listener = tokio::net::TcpListener::bind((
-        std::net::Ipv4Addr::LOCALHOST,
-        0,
-    ))
-    .await
-    .context("bind master proposal MCP HTTP endpoint")?;
-    let proposal_mcp_endpoint = format!(
+    let session_mcp_listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+        .await
+        .context("bind master session MCP HTTP endpoint")?;
+    let session_mcp_endpoint = format!(
         "http://{}/mcp",
-        proposal_mcp_listener
+        session_mcp_listener
             .local_addr()
-            .context("read master proposal MCP HTTP endpoint")?
+            .context("read master session MCP HTTP endpoint")?
     );
     let inner = Arc::new(MasterStateInner {
         session_to_helper: Mutex::new(HashMap::new()),
-        proposal_mcp_endpoints: proposal_mcp::Endpoints::new(proposal_mcp_endpoint),
-        proposal_mcp_capabilities: proposal_mcp::CapabilityRegistry::default(),
+        session_mcp_endpoints: session_mcp::Endpoints::new(session_mcp_endpoint),
+        session_mcp_capabilities: session_mcp::CapabilityRegistry::default(),
         pending_usage: Mutex::new(HashMap::new()),
         usage_generation: watch::channel(0u64).0,
         registry: crate::session_registry::InMemoryRegistry::shared(),
@@ -2423,15 +2420,13 @@ async fn run_master_loop(config: MasterConfig, pipe_name: String) -> Result<()> 
         wsl_seed_in_flight: std::sync::atomic::AtomicBool::new(false),
     });
     {
-        let proposal_mcp_state = Arc::clone(&inner);
+        let session_mcp_state = Arc::clone(&inner);
         tokio::task::spawn_local(async move {
-            if let Err(error) =
-                proposal_mcp::run(proposal_mcp_listener, proposal_mcp_state).await
-            {
+            if let Err(error) = session_mcp::run(session_mcp_listener, session_mcp_state).await {
                 tracing::error!(
-                    target: "proposal_mcp",
+                    target: "session_mcp",
                     error = %format!("{error:#}"),
-                    "master proposal MCP HTTP endpoint stopped"
+                    "master session MCP HTTP endpoint stopped"
                 );
             }
         });
@@ -3088,7 +3083,7 @@ async fn reap_agent(
         state.orphaned_sessions.lock().await.remove(key);
     }
     let capabilities_removed = state
-        .proposal_mcp_capabilities
+        .session_mcp_capabilities
         .remove_owner(instance_id)
         .await;
     tracing::info!(

--- a/tools/wta/src/master/proposal_mcp.rs
+++ b/tools/wta/src/master/proposal_mcp.rs
@@ -17,6 +17,7 @@ use crate::agent_tools::action_proposal::mcp::{
     HelperRequest, SERVER_ID_HEX_LEN, SERVER_NAME_PREFIX,
 };
 use crate::agent_tools::action_proposal::pipe::ProposalValidationResponse;
+use crate::agent_tools::user_input::{UserInputRequest, UserInputResponse};
 
 const ENDPOINT_PATH: &str = "/mcp";
 const MAX_HEADER_BYTES: usize = 32 * 1024;
@@ -24,6 +25,7 @@ const MAX_BODY_BYTES: usize = 1024 * 1024;
 const MAX_CONNECTIONS: usize = 32;
 const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 const HELPER_TIMEOUT: Duration = Duration::from_secs(25);
+const USER_INPUT_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2024-11-05", "2025-03-26", "2025-06-18"];
 
 #[cfg(windows)]
@@ -64,7 +66,7 @@ def forward(request):
         ["powershell.exe", "-NoLogo", "-NoProfile", "-NonInteractive",
          "-EncodedCommand", POWERSHELL_ENCODED],
         input=request, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
-        timeout=35, check=False)
+        timeout=610, check=False)
     if process.returncode != 0:
         raise RuntimeError("Windows bridge exited with a nonzero status")
     return process.stdout
@@ -343,6 +345,7 @@ impl CapabilityRegistry {
     }
 }
 
+#[derive(Clone)]
 enum CapabilityResolution {
     Bound(acp::schema::v1::SessionId),
     Pending,
@@ -747,11 +750,13 @@ async fn serve_connection(
                     "received terminal action MCP call"
                 );
             }
-            let response =
-                crate::agent_tools::action_proposal::mcp::dispatch(message, |arguments| {
-                    submit_to_helper(&state, capability, arguments)
-                })
-                .await;
+            let action_capability = capability.clone();
+            let response = crate::agent_tools::action_proposal::mcp::dispatch(
+                message,
+                |arguments| submit_to_helper(&state, action_capability, arguments),
+                |arguments| submit_user_input_to_helper(&state, capability, arguments),
+            )
+            .await;
             if let Some(response) = response {
                 let body = serde_json::to_vec(&response)?;
                 write_response(&mut stream, 200, "OK", "application/json", &body).await?;
@@ -779,15 +784,84 @@ async fn submit_to_helper(
     arguments: Value,
 ) -> Result<ProposalValidationResponse> {
     let started = std::time::Instant::now();
+    let (session_id, response) = forward_to_helper(
+        state,
+        capability,
+        arguments,
+        "request_terminal_actions",
+        crate::agent_tools::action_proposal::mcp::HELPER_REQUEST_METHOD,
+        HELPER_TIMEOUT,
+    )
+    .await?;
+    let response: ProposalValidationResponse =
+        serde_json::from_str(&response).context("decode Helper proposal response")?;
+    tracing::info!(
+        target: "proposal_mcp",
+        step = "helper→master",
+        op = "request_terminal_actions",
+        session_id = %session_id,
+        status = ?response.status,
+        retryable = response.retryable,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "terminal action MCP call completed"
+    );
+    Ok(response)
+}
+
+async fn submit_user_input_to_helper(
+    state: &MasterStateInner,
+    capability: CapabilityResolution,
+    arguments: Value,
+) -> Result<UserInputResponse> {
+    let request: UserInputRequest =
+        serde_json::from_value(arguments).context("decode user input request")?;
+    let request = request.validate().context("validate user input request")?;
+    let arguments = serde_json::to_value(request).context("encode user input request")?;
+    let started = std::time::Instant::now();
+    let (session_id, response) = forward_to_helper(
+        state,
+        capability,
+        arguments,
+        "request_user_input",
+        crate::agent_tools::action_proposal::mcp::USER_INPUT_HELPER_REQUEST_METHOD,
+        USER_INPUT_TIMEOUT,
+    )
+    .await?;
+    let response: UserInputResponse =
+        serde_json::from_str(&response).context("decode Helper user input response")?;
+    tracing::info!(
+        target: "proposal_mcp",
+        step = "helper→master",
+        op = "request_user_input",
+        session_id = %session_id,
+        outcome = match &response {
+            UserInputResponse::Answered { .. } => "answered",
+            UserInputResponse::Cancelled => "cancelled",
+        },
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "user input MCP call completed"
+    );
+    Ok(response)
+}
+
+async fn forward_to_helper(
+    state: &MasterStateInner,
+    capability: CapabilityResolution,
+    arguments: Value,
+    op: &'static str,
+    helper_method: &'static str,
+    timeout: Duration,
+) -> Result<(acp::schema::v1::SessionId, String)> {
+    let started = std::time::Instant::now();
     let session_id = match capability {
         CapabilityResolution::Bound(session_id) => session_id,
         CapabilityResolution::Pending => {
             tracing::warn!(
                 target: "proposal_mcp",
                 step = "master→helper",
-                op = "request_terminal_actions",
+                op,
                 stage = "resolve_capability",
-                "terminal action MCP call rejected because its ACP session is not bound"
+                "MCP call rejected because its ACP session is not bound"
             );
             anyhow::bail!("ACP session is not bound yet");
         }
@@ -795,9 +869,9 @@ async fn submit_to_helper(
             tracing::warn!(
                 target: "proposal_mcp",
                 step = "master→helper",
-                op = "request_terminal_actions",
+                op,
                 stage = "resolve_capability",
-                "terminal action MCP call rejected because its capability is unknown"
+                "MCP call rejected because its capability is unknown"
             );
             anyhow::bail!("MCP capability is unknown");
         }
@@ -810,10 +884,10 @@ async fn submit_to_helper(
         tracing::warn!(
             target: "proposal_mcp",
             step = "master→helper",
-            op = "request_terminal_actions",
+            op,
             stage = "resolve_helper",
             session_id = %session_id,
-            "terminal action MCP call rejected because its owning Helper is disconnected"
+            "MCP call rejected because its owning Helper is disconnected"
         );
         anyhow::bail!("owning Helper is disconnected");
     };
@@ -821,11 +895,11 @@ async fn submit_to_helper(
         tracing::error!(
             target: "proposal_mcp",
             step = "master→helper",
-            op = "request_terminal_actions",
+            op,
             stage = "resolve_helper",
             helper_id = ?route.helper_id,
             session_id = %session_id,
-            "terminal action MCP route has no Helper forwarder"
+            "MCP route has no Helper forwarder"
         );
         anyhow::bail!("owning Helper route has no forwarder");
     };
@@ -833,41 +907,37 @@ async fn submit_to_helper(
         session_id: session_id.to_string(),
         arguments,
     })
-    .context("encode Helper proposal request")?;
-    let request = acp::schema::v1::ExtRequest::new(
-        crate::agent_tools::action_proposal::mcp::HELPER_REQUEST_METHOD,
-        params.into(),
-    );
+    .context("encode Helper request")?;
+    let request = acp::schema::v1::ExtRequest::new(helper_method, params.into());
     tracing::info!(
         target: "proposal_mcp",
         step = "master→helper",
-        op = "request_terminal_actions",
+        op,
         helper_id = ?route.helper_id,
         session_id = %session_id,
-        "routing terminal action request to owning Helper"
+        "routing MCP request to owning Helper"
     );
-    let response = match tokio::time::timeout(HELPER_TIMEOUT, forwarder.ext_method(request)).await {
+    let response = match tokio::time::timeout(timeout, forwarder.ext_method(request)).await {
         Ok(Ok(response)) => response,
         Ok(Err(error)) => {
             tracing::warn!(
                 target: "proposal_mcp",
                 step = "helper→master",
-                op = "request_terminal_actions",
+                op,
                 stage = "helper_rpc",
                 helper_id = ?route.helper_id,
                 session_id = %session_id,
                 elapsed_ms = started.elapsed().as_millis() as u64,
                 error_code = ?error.code,
-                "owning Helper rejected terminal action request"
+                "owning Helper rejected MCP request"
             );
-            return Err(anyhow::Error::new(error)
-                .context("owning Helper rejected terminal action request"));
+            return Err(anyhow::Error::new(error).context("owning Helper rejected MCP request"));
         }
         Err(_) => {
             tracing::warn!(
                 target: "proposal_mcp",
                 step = "helper→master",
-                op = "request_terminal_actions",
+                op,
                 stage = "helper_rpc",
                 helper_id = ?route.helper_id,
                 session_id = %session_id,
@@ -877,34 +947,7 @@ async fn submit_to_helper(
             anyhow::bail!("timed out waiting for owning Helper");
         }
     };
-    let response: ProposalValidationResponse = match serde_json::from_str(response.0.get()) {
-        Ok(response) => response,
-        Err(error) => {
-            tracing::warn!(
-                target: "proposal_mcp",
-                step = "helper→master",
-                op = "request_terminal_actions",
-                stage = "decode_response",
-                helper_id = ?route.helper_id,
-                session_id = %session_id,
-                elapsed_ms = started.elapsed().as_millis() as u64,
-                "failed to decode Helper terminal action response"
-            );
-            return Err(error).context("decode Helper proposal response");
-        }
-    };
-    tracing::info!(
-        target: "proposal_mcp",
-        step = "helper→master",
-        op = "request_terminal_actions",
-        helper_id = ?route.helper_id,
-        session_id = %session_id,
-        status = ?response.status,
-        retryable = response.retryable,
-        elapsed_ms = started.elapsed().as_millis() as u64,
-        "terminal action MCP call completed"
-    );
-    Ok(response)
+    Ok((session_id, response.0.get().to_string()))
 }
 
 struct HttpRequest {

--- a/tools/wta/src/master/proposal_mcp.rs
+++ b/tools/wta/src/master/proposal_mcp.rs
@@ -747,7 +747,7 @@ async fn serve_connection(
                     op = "tools/call",
                     session_id = session_id.as_deref(),
                     capability_bound = session_id.is_some(),
-                    "received terminal action MCP call"
+                    "received session MCP call"
                 );
             }
             let action_capability = capability.clone();

--- a/tools/wta/src/master/session_mcp.rs
+++ b/tools/wta/src/master/session_mcp.rs
@@ -11,18 +11,21 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use super::{AgentInstanceId, MasterStateInner};
+use super::{AgentInstanceId, HelperId, MasterStateInner};
 use crate::agent_source::AgentSource;
-use crate::agent_tools::action_proposal::mcp::{
-    HelperRequest, SERVER_ID_HEX_LEN, SERVER_NAME_PREFIX,
-};
 use crate::agent_tools::action_proposal::pipe::ProposalValidationResponse;
+use crate::agent_tools::session_mcp::{
+    CancelUserInputHelperRequest, HelperRequest, UserInputHelperRequest, SERVER_ID_HEX_LEN,
+    SERVER_NAME_PREFIX,
+};
 use crate::agent_tools::user_input::{UserInputRequest, UserInputResponse};
+use crate::protocol::acp::conn;
 
 const ENDPOINT_PATH: &str = "/mcp";
 const MAX_HEADER_BYTES: usize = 32 * 1024;
 const MAX_BODY_BYTES: usize = 1024 * 1024;
 const MAX_CONNECTIONS: usize = 32;
+const MAX_USER_INPUT_CONNECTIONS: usize = 32;
 const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 const HELPER_TIMEOUT: Duration = Duration::from_secs(25);
 const USER_INPUT_TIMEOUT: Duration = Duration::from_secs(10 * 60);
@@ -33,6 +36,7 @@ const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 const WSL_RELAY_SCRIPT: &str = r#"
 import base64
+import json
 import os
 import socket
 import socketserver
@@ -45,6 +49,7 @@ UPSTREAM_HOST = sys.argv[1]
 UPSTREAM_PORT = sys.argv[2]
 LISTEN_PORT = int(sys.argv[3])
 MAX_CONNECTIONS = 32
+MAX_USER_INPUT_CONNECTIONS = 32
 READ_TIMEOUT_SECONDS = 5
 POWERSHELL = r'''
 __D__client = [Net.Sockets.TcpClient]::new()
@@ -119,18 +124,37 @@ def read_request(sock):
         if not chunk:
             raise ValueError("client disconnected before HTTP body")
         body += chunk
-    return b"\r\n".join(rewritten) + b"\r\n\r\n" + body[:content_length]
+    body = body[:content_length]
+    is_user_input = False
+    try:
+        message = json.loads(body.decode("utf-8"))
+        is_user_input = (
+            message.get("method") == "tools/call" and
+            message.get("params", {}).get("name") == "request_user_input")
+    except (UnicodeDecodeError, json.JSONDecodeError, AttributeError):
+        pass
+    return b"\r\n".join(rewritten) + b"\r\n\r\n" + body, is_user_input
 
 class Handler(socketserver.BaseRequestHandler):
     def handle(self):
         self.request.settimeout(READ_TIMEOUT_SECONDS)
+        if not self.server.read_slots.acquire(blocking=False):
+            send_response(self.request, 503, "Service Unavailable", "relay is busy")
+            return
         try:
-            request = read_request(self.request)
+            request, is_user_input = read_request(self.request)
         except socket.timeout:
             send_response(self.request, 408, "Request Timeout", "request timed out")
             return
         except (OSError, ValueError):
             send_response(self.request, 400, "Bad Request", "invalid HTTP request")
+            return
+        finally:
+            self.server.read_slots.release()
+        slots = (self.server.user_input_slots if is_user_input
+                 else self.server.request_slots)
+        if not slots.acquire(blocking=False):
+            send_response(self.request, 503, "Service Unavailable", "relay is busy")
             return
         try:
             response = forward(request)
@@ -140,6 +164,8 @@ class Handler(socketserver.BaseRequestHandler):
         except (OSError, RuntimeError):
             send_response(self.request, 502, "Bad Gateway", "Windows bridge failed")
             return
+        finally:
+            slots.release()
         self.request.sendall(response)
 
 class Server(socketserver.ThreadingTCPServer):
@@ -148,25 +174,11 @@ class Server(socketserver.ThreadingTCPServer):
     request_queue_size = MAX_CONNECTIONS
 
     def __init__(self, server_address, handler):
-        self.connection_slots = threading.BoundedSemaphore(MAX_CONNECTIONS)
+        self.read_slots = threading.BoundedSemaphore(MAX_CONNECTIONS)
+        self.request_slots = threading.BoundedSemaphore(MAX_CONNECTIONS)
+        self.user_input_slots = threading.BoundedSemaphore(
+            MAX_USER_INPUT_CONNECTIONS)
         super().__init__(server_address, handler)
-
-    def process_request(self, request, client_address):
-        if not self.connection_slots.acquire(blocking=False):
-            send_response(request, 503, "Service Unavailable", "relay is busy")
-            self.shutdown_request(request)
-            return
-        try:
-            super().process_request(request, client_address)
-        except Exception:
-            self.connection_slots.release()
-            raise
-
-    def process_request_thread(self, request, client_address):
-        try:
-            super().process_request_thread(request, client_address)
-        finally:
-            self.connection_slots.release()
 
 def exit_when_owner_disconnects():
     try:
@@ -229,6 +241,7 @@ pub(super) struct PendingCapability {
 #[derive(Default)]
 pub(super) struct CapabilityRegistry {
     routes: Mutex<CapabilityRoutes>,
+    active_user_inputs: Arc<std::sync::Mutex<HashSet<acp::schema::v1::SessionId>>>,
 }
 
 #[derive(Default)]
@@ -241,6 +254,19 @@ struct CapabilityRoutes {
 struct CapabilityRoute {
     session_id: Option<acp::schema::v1::SessionId>,
     owner: AgentInstanceId,
+}
+
+struct UserInputLease {
+    active: Arc<std::sync::Mutex<HashSet<acp::schema::v1::SessionId>>>,
+    session_id: acp::schema::v1::SessionId,
+}
+
+impl Drop for UserInputLease {
+    fn drop(&mut self) {
+        if let Ok(mut active) = self.active.lock() {
+            active.remove(&self.session_id);
+        }
+    }
 }
 
 impl CapabilityRegistry {
@@ -324,6 +350,24 @@ impl CapabilityRegistry {
         }
     }
 
+    fn try_begin_user_input(
+        &self,
+        session_id: acp::schema::v1::SessionId,
+    ) -> Result<UserInputLease> {
+        let mut active = self
+            .active_user_inputs
+            .lock()
+            .map_err(|_| anyhow::anyhow!("user input request registry is unavailable"))?;
+        if !active.insert(session_id.clone()) {
+            anyhow::bail!("this ACP session already has a pending user input request");
+        }
+        drop(active);
+        Ok(UserInputLease {
+            active: Arc::clone(&self.active_user_inputs),
+            session_id,
+        })
+    }
+
     fn remove_capability(routes: &mut CapabilityRoutes, hash: &[u8; 32]) {
         let Some(route) = routes.by_capability.remove(hash) else {
             return;
@@ -352,6 +396,48 @@ enum CapabilityResolution {
     Unknown,
 }
 
+struct UserInputForwardGuard {
+    forwarder: conn::AgentLink,
+    cancel_request: Option<acp::schema::v1::ExtRequest>,
+}
+
+impl UserInputForwardGuard {
+    fn new(
+        forwarder: conn::AgentLink,
+        request_id: &str,
+        session_id: &acp::schema::v1::SessionId,
+    ) -> Result<Self> {
+        let params = serde_json::value::to_raw_value(&CancelUserInputHelperRequest {
+            request_id: request_id.to_string(),
+            session_id: session_id.to_string(),
+        })
+        .context("encode Helper user input cancellation")?;
+        Ok(Self {
+            forwarder,
+            cancel_request: Some(acp::schema::v1::ExtRequest::new(
+                crate::agent_tools::session_mcp::CANCEL_USER_INPUT_HELPER_REQUEST_METHOD,
+                params.into(),
+            )),
+        })
+    }
+
+    fn disarm(&mut self) {
+        self.cancel_request = None;
+    }
+}
+
+impl Drop for UserInputForwardGuard {
+    fn drop(&mut self) {
+        let Some(request) = self.cancel_request.take() else {
+            return;
+        };
+        let forwarder = self.forwarder.clone();
+        tokio::task::spawn_local(async move {
+            let _ = forwarder.ext_method(request).await;
+        });
+    }
+}
+
 pub(super) fn server_config(
     endpoint: &str,
     pending: &PendingCapability,
@@ -368,11 +454,11 @@ pub(super) async fn endpoint_for(
     source: &AgentSource,
 ) -> Result<String> {
     let AgentSource::Wsl { distro } = source else {
-        return Ok(state.proposal_mcp_endpoints.host.clone());
+        return Ok(state.session_mcp_endpoints.host.clone());
     };
 
     let relay_slot = {
-        let mut relays = state.proposal_mcp_endpoints.wsl.lock().await;
+        let mut relays = state.session_mcp_endpoints.wsl.lock().await;
         Arc::clone(
             relays
                 .entry(distro.clone())
@@ -388,21 +474,16 @@ pub(super) async fn endpoint_for(
     }
 
     let upstream = state
-        .proposal_mcp_endpoints
+        .session_mcp_endpoints
         .host
         .strip_prefix("http://")
         .and_then(|value| value.strip_suffix(ENDPOINT_PATH))
-        .context("proposal MCP host endpoint is malformed")?;
+        .context("session MCP host endpoint is malformed")?;
     let (upstream_host, upstream_port) = upstream
         .rsplit_once(':')
-        .context("proposal MCP host endpoint has no port")?;
-    let relay = start_wsl_relay(
-        distro,
-        upstream_host,
-        upstream_port,
-        slot.port.unwrap_or(0),
-    )
-    .await?;
+        .context("session MCP host endpoint has no port")?;
+    let relay =
+        start_wsl_relay(distro, upstream_host, upstream_port, slot.port.unwrap_or(0)).await?;
     let endpoint = relay.endpoint.clone();
     slot.port = Some(relay.port);
     slot.relay = Some(relay);
@@ -448,11 +529,11 @@ async fn start_wsl_relay(
 
     let mut child = command
         .spawn()
-        .with_context(|| format!("start proposal MCP relay in WSL distro {distro}"))?;
+        .with_context(|| format!("start session MCP relay in WSL distro {distro}"))?;
     let stdout = child
         .stdout
         .take()
-        .context("WSL proposal MCP relay has no stdout")?;
+        .context("WSL session MCP relay has no stdout")?;
     let mut stdout = tokio::io::BufReader::new(stdout);
     let mut port = String::new();
     tokio::time::timeout(
@@ -460,21 +541,21 @@ async fn start_wsl_relay(
         tokio::io::AsyncBufReadExt::read_line(&mut stdout, &mut port),
     )
     .await
-    .with_context(|| format!("timed out starting proposal MCP relay in {distro}"))?
-    .with_context(|| format!("read proposal MCP relay port from {distro}"))?;
+    .with_context(|| format!("timed out starting session MCP relay in {distro}"))?
+    .with_context(|| format!("read session MCP relay port from {distro}"))?;
     let port = port
         .trim()
         .parse::<u16>()
-        .with_context(|| format!("invalid proposal MCP relay port from {distro}"))?;
+        .with_context(|| format!("invalid session MCP relay port from {distro}"))?;
     if child.try_wait()?.is_some() {
-        anyhow::bail!("proposal MCP relay exited during startup in {distro}");
+        anyhow::bail!("session MCP relay exited during startup in {distro}");
     }
     let endpoint = format!("http://127.0.0.1:{port}{ENDPOINT_PATH}");
     tracing::info!(
-        target: "proposal_mcp",
+        target: "session_mcp",
         distro,
         endpoint = %endpoint,
-        "WSL proposal MCP loopback relay ready"
+        "WSL session MCP loopback relay ready"
     );
     Ok(WslRelay {
         endpoint,
@@ -505,19 +586,19 @@ fn spawn_wsl_relay_supervisor(
                     }
                     Ok(Some(status)) => {
                         tracing::warn!(
-                            target: "proposal_mcp",
+                            target: "session_mcp",
                             distro = %distro,
                             ?status,
-                            "WSL proposal MCP relay exited; restarting on the same port"
+                            "WSL session MCP relay exited; restarting on the same port"
                         );
                         true
                     }
                     Err(error) => {
                         tracing::warn!(
-                            target: "proposal_mcp",
+                            target: "session_mcp",
                             distro = %distro,
                             %error,
-                            "failed to inspect WSL proposal MCP relay; restarting on the same port"
+                            "failed to inspect WSL session MCP relay; restarting on the same port"
                         );
                         true
                     }
@@ -536,21 +617,21 @@ fn spawn_wsl_relay_supervisor(
                     slot.relay = Some(relay);
                     retry_delay = Duration::from_secs(1);
                     tracing::info!(
-                        target: "proposal_mcp",
+                        target: "session_mcp",
                         distro = %distro,
                         port,
-                        "WSL proposal MCP relay restarted"
+                        "WSL session MCP relay restarted"
                     );
                 }
                 Err(error) => {
                     retry_delay = (retry_delay * 2).min(Duration::from_secs(30));
                     tracing::warn!(
-                        target: "proposal_mcp",
+                        target: "session_mcp",
                         distro = %distro,
                         port,
                         retry_secs = retry_delay.as_secs(),
                         error = %format!("{error:#}"),
-                        "failed to restart WSL proposal MCP relay"
+                        "failed to restart WSL session MCP relay"
                     );
                 }
             }
@@ -559,41 +640,41 @@ fn spawn_wsl_relay_supervisor(
 }
 
 pub(super) async fn run(listener: TcpListener, state: Arc<MasterStateInner>) -> Result<()> {
-    let address = listener.local_addr().context("read proposal MCP address")?;
+    let address = listener.local_addr().context("read session MCP address")?;
     tracing::info!(
-        target: "proposal_mcp",
+        target: "session_mcp",
         address = %address,
-        "master proposal MCP HTTP endpoint listening"
+        "master session MCP HTTP endpoint listening"
     );
     let connections = Arc::new(tokio::sync::Semaphore::new(MAX_CONNECTIONS));
+    let user_input_connections = Arc::new(tokio::sync::Semaphore::new(MAX_USER_INPUT_CONNECTIONS));
     loop {
-        let (stream, peer) = listener
-            .accept()
-            .await
-            .context("accept proposal MCP HTTP")?;
+        let (stream, peer) = listener.accept().await.context("accept session MCP HTTP")?;
         if !peer.ip().is_loopback() {
             tracing::warn!(
-                target: "proposal_mcp",
+                target: "session_mcp",
                 peer = %peer,
-                "rejecting non-loopback proposal MCP connection"
+                "rejecting non-loopback session MCP connection"
             );
             continue;
         }
         let Ok(permit) = Arc::clone(&connections).try_acquire_owned() else {
             tracing::warn!(
-                target: "proposal_mcp",
-                "rejecting proposal MCP connection at concurrency limit"
+                target: "session_mcp",
+                "rejecting session MCP connection at concurrency limit"
             );
             continue;
         };
         let state = Arc::clone(&state);
+        let user_input_connections = Arc::clone(&user_input_connections);
         tokio::task::spawn_local(async move {
-            let _permit = permit;
-            if let Err(error) = serve_connection(stream, address, state).await {
+            if let Err(error) =
+                serve_connection(stream, address, state, permit, user_input_connections).await
+            {
                 tracing::debug!(
-                    target: "proposal_mcp",
+                    target: "session_mcp",
                     error = %format!("{error:#}"),
-                    "proposal MCP HTTP connection failed"
+                    "session MCP HTTP connection failed"
                 );
             }
         });
@@ -604,7 +685,10 @@ async fn serve_connection(
     mut stream: TcpStream,
     address: std::net::SocketAddr,
     state: Arc<MasterStateInner>,
+    connection_permit: tokio::sync::OwnedSemaphorePermit,
+    user_input_connections: Arc<tokio::sync::Semaphore>,
 ) -> Result<()> {
+    let mut connection_permit = Some(connection_permit);
     let request = match tokio::time::timeout(HTTP_REQUEST_TIMEOUT, read_request(&mut stream)).await
     {
         Ok(Ok(request)) => request,
@@ -669,7 +753,7 @@ async fn serve_connection(
         .await?;
         return Ok(());
     };
-    let capability = state.proposal_mcp_capabilities.resolve(secret).await;
+    let capability = state.session_mcp_capabilities.resolve(secret).await;
     if matches!(capability, CapabilityResolution::Unknown) {
         write_response(
             &mut stream,
@@ -724,17 +808,34 @@ async fn serve_connection(
             let message: Value = match serde_json::from_slice(&request.body) {
                 Ok(message) => message,
                 Err(_) => {
-                    let body = serde_json::to_vec(
-                        &crate::agent_tools::action_proposal::mcp::error_response(
+                    let body =
+                        serde_json::to_vec(&crate::agent_tools::session_mcp::error_response(
                             Value::Null,
                             -32700,
                             "parse error",
-                        ),
-                    )?;
+                        ))?;
                     write_response(&mut stream, 400, "Bad Request", "application/json", &body)
                         .await?;
                     return Ok(());
                 }
+            };
+            let is_user_input = is_user_input_call(&message);
+            let _user_input_permit = if is_user_input {
+                connection_permit.take();
+                let Ok(permit) = user_input_connections.try_acquire_owned() else {
+                    write_response(
+                        &mut stream,
+                        503,
+                        "Service Unavailable",
+                        "text/plain",
+                        b"too many pending user input requests",
+                    )
+                    .await?;
+                    return Ok(());
+                };
+                Some(permit)
+            } else {
+                None
             };
             if message.get("method").and_then(Value::as_str) == Some("tools/call") {
                 let session_id = match &capability {
@@ -742,7 +843,7 @@ async fn serve_connection(
                     CapabilityResolution::Pending | CapabilityResolution::Unknown => None,
                 };
                 tracing::info!(
-                    target: "proposal_mcp",
+                    target: "session_mcp",
                     step = "agent→master",
                     op = "tools/call",
                     session_id = session_id.as_deref(),
@@ -751,12 +852,36 @@ async fn serve_connection(
                 );
             }
             let action_capability = capability.clone();
-            let response = crate::agent_tools::action_proposal::mcp::dispatch(
+            let response = crate::agent_tools::session_mcp::dispatch(
                 message,
                 |arguments| submit_to_helper(&state, action_capability, arguments),
                 |arguments| submit_user_input_to_helper(&state, capability, arguments),
-            )
-            .await;
+            );
+            let response = if is_user_input {
+                tokio::pin!(response);
+                let mut unexpected = [0u8; 1];
+                tokio::select! {
+                    response = &mut response => response,
+                    read = stream.read(&mut unexpected) => {
+                        match read {
+                            Ok(0) | Err(_) => return Ok(()),
+                            Ok(_) => {
+                                write_response(
+                                    &mut stream,
+                                    400,
+                                    "Bad Request",
+                                    "text/plain",
+                                    b"HTTP pipelining is not supported",
+                                )
+                                .await?;
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+            } else {
+                response.await
+            };
             if let Some(response) = response {
                 let body = serde_json::to_vec(&response)?;
                 write_response(&mut stream, 200, "OK", "application/json", &body).await?;
@@ -778,6 +903,11 @@ async fn serve_connection(
     Ok(())
 }
 
+fn is_user_input_call(message: &Value) -> bool {
+    message.get("method").and_then(Value::as_str) == Some("tools/call")
+        && message.pointer("/params/name").and_then(Value::as_str) == Some("request_user_input")
+}
+
 async fn submit_to_helper(
     state: &MasterStateInner,
     capability: CapabilityResolution,
@@ -789,14 +919,14 @@ async fn submit_to_helper(
         capability,
         arguments,
         "request_terminal_actions",
-        crate::agent_tools::action_proposal::mcp::HELPER_REQUEST_METHOD,
+        crate::agent_tools::session_mcp::HELPER_REQUEST_METHOD,
         HELPER_TIMEOUT,
     )
     .await?;
     let response: ProposalValidationResponse =
         serde_json::from_str(&response).context("decode Helper proposal response")?;
     tracing::info!(
-        target: "proposal_mcp",
+        target: "session_mcp",
         step = "helper→master",
         op = "request_terminal_actions",
         session_id = %session_id,
@@ -816,24 +946,78 @@ async fn submit_user_input_to_helper(
     let request: UserInputRequest =
         serde_json::from_value(arguments).context("decode user input request")?;
     let request = request.validate().context("validate user input request")?;
-    let arguments = serde_json::to_value(request).context("encode user input request")?;
     let started = std::time::Instant::now();
-    let (session_id, response) = forward_to_helper(
-        state,
-        capability,
-        arguments,
-        "request_user_input",
-        crate::agent_tools::action_proposal::mcp::USER_INPUT_HELPER_REQUEST_METHOD,
-        USER_INPUT_TIMEOUT,
-    )
-    .await?;
-    let response: UserInputResponse =
-        serde_json::from_str(&response).context("decode Helper user input response")?;
+    let (session_id, helper_id, forwarder) =
+        resolve_helper(state, capability, "request_user_input").await?;
+    let _lease = state
+        .session_mcp_capabilities
+        .try_begin_user_input(session_id.clone())?;
+    let request_id = Uuid::new_v4().simple().to_string();
+    let params = serde_json::value::to_raw_value(&UserInputHelperRequest {
+        request_id: request_id.clone(),
+        session_id: session_id.to_string(),
+        request,
+    })
+    .context("encode Helper user input request")?;
+    let helper_request = acp::schema::v1::ExtRequest::new(
+        crate::agent_tools::session_mcp::USER_INPUT_HELPER_REQUEST_METHOD,
+        params.into(),
+    );
+    let mut cancel_guard = UserInputForwardGuard::new(forwarder.clone(), &request_id, &session_id)?;
     tracing::info!(
-        target: "proposal_mcp",
+        target: "session_mcp",
+        step = "master→helper",
+        op = "request_user_input",
+        helper_id = ?helper_id,
+        session_id = %session_id,
+        request_id = %request_id,
+        "routing user input request to owning Helper"
+    );
+    let helper_response = match tokio::time::timeout(
+        USER_INPUT_TIMEOUT,
+        forwarder.ext_method(helper_request),
+    )
+    .await
+    {
+        Ok(Ok(response)) => response,
+        Ok(Err(error)) => {
+            tracing::warn!(
+                target: "session_mcp",
+                step = "helper→master",
+                op = "request_user_input",
+                helper_id = ?helper_id,
+                session_id = %session_id,
+                request_id = %request_id,
+                error_code = ?error.code,
+                "owning Helper rejected user input request"
+            );
+            return Err(
+                anyhow::Error::new(error).context("owning Helper rejected user input request")
+            );
+        }
+        Err(_) => {
+            tracing::warn!(
+                target: "session_mcp",
+                step = "helper→master",
+                op = "request_user_input",
+                helper_id = ?helper_id,
+                session_id = %session_id,
+                request_id = %request_id,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "timed out waiting for user input"
+            );
+            anyhow::bail!("timed out waiting for user input");
+        }
+    };
+    let response: UserInputResponse = serde_json::from_str(helper_response.0.get())
+        .context("decode Helper user input response")?;
+    cancel_guard.disarm();
+    tracing::info!(
+        target: "session_mcp",
         step = "helper→master",
         op = "request_user_input",
         session_id = %session_id,
+        request_id = %request_id,
         outcome = match &response {
             UserInputResponse::Answered { .. } => "answered",
             UserInputResponse::Cancelled => "cancelled",
@@ -844,20 +1028,16 @@ async fn submit_user_input_to_helper(
     Ok(response)
 }
 
-async fn forward_to_helper(
+async fn resolve_helper(
     state: &MasterStateInner,
     capability: CapabilityResolution,
-    arguments: Value,
     op: &'static str,
-    helper_method: &'static str,
-    timeout: Duration,
-) -> Result<(acp::schema::v1::SessionId, String)> {
-    let started = std::time::Instant::now();
+) -> Result<(acp::schema::v1::SessionId, HelperId, conn::AgentLink)> {
     let session_id = match capability {
         CapabilityResolution::Bound(session_id) => session_id,
         CapabilityResolution::Pending => {
             tracing::warn!(
-                target: "proposal_mcp",
+                target: "session_mcp",
                 step = "master→helper",
                 op,
                 stage = "resolve_capability",
@@ -867,7 +1047,7 @@ async fn forward_to_helper(
         }
         CapabilityResolution::Unknown => {
             tracing::warn!(
-                target: "proposal_mcp",
+                target: "session_mcp",
                 step = "master→helper",
                 op,
                 stage = "resolve_capability",
@@ -882,7 +1062,7 @@ async fn forward_to_helper(
     };
     let Some(route) = route else {
         tracing::warn!(
-            target: "proposal_mcp",
+            target: "session_mcp",
             step = "master→helper",
             op,
             stage = "resolve_helper",
@@ -893,7 +1073,7 @@ async fn forward_to_helper(
     };
     let Some(forwarder) = route.forwarder else {
         tracing::error!(
-            target: "proposal_mcp",
+            target: "session_mcp",
             step = "master→helper",
             op,
             stage = "resolve_helper",
@@ -903,6 +1083,19 @@ async fn forward_to_helper(
         );
         anyhow::bail!("owning Helper route has no forwarder");
     };
+    Ok((session_id, route.helper_id, forwarder))
+}
+
+async fn forward_to_helper(
+    state: &MasterStateInner,
+    capability: CapabilityResolution,
+    arguments: Value,
+    op: &'static str,
+    helper_method: &'static str,
+    timeout: Duration,
+) -> Result<(acp::schema::v1::SessionId, String)> {
+    let started = std::time::Instant::now();
+    let (session_id, helper_id, forwarder) = resolve_helper(state, capability, op).await?;
     let params = serde_json::value::to_raw_value(&HelperRequest {
         session_id: session_id.to_string(),
         arguments,
@@ -910,10 +1103,10 @@ async fn forward_to_helper(
     .context("encode Helper request")?;
     let request = acp::schema::v1::ExtRequest::new(helper_method, params.into());
     tracing::info!(
-        target: "proposal_mcp",
+        target: "session_mcp",
         step = "master→helper",
         op,
-        helper_id = ?route.helper_id,
+        helper_id = ?helper_id,
         session_id = %session_id,
         "routing MCP request to owning Helper"
     );
@@ -921,11 +1114,11 @@ async fn forward_to_helper(
         Ok(Ok(response)) => response,
         Ok(Err(error)) => {
             tracing::warn!(
-                target: "proposal_mcp",
+                target: "session_mcp",
                 step = "helper→master",
                 op,
                 stage = "helper_rpc",
-                helper_id = ?route.helper_id,
+                helper_id = ?helper_id,
                 session_id = %session_id,
                 elapsed_ms = started.elapsed().as_millis() as u64,
                 error_code = ?error.code,
@@ -935,11 +1128,11 @@ async fn forward_to_helper(
         }
         Err(_) => {
             tracing::warn!(
-                target: "proposal_mcp",
+                target: "session_mcp",
                 step = "helper→master",
                 op,
                 stage = "helper_rpc",
-                helper_id = ?route.helper_id,
+                helper_id = ?helper_id,
                 session_id = %session_id,
                 elapsed_ms = started.elapsed().as_millis() as u64,
                 "timed out waiting for owning Helper"
@@ -1127,6 +1320,16 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn user_input_lease_allows_only_one_request_per_session() {
+        let registry = CapabilityRegistry::default();
+        let session_id = acp::schema::v1::SessionId::new("session");
+        let lease = registry.try_begin_user_input(session_id.clone()).unwrap();
+        assert!(registry.try_begin_user_input(session_id.clone()).is_err());
+        drop(lease);
+        assert!(registry.try_begin_user_input(session_id).is_ok());
+    }
+
     #[tokio::test]
     async fn server_configs_isolate_session_identity_and_capability() {
         let registry = CapabilityRegistry::default();
@@ -1134,28 +1337,26 @@ mod tests {
         let other = registry.prepare(AgentInstanceId::new_v4(), None).await;
         let config = server_config("http://127.0.0.1:4321/mcp", &pending);
         let acp::schema::v1::McpServer::Http(config) = config else {
-            panic!("proposal MCP must use HTTP");
+            panic!("session MCP must use HTTP");
         };
         let other_config = server_config("http://127.0.0.1:4321/mcp", &other);
         let acp::schema::v1::McpServer::Http(other_config) = other_config else {
-            panic!("proposal MCP must use HTTP");
+            panic!("session MCP must use HTTP");
         };
         let repeated = server_config("http://127.0.0.1:4321/mcp", &pending);
         let acp::schema::v1::McpServer::Http(repeated) = repeated else {
-            panic!("proposal MCP must use HTTP");
+            panic!("session MCP must use HTTP");
         };
         assert_ne!(config.name, other_config.name);
         assert_eq!(config.name, repeated.name);
         let server_id = config
             .name
             .strip_prefix("intellterm_")
-            .expect("proposal MCP server name must use the reserved prefix");
+            .expect("session MCP server name must use the reserved prefix");
         assert_eq!(server_id.len(), 20);
-        assert!(
-            server_id
-                .chars()
-                .all(|ch| ch.is_ascii_digit() || ('a'..='f').contains(&ch))
-        );
+        assert!(server_id
+            .chars()
+            .all(|ch| ch.is_ascii_digit() || ('a'..='f').contains(&ch)));
         assert!(format!("mcp__{}__request_terminal_actions", config.name).len() <= 64);
         assert!(!config.name.contains(&pending.secret));
         assert_eq!(config.url, "http://127.0.0.1:4321/mcp");
@@ -1176,10 +1377,7 @@ mod tests {
         let retained = registry.prepare(retained_owner, None).await;
         assert!(
             registry
-                .bind(
-                    &removed,
-                    acp::schema::v1::SessionId::new("removed-session")
-                )
+                .bind(&removed, acp::schema::v1::SessionId::new("removed-session"))
                 .await
         );
         assert!(

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -140,7 +140,7 @@ async fn delayed_clean_probe_does_not_block_initialize_and_notifies_bound_helper
             );
             assert!(
                 wta_meta.proposal_mcp.is_none(),
-                "unavailable proposal MCP must not be advertised"
+                "unavailable session MCP must not be advertised"
             );
 
             let mut response = initialize_response_for_agent(&agent, true)
@@ -151,7 +151,7 @@ async fn delayed_clean_probe_does_not_block_initialize_and_notifies_bound_helper
                     .proposal_mcp
                     .as_deref(),
                 Some("http-v1"),
-                "reachable proposal MCP must be advertised to the Helper"
+                "reachable session MCP must be advertised to the Helper"
             );
 
             assert!(complete_tx
@@ -541,10 +541,10 @@ fn pool_key_dedupes_same_selection_and_separates_distinct_agents() {
 fn make_state() -> Arc<MasterStateInner> {
     Arc::new(MasterStateInner {
         session_to_helper: Mutex::new(HashMap::new()),
-        proposal_mcp_endpoints: proposal_mcp::Endpoints::new(
+        session_mcp_endpoints: session_mcp::Endpoints::new(
             "http://127.0.0.1:1/mcp".to_string(),
         ),
-        proposal_mcp_capabilities: proposal_mcp::CapabilityRegistry::default(),
+        session_mcp_capabilities: session_mcp::CapabilityRegistry::default(),
         pending_usage: Mutex::new(HashMap::new()),
         usage_generation: watch::channel(0u64).0,
         registry: crate::session_registry::InMemoryRegistry::shared(),
@@ -1020,11 +1020,11 @@ async fn stale_reaper_revokes_only_dead_agent_capabilities() {
     let dead_instance = AgentInstanceId::new_v4();
     let replacement_instance = AgentInstanceId::new_v4();
     state
-        .proposal_mcp_capabilities
+        .session_mcp_capabilities
         .prepare(dead_instance, None)
         .await;
     state
-        .proposal_mcp_capabilities
+        .session_mcp_capabilities
         .prepare(replacement_instance, None)
         .await;
 
@@ -1041,7 +1041,7 @@ async fn stale_reaper_revokes_only_dead_agent_capabilities() {
     );
     assert_eq!(
         state
-            .proposal_mcp_capabilities
+            .session_mcp_capabilities
             .remove_owner(dead_instance)
             .await,
         0,
@@ -1049,7 +1049,7 @@ async fn stale_reaper_revokes_only_dead_agent_capabilities() {
     );
     assert_eq!(
         state
-            .proposal_mcp_capabilities
+            .session_mcp_capabilities
             .remove_owner(replacement_instance)
             .await,
         1,
@@ -2197,10 +2197,10 @@ impl crate::shell::wt_channel::WtChannel for MockWtChannel {
 fn make_state_with_wt(wt: Arc<dyn crate::shell::wt_channel::WtChannel>) -> Arc<MasterStateInner> {
     Arc::new(MasterStateInner {
         session_to_helper: Mutex::new(HashMap::new()),
-        proposal_mcp_endpoints: proposal_mcp::Endpoints::new(
+        session_mcp_endpoints: session_mcp::Endpoints::new(
             "http://127.0.0.1:1/mcp".to_string(),
         ),
-        proposal_mcp_capabilities: proposal_mcp::CapabilityRegistry::default(),
+        session_mcp_capabilities: session_mcp::CapabilityRegistry::default(),
         pending_usage: Mutex::new(HashMap::new()),
         usage_generation: watch::channel(0u64).0,
         registry: crate::session_registry::InMemoryRegistry::shared(),

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1583,6 +1583,39 @@ impl WtaClient {
         Ok(acp::schema::v1::ExtResponse::new(raw.into()))
     }
 
+    async fn request_user_input(
+        &self,
+        args: acp::schema::v1::ExtRequest,
+    ) -> acp::Result<acp::schema::v1::ExtResponse> {
+        let helper_request: crate::agent_tools::action_proposal::mcp::HelperRequest =
+            serde_json::from_str(args.params.get()).map_err(|error| {
+                acp::Error::invalid_params()
+                    .data(format!("invalid user input request parameters: {error}"))
+            })?;
+        let request: crate::agent_tools::user_input::UserInputRequest =
+            serde_json::from_value(helper_request.arguments)
+                .map_err(|error| acp::Error::invalid_params().data(error.to_string()))?;
+        let request = request
+            .validate()
+            .map_err(|error| acp::Error::invalid_params().data(error.to_string()))?;
+        let (responder, response) = tokio::sync::oneshot::channel();
+        self.state
+            .event_tx
+            .send(AppEvent::UserInputRequest {
+                session_id: helper_request.session_id,
+                request,
+                responder,
+            })
+            .map_err(|_| acp::Error::internal_error().data("Helper UI is unavailable"))?;
+        let response = response
+            .await
+            .unwrap_or(crate::agent_tools::user_input::UserInputResponse::Cancelled);
+        let raw = serde_json::value::to_raw_value(&response).map_err(|error| {
+            acp::Error::internal_error().data(format!("encode user input response: {error}"))
+        })?;
+        Ok(acp::schema::v1::ExtResponse::new(raw.into()))
+    }
+
     /// Receive `intellterm.wta/session_{added,removed}` notifications
     /// pushed by master so the helper's local `alive` mirror stays in
     /// sync without polling. We translate to an `AppEvent` rather than
@@ -2182,6 +2215,18 @@ pub async fn run_acp_client_over_pipe(
                                 conn::respond_enum(
                                     responder,
                                     c.request_terminal_actions(a)
+                                        .await
+                                        .map(R::ExtMethodResponse),
+                                )
+                            }
+                            Q::ExtMethodRequest(a)
+                                if crate::agent_tools::action_proposal::mcp::user_input_helper_method_matches(
+                                    &a.method,
+                                ) =>
+                            {
+                                conn::respond_enum(
+                                    responder,
+                                    c.request_user_input(a)
                                         .await
                                         .map(R::ExtMethodResponse),
                                 )

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -374,7 +374,7 @@ struct ClientState {
     provider_probe_capture: ProviderProbeCapture,
     standard_usage_sessions: Mutex<HashSet<String>>,
     proposal_channels: Arc<crate::agent_tools::action_proposal::channel::ProposalChannelManager>,
-    hidden_tool_calls: std::sync::Mutex<HashSet<(String, String)>>,
+    hidden_tool_calls: std::sync::Mutex<HashMap<(String, String), SessionMcpTool>>,
 }
 
 #[derive(Default)]
@@ -414,6 +414,43 @@ impl ProviderProbeCapture {
 #[derive(Clone)]
 struct WtaClient {
     state: Arc<ClientState>,
+}
+
+struct UserInputUiGuard {
+    event_tx: mpsc::UnboundedSender<AppEvent>,
+    request_id: String,
+    session_id: String,
+    armed: bool,
+}
+
+impl UserInputUiGuard {
+    fn new(
+        event_tx: mpsc::UnboundedSender<AppEvent>,
+        request_id: String,
+        session_id: String,
+    ) -> Self {
+        Self {
+            event_tx,
+            request_id,
+            session_id,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for UserInputUiGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = self.event_tx.send(AppEvent::CancelUserInputRequest {
+                request_id: self.request_id.clone(),
+                session_id: self.session_id.clone(),
+            });
+        }
+    }
 }
 
 /// Maximum characters kept in a tool-call `location` hint before truncation.
@@ -705,41 +742,79 @@ fn proposal_command_candidate(raw_input: Option<&serde_json::Value>) -> Option<&
     raw_input?.as_object()?.get("command")?.as_str()
 }
 
-fn is_proposal_mcp_server_name(name: &str) -> bool {
-    crate::agent_tools::action_proposal::mcp::server_name_matches(name)
+fn is_session_mcp_server_name(name: &str) -> bool {
+    crate::agent_tools::session_mcp::server_name_matches(name)
 }
 
-fn is_proposal_mcp_tool_title(title: Option<&str>) -> bool {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionMcpTool {
+    TerminalActions,
+    UserInput,
+}
+
+impl SessionMcpTool {
+    fn name(self) -> &'static str {
+        match self {
+            Self::TerminalActions => "request_terminal_actions",
+            Self::UserInput => "request_user_input",
+        }
+    }
+}
+
+fn session_mcp_tool_from_title(title: Option<&str>) -> Option<SessionMcpTool> {
     let Some(title) = title.map(str::trim) else {
-        return false;
+        return None;
     };
     let title = title.strip_prefix("Use MCP tool: ").unwrap_or(title);
-    if let Some(server_name) = title.strip_suffix("/request_terminal_actions") {
-        return is_proposal_mcp_server_name(server_name);
+    for tool in [SessionMcpTool::TerminalActions, SessionMcpTool::UserInput] {
+        for separator in ["/", "-"] {
+            if let Some(server_name) = title.strip_suffix(&format!("{separator}{}", tool.name())) {
+                if is_session_mcp_server_name(server_name) {
+                    return Some(tool);
+                }
+            }
+        }
+        if title
+            .strip_prefix("mcp__")
+            .and_then(|title| title.strip_suffix(&format!("__{}", tool.name())))
+            .is_some_and(is_session_mcp_server_name)
+        {
+            return Some(tool);
+        }
     }
-    if let Some(server_name) = title.strip_suffix("-request_terminal_actions") {
-        return is_proposal_mcp_server_name(server_name);
-    }
-    title
-        .strip_prefix("mcp__")
-        .and_then(|title| title.strip_suffix("__request_terminal_actions"))
-        .is_some_and(is_proposal_mcp_server_name)
+    None
 }
 
-fn is_proposal_mcp_tool_call(title: Option<&str>, raw_input: Option<&serde_json::Value>) -> bool {
-    if is_proposal_mcp_tool_title(title) {
-        return true;
+fn session_mcp_tool_call(
+    title: Option<&str>,
+    raw_input: Option<&serde_json::Value>,
+) -> Option<SessionMcpTool> {
+    if let Some(tool) = session_mcp_tool_from_title(title) {
+        return Some(tool);
     }
-    if title.map(str::trim) != Some("request_terminal_actions") {
-        return false;
-    }
-    let Some(raw_input) = raw_input else {
-        return false;
+    let tool = match title.map(str::trim) {
+        Some("request_terminal_actions") => SessionMcpTool::TerminalActions,
+        Some("request_user_input") => SessionMcpTool::UserInput,
+        _ => return None,
     };
-    serde_json::to_vec(raw_input).is_ok_and(|payload| {
-        crate::agent_tools::action_proposal::schema::parse_mcp_proposal_payload(&payload, false)
-            .is_ok()
-    })
+    let Some(raw_input) = raw_input else {
+        return None;
+    };
+    let valid = match tool {
+        SessionMcpTool::TerminalActions => serde_json::to_vec(raw_input).is_ok_and(|payload| {
+            crate::agent_tools::action_proposal::schema::parse_mcp_proposal_payload(&payload, false)
+                .is_ok()
+        }),
+        SessionMcpTool::UserInput => serde_json::from_value::<
+            crate::agent_tools::user_input::UserInputRequest,
+        >(raw_input.clone())
+        .is_ok_and(|request| request.validate().is_ok()),
+    };
+    if valid {
+        Some(tool)
+    } else {
+        None
+    }
 }
 
 fn looks_like_proposal_command(command: &str) -> bool {
@@ -823,24 +898,34 @@ impl WtaClient {
         }
     }
 
-    fn hide_proposal_tool_call(&self, session_id: &str, tool_call_id: &str) {
+    fn hide_session_mcp_tool_call(
+        &self,
+        session_id: &str,
+        tool_call_id: &str,
+        tool: SessionMcpTool,
+    ) {
         self.state
             .hidden_tool_calls
             .lock()
             .unwrap()
-            .insert((session_id.to_string(), tool_call_id.to_string()));
+            .insert((session_id.to_string(), tool_call_id.to_string()), tool);
         let _ = self.state.event_tx.send(AppEvent::HideToolCall {
             session_id: session_id.to_string(),
             id: tool_call_id.to_string(),
         });
     }
 
-    fn tool_call_is_hidden(&self, session_id: &str, tool_call_id: &str) -> bool {
+    fn hidden_session_mcp_tool(
+        &self,
+        session_id: &str,
+        tool_call_id: &str,
+    ) -> Option<SessionMcpTool> {
         self.state
             .hidden_tool_calls
             .lock()
             .unwrap()
-            .contains(&(session_id.to_string(), tool_call_id.to_string()))
+            .get(&(session_id.to_string(), tool_call_id.to_string()))
+            .copied()
     }
 
     async fn request_permission(
@@ -856,12 +941,19 @@ impl WtaClient {
         let session_id = args.session_id.0.to_string();
         let tool_call_id = args.tool_call.tool_call_id.to_string();
         let proposal_candidate = proposal_permission_command_candidate(&args);
-        let proposal_mcp_tool = is_proposal_mcp_tool_call(
+        let session_mcp_tool = session_mcp_tool_call(
             args.tool_call.fields.title.as_deref(),
             args.tool_call.fields.raw_input.as_ref(),
-        ) || self.tool_call_is_hidden(&session_id, &tool_call_id);
-        if proposal_mcp_tool || proposal_candidate.is_some_and(looks_like_proposal_command) {
-            self.hide_proposal_tool_call(&session_id, &tool_call_id);
+        )
+        .or_else(|| self.hidden_session_mcp_tool(&session_id, &tool_call_id));
+        if let Some(tool) = session_mcp_tool {
+            self.hide_session_mcp_tool_call(&session_id, &tool_call_id, tool);
+        } else if proposal_candidate.is_some_and(looks_like_proposal_command) {
+            self.hide_session_mcp_tool_call(
+                &session_id,
+                &tool_call_id,
+                SessionMcpTool::TerminalActions,
+            );
         }
         let title = args
             .tool_call
@@ -889,7 +981,7 @@ impl WtaClient {
             .prompt_timing
             .permission_requested(&session_id, &description);
 
-        if proposal_mcp_tool {
+        if let Some(tool) = session_mcp_tool {
             let Some(option) = args
                 .options
                 .iter()
@@ -902,28 +994,32 @@ impl WtaClient {
                     acp::schema::v1::RequestPermissionOutcome::Cancelled,
                 ));
             };
-            let permission_result = self
-                .state
-                .proposal_channels
-                .validate_mcp_permission(&session_id);
+            let permission_result = match tool {
+                SessionMcpTool::TerminalActions => self
+                    .state
+                    .proposal_channels
+                    .validate_mcp_permission(&session_id),
+                SessionMcpTool::UserInput => Ok(()),
+            };
             tracing::info!(
-                target: "proposal_permission",
+                target: "session_mcp_permission",
                 session_id = %session_id,
+                tool = tool.name(),
                 approved = permission_result.is_ok(),
                 status = ?permission_result.as_ref().err().map(|failure| failure.status),
-                "silently resolving proposal MCP permission"
+                "silently resolving session MCP permission"
             );
             if permission_result.is_err() {
                 self.state
                     .prompt_timing
-                    .permission_resolved(&session_id, "proposal_permission_rejected");
+                    .permission_resolved(&session_id, "session_mcp_permission_rejected");
                 return Ok(acp::schema::v1::RequestPermissionResponse::new(
                     acp::schema::v1::RequestPermissionOutcome::Cancelled,
                 ));
             }
             self.state
                 .prompt_timing
-                .permission_resolved(&session_id, "proposal_allow_once");
+                .permission_resolved(&session_id, "session_mcp_allow_once");
             return Ok(acp::schema::v1::RequestPermissionResponse::new(
                 acp::schema::v1::RequestPermissionOutcome::Selected(
                     acp::schema::v1::SelectedPermissionOutcome::new(option.option_id.clone()),
@@ -1115,14 +1211,23 @@ impl WtaClient {
             }
             acp::schema::v1::SessionUpdate::ToolCall(tool_call) => {
                 let tool_call_id = tool_call.tool_call_id.to_string();
-                if is_proposal_mcp_tool_call(Some(&tool_call.title), tool_call.raw_input.as_ref())
-                    || proposal_command_candidate(tool_call.raw_input.as_ref())
-                        .is_some_and(looks_like_proposal_command)
+                if let Some(tool) =
+                    session_mcp_tool_call(Some(&tool_call.title), tool_call.raw_input.as_ref())
                 {
-                    self.hide_proposal_tool_call(&sid, &tool_call_id);
+                    self.hide_session_mcp_tool_call(&sid, &tool_call_id, tool);
                     return Ok(());
                 }
-                if self.tool_call_is_hidden(&sid, &tool_call_id) {
+                if proposal_command_candidate(tool_call.raw_input.as_ref())
+                    .is_some_and(looks_like_proposal_command)
+                {
+                    self.hide_session_mcp_tool_call(
+                        &sid,
+                        &tool_call_id,
+                        SessionMcpTool::TerminalActions,
+                    );
+                    return Ok(());
+                }
+                if self.hidden_session_mcp_tool(&sid, &tool_call_id).is_some() {
                     return Ok(());
                 }
                 self.state
@@ -1151,17 +1256,24 @@ impl WtaClient {
             }
             acp::schema::v1::SessionUpdate::ToolCallUpdate(update) => {
                 let tool_call_id = update.tool_call_id.to_string();
-                if is_proposal_mcp_tool_call(
+                if let Some(tool) = session_mcp_tool_call(
                     update.fields.title.as_deref(),
                     update.fields.raw_input.as_ref(),
-                )
-                    || proposal_command_candidate(update.fields.raw_input.as_ref())
-                        .is_some_and(looks_like_proposal_command)
-                {
-                    self.hide_proposal_tool_call(&sid, &tool_call_id);
+                ) {
+                    self.hide_session_mcp_tool_call(&sid, &tool_call_id, tool);
                     return Ok(());
                 }
-                if self.tool_call_is_hidden(&sid, &tool_call_id) {
+                if proposal_command_candidate(update.fields.raw_input.as_ref())
+                    .is_some_and(looks_like_proposal_command)
+                {
+                    self.hide_session_mcp_tool_call(
+                        &sid,
+                        &tool_call_id,
+                        SessionMcpTool::TerminalActions,
+                    );
+                    return Ok(());
+                }
+                if self.hidden_session_mcp_tool(&sid, &tool_call_id).is_some() {
                     return Ok(());
                 }
                 // Failed updates frequently carry a `raw_output.message`
@@ -1437,7 +1549,7 @@ impl WtaClient {
             ValidationPhase,
         };
 
-        let request: crate::agent_tools::action_proposal::mcp::HelperRequest =
+        let request: crate::agent_tools::session_mcp::HelperRequest =
             serde_json::from_str(args.params.get()).map_err(|error| {
                 acp::Error::invalid_params().data(format!(
                     "invalid terminal action request parameters: {error}"
@@ -1587,21 +1699,25 @@ impl WtaClient {
         &self,
         args: acp::schema::v1::ExtRequest,
     ) -> acp::Result<acp::schema::v1::ExtResponse> {
-        let helper_request: crate::agent_tools::action_proposal::mcp::HelperRequest =
+        let helper_request: crate::agent_tools::session_mcp::UserInputHelperRequest =
             serde_json::from_str(args.params.get()).map_err(|error| {
                 acp::Error::invalid_params()
                     .data(format!("invalid user input request parameters: {error}"))
             })?;
-        let request: crate::agent_tools::user_input::UserInputRequest =
-            serde_json::from_value(helper_request.arguments)
-                .map_err(|error| acp::Error::invalid_params().data(error.to_string()))?;
-        let request = request
+        let request = helper_request
+            .request
             .validate()
             .map_err(|error| acp::Error::invalid_params().data(error.to_string()))?;
         let (responder, response) = tokio::sync::oneshot::channel();
+        let mut guard = UserInputUiGuard::new(
+            self.state.event_tx.clone(),
+            helper_request.request_id.clone(),
+            helper_request.session_id.clone(),
+        );
         self.state
             .event_tx
             .send(AppEvent::UserInputRequest {
+                request_id: helper_request.request_id,
                 session_id: helper_request.session_id,
                 request,
                 responder,
@@ -1610,10 +1726,35 @@ impl WtaClient {
         let response = response
             .await
             .unwrap_or(crate::agent_tools::user_input::UserInputResponse::Cancelled);
+        guard.disarm();
         let raw = serde_json::value::to_raw_value(&response).map_err(|error| {
             acp::Error::internal_error().data(format!("encode user input response: {error}"))
         })?;
         Ok(acp::schema::v1::ExtResponse::new(raw.into()))
+    }
+
+    async fn cancel_user_input(
+        &self,
+        args: acp::schema::v1::ExtRequest,
+    ) -> acp::Result<acp::schema::v1::ExtResponse> {
+        let request: crate::agent_tools::session_mcp::CancelUserInputHelperRequest =
+            serde_json::from_str(args.params.get()).map_err(|error| {
+                acp::Error::invalid_params().data(format!(
+                    "invalid user input cancellation parameters: {error}"
+                ))
+            })?;
+        self.state
+            .event_tx
+            .send(AppEvent::CancelUserInputRequest {
+                request_id: request.request_id,
+                session_id: request.session_id,
+            })
+            .map_err(|_| acp::Error::internal_error().data("Helper UI is unavailable"))?;
+        Ok(acp::schema::v1::ExtResponse::new(
+            serde_json::value::RawValue::from_string("{}".to_string())
+                .map_err(|error| acp::Error::internal_error().data(error.to_string()))?
+                .into(),
+        ))
     }
 
     /// Receive `intellterm.wta/session_{added,removed}` notifications
@@ -2161,7 +2302,7 @@ pub async fn run_acp_client_over_pipe(
         provider_probe_capture: ProviderProbeCapture::default(),
         standard_usage_sessions: Mutex::new(HashSet::new()),
         proposal_channels: Arc::clone(&proposal_channels),
-        hidden_tool_calls: std::sync::Mutex::new(std::collections::HashSet::new()),
+        hidden_tool_calls: std::sync::Mutex::new(std::collections::HashMap::new()),
     });
 
     let client = WtaClient {
@@ -2208,7 +2349,7 @@ pub async fn run_acp_client_over_pipe(
                                 c.kill_terminal(a).await.map(R::KillTerminalResponse),
                             ),
                             Q::ExtMethodRequest(a)
-                                if crate::agent_tools::action_proposal::mcp::helper_method_matches(
+                                if crate::agent_tools::session_mcp::helper_method_matches(
                                     &a.method,
                                 ) =>
                             {
@@ -2220,13 +2361,25 @@ pub async fn run_acp_client_over_pipe(
                                 )
                             }
                             Q::ExtMethodRequest(a)
-                                if crate::agent_tools::action_proposal::mcp::user_input_helper_method_matches(
+                                if crate::agent_tools::session_mcp::user_input_helper_method_matches(
                                     &a.method,
                                 ) =>
                             {
                                 conn::respond_enum(
                                     responder,
                                     c.request_user_input(a)
+                                        .await
+                                        .map(R::ExtMethodResponse),
+                                )
+                            }
+                            Q::ExtMethodRequest(a)
+                                if crate::agent_tools::session_mcp::cancel_user_input_helper_method_matches(
+                                    &a.method,
+                                ) =>
+                            {
+                                conn::respond_enum(
+                                    responder,
+                                    c.cancel_user_input(a)
                                         .await
                                         .map(R::ExtMethodResponse),
                                 )
@@ -3909,15 +4062,15 @@ mod tests {
     use super::acp;
     use super::{
         acp_result_failure_fields, bounded_tool_output_parts, complete_prompt_request,
-        inject_wta_pane_meta, is_proposal_mcp_tool_title, is_redundant_startup_model_error,
-        post_login_authenticate_error,
+        inject_wta_pane_meta, is_redundant_startup_model_error, post_login_authenticate_error,
+        session_mcp_tool_from_title, SessionMcpTool,
         timeout_result_failure_fields, tool_call_exit_code, tool_call_kind_label, ClientState,
         PromptTimingState, PromptUsageIdentity, SoftStopReason, WtaClient,
     };
     use crate::app_contracts::AppEvent;
     use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
     use crate::shell::ShellManager;
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::sync::{Arc, Mutex};
     use tokio::sync::mpsc;
 
@@ -4010,7 +4163,7 @@ mod tests {
             provider_probe_capture: super::ProviderProbeCapture::default(),
             standard_usage_sessions: Mutex::new(HashSet::new()),
             proposal_channels: manager,
-            hidden_tool_calls: Mutex::new(HashSet::new()),
+            hidden_tool_calls: Mutex::new(HashMap::new()),
         });
         (WtaClient { state }, event_rx)
     }
@@ -4099,6 +4252,155 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn user_input_mcp_permission_is_silent() {
+        use acp::schema::v1::{
+            PermissionOption, PermissionOptionKind, RequestPermissionRequest, ToolCallId,
+            ToolCallUpdate, ToolCallUpdateFields,
+        };
+
+        let manager =
+            Arc::new(crate::agent_tools::action_proposal::channel::ProposalChannelManager::new());
+        let (client, mut event_rx) = proposal_test_client(manager);
+        let response = client
+            .request_permission(RequestPermissionRequest::new(
+                acp::schema::v1::SessionId::new("input-session"),
+                ToolCallUpdate::new(
+                    ToolCallId::new("input-tool"),
+                    ToolCallUpdateFields::new()
+                        .title("request_user_input")
+                        .raw_input(serde_json::json!({
+                            "question": "Choose",
+                            "choices": ["A", "B"]
+                        })),
+                ),
+                vec![PermissionOption::new(
+                    "allow-once",
+                    "Allow once",
+                    PermissionOptionKind::AllowOnce,
+                )],
+            ))
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            response.outcome,
+            acp::schema::v1::RequestPermissionOutcome::Selected(_)
+        ));
+        assert!(matches!(
+            event_rx.try_recv(),
+            Ok(AppEvent::HideToolCall { session_id, id })
+                if session_id == "input-session" && id == "input-tool"
+        ));
+        assert!(event_rx.try_recv().is_err());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dropped_user_input_extension_cancels_its_modal() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let manager = Arc::new(
+                    crate::agent_tools::action_proposal::channel::ProposalChannelManager::new(),
+                );
+                let (client, mut event_rx) = proposal_test_client(manager);
+                let params = serde_json::value::to_raw_value(
+                    &crate::agent_tools::session_mcp::UserInputHelperRequest {
+                        request_id: "request-1".into(),
+                        session_id: "input-session".into(),
+                        request: crate::agent_tools::user_input::UserInputRequest {
+                            question: "Choose".into(),
+                            choices: vec!["A".into()],
+                            allow_freeform: false,
+                        },
+                    },
+                )
+                .unwrap();
+                let task = tokio::task::spawn_local(async move {
+                    client
+                        .request_user_input(acp::schema::v1::ExtRequest::new(
+                            crate::agent_tools::session_mcp::USER_INPUT_HELPER_REQUEST_METHOD,
+                            params.into(),
+                        ))
+                        .await
+                });
+
+                assert!(matches!(
+                    event_rx.recv().await,
+                    Some(AppEvent::UserInputRequest {
+                        request_id,
+                        session_id,
+                        ..
+                    }) if request_id == "request-1" && session_id == "input-session"
+                ));
+                task.abort();
+                let _ = task.await;
+                assert!(matches!(
+                    event_rx.recv().await,
+                    Some(AppEvent::CancelUserInputRequest {
+                        request_id,
+                        session_id,
+                    }) if request_id == "request-1" && session_id == "input-session"
+                ));
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn user_input_extension_returns_the_modal_answer() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let manager = Arc::new(
+                    crate::agent_tools::action_proposal::channel::ProposalChannelManager::new(),
+                );
+                let (client, mut event_rx) = proposal_test_client(manager);
+                let params = serde_json::value::to_raw_value(
+                    &crate::agent_tools::session_mcp::UserInputHelperRequest {
+                        request_id: "request-2".into(),
+                        session_id: "input-session".into(),
+                        request: crate::agent_tools::user_input::UserInputRequest {
+                            question: "Choose".into(),
+                            choices: vec!["A".into(), "B".into()],
+                            allow_freeform: false,
+                        },
+                    },
+                )
+                .unwrap();
+                let task = tokio::task::spawn_local(async move {
+                    client
+                        .request_user_input(acp::schema::v1::ExtRequest::new(
+                            crate::agent_tools::session_mcp::USER_INPUT_HELPER_REQUEST_METHOD,
+                            params.into(),
+                        ))
+                        .await
+                });
+
+                let responder = match event_rx.recv().await {
+                    Some(AppEvent::UserInputRequest { responder, .. }) => responder,
+                    _ => panic!("expected user input request"),
+                };
+                responder
+                    .send(
+                        crate::agent_tools::user_input::UserInputResponse::Answered {
+                            answer: "B".into(),
+                            selected_index: Some(1),
+                        },
+                    )
+                    .unwrap();
+                let response = task.await.unwrap().unwrap();
+                let decoded: crate::agent_tools::user_input::UserInputResponse =
+                    serde_json::from_str(response.0.get()).unwrap();
+                assert_eq!(
+                    decoded,
+                    crate::agent_tools::user_input::UserInputResponse::Answered {
+                        answer: "B".into(),
+                        selected_index: Some(1),
+                    }
+                );
+                assert!(event_rx.try_recv().is_err());
+            })
+            .await;
+    }
+
+    #[tokio::test]
     async fn proposal_mcp_extension_validates_and_commits_on_the_owning_helper() {
         let manager =
             Arc::new(crate::agent_tools::action_proposal::channel::ProposalChannelManager::new());
@@ -4106,19 +4408,18 @@ mod tests {
             .issue("proposal-session".into(), 1, None, false)
             .unwrap();
         let (client, mut event_rx) = proposal_test_client(Arc::clone(&manager));
-        let params = serde_json::value::to_raw_value(
-            &crate::agent_tools::action_proposal::mcp::HelperRequest {
+        let params =
+            serde_json::value::to_raw_value(&crate::agent_tools::session_mcp::HelperRequest {
                 session_id: "proposal-session".to_string(),
                 arguments: serde_json::json!({
                     "type": "send",
                     "title": "Run test",
                     "input": "cargo test"
                 }),
-            },
-        )
-        .unwrap();
+            })
+            .unwrap();
         let request = acp::schema::v1::ExtRequest::new(
-            crate::agent_tools::action_proposal::mcp::HELPER_REQUEST_METHOD,
+            crate::agent_tools::session_mcp::HELPER_REQUEST_METHOD,
             params.into(),
         );
 
@@ -4311,29 +4612,32 @@ mod tests {
     }
 
     #[test]
-    fn proposal_mcp_tool_title_accepts_copilot_http_permission_shape() {
+    fn session_mcp_tool_title_accepts_supported_permission_shapes() {
         let dynamic = "intellterm_01234567890123456789";
-        assert!(is_proposal_mcp_tool_title(Some(
-            "Use MCP tool: intelligent_terminal/request_terminal_actions"
-        )));
-        assert!(is_proposal_mcp_tool_title(Some(
-            "intelligent_terminal-request_terminal_actions"
-        )));
-        assert!(is_proposal_mcp_tool_title(Some(&format!(
-            "Use MCP tool: {dynamic}/request_terminal_actions"
-        ))));
-        assert!(is_proposal_mcp_tool_title(Some(&format!(
-            "mcp__{dynamic}__request_terminal_actions"
-        ))));
-        assert!(!is_proposal_mcp_tool_title(Some(
-            "intellterm_0123456789abcdef/request_terminal_actions"
-        )));
-        assert!(!is_proposal_mcp_tool_title(Some(
-            "intellterm_0123456789012345678A/request_terminal_actions"
-        )));
-        assert!(!is_proposal_mcp_tool_title(Some(
-            "Use MCP tool: other/request_terminal_actions"
-        )));
+        for title in [
+            "Use MCP tool: intelligent_terminal/request_terminal_actions".to_string(),
+            "intelligent_terminal-request_terminal_actions".to_string(),
+            format!("Use MCP tool: {dynamic}/request_terminal_actions"),
+            format!("mcp__{dynamic}__request_terminal_actions"),
+        ] {
+            assert_eq!(
+                session_mcp_tool_from_title(Some(&title)),
+                Some(SessionMcpTool::TerminalActions)
+            );
+        }
+        assert_eq!(
+            session_mcp_tool_from_title(Some(&format!(
+                "Use MCP tool: {dynamic}/request_user_input"
+            ))),
+            Some(SessionMcpTool::UserInput)
+        );
+        for title in [
+            "intellterm_0123456789abcdef/request_terminal_actions",
+            "intellterm_0123456789012345678A/request_terminal_actions",
+            "Use MCP tool: other/request_terminal_actions",
+        ] {
+            assert_eq!(session_mcp_tool_from_title(Some(title)), None);
+        }
     }
 
     /// Regression for the cross-window focus bug: the helper-over-pipe
@@ -4639,7 +4943,7 @@ mod tests {
                 proposal_channels: Arc::new(
                     crate::agent_tools::action_proposal::channel::ProposalChannelManager::new(),
                 ),
-                hidden_tool_calls: std::sync::Mutex::new(std::collections::HashSet::new()),
+                hidden_tool_calls: std::sync::Mutex::new(std::collections::HashMap::new()),
             });
             (WtaClient { state }, rx)
         }

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -332,7 +332,7 @@ fn connect_with(
         proposal_channels: Arc::new(
             crate::agent_tools::action_proposal::channel::ProposalChannelManager::new(),
         ),
-        hidden_tool_calls: Mutex::new(HashSet::new()),
+        hidden_tool_calls: Mutex::new(HashMap::new()),
     });
     let wta = WtaClient { state };
 
@@ -678,7 +678,7 @@ fn connect_for_dispatch(behavior: MockBehavior) -> DispatchHarness {
         provider_probe_capture: ProviderProbeCapture::default(),
         standard_usage_sessions: Mutex::new(HashSet::new()),
         proposal_channels: Arc::clone(&proposal_channels),
-        hidden_tool_calls: Mutex::new(HashSet::new()),
+        hidden_tool_calls: Mutex::new(HashMap::new()),
     });
     let wta = WtaClient { state };
 
@@ -1772,7 +1772,7 @@ fn bare_client() -> (WtaClient, mpsc::UnboundedReceiver<AppEvent>) {
         proposal_channels: Arc::new(
             crate::agent_tools::action_proposal::channel::ProposalChannelManager::new(),
         ),
-        hidden_tool_calls: Mutex::new(HashSet::new()),
+        hidden_tool_calls: Mutex::new(HashMap::new()),
     });
     (WtaClient { state }, event_rx)
 }
@@ -2144,7 +2144,7 @@ async fn session_notification_hides_proposal_mcp_tool_call() {
     ));
     assert!(
         rx.try_recv().is_err(),
-        "proposal MCP ToolCall must not reach the chat UI"
+        "session MCP ToolCall must not reach the chat UI"
     );
 }
 

--- a/tools/wta/src/protocol/acp/prompt.rs
+++ b/tools/wta/src/protocol/acp/prompt.rs
@@ -276,6 +276,8 @@ mod tests {
             assert!(!prompt.contains("```json"));
         }
         assert!(EMBEDDED_DEFAULT_PROMPT.contains("Submit exactly one action"));
+        assert!(EMBEDDED_DEFAULT_PROMPT.contains("`request_user_input`"));
+        assert!(EMBEDDED_DEFAULT_PROMPT.contains("instead of guessing"));
         assert!(EMBEDDED_AUTOFIX_PROMPT.contains("Submit exactly one `send` action"));
     }
 

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -3,7 +3,7 @@ use ratatui::prelude::*;
 
 use super::{
     action_panel, agent_popup, agents_view, auth, chat, command_popup, debug_panel, input,
-    model_popup, permission, recommendations, setup,
+    model_popup, permission, recommendations, setup, user_input,
 };
 
 pub fn render(frame: &mut Frame, app: &mut App) {
@@ -260,6 +260,10 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     // `/help` overlay sits on top of everything so the user can always
     // dismiss it with Esc.
     command_popup::render_help_overlay(frame, app, area);
+
+    if let Some(request) = app.current_tab().user_input.front() {
+        user_input::render(frame, request, chunks[7]);
+    }
 }
 
 /// Truncate `s` so its rendered (display-cell) width fits in `max` columns,

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -257,13 +257,13 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         agent_popup::render_popup(frame, agent_state, chunks[7]);
     }
 
-    // `/help` overlay sits on top of everything so the user can always
-    // dismiss it with Esc.
-    command_popup::render_help_overlay(frame, app, area);
-
     if let Some(request) = app.current_tab().user_input.front() {
         user_input::render(frame, request, chunks[7]);
     }
+
+    // `/help` overlay sits on top of everything so the user can always
+    // dismiss it with Esc.
+    command_popup::render_help_overlay(frame, app, area);
 }
 
 /// Truncate `s` so its rendered (display-cell) width fits in `max` columns,

--- a/tools/wta/src/ui/mod.rs
+++ b/tools/wta/src/ui/mod.rs
@@ -15,6 +15,7 @@ mod popup;
 mod recommendations;
 pub mod setup;
 pub mod shimmer;
+mod user_input;
 
 pub use agent_popup::AgentPopupState;
 pub use command_popup::{PopupCandidates, PopupState};

--- a/tools/wta/src/ui/user_input.rs
+++ b/tools/wta/src/ui/user_input.rs
@@ -1,5 +1,6 @@
 use ratatui::prelude::*;
-use ratatui::widgets::{Clear, Paragraph, Wrap};
+use ratatui::widgets::{Clear, Paragraph};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::app::UserInputState;
 use crate::theme;
@@ -23,29 +24,66 @@ pub fn render(frame: &mut Frame, request: &UserInputState, input_area: Rect) {
         return;
     }
 
-    let mut lines = vec![
-        Line::styled(request.request.question.as_str(), theme::INPUT_TEXT),
-        Line::from(""),
-    ];
+    let [body, hint] = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(inner);
+    let (lines, selected_start, selected_end) = content_lines(request, body.width as usize);
+    let visible_rows = body.height as usize;
+    let scroll = if selected_end > visible_rows {
+        selected_end.saturating_sub(visible_rows)
+    } else {
+        selected_start.min(lines.len().saturating_sub(visible_rows))
+    };
+
+    frame.render_widget(
+        Paragraph::new(lines).scroll((scroll.min(u16::MAX as usize) as u16, 0)),
+        body,
+    );
+    frame.render_widget(
+        Paragraph::new(Line::styled("↑ ↓   ↵   Esc", theme::DIM)),
+        hint,
+    );
+}
+
+fn content_lines(request: &UserInputState, width: usize) -> (Vec<Line<'static>>, usize, usize) {
+    let mut lines = wrap_text(&request.request.question, width)
+        .into_iter()
+        .map(|line| Line::styled(line, theme::INPUT_TEXT))
+        .collect::<Vec<_>>();
+    lines.push(Line::from(""));
+    let mut selected_start = 0;
+    let mut selected_end = 1;
+
     for (index, choice) in request.request.choices.iter().enumerate() {
-        let marker = if request.selected == index { "● " } else { "○ " };
+        let selected = request.selected == index;
+        let marker = if selected { "● " } else { "○ " };
         let style = if request.selected == index {
             theme::SELECTED
         } else {
             theme::INPUT_TEXT
         };
-        lines.push(Line::styled(format!("{marker}{choice}"), style));
+        let start = lines.len();
+        push_wrapped_option(&mut lines, marker, choice, width, style);
+        if selected {
+            selected_start = start;
+            selected_end = lines.len();
+        }
     }
     if request.request.allow_freeform {
         let selected = request.freeform_selected();
         let marker = if selected { "● " } else { "○ " };
         let value = if request.input.is_empty() {
             "_".to_string()
-        } else if selected {
-            format!("{}█", request.input)
         } else {
-            request.input.clone()
+            tail_to_width(
+                &request.input,
+                width.saturating_sub(marker.width() + usize::from(selected)),
+            )
         };
+        let value = if selected {
+            format!("{value}█")
+        } else {
+            value
+        };
+        let start = lines.len();
         lines.push(Line::styled(
             format!("{marker}{value}"),
             if selected {
@@ -54,9 +92,107 @@ pub fn render(frame: &mut Frame, request: &UserInputState, input_area: Rect) {
                 theme::INPUT_TEXT
             },
         ));
+        if selected {
+            selected_start = start;
+            selected_end = lines.len();
+        }
     }
-    lines.push(Line::from(""));
-    lines.push(Line::styled("↑ ↓   ↵   Esc", theme::DIM));
+    (lines, selected_start, selected_end)
+}
 
-    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+fn push_wrapped_option(
+    lines: &mut Vec<Line<'static>>,
+    marker: &str,
+    value: &str,
+    width: usize,
+    style: Style,
+) {
+    let content_width = width.saturating_sub(marker.width()).max(1);
+    let wrapped = wrap_text(value, content_width);
+    for (index, line) in wrapped.into_iter().enumerate() {
+        let prefix = if index == 0 { marker } else { "  " };
+        lines.push(Line::styled(format!("{prefix}{line}"), style));
+    }
+}
+
+fn wrap_text(value: &str, width: usize) -> Vec<String> {
+    let width = width.max(1);
+    let mut output = Vec::new();
+    for source_line in value.split('\n') {
+        let mut line = String::new();
+        let mut line_width: usize = 0;
+        for character in source_line.chars() {
+            let character_width = UnicodeWidthChar::width(character).unwrap_or(0);
+            if line_width > 0 && line_width.saturating_add(character_width) > width {
+                output.push(std::mem::take(&mut line));
+                line_width = 0;
+            }
+            line.push(character);
+            line_width = line_width.saturating_add(character_width);
+        }
+        output.push(line);
+    }
+    output
+}
+
+fn tail_to_width(value: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    let mut kept = Vec::new();
+    let mut used: usize = 0;
+    let mut omitted = false;
+    for character in value.chars().rev() {
+        let character_width = UnicodeWidthChar::width(character).unwrap_or(0);
+        if used.saturating_add(character_width) > width {
+            omitted = true;
+            break;
+        }
+        kept.push(character);
+        used = used.saturating_add(character_width);
+    }
+    if omitted {
+        while used >= width {
+            let Some(character) = kept.pop() else {
+                break;
+            };
+            used = used.saturating_sub(UnicodeWidthChar::width(character).unwrap_or(0));
+        }
+        kept.push('…');
+    }
+    kept.into_iter().rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_tools::user_input::UserInputRequest;
+
+    fn state(selected: usize) -> UserInputState {
+        UserInputState {
+            request_id: "request".into(),
+            request: UserInputRequest {
+                question: "A long question that wraps".into(),
+                choices: vec!["first long choice".into(), "second long choice".into()],
+                allow_freeform: true,
+            },
+            selected,
+            input: "abcdefghijklmnopqrstuvwxyz".into(),
+            responder: None,
+        }
+    }
+
+    #[test]
+    fn selected_option_range_tracks_wrapped_rows() {
+        let (_, start, end) = content_lines(&state(1), 8);
+        assert!(end > start + 1);
+    }
+
+    #[test]
+    fn freeform_keeps_the_visible_tail_bounded() {
+        let visible = tail_to_width("abcdefghijklmnopqrstuvwxyz", 8);
+        assert!(visible.width() <= 8);
+        assert!(visible.starts_with('…'));
+        assert!(visible.ends_with('z'));
+    }
 }

--- a/tools/wta/src/ui/user_input.rs
+++ b/tools/wta/src/ui/user_input.rs
@@ -1,0 +1,62 @@
+use ratatui::prelude::*;
+use ratatui::widgets::{Clear, Paragraph, Wrap};
+
+use crate::app::UserInputState;
+use crate::theme;
+
+use super::popup;
+
+const MAX_VISIBLE_ROWS: u16 = 14;
+
+pub fn render(frame: &mut Frame, request: &UserInputState, input_area: Rect) {
+    let content_rows = (request.request.choices.len() as u16)
+        .saturating_add(u16::from(request.request.allow_freeform))
+        .saturating_add(4)
+        .min(MAX_VISIBLE_ROWS);
+    let area = popup::anchored_above(frame, input_area, content_rows);
+    frame.render_widget(Clear, area);
+
+    let block = popup::block(" ? ".to_string());
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if inner.is_empty() {
+        return;
+    }
+
+    let mut lines = vec![
+        Line::styled(request.request.question.as_str(), theme::INPUT_TEXT),
+        Line::from(""),
+    ];
+    for (index, choice) in request.request.choices.iter().enumerate() {
+        let marker = if request.selected == index { "● " } else { "○ " };
+        let style = if request.selected == index {
+            theme::SELECTED
+        } else {
+            theme::INPUT_TEXT
+        };
+        lines.push(Line::styled(format!("{marker}{choice}"), style));
+    }
+    if request.request.allow_freeform {
+        let selected = request.freeform_selected();
+        let marker = if selected { "● " } else { "○ " };
+        let value = if request.input.is_empty() {
+            "_".to_string()
+        } else if selected {
+            format!("{}█", request.input)
+        } else {
+            request.input.clone()
+        };
+        lines.push(Line::styled(
+            format!("{marker}{value}"),
+            if selected {
+                theme::SELECTED
+            } else {
+                theme::INPUT_TEXT
+            },
+        ));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::styled("↑ ↓   ↵   Esc", theme::DIM));
+
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+}


### PR DESCRIPTION
## Why
ACP only stabilized structured user input through `elicitation/create` on July 24, 2026, and agent-side adoption is still limited. In particular, two agents supported by Intelligent Terminal already have native clarification UI but do not currently expose it through standard ACP elicitation:

- **Copilot CLI** has a native `ask_user` flow, but its ACP mode does not emit standard elicitation; support remains tracked by [github/copilot-cli#2109](https://github.com/github/copilot-cli/issues/2109).
- **OpenCode** has internal `question.asked` / replied / rejected events, but its released/current adapter does not yet map that flow to ACP elicitation. The work is explicitly tracked by [issue #38121](https://github.com/anomalyco/opencode/issues/38121), and [PR #38311](https://github.com/anomalyco/opencode/pull/38311) implements the bridge, but remains open and unmerged as of August 12, 2026. The current adapter still has no elicitation handler ([source](https://github.com/anomalyco/opencode/blob/1f94d8a3c86b67f4f49a0e341de74e9188381b3a/packages/opencode/src/acp/service.ts#L52-L53)).

See the ACP announcement: [Elicitation is stabilized](https://agentclientprotocol.com/announcements/elicitation-stabilized).

Without a portable structured-input path, agents running inside Intelligent Terminal either avoid asking blocking clarification questions or fall back to unstructured chat text. This PR provides an immediately usable, provider-neutral session MCP action while ACP elicitation adoption catches up. It deliberately does **not** intercept, parse, or replace provider-native question tools.

## Summary
- add a generic Session MCP `request_user_input` tool for blocking choice and freeform questions
- route requests through the existing capability-bound master-to-helper path and render them in the owning tab
- cancel exact pending prompts on timeout, disconnect, or turn cancellation, with one active request per session
- keep modal focus and long-content rendering reliable while returning structured answered/cancelled results
- document that this is a WTA-owned fallback rather than a provider-specific bridge

<img width="1247" height="258" alt="request_user_input choice UI" src="https://github.com/user-attachments/assets/8f20220b-a2a7-4599-9649-2b0c68d74f9b" />

## Validation
- `cargo test --manifest-path tools\wta\Cargo.toml` (1464 passed)
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools\wta\Cargo.toml`
- `cmd.exe /c "tools\razzle.cmd && bcz no_clean"`
- deployed and launched the Debug package successfully
