### PR TITLE
Agent pane: Release replaced agent pane sessions

### DIFF
--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -397,22 +397,68 @@ async fn rollback_swapped_session_route(
     helper_id: HelperId,
     session_id: &acp::schema::v1::SessionId,
     previous: Option<HelperRoute>,
-) -> bool {
+) -> SwappedSessionRouteRollback {
     let gate = session_lifecycle_gate(state, session_id).await;
     let _guard = gate.lock().await;
     let mut routes = state.session_to_helper.lock().await;
+    rollback_swapped_session_route_locked(&mut routes, helper_id, session_id, previous)
+}
+
+async fn rollback_orphan_rebind(
+    state: &MasterStateInner,
+    helper_id: HelperId,
+    agent_key: &AgentCmdKey,
+    session_id: &acp::schema::v1::SessionId,
+    previous: Option<HelperRoute>,
+) -> SwappedSessionRouteRollback {
+    let gate = session_lifecycle_gate(state, session_id).await;
+    let _guard = gate.lock().await;
+    let (rollback, route_absent) = {
+        let mut routes = state.session_to_helper.lock().await;
+        let rollback =
+            rollback_swapped_session_route_locked(&mut routes, helper_id, session_id, previous);
+        (rollback, !routes.contains_key(session_id))
+    };
+    if rollback == SwappedSessionRouteRollback::Restored && route_absent {
+        state
+            .orphaned_sessions
+            .lock()
+            .await
+            .entry(agent_key.clone())
+            .or_default()
+            .insert(session_id.clone());
+    }
+    rollback
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SwappedSessionRouteRollback {
+    Restored,
+    OwnershipChanged {
+        current_agent_instance_id: Option<AgentInstanceId>,
+    },
+}
+
+fn rollback_swapped_session_route_locked(
+    routes: &mut HashMap<acp::schema::v1::SessionId, HelperRoute>,
+    helper_id: HelperId,
+    session_id: &acp::schema::v1::SessionId,
+    previous: Option<HelperRoute>,
+) -> SwappedSessionRouteRollback {
     if !routes
         .get(session_id)
         .is_some_and(|route| route.helper_id == helper_id)
     {
-        return false;
+        return SwappedSessionRouteRollback::OwnershipChanged {
+            current_agent_instance_id: routes.get(session_id).map(|route| route.agent_instance_id),
+        };
     }
     if let Some(previous) = previous {
         routes.insert(session_id.clone(), previous);
     } else {
         routes.remove(session_id);
     }
-    true
+    SwappedSessionRouteRollback::Restored
 }
 
 const SESSION_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
@@ -1472,6 +1518,35 @@ impl HelperHandler {
             .map_err(|_| self.load_session_timeout_error(total_timeout, "agent_rpc"))?
     }
 
+    async fn rollback_and_maybe_close_loaded_target(
+        &self,
+        agent: &AgentCli,
+        session_id: &acp::schema::v1::SessionId,
+        previous: Option<HelperRoute>,
+        previous_used_same_agent: bool,
+        timeout: std::time::Duration,
+    ) -> SwappedSessionRouteRollback {
+        let gate = session_lifecycle_gate(&self.state, session_id).await;
+        let _guard = gate.lock().await;
+        let rollback = {
+            let mut routes = self.state.session_to_helper.lock().await;
+            rollback_swapped_session_route_locked(&mut routes, self.helper_id, session_id, previous)
+        };
+        let should_close = match rollback {
+            SwappedSessionRouteRollback::Restored => !previous_used_same_agent,
+            SwappedSessionRouteRollback::OwnershipChanged {
+                current_agent_instance_id,
+            } => current_agent_instance_id != Some(agent.instance_id),
+        };
+        if should_close {
+            // Keep the SessionId lifecycle gate held through the send so a
+            // same-agent rebind cannot start after the safety check.
+            self.best_effort_close_loaded_target(agent, session_id, timeout)
+                .await;
+        }
+        rollback
+    }
+
     async fn best_effort_close_loaded_target(
         &self,
         agent: &AgentCli,
@@ -2096,28 +2171,22 @@ impl HelperHandler {
                     // needs touching — we never wrote to `registry` and we
                     // never broadcast `session_added`, so peers never saw
                     // this row.
-                    let route_rolled_back = rollback_swapped_session_route(
-                        &self.state,
-                        self.helper_id,
-                        &session_id,
-                        previous_target_route,
-                    )
-                    .await;
-                    if route_rolled_back && !previous_target_used_same_agent {
-                        let remaining =
-                            deadline.saturating_duration_since(tokio::time::Instant::now());
-                        self.best_effort_close_loaded_target(
+                    let route_rollback = self
+                        .rollback_and_maybe_close_loaded_target(
                             &agent,
                             &session_id,
-                            remaining.min(rollback_reserve),
+                            previous_target_route,
+                            previous_target_used_same_agent,
+                            deadline
+                                .saturating_duration_since(tokio::time::Instant::now())
+                                .min(rollback_reserve),
                         )
                         .await;
-                    }
                     tracing::warn!(
                         target: "master",
                         helper_id = ?self.helper_id,
                         session_id = ?session_id,
-                        route_rolled_back,
+                        route_rollback = ?route_rollback,
                         error = %err,
                         "load_session failed; rolled back routing entry"
                     );
@@ -2152,41 +2221,41 @@ impl HelperHandler {
                     if let Some(pending) = session_mcp.as_ref() {
                         self.state.session_mcp_capabilities.cancel(pending).await;
                     }
-                    let route_rolled_back = rollback_swapped_session_route(
-                        &self.state,
-                        self.helper_id,
-                        &session_id,
-                        previous_target_route,
-                    )
-                    .await;
-                    if is_orphan_rebind {
-                        self.state
-                            .orphaned_sessions
-                            .lock()
-                            .await
-                            .entry(agent.cmd_key.clone())
-                            .or_default()
-                            .insert(session_id.clone());
-                    }
-                    if loaded_target_physically
-                        && route_rolled_back
-                        && !previous_target_used_same_agent
-                    {
-                        let remaining =
-                            deadline.saturating_duration_since(tokio::time::Instant::now());
-                        self.best_effort_close_loaded_target(
+                    let route_rollback = if loaded_target_physically {
+                        self.rollback_and_maybe_close_loaded_target(
                             &agent,
                             &session_id,
-                            remaining.min(rollback_reserve),
+                            previous_target_route,
+                            previous_target_used_same_agent,
+                            deadline
+                                .saturating_duration_since(tokio::time::Instant::now())
+                                .min(rollback_reserve),
                         )
-                        .await;
-                    }
+                        .await
+                    } else if is_orphan_rebind {
+                        rollback_orphan_rebind(
+                            &self.state,
+                            self.helper_id,
+                            &agent.cmd_key,
+                            &session_id,
+                            previous_target_route,
+                        )
+                        .await
+                    } else {
+                        rollback_swapped_session_route(
+                            &self.state,
+                            self.helper_id,
+                            &session_id,
+                            previous_target_route,
+                        )
+                        .await
+                    };
                     tracing::error!(
                         target: "master",
                         helper_id = ?self.helper_id,
                         old_session_id = %previous_session_id,
                         target_session_id = %session_id,
-                        route_rolled_back,
+                        route_rollback = ?route_rollback,
                         "predecessor close failed after session/load; target transaction rolled back"
                     );
                     return Err(error);

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -50,6 +50,7 @@ use std::sync::{Arc, OnceLock};
 /// helper sharing this master.
 const NOTIF_CHANNEL_CAPACITY: usize = 1024;
 const SESSION_NEW_TIMEOUT_SECS: u64 = 120;
+const SESSION_LOAD_TIMEOUT_SECS: u64 = 55;
 const MASTER_PIPE_DISCOVERY_FILE: &str = "master-pipe.txt";
 
 use agent_client_protocol as acp;
@@ -1259,6 +1260,35 @@ impl HelperHandler {
             }))
         })?
     }
+
+    /// Forward `session/load` to this helper's bound agent CLI under the
+    /// master's deadline. This deadline must expire before the helper's
+    /// outer 60-second timeout so the replacement transaction can roll back
+    /// routing and MCP state before the helper falls back to `session/new`.
+    async fn forward_load_session_to_agent(
+        &self,
+        args: acp::schema::v1::LoadSessionRequest,
+        timeout: std::time::Duration,
+    ) -> acp::Result<acp::schema::v1::LoadSessionResponse> {
+        let timeout_secs = timeout.as_secs();
+        let agent = self.resolved_agent("load_session")?;
+        tokio::time::timeout(timeout, agent.conn.load_session(args))
+            .await
+            .map_err(|_| {
+                let message = format!("agent CLI session/load timed out after {timeout_secs}s");
+                tracing::error!(
+                    target: "master",
+                    step = "helper→agent",
+                    op = "load_session",
+                    helper_id = ?self.helper_id,
+                    timeout_secs,
+                    "agent CLI session/load timed out"
+                );
+                acp::Error::new(-32603, message.clone()).data(serde_json::json!({
+                    "message": message
+                }))
+            })?
+    }
 }
 
 impl HelperHandler {
@@ -1645,6 +1675,18 @@ impl HelperHandler {
         &self,
         args: acp::schema::v1::LoadSessionRequest,
     ) -> acp::Result<acp::schema::v1::LoadSessionResponse> {
+        self.load_session_with_timeout(
+            args,
+            std::time::Duration::from_secs(SESSION_LOAD_TIMEOUT_SECS),
+        )
+        .await
+    }
+
+    async fn load_session_with_timeout(
+        &self,
+        args: acp::schema::v1::LoadSessionRequest,
+        timeout: std::time::Duration,
+    ) -> acp::Result<acp::schema::v1::LoadSessionResponse> {
         let _replacement_guard = self.replacement_gate.lock().await;
         let mut args = args;
         let wta_meta = crate::session_registry::extract_wta_meta(&mut args.meta);
@@ -1753,7 +1795,7 @@ impl HelperHandler {
             } else {
                 None
             };
-            match agent.conn.load_session(args).await {
+            match self.forward_load_session_to_agent(args, timeout).await {
                 Ok(resp) => {
                     if let Some(pending) = session_mcp.as_ref() {
                         if !self

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -360,6 +360,52 @@ async fn bind_session_route(
     routes.len()
 }
 
+/// Retire one session deliberately replaced by its owning helper.
+///
+/// ACP has no session-close request, so the helper first sends
+/// `session/cancel` to stop any active turn. Once the replacement session is
+/// live, master drops every WTA-owned resource for the old SessionId so it is
+/// no longer routable or advertised as live.
+async fn retire_replaced_session(
+    state: &MasterStateInner,
+    helper_id: HelperId,
+    session_id: &acp::schema::v1::SessionId,
+) -> bool {
+    let removed = {
+        let mut routes = state.session_to_helper.lock().await;
+        if routes
+            .get(session_id)
+            .is_some_and(|route| route.helper_id == helper_id)
+        {
+            routes.remove(session_id);
+            true
+        } else {
+            false
+        }
+    };
+    if !removed {
+        return false;
+    }
+
+    state.pending_usage.lock().await.remove(session_id);
+    state
+        .session_mcp_capabilities
+        .remove_session(session_id)
+        .await;
+    state.registry.remove(session_id).await;
+    broadcast_ext_to_helpers(
+        state,
+        crate::session_registry::build_session_removed_notification(session_id),
+    )
+    .await;
+    broadcast_ext_to_helpers(
+        state,
+        crate::session_registry::build_sessions_changed_notification(),
+    )
+    .await;
+    true
+}
+
 /// Canonical key for the agent-CLI pool: authoritative agent identity,
 /// execution source, and full command line. Two tabs with the same identity,
 /// source, and command share one CLI; custom and built-in agents never share
@@ -1428,6 +1474,13 @@ impl HelperHandler {
         // in the same place as the routing entry.
         let mut args = args;
         let wta_meta = crate::session_registry::extract_wta_meta(&mut args.meta);
+        let previous_session_id = self
+            .state
+            .helper_meta
+            .lock()
+            .await
+            .get(&self.helper_id)
+            .and_then(|meta| meta.last_session_id.clone());
         let cwd_for_registry = args.cwd.clone();
         let agent = self.resolved_agent("new_session")?;
         let session_mcp_endpoint = self
@@ -1523,6 +1576,20 @@ impl HelperHandler {
             .ok()
             .map(|d| d.as_millis() as u64);
         self.state.registry.upsert(info.clone()).await;
+        if let Some(previous_session_id) =
+            previous_session_id.filter(|sid| sid != &resp.session_id)
+        {
+            let retired =
+                retire_replaced_session(&self.state, self.helper_id, &previous_session_id).await;
+            tracing::info!(
+                target: "master",
+                helper_id = ?self.helper_id,
+                old_session_id = %previous_session_id,
+                new_session_id = %resp.session_id,
+                retired,
+                "retired session replaced by session/new"
+            );
+        }
         // Record crash-recovery metadata for this helper: the owning
         // WT tab StableId (so master can address a `restart_agent_pane`
         // event on disconnect) and the just-created session as the

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -1261,6 +1261,27 @@ impl HelperHandler {
         })?
     }
 
+    fn load_session_timeout_error(
+        &self,
+        timeout: std::time::Duration,
+        phase: &'static str,
+    ) -> acp::Error {
+        let timeout_secs = timeout.as_secs();
+        let message = format!("agent CLI session/load timed out after {timeout_secs}s");
+        tracing::error!(
+            target: "master",
+            step = "helper→agent",
+            op = "load_session",
+            helper_id = ?self.helper_id,
+            phase,
+            timeout_secs,
+            "agent CLI session/load timed out"
+        );
+        acp::Error::new(-32603, message.clone()).data(serde_json::json!({
+            "message": message
+        }))
+    }
+
     /// Forward `session/load` to this helper's bound agent CLI under the
     /// master's deadline. This deadline must expire before the helper's
     /// outer 60-second timeout so the replacement transaction can roll back
@@ -1268,26 +1289,13 @@ impl HelperHandler {
     async fn forward_load_session_to_agent(
         &self,
         args: acp::schema::v1::LoadSessionRequest,
-        timeout: std::time::Duration,
+        rpc_timeout: std::time::Duration,
+        total_timeout: std::time::Duration,
     ) -> acp::Result<acp::schema::v1::LoadSessionResponse> {
-        let timeout_secs = timeout.as_secs();
         let agent = self.resolved_agent("load_session")?;
-        tokio::time::timeout(timeout, agent.conn.load_session(args))
+        tokio::time::timeout(rpc_timeout, agent.conn.load_session(args))
             .await
-            .map_err(|_| {
-                let message = format!("agent CLI session/load timed out after {timeout_secs}s");
-                tracing::error!(
-                    target: "master",
-                    step = "helper→agent",
-                    op = "load_session",
-                    helper_id = ?self.helper_id,
-                    timeout_secs,
-                    "agent CLI session/load timed out"
-                );
-                acp::Error::new(-32603, message.clone()).data(serde_json::json!({
-                    "message": message
-                }))
-            })?
+            .map_err(|_| self.load_session_timeout_error(total_timeout, "agent_rpc"))?
     }
 }
 
@@ -1687,7 +1695,10 @@ impl HelperHandler {
         args: acp::schema::v1::LoadSessionRequest,
         timeout: std::time::Duration,
     ) -> acp::Result<acp::schema::v1::LoadSessionResponse> {
-        let _replacement_guard = self.replacement_gate.lock().await;
+        let deadline = tokio::time::Instant::now() + timeout;
+        let _replacement_guard = tokio::time::timeout_at(deadline, self.replacement_gate.lock())
+            .await
+            .map_err(|_| self.load_session_timeout_error(timeout, "replacement_gate"))?;
         let mut args = args;
         let wta_meta = crate::session_registry::extract_wta_meta(&mut args.meta);
         let session_id = args.session_id.clone();
@@ -1795,7 +1806,11 @@ impl HelperHandler {
             } else {
                 None
             };
-            match self.forward_load_session_to_agent(args, timeout).await {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            match self
+                .forward_load_session_to_agent(args, remaining, timeout)
+                .await
+            {
                 Ok(resp) => {
                     if let Some(pending) = session_mcp.as_ref() {
                         if !self

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -1135,6 +1135,10 @@ struct HelperHandler {
     /// `resolved_agent()` always finds it populated for those.
     agent: Arc<OnceLock<Arc<AgentCli>>>,
     state: Arc<MasterStateInner>,
+    /// Serializes complete session replacement transactions for this helper.
+    /// Shared by every cloned request handler, while unrelated helpers retain
+    /// their own independent gate. This is always acquired before state locks.
+    replacement_gate: Arc<Mutex<()>>,
     /// Notification fan-in for this helper. `new_session` /
     /// `load_session` writes `(SessionId → this sender)` into
     /// `state.session_to_helper` so future agent-CLI notifications
@@ -1461,6 +1465,7 @@ impl HelperHandler {
         &self,
         args: acp::schema::v1::NewSessionRequest,
     ) -> acp::Result<acp::schema::v1::NewSessionResponse> {
+        let _replacement_guard = self.replacement_gate.lock().await;
         // Pull our `_meta.wta` payload off the request before forwarding
         // to the agent CLI. Two reasons we strip here and not after the
         // RPC: (1) the spec lets third-party agents reject unknown
@@ -1640,9 +1645,17 @@ impl HelperHandler {
         &self,
         args: acp::schema::v1::LoadSessionRequest,
     ) -> acp::Result<acp::schema::v1::LoadSessionResponse> {
+        let _replacement_guard = self.replacement_gate.lock().await;
         let mut args = args;
         let wta_meta = crate::session_registry::extract_wta_meta(&mut args.meta);
         let session_id = args.session_id.clone();
+        let previous_session_id = self
+            .state
+            .helper_meta
+            .lock()
+            .await
+            .get(&self.helper_id)
+            .and_then(|meta| meta.last_session_id.clone());
         let cwd_for_registry = args.cwd.clone();
         tracing::info!(
             target: "master",
@@ -1841,6 +1854,18 @@ impl HelperHandler {
             }
         }
         self.state.registry.upsert(info.clone()).await;
+        if let Some(previous_session_id) = previous_session_id.filter(|sid| sid != &session_id) {
+            let retired =
+                retire_replaced_session(&self.state, self.helper_id, &previous_session_id).await;
+            tracing::info!(
+                target: "master",
+                helper_id = ?self.helper_id,
+                old_session_id = %previous_session_id,
+                new_session_id = %session_id,
+                retired,
+                "retired session replaced by session/load"
+            );
+        }
         // Refresh crash-recovery metadata so a later resume targets this session.
         {
             let mut meta = self.state.helper_meta.lock().await;
@@ -3203,6 +3228,7 @@ async fn serve_helper(
         // HelperHandler::initialize → get_or_spawn_agent).
         agent: Arc::new(OnceLock::new()),
         state: Arc::clone(&state),
+        replacement_gate: Arc::new(Mutex::new(())),
         notif_tx,
         agent_side_slot: Arc::clone(&agent_side_slot),
     };

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -371,22 +371,19 @@ async fn retire_replaced_session(
     helper_id: HelperId,
     session_id: &acp::schema::v1::SessionId,
 ) -> bool {
-    let removed = {
-        let mut routes = state.session_to_helper.lock().await;
-        if routes
-            .get(session_id)
-            .is_some_and(|route| route.helper_id == helper_id)
-        {
-            routes.remove(session_id);
-            true
-        } else {
-            false
-        }
-    };
-    if !removed {
+    let mut routes = state.session_to_helper.lock().await;
+    if !routes
+        .get(session_id)
+        .is_some_and(|route| route.helper_id == helper_id)
+    {
         return false;
     }
+    routes.remove(session_id);
 
+    // Keep the route lock through all session-scoped cleanup and removal
+    // broadcasts so load_session cannot rebind this SessionId mid-retirement.
+    // This follows the state lock order: route before usage, registry, or
+    // helper-subscriber state; none of those paths re-enters the route map.
     state.pending_usage.lock().await.remove(session_id);
     state
         .session_mcp_capabilities

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -40,7 +40,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::future::Future;
 use std::path::PathBuf;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, OnceLock, Weak};
 
 /// Per-helper notification channel capacity. Sized for bursty chunk
 /// streaming during a single agent turn; well above what a healthy
@@ -51,6 +51,7 @@ use std::sync::{Arc, OnceLock};
 const NOTIF_CHANNEL_CAPACITY: usize = 1024;
 const SESSION_NEW_TIMEOUT_SECS: u64 = 120;
 const SESSION_LOAD_TIMEOUT_SECS: u64 = 55;
+const SESSION_ROLLBACK_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 const MASTER_PIPE_DISCOVERY_FILE: &str = "master-pipe.txt";
 
 use agent_client_protocol as acp;
@@ -99,6 +100,7 @@ type AgentCell = Arc<tokio::sync::OnceCell<Arc<AgentCli>>>;
 #[derive(Clone)]
 struct HelperRoute {
     helper_id: HelperId,
+    agent_instance_id: AgentInstanceId,
     notif_tx: mpsc::Sender<acp::schema::v1::SessionNotification>,
     forwarder: Option<conn::AgentLink>,
     /// Per-route counter for back-pressure log rate-limiting.
@@ -127,6 +129,11 @@ struct HelperRoute {
 /// notifications from the agent CLI) and each helper's `acp::Agent`
 /// impl (receives requests from one helper).
 struct MasterStateInner {
+    /// Weak cache of per-SessionId lifecycle gates. Route mutations take the
+    /// corresponding gate before `session_to_helper`; physical close holds it
+    /// across the ACP round-trip without blocking unrelated SessionIds.
+    session_lifecycle_gates:
+        Mutex<HashMap<acp::schema::v1::SessionId, Weak<tokio::sync::Mutex<()>>>>,
     /// Routes inbound traffic from the agent CLI back to the helper
     /// that owns the session. Inserted by the helper's `new_session`
     /// / `load_session` handlers atomically (before responding to
@@ -167,13 +174,9 @@ struct MasterStateInner {
     /// title/updated_at — has a typed home that isn't intertwined
     /// with notification-channel plumbing.
     ///
-    /// Lock ordering: always take `session_to_helper` *before*
-    /// touching `registry` to keep the helper-disconnect cleanup
-    /// path single-threaded (it walks `session_to_helper` for ids
-    /// and then issues `registry.remove`). Holding `session_to_helper`
-    /// while awaiting on `registry` is safe — the registry's interior
-    /// lock is sub-µs sync HashMap work that does not re-enter
-    /// `session_to_helper`.
+    /// Route-mutation lock ordering is per-session lifecycle gate, then
+    /// `session_to_helper`, then subordinate state such as `registry`.
+    /// Route reads do not need the lifecycle gate.
     pub(crate) registry: Arc<dyn crate::session_registry::SessionRegistry>,
     /// Per-helper subscribers for `intellterm.wta/*` ExtNotifications
     /// fanned out from master. Populated by `serve_helper` on connect
@@ -349,11 +352,27 @@ struct MasterStateInner {
     wsl_seed_in_flight: std::sync::atomic::AtomicBool,
 }
 
+async fn session_lifecycle_gate(
+    state: &MasterStateInner,
+    session_id: &acp::schema::v1::SessionId,
+) -> Arc<tokio::sync::Mutex<()>> {
+    let mut gates = state.session_lifecycle_gates.lock().await;
+    gates.retain(|_, gate| gate.strong_count() > 0);
+    if let Some(gate) = gates.get(session_id).and_then(Weak::upgrade) {
+        return gate;
+    }
+    let gate = Arc::new(tokio::sync::Mutex::new(()));
+    gates.insert(session_id.clone(), Arc::downgrade(&gate));
+    gate
+}
+
 async fn bind_session_route(
     state: &MasterStateInner,
     session_id: acp::schema::v1::SessionId,
     route: HelperRoute,
 ) -> usize {
+    let gate = session_lifecycle_gate(state, &session_id).await;
+    let _guard = gate.lock().await;
     let mut routes = state.session_to_helper.lock().await;
     let mut pending_usage = state.pending_usage.lock().await;
     pending_usage.remove(&session_id);
@@ -361,17 +380,26 @@ async fn bind_session_route(
     routes.len()
 }
 
-/// Retire one session deliberately replaced by its owning helper.
-///
-/// ACP has no session-close request, so the helper first sends
-/// `session/cancel` to stop any active turn. Once the replacement session is
-/// live, master drops every WTA-owned resource for the old SessionId so it is
-/// no longer routable or advertised as live.
-async fn retire_replaced_session(
+async fn swap_session_route(
+    state: &MasterStateInner,
+    session_id: acp::schema::v1::SessionId,
+    route: HelperRoute,
+) -> Option<HelperRoute> {
+    let gate = session_lifecycle_gate(state, &session_id).await;
+    let _guard = gate.lock().await;
+    let mut routes = state.session_to_helper.lock().await;
+    state.pending_usage.lock().await.remove(&session_id);
+    routes.insert(session_id, route)
+}
+
+async fn rollback_swapped_session_route(
     state: &MasterStateInner,
     helper_id: HelperId,
     session_id: &acp::schema::v1::SessionId,
+    previous: Option<HelperRoute>,
 ) -> bool {
+    let gate = session_lifecycle_gate(state, session_id).await;
+    let _guard = gate.lock().await;
     let mut routes = state.session_to_helper.lock().await;
     if !routes
         .get(session_id)
@@ -379,12 +407,147 @@ async fn retire_replaced_session(
     {
         return false;
     }
-    routes.remove(session_id);
+    if let Some(previous) = previous {
+        routes.insert(session_id.clone(), previous);
+    } else {
+        routes.remove(session_id);
+    }
+    true
+}
 
-    // Keep the route lock through all session-scoped cleanup and removal
-    // broadcasts so load_session cannot rebind this SessionId mid-retirement.
-    // This follows the state lock order: route before usage, registry, or
-    // helper-subscriber state; none of those paths re-enters the route map.
+const SESSION_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReplacedSessionCleanup {
+    NotOwned,
+    PhysicallyClosed,
+    LogicalFallback,
+}
+
+/// Close and retire one session deliberately replaced by its owning helper.
+///
+/// The per-SessionId lifecycle gate stays held across ownership validation,
+/// the bounded `session/close` RPC (or unsupported-agent cancel fallback), all
+/// WTA cleanup, and removal broadcasts. The global route lock is held only for
+/// short map operations, so agent callbacks can still perform route lookups
+/// while the close response is pending.
+async fn close_and_retire_replaced_session(
+    state: &MasterStateInner,
+    helper_id: HelperId,
+    agent: &AgentCli,
+    session_id: &acp::schema::v1::SessionId,
+    timeout: std::time::Duration,
+) -> acp::Result<ReplacedSessionCleanup> {
+    let gate = session_lifecycle_gate(state, session_id).await;
+    let _guard = gate.lock().await;
+    {
+        let routes = state.session_to_helper.lock().await;
+        if !routes
+            .get(session_id)
+            .is_some_and(|route| route.helper_id == helper_id)
+        {
+            return Ok(ReplacedSessionCleanup::NotOwned);
+        }
+    }
+
+    let cleanup = if !agent_supports_session_close(agent) {
+        tracing::warn!(
+            target: "master",
+            step = "helper→agent",
+            op = "close_replaced_session",
+            helper_id = ?helper_id,
+            old_session_id = %session_id,
+            outcome = "unsupported_logical_fallback",
+            "agent does not advertise session/close; cancelling best-effort and retiring only WTA state"
+        );
+        if let Err(error) = agent
+            .conn
+            .cancel(acp::schema::v1::CancelNotification::new(session_id.clone()))
+            .await
+        {
+            tracing::warn!(
+                target: "master",
+                step = "helper→agent",
+                op = "cancel_replaced_session",
+                helper_id = ?helper_id,
+                old_session_id = %session_id,
+                error = %error,
+                "legacy session/cancel fallback failed"
+            );
+        }
+        ReplacedSessionCleanup::LogicalFallback
+    } else {
+        let started = std::time::Instant::now();
+        match tokio::time::timeout(
+            timeout,
+            agent
+                .conn
+                .close_session(acp::schema::v1::CloseSessionRequest::new(
+                    session_id.clone(),
+                )),
+        )
+        .await
+        {
+            Ok(Ok(_)) => {
+                tracing::info!(
+                    target: "master",
+                    step = "helper→agent",
+                    op = "close_replaced_session",
+                    helper_id = ?helper_id,
+                    old_session_id = %session_id,
+                    outcome = "closed",
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    "physically closed replaced ACP session"
+                );
+                ReplacedSessionCleanup::PhysicallyClosed
+            }
+            Ok(Err(error)) => {
+                tracing::error!(
+                    target: "master",
+                    step = "helper→agent",
+                    op = "close_replaced_session",
+                    helper_id = ?helper_id,
+                    old_session_id = %session_id,
+                    outcome = "acp_error",
+                    error = %error,
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    "failed to physically close replaced ACP session"
+                );
+                return Err(error);
+            }
+            Err(_) => {
+                let message =
+                    format!("agent CLI session/close timed out for replaced session {session_id}");
+                tracing::error!(
+                    target: "master",
+                    step = "helper→agent",
+                    op = "close_replaced_session",
+                    helper_id = ?helper_id,
+                    old_session_id = %session_id,
+                    outcome = "timeout",
+                    timeout_ms = timeout.as_millis() as u64,
+                    "timed out physically closing replaced ACP session"
+                );
+                return Err(
+                    acp::Error::new(-32603, message.clone()).data(serde_json::json!({
+                        "message": message
+                    })),
+                );
+            }
+        }
+    };
+
+    {
+        let mut routes = state.session_to_helper.lock().await;
+        if !routes
+            .get(session_id)
+            .is_some_and(|route| route.helper_id == helper_id)
+        {
+            unreachable!("session route cannot change while its lifecycle gate is held");
+        }
+        routes.remove(session_id);
+    }
+
     state.pending_usage.lock().await.remove(session_id);
     state
         .session_mcp_capabilities
@@ -401,7 +564,16 @@ async fn retire_replaced_session(
         crate::session_registry::build_sessions_changed_notification(),
     )
     .await;
-    true
+    Ok(cleanup)
+}
+
+fn agent_supports_session_close(agent: &AgentCli) -> bool {
+    agent
+        .cached_init_resp
+        .agent_capabilities
+        .session_capabilities
+        .close
+        .is_some()
 }
 
 /// Canonical key for the agent-CLI pool: authoritative agent identity,
@@ -917,18 +1089,20 @@ impl MasterClient {
                         // that runs.
                         //
                         // CRITICAL: only remove if the entry STILL
-                        // belongs to the helper we snapshotted. A
+                        // is the exact route we snapshotted. A
                         // freshly-issued `load_session` can have
-                        // rebound the same SessionId to a different
-                        // helper between our snapshot and now —
+                        // rebound the same SessionId to a new channel,
+                        // even for the same helper, between our snapshot and now —
                         // clobbering that new entry would silently
-                        // break notification delivery for the new
-                        // helper. `helper_id` is unique per master
-                        // lifetime (monotonic counter), so equality is
-                        // a sufficient identity check.
+                        // break notification delivery for the new route.
+                        let gate = session_lifecycle_gate(&self.state, &sid).await;
+                        let _guard = gate.lock().await;
                         let mut map = self.state.session_to_helper.lock().await;
                         match map.get(&sid) {
-                            Some(current) if current.helper_id == snap_helper_id => {
+                            Some(current)
+                                if current.helper_id == snap_helper_id
+                                    && current.notif_tx.same_channel(&tx) =>
+                            {
                                 map.remove(&sid);
                                 tracing::warn!(
                                     target: "master",
@@ -945,7 +1119,7 @@ impl MasterClient {
                                     kind = %kind,
                                     stale_helper_id = ?snap_helper_id,
                                     current_helper_id = ?current.helper_id,
-                                    "helper notification channel closed but SessionId has been rebound to a different helper — dropping update, leaving new route intact"
+                                    "helper notification channel closed but SessionId has been rebound — dropping update, leaving new route intact"
                                 );
                             }
                             None => {
@@ -1297,6 +1471,57 @@ impl HelperHandler {
             .await
             .map_err(|_| self.load_session_timeout_error(total_timeout, "agent_rpc"))?
     }
+
+    async fn best_effort_close_loaded_target(
+        &self,
+        agent: &AgentCli,
+        session_id: &acp::schema::v1::SessionId,
+        timeout: std::time::Duration,
+    ) {
+        if !agent_supports_session_close(agent) || timeout.is_zero() {
+            return;
+        }
+        match tokio::time::timeout(
+            timeout,
+            agent
+                .conn
+                .close_session(acp::schema::v1::CloseSessionRequest::new(
+                    session_id.clone(),
+                )),
+        )
+        .await
+        {
+            Ok(Ok(_)) => tracing::info!(
+                target: "master",
+                step = "helper→agent",
+                op = "rollback_close_loaded_target",
+                helper_id = ?self.helper_id,
+                session_id = %session_id,
+                outcome = "closed",
+                "closed newly loaded target after predecessor close failed"
+            ),
+            Ok(Err(error)) => tracing::warn!(
+                target: "master",
+                step = "helper→agent",
+                op = "rollback_close_loaded_target",
+                helper_id = ?self.helper_id,
+                session_id = %session_id,
+                outcome = "acp_error",
+                error = %error,
+                "failed to close newly loaded target during rollback"
+            ),
+            Err(_) => tracing::warn!(
+                target: "master",
+                step = "helper→agent",
+                op = "rollback_close_loaded_target",
+                helper_id = ?self.helper_id,
+                session_id = %session_id,
+                outcome = "timeout",
+                timeout_ms = timeout.as_millis() as u64,
+                "timed out closing newly loaded target during rollback"
+            ),
+        }
+    }
 }
 
 impl HelperHandler {
@@ -1523,6 +1748,33 @@ impl HelperHandler {
             .and_then(|meta| meta.last_session_id.clone());
         let cwd_for_registry = args.cwd.clone();
         let agent = self.resolved_agent("new_session")?;
+        if let Some(previous_session_id) = previous_session_id.as_ref() {
+            let cleanup = close_and_retire_replaced_session(
+                &self.state,
+                self.helper_id,
+                &agent,
+                previous_session_id,
+                SESSION_CLOSE_TIMEOUT,
+            )
+            .await?;
+            {
+                let mut meta = self.state.helper_meta.lock().await;
+                if meta
+                    .get(&self.helper_id)
+                    .and_then(|meta| meta.last_session_id.as_ref())
+                    == Some(previous_session_id)
+                {
+                    meta.entry(self.helper_id).or_default().last_session_id = None;
+                }
+            }
+            tracing::info!(
+                target: "master",
+                helper_id = ?self.helper_id,
+                old_session_id = %previous_session_id,
+                cleanup = ?cleanup,
+                "finished predecessor cleanup before session/new"
+            );
+        }
         let session_mcp_endpoint = self
             .session_mcp_endpoint_for_session(&agent, &wta_meta, "new_session")
             .await?;
@@ -1586,6 +1838,7 @@ impl HelperHandler {
             resp.session_id.clone(),
             HelperRoute {
                 helper_id: self.helper_id,
+                agent_instance_id: agent.instance_id,
                 notif_tx: self.notif_tx.clone(),
                 forwarder: Some(forwarder),
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -1616,20 +1869,6 @@ impl HelperHandler {
             .ok()
             .map(|d| d.as_millis() as u64);
         self.state.registry.upsert(info.clone()).await;
-        if let Some(previous_session_id) =
-            previous_session_id.filter(|sid| sid != &resp.session_id)
-        {
-            let retired =
-                retire_replaced_session(&self.state, self.helper_id, &previous_session_id).await;
-            tracing::info!(
-                target: "master",
-                helper_id = ?self.helper_id,
-                old_session_id = %previous_session_id,
-                new_session_id = %resp.session_id,
-                retired,
-                "retired session replaced by session/new"
-            );
-        }
         // Record crash-recovery metadata for this helper: the owning
         // WT tab StableId (so master can address a `restart_agent_pane`
         // event on disconnect) and the just-created session as the
@@ -1709,6 +1948,11 @@ impl HelperHandler {
             .await
             .get(&self.helper_id)
             .and_then(|meta| meta.last_session_id.clone());
+        let rollback_reserve = previous_session_id
+            .as_ref()
+            .is_some_and(|sid| sid != &session_id)
+            .then(|| SESSION_ROLLBACK_CLOSE_TIMEOUT.min(timeout / 2))
+            .unwrap_or_default();
         let cwd_for_registry = args.cwd.clone();
         tracing::info!(
             target: "master",
@@ -1738,17 +1982,21 @@ impl HelperHandler {
         // any peer-visible flicker.
         let agent = self.resolved_agent("load_session")?;
         let forwarder = self.forwarder_for_route("load_session")?;
-        bind_session_route(
+        let previous_target_route = swap_session_route(
             &self.state,
             session_id.clone(),
             HelperRoute {
                 helper_id: self.helper_id,
+                agent_instance_id: agent.instance_id,
                 notif_tx: self.notif_tx.clone(),
                 forwarder: Some(forwarder),
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             },
         )
         .await;
+        let previous_target_used_same_agent = previous_target_route
+            .as_ref()
+            .is_some_and(|route| route.agent_instance_id == agent.instance_id);
         // Orphan re-bind fast path: this session's previous helper
         // disconnected but the shared CLI still has it loaded (tracked in
         // `orphaned_sessions` under this agent's key). Re-attach onto the
@@ -1769,6 +2017,8 @@ impl HelperHandler {
         // Both a re-bind and a real `session/load` resume the session; only a
         // genuine load failure rolls back. Resolve the response, then register
         // the resumed row once for either success path.
+        let mut session_mcp = None;
+        let mut loaded_target_physically = false;
         let resp = if is_orphan_rebind {
             tracing::info!(
                 target: "master",
@@ -1786,15 +2036,17 @@ impl HelperHandler {
             {
                 Ok(endpoint) => endpoint,
                 Err(error) => {
-                    self.state
-                        .session_to_helper
-                        .lock()
-                        .await
-                        .remove(&session_id);
+                    rollback_swapped_session_route(
+                        &self.state,
+                        self.helper_id,
+                        &session_id,
+                        previous_target_route,
+                    )
+                    .await;
                     return Err(error);
                 }
             };
-            let session_mcp = if let Some(endpoint) = session_mcp_endpoint {
+            session_mcp = if let Some(endpoint) = session_mcp_endpoint {
                 let pending = self
                     .state
                     .session_mcp_capabilities
@@ -1807,33 +2059,24 @@ impl HelperHandler {
                 None
             };
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            match self
-                .forward_load_session_to_agent(args, remaining, timeout)
-                .await
-            {
+            let load_rpc_timeout = remaining.saturating_sub(rollback_reserve);
+            let load_result = if load_rpc_timeout.is_zero() {
+                Err(self.load_session_timeout_error(timeout, "agent_rpc"))
+            } else {
+                self.forward_load_session_to_agent(args, load_rpc_timeout, timeout)
+                    .await
+            };
+            match load_result {
                 Ok(resp) => {
-                    if let Some(pending) = session_mcp.as_ref() {
-                        if !self
-                            .state
-                            .session_mcp_capabilities
-                            .bind(pending, session_id.clone())
-                            .await
-                        {
-                            tracing::warn!(
-                                target: "session_mcp",
-                                session_id = %session_id,
-                                "session MCP capability disappeared before load binding"
-                            );
-                        }
-                    }
+                    loaded_target_physically = true;
                     resp
                 }
                 // Fallback for an orphan we didn't track (e.g. it predates
                 // this master): the CLI reports "already loaded", so re-bind
                 // onto the pre-registered routing just like the fast path.
                 Err(err) if is_already_loaded_error(&err) => {
-                    if let Some(pending) = session_mcp.as_ref() {
-                        self.state.session_mcp_capabilities.cancel(pending).await;
+                    if let Some(pending) = session_mcp.take() {
+                        self.state.session_mcp_capabilities.cancel(&pending).await;
                     }
                     tracing::info!(
                         target: "master",
@@ -1853,14 +2096,28 @@ impl HelperHandler {
                     // needs touching — we never wrote to `registry` and we
                     // never broadcast `session_added`, so peers never saw
                     // this row.
-                    {
-                        let mut map = self.state.session_to_helper.lock().await;
-                        map.remove(&session_id);
+                    let route_rolled_back = rollback_swapped_session_route(
+                        &self.state,
+                        self.helper_id,
+                        &session_id,
+                        previous_target_route,
+                    )
+                    .await;
+                    if route_rolled_back && !previous_target_used_same_agent {
+                        let remaining =
+                            deadline.saturating_duration_since(tokio::time::Instant::now());
+                        self.best_effort_close_loaded_target(
+                            &agent,
+                            &session_id,
+                            remaining.min(rollback_reserve),
+                        )
+                        .await;
                     }
                     tracing::warn!(
                         target: "master",
                         helper_id = ?self.helper_id,
                         session_id = ?session_id,
+                        route_rolled_back,
                         error = %err,
                         "load_session failed; rolled back routing entry"
                     );
@@ -1868,6 +2125,97 @@ impl HelperHandler {
                 }
             }
         };
+
+        if let Some(previous_session_id) = previous_session_id
+            .as_ref()
+            .filter(|sid| *sid != &session_id)
+        {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            let close_timeout = remaining
+                .saturating_sub(rollback_reserve)
+                .min(SESSION_CLOSE_TIMEOUT);
+            let close_result = if close_timeout.is_zero() {
+                Err(self.load_session_timeout_error(timeout, "predecessor_close"))
+            } else {
+                close_and_retire_replaced_session(
+                    &self.state,
+                    self.helper_id,
+                    &agent,
+                    previous_session_id,
+                    close_timeout,
+                )
+                .await
+            };
+            let cleanup = match close_result {
+                Ok(cleanup) => cleanup,
+                Err(error) => {
+                    if let Some(pending) = session_mcp.as_ref() {
+                        self.state.session_mcp_capabilities.cancel(pending).await;
+                    }
+                    let route_rolled_back = rollback_swapped_session_route(
+                        &self.state,
+                        self.helper_id,
+                        &session_id,
+                        previous_target_route,
+                    )
+                    .await;
+                    if is_orphan_rebind {
+                        self.state
+                            .orphaned_sessions
+                            .lock()
+                            .await
+                            .entry(agent.cmd_key.clone())
+                            .or_default()
+                            .insert(session_id.clone());
+                    }
+                    if loaded_target_physically
+                        && route_rolled_back
+                        && !previous_target_used_same_agent
+                    {
+                        let remaining =
+                            deadline.saturating_duration_since(tokio::time::Instant::now());
+                        self.best_effort_close_loaded_target(
+                            &agent,
+                            &session_id,
+                            remaining.min(rollback_reserve),
+                        )
+                        .await;
+                    }
+                    tracing::error!(
+                        target: "master",
+                        helper_id = ?self.helper_id,
+                        old_session_id = %previous_session_id,
+                        target_session_id = %session_id,
+                        route_rolled_back,
+                        "predecessor close failed after session/load; target transaction rolled back"
+                    );
+                    return Err(error);
+                }
+            };
+            tracing::info!(
+                target: "master",
+                helper_id = ?self.helper_id,
+                old_session_id = %previous_session_id,
+                new_session_id = %session_id,
+                cleanup = ?cleanup,
+                "finished predecessor cleanup after successful session/load"
+            );
+        }
+
+        if let Some(pending) = session_mcp.as_ref() {
+            if !self
+                .state
+                .session_mcp_capabilities
+                .bind(pending, session_id.clone())
+                .await
+            {
+                tracing::warn!(
+                    target: "session_mcp",
+                    session_id = %session_id,
+                    "session MCP capability disappeared before load binding"
+                );
+            }
+        }
 
         let (available_models, current_model_id) =
             update_model_switch_channel_from_load(&session_id, &resp);
@@ -1911,18 +2259,6 @@ impl HelperHandler {
             }
         }
         self.state.registry.upsert(info.clone()).await;
-        if let Some(previous_session_id) = previous_session_id.filter(|sid| sid != &session_id) {
-            let retired =
-                retire_replaced_session(&self.state, self.helper_id, &previous_session_id).await;
-            tracing::info!(
-                target: "master",
-                helper_id = ?self.helper_id,
-                old_session_id = %previous_session_id,
-                new_session_id = %session_id,
-                retired,
-                "retired session replaced by session/load"
-            );
-        }
         // Refresh crash-recovery metadata so a later resume targets this session.
         {
             let mut meta = self.state.helper_meta.lock().await;
@@ -2537,6 +2873,7 @@ async fn run_master_loop(config: MasterConfig, pipe_name: String) -> Result<()> 
             .context("read master session MCP HTTP endpoint")?
     );
     let inner = Arc::new(MasterStateInner {
+        session_lifecycle_gates: Mutex::new(HashMap::new()),
         session_to_helper: Mutex::new(HashMap::new()),
         session_mcp_endpoints: session_mcp::Endpoints::new(session_mcp_endpoint),
         session_mcp_capabilities: session_mcp::CapabilityRegistry::default(),
@@ -2918,7 +3255,7 @@ async fn spawn_one_agent(
         source,
         ChildEnvironmentPolicy::ApplySharedProvider,
     )
-        .with_context(|| format!("failed to spawn agent CLI: {agent_cmd}"))?;
+    .with_context(|| format!("failed to spawn agent CLI: {agent_cmd}"))?;
     tracing::info!(
         target: "master",
         program = %spawn_result.resolved_program,
@@ -3321,7 +3658,7 @@ async fn serve_helper(
                     let h = h.clone();
                     async move {
                         use acp::schema::v1::{AgentResponse as R, ClientRequest as Q};
-            match req {
+                        match req {
                             Q::InitializeRequest(a) => conn::respond_enum(
                                 responder,
                                 h.initialize(a).await.map(R::InitializeResponse),
@@ -3352,13 +3689,13 @@ async fn serve_helper(
                                 responder,
                                 h.list_sessions(a).await.map(R::ListSessionsResponse),
                             ),
-                Q::PromptRequest(a) => h.prompt(a, responder).await,
+                            Q::PromptRequest(a) => h.prompt(a, responder).await,
                             Q::ExtMethodRequest(a) => conn::respond_enum(
                                 responder,
                                 h.ext_method(a).await.map(R::ExtMethodResponse),
                             ),
-                _ => responder.respond_with_error(acp::Error::method_not_found()),
-            }
+                            _ => responder.respond_with_error(acp::Error::method_not_found()),
+                        }
                     }
                 }
             },
@@ -3373,7 +3710,7 @@ async fn serve_helper(
                         if let acp::schema::v1::ClientNotification::CancelNotification(n) = notif {
                             let _ = h.cancel(n).await;
                         }
-            Ok(())
+                        Ok(())
                     }
                 }
             },
@@ -3590,28 +3927,33 @@ async fn drop_sessions_for_helper(
     state: &MasterStateInner,
     helper_id: HelperId,
 ) -> Vec<acp::schema::v1::SessionId> {
-    // Collect the owned SessionIds first so we can drop them from the
-    // live registry too. Single pass through `session_to_helper` while
-    // we already hold its lock; the corresponding `registry.remove`
-    // calls happen after we release `session_to_helper` to keep with
-    // the lock ordering doc'd on `MasterStateInner::registry`.
-    let victims: Vec<acp::schema::v1::SessionId> = {
-        let mut map = state.session_to_helper.lock().await;
-        let victims = map
-            .iter()
+    let candidates = {
+        let map = state.session_to_helper.lock().await;
+        map.iter()
             .filter_map(|(sid, route)| (route.helper_id == helper_id).then(|| sid.clone()))
-            .collect::<Vec<_>>();
-        map.retain(|_, route| route.helper_id != helper_id);
-        victims
+            .collect::<Vec<_>>()
     };
-    {
-        let mut pending_usage = state.pending_usage.lock().await;
-        for session_id in &victims {
-            pending_usage.remove(session_id);
+    let mut victims = Vec::with_capacity(candidates.len());
+    for session_id in candidates {
+        let gate = session_lifecycle_gate(state, &session_id).await;
+        let _guard = gate.lock().await;
+        let removed = {
+            let mut map = state.session_to_helper.lock().await;
+            if map
+                .get(&session_id)
+                .is_some_and(|route| route.helper_id == helper_id)
+            {
+                map.remove(&session_id);
+                true
+            } else {
+                false
+            }
+        };
+        if !removed {
+            continue;
         }
-    }
-    for sid in &victims {
-        state.registry.remove(sid).await;
+        state.pending_usage.lock().await.remove(&session_id);
+        state.registry.remove(&session_id).await;
         // Broadcast removal so every still-attached helper drops the
         // row from its mirror. The disconnecting helper itself has
         // (almost always) already been removed from
@@ -3620,7 +3962,7 @@ async fn drop_sessions_for_helper(
         // peers it should reach.
         broadcast_ext_to_helpers(
             state,
-            crate::session_registry::build_session_removed_notification(sid),
+            crate::session_registry::build_session_removed_notification(&session_id),
         )
         .await;
         broadcast_ext_to_helpers(
@@ -3628,6 +3970,7 @@ async fn drop_sessions_for_helper(
             crate::session_registry::build_sessions_changed_notification(),
         )
         .await;
+        victims.push(session_id);
     }
     victims
 }

--- a/tools/wta/src/master/session_mcp.rs
+++ b/tools/wta/src/master/session_mcp.rs
@@ -336,18 +336,12 @@ impl CapabilityRegistry {
     }
 
     pub(super) async fn remove_session(&self, session_id: &acp::schema::v1::SessionId) -> bool {
-        let removed = {
-            let mut routes = self.routes.lock().await;
-            let Some(hash) = routes.by_session.get(session_id).copied() else {
-                return false;
-            };
-            Self::remove_capability(&mut routes, &hash);
-            true
+        let mut routes = self.routes.lock().await;
+        let Some(hash) = routes.by_session.get(session_id).copied() else {
+            return false;
         };
-        if let Ok(mut active) = self.active_user_inputs.lock() {
-            active.remove(session_id);
-        }
-        removed
+        Self::remove_capability(&mut routes, &hash);
+        true
     }
 
     async fn resolve(&self, secret: &str) -> CapabilityResolution {
@@ -1355,6 +1349,20 @@ mod tests {
         let registry = CapabilityRegistry::default();
         let session_id = acp::schema::v1::SessionId::new("session");
         let lease = registry.try_begin_user_input(session_id.clone()).unwrap();
+        assert!(registry.try_begin_user_input(session_id.clone()).is_err());
+        drop(lease);
+        assert!(registry.try_begin_user_input(session_id).is_ok());
+    }
+
+    #[tokio::test]
+    async fn removing_session_preserves_active_user_input_lease() {
+        let registry = CapabilityRegistry::default();
+        let session_id = acp::schema::v1::SessionId::new("session");
+        let pending = registry.prepare(AgentInstanceId::new_v4(), None).await;
+        assert!(registry.bind(&pending, session_id.clone()).await);
+        let lease = registry.try_begin_user_input(session_id.clone()).unwrap();
+
+        assert!(registry.remove_session(&session_id).await);
         assert!(registry.try_begin_user_input(session_id.clone()).is_err());
         drop(lease);
         assert!(registry.try_begin_user_input(session_id).is_ok());

--- a/tools/wta/src/master/session_mcp.rs
+++ b/tools/wta/src/master/session_mcp.rs
@@ -335,6 +335,21 @@ impl CapabilityRegistry {
         count
     }
 
+    pub(super) async fn remove_session(&self, session_id: &acp::schema::v1::SessionId) -> bool {
+        let removed = {
+            let mut routes = self.routes.lock().await;
+            let Some(hash) = routes.by_session.get(session_id).copied() else {
+                return false;
+            };
+            Self::remove_capability(&mut routes, &hash);
+            true
+        };
+        if let Ok(mut active) = self.active_user_inputs.lock() {
+            active.remove(session_id);
+        }
+        removed
+    }
+
     async fn resolve(&self, secret: &str) -> CapabilityResolution {
         match self
             .routes
@@ -1318,6 +1333,21 @@ mod tests {
             registry.resolve(&replacement.secret).await,
             CapabilityResolution::Unknown
         ));
+    }
+
+    #[tokio::test]
+    async fn removing_session_revokes_its_capability() {
+        let registry = CapabilityRegistry::default();
+        let session_id = acp::schema::v1::SessionId::new("session");
+        let pending = registry.prepare(AgentInstanceId::new_v4(), None).await;
+        assert!(registry.bind(&pending, session_id.clone()).await);
+
+        assert!(registry.remove_session(&session_id).await);
+        assert!(matches!(
+            registry.resolve(&pending.secret).await,
+            CapabilityResolution::Unknown
+        ));
+        assert!(!registry.remove_session(&session_id).await);
     }
 
     #[test]

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -30,9 +30,16 @@ struct BlockingCloseAgent {
     events: mpsc::UnboundedSender<ReplacementEvent>,
 }
 
+#[derive(Clone)]
+struct RebindDuringCloseAgent {
+    predecessor: SessionId,
+    events: mpsc::UnboundedSender<ReplacementEvent>,
+}
+
 enum ReplacementEvent {
     Close(SessionId),
     BlockingClose(SessionId, tokio::sync::oneshot::Sender<()>),
+    FailingClose(SessionId, tokio::sync::oneshot::Sender<()>),
     Load(SessionId),
     New(usize, tokio::sync::oneshot::Sender<()>),
 }
@@ -117,6 +124,39 @@ impl BlockingCloseAgent {
             .await
             .map_err(|_| acp::Error::internal_error().data("test release sender dropped"))?;
         Ok(acp::schema::v1::CloseSessionResponse::new())
+    }
+}
+
+impl RebindDuringCloseAgent {
+    async fn load_session(
+        &self,
+        args: acp::schema::v1::LoadSessionRequest,
+    ) -> acp::Result<acp::schema::v1::LoadSessionResponse> {
+        self.events
+            .send(ReplacementEvent::Load(args.session_id))
+            .map_err(|_| acp::Error::internal_error().data("test event receiver dropped"))?;
+        Ok(acp::schema::v1::LoadSessionResponse::new())
+    }
+
+    async fn close_session(
+        &self,
+        args: acp::schema::v1::CloseSessionRequest,
+    ) -> acp::Result<acp::schema::v1::CloseSessionResponse> {
+        if args.session_id == self.predecessor {
+            let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+            self.events
+                .send(ReplacementEvent::FailingClose(args.session_id, release_tx))
+                .map_err(|_| acp::Error::internal_error().data("test event receiver dropped"))?;
+            release_rx
+                .await
+                .map_err(|_| acp::Error::internal_error().data("test release sender dropped"))?;
+            Err(acp::Error::internal_error().data("injected predecessor close failure"))
+        } else {
+            self.events
+                .send(ReplacementEvent::Close(args.session_id))
+                .map_err(|_| acp::Error::internal_error().data("test event receiver dropped"))?;
+            Ok(acp::schema::v1::CloseSessionResponse::new())
+        }
     }
 }
 
@@ -761,6 +801,68 @@ fn client_connection_to_controlled_new_session_agent(
         let _ = client_io.await;
     });
 
+    client_conn
+}
+
+fn client_connection_to_rebind_during_close_agent(
+    predecessor: SessionId,
+    events: mpsc::UnboundedSender<ReplacementEvent>,
+) -> conn::ClientLink {
+    let (client_pipe, agent_pipe) = tokio::io::duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_pipe);
+    let (agent_read, agent_write) = tokio::io::split(agent_pipe);
+    let mock = RebindDuringCloseAgent {
+        predecessor,
+        events,
+    };
+    let agent_builder = acp::Agent
+        .builder()
+        .name("rebind-during-close-agent")
+        .on_receive_request(
+            {
+                let mock = mock.clone();
+                move |req: acp::schema::v1::LoadSessionRequest,
+                      responder: acp::Responder<acp::schema::v1::LoadSessionResponse>,
+                      _cx| {
+                    let mock = mock.clone();
+                    async move {
+                        match mock.load_session(req).await {
+                            Ok(response) => responder.respond(response),
+                            Err(error) => responder.respond_with_error(error),
+                        }
+                    }
+                }
+            },
+            acp::on_receive_request!(),
+        )
+        .on_receive_request(
+            move |req: acp::schema::v1::CloseSessionRequest,
+                  responder: acp::Responder<acp::schema::v1::CloseSessionResponse>,
+                  _cx| {
+                let mock = mock.clone();
+                async move {
+                    match mock.close_session(req).await {
+                        Ok(response) => responder.respond(response),
+                        Err(error) => responder.respond_with_error(error),
+                    }
+                }
+            },
+            acp::on_receive_request!(),
+        );
+    let (_agent_conn, agent_io) = conn::spawn_agent(
+        agent_builder,
+        conn::byte_streams(agent_write.compat_write(), agent_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = agent_io.await;
+    });
+    let (client_conn, client_io) = conn::spawn_client(
+        acp::Client.builder().name("rebind-during-close-client"),
+        conn::byte_streams(client_write.compat_write(), client_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = client_io.await;
+    });
     client_conn
 }
 
@@ -2277,6 +2379,282 @@ async fn load_close_failure_closes_target_when_restored_route_uses_another_agent
                 HashSet::from([old_session]),
                 "the target loaded into the current agent must be physically closed"
             );
+        })
+        .await;
+}
+
+async fn run_target_rebound_during_predecessor_close_failure(rebound_to_current_agent: bool) {
+    let state = make_state();
+    let helper_id = HelperId(30);
+    let peer_id = HelperId(31);
+    let old_session = SessionId::new("rebound-old");
+    let target_session = SessionId::new("rebound-target");
+    let current_agent_instance = AgentInstanceId::new_v4();
+    let rebound_agent_instance = if rebound_to_current_agent {
+        current_agent_instance
+    } else {
+        AgentInstanceId::new_v4()
+    };
+    let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+    let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+    let (peer_tx, _peer_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+    let agent_side_slot = Arc::new(OnceLock::new());
+    agent_side_slot
+        .set(agent_link_to_noop_client())
+        .expect("agent-side forwarder should be set once");
+    let mut cached_init_resp =
+        acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+    cached_init_resp
+        .agent_capabilities
+        .session_capabilities
+        .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+    let agent = Arc::new(OnceLock::new());
+    assert!(agent
+        .set(Arc::new(AgentCli {
+            instance_id: current_agent_instance,
+            conn: client_connection_to_rebind_during_close_agent(old_session.clone(), events_tx,),
+            cached_init_resp,
+            cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+            source: crate::agent_source::AgentSource::Host,
+            cmd_key: "rebind-during-close-agent".to_string(),
+            cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+            bound_helpers: Mutex::new(HashSet::new()),
+        }))
+        .is_ok());
+    let handler = HelperHandler {
+        helper_id,
+        agent,
+        state: Arc::clone(&state),
+        replacement_gate: Arc::new(Mutex::new(())),
+        notif_tx: notif_tx.clone(),
+        agent_side_slot,
+    };
+    bind_session_route(
+        &state,
+        old_session.clone(),
+        HelperRoute {
+            helper_id,
+            agent_instance_id: current_agent_instance,
+            notif_tx,
+            forwarder: Some(agent_link_to_noop_client()),
+            consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        },
+    )
+    .await;
+    state.helper_meta.lock().await.insert(
+        helper_id,
+        HelperRecoveryMeta {
+            last_session_id: Some(old_session.clone()),
+            ..Default::default()
+        },
+    );
+
+    let request = tokio::task::spawn_local({
+        let handler = handler.clone();
+        let target_session = target_session.clone();
+        async move {
+            handler
+                .load_session_with_timeout(
+                    acp::schema::v1::LoadSessionRequest::new(
+                        target_session,
+                        PathBuf::from("C:\\target"),
+                    ),
+                    std::time::Duration::from_secs(3),
+                )
+                .await
+        }
+    });
+    assert!(matches!(
+        events_rx.recv().await,
+        Some(ReplacementEvent::Load(ref sid)) if sid == &target_session
+    ));
+    let release = match events_rx.recv().await {
+        Some(ReplacementEvent::FailingClose(sid, release)) if sid == old_session => release,
+        _ => panic!("predecessor close must block before failing"),
+    };
+    bind_session_route(
+        &state,
+        target_session.clone(),
+        HelperRoute {
+            helper_id: peer_id,
+            agent_instance_id: rebound_agent_instance,
+            notif_tx: peer_tx,
+            forwarder: Some(agent_link_to_noop_client()),
+            consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        },
+    )
+    .await;
+    release
+        .send(())
+        .expect("predecessor close should still be waiting");
+    let error = request
+        .await
+        .expect("load task should finish")
+        .expect_err("predecessor close failure must fail the transaction");
+    assert!(format!("{error}").contains("injected predecessor close failure"));
+
+    if rebound_to_current_agent {
+        assert!(
+            events_rx.try_recv().is_err(),
+            "same-agent rebound owns the physical target and must suppress rollback close"
+        );
+    } else {
+        assert!(matches!(
+            events_rx.try_recv(),
+            Ok(ReplacementEvent::Close(ref sid)) if sid == &target_session
+        ));
+        assert!(events_rx.try_recv().is_err());
+    }
+    let routes = state.session_to_helper.lock().await;
+    assert_eq!(routes[&target_session].helper_id, peer_id);
+    assert_eq!(
+        routes[&target_session].agent_instance_id,
+        rebound_agent_instance
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn load_close_failure_closes_target_rebound_to_different_agent() {
+    tokio::task::LocalSet::new()
+        .run_until(run_target_rebound_during_predecessor_close_failure(false))
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn load_close_failure_keeps_target_rebound_to_same_agent() {
+    tokio::task::LocalSet::new()
+        .run_until(run_target_rebound_during_predecessor_close_failure(true))
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn orphan_rebind_close_failure_does_not_mark_target_owned_by_another_helper() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(32);
+            let peer_id = HelperId(33);
+            let old_session = SessionId::new("orphan-rebound-old");
+            let target_session = SessionId::new("orphan-rebound-target");
+            let current_agent_instance = AgentInstanceId::new_v4();
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let (peer_tx, _peer_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let agent_key = "orphan-rebind-close-agent".to_string();
+            let agent_side_slot = Arc::new(OnceLock::new());
+            agent_side_slot
+                .set(agent_link_to_noop_client())
+                .expect("agent-side forwarder should be set once");
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(OnceLock::new());
+            assert!(agent
+                .set(Arc::new(AgentCli {
+                    instance_id: current_agent_instance,
+                    conn: client_connection_to_rebind_during_close_agent(
+                        old_session.clone(),
+                        events_tx,
+                    ),
+                    cached_init_resp,
+                    cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                    source: crate::agent_source::AgentSource::Host,
+                    cmd_key: agent_key.clone(),
+                    cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                    bound_helpers: Mutex::new(HashSet::new()),
+                }))
+                .is_ok());
+            let handler = HelperHandler {
+                helper_id,
+                agent,
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx: notif_tx.clone(),
+                agent_side_slot,
+            };
+            bind_session_route(
+                &state,
+                old_session.clone(),
+                HelperRoute {
+                    helper_id,
+                    agent_instance_id: current_agent_instance,
+                    notif_tx,
+                    forwarder: Some(agent_link_to_noop_client()),
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry(agent_key.clone())
+                .or_default()
+                .insert(target_session.clone());
+            state.helper_meta.lock().await.insert(
+                helper_id,
+                HelperRecoveryMeta {
+                    last_session_id: Some(old_session.clone()),
+                    ..Default::default()
+                },
+            );
+
+            let request = tokio::task::spawn_local({
+                let handler = handler.clone();
+                let target_session = target_session.clone();
+                async move {
+                    handler
+                        .load_session_with_timeout(
+                            acp::schema::v1::LoadSessionRequest::new(
+                                target_session,
+                                PathBuf::from("C:\\target"),
+                            ),
+                            std::time::Duration::from_secs(3),
+                        )
+                        .await
+                }
+            });
+            let release = match events_rx.recv().await {
+                Some(ReplacementEvent::FailingClose(sid, release)) if sid == old_session => release,
+                _ => panic!("orphan rebind must skip load and reach predecessor close"),
+            };
+            bind_session_route(
+                &state,
+                target_session.clone(),
+                HelperRoute {
+                    helper_id: peer_id,
+                    agent_instance_id: AgentInstanceId::new_v4(),
+                    notif_tx: peer_tx,
+                    forwarder: Some(agent_link_to_noop_client()),
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+            release
+                .send(())
+                .expect("predecessor close should still be waiting");
+            request
+                .await
+                .expect("load task should finish")
+                .expect_err("predecessor close failure must fail the transaction");
+
+            assert!(
+                !state
+                    .orphaned_sessions
+                    .lock()
+                    .await
+                    .get(&agent_key)
+                    .is_some_and(|sessions| sessions.contains(&target_session)),
+                "ownership change must not restore the orphan marker"
+            );
+            assert_eq!(
+                state.session_to_helper.lock().await[&target_session].helper_id,
+                peer_id
+            );
+            assert!(events_rx.try_recv().is_err());
         })
         .await;
 }

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -1899,6 +1899,73 @@ async fn drop_sessions_for_helper_broadcasts_session_removed_to_peers() {
     assert_eq!(got, expected);
 }
 
+#[tokio::test]
+async fn retiring_replaced_session_releases_only_the_owners_old_session() {
+    use crate::session_registry::{self, SessionInfo};
+    use std::path::PathBuf;
+
+    let state = make_state();
+    let owner = HelperId(1);
+    let peer = HelperId(2);
+    let old_sid = SessionId::new("old");
+    let peer_sid = SessionId::new("peer");
+    let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+    {
+        let mut routes = state.session_to_helper.lock().await;
+        for (sid, helper_id) in [(&old_sid, owner), (&peer_sid, peer)] {
+            routes.insert(
+                sid.clone(),
+                HelperRoute {
+                    helper_id,
+                    notif_tx: notif_tx.clone(),
+                    forwarder: None,
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            );
+        }
+    }
+    state
+        .registry
+        .upsert(SessionInfo::new(
+            old_sid.clone(),
+            PathBuf::from("C:\\old"),
+        ))
+        .await;
+    state
+        .registry
+        .upsert(SessionInfo::new(
+            peer_sid.clone(),
+            PathBuf::from("C:\\peer"),
+        ))
+        .await;
+    let (ext_tx, mut ext_rx) = mpsc::unbounded_channel();
+    state
+        .helper_ext_subscribers
+        .lock()
+        .await
+        .insert(peer, ext_tx);
+
+    assert!(retire_replaced_session(&state, owner, &old_sid).await);
+    assert!(!retire_replaced_session(&state, owner, &peer_sid).await);
+
+    let routes = state.session_to_helper.lock().await;
+    assert!(!routes.contains_key(&old_sid));
+    assert!(routes.contains_key(&peer_sid));
+    drop(routes);
+    assert!(state.registry.lookup(&old_sid).await.is_none());
+    assert!(state.registry.lookup(&peer_sid).await.is_some());
+
+    assert!(matches!(
+        session_registry::parse_ext_notification(&ext_rx.try_recv().unwrap()),
+        session_registry::WtaExtNotification::SessionRemoved(sid) if sid == old_sid
+    ));
+    assert!(matches!(
+        session_registry::parse_ext_notification(&ext_rx.try_recv().unwrap()),
+        session_registry::WtaExtNotification::SessionsChanged
+    ));
+    assert!(ext_rx.try_recv().is_err());
+}
+
 /// `route_for` (used by every `MasterClient::<client-method>`
 /// forwarder) must return `internal_error` when the agent CLI
 /// sends a request for a session that no helper has registered

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -1966,6 +1966,74 @@ async fn retiring_replaced_session_releases_only_the_owners_old_session() {
     assert!(ext_rx.try_recv().is_err());
 }
 
+#[tokio::test]
+async fn retiring_replaced_session_serializes_rebinding_through_cleanup_broadcasts() {
+    use crate::session_registry::SessionInfo;
+    use std::path::PathBuf;
+
+    let state = make_state();
+    let sid = SessionId::new("rebound-during-retirement");
+    let old_owner = HelperId(1);
+    let new_owner = HelperId(2);
+    let (old_tx, _old_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+    let (new_tx, _new_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+    state.session_to_helper.lock().await.insert(
+        sid.clone(),
+        HelperRoute {
+            helper_id: old_owner,
+            notif_tx: old_tx,
+            forwarder: None,
+            consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        },
+    );
+    state
+        .registry
+        .upsert(SessionInfo::new(sid.clone(), PathBuf::from("C:\\old")))
+        .await;
+
+    // Stall retirement at its first removal broadcast. Once the registry row
+    // disappears, cleanup has reached that stall and must still own the route
+    // lock so a concurrent load_session cannot rebind the same SessionId.
+    let subscribers = state.helper_ext_subscribers.lock().await;
+    let retiring_state = Arc::clone(&state);
+    let retiring_sid = sid.clone();
+    let retire = tokio::spawn(async move {
+        retire_replaced_session(&retiring_state, old_owner, &retiring_sid).await
+    });
+    while state.registry.lookup(&sid).await.is_some() {
+        tokio::task::yield_now().await;
+    }
+
+    let binding_state = Arc::clone(&state);
+    let binding_sid = sid.clone();
+    let bind = tokio::spawn(async move {
+        bind_session_route(
+            &binding_state,
+            binding_sid,
+            HelperRoute {
+                helper_id: new_owner,
+                notif_tx: new_tx,
+                forwarder: None,
+                consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            },
+        )
+        .await
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    assert!(
+        !bind.is_finished(),
+        "rebind must wait until old session cleanup and broadcasts finish"
+    );
+
+    drop(subscribers);
+    assert!(retire.await.unwrap());
+    bind.await.unwrap();
+    assert_eq!(
+        state.session_to_helper.lock().await[&sid].helper_id,
+        new_owner
+    );
+}
+
 /// `route_for` (used by every `MasterClient::<client-method>`
 /// forwarder) must return `internal_error` when the agent CLI
 /// sends a request for a session that no helper has registered

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -1049,6 +1049,91 @@ async fn new_session_timeout_is_enforced_by_master_forwarder() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn load_session_gate_timeout_does_not_reach_agent_or_mutate_state() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(2);
+            let agent_instance = AgentInstanceId::new_v4();
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let agent_side_slot = Arc::new(OnceLock::new());
+            agent_side_slot
+                .set(agent_link_to_noop_client())
+                .expect("agent-side forwarder should be set once");
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp.agent_capabilities.mcp_capabilities.http = true;
+            let (load_arrivals_tx, mut load_arrivals_rx) = mpsc::unbounded_channel();
+            let agent = Arc::new(OnceLock::new());
+            assert!(agent
+                .set(Arc::new(AgentCli {
+                    instance_id: agent_instance,
+                    conn: client_connection_to_pending_load_session_agent(load_arrivals_tx),
+                    cached_init_resp,
+                    cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                    source: crate::agent_source::AgentSource::Host,
+                    cmd_key: "pending-load-session-agent".to_string(),
+                    cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                    bound_helpers: Mutex::new(HashSet::new()),
+                }))
+                .is_ok());
+            let handler = HelperHandler {
+                helper_id,
+                agent,
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx,
+                agent_side_slot,
+            };
+            let gated_session = SessionId::new("gate-timeout-session");
+            let mut request = acp::schema::v1::LoadSessionRequest::new(
+                gated_session.clone(),
+                PathBuf::from("C:\\repo-a"),
+            );
+            crate::session_registry::inject_wta_meta(
+                &mut request.meta,
+                &crate::session_registry::WtaMeta {
+                    proposal_mcp: Some("http-v1".to_string()),
+                    ..Default::default()
+                },
+            );
+
+            let replacement_guard = handler.replacement_gate.lock().await;
+            let error = handler
+                .load_session_with_timeout(request, std::time::Duration::from_millis(10))
+                .await
+                .expect_err("master should include gate acquisition in the load deadline");
+            drop(replacement_guard);
+
+            assert_eq!(error.code, acp::ErrorCode::InternalError);
+            assert!(format!("{error}").contains("agent CLI session/load timed out"));
+            assert!(
+                matches!(
+                    load_arrivals_rx.try_recv(),
+                    Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+                ),
+                "gate timeout must not forward session/load to the agent"
+            );
+            assert!(!state
+                .session_to_helper
+                .lock()
+                .await
+                .contains_key(&gated_session));
+            assert!(state.registry.lookup(&gated_session).await.is_none());
+            assert!(!state.helper_meta.lock().await.contains_key(&helper_id));
+            assert_eq!(
+                state
+                    .session_mcp_capabilities
+                    .remove_owner(agent_instance)
+                    .await,
+                0,
+                "gate timeout must not prepare a session MCP capability"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn load_session_timeout_rolls_back_replacement_state_and_releases_gate() {
     tokio::task::LocalSet::new()
         .run_until(async {

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -11,6 +11,36 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 #[derive(Clone)]
 struct PendingNewSessionAgent;
 
+#[derive(Clone)]
+struct ControlledNewSessionAgent {
+    next: Arc<std::sync::atomic::AtomicUsize>,
+    arrivals: mpsc::UnboundedSender<(usize, tokio::sync::oneshot::Sender<()>)>,
+}
+
+impl ControlledNewSessionAgent {
+    async fn new_session(
+        &self,
+        _args: acp::schema::v1::NewSessionRequest,
+    ) -> acp::Result<acp::schema::v1::NewSessionResponse> {
+        let index = self.next.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        self.arrivals
+            .send((index, release_tx))
+            .map_err(|_| acp::Error::internal_error().data("test arrival receiver dropped"))?;
+        release_rx
+            .await
+            .map_err(|_| acp::Error::internal_error().data("test release sender dropped"))?;
+        let session_id = match index {
+            0 => "replacement-b",
+            1 => "replacement-c",
+            _ => return Err(acp::Error::internal_error().data("unexpected test request")),
+        };
+        Ok(acp::schema::v1::NewSessionResponse::new(SessionId::new(
+            session_id,
+        )))
+    }
+}
+
 impl PendingNewSessionAgent {
     async fn initialize(
         &self,
@@ -567,6 +597,77 @@ fn make_state() -> Arc<MasterStateInner> {
     })
 }
 
+fn client_connection_to_controlled_new_session_agent(
+    arrivals: mpsc::UnboundedSender<(usize, tokio::sync::oneshot::Sender<()>)>,
+) -> conn::ClientLink {
+    let (client_pipe, agent_pipe) = tokio::io::duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_pipe);
+    let (agent_read, agent_write) = tokio::io::split(agent_pipe);
+
+    let mock = ControlledNewSessionAgent {
+        next: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        arrivals,
+    };
+    let agent_builder = acp::Agent
+        .builder()
+        .name("controlled-new-session-agent")
+        .on_receive_request(
+            {
+                let mock = mock.clone();
+                move |req: acp::schema::v1::NewSessionRequest,
+                      responder: acp::Responder<acp::schema::v1::NewSessionResponse>,
+                      _cx| {
+                    let mock = mock.clone();
+                    async move {
+                        match mock.new_session(req).await {
+                            Ok(response) => responder.respond(response),
+                            Err(error) => responder.respond_with_error(error),
+                        }
+                    }
+                }
+            },
+            acp::on_receive_request!(),
+        );
+    let (_agent_conn, agent_io) = conn::spawn_agent(
+        agent_builder,
+        conn::byte_streams(agent_write.compat_write(), agent_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = agent_io.await;
+    });
+
+    let (client_conn, client_io) = conn::spawn_client(
+        acp::Client.builder().name("controlled-new-session-client"),
+        conn::byte_streams(client_write.compat_write(), client_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = client_io.await;
+    });
+
+    client_conn
+}
+
+fn agent_link_to_noop_client() -> conn::AgentLink {
+    let (agent_pipe, client_pipe) = tokio::io::duplex(4096);
+    let (agent_read, agent_write) = tokio::io::split(agent_pipe);
+    let (client_read, client_write) = tokio::io::split(client_pipe);
+    let (agent_link, agent_io) = conn::spawn_agent(
+        acp::Agent.builder().name("noop-helper-agent"),
+        conn::byte_streams(agent_write.compat_write(), agent_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = agent_io.await;
+    });
+    let (_client_link, client_io) = conn::spawn_client(
+        acp::Client.builder().name("noop-helper-client"),
+        conn::byte_streams(client_write.compat_write(), client_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = client_io.await;
+    });
+    agent_link
+}
+
 fn client_connection_to_pending_new_session_agent() -> conn::ClientLink {
     let (client_pipe, agent_pipe) = tokio::io::duplex(4096);
     let (client_read, client_write) = tokio::io::split(client_pipe);
@@ -691,6 +792,7 @@ fn model_handler(agent: Arc<AgentCli>, helper_id: u64) -> HelperHandler {
         helper_id: HelperId(helper_id),
         agent: slot,
         state: make_state(),
+        replacement_gate: Arc::new(Mutex::new(())),
         notif_tx,
         agent_side_slot: Arc::new(OnceLock::new()),
     }
@@ -858,6 +960,7 @@ async fn new_session_timeout_is_enforced_by_master_forwarder() {
                 helper_id: HelperId(1),
                 agent,
                 state: make_state(),
+                replacement_gate: Arc::new(Mutex::new(())),
                 notif_tx,
                 agent_side_slot: Arc::new(OnceLock::new()),
             };
@@ -886,6 +989,7 @@ fn cloned_helper_handlers_share_the_lazy_agent_binding() {
         helper_id: HelperId(1),
         agent: Arc::new(OnceLock::new()),
         state: make_state(),
+        replacement_gate: Arc::new(Mutex::new(())),
         notif_tx,
         agent_side_slot: Arc::new(OnceLock::new()),
     };
@@ -895,6 +999,153 @@ fn cloned_helper_handlers_share_the_lazy_agent_binding() {
         Arc::ptr_eq(&handler.agent, &request_handler.agent),
         "all request handler clones must share initialize's binding slot"
     );
+    assert!(
+        Arc::ptr_eq(&handler.replacement_gate, &request_handler.replacement_gate),
+        "all request handler clones must share the replacement gate"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn overlapping_new_sessions_retire_the_intermediate_replacement() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(17);
+            let initial_session = SessionId::new("replacement-a");
+            let intermediate_session = SessionId::new("replacement-b");
+            let final_session = SessionId::new("replacement-c");
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let (arrivals_tx, mut arrivals_rx) = mpsc::unbounded_channel();
+            let agent_side_slot = Arc::new(OnceLock::new());
+            agent_side_slot
+                .set(agent_link_to_noop_client())
+                .expect("agent-side forwarder should be set once");
+            let agent = Arc::new(OnceLock::new());
+            assert!(agent
+                .set(Arc::new(AgentCli {
+                    instance_id: AgentInstanceId::new_v4(),
+                    conn: client_connection_to_controlled_new_session_agent(arrivals_tx),
+                    cached_init_resp: acp::schema::v1::InitializeResponse::new(
+                        acp::schema::ProtocolVersion::V1,
+                    ),
+                    cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                    source: crate::agent_source::AgentSource::Host,
+                    cmd_key: "serialized-replacement-agent".to_string(),
+                    cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                    bound_helpers: Mutex::new(HashSet::new()),
+                }))
+                .is_ok());
+            let handler = HelperHandler {
+                helper_id,
+                agent,
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx: notif_tx.clone(),
+                agent_side_slot,
+            };
+
+            bind_session_route(
+                &state,
+                initial_session.clone(),
+                HelperRoute {
+                    helper_id,
+                    notif_tx,
+                    forwarder: Some(agent_link_to_noop_client()),
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+            state
+                .registry
+                .upsert(crate::session_registry::SessionInfo::new(
+                    initial_session.clone(),
+                    PathBuf::from(r"C:\repo-a"),
+                ))
+                .await;
+            state.helper_meta.lock().await.insert(
+                helper_id,
+                HelperRecoveryMeta {
+                    last_session_id: Some(initial_session.clone()),
+                    ..Default::default()
+                },
+            );
+
+            let first = tokio::task::spawn_local({
+                let handler = handler.clone();
+                async move {
+                    handler
+                        .new_session(acp::schema::v1::NewSessionRequest::new(PathBuf::from(
+                            r"C:\repo-b",
+                        )))
+                        .await
+                }
+            });
+            let (first_index, release_first) = arrivals_rx
+                .recv()
+                .await
+                .expect("first replacement should reach the agent");
+            assert_eq!(first_index, 0);
+
+            let (second_started_tx, second_started_rx) = tokio::sync::oneshot::channel();
+            let second = tokio::task::spawn_local({
+                let handler = handler.clone();
+                async move {
+                    let _ = second_started_tx.send(());
+                    handler
+                        .new_session(acp::schema::v1::NewSessionRequest::new(PathBuf::from(
+                            r"C:\repo-c",
+                        )))
+                        .await
+                }
+            });
+            second_started_rx
+                .await
+                .expect("overlapping replacement task should start");
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(25), arrivals_rx.recv(),)
+                    .await
+                    .is_err(),
+                "the second replacement must wait for the first transaction"
+            );
+
+            release_first
+                .send(())
+                .expect("first replacement should still be waiting");
+            let first_response = first
+                .await
+                .expect("first replacement task should finish")
+                .expect("first replacement should succeed");
+            assert_eq!(first_response.session_id, intermediate_session);
+
+            let (second_index, release_second) = arrivals_rx
+                .recv()
+                .await
+                .expect("final replacement should reach the agent after the first commits");
+            assert_eq!(second_index, 1);
+            release_second
+                .send(())
+                .expect("final replacement should still be waiting");
+            let second_response = second
+                .await
+                .expect("final replacement task should finish")
+                .expect("final replacement should succeed");
+            assert_eq!(second_response.session_id, final_session);
+
+            let routes = state.session_to_helper.lock().await;
+            assert_eq!(routes.len(), 1);
+            assert!(routes.contains_key(&final_session));
+            assert!(!routes.contains_key(&initial_session));
+            assert!(!routes.contains_key(&intermediate_session));
+            drop(routes);
+            assert!(state.registry.lookup(&initial_session).await.is_none());
+            assert!(state.registry.lookup(&intermediate_session).await.is_none());
+            assert!(state.registry.lookup(&final_session).await.is_some());
+            assert_eq!(
+                state.helper_meta.lock().await[&helper_id].last_session_id,
+                Some(final_session)
+            );
+        })
+        .await;
 }
 
 /// An orphan session's `request_permission` (owning tab closed
@@ -1204,6 +1455,7 @@ async fn prompt_forward_survives_reentrant_permission() {
                 helper_id: HelperId(1),
                 agent,
                 state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
                 notif_tx: notif_tx.clone(),
                 agent_side_slot: Arc::new(OnceLock::new()),
             };

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -12,6 +12,11 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 struct PendingNewSessionAgent;
 
 #[derive(Clone)]
+struct PendingLoadSessionAgent {
+    arrivals: mpsc::UnboundedSender<usize>,
+}
+
+#[derive(Clone)]
 struct ControlledNewSessionAgent {
     next: Arc<std::sync::atomic::AtomicUsize>,
     arrivals: mpsc::UnboundedSender<(usize, tokio::sync::oneshot::Sender<()>)>,
@@ -38,6 +43,18 @@ impl ControlledNewSessionAgent {
         Ok(acp::schema::v1::NewSessionResponse::new(SessionId::new(
             session_id,
         )))
+    }
+}
+
+impl PendingLoadSessionAgent {
+    async fn load_session(
+        &self,
+        args: acp::schema::v1::LoadSessionRequest,
+    ) -> acp::Result<acp::schema::v1::LoadSessionResponse> {
+        self.arrivals
+            .send(args.mcp_servers.len())
+            .map_err(|_| acp::Error::internal_error().data("test arrival receiver dropped"))?;
+        futures::future::pending().await
     }
 }
 
@@ -668,6 +685,55 @@ fn agent_link_to_noop_client() -> conn::AgentLink {
     agent_link
 }
 
+fn client_connection_to_pending_load_session_agent(
+    arrivals: mpsc::UnboundedSender<usize>,
+) -> conn::ClientLink {
+    let (client_pipe, agent_pipe) = tokio::io::duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_pipe);
+    let (agent_read, agent_write) = tokio::io::split(agent_pipe);
+
+    let mock = PendingLoadSessionAgent { arrivals };
+    let agent_builder = acp::Agent
+        .builder()
+        .name("pending-load-session-agent")
+        .on_receive_request(
+            {
+                let mock = mock.clone();
+                move |req: acp::schema::v1::ClientRequest, responder, _cx| {
+                    let mock = mock.clone();
+                    async move {
+                        use acp::schema::v1::{AgentResponse as R, ClientRequest as Q};
+                        match req {
+                            Q::LoadSessionRequest(args) => conn::respond_enum(
+                                responder,
+                                mock.load_session(args).await.map(R::LoadSessionResponse),
+                            ),
+                            _ => responder.respond_with_error(acp::Error::method_not_found()),
+                        }
+                    }
+                }
+            },
+            acp::on_receive_request!(),
+        );
+    let (_agent_conn, agent_io) = conn::spawn_agent(
+        agent_builder,
+        conn::byte_streams(agent_write.compat_write(), agent_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = agent_io.await;
+    });
+
+    let (client_conn, client_io) = conn::spawn_client(
+        acp::Client.builder().name("pending-load-session-client"),
+        conn::byte_streams(client_write.compat_write(), client_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = client_io.await;
+    });
+
+    client_conn
+}
+
 fn client_connection_to_pending_new_session_agent() -> conn::ClientLink {
     let (client_pipe, agent_pipe) = tokio::io::duplex(4096);
     let (client_read, client_write) = tokio::io::split(client_pipe);
@@ -982,6 +1048,92 @@ async fn new_session_timeout_is_enforced_by_master_forwarder() {
         .await;
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn load_session_timeout_rolls_back_replacement_state_and_releases_gate() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(2);
+            let agent_instance = AgentInstanceId::new_v4();
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let agent_side_slot = Arc::new(OnceLock::new());
+            agent_side_slot
+                .set(agent_link_to_noop_client())
+                .expect("agent-side forwarder should be set once");
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp.agent_capabilities.mcp_capabilities.http = true;
+            let (load_arrivals_tx, mut load_arrivals_rx) = mpsc::unbounded_channel();
+            let agent = Arc::new(OnceLock::new());
+            assert!(agent
+                .set(Arc::new(AgentCli {
+                    instance_id: agent_instance,
+                    conn: client_connection_to_pending_load_session_agent(load_arrivals_tx),
+                    cached_init_resp,
+                    cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                    source: crate::agent_source::AgentSource::Host,
+                    cmd_key: "pending-load-session-agent".to_string(),
+                    cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                    bound_helpers: Mutex::new(HashSet::new()),
+                }))
+                .is_ok());
+            let handler = HelperHandler {
+                helper_id,
+                agent,
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx,
+                agent_side_slot,
+            };
+            let timed_out_session = SessionId::new("timed-out-session");
+            let mut request = acp::schema::v1::LoadSessionRequest::new(
+                timed_out_session.clone(),
+                PathBuf::from("C:\\repo-a"),
+            );
+            crate::session_registry::inject_wta_meta(
+                &mut request.meta,
+                &crate::session_registry::WtaMeta {
+                    proposal_mcp: Some("http-v1".to_string()),
+                    ..Default::default()
+                },
+            );
+
+            let error = handler
+                .load_session_with_timeout(request, std::time::Duration::from_millis(10))
+                .await
+                .expect_err("master should time out a hung agent session/load");
+
+            assert_eq!(
+                load_arrivals_rx.recv().await,
+                Some(1),
+                "load request must carry the pending session MCP capability"
+            );
+            assert_eq!(error.code, acp::ErrorCode::InternalError);
+            assert!(format!("{error}").contains("agent CLI session/load timed out"));
+            assert!(!state
+                .session_to_helper
+                .lock()
+                .await
+                .contains_key(&timed_out_session));
+            assert_eq!(
+                state
+                    .session_mcp_capabilities
+                    .remove_owner(agent_instance)
+                    .await,
+                0,
+                "timed-out load must cancel its pending MCP capability"
+            );
+
+            let _replacement_guard = tokio::time::timeout(
+                std::time::Duration::from_millis(50),
+                handler.replacement_gate.lock(),
+            )
+            .await
+            .expect("replacement gate must be released for fallback session/new");
+        })
+        .await;
+}
+
 #[test]
 fn cloned_helper_handlers_share_the_lazy_agent_binding() {
     let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
@@ -1059,7 +1211,7 @@ async fn overlapping_new_sessions_retire_the_intermediate_replacement() {
                 .registry
                 .upsert(crate::session_registry::SessionInfo::new(
                     initial_session.clone(),
-                    PathBuf::from(r"C:\repo-a"),
+                    PathBuf::from("C:\\repo-a"),
                 ))
                 .await;
             state.helper_meta.lock().await.insert(
@@ -1075,7 +1227,7 @@ async fn overlapping_new_sessions_retire_the_intermediate_replacement() {
                 async move {
                     handler
                         .new_session(acp::schema::v1::NewSessionRequest::new(PathBuf::from(
-                            r"C:\repo-b",
+                            "C:\\repo-b",
                         )))
                         .await
                 }
@@ -1093,7 +1245,7 @@ async fn overlapping_new_sessions_retire_the_intermediate_replacement() {
                     let _ = second_started_tx.send(());
                     handler
                         .new_session(acp::schema::v1::NewSessionRequest::new(PathBuf::from(
-                            r"C:\repo-c",
+                            "C:\\repo-c",
                         )))
                         .await
                 }

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -19,7 +19,22 @@ struct PendingLoadSessionAgent {
 #[derive(Clone)]
 struct ControlledNewSessionAgent {
     next: Arc<std::sync::atomic::AtomicUsize>,
-    arrivals: mpsc::UnboundedSender<(usize, tokio::sync::oneshot::Sender<()>)>,
+    events: mpsc::UnboundedSender<ReplacementEvent>,
+    live_sessions: Arc<Mutex<HashSet<SessionId>>>,
+    fail_close: Option<SessionId>,
+    failed_closes: Arc<Mutex<HashSet<SessionId>>>,
+}
+
+#[derive(Clone)]
+struct BlockingCloseAgent {
+    events: mpsc::UnboundedSender<ReplacementEvent>,
+}
+
+enum ReplacementEvent {
+    Close(SessionId),
+    BlockingClose(SessionId, tokio::sync::oneshot::Sender<()>),
+    Load(SessionId),
+    New(usize, tokio::sync::oneshot::Sender<()>),
 }
 
 impl ControlledNewSessionAgent {
@@ -29,8 +44,8 @@ impl ControlledNewSessionAgent {
     ) -> acp::Result<acp::schema::v1::NewSessionResponse> {
         let index = self.next.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let (release_tx, release_rx) = tokio::sync::oneshot::channel();
-        self.arrivals
-            .send((index, release_tx))
+        self.events
+            .send(ReplacementEvent::New(index, release_tx))
             .map_err(|_| acp::Error::internal_error().data("test arrival receiver dropped"))?;
         release_rx
             .await
@@ -40,9 +55,40 @@ impl ControlledNewSessionAgent {
             1 => "replacement-c",
             _ => return Err(acp::Error::internal_error().data("unexpected test request")),
         };
-        Ok(acp::schema::v1::NewSessionResponse::new(SessionId::new(
-            session_id,
-        )))
+        let session_id = SessionId::new(session_id);
+        self.live_sessions.lock().await.insert(session_id.clone());
+        Ok(acp::schema::v1::NewSessionResponse::new(session_id))
+    }
+
+    async fn close_session(
+        &self,
+        args: acp::schema::v1::CloseSessionRequest,
+    ) -> acp::Result<acp::schema::v1::CloseSessionResponse> {
+        self.events
+            .send(ReplacementEvent::Close(args.session_id.clone()))
+            .map_err(|_| acp::Error::internal_error().data("test event receiver dropped"))?;
+        if self.fail_close.as_ref() == Some(&args.session_id)
+            && self
+                .failed_closes
+                .lock()
+                .await
+                .insert(args.session_id.clone())
+        {
+            return Err(acp::Error::internal_error().data("injected close failure"));
+        }
+        self.live_sessions.lock().await.remove(&args.session_id);
+        Ok(acp::schema::v1::CloseSessionResponse::new())
+    }
+
+    async fn load_session(
+        &self,
+        args: acp::schema::v1::LoadSessionRequest,
+    ) -> acp::Result<acp::schema::v1::LoadSessionResponse> {
+        self.events
+            .send(ReplacementEvent::Load(args.session_id.clone()))
+            .map_err(|_| acp::Error::internal_error().data("test event receiver dropped"))?;
+        self.live_sessions.lock().await.insert(args.session_id);
+        Ok(acp::schema::v1::LoadSessionResponse::new())
     }
 }
 
@@ -55,6 +101,22 @@ impl PendingLoadSessionAgent {
             .send(args.mcp_servers.len())
             .map_err(|_| acp::Error::internal_error().data("test arrival receiver dropped"))?;
         futures::future::pending().await
+    }
+}
+
+impl BlockingCloseAgent {
+    async fn close_session(
+        &self,
+        args: acp::schema::v1::CloseSessionRequest,
+    ) -> acp::Result<acp::schema::v1::CloseSessionResponse> {
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        self.events
+            .send(ReplacementEvent::BlockingClose(args.session_id, release_tx))
+            .map_err(|_| acp::Error::internal_error().data("test event receiver dropped"))?;
+        release_rx
+            .await
+            .map_err(|_| acp::Error::internal_error().data("test release sender dropped"))?;
+        Ok(acp::schema::v1::CloseSessionResponse::new())
     }
 }
 
@@ -483,7 +545,7 @@ fn allowed_ids_absent_is_no_policy_present_but_empty_is_block_all() {
     assert_eq!(set, allow_set(&["gemini", "copilot"]));
     // Unknown ids mixed with a real id: only the real id survives.
     let mixed = normalize_allowed_agent_ids(&["custom:myapp".to_string(), "claude".to_string()])
-    .expect("one real id survives");
+        .expect("one real id survives");
     assert_eq!(mixed, allow_set(&["claude"]));
 
     // End-to-end through resolve_agent_selection:
@@ -587,10 +649,9 @@ fn pool_key_dedupes_same_selection_and_separates_distinct_agents() {
 
 fn make_state() -> Arc<MasterStateInner> {
     Arc::new(MasterStateInner {
+        session_lifecycle_gates: Mutex::new(HashMap::new()),
         session_to_helper: Mutex::new(HashMap::new()),
-        session_mcp_endpoints: session_mcp::Endpoints::new(
-            "http://127.0.0.1:1/mcp".to_string(),
-        ),
+        session_mcp_endpoints: session_mcp::Endpoints::new("http://127.0.0.1:1/mcp".to_string()),
         session_mcp_capabilities: session_mcp::CapabilityRegistry::default(),
         pending_usage: Mutex::new(HashMap::new()),
         usage_generation: watch::channel(0u64).0,
@@ -615,7 +676,9 @@ fn make_state() -> Arc<MasterStateInner> {
 }
 
 fn client_connection_to_controlled_new_session_agent(
-    arrivals: mpsc::UnboundedSender<(usize, tokio::sync::oneshot::Sender<()>)>,
+    events: mpsc::UnboundedSender<ReplacementEvent>,
+    live_sessions: Arc<Mutex<HashSet<SessionId>>>,
+    fail_close: Option<SessionId>,
 ) -> conn::ClientLink {
     let (client_pipe, agent_pipe) = tokio::io::duplex(4096);
     let (client_read, client_write) = tokio::io::split(client_pipe);
@@ -623,7 +686,10 @@ fn client_connection_to_controlled_new_session_agent(
 
     let mock = ControlledNewSessionAgent {
         next: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-        arrivals,
+        events,
+        live_sessions,
+        fail_close,
+        failed_closes: Arc::new(Mutex::new(HashSet::new())),
     };
     let agent_builder = acp::Agent
         .builder()
@@ -637,6 +703,40 @@ fn client_connection_to_controlled_new_session_agent(
                     let mock = mock.clone();
                     async move {
                         match mock.new_session(req).await {
+                            Ok(response) => responder.respond(response),
+                            Err(error) => responder.respond_with_error(error),
+                        }
+                    }
+                }
+            },
+            acp::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let mock = mock.clone();
+                move |req: acp::schema::v1::LoadSessionRequest,
+                      responder: acp::Responder<acp::schema::v1::LoadSessionResponse>,
+                      _cx| {
+                    let mock = mock.clone();
+                    async move {
+                        match mock.load_session(req).await {
+                            Ok(response) => responder.respond(response),
+                            Err(error) => responder.respond_with_error(error),
+                        }
+                    }
+                }
+            },
+            acp::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let mock = mock.clone();
+                move |req: acp::schema::v1::CloseSessionRequest,
+                      responder: acp::Responder<acp::schema::v1::CloseSessionResponse>,
+                      _cx| {
+                    let mock = mock.clone();
+                    async move {
+                        match mock.close_session(req).await {
                             Ok(response) => responder.respond(response),
                             Err(error) => responder.respond_with_error(error),
                         }
@@ -661,6 +761,201 @@ fn client_connection_to_controlled_new_session_agent(
         let _ = client_io.await;
     });
 
+    client_conn
+}
+
+fn client_connection_to_blocking_close_agent(
+    events: mpsc::UnboundedSender<ReplacementEvent>,
+) -> conn::ClientLink {
+    let (client_pipe, agent_pipe) = tokio::io::duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_pipe);
+    let (agent_read, agent_write) = tokio::io::split(agent_pipe);
+    let mock = BlockingCloseAgent { events };
+    let agent_builder = acp::Agent
+        .builder()
+        .name("blocking-close-agent")
+        .on_receive_request(
+            move |req: acp::schema::v1::CloseSessionRequest,
+                  responder: acp::Responder<acp::schema::v1::CloseSessionResponse>,
+                  _cx| {
+                let mock = mock.clone();
+                async move {
+                    match mock.close_session(req).await {
+                        Ok(response) => responder.respond(response),
+                        Err(error) => responder.respond_with_error(error),
+                    }
+                }
+            },
+            acp::on_receive_request!(),
+        );
+    let (_agent_conn, agent_io) = conn::spawn_agent(
+        agent_builder,
+        conn::byte_streams(agent_write.compat_write(), agent_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = agent_io.await;
+    });
+    let (client_conn, client_io) = conn::spawn_client(
+        acp::Client.builder().name("blocking-close-client"),
+        conn::byte_streams(client_write.compat_write(), client_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = client_io.await;
+    });
+    client_conn
+}
+
+fn client_connection_to_callback_close_agent(
+    state: Arc<MasterStateInner>,
+    callback_completed: tokio::sync::oneshot::Sender<()>,
+) -> conn::ClientLink {
+    use acp::schema::v1::{
+        AgentRequest, ClientResponse, PermissionOption, PermissionOptionId, PermissionOptionKind,
+        RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse, ToolCallId,
+        ToolCallUpdate, ToolCallUpdateFields,
+    };
+
+    let (client_pipe, agent_pipe) = tokio::io::duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_pipe);
+    let (agent_read, agent_write) = tokio::io::split(agent_pipe);
+    let callback_completed = Arc::new(std::sync::Mutex::new(Some(callback_completed)));
+    let agent_builder = acp::Agent
+        .builder()
+        .name("callback-close-agent")
+        .on_receive_request(
+            move |req: acp::schema::v1::CloseSessionRequest,
+                  responder: acp::Responder<acp::schema::v1::CloseSessionResponse>,
+                  cx: acp::ConnectionTo<acp::Client>| {
+                let callback_completed = Arc::clone(&callback_completed);
+                async move {
+                    tokio::task::spawn_local(async move {
+                        let permission = RequestPermissionRequest::new(
+                            req.session_id,
+                            ToolCallUpdate::new(
+                                ToolCallId::new("close-callback"),
+                                ToolCallUpdateFields::new().title("close callback"),
+                            ),
+                            vec![PermissionOption::new(
+                                PermissionOptionId::new("cancel"),
+                                "Cancel",
+                                PermissionOptionKind::RejectOnce,
+                            )],
+                        );
+                        let _ = cx.send_request(permission).block_task().await;
+                        if let Some(tx) = callback_completed.lock().unwrap().take() {
+                            let _ = tx.send(());
+                        }
+                        responder.respond(acp::schema::v1::CloseSessionResponse::new())
+                    });
+                    Ok(())
+                }
+            },
+            acp::on_receive_request!(),
+        );
+    let (_agent_conn, agent_io) = conn::spawn_agent(
+        agent_builder,
+        conn::byte_streams(agent_write.compat_write(), agent_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = agent_io.await;
+    });
+
+    let master_client = MasterClient { state };
+    let client_builder = acp::Client
+        .builder()
+        .name("callback-close-client")
+        .on_receive_request(
+            move |req: AgentRequest, responder, _cx| {
+                let master_client = master_client.clone();
+                async move {
+                    match req {
+                        AgentRequest::RequestPermissionRequest(args) => {
+                            let result = master_client
+                                .route_for(&args.session_id, "close_callback")
+                                .await
+                                .map(|_| {
+                                    ClientResponse::RequestPermissionResponse(
+                                        RequestPermissionResponse::new(
+                                            RequestPermissionOutcome::Cancelled,
+                                        ),
+                                    )
+                                });
+                            conn::respond_enum(responder, result)
+                        }
+                        _ => responder.respond_with_error(acp::Error::method_not_found()),
+                    }
+                }
+            },
+            acp::on_receive_request!(),
+        );
+    let (client_conn, client_io) = conn::spawn_client(
+        client_builder,
+        conn::byte_streams(client_write.compat_write(), client_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = client_io.await;
+    });
+    client_conn
+}
+
+fn client_connection_to_deadline_rollback_agent(
+    blocked_session: SessionId,
+    events: mpsc::UnboundedSender<ReplacementEvent>,
+) -> conn::ClientLink {
+    let (client_pipe, agent_pipe) = tokio::io::duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_pipe);
+    let (agent_read, agent_write) = tokio::io::split(agent_pipe);
+    let load_events = events.clone();
+    let agent_builder = acp::Agent
+        .builder()
+        .name("deadline-rollback-agent")
+        .on_receive_request(
+            move |req: acp::schema::v1::LoadSessionRequest,
+                  responder: acp::Responder<acp::schema::v1::LoadSessionResponse>,
+                  _cx| {
+                let events = load_events.clone();
+                async move {
+                    let _ = events.send(ReplacementEvent::Load(req.session_id));
+                    responder.respond(acp::schema::v1::LoadSessionResponse::new())
+                }
+            },
+            acp::on_receive_request!(),
+        )
+        .on_receive_request(
+            move |req: acp::schema::v1::CloseSessionRequest,
+                  responder: acp::Responder<acp::schema::v1::CloseSessionResponse>,
+                  _cx| {
+                let events = events.clone();
+                let blocked_session = blocked_session.clone();
+                async move {
+                    let _ = events.send(ReplacementEvent::Close(req.session_id.clone()));
+                    if req.session_id == blocked_session {
+                        tokio::task::spawn_local(async move {
+                            futures::future::pending::<()>().await;
+                            responder.respond(acp::schema::v1::CloseSessionResponse::new())
+                        });
+                        Ok(())
+                    } else {
+                        responder.respond(acp::schema::v1::CloseSessionResponse::new())
+                    }
+                }
+            },
+            acp::on_receive_request!(),
+        );
+    let (_agent_conn, agent_io) = conn::spawn_agent(
+        agent_builder,
+        conn::byte_streams(agent_write.compat_write(), agent_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = agent_io.await;
+    });
+    let (client_conn, client_io) = conn::spawn_client(
+        acp::Client.builder().name("deadline-rollback-client"),
+        conn::byte_streams(client_write.compat_write(), client_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = client_io.await;
+    });
     client_conn
 }
 
@@ -750,7 +1045,7 @@ fn client_connection_to_pending_new_session_agent() -> conn::ClientLink {
                     let m = m.clone();
                     async move {
                         use acp::schema::v1::{AgentResponse as R, ClientRequest as Q};
-            match req {
+                        match req {
                             Q::InitializeRequest(a) => conn::respond_enum(
                                 responder,
                                 m.initialize(a).await.map(R::InitializeResponse),
@@ -763,8 +1058,8 @@ fn client_connection_to_pending_new_session_agent() -> conn::ClientLink {
                                 responder,
                                 m.new_session(a).await.map(R::NewSessionResponse),
                             ),
-                _ => responder.respond_with_error(acp::Error::method_not_found()),
-            }
+                            _ => responder.respond_with_error(acp::Error::method_not_found()),
+                        }
                     }
                 }
             },
@@ -1252,19 +1547,28 @@ async fn overlapping_new_sessions_retire_the_intermediate_replacement() {
             let intermediate_session = SessionId::new("replacement-b");
             let final_session = SessionId::new("replacement-c");
             let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
-            let (arrivals_tx, mut arrivals_rx) = mpsc::unbounded_channel();
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let live_sessions = Arc::new(Mutex::new(HashSet::from([initial_session.clone()])));
             let agent_side_slot = Arc::new(OnceLock::new());
             agent_side_slot
                 .set(agent_link_to_noop_client())
                 .expect("agent-side forwarder should be set once");
             let agent = Arc::new(OnceLock::new());
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
             assert!(agent
                 .set(Arc::new(AgentCli {
                     instance_id: AgentInstanceId::new_v4(),
-                    conn: client_connection_to_controlled_new_session_agent(arrivals_tx),
-                    cached_init_resp: acp::schema::v1::InitializeResponse::new(
-                        acp::schema::ProtocolVersion::V1,
+                    conn: client_connection_to_controlled_new_session_agent(
+                        events_tx,
+                        Arc::clone(&live_sessions),
+                        None,
                     ),
+                    cached_init_resp,
                     cli_source: Some(crate::agent_sessions::CliSource::Copilot),
                     source: crate::agent_source::AgentSource::Host,
                     cmd_key: "serialized-replacement-agent".to_string(),
@@ -1286,6 +1590,7 @@ async fn overlapping_new_sessions_retire_the_intermediate_replacement() {
                 initial_session.clone(),
                 HelperRoute {
                     helper_id,
+                    agent_instance_id: AgentInstanceId::nil(),
                     notif_tx,
                     forwarder: Some(agent_link_to_noop_client()),
                     consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -1317,10 +1622,21 @@ async fn overlapping_new_sessions_retire_the_intermediate_replacement() {
                         .await
                 }
             });
-            let (first_index, release_first) = arrivals_rx
+            let first_close = events_rx
                 .recv()
                 .await
-                .expect("first replacement should reach the agent");
+                .expect("first replacement should close its predecessor");
+            assert!(matches!(
+                first_close,
+                ReplacementEvent::Close(ref sid) if sid == &initial_session
+            ));
+            let ReplacementEvent::New(first_index, release_first) = events_rx
+                .recv()
+                .await
+                .expect("first replacement should reach the agent")
+            else {
+                panic!("session/new must follow predecessor close");
+            };
             assert_eq!(first_index, 0);
 
             let (second_started_tx, second_started_rx) = tokio::sync::oneshot::channel();
@@ -1339,7 +1655,7 @@ async fn overlapping_new_sessions_retire_the_intermediate_replacement() {
                 .await
                 .expect("overlapping replacement task should start");
             assert!(
-                tokio::time::timeout(std::time::Duration::from_millis(25), arrivals_rx.recv(),)
+                tokio::time::timeout(std::time::Duration::from_millis(25), events_rx.recv(),)
                     .await
                     .is_err(),
                 "the second replacement must wait for the first transaction"
@@ -1354,10 +1670,21 @@ async fn overlapping_new_sessions_retire_the_intermediate_replacement() {
                 .expect("first replacement should succeed");
             assert_eq!(first_response.session_id, intermediate_session);
 
-            let (second_index, release_second) = arrivals_rx
+            let second_close = events_rx
                 .recv()
                 .await
-                .expect("final replacement should reach the agent after the first commits");
+                .expect("second replacement should close the intermediate session");
+            assert!(matches!(
+                second_close,
+                ReplacementEvent::Close(ref sid) if sid == &intermediate_session
+            ));
+            let ReplacementEvent::New(second_index, release_second) = events_rx
+                .recv()
+                .await
+                .expect("final replacement should reach the agent after the close")
+            else {
+                panic!("final session/new must follow intermediate close");
+            };
             assert_eq!(second_index, 1);
             release_second
                 .send(())
@@ -1379,7 +1706,688 @@ async fn overlapping_new_sessions_retire_the_intermediate_replacement() {
             assert!(state.registry.lookup(&final_session).await.is_some());
             assert_eq!(
                 state.helper_meta.lock().await[&helper_id].last_session_id,
-                Some(final_session)
+                Some(final_session.clone())
+            );
+            assert_eq!(
+                *live_sessions.lock().await,
+                HashSet::from([final_session]),
+                "only the final physical ACP session should remain live"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn unsupported_close_falls_back_to_logical_retirement() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(18);
+            let old_session = SessionId::new("unsupported-old");
+            let replacement = SessionId::new("replacement-b");
+            let live_sessions = Arc::new(Mutex::new(HashSet::from([old_session.clone()])));
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let agent_side_slot = Arc::new(OnceLock::new());
+            agent_side_slot
+                .set(agent_link_to_noop_client())
+                .expect("agent-side forwarder should be set once");
+            let agent = Arc::new(OnceLock::new());
+            assert!(agent
+                .set(Arc::new(AgentCli {
+                    instance_id: AgentInstanceId::new_v4(),
+                    conn: client_connection_to_controlled_new_session_agent(
+                        events_tx,
+                        Arc::clone(&live_sessions),
+                        None,
+                    ),
+                    cached_init_resp: acp::schema::v1::InitializeResponse::new(
+                        acp::schema::ProtocolVersion::V1,
+                    ),
+                    cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                    source: crate::agent_source::AgentSource::Host,
+                    cmd_key: "unsupported-close-agent".to_string(),
+                    cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                    bound_helpers: Mutex::new(HashSet::new()),
+                }))
+                .is_ok());
+            let handler = HelperHandler {
+                helper_id,
+                agent,
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx: notif_tx.clone(),
+                agent_side_slot,
+            };
+            bind_session_route(
+                &state,
+                old_session.clone(),
+                HelperRoute {
+                    helper_id,
+                    agent_instance_id: AgentInstanceId::nil(),
+                    notif_tx,
+                    forwarder: Some(agent_link_to_noop_client()),
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+            state
+                .registry
+                .upsert(crate::session_registry::SessionInfo::new(
+                    old_session.clone(),
+                    PathBuf::from("C:\\old"),
+                ))
+                .await;
+            state.helper_meta.lock().await.insert(
+                helper_id,
+                HelperRecoveryMeta {
+                    last_session_id: Some(old_session.clone()),
+                    ..Default::default()
+                },
+            );
+
+            let request = tokio::task::spawn_local({
+                let handler = handler.clone();
+                async move {
+                    handler
+                        .new_session(acp::schema::v1::NewSessionRequest::new(PathBuf::from(
+                            "C:\\new",
+                        )))
+                        .await
+                }
+            });
+            let ReplacementEvent::New(index, release) = events_rx
+                .recv()
+                .await
+                .expect("replacement should be created")
+            else {
+                panic!("unsupported agents must not receive session/close");
+            };
+            assert_eq!(index, 0);
+            release.send(()).unwrap();
+            assert_eq!(
+                request.await.unwrap().unwrap().session_id,
+                replacement.clone()
+            );
+
+            let routes = state.session_to_helper.lock().await;
+            assert!(!routes.contains_key(&old_session));
+            assert!(routes.contains_key(&replacement));
+            drop(routes);
+            assert!(state.registry.lookup(&old_session).await.is_none());
+            assert_eq!(
+                *live_sessions.lock().await,
+                HashSet::from([old_session, replacement]),
+                "unsupported agents can only be logically retired"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn close_failure_keeps_predecessor_and_does_not_create_replacement() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(19);
+            let old_session = SessionId::new("close-failure-old");
+            let live_sessions = Arc::new(Mutex::new(HashSet::from([old_session.clone()])));
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let agent_side_slot = Arc::new(OnceLock::new());
+            agent_side_slot
+                .set(agent_link_to_noop_client())
+                .expect("agent-side forwarder should be set once");
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(OnceLock::new());
+            assert!(agent
+                .set(Arc::new(AgentCli {
+                    instance_id: AgentInstanceId::new_v4(),
+                    conn: client_connection_to_controlled_new_session_agent(
+                        events_tx,
+                        Arc::clone(&live_sessions),
+                        Some(old_session.clone()),
+                    ),
+                    cached_init_resp,
+                    cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                    source: crate::agent_source::AgentSource::Host,
+                    cmd_key: "failing-close-agent".to_string(),
+                    cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                    bound_helpers: Mutex::new(HashSet::new()),
+                }))
+                .is_ok());
+            let handler = HelperHandler {
+                helper_id,
+                agent,
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx: notif_tx.clone(),
+                agent_side_slot,
+            };
+            bind_session_route(
+                &state,
+                old_session.clone(),
+                HelperRoute {
+                    helper_id,
+                    agent_instance_id: AgentInstanceId::nil(),
+                    notif_tx,
+                    forwarder: Some(agent_link_to_noop_client()),
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+            state
+                .registry
+                .upsert(crate::session_registry::SessionInfo::new(
+                    old_session.clone(),
+                    PathBuf::from("C:\\old"),
+                ))
+                .await;
+            state.helper_meta.lock().await.insert(
+                helper_id,
+                HelperRecoveryMeta {
+                    last_session_id: Some(old_session.clone()),
+                    ..Default::default()
+                },
+            );
+
+            let error = handler
+                .new_session(acp::schema::v1::NewSessionRequest::new(PathBuf::from(
+                    "C:\\new",
+                )))
+                .await
+                .expect_err("close failure must abort replacement");
+            assert!(format!("{error}").contains("injected close failure"));
+            assert!(matches!(
+                events_rx.try_recv(),
+                Ok(ReplacementEvent::Close(ref sid)) if sid == &old_session
+            ));
+            assert!(
+                events_rx.try_recv().is_err(),
+                "session/new must not be sent"
+            );
+            assert!(state
+                .session_to_helper
+                .lock()
+                .await
+                .contains_key(&old_session));
+            assert!(state.registry.lookup(&old_session).await.is_some());
+            assert_eq!(
+                state.helper_meta.lock().await[&helper_id].last_session_id,
+                Some(old_session.clone()),
+                "close failure must preserve predecessor metadata for retry"
+            );
+            assert_eq!(
+                *live_sessions.lock().await,
+                HashSet::from([old_session.clone()])
+            );
+
+            let retry = tokio::task::spawn_local({
+                let handler = handler.clone();
+                async move {
+                    handler
+                        .new_session(acp::schema::v1::NewSessionRequest::new(PathBuf::from(
+                            "C:\\retry",
+                        )))
+                        .await
+                }
+            });
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Close(ref sid)) if sid == &old_session
+            ));
+            let ReplacementEvent::New(index, release) = events_rx
+                .recv()
+                .await
+                .expect("retry must create only after closing the same predecessor")
+            else {
+                panic!("retry must issue session/new after predecessor close");
+            };
+            assert_eq!(index, 0);
+            drop(release);
+            retry
+                .await
+                .unwrap()
+                .expect_err("injected session/new failure must surface");
+            assert_eq!(
+                state.helper_meta.lock().await[&helper_id].last_session_id,
+                None,
+                "metadata must stay empty after the predecessor was retired"
+            );
+            assert!(!state
+                .session_to_helper
+                .lock()
+                .await
+                .contains_key(&old_session));
+            assert!(live_sessions.lock().await.is_empty());
+
+            let final_attempt = tokio::task::spawn_local({
+                let handler = handler.clone();
+                async move {
+                    handler
+                        .new_session(acp::schema::v1::NewSessionRequest::new(PathBuf::from(
+                            "C:\\final",
+                        )))
+                        .await
+                }
+            });
+            let ReplacementEvent::New(index, release) = events_rx
+                .recv()
+                .await
+                .expect("no stale predecessor close should precede the final session/new")
+            else {
+                panic!("metadata None must make the final attempt start with session/new");
+            };
+            assert_eq!(index, 1);
+            release.send(()).unwrap();
+            let replacement = final_attempt.await.unwrap().unwrap().session_id;
+            assert_eq!(replacement, SessionId::new("replacement-c"));
+            assert_eq!(
+                state.helper_meta.lock().await[&helper_id].last_session_id,
+                Some(replacement.clone())
+            );
+            assert_eq!(*live_sessions.lock().await, HashSet::from([replacement]));
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn load_close_failure_restores_target_route_and_capability() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(20);
+            let peer_id = HelperId(21);
+            let old_session = SessionId::new("load-old");
+            let target_session = SessionId::new("load-target");
+            let live_sessions = Arc::new(Mutex::new(HashSet::from([old_session.clone()])));
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let (peer_tx, _peer_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let agent_instance = AgentInstanceId::new_v4();
+            let peer_route = HelperRoute {
+                helper_id: peer_id,
+                agent_instance_id: agent_instance,
+                notif_tx: peer_tx,
+                forwarder: Some(agent_link_to_noop_client()),
+                consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            };
+            let agent_side_slot = Arc::new(OnceLock::new());
+            agent_side_slot
+                .set(agent_link_to_noop_client())
+                .expect("agent-side forwarder should be set once");
+            let previous_capability_owner = AgentInstanceId::new_v4();
+            let previous_capability = state
+                .session_mcp_capabilities
+                .prepare(previous_capability_owner, Some(target_session.clone()))
+                .await;
+            assert!(
+                state
+                    .session_mcp_capabilities
+                    .bind(&previous_capability, target_session.clone())
+                    .await
+            );
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            cached_init_resp.agent_capabilities.mcp_capabilities.http = true;
+            let agent = Arc::new(OnceLock::new());
+            assert!(
+                agent
+                    .set(Arc::new(AgentCli {
+                        instance_id: agent_instance,
+                        conn: client_connection_to_controlled_new_session_agent(
+                            events_tx,
+                            Arc::clone(&live_sessions),
+                            Some(old_session.clone()),
+                        ),
+                        cached_init_resp,
+                        cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                        source: crate::agent_source::AgentSource::Host,
+                        cmd_key: "load-close-failure-agent".to_string(),
+                        cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                        bound_helpers: Mutex::new(HashSet::new()),
+                    }))
+                    .is_ok()
+            );
+            let handler = HelperHandler {
+                helper_id,
+                agent,
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx: notif_tx.clone(),
+                agent_side_slot,
+            };
+            bind_session_route(
+                &state,
+                old_session.clone(),
+                HelperRoute {
+                    helper_id,
+                    agent_instance_id: AgentInstanceId::nil(),
+                    notif_tx,
+                    forwarder: Some(agent_link_to_noop_client()),
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+            state
+                .session_to_helper
+                .lock()
+                .await
+                .insert(target_session.clone(), peer_route);
+            state
+                .registry
+                .upsert(crate::session_registry::SessionInfo::new(
+                    old_session.clone(),
+                    PathBuf::from("C:\\old"),
+                ))
+                .await;
+            state.helper_meta.lock().await.insert(
+                helper_id,
+                HelperRecoveryMeta {
+                    last_session_id: Some(old_session.clone()),
+                    ..Default::default()
+                },
+            );
+            let mut request = acp::schema::v1::LoadSessionRequest::new(
+                target_session.clone(),
+                PathBuf::from("C:\\target"),
+            );
+            crate::session_registry::inject_wta_meta(
+                &mut request.meta,
+                &crate::session_registry::WtaMeta {
+                    proposal_mcp: Some("http-v1".to_string()),
+                    ..Default::default()
+                },
+            );
+
+            let error = handler
+                .load_session_with_timeout(request, std::time::Duration::from_secs(1))
+                .await
+                .expect_err("predecessor close failure must roll back the loaded target");
+            assert!(format!("{error}").contains("injected close failure"));
+            assert!(matches!(
+                events_rx.try_recv(),
+                Ok(ReplacementEvent::Load(ref sid)) if sid == &target_session
+            ));
+            assert!(matches!(
+                events_rx.try_recv(),
+                Ok(ReplacementEvent::Close(ref sid)) if sid == &old_session
+            ));
+            assert!(events_rx.try_recv().is_err());
+            let routes = state.session_to_helper.lock().await;
+            assert_eq!(routes[&old_session].helper_id, helper_id);
+            assert_eq!(
+                routes[&target_session].helper_id, peer_id,
+                "rollback must restore, not delete, a preexisting target route"
+            );
+            drop(routes);
+            assert_eq!(
+                state.helper_meta.lock().await[&helper_id].last_session_id,
+                Some(old_session.clone())
+            );
+            assert_eq!(
+                state
+                    .session_mcp_capabilities
+                    .remove_owner(agent_instance)
+                    .await,
+                0,
+                "the failed load's newly prepared capability must be revoked"
+            );
+            assert_eq!(
+                state
+                    .session_mcp_capabilities
+                    .remove_owner(previous_capability_owner)
+                    .await,
+                1,
+                "the target's preexisting capability must survive rollback"
+            );
+            assert_eq!(
+                *live_sessions.lock().await,
+                HashSet::from([old_session, target_session]),
+                "a preexisting target route must prevent rollback from closing another helper's session"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn load_close_failure_closes_target_when_restored_route_uses_another_agent() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(22);
+            let peer_id = HelperId(23);
+            let old_session = SessionId::new("cross-agent-old");
+            let target_session = SessionId::new("cross-agent-target");
+            let live_sessions = Arc::new(Mutex::new(HashSet::from([old_session.clone()])));
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let (peer_tx, _peer_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let current_agent_instance = AgentInstanceId::new_v4();
+            let previous_agent_instance = AgentInstanceId::new_v4();
+            let agent_side_slot = Arc::new(OnceLock::new());
+            agent_side_slot
+                .set(agent_link_to_noop_client())
+                .expect("agent-side forwarder should be set once");
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(OnceLock::new());
+            assert!(agent
+                .set(Arc::new(AgentCli {
+                    instance_id: current_agent_instance,
+                    conn: client_connection_to_controlled_new_session_agent(
+                        events_tx,
+                        Arc::clone(&live_sessions),
+                        Some(old_session.clone()),
+                    ),
+                    cached_init_resp,
+                    cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                    source: crate::agent_source::AgentSource::Host,
+                    cmd_key: "cross-agent-close-failure".to_string(),
+                    cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                    bound_helpers: Mutex::new(HashSet::new()),
+                }))
+                .is_ok());
+            let handler = HelperHandler {
+                helper_id,
+                agent,
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx: notif_tx.clone(),
+                agent_side_slot,
+            };
+            bind_session_route(
+                &state,
+                old_session.clone(),
+                HelperRoute {
+                    helper_id,
+                    agent_instance_id: current_agent_instance,
+                    notif_tx,
+                    forwarder: Some(agent_link_to_noop_client()),
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+            bind_session_route(
+                &state,
+                target_session.clone(),
+                HelperRoute {
+                    helper_id: peer_id,
+                    agent_instance_id: previous_agent_instance,
+                    notif_tx: peer_tx,
+                    forwarder: Some(agent_link_to_noop_client()),
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+            state.helper_meta.lock().await.insert(
+                helper_id,
+                HelperRecoveryMeta {
+                    last_session_id: Some(old_session.clone()),
+                    ..Default::default()
+                },
+            );
+
+            let error = handler
+                .load_session_with_timeout(
+                    acp::schema::v1::LoadSessionRequest::new(
+                        target_session.clone(),
+                        PathBuf::from("C:\\target"),
+                    ),
+                    std::time::Duration::from_secs(3),
+                )
+                .await
+                .expect_err("predecessor close failure must roll back the loaded target");
+            assert!(format!("{error}").contains("injected close failure"));
+            assert!(matches!(
+                events_rx.try_recv(),
+                Ok(ReplacementEvent::Load(ref sid)) if sid == &target_session
+            ));
+            assert!(matches!(
+                events_rx.try_recv(),
+                Ok(ReplacementEvent::Close(ref sid)) if sid == &old_session
+            ));
+            assert!(matches!(
+                events_rx.try_recv(),
+                Ok(ReplacementEvent::Close(ref sid)) if sid == &target_session
+            ));
+            assert!(events_rx.try_recv().is_err());
+            let routes = state.session_to_helper.lock().await;
+            assert_eq!(routes[&target_session].helper_id, peer_id);
+            assert_eq!(
+                routes[&target_session].agent_instance_id,
+                previous_agent_instance
+            );
+            drop(routes);
+            assert_eq!(
+                *live_sessions.lock().await,
+                HashSet::from([old_session]),
+                "the target loaded into the current agent must be physically closed"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn load_reserves_time_to_close_loaded_target_after_predecessor_timeout() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(24);
+            let old_session = SessionId::new("deadline-old");
+            let target_session = SessionId::new("deadline-target");
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let agent_instance_id = AgentInstanceId::new_v4();
+            let agent_side_slot = Arc::new(OnceLock::new());
+            agent_side_slot
+                .set(agent_link_to_noop_client())
+                .expect("agent-side forwarder should be set once");
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(OnceLock::new());
+            assert!(agent
+                .set(Arc::new(AgentCli {
+                    instance_id: agent_instance_id,
+                    conn: client_connection_to_deadline_rollback_agent(
+                        old_session.clone(),
+                        events_tx,
+                    ),
+                    cached_init_resp,
+                    cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                    source: crate::agent_source::AgentSource::Host,
+                    cmd_key: "deadline-rollback-agent".to_string(),
+                    cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                    bound_helpers: Mutex::new(HashSet::new()),
+                }))
+                .is_ok());
+            let handler = HelperHandler {
+                helper_id,
+                agent,
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx: notif_tx.clone(),
+                agent_side_slot,
+            };
+            bind_session_route(
+                &state,
+                old_session.clone(),
+                HelperRoute {
+                    helper_id,
+                    agent_instance_id,
+                    notif_tx,
+                    forwarder: Some(agent_link_to_noop_client()),
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+            state.helper_meta.lock().await.insert(
+                helper_id,
+                HelperRecoveryMeta {
+                    last_session_id: Some(old_session.clone()),
+                    ..Default::default()
+                },
+            );
+
+            let request = tokio::task::spawn_local({
+                let handler = handler.clone();
+                let target_session = target_session.clone();
+                async move {
+                    handler
+                        .load_session_with_timeout(
+                            acp::schema::v1::LoadSessionRequest::new(
+                                target_session,
+                                PathBuf::from("C:\\target"),
+                            ),
+                            std::time::Duration::from_millis(200),
+                        )
+                        .await
+                }
+            });
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Load(ref sid)) if sid == &target_session
+            ));
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Close(ref sid)) if sid == &old_session
+            ));
+
+            assert!(matches!(
+                tokio::time::timeout(std::time::Duration::from_secs(1), events_rx.recv())
+                    .await
+                    .expect("rollback close must use its reserved deadline slice"),
+                Some(ReplacementEvent::Close(ref sid)) if sid == &target_session
+            ));
+            let error = request
+                .await
+                .expect("load task should finish")
+                .expect_err("predecessor timeout must fail the transaction");
+            assert!(format!("{error}").contains("timed out"));
+            assert!(
+                !state
+                    .session_to_helper
+                    .lock()
+                    .await
+                    .contains_key(&target_session),
+                "rolled-back target route must be removed"
             );
         })
         .await;
@@ -1461,24 +2469,12 @@ async fn reap_agent_drops_only_its_own_orphans() {
         cell
     };
     let stale_cell = Arc::new(tokio::sync::OnceCell::new());
-    reap_agent(
-        &state,
-        &key_a,
-        &stale_cell,
-        AgentInstanceId::new_v4(),
-    )
-    .await;
+    reap_agent(&state, &key_a, &stale_cell, AgentInstanceId::new_v4()).await;
     assert!(
         state.agents.lock().await.contains_key(&key_a),
         "a stale reaper must not remove a replacement pool entry"
     );
-    reap_agent(
-        &state,
-        &key_a,
-        &cell,
-        AgentInstanceId::new_v4(),
-    )
-    .await;
+    reap_agent(&state, &key_a, &cell, AgentInstanceId::new_v4()).await;
     let orphans = state.orphaned_sessions.lock().await;
     assert!(
         !orphans.contains_key(&key_a),
@@ -1584,47 +2580,47 @@ async fn prompt_forward_survives_reentrant_permission() {
                 let (ar, aw) = tokio::io::split(mock_agent_pipe);
                 let builder =
                     acp::Agent
-                    .builder()
-                    .name("mock-reentrant-agent")
-                    .on_receive_request(
-                        move |req: ClientRequest,
-                              responder,
-                              cx: acp::ConnectionTo<acp::Client>| async move {
-                            match req {
-                                ClientRequest::PromptRequest(a) => {
-                                    let sid = a.session_id.clone();
-                                    tokio::task::spawn_local(async move {
-                                        let perm = RequestPermissionRequest::new(
-                                            sid,
-                                            ToolCallUpdate::new(
-                                                ToolCallId::new("tool-1"),
-                                                ToolCallUpdateFields::new()
-                                                    .title("Run: echo hi"),
-                                            ),
-                                            vec![PermissionOption::new(
-                                                PermissionOptionId::new("allow-once"),
-                                                "Allow once",
-                                                PermissionOptionKind::AllowOnce,
-                                            )],
-                                        );
-                                        // block_task from a spawned task is safe.
-                                        let _ = cx.send_request(perm).block_task().await;
-                                        let _ = conn::respond_enum(
-                                            responder,
-                                            Ok(AgentResponse::PromptResponse(
-                                                PromptResponse::new(StopReason::EndTurn),
-                                            )),
-                                        );
-                                    });
-                                    Ok(())
-                                }
+                        .builder()
+                        .name("mock-reentrant-agent")
+                        .on_receive_request(
+                            move |req: ClientRequest,
+                                  responder,
+                                  cx: acp::ConnectionTo<acp::Client>| async move {
+                                match req {
+                                    ClientRequest::PromptRequest(a) => {
+                                        let sid = a.session_id.clone();
+                                        tokio::task::spawn_local(async move {
+                                            let perm = RequestPermissionRequest::new(
+                                                sid,
+                                                ToolCallUpdate::new(
+                                                    ToolCallId::new("tool-1"),
+                                                    ToolCallUpdateFields::new()
+                                                        .title("Run: echo hi"),
+                                                ),
+                                                vec![PermissionOption::new(
+                                                    PermissionOptionId::new("allow-once"),
+                                                    "Allow once",
+                                                    PermissionOptionKind::AllowOnce,
+                                                )],
+                                            );
+                                            // block_task from a spawned task is safe.
+                                            let _ = cx.send_request(perm).block_task().await;
+                                            let _ = conn::respond_enum(
+                                                responder,
+                                                Ok(AgentResponse::PromptResponse(
+                                                    PromptResponse::new(StopReason::EndTurn),
+                                                )),
+                                            );
+                                        });
+                                        Ok(())
+                                    }
                                     _ => {
                                         responder.respond_with_error(acp::Error::method_not_found())
                                     }
-                            }
-                        },
-                        acp::on_receive_request!(),
-                    );
+                                }
+                            },
+                            acp::on_receive_request!(),
+                        );
                 let (_agent_link, agent_io) =
                     conn::spawn_agent(builder, conn::byte_streams(aw.compat_write(), ar.compat()));
                 tokio::task::spawn_local(async move {
@@ -1734,6 +2730,7 @@ async fn prompt_forward_survives_reentrant_permission() {
                 sid.clone(),
                 HelperRoute {
                     helper_id: HelperId(1),
+                    agent_instance_id: AgentInstanceId::nil(),
                     notif_tx,
                     forwarder: Some(master_to_helper),
                     consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -1750,16 +2747,16 @@ async fn prompt_forward_survives_reentrant_permission() {
                         move |req: AgentRequest, responder, _cx| async move {
                             match req {
                                 AgentRequest::RequestPermissionRequest(_a) => conn::respond_enum(
-                                        responder,
-                                        Ok(ClientResponse::RequestPermissionResponse(
-                                            RequestPermissionResponse::new(
-                                                RequestPermissionOutcome::Selected(
-                                                    SelectedPermissionOutcome::new(
-                                                        PermissionOptionId::new("allow-once"),
-                                                    ),
+                                    responder,
+                                    Ok(ClientResponse::RequestPermissionResponse(
+                                        RequestPermissionResponse::new(
+                                            RequestPermissionOutcome::Selected(
+                                                SelectedPermissionOutcome::new(
+                                                    PermissionOptionId::new("allow-once"),
                                                 ),
                                             ),
-                                        )),
+                                        ),
+                                    )),
                                 ),
                                 _ => responder.respond_with_error(acp::Error::method_not_found()),
                             }
@@ -1849,6 +2846,7 @@ async fn session_notification_routes_to_owning_helper() {
             sid1.clone(),
             HelperRoute {
                 helper_id: HelperId(1),
+                agent_instance_id: AgentInstanceId::nil(),
                 notif_tx: tx1,
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -1858,6 +2856,7 @@ async fn session_notification_routes_to_owning_helper() {
             sid2.clone(),
             HelperRoute {
                 helper_id: HelperId(2),
+                agent_instance_id: AgentInstanceId::nil(),
                 notif_tx: tx2,
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -1887,6 +2886,7 @@ async fn session_notification_drops_entry_on_send_failure() {
             sid.clone(),
             HelperRoute {
                 helper_id: HelperId(7),
+                agent_instance_id: AgentInstanceId::nil(),
                 notif_tx: tx,
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -1928,8 +2928,8 @@ async fn session_notification_preserves_rebound_route_on_closed() {
     // try_send. We need the snapshot to capture A but the rebind
     // to happen before try_send wakes Closed. Easiest: drop A's
     // receiver, then immediately rebind to B in the same task,
-    // then route — `try_send` sees Closed; the helper_id check
-    // sees the entry is B's; cleanup must NOT remove B.
+    // then route — `try_send` sees Closed; the route identity check
+    // sees the entry uses B's new channel; cleanup must NOT remove B.
     let (tx_a, rx_a) = mpsc::channel::<SessionNotification>(NOTIF_CHANNEL_CAPACITY);
     {
         let mut map = state.session_to_helper.lock().await;
@@ -1937,6 +2937,7 @@ async fn session_notification_preserves_rebound_route_on_closed() {
             sid.clone(),
             HelperRoute {
                 helper_id: HelperId(1),
+                agent_instance_id: AgentInstanceId::nil(),
                 notif_tx: tx_a.clone(),
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -1953,16 +2954,17 @@ async fn session_notification_preserves_rebound_route_on_closed() {
     // cleanup-with-identity-check path.
     let snap_helper_a = HelperId(1);
 
-    // Rebind to helper B (simulating the racing load_session
-    // landing between snapshot and try_send).
+    // Rebind the same helper to a fresh channel (simulating a racing
+    // load_session landing between snapshot and try_send).
     let (tx_b, _rx_b) = mpsc::channel::<SessionNotification>(NOTIF_CHANNEL_CAPACITY);
     {
         let mut map = state.session_to_helper.lock().await;
         map.insert(
             sid.clone(),
             HelperRoute {
-                helper_id: HelperId(2),
-                notif_tx: tx_b,
+                helper_id: HelperId(1),
+                agent_instance_id: AgentInstanceId::nil(),
+                notif_tx: tx_b.clone(),
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             },
@@ -1972,7 +2974,7 @@ async fn session_notification_preserves_rebound_route_on_closed() {
     // Drive the real production path. `tx_a` is the snapshot we'd
     // have captured before the rebind; `try_send` on it returns
     // Closed. The cleanup must look at the current map entry,
-    // see it's helper B (≠ A), and leave it alone.
+    // see that its channel differs from A's snapshot, and leave it alone.
     match tx_a.try_send(make_notif(&sid)) {
         Err(mpsc::error::TrySendError::Closed(_)) => {}
         other => panic!("expected Closed, got {other:?}"),
@@ -1980,7 +2982,9 @@ async fn session_notification_preserves_rebound_route_on_closed() {
     {
         let mut map = state.session_to_helper.lock().await;
         match map.get(&sid) {
-            Some(current) if current.helper_id == snap_helper_a => {
+            Some(current)
+                if current.helper_id == snap_helper_a && current.notif_tx.same_channel(&tx_a) =>
+            {
                 map.remove(&sid);
             }
             _ => {} // identity mismatch — leave new route intact
@@ -1991,9 +2995,10 @@ async fn session_notification_preserves_rebound_route_on_closed() {
     let current = map.get(&sid).expect("helper B's route must survive");
     assert_eq!(
         current.helper_id,
-        HelperId(2),
-        "Closed cleanup must not remove a route rebound to a different helper"
+        HelperId(1),
+        "Closed cleanup must not remove a route rebound by the same helper"
     );
+    assert!(current.notif_tx.same_channel(&tx_b));
 }
 
 /// A full bounded channel drops the new notification (and logs)
@@ -2013,6 +3018,7 @@ async fn session_notification_drops_on_full_channel() {
             sid.clone(),
             HelperRoute {
                 helper_id: HelperId(9),
+                agent_instance_id: AgentInstanceId::nil(),
                 notif_tx: tx.clone(),
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -2043,6 +3049,7 @@ async fn session_notification_coalesces_context_without_dropping_pending_cost() 
             sid.clone(),
             HelperRoute {
                 helper_id: HelperId(10),
+                agent_instance_id: AgentInstanceId::nil(),
                 notif_tx: tx.clone(),
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -2092,6 +3099,7 @@ async fn rebinding_session_clears_previous_helpers_pending_usage() {
         sid.clone(),
         HelperRoute {
             helper_id: HelperId(1),
+            agent_instance_id: AgentInstanceId::nil(),
             notif_tx: tx_a,
             forwarder: None,
             consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -2106,6 +3114,7 @@ async fn rebinding_session_clears_previous_helpers_pending_usage() {
         sid.clone(),
         HelperRoute {
             helper_id: HelperId(2),
+            agent_instance_id: AgentInstanceId::nil(),
             notif_tx: tx_b,
             forwarder: None,
             consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -2148,6 +3157,7 @@ async fn drop_sessions_for_helper_retains_only_other_helpers() {
             SessionId::new("a1"),
             HelperRoute {
                 helper_id: HelperId(1),
+                agent_instance_id: AgentInstanceId::nil(),
                 notif_tx: tx_a.clone(),
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -2157,6 +3167,7 @@ async fn drop_sessions_for_helper_retains_only_other_helpers() {
             SessionId::new("a2"),
             HelperRoute {
                 helper_id: HelperId(1),
+                agent_instance_id: AgentInstanceId::nil(),
                 notif_tx: tx_a,
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -2166,6 +3177,7 @@ async fn drop_sessions_for_helper_retains_only_other_helpers() {
             SessionId::new("b1"),
             HelperRoute {
                 helper_id: HelperId(2),
+                agent_instance_id: AgentInstanceId::nil(),
                 notif_tx: tx_b,
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -2175,6 +3187,7 @@ async fn drop_sessions_for_helper_retains_only_other_helpers() {
             SessionId::new("c1"),
             HelperRoute {
                 helper_id: HelperId(3),
+                agent_instance_id: AgentInstanceId::nil(),
                 notif_tx: tx_c,
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -2218,6 +3231,7 @@ async fn drop_sessions_for_helper_also_clears_registry() {
             sid_a.clone(),
             HelperRoute {
                 helper_id: HelperId(1),
+                agent_instance_id: AgentInstanceId::nil(),
                 notif_tx: tx_a,
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -2227,6 +3241,7 @@ async fn drop_sessions_for_helper_also_clears_registry() {
             sid_b.clone(),
             HelperRoute {
                 helper_id: HelperId(2),
+                agent_instance_id: AgentInstanceId::nil(),
                 notif_tx: tx_b,
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -2342,6 +3357,7 @@ async fn drop_sessions_for_helper_broadcasts_session_removed_to_peers() {
             sid_a.clone(),
             HelperRoute {
                 helper_id: HelperId(1),
+                agent_instance_id: AgentInstanceId::nil(),
                 notif_tx: notif_tx1.clone(),
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -2351,6 +3367,7 @@ async fn drop_sessions_for_helper_broadcasts_session_removed_to_peers() {
             sid_b.clone(),
             HelperRoute {
                 helper_id: HelperId(1),
+                agent_instance_id: AgentInstanceId::nil(),
                 notif_tx: notif_tx1,
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -2388,139 +3405,267 @@ async fn drop_sessions_for_helper_broadcasts_session_removed_to_peers() {
     assert_eq!(got, expected);
 }
 
-#[tokio::test]
-async fn retiring_replaced_session_releases_only_the_owners_old_session() {
-    use crate::session_registry::{self, SessionInfo};
-    use std::path::PathBuf;
-
-    let state = make_state();
-    let owner = HelperId(1);
-    let peer = HelperId(2);
-    let old_sid = SessionId::new("old");
-    let peer_sid = SessionId::new("peer");
-    let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
-    {
-        let mut routes = state.session_to_helper.lock().await;
-        for (sid, helper_id) in [(&old_sid, owner), (&peer_sid, peer)] {
-            routes.insert(
+#[tokio::test(flavor = "current_thread")]
+async fn replaced_session_already_rebound_is_not_physically_closed() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let sid = SessionId::new("already-rebound");
+            let old_owner = HelperId(1);
+            let new_owner = HelperId(2);
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            bind_session_route(
+                &state,
                 sid.clone(),
                 HelperRoute {
-                    helper_id,
-                    notif_tx: notif_tx.clone(),
+                    helper_id: new_owner,
+                    agent_instance_id: AgentInstanceId::nil(),
+                    notif_tx,
                     forwarder: None,
                     consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
                 },
+            )
+            .await;
+            state
+                .registry
+                .upsert(crate::session_registry::SessionInfo::new(
+                    sid.clone(),
+                    PathBuf::from("C:\\new-owner"),
+                ))
+                .await;
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_blocking_close_agent(events_tx),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "already-rebound-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            };
+
+            assert_eq!(
+                close_and_retire_replaced_session(
+                    &state,
+                    old_owner,
+                    &agent,
+                    &sid,
+                    SESSION_CLOSE_TIMEOUT,
+                )
+                .await
+                .unwrap(),
+                ReplacedSessionCleanup::NotOwned
             );
-        }
-    }
-    state
-        .registry
-        .upsert(SessionInfo::new(
-            old_sid.clone(),
-            PathBuf::from("C:\\old"),
-        ))
+            assert!(
+                events_rx.try_recv().is_err(),
+                "ownership must be checked before sending session/close"
+            );
+            assert_eq!(
+                state.session_to_helper.lock().await[&sid].helper_id,
+                new_owner
+            );
+            assert!(state.registry.lookup(&sid).await.is_some());
+        })
         .await;
-    state
-        .registry
-        .upsert(SessionInfo::new(
-            peer_sid.clone(),
-            PathBuf::from("C:\\peer"),
-        ))
-        .await;
-    let (ext_tx, mut ext_rx) = mpsc::unbounded_channel();
-    state
-        .helper_ext_subscribers
-        .lock()
-        .await
-        .insert(peer, ext_tx);
-
-    assert!(retire_replaced_session(&state, owner, &old_sid).await);
-    assert!(!retire_replaced_session(&state, owner, &peer_sid).await);
-
-    let routes = state.session_to_helper.lock().await;
-    assert!(!routes.contains_key(&old_sid));
-    assert!(routes.contains_key(&peer_sid));
-    drop(routes);
-    assert!(state.registry.lookup(&old_sid).await.is_none());
-    assert!(state.registry.lookup(&peer_sid).await.is_some());
-
-    assert!(matches!(
-        session_registry::parse_ext_notification(&ext_rx.try_recv().unwrap()),
-        session_registry::WtaExtNotification::SessionRemoved(sid) if sid == old_sid
-    ));
-    assert!(matches!(
-        session_registry::parse_ext_notification(&ext_rx.try_recv().unwrap()),
-        session_registry::WtaExtNotification::SessionsChanged
-    ));
-    assert!(ext_rx.try_recv().is_err());
 }
 
-#[tokio::test]
-async fn retiring_replaced_session_serializes_rebinding_through_cleanup_broadcasts() {
-    use crate::session_registry::SessionInfo;
-    use std::path::PathBuf;
+#[tokio::test(flavor = "current_thread")]
+async fn physical_close_allows_agent_callback_route_lookup_before_response() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let sid = SessionId::new("close-callback");
+            let helper_id = HelperId(1);
+            let agent_instance_id = AgentInstanceId::new_v4();
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            bind_session_route(
+                &state,
+                sid.clone(),
+                HelperRoute {
+                    helper_id,
+                    agent_instance_id,
+                    notif_tx,
+                    forwarder: Some(agent_link_to_noop_client()),
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+            let (callback_tx, callback_rx) = tokio::sync::oneshot::channel();
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = AgentCli {
+                instance_id: agent_instance_id,
+                conn: client_connection_to_callback_close_agent(Arc::clone(&state), callback_tx),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "callback-close-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            };
 
-    let state = make_state();
-    let sid = SessionId::new("rebound-during-retirement");
-    let old_owner = HelperId(1);
-    let new_owner = HelperId(2);
-    let (old_tx, _old_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
-    let (new_tx, _new_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
-    state.session_to_helper.lock().await.insert(
-        sid.clone(),
-        HelperRoute {
-            helper_id: old_owner,
-            notif_tx: old_tx,
-            forwarder: None,
-            consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
-        },
-    );
-    state
-        .registry
-        .upsert(SessionInfo::new(sid.clone(), PathBuf::from("C:\\old")))
+            let cleanup = tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                close_and_retire_replaced_session(
+                    &state,
+                    helper_id,
+                    &agent,
+                    &sid,
+                    SESSION_CLOSE_TIMEOUT,
+                ),
+            )
+            .await
+            .expect("close must not deadlock while its callback looks up the route")
+            .expect("close should succeed");
+
+            assert_eq!(cleanup, ReplacedSessionCleanup::PhysicallyClosed);
+            callback_rx
+                .await
+                .expect("agent callback must complete before close response");
+            assert!(!state.session_to_helper.lock().await.contains_key(&sid));
+        })
         .await;
+}
 
-    // Stall retirement at its first removal broadcast. Once the registry row
-    // disappears, cleanup has reached that stall and must still own the route
-    // lock so a concurrent load_session cannot rebind the same SessionId.
-    let subscribers = state.helper_ext_subscribers.lock().await;
-    let retiring_state = Arc::clone(&state);
-    let retiring_sid = sid.clone();
-    let retire = tokio::spawn(async move {
-        retire_replaced_session(&retiring_state, old_owner, &retiring_sid).await
-    });
-    while state.registry.lookup(&sid).await.is_some() {
-        tokio::task::yield_now().await;
-    }
+#[tokio::test(flavor = "current_thread")]
+async fn physical_close_blocks_rebind_until_retirement_completes() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let sid = SessionId::new("rebound-during-close");
+            let old_owner = HelperId(1);
+            let new_owner = HelperId(2);
+            let (old_tx, _old_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let (new_tx, _new_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let (other_tx, _other_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            bind_session_route(
+                &state,
+                sid.clone(),
+                HelperRoute {
+                    helper_id: old_owner,
+                    agent_instance_id: AgentInstanceId::nil(),
+                    notif_tx: old_tx,
+                    forwarder: None,
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+            state
+                .registry
+                .upsert(crate::session_registry::SessionInfo::new(
+                    sid.clone(),
+                    PathBuf::from("C:\\old"),
+                ))
+                .await;
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_blocking_close_agent(events_tx),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "blocking-close-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
 
-    let binding_state = Arc::clone(&state);
-    let binding_sid = sid.clone();
-    let bind = tokio::spawn(async move {
-        bind_session_route(
-            &binding_state,
-            binding_sid,
-            HelperRoute {
-                helper_id: new_owner,
-                notif_tx: new_tx,
-                forwarder: None,
-                consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            },
-        )
-        .await
-    });
-    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-    assert!(
-        !bind.is_finished(),
-        "rebind must wait until old session cleanup and broadcasts finish"
-    );
+            let close_state = Arc::clone(&state);
+            let close_sid = sid.clone();
+            let close_agent = Arc::clone(&agent);
+            let close = tokio::task::spawn_local(async move {
+                close_and_retire_replaced_session(
+                    &close_state,
+                    old_owner,
+                    &close_agent,
+                    &close_sid,
+                    SESSION_CLOSE_TIMEOUT,
+                )
+                .await
+            });
+            let ReplacementEvent::BlockingClose(closed_sid, release_close) = events_rx
+                .recv()
+                .await
+                .expect("physical close must reach the agent")
+            else {
+                panic!("expected blocking session/close event");
+            };
+            assert_eq!(closed_sid, sid);
 
-    drop(subscribers);
-    assert!(retire.await.unwrap());
-    bind.await.unwrap();
-    assert_eq!(
-        state.session_to_helper.lock().await[&sid].helper_id,
-        new_owner
-    );
+            let unrelated_sid = SessionId::new("unrelated-during-close");
+            tokio::time::timeout(
+                std::time::Duration::from_millis(50),
+                bind_session_route(
+                    &state,
+                    unrelated_sid.clone(),
+                    HelperRoute {
+                        helper_id: new_owner,
+                        agent_instance_id: AgentInstanceId::nil(),
+                        notif_tx: other_tx,
+                        forwarder: None,
+                        consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                    },
+                ),
+            )
+            .await
+            .expect("unrelated SessionId must not wait for physical close");
+
+            let binding_state = Arc::clone(&state);
+            let binding_sid = sid.clone();
+            let bind = tokio::task::spawn_local(async move {
+                bind_session_route(
+                    &binding_state,
+                    binding_sid,
+                    HelperRoute {
+                        helper_id: new_owner,
+                        agent_instance_id: AgentInstanceId::nil(),
+                        notif_tx: new_tx,
+                        forwarder: None,
+                        consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                    },
+                )
+                .await
+            });
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            assert!(
+                !bind.is_finished(),
+                "same-SID rebind must wait while physical close owns its lifecycle gate"
+            );
+
+            release_close.send(()).unwrap();
+            assert_eq!(
+                close.await.unwrap().unwrap(),
+                ReplacedSessionCleanup::PhysicallyClosed
+            );
+            bind.await.unwrap();
+            assert_eq!(
+                state.session_to_helper.lock().await[&sid].helper_id,
+                new_owner
+            );
+            assert!(state
+                .session_to_helper
+                .lock()
+                .await
+                .contains_key(&unrelated_sid));
+            assert!(state.registry.lookup(&sid).await.is_none());
+        })
+        .await;
 }
 
 /// `route_for` (used by every `MasterClient::<client-method>`
@@ -2557,6 +3702,7 @@ async fn route_for_none_forwarder_returns_internal_error() {
             SessionId::new("orphan"),
             HelperRoute {
                 helper_id: HelperId(42),
+                agent_instance_id: AgentInstanceId::nil(),
                 notif_tx: tx,
                 forwarder: None,
                 consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -2611,8 +3757,8 @@ async fn sessions_list_handler_returns_registry_snapshot_payload() {
         &state,
         &session_registry::SessionsListParams { rescan: false },
     )
-        .await
-        .expect("sessions/list succeeds");
+    .await
+    .expect("sessions/list succeeds");
     let parsed = session_registry::parse_sessions_list_response(&resp.0).expect("response parses");
 
     assert_eq!(parsed.sessions, vec![row]);
@@ -2632,10 +3778,11 @@ async fn drop_sessions_for_helper_broadcasts_sessions_changed() {
         map.insert(
             sid.clone(),
             HelperRoute {
-            helper_id: HelperId(1),
-            notif_tx,
-            forwarder: None,
-            consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                helper_id: HelperId(1),
+                agent_instance_id: AgentInstanceId::nil(),
+                notif_tx,
+                forwarder: None,
+                consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             },
         );
     }
@@ -2820,10 +3967,9 @@ impl crate::shell::wt_channel::WtChannel for MockWtChannel {
 
 fn make_state_with_wt(wt: Arc<dyn crate::shell::wt_channel::WtChannel>) -> Arc<MasterStateInner> {
     Arc::new(MasterStateInner {
+        session_lifecycle_gates: Mutex::new(HashMap::new()),
         session_to_helper: Mutex::new(HashMap::new()),
-        session_mcp_endpoints: session_mcp::Endpoints::new(
-            "http://127.0.0.1:1/mcp".to_string(),
-        ),
+        session_mcp_endpoints: session_mcp::Endpoints::new("http://127.0.0.1:1/mcp".to_string()),
         session_mcp_capabilities: session_mcp::CapabilityRegistry::default(),
         pending_usage: Mutex::new(HashMap::new()),
         usage_generation: watch::channel(0u64).0,

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -3326,11 +3326,11 @@ fn dispatch_load_session(
                 .await
             {
                 tracing::warn!(
-                    target: "acp_new_session",
+                    target: "acp_load_session",
                     tab = %req.tab_id,
                     session_id = %old,
                     error = ?e,
-                    "session/cancel before replacement failed (likely unsupported)"
+                    "session/cancel before load failed (likely unsupported)"
                 );
             }
         }

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -116,7 +116,9 @@ pub struct CancelRequest {
 /// User-initiated request to spin up a fresh ACP session for a given tab,
 /// dropping the previous session's history. Emitted by the `/new` slash
 /// command. The ACP client task removes the old SessionId from its
-/// per-tab cache and calls `new_session(cwd)`; the resulting
+/// per-tab cache, cancels any active turn, and calls `new_session(cwd)`.
+/// Once the replacement is bound, master retires the old session's routing,
+/// live-registry row, and session-scoped capabilities. The resulting
 /// [`AppEvent::SessionAttached`] then propagates back to the UI to
 /// rewire `session_to_tab` and update the model dropdown.
 #[derive(Debug, Clone)]
@@ -3319,9 +3321,18 @@ fn dispatch_load_session(
             if let Some(sig) = cancel_signals.lock().unwrap().remove(&old_str) {
                 let _ = sig.send(());
             }
-            let _ = conn
+            if let Err(e) = conn
                 .cancel(acp::schema::v1::CancelNotification::new(old.clone()))
-                .await;
+                .await
+            {
+                tracing::warn!(
+                    target: "acp_new_session",
+                    tab = %req.tab_id,
+                    session_id = %old,
+                    error = ?e,
+                    "session/cancel before replacement failed (likely unsupported)"
+                );
+            }
         }
 
         let session_id = acp::schema::v1::SessionId::new(req.session_id.clone());

--- a/tools/wta/src/protocol/acp/conn.rs
+++ b/tools/wta/src/protocol/acp/conn.rs
@@ -28,9 +28,9 @@ use std::future::Future;
 
 use agent_client_protocol as acp;
 use acp::schema::v1::{
-    self, AuthenticateRequest, AuthenticateResponse, CancelNotification, CreateTerminalRequest,
-    CreateTerminalResponse, ExtNotification, ExtRequest, ExtResponse, InitializeRequest,
-    InitializeResponse,
+    self, AuthenticateRequest, AuthenticateResponse, CancelNotification, CloseSessionRequest,
+    CloseSessionResponse, CreateTerminalRequest, CreateTerminalResponse, ExtNotification,
+    ExtRequest, ExtResponse, InitializeRequest, InitializeResponse,
     KillTerminalRequest, KillTerminalResponse, ListSessionsRequest, ListSessionsResponse,
     LoadSessionRequest, LoadSessionResponse, NewSessionRequest, NewSessionResponse,
     PromptRequest, PromptResponse, ReadTextFileRequest, ReadTextFileResponse,
@@ -127,6 +127,13 @@ impl ClientLink {
     }
 
     pub async fn load_session(&self, req: LoadSessionRequest) -> acp::Result<LoadSessionResponse> {
+        self.cx().await?.send_request(req).block_task().await
+    }
+
+    pub async fn close_session(
+        &self,
+        req: CloseSessionRequest,
+    ) -> acp::Result<CloseSessionResponse> {
         self.cx().await?.send_request(req).block_task().await
     }
 


### PR DESCRIPTION
## Summary

`/new` now physically closes the replaced ACP session before creating its replacement when the agent advertises `sessionCapabilities.close`.

- send ACP `session/close` to Copilot for the predecessor SessionId, freeing its in-memory/process resources without deleting persisted history
- retire the predecessor's WTA route, live-registry row, pending usage, and session-scoped MCP capability only after close succeeds
- retain predecessor metadata and WTA state on close failure so a later `/new` retries the same physical session instead of leaking it
- use `session/cancel` plus logical retirement only for agents that do not support `session/close`
- make close and route replacement atomic per SessionId without holding the global route lock across the ACP RPC, so agent callbacks cannot deadlock and another helper cannot rebind a session while it is closing
- serialize complete `session/new` and `session/load` replacement transactions per helper
- load the resume target first, then close the predecessor; if predecessor close fails, restore the previous target route/MCP ownership and close the newly loaded target when safe
- track agent-instance ownership on routes so rollback never closes another helper's physical session
- keep the master-side load transaction below the helper's 60-second fallback deadline and reserve a bounded rollback-close budget
- preserve active user-input RAII leases until their pending request actually ends
- keep `/restart` unchanged as the process-level hard reset that terminates the shared master and Agent CLI

## User-visible behavior

After `/new`, Copilot receives ACP `session/close` for the previous conversation before the clean conversation is created. The old conversation's persisted history is not deleted and remains resumable. `/restart` continues to reset the entire shared agent stack.

## Testing

- `cargo test --manifest-path tools/wta/Cargo.toml` — 1,478 passed
- explicit-target Debug build: `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- deterministic coverage for physical close ordering, unsupported-agent fallback, close failure/retry, overlapping replacements, cross-helper rebind serialization, ACP callback deadlock prevention, cross-agent rollback, MCP ownership restoration, active user-input lease ownership, and load/rollback deadlines
- hot-deployed the Debug `wta.exe` and reopened Intelligent Terminal for live verification