### PR TITLE
Improve slash command search

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -4284,7 +4284,7 @@ impl App {
         // When the transport to master is lost, only /restart can run — so the
         // popup simply doesn't show the other commands (rather than greying
         // them). Collapse the candidate list to /restart if it's among the
-        // prefix matches; otherwise show nothing (the typed prefix excludes
+        // search matches; otherwise show nothing (the typed query excludes
         // it, e.g. "/new"), and the Enter handler surfaces the reconnect hint.
         // Static command and move candidates borrow the tab's lists. Agent
         // candidates are filtered from the small cached available-agent list.
@@ -4313,6 +4313,11 @@ impl App {
             candidates,
             selected: tab.command_popup_selected,
             pane_focused: self.pane_focused,
+            command_query: tab
+                .input
+                .trim_start()
+                .strip_prefix('/')
+                .unwrap_or_default(),
             current_model: self.current_model_display(),
         })
     }

--- a/tools/wta/src/app/input_edit.rs
+++ b/tools/wta/src/app/input_edit.rs
@@ -248,7 +248,7 @@ impl TabSession {
             self.move_position_candidates = commands::match_move_positions(prefix);
         } else if commands::is_command_prefix(&self.input) {
             // Strip leading whitespace + the `/` to get the user's
-            // partial name. `is_command_prefix` already guarantees the
+            // name query. `is_command_prefix` already guarantees the
             // shape, so the unwrap is safe.
             let trimmed = self.input.trim_start();
             let name = trimmed.strip_prefix('/').unwrap_or("");

--- a/tools/wta/src/commands.rs
+++ b/tools/wta/src/commands.rs
@@ -464,6 +464,9 @@ mod tests {
         assert_eq!(middle.len(), 1);
         assert_eq!(middle[0].name, "clear");
 
+        let ranked: Vec<_> = matches("st").into_iter().map(|spec| spec.name).collect();
+        assert_eq!(ranked, vec!["stop", "restart"]);
+
         let none = matches("zzz");
         assert!(none.is_empty());
     }

--- a/tools/wta/src/commands.rs
+++ b/tools/wta/src/commands.rs
@@ -3,7 +3,7 @@
 //! The user types `/foo` in the input box; on Enter, [`parse`] resolves the
 //! input to a [`ParsedCommand`] (or returns `None`, in which case the line is
 //! sent as a normal prompt). The autocomplete popup uses [`matches`] for
-//! prefix-filtered suggestions.
+//! substring-filtered suggestions, with prefix matches ranked first.
 //!
 //! See `tools/wta/src/app.rs` `App::handle_slash_command` for dispatch and
 //! `tools/wta/src/ui/command_popup.rs` for rendering.
@@ -269,15 +269,16 @@ pub fn lookup(name: &str) -> Option<&'static CommandSpec> {
         .find(|spec| spec.name.eq_ignore_ascii_case(name))
 }
 
-/// Prefix-match against the registry (case-insensitive). An empty prefix
-/// returns the full registry in declaration order. Used by the autocomplete
-/// popup.
-pub fn matches(prefix: &str) -> Vec<&'static CommandSpec> {
-    let needle = prefix.trim().to_ascii_lowercase();
-    REGISTRY
+/// Substring-match against the registry (case-insensitive), ranking prefix
+/// matches before other contains matches. An empty query returns the full
+/// registry in declaration order. Used by the autocomplete popup.
+pub fn matches(query: &str) -> Vec<&'static CommandSpec> {
+    let needle = query.trim().to_ascii_lowercase();
+    let (prefix_matches, contains_matches): (Vec<_>, Vec<_>) = REGISTRY
         .iter()
-        .filter(|spec| spec.name.starts_with(&needle))
-        .collect()
+        .filter(|spec| spec.name.contains(&needle))
+        .partition(|spec| spec.name.starts_with(&needle));
+    prefix_matches.into_iter().chain(contains_matches).collect()
 }
 
 /// Resolve a `/move` argument from either its full name or one-letter alias.
@@ -451,7 +452,7 @@ mod tests {
     }
 
     #[test]
-    fn matches_filters_by_prefix() {
+    fn matches_filters_by_substring_and_ranks_prefixes_first() {
         let all = matches("");
         assert_eq!(all.len(), REGISTRY.len());
 
@@ -459,15 +460,19 @@ mod tests {
         assert_eq!(h.len(), 1);
         assert_eq!(h[0].name, "help");
 
+        let middle = matches("lear");
+        assert_eq!(middle.len(), 1);
+        assert_eq!(middle[0].name, "clear");
+
         let none = matches("zzz");
         assert!(none.is_empty());
     }
 
     #[test]
     fn matches_case_insensitive() {
-        let h = matches("HE");
-        assert_eq!(h.len(), 1);
-        assert_eq!(h[0].name, "help");
+        let sessions = matches("IONS");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].name, "sessions");
     }
 
     #[test]

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -879,3 +879,14 @@ fn connected_popup_visible_for_any_prefix() {
         "a healthy connection must keep the normal popup behavior"
     );
 }
+
+#[test]
+fn connected_popup_matches_command_name_substrings() {
+    let mut app = test_app();
+    type_input(&mut app, "/lear");
+
+    assert!(
+        app.command_popup_visible(),
+        "typing a substring of /clear must show the command popup"
+    );
+}

--- a/tools/wta/src/theme.rs
+++ b/tools/wta/src/theme.rs
@@ -28,6 +28,10 @@ pub const IN_PROGRESS: Style = Style::new()
     .add_modifier(Modifier::BOLD)
     .add_modifier(Modifier::ITALIC);
 pub const DIM: Style = Style::new().fg(Color::DarkGray);
+pub const SEARCH_MATCH: Style = Style::new()
+    .fg(Color::Yellow)
+    .add_modifier(Modifier::BOLD)
+    .add_modifier(Modifier::UNDERLINED);
 // Match the /sessions cursor: cyan foreground with no full-row background.
 pub const SELECTED: Style = Style::new().fg(Color::Cyan);
 // Preserve the selection when the pane loses focus without presenting it as

--- a/tools/wta/src/ui/command_popup.rs
+++ b/tools/wta/src/ui/command_popup.rs
@@ -236,7 +236,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_query_keeps_command_name_unhighlighted() {
+    fn empty_query_keeps_command_name_plain() {
         let spans = command_name_spans("clear", "");
 
         assert_eq!(spans.len(), 1);

--- a/tools/wta/src/ui/command_popup.rs
+++ b/tools/wta/src/ui/command_popup.rs
@@ -23,6 +23,9 @@ pub struct PopupState<'a> {
     pub candidates: PopupCandidates<'a>,
     pub selected: usize,
     pub pane_focused: bool,
+    /// Text after the leading `/`, used to highlight the matching part of
+    /// command-name candidates.
+    pub command_query: &'a str,
     /// Effective model for the active pane (per-pane `/model` override, else
     /// the global one). Appended to the `/model` row so the user sees what
     /// they're currently on while typing the command. `None` when no model
@@ -59,10 +62,8 @@ pub fn render_popup(frame: &mut Frame, state: PopupState<'_>, input_area: Rect) 
         PopupCandidates::Commands(candidates) => candidates
             .iter()
             .map(|spec| {
-                let mut spans = vec![
-                    Span::styled(format!(" /{:<8} ", spec.name), theme::INPUT_TEXT),
-                    Span::styled(spec.summary(), theme::DIM),
-                ];
+                let mut spans = command_name_spans(spec.name, state.command_query);
+                spans.push(Span::styled(spec.summary(), theme::DIM));
                 // The `/model` row shows the pane's current model so the user can
                 // see what they're on before opening the picker.
                 if spec.name == "model" {
@@ -111,6 +112,30 @@ pub fn render_popup(frame: &mut Frame, state: PopupState<'_>, input_area: Rect) 
     list_state.select(popup_highlight(candidate_count, state.selected));
 
     frame.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn command_name_spans(name: &str, query: &str) -> Vec<Span<'static>> {
+    let padded_name = format!("{name:<8} ");
+    let needle = query.trim().to_ascii_lowercase();
+    let Some(start) = (!needle.is_empty())
+        .then(|| name.to_ascii_lowercase().find(&needle))
+        .flatten()
+    else {
+        return vec![Span::styled(
+            format!(" /{padded_name}"),
+            theme::INPUT_TEXT,
+        )];
+    };
+    let end = start + needle.len();
+
+    vec![
+        Span::styled(format!(" /{}", &name[..start]), theme::INPUT_TEXT),
+        Span::styled(name[start..end].to_string(), theme::SEARCH_MATCH),
+        Span::styled(
+            format!("{}{}", &name[end..], &padded_name[name.len()..]),
+            theme::INPUT_TEXT,
+        ),
+    ]
 }
 
 /// Which row the command popup highlights: the user's cursor index, clamped
@@ -172,8 +197,9 @@ pub fn render_help_overlay(frame: &mut Frame, app: &App, area: Rect) {
 
 #[cfg(test)]
 mod tests {
-    use super::popup_highlight;
+    use super::{command_name_spans, popup_highlight};
     use crate::commands;
+    use crate::theme;
 
     fn spec(name: &str) -> &'static commands::CommandSpec {
         commands::lookup(name).expect("registered command")
@@ -196,5 +222,25 @@ mod tests {
     #[test]
     fn empty_candidates_highlight_nothing() {
         assert_eq!(popup_highlight(0, 0), None);
+    }
+
+    #[test]
+    fn command_name_highlights_matching_substring() {
+        let spans = command_name_spans("clear", "LEAR");
+
+        assert_eq!(spans.len(), 3);
+        assert_eq!(spans[0].content, " /c");
+        assert_eq!(spans[1].content, "lear");
+        assert_eq!(spans[1].style, theme::SEARCH_MATCH);
+        assert_eq!(spans[2].content, "    ");
+    }
+
+    #[test]
+    fn empty_query_keeps_command_name_unhighlighted() {
+        let spans = command_name_spans("clear", "");
+
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].content, " /clear    ");
+        assert_eq!(spans[0].style, theme::INPUT_TEXT);
     }
 }


### PR DESCRIPTION
## Summary
- match slash commands by case-insensitive substring while ranking prefix matches first
- highlight the matched command-name text in autocomplete results
- cover substring filtering and rendering with unit tests

## Testing
- cargo test --manifest-path tools/wta/Cargo.toml
- manually verified /lear matches /clear in the agent pane

<img width="1124" height="462" alt="image" src="https://github.com/user-attachments/assets/489ed08f-c7c5-4370-9746-ef590fc686a5" />
