### PR TITLE
Update and pin ACP wrappers

### DIFF
--- a/doc/installing-dependencies.md
+++ b/doc/installing-dependencies.md
@@ -90,8 +90,8 @@ new `winget.exe` is picked up on `PATH`, then verify with
 **Why you need it:** Claude Code, OpenAI Codex, and Gemini CLI are all
 distributed as npm packages. Intelligent Terminal also launches Claude and
 Codex through `npx` wrappers
-(`npx -y @agentclientprotocol/claude-agent-acp` and
-`npx -y @agentclientprotocol/codex-acp@1.1.4`), which require a working Node.js +
+(`npx -y @agentclientprotocol/claude-agent-acp@0.64.2` and
+`npx -y @agentclientprotocol/codex-acp@1.1.9`), which require a working Node.js +
 `npm` + `npx` toolchain on `PATH`. You can skip this section if you only
 plan to use GitHub Copilot CLI.
 
@@ -219,7 +219,7 @@ Intelligent Terminal launches it through the
 wrapper. The wrapper is fetched on demand at run time with:
 
 ```powershell
-npx -y @agentclientprotocol/claude-agent-acp@0.59.0
+npx -y @agentclientprotocol/claude-agent-acp@0.64.2
 ```
 
 You do **not** need to install anything for this — the only prerequisite
@@ -266,7 +266,7 @@ Intelligent Terminal launches it through the
 wrapper. The wrapper is fetched on demand at run time with:
 
 ```powershell
-npx -y @agentclientprotocol/codex-acp@1.1.4
+npx -y @agentclientprotocol/codex-acp@1.1.9
 ```
 
 You do **not** need to install anything for this — the only prerequisite

--- a/doc/installing-dependencies.md
+++ b/doc/installing-dependencies.md
@@ -90,8 +90,8 @@ new `winget.exe` is picked up on `PATH`, then verify with
 **Why you need it:** Claude Code, OpenAI Codex, and Gemini CLI are all
 distributed as npm packages. Intelligent Terminal also launches Claude and
 Codex through `npx` wrappers
-(`npx -y @agentclientprotocol/claude-agent-acp@0.64.2` and
-`npx -y @agentclientprotocol/codex-acp@1.1.9`), which require a working Node.js +
+(`npx -y @agentclientprotocol/claude-agent-acp@0.65.0` and
+`npx -y @agentclientprotocol/codex-acp@1.1.13`), which require a working Node.js +
 `npm` + `npx` toolchain on `PATH`. You can skip this section if you only
 plan to use GitHub Copilot CLI.
 
@@ -219,7 +219,7 @@ Intelligent Terminal launches it through the
 wrapper. The wrapper is fetched on demand at run time with:
 
 ```powershell
-npx -y @agentclientprotocol/claude-agent-acp@0.64.2
+npx -y @agentclientprotocol/claude-agent-acp@0.65.0
 ```
 
 You do **not** need to install anything for this — the only prerequisite
@@ -266,7 +266,7 @@ Intelligent Terminal launches it through the
 wrapper. The wrapper is fetched on demand at run time with:
 
 ```powershell
-npx -y @agentclientprotocol/codex-acp@1.1.9
+npx -y @agentclientprotocol/codex-acp@1.1.13
 ```
 
 You do **not** need to install anything for this — the only prerequisite

--- a/doc/specs/session-history-via-acp.md
+++ b/doc/specs/session-history-via-acp.md
@@ -256,8 +256,8 @@ through the `wsl.exe` stdio bridge.
 | CLI | ACP launch (`agent_registry.rs`) | `sessionCapabilities.list` | `list_sessions` result |
 |-----|----------------------------------|----------------------------|------------------------|
 | **copilot** | native `--acp --stdio` (`:87`) | `Some` | OK — 50 host sessions |
-| **claude** | `npx -y @agentclientprotocol/claude-agent-acp` (`:109`) | `Some` | OK — 21 host sessions |
-| **codex** | `npx -y @agentclientprotocol/codex-acp@1.1.4` (`:127`) | `Some` | OK — host sessions |
+| **claude** | `npx -y @agentclientprotocol/claude-agent-acp@0.64.2` (`:109`) | `Some` | OK — 21 host sessions |
+| **codex** | `npx -y @agentclientprotocol/codex-acp@1.1.9` (`:127`) | `Some` | OK — host sessions |
 | **gemini** | native `--experimental-acp` (`:144`) | **`None`** | **`Method not found`** |
 
 Versions observed: copilot 1.0.64–1.0.66, claude-agent-acp 0.52.0, codex-acp
@@ -269,7 +269,7 @@ fallback is kept for it.
 
 The Codex results above were collected with the now-deprecated
 `@zed-industries/codex-acp`. The current runtime launch command is
-`npx -y @agentclientprotocol/codex-acp@1.1.4`; the original measurements and
+`npx -y @agentclientprotocol/codex-acp@1.1.9`; the original measurements and
 reproduction command below are retained as historical evidence.
 
 ### 2. `session/list` returns full on-disk history, not just live sessions — and only *real* sessions

--- a/doc/specs/session-history-via-acp.md
+++ b/doc/specs/session-history-via-acp.md
@@ -256,8 +256,8 @@ through the `wsl.exe` stdio bridge.
 | CLI | ACP launch (`agent_registry.rs`) | `sessionCapabilities.list` | `list_sessions` result |
 |-----|----------------------------------|----------------------------|------------------------|
 | **copilot** | native `--acp --stdio` (`:87`) | `Some` | OK — 50 host sessions |
-| **claude** | `npx -y @agentclientprotocol/claude-agent-acp@0.64.2` (`:109`) | `Some` | OK — 21 host sessions |
-| **codex** | `npx -y @agentclientprotocol/codex-acp@1.1.9` (`:127`) | `Some` | OK — host sessions |
+| **claude** | `npx -y @agentclientprotocol/claude-agent-acp@0.65.0` (`:109`) | `Some` | OK — 21 host sessions |
+| **codex** | `npx -y @agentclientprotocol/codex-acp@1.1.13` (`:127`) | `Some` | OK — host sessions |
 | **gemini** | native `--experimental-acp` (`:144`) | **`None`** | **`Method not found`** |
 
 Versions observed: copilot 1.0.64–1.0.66, claude-agent-acp 0.52.0, codex-acp
@@ -269,7 +269,7 @@ fallback is kept for it.
 
 The Codex results above were collected with the now-deprecated
 `@zed-industries/codex-acp`. The current runtime launch command is
-`npx -y @agentclientprotocol/codex-acp@1.1.9`; the original measurements and
+`npx -y @agentclientprotocol/codex-acp@1.1.13`; the original measurements and
 reproduction command below are retained as historical evidence.
 
 ### 2. `session/list` returns full on-disk history, not just live sessions — and only *real* sessions

--- a/src/cascadia/inc/AcpModelUtils.h
+++ b/src/cascadia/inc/AcpModelUtils.h
@@ -58,11 +58,11 @@ namespace Microsoft::Terminal::AcpModels
     {
         if (agentId == L"claude")
         {
-            return L"npx -y @agentclientprotocol/claude-agent-acp";
+            return L"npx -y @agentclientprotocol/claude-agent-acp@0.64.2";
         }
         if (agentId == L"codex")
         {
-            return L"npx -y @agentclientprotocol/codex-acp@1.1.4";
+            return L"npx -y @agentclientprotocol/codex-acp@1.1.9";
         }
         if (agentId == L"opencode")
         {

--- a/src/cascadia/inc/AcpModelUtils.h
+++ b/src/cascadia/inc/AcpModelUtils.h
@@ -58,11 +58,11 @@ namespace Microsoft::Terminal::AcpModels
     {
         if (agentId == L"claude")
         {
-            return L"npx -y @agentclientprotocol/claude-agent-acp@0.64.2";
+            return L"npx -y @agentclientprotocol/claude-agent-acp@0.65.0";
         }
         if (agentId == L"codex")
         {
-            return L"npx -y @agentclientprotocol/codex-acp@1.1.9";
+            return L"npx -y @agentclientprotocol/codex-acp@1.1.13";
         }
         if (agentId == L"opencode")
         {

--- a/src/cascadia/ut_app/AcpModelUtilsTests.cpp
+++ b/src/cascadia/ut_app/AcpModelUtilsTests.cpp
@@ -33,8 +33,8 @@ namespace TerminalAppUnitTests
     void AcpModelUtilsTests::MapsAgentIdsToAcpCommands()
     {
         VERIFY_ARE_EQUAL(std::wstring{ L"copilot --acp --stdio" }, BuildAgentCommandLine(L"copilot"));
-        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/claude-agent-acp@0.64.2" }, BuildAgentCommandLine(L"claude"));
-        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/codex-acp@1.1.9" }, BuildAgentCommandLine(L"codex"));
+        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/claude-agent-acp@0.65.0" }, BuildAgentCommandLine(L"claude"));
+        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/codex-acp@1.1.13" }, BuildAgentCommandLine(L"codex"));
         VERIFY_ARE_EQUAL(std::wstring{ L"gemini --experimental-acp" }, BuildAgentCommandLine(L"gemini"));
         VERIFY_ARE_EQUAL(std::wstring{ L"opencode acp" }, BuildAgentCommandLine(L"opencode"));
         VERIFY_ARE_EQUAL(std::wstring{ L"other-agent" }, BuildAgentCommandLine(L"other-agent"));
@@ -45,8 +45,8 @@ namespace TerminalAppUnitTests
         constexpr std::wstring_view model{ L"gpt-5" };
         VERIFY_ARE_EQUAL(std::wstring{ L"copilot --acp --stdio --model gpt-5" }, BuildAgentCommandLine(L"copilot", model));
         VERIFY_ARE_EQUAL(std::wstring{ L"gemini --experimental-acp --model gpt-5" }, BuildAgentCommandLine(L"gemini", model));
-        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/claude-agent-acp@0.64.2" }, BuildAgentCommandLine(L"claude", model));
-        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/codex-acp@1.1.9" }, BuildAgentCommandLine(L"codex", model));
+        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/claude-agent-acp@0.65.0" }, BuildAgentCommandLine(L"claude", model));
+        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/codex-acp@1.1.13" }, BuildAgentCommandLine(L"codex", model));
         VERIFY_ARE_EQUAL(std::wstring{ L"opencode acp" }, BuildAgentCommandLine(L"opencode", model));
         VERIFY_ARE_EQUAL(std::wstring{ L"other-agent" }, BuildAgentCommandLine(L"other-agent", model));
     }

--- a/src/cascadia/ut_app/AcpModelUtilsTests.cpp
+++ b/src/cascadia/ut_app/AcpModelUtilsTests.cpp
@@ -33,8 +33,8 @@ namespace TerminalAppUnitTests
     void AcpModelUtilsTests::MapsAgentIdsToAcpCommands()
     {
         VERIFY_ARE_EQUAL(std::wstring{ L"copilot --acp --stdio" }, BuildAgentCommandLine(L"copilot"));
-        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/claude-agent-acp" }, BuildAgentCommandLine(L"claude"));
-        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/codex-acp@1.1.4" }, BuildAgentCommandLine(L"codex"));
+        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/claude-agent-acp@0.64.2" }, BuildAgentCommandLine(L"claude"));
+        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/codex-acp@1.1.9" }, BuildAgentCommandLine(L"codex"));
         VERIFY_ARE_EQUAL(std::wstring{ L"gemini --experimental-acp" }, BuildAgentCommandLine(L"gemini"));
         VERIFY_ARE_EQUAL(std::wstring{ L"opencode acp" }, BuildAgentCommandLine(L"opencode"));
         VERIFY_ARE_EQUAL(std::wstring{ L"other-agent" }, BuildAgentCommandLine(L"other-agent"));
@@ -45,8 +45,8 @@ namespace TerminalAppUnitTests
         constexpr std::wstring_view model{ L"gpt-5" };
         VERIFY_ARE_EQUAL(std::wstring{ L"copilot --acp --stdio --model gpt-5" }, BuildAgentCommandLine(L"copilot", model));
         VERIFY_ARE_EQUAL(std::wstring{ L"gemini --experimental-acp --model gpt-5" }, BuildAgentCommandLine(L"gemini", model));
-        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/claude-agent-acp" }, BuildAgentCommandLine(L"claude", model));
-        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/codex-acp@1.1.4" }, BuildAgentCommandLine(L"codex", model));
+        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/claude-agent-acp@0.64.2" }, BuildAgentCommandLine(L"claude", model));
+        VERIFY_ARE_EQUAL(std::wstring{ L"npx -y @agentclientprotocol/codex-acp@1.1.9" }, BuildAgentCommandLine(L"codex", model));
         VERIFY_ARE_EQUAL(std::wstring{ L"opencode acp" }, BuildAgentCommandLine(L"opencode", model));
         VERIFY_ARE_EQUAL(std::wstring{ L"other-agent" }, BuildAgentCommandLine(L"other-agent", model));
     }

--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -145,8 +145,8 @@ relay. Other Windows Terminal operations remain available through the `wta` /
 Claude and Codex are launched through ACP adapters:
 
 ```
-wta --agent "npx -y @agentclientprotocol/claude-agent-acp"
-wta --agent "npx -y @agentclientprotocol/codex-acp@1.1.4"
+wta --agent "npx -y @agentclientprotocol/claude-agent-acp@0.64.2"
+wta --agent "npx -y @agentclientprotocol/codex-acp@1.1.9"
 ```
 
 The Terminal settings layer resolves the built-in agent IDs to these adapter commands.

--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -145,8 +145,8 @@ relay. Other Windows Terminal operations remain available through the `wta` /
 Claude and Codex are launched through ACP adapters:
 
 ```
-wta --agent "npx -y @agentclientprotocol/claude-agent-acp@0.64.2"
-wta --agent "npx -y @agentclientprotocol/codex-acp@1.1.9"
+wta --agent "npx -y @agentclientprotocol/claude-agent-acp@0.65.0"
+wta --agent "npx -y @agentclientprotocol/codex-acp@1.1.13"
 ```
 
 The Terminal settings layer resolves the built-in agent IDs to these adapter commands.

--- a/tools/wta/acp-multi-session-concurrency.md
+++ b/tools/wta/acp-multi-session-concurrency.md
@@ -54,7 +54,7 @@ The prompt was deliberately model-bound work that streams gradually:
 
 The Codex row below records the deprecated `@zed-industries/codex-acp`
 adapter used when this experiment was run. The current runtime uses
-`@agentclientprotocol/codex-acp@1.1.9`; these historical timings have not been
+`@agentclientprotocol/codex-acp@1.1.13`; these historical timings have not been
 re-attributed to the replacement adapter.
 
 Each agent received the same prompt twice (one per session) at `t = 0` after

--- a/tools/wta/acp-multi-session-concurrency.md
+++ b/tools/wta/acp-multi-session-concurrency.md
@@ -54,7 +54,7 @@ The prompt was deliberately model-bound work that streams gradually:
 
 The Codex row below records the deprecated `@zed-industries/codex-acp`
 adapter used when this experiment was run. The current runtime uses
-`@agentclientprotocol/codex-acp@1.1.4`; these historical timings have not been
+`@agentclientprotocol/codex-acp@1.1.9`; these historical timings have not been
 re-attributed to the replacement adapter.
 
 Each agent received the same prompt twice (one per session) at `t = 0` after

--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -127,7 +127,7 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         // `claude` shim implies node/npx are present, so this works whenever
         // delegate mode does. (Renamed from the deprecated
         // `@zed-industries/claude-code-acp`; see issue #257.)
-        acp_launch_command: "npx -y @agentclientprotocol/claude-agent-acp@0.64.2",
+        acp_launch_command: "npx -y @agentclientprotocol/claude-agent-acp@0.65.0",
         acp_model_flags: &[],
         acp_auth_flow: AcpAuthFlow::External,
         byok_mode: ByokMode::Unsupported,
@@ -147,7 +147,7 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         acp_flags: &[],
         // Codex CLI itself doesn't speak ACP. Use the ACP-project-maintained
         // adapter, pinned so a future npm release cannot silently break startup.
-        acp_launch_command: "npx -y @agentclientprotocol/codex-acp@1.1.9",
+        acp_launch_command: "npx -y @agentclientprotocol/codex-acp@1.1.13",
         acp_model_flags: &[],
         acp_auth_flow: AcpAuthFlow::External,
         byok_mode: ByokMode::Unsupported,
@@ -347,7 +347,7 @@ pub fn resolve_agent_id_from_cmd(agent_cmd: &str) -> &'static str {
 /// E.g. `build_acp_command("copilot", Some("gpt-5"))` → `"copilot --acp --stdio --model gpt-5"`.
 /// For agents whose CLI doesn't speak ACP natively (claude, codex), this
 /// returns the adapter launch command instead — e.g.
-/// `build_acp_command("claude", None)` → `"npx -y @agentclientprotocol/claude-agent-acp@0.64.2"`.
+/// `build_acp_command("claude", None)` → `"npx -y @agentclientprotocol/claude-agent-acp@0.65.0"`.
 pub fn build_acp_command(agent_id: &str, model: Option<&str>) -> String {
     let profile = lookup_profile_by_id(agent_id);
 
@@ -571,11 +571,11 @@ mod tests {
     fn resolve_agent_id_from_cmd_recognises_adapter_launches() {
         // Exact match against the known adapter command.
         assert_eq!(
-            resolve_agent_id_from_cmd("npx -y @agentclientprotocol/claude-agent-acp@0.64.2"),
+            resolve_agent_id_from_cmd("npx -y @agentclientprotocol/claude-agent-acp@0.65.0"),
             "claude",
         );
         assert_eq!(
-            resolve_agent_id_from_cmd("npx -y @agentclientprotocol/codex-acp@1.1.9"),
+            resolve_agent_id_from_cmd("npx -y @agentclientprotocol/codex-acp@1.1.13"),
             "codex",
         );
         assert_eq!(
@@ -589,7 +589,7 @@ mod tests {
         // Adapter prefix with extra trailing args still resolves.
         assert_eq!(
             resolve_agent_id_from_cmd(
-                "npx -y @agentclientprotocol/claude-agent-acp@0.64.2 --debug"
+                "npx -y @agentclientprotocol/claude-agent-acp@0.65.0 --debug"
             ),
             "claude",
         );
@@ -614,7 +614,7 @@ mod tests {
     #[test]
     fn strip_acp_flags_recognises_codex_adapter_compatibility_commands() {
         for command in [
-            "npx -y @agentclientprotocol/codex-acp@1.1.9",
+            "npx -y @agentclientprotocol/codex-acp@1.1.13",
             "npx -y @agentclientprotocol/codex-acp",
             "npx -y @zed-industries/codex-acp",
             "npx -y @zed-industries/codex-acp --debug",
@@ -630,7 +630,7 @@ mod tests {
     fn codex_acp_launch_command_stays_pinned() {
         assert_eq!(
             build_acp_command("codex", None),
-            "npx -y @agentclientprotocol/codex-acp@1.1.9",
+            "npx -y @agentclientprotocol/codex-acp@1.1.13",
         );
     }
 

--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -127,7 +127,7 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         // `claude` shim implies node/npx are present, so this works whenever
         // delegate mode does. (Renamed from the deprecated
         // `@zed-industries/claude-code-acp`; see issue #257.)
-        acp_launch_command: "npx -y @agentclientprotocol/claude-agent-acp@0.59.0",
+        acp_launch_command: "npx -y @agentclientprotocol/claude-agent-acp@0.64.2",
         acp_model_flags: &[],
         acp_auth_flow: AcpAuthFlow::External,
         byok_mode: ByokMode::Unsupported,
@@ -147,7 +147,7 @@ pub const KNOWN_AGENTS: &[AgentProfile] = &[
         acp_flags: &[],
         // Codex CLI itself doesn't speak ACP. Use the ACP-project-maintained
         // adapter, pinned so a future npm release cannot silently break startup.
-        acp_launch_command: "npx -y @agentclientprotocol/codex-acp@1.1.4",
+        acp_launch_command: "npx -y @agentclientprotocol/codex-acp@1.1.9",
         acp_model_flags: &[],
         acp_auth_flow: AcpAuthFlow::External,
         byok_mode: ByokMode::Unsupported,
@@ -347,7 +347,7 @@ pub fn resolve_agent_id_from_cmd(agent_cmd: &str) -> &'static str {
 /// E.g. `build_acp_command("copilot", Some("gpt-5"))` → `"copilot --acp --stdio --model gpt-5"`.
 /// For agents whose CLI doesn't speak ACP natively (claude, codex), this
 /// returns the adapter launch command instead — e.g.
-/// `build_acp_command("claude", None)` → `"npx -y @agentclientprotocol/claude-agent-acp"`.
+/// `build_acp_command("claude", None)` → `"npx -y @agentclientprotocol/claude-agent-acp@0.64.2"`.
 pub fn build_acp_command(agent_id: &str, model: Option<&str>) -> String {
     let profile = lookup_profile_by_id(agent_id);
 
@@ -571,11 +571,11 @@ mod tests {
     fn resolve_agent_id_from_cmd_recognises_adapter_launches() {
         // Exact match against the known adapter command.
         assert_eq!(
-            resolve_agent_id_from_cmd("npx -y @agentclientprotocol/claude-agent-acp@0.59.0"),
+            resolve_agent_id_from_cmd("npx -y @agentclientprotocol/claude-agent-acp@0.64.2"),
             "claude",
         );
         assert_eq!(
-            resolve_agent_id_from_cmd("npx -y @agentclientprotocol/codex-acp@1.1.4"),
+            resolve_agent_id_from_cmd("npx -y @agentclientprotocol/codex-acp@1.1.9"),
             "codex",
         );
         assert_eq!(
@@ -589,7 +589,7 @@ mod tests {
         // Adapter prefix with extra trailing args still resolves.
         assert_eq!(
             resolve_agent_id_from_cmd(
-                "npx -y @agentclientprotocol/claude-agent-acp@0.59.0 --debug"
+                "npx -y @agentclientprotocol/claude-agent-acp@0.64.2 --debug"
             ),
             "claude",
         );
@@ -614,7 +614,7 @@ mod tests {
     #[test]
     fn strip_acp_flags_recognises_codex_adapter_compatibility_commands() {
         for command in [
-            "npx -y @agentclientprotocol/codex-acp@1.1.4",
+            "npx -y @agentclientprotocol/codex-acp@1.1.9",
             "npx -y @agentclientprotocol/codex-acp",
             "npx -y @zed-industries/codex-acp",
             "npx -y @zed-industries/codex-acp --debug",
@@ -630,7 +630,7 @@ mod tests {
     fn codex_acp_launch_command_stays_pinned() {
         assert_eq!(
             build_acp_command("codex", None),
-            "npx -y @agentclientprotocol/codex-acp@1.1.4",
+            "npx -y @agentclientprotocol/codex-acp@1.1.9",
         );
     }
 

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -2084,7 +2084,7 @@ mod tests {
     #[test]
     fn pinned_session_id_appended_for_adapter_launch_command() {
         // Regression for the agent-identification bug behind PR review: an
-        // adapter-style launch ("npx -y @agentclientprotocol/claude-agent-acp@0.59.0" ->
+        // adapter-style launch ("npx -y @agentclientprotocol/claude-agent-acp@0.64.2" ->
         // claude) must still be recognized as a pinnable agent. The old
         // `split_whitespace().next()` + lookup_profile saw "npx" ->
         // DEFAULT_PROFILE -> no --session-id; `resolve_agent_id_from_cmd`
@@ -2093,7 +2093,7 @@ mod tests {
             id: "claude".to_string(),
             name: "Claude".to_string(),
             description: "Launches claude as a delegate agent.".to_string(),
-            commandline: "npx -y @agentclientprotocol/claude-agent-acp@0.59.0".to_string(),
+            commandline: "npx -y @agentclientprotocol/claude-agent-acp@0.64.2".to_string(),
             prompt_delivery: DelegatePromptDelivery::LaunchWithStartupPrompt,
             model: None,
         };
@@ -3349,7 +3349,7 @@ mod tests {
             r#""C:\npm tools\codex.cmd" --search"#
         ));
         assert!(!is_direct_known_agent_command(
-            "npx -y @agentclientprotocol/codex-acp@1.1.4"
+            "npx -y @agentclientprotocol/codex-acp@1.1.9"
         ));
     }
 

--- a/tools/wta/src/coordinator.rs
+++ b/tools/wta/src/coordinator.rs
@@ -2084,7 +2084,7 @@ mod tests {
     #[test]
     fn pinned_session_id_appended_for_adapter_launch_command() {
         // Regression for the agent-identification bug behind PR review: an
-        // adapter-style launch ("npx -y @agentclientprotocol/claude-agent-acp@0.64.2" ->
+        // adapter-style launch ("npx -y @agentclientprotocol/claude-agent-acp@0.65.0" ->
         // claude) must still be recognized as a pinnable agent. The old
         // `split_whitespace().next()` + lookup_profile saw "npx" ->
         // DEFAULT_PROFILE -> no --session-id; `resolve_agent_id_from_cmd`
@@ -2093,7 +2093,7 @@ mod tests {
             id: "claude".to_string(),
             name: "Claude".to_string(),
             description: "Launches claude as a delegate agent.".to_string(),
-            commandline: "npx -y @agentclientprotocol/claude-agent-acp@0.64.2".to_string(),
+            commandline: "npx -y @agentclientprotocol/claude-agent-acp@0.65.0".to_string(),
             prompt_delivery: DelegatePromptDelivery::LaunchWithStartupPrompt,
             model: None,
         };
@@ -3349,7 +3349,7 @@ mod tests {
             r#""C:\npm tools\codex.cmd" --search"#
         ));
         assert!(!is_direct_known_agent_command(
-            "npx -y @agentclientprotocol/codex-acp@1.1.9"
+            "npx -y @agentclientprotocol/codex-acp@1.1.13"
         ));
     }
 

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -334,7 +334,7 @@ fn model_is_folded_in_for_native_agents_and_ignored_for_adapters() {
     // Adapter agent (claude via npx) ignores the model here — it's
     // applied later via setSessionModel — so the command is stable.
     let (cmd, id) = resolve(None, Some("claude"), Some("opus-4"));
-    assert_eq!(cmd, "npx -y @agentclientprotocol/claude-agent-acp@0.64.2");
+    assert_eq!(cmd, "npx -y @agentclientprotocol/claude-agent-acp@0.65.0");
     assert_eq!(id.as_deref(), Some("claude"));
 }
 

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -334,7 +334,7 @@ fn model_is_folded_in_for_native_agents_and_ignored_for_adapters() {
     // Adapter agent (claude via npx) ignores the model here — it's
     // applied later via setSessionModel — so the command is stable.
     let (cmd, id) = resolve(None, Some("claude"), Some("opus-4"));
-    assert_eq!(cmd, "npx -y @agentclientprotocol/claude-agent-acp@0.59.0");
+    assert_eq!(cmd, "npx -y @agentclientprotocol/claude-agent-acp@0.64.2");
     assert_eq!(id.as_deref(), Some("claude"));
 }
 

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -3698,7 +3698,7 @@ mod tests {
         // fields, including `model` (which used to ride inside
         // `agent_cmd` and now travels on its own).
         let original = WtaMeta {
-            agent_cmd: Some("npx -y @agentclientprotocol/claude-agent-acp@0.59.0".to_string()),
+            agent_cmd: Some("npx -y @agentclientprotocol/claude-agent-acp@0.64.2".to_string()),
             agent_id: Some("gemini".to_string()),
             model: Some("gemini-2.5-pro".to_string()),
             agent_source: Some("wsl".to_string()),

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -3698,7 +3698,7 @@ mod tests {
         // fields, including `model` (which used to ride inside
         // `agent_cmd` and now travels on its own).
         let original = WtaMeta {
-            agent_cmd: Some("npx -y @agentclientprotocol/claude-agent-acp@0.64.2".to_string()),
+            agent_cmd: Some("npx -y @agentclientprotocol/claude-agent-acp@0.65.0".to_string()),
             agent_id: Some("gemini".to_string()),
             model: Some("gemini-2.5-pro".to_string()),
             agent_source: Some("wsl".to_string()),

--- a/tools/wta/src/wsl_acp.rs
+++ b/tools/wta/src/wsl_acp.rs
@@ -290,11 +290,11 @@ mod tests {
         );
         assert_eq!(
             acp_command_for(&CliSource::Claude).as_deref(),
-            Some("npx -y @agentclientprotocol/claude-agent-acp@0.64.2")
+            Some("npx -y @agentclientprotocol/claude-agent-acp@0.65.0")
         );
         assert_eq!(
             acp_command_for(&CliSource::Codex).as_deref(),
-            Some("npx -y @agentclientprotocol/codex-acp@1.1.9")
+            Some("npx -y @agentclientprotocol/codex-acp@1.1.13")
         );
         assert_eq!(
             acp_command_for(&CliSource::OpenCode).as_deref(),

--- a/tools/wta/src/wsl_acp.rs
+++ b/tools/wta/src/wsl_acp.rs
@@ -290,11 +290,11 @@ mod tests {
         );
         assert_eq!(
             acp_command_for(&CliSource::Claude).as_deref(),
-            Some("npx -y @agentclientprotocol/claude-agent-acp@0.59.0")
+            Some("npx -y @agentclientprotocol/claude-agent-acp@0.64.2")
         );
         assert_eq!(
             acp_command_for(&CliSource::Codex).as_deref(),
-            Some("npx -y @agentclientprotocol/codex-acp@1.1.4")
+            Some("npx -y @agentclientprotocol/codex-acp@1.1.9")
         );
         assert_eq!(
             acp_command_for(&CliSource::OpenCode).as_deref(),


### PR DESCRIPTION
## Summary

- pin Claude ACP wrapper to the latest npm-published version, 0.65.0
- pin Codex ACP wrapper to the latest npm-published version, 1.1.13
- keep host, WSL, tests, and documentation on the same wrapper versions

## Validation

- `cargo test --manifest-path tools/wta/Cargo.toml` (1,465 passed)
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- full Debug Terminal build (`bcz no_clean`)
- `AcpModelUtilsTests` (12 passed)
- completed live ACP initialization and model discovery with both pinned npm packages
- deployed the Debug package and confirmed the running WTA master launches Claude ACP `0.65.0`