### PR TITLE
Agent pane: Add ACP session config options

### DIFF
--- a/doc/specs/acp-v1-support-completion-plan.md
+++ b/doc/specs/acp-v1-support-completion-plan.md
@@ -1,6 +1,7 @@
 # ACP v1 Support Completion Plan
 
-**Status**: Implementation in progress; Phase 1 core tool details landed locally  
+**Status**: Implementation in progress; Phase 1 core tool details are on `main`;
+Phase 4 select-option support is implemented locally
 **Scope**: `tools/wta`, the agent-pane TUI, and the helper/master ACP bridge  
 **Baseline**: ACP wire `protocolVersion: 1`  
 **Last updated**: 2026-08-12
@@ -124,8 +125,8 @@ merge authorization scopes or synthesize options such as `AllowAlways`.
 
 ### Phase 1: Tool Details follow-up to PR #601
 
-**Implementation status**: Core support is complete on
-`dev/vanzue/acp-tool-details-wave2`.
+**Implementation status**: Core support landed on `main` through PRs #601 and
+#611.
 Standard content, diffs, terminal references/output, rich-content placeholders,
 location lines, collection replacement, persistence compatibility, and
 expanded completed-turn details are covered. A direct file-open action and a
@@ -201,6 +202,12 @@ not currently have a safe file-handler selection model.
 - Close and delete are separate user actions with separate tests.
 
 ### Phase 4: Generic config options and Agent commands
+
+**Implementation status**: The first Config Options slice is implemented
+locally. WTA preserves ordered select options per Session, replaces complete
+snapshots from new/load/update/set responses, exposes a generic `/config`
+two-level picker, and routes `/model` through the standard model option when
+one exists. Boolean options and Agent commands remain follow-ups.
 
 1. Store the complete ordered `configOptions` collection per session.
 2. Render all supported select options, not only the `model` category.

--- a/tools/wta/locales/af-ZA.yml
+++ b/tools/wta/locales/af-ZA.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "Agent-oorskakeling is nie beskikbaar buite 'n 
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Kies die model vir hierdie paneel (/model <id> om direk oor te skakel)"  # {Locked="/model","<id>"}
+commands.config.summary: "Stel hierdie agent-sessie op"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Skuif hierdie oortjie se agentpaneel (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Kies model (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Die gekoppelde agent het geen kiesbare modelle aangekondig nie."
 system.model_set: "Model vir hierdie paneel gestel op %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Sessie-konfigurasie (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Die gekoppelde agent het geen konfigureerbare sessie-opsies geadverteer nie."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Kon nie %{option} bywerk nie: %{error}"
 system.model_unknown: "Onbekende model %{model} — tik /model om die beskikbare lys te sien."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/am-ET.yml
+++ b/tools/wta/locales/am-ET.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "የኤጅንት መቀያየር ከWindows Ter
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "ለዚህ ፓነል ሞዴሉን ይምረጡ (በቀጥታ ለመቀየር /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "የዚህን ኤጀንት ክፍለ-ጊዜ ያዋቅሩ"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "የዚህን ትር ኤጅንት ገጽታ ያንቀሳቅሱ (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "ሞዴል ይምረጡ (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "የተገናኘው ኤጅንት ምንም ሊመረጥ የሚችል ሞዴል አላስታወቀም።"
 system.model_set: "የዚህ ፓነል ሞዴል ወደ %{model} ተቀናብሯል።"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "የክፍለ-ጊዜ ውቅር (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "የተገናኘው ኤጀንት ምንም የሚዋቀሩ የክፍለ-ጊዜ አማራጮችን አላስተዋወቀም።"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} ማዘመን አልተሳካም፦ %{error}"
 system.model_unknown: "ያልታወቀ ሞዴል %{model} — የሚገኘውን ዝርዝር ለማየት /model ይተይቡ።"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ar-SA.yml
+++ b/tools/wta/locales/ar-SA.yml
@@ -217,8 +217,17 @@ system.agent_switch_unavailable: "تبديل عامل الذكاء الاصطن�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "اختر النموذج لهذه اللوحة (/model <id> للتبديل مباشرةً)"  # {Locked="/model","<id>"}
+commands.config.summary: "تكوين جلسة عامل الذكاء الاصطناعي هذه"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "نقل لوحة عامل الذكاء الاصطناعي لعلامة التبويب هذه (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "اختر النموذج (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "لم يُعلن عامل الذكاء الاصطناعي المتصل عن أي نماذج قابلة للاختيار."
 system.model_set: "تم تعيين نموذج هذه اللوحة إلى %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "تكوين الجلسة (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "لم يعلن عامل الذكاء الاصطناعي المتصل عن أي خيارات جلسة قابلة للتكوين."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "فشل تحديث %{option}: %{error}"
 system.model_unknown: "نموذج غير معروف %{model} — اكتب /model لعرض القائمة المتاحة."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/as-IN.yml
+++ b/tools/wta/locales/as-IN.yml
@@ -218,8 +218,17 @@ system.agent_switch_unavailable: "উইণ্ড’জ টাৰ্মিনে
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "এই পেনৰ বাবে মডেল বাছনি কৰক (পোনপটীয়াকৈ সলাবলৈ /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "এই এজেণ্ট ছিচেন কনফিগাৰ কৰক"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "এই টেবৰ এজেণ্ট পেন স্থানান্তৰ কৰক (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "মডেল বাছনি কৰক (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "সংযুক্ত এজেণ্টে কোনো বাছনিযোগ্য মডেল ঘোষণা কৰা নাই।"
 system.model_set: "এই পেনৰ বাবে মডেল %{model} লৈ ছেট কৰা হ'ল।"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "ছিচেন কনফিগাৰেচন (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "সংযুক্ত এজেণ্টে কোনো কনফিগাৰযোগ্য ছিচেন বিকল্প বিজ্ঞাপন কৰা নাছিল।"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "আপডেট কৰিবলৈ ব্যৰ্থ হ’ল %{option}: %{error}"
 system.model_unknown: "অজ্ঞাত মডেল %{model} — উপলব্ধ তালিকা চাবলৈ /model টাইপ কৰক।"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/az-Latn-AZ.yml
+++ b/tools/wta/locales/az-Latn-AZ.yml
@@ -217,8 +217,17 @@ system.agent_switch_unavailable: "Agent keçidi Windows Terminal tabından kəna
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Bu panel üçün modeli seçin (birbaşa keçmək üçün /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "Bu agent sessiyasını konfiqurasiya edin"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Bu tabın agent panelini köçür (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Model seçin (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Qoşulmuş agent heç bir seçilə bilən model elan etmədi."
 system.model_set: "Bu panel üçün model %{model} olaraq təyin edildi."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Sessiya konfiqurasiyası (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Qoşulmuş agent heç bir konfiqurasiya edilə bilən sessiya seçimi elan etmədi."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} yenilənməsi uğursuz oldu: %{error}"
 system.model_unknown: "Naməlum model %{model} — əlçatan siyahını görmək üçün /model yazın."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/bg-BG.yml
+++ b/tools/wta/locales/bg-BG.yml
@@ -217,8 +217,17 @@ system.agent_switch_unavailable: "Превключването на агенти
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Изберете модела за този панел (/model <id> за директно превключване)"  # {Locked="/model","<id>"}
+commands.config.summary: "Конфигуриране на тази сесия на агента"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Преместване на панела на агента за този раздел (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Изберете модел (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Свързаният агент не обяви никакви избираеми модели."
 system.model_set: "Моделът за този панел е зададен на %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Конфигурация на сесията (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Свързаният агент не е обявил опции за сесия, които могат да се конфигурират."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Актуализирането на %{option} беше неуспешно: %{error}"
 system.model_unknown: "Неизвестен модел %{model} — въведете /model, за да видите наличния списък."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/bn-IN.yml
+++ b/tools/wta/locales/bn-IN.yml
@@ -218,8 +218,17 @@ system.agent_switch_unavailable: "উইন্ডোজ টার্মিনা
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "এই পেনের জন্য মডেল নির্বাচন করুন (সরাসরি পরিবর্তন করতে /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "এই এজেন্ট সেশন কনফিগার করুন"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "এই ট্যাবের এজেন্ট পেনটি সরান (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "মডেল নির্বাচন করুন (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "সংযুক্ত এজেন্ট কোনো নির্বাচনযোগ্য মডেল ঘোষণা করেনি।"
 system.model_set: "এই পেনের জন্য মডেল %{model}-এ সেট করা হয়েছে।"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "সেশন কনফিগারেশন (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "সংযুক্ত এজেন্ট কোনো কনফিগারযোগ্য সেশন বিকল্প বিজ্ঞাপন করেনি।"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} আপডেট করতে ব্যর্থ হয়েছে: %{error}"
 system.model_unknown: "অজানা মডেল %{model} — উপলব্ধ তালিকা দেখতে /model টাইপ করুন।"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/bs-Latn-BA.yml
+++ b/tools/wta/locales/bs-Latn-BA.yml
@@ -217,8 +217,17 @@ system.agent_switch_unavailable: "Prebacivanje agenta nije dostupno izvan kartic
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Izaberite model za ovaj panel (/model <id> za direktnu promjenu)"  # {Locked="/model","<id>"}
+commands.config.summary: "Konfigurišite ovu sesiju agenta"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Premjestite panel agenta za ovu karticu (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Izaberite model (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Povezani agent nije oglasio nijedan model koji se može izabrati."
 system.model_set: "Model za ovaj panel postavljen je na %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Konfiguracija sesije (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Povezani agent nije reklamirao nijednu opciju sesije koja se može konfigurisati."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Ažuriranje opcije %{option} nije uspjelo: %{error}"
 system.model_unknown: "Nepoznat model %{model} — upišite /model da vidite dostupnu listu."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ca-ES.yml
+++ b/tools/wta/locales/ca-ES.yml
@@ -217,8 +217,17 @@ system.agent_switch_unavailable: "La commutació d'agent no està disponible for
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Trieu el model per a aquest tauler (/model <id> per canviar directament)"  # {Locked="/model","<id>"}
+commands.config.summary: "Configureu aquesta sessió de l’agent"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Mou el tauler d'agent d'aquesta pestanya (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Seleccioneu el model (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "L’agent connectat no ha anunciat cap model seleccionable."
 system.model_set: "El model d’aquest tauler s’ha establert a %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Configuració de la sessió (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "L’agent connectat no ha anunciat cap opció de sessió configurable."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "No s’ha pogut actualitzar %{option}: %{error}"
 system.model_unknown: "Model desconegut %{model} — escriviu /model per veure la llista disponible."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ca-Es-VALENCIA.yml
+++ b/tools/wta/locales/ca-Es-VALENCIA.yml
@@ -217,8 +217,17 @@ system.agent_switch_unavailable: "La commutació d'agent no està disponible for
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Trieu el model per a este panell (/model <id> per a canviar directament)"  # {Locked="/model","<id>"}
+commands.config.summary: "Configureu esta sessió de l’agent"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Mou el panell d'agent d'esta pestanya (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Seleccioneu el model (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "L’agent connectat no ha anunciat cap model seleccionable."
 system.model_set: "El model d’este panell s’ha establit a %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Configuració de la sessió (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "L’agent connectat no ha anunciat cap opció de sessió configurable."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "No s’ha pogut actualitzar %{option}: %{error}"
 system.model_unknown: "Model desconegut %{model} — escriviu /model per a vore la llista disponible."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/cs-CZ.yml
+++ b/tools/wta/locales/cs-CZ.yml
@@ -217,8 +217,17 @@ system.agent_switch_unavailable: "Přepínání agentů není mimo kartu Windows
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Vyberte model pro tento panel (/model <id> pro přímé přepnutí)"  # {Locked="/model","<id>"}
+commands.config.summary: "Nakonfigurujte tuto relaci agenta"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Přesunout panel agenta pro tuto kartu (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Vyberte model (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Připojený agent neohlásil žádné dostupné modely."
 system.model_set: "Model pro tento panel nastaven na %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Konfigurace relace (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Připojený agent nenabídl žádné možnosti relace k nastavení."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Aktualizace %{option} se nezdařila: %{error}"
 system.model_unknown: "Neznámý model %{model} — zadáním /model zobrazíte dostupný seznam."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/cy-GB.yml
+++ b/tools/wta/locales/cy-GB.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "Nid yw newid asiant ar gael y tu allan i dab W
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Dewiswch y model ar gyfer y paen hwn (/model <id> i newid yn uniongyrchol)"  # {Locked="/model","<id>"}
+commands.config.summary: "Ffurfweddu sesiwn yr asiant hwn"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Symud paen asiant y tab hwn (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Dewiswch model (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Ni hysbysebodd yr asiant cysylltiedig unrhyw fodelau dethol."
 system.model_set: "Gosodwyd y model ar gyfer y paen hwn i %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Ffurfweddiad sesiwn (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Nid oedd yr asiant cysylltiedig yn hysbysebu unrhyw opsiynau sesiwn ffurfweddadwy."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Methwyd â diupdate %{option}: %{error}"
 system.model_unknown: "Model anhysbys %{model} — teipiwch /model i weld y rhestr sydd ar gael."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/da-DK.yml
+++ b/tools/wta/locales/da-DK.yml
@@ -217,8 +217,17 @@ system.agent_switch_unavailable: "Agentskift er ikke tilgængeligt uden for en W
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Vælg modellen til denne panel (/model <id> for at skifte direkte)"  # {Locked="/model","<id>"}
+commands.config.summary: "Konfigurer denne agentsession"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Flyt denne fanes agentpanel (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Vælg model (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Den tilsluttede agent annoncerede ingen modeller, der kan vælges."
 system.model_set: "Modellen til denne panel er angivet til %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Sessionskonfiguration (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Den tilsluttede agent annoncerede ingen konfigurerbare sessionsindstillinger."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Kunne ikke opdatere %{option}: %{error}"
 system.model_unknown: "Ukendt model %{model} — skriv /model for at se den tilgængelige liste."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/de-DE.yml
+++ b/tools/wta/locales/de-DE.yml
@@ -217,8 +217,17 @@ system.agent_switch_unavailable: "Das Umschalten des Agenten ist außerhalb eine
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Modell für diesen Bereich auswählen (/model <id> zum direkten Wechseln)"  # {Locked="/model","<id>"}
+commands.config.summary: "Diese Agenten-Sitzung konfigurieren"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Agentenbereich dieser Registerkarte verschieben (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Modell auswählen (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Der verbundene Agent hat keine auswählbaren Modelle angekündigt."
 system.model_set: "Modell für diesen Bereich auf %{model} festgelegt."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Sitzungskonfiguration (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Der verbundene Agent hat keine konfigurierbaren Sitzungsoptionen angekündigt."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} konnte nicht aktualisiert werden: %{error}"
 system.model_unknown: "Unbekanntes Modell %{model} — geben Sie /model ein, um die verfügbare Liste anzuzeigen."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/el-GR.yml
+++ b/tools/wta/locales/el-GR.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "Η εναλλαγή πρακτόρων δεν 
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Επιλέξτε το μοντέλο για αυτό το πλαίσιο (/model <id> για άμεση εναλλαγή)"  # {Locked="/model","<id>"}
+commands.config.summary: "Διαμόρφωση αυτής της περιόδου λειτουργίας παράγοντα"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Μετακίνηση του πλαισίου παράγοντα αυτής της καρτέλας (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Επιλέξτε μοντέλο (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Ο συνδεδεμένος agent δεν δήλωσε κανένα επιλέξιμο μοντέλο."
 system.model_set: "Το μοντέλο για αυτό το πλαίσιο ορίστηκε σε %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Διαμόρφωση περιόδου λειτουργίας (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Ο συνδεδεμένος παράγοντας δεν διαφήμισε καμία διαμορφώσιμη επιλογή περιόδου λειτουργίας."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Αποτυχία ενημέρωσης του %{option}: %{error}"
 system.model_unknown: "Άγνωστο μοντέλο %{model} — πληκτρολογήστε /model για να δείτε τη διαθέσιμη λίστα."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/en-GB.yml
+++ b/tools/wta/locales/en-GB.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Agent switching is unavailable outside a Windo
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Pick the model for this pane (/model <id> to switch directly)"  # {Locked="/model","<id>"}
+commands.config.summary: "Configure this agent session"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Move this tab's agent pane (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Select model (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "The connected agent did not advertise any selectable models."
 system.model_set: "Model for this pane set to %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Session configuration (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "The connected agent did not advertise any configurable session options."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Failed to update %{option}: %{error}"
 system.model_unknown: "Unknown model %{model} — type /model to see the available list."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/en-US.yml
+++ b/tools/wta/locales/en-US.yml
@@ -91,6 +91,7 @@ commands.stop.summary: "Cancel the in-flight prompt"
 commands.sessions.summary: "Open the historical sessions picker (Ctrl+Shift+/)"  # {Locked="Ctrl+Shift+/"}
 commands.agent.summary: "Pick the agent for this tab (/agent <id> to switch directly)"  # {Locked="/agent","<id>"}
 commands.model.summary: "Pick the model for this pane (/model <id> to switch directly)"  # {Locked="/model","<id>"}
+commands.config.summary: "Configure this agent session"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Move this tab's agent pane (/move <position>)"  # {Locked="/move","<position>"}
 
 # ── Agent picker (src/ui/agent_popup.rs) ────────────────────────────────────
@@ -112,6 +113,14 @@ system.no_models: "The connected agent did not advertise any selectable models."
 system.model_set: "Model for this pane set to %{model}."
 # {model} is the unrecognized text the user typed after /model.
 system.model_unknown: "Unknown model %{model} — type /model to see the available list."
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Session configuration (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "The connected agent did not advertise any configurable session options."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Failed to update %{option}: %{error}"
 
 # ── Recommendations panel (src/ui/recommendations.rs) ───────────────────────
 # {Locked="Enter","Esc","↑","↓","←","→","↵"} - key names and arrow/Return-key

--- a/tools/wta/locales/es-ES.yml
+++ b/tools/wta/locales/es-ES.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "El cambio de agente no está disponible fuera 
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Elija el modelo para este panel (/model <id> para cambiar directamente)"  # {Locked="/model","<id>"}
+commands.config.summary: "Configurar esta sesión del agente"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Mover el panel del agente de esta pestaña (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Seleccionar modelo (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "El agente conectado no anunció ningún modelo seleccionable."
 system.model_set: "El modelo para este panel se ha establecido en %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Configuración de la sesión (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "El agente conectado no anunció ninguna opción de sesión configurable."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Error al actualizar %{option}: %{error}"
 system.model_unknown: "Modelo desconocido %{model} — escriba /model para ver la lista disponible."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/es-MX.yml
+++ b/tools/wta/locales/es-MX.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "El cambio de agente no está disponible fuera 
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Elige el modelo para este panel (/model <id> para cambiar directamente)"  # {Locked="/model","<id>"}
+commands.config.summary: "Configurar esta sesión del agente"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Mover el panel del agente de esta pestaña (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Seleccionar modelo (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "El agente conectado no anunció ningún modelo seleccionable."
 system.model_set: "El modelo para este panel se estableció en %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Configuración de la sesión (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "El agente conectado no anunció ninguna opción de sesión configurable."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Error al actualizar %{option}: %{error}"
 system.model_unknown: "Modelo desconocido %{model} — escribe /model para ver la lista disponible."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/et-EE.yml
+++ b/tools/wta/locales/et-EE.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Agendi vahetamine pole väljaspool Windows Ter
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Valige selle paani mudel (/model <id> otse vahetamiseks)"  # {Locked="/model","<id>"}
+commands.config.summary: "Konfigureerige see agendiseanss"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Teisalda selle vahekaardi agendipaneel (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Valige mudel (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Ühendatud agent ei reklaaminud ühtegi valitavat mudelit."
 system.model_set: "Selle paani mudeliks määrati %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Seansi konfigureerimine (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Ühendatud agent ei teavitanud ühestki konfigureeritavast seansisuvandist."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Valiku %{option} värskendamine nurjus: %{error}"
 system.model_unknown: "Tundmatu mudel %{model} — tippige /model saadaolevate mudelite loendi nägemiseks."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/eu-ES.yml
+++ b/tools/wta/locales/eu-ES.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Agente-aldaketa ez dago erabilgarri Windows Te
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Aukeratu panel honetarako modeloa (/model <id> zuzenean aldatzeko)"  # {Locked="/model","<id>"}
+commands.config.summary: "Konfiguratu agentearen saio hau"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Mugitu fitxa honen agente-panela (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Hautatu modeloa (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Konektatutako agenteak ez du modelo hautagarririk iragarri."
 system.model_set: "Panel honetarako modeloa %{model} gisa ezarri da."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Saioaren konfigurazioa (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Konektatutako agenteak ez du saio-aukera konfiguragarririk iragarri."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Ezin izan da %{option} eguneratu: %{error}"
 system.model_unknown: "%{model} modelo ezezaguna — idatzi /model erabilgarri dagoen zerrenda ikusteko."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/fa-IR.yml
+++ b/tools/wta/locales/fa-IR.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "تغییر عامل در خارج از برگ�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "مدل این پنل را انتخاب کنید (/model <id> برای تغییر مستقیم)"  # {Locked="/model","<id>"}
+commands.config.summary: "پیکربندی این نشست عامل"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "انتقال پنل عامل این زبانه (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "انتخاب مدل (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "عامل هوش مصنوعی متصل هیچ مدل قابل انتخابی را اعلام نکرد."
 system.model_set: "مدل این پنل روی %{model} تنظیم شد."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "پیکربندی نشست (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "عامل متصل هیچ گزینه نشست قابل پیکربندی را تبلیغ نکرد."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "به‌روزرسانی %{option} ناموفق بود: %{error}"
 system.model_unknown: "مدل ناشناخته %{model} — برای دیدن فهرست در دسترس، /model را تایپ کنید."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/fi-FI.yml
+++ b/tools/wta/locales/fi-FI.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Agentin vaihtaminen ei ole käytettävissä Wi
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Valitse tämän paneelin malli (/model <id> vaihtaaksesi suoraan)"  # {Locked="/model","<id>"}
+commands.config.summary: "Määritä tämä agentti-istunto"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Siirrä tämän välilehden agenttipaneeli (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Valitse malli (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Yhdistetty agentti ei ilmoittanut yhtään valittavissa olevaa mallia."
 system.model_set: "Tämän paneelin malliksi asetettiin %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Istunnon määritys (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Yhdistetty agentti ei ilmoittanut mitään määritettävissä olevia istuntovaihtoehtoja."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Kohteen %{option} päivittäminen epäonnistui: %{error}"
 system.model_unknown: "Tuntematon malli %{model} — kirjoita /model nähdäksesi käytettävissä olevien mallien luettelon."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/fil-PH.yml
+++ b/tools/wta/locales/fil-PH.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Hindi available ang paglipat ng agent sa labas
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Piliin ang modelo para sa pane na ito (/model <id> para magpalit nang diretso)"  # {Locked="/model","<id>"}
+commands.config.summary: "I-configure ang session ng agent na ito"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Ilipat ang agent pane ng tab na ito (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Pumili ng modelo (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Hindi nag-advertise ang nakakonektang agent ng anumang napipiling modelo."
 system.model_set: "Itinakda sa %{model} ang modelo para sa pane na ito."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Configuration ng session (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Walang inianunsyong anumang pwedeng i-configure na opsyon sa session ang nakakonektang agent."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Bigo sa pag-update ng %{option}: %{error}"
 system.model_unknown: "Hindi kilalang modelo %{model} — i-type ang /model para makita ang available na listahan."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/fr-CA.yml
+++ b/tools/wta/locales/fr-CA.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Le changement d'agent n'est pas disponible en 
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Choisissez le modèle pour ce volet (/model <id> pour changer directement)"  # {Locked="/model","<id>"}
+commands.config.summary: "Configurer cette session d’agent"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Déplacer le volet de l'agent de cet onglet (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Sélectionner le modèle (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "L'agent connecté n'a annoncé aucun modèle sélectionnable."
 system.model_set: "Le modèle pour ce volet est défini sur %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Configuration de la session (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "L’agent connecté n’a annoncé aucune option de session configurable."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Échec de la mise à jour de %{option} : %{error}"
 system.model_unknown: "Modèle inconnu %{model} — tapez /model pour afficher la liste disponible."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/fr-FR.yml
+++ b/tools/wta/locales/fr-FR.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Le changement d'agent n'est pas disponible en 
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Choisir le modèle pour ce volet (/model <id> pour changer directement)"  # {Locked="/model","<id>"}
+commands.config.summary: "Configurer cette session d’agent"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Déplacer le volet de l'agent de cet onglet (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Sélectionner le modèle (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "L’agent connecté n’a annoncé aucun modèle sélectionnable."
 system.model_set: "Modèle de ce volet défini sur %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Configuration de la session (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "L’agent connecté n’a annoncé aucune option de session configurable."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Échec de la mise à jour de %{option} : %{error}"
 system.model_unknown: "Modèle inconnu %{model} — tapez /model pour afficher la liste disponible."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ga-IE.yml
+++ b/tools/wta/locales/ga-IE.yml
@@ -214,8 +214,17 @@ system.agent_switch_unavailable: "Níl athrú gníomhaire ar fáil lasmuigh de c
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Roghnaigh an samhail don phána seo (/model <id> chun athrú go díreach)"  # {Locked="/model","<id>"}
+commands.config.summary: "Cumfiguraigh an seisiún gníomhaire seo"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Bog pána gníomhaire an chluaisín seo (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Roghnaigh samhail (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Níor fhógair an gníomhaire ceangailte aon tsamhail in-roghnaithe."
 system.model_set: "Samhail an phána seo socraithe go %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Cumraíocht seisiúin (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Níor fhógair an gníomhaire nasctha aon roghanna seisiúin in-cumraithe."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Theip ar nuashonrú %{option}: %{error}"
 system.model_unknown: "Samhail anaithnid %{model} — clóscríobh /model chun an liosta atá ar fáil a fheiceáil."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/gd-gb.yml
+++ b/tools/wta/locales/gd-gb.yml
@@ -214,8 +214,17 @@ system.agent_switch_unavailable: "Chan eil atharrachadh àidhent ri fhaighinn b�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Tagh am modail airson a' phana seo (/model <id> gus atharrachadh gu dìreach)"  # {Locked="/model","<id>"}
+commands.config.summary: "Rèitich an seisean àidhent seo"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Gluais panail àidseant an taba seo (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Tagh modail (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Cha do dh'ainmich an t-àidseant ceangailte modail sam bith a ghabhas taghadh."
 system.model_set: "Chaidh modail a' phana seo a shuidheachadh gu %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Rèiteachadh seisein (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Cha do chuir an t-àidhent ceangailte roghainn seisein sam bith a ghabhas rèiteachadh an cèill."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Dh’fhàillig ùrachadh %{option}: %{error}"
 system.model_unknown: "Modail neo-aithnichte %{model} — sgrìobh /model gus an liosta a tha ri làimh fhaicinn."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/gl-ES.yml
+++ b/tools/wta/locales/gl-ES.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "O cambio de axente non está dispoñible fóra
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Escolla o modelo para este panel (/model <id> para cambiar directamente)"  # {Locked="/model","<id>"}
+commands.config.summary: "Configurar esta sesión do agente"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Mover o panel de axente desta pestana (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Seleccionar modelo (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "O axente conectado non anunciou ningún modelo seleccionable."
 system.model_set: "O modelo deste panel estableceuse en %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Configuración da sesión (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "O agente conectado non anunciou ningunha opción de sesión configurable."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Produciuse un erro ao actualizar %{option}: %{error}"
 system.model_unknown: "Modelo descoñecido %{model} — escriba /model para ver a lista dispoñible."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/gu-IN.yml
+++ b/tools/wta/locales/gu-IN.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "વિન્ડોઝ ટર્મિનલ �
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "આ પેન માટે મોડેલ પસંદ કરો (સીધું બદલવા /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "આ એજન્ટ સત્ર કન્ફિગર કરો"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "આ ટેબની એજન્ટ પેન ખસેડો (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "મોડેલ પસંદ કરો (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "જોડાયેલ એજન્ટે કોઈ પસંદ કરી શકાય તેવા મોડેલ જાહેર કર્યા નથી."
 system.model_set: "આ પેન માટેનું મોડેલ %{model} પર સેટ કર્યું."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "સત્ર કન્ફિગરેશન (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "કનેક્ટેડ એજન્ટે કોઈ કન્ફિગર કરી શકાય તેવા સત્ર વિકલ્પોની જાહેરાત કરી નથી."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} અપડેટ કરવામાં નિષ્ફળ: %{error}"
 system.model_unknown: "અજ્ઞાત મોડેલ %{model} — ઉપલબ્ધ સૂચિ જોવા /model ટાઇપ કરો."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/he-IL.yml
+++ b/tools/wta/locales/he-IL.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "מעבר בין סוכנים אינו זמין
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "בחר את המודל עבור חלונית זו (/model <id> למעבר ישיר)"  # {Locked="/model","<id>"}
+commands.config.summary: "קבע את תצורת הפעלה זו של הסוכן"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "העבר את חלונית הסוכן של כרטיסייה זו (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "בחר מודל (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "הסוכן המחובר לא פרסם מודלים הניתנים לבחירה."
 system.model_set: "המודל עבור חלונית זו הוגדר ל-%{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "תצורת הפעלה (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "הסוכן המחובר לא פרסם אפשרויות הפעלה הניתנות לקביעת תצורה."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "עדכון %{option} נכשל: %{error}"
 system.model_unknown: "מודל לא ידוע %{model} — הקלד /model כדי לראות את הרשימה הזמינה."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/hi-IN.yml
+++ b/tools/wta/locales/hi-IN.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "विंडोज टर्मिनल ट�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "इस पेन के लिए मॉडल चुनें (सीधे बदलने के लिए /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "इस एजेंट सत्र को कॉन्फ़िगर करें"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "इस टैब के एजेंट पेन को स्थानांतरित करें (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "मॉडल चुनें (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "कनेक्टेड एजेंट ने कोई चयन योग्य मॉडल घोषित नहीं किया।"
 system.model_set: "इस पेन के लिए मॉडल %{model} पर सेट किया गया।"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "सत्र कॉन्फ़िगरेशन (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "कनेक्ट किए गए एजेंट ने किसी भी कॉन्फ़िगर योग्य सत्र विकल्प का विज्ञापन नहीं किया।"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} को अपडेट करने में विफल: %{error}"
 system.model_unknown: "अज्ञात मॉडल %{model} — उपलब्ध सूची देखने के लिए /model टाइप करें।"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/hr-HR.yml
+++ b/tools/wta/locales/hr-HR.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Prebacivanje agenata nije dostupno izvan karti
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Odaberite model za ovo okno (/model <id> za izravno prebacivanje)"  # {Locked="/model","<id>"}
+commands.config.summary: "Konfigurirajte ovu sesiju agenta"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Premjesti okno agenta ove kartice (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Odaberite model (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Povezani agent nije oglasio nijedan model koji se može odabrati."
 system.model_set: "Model za ovo okno postavljen je na %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Konfiguracija sesije (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Povezani agent nije najavio nikakve konfigurabilne opcije sesije."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Ažuriranje opcije %{option} nije uspjelo: %{error}"
 system.model_unknown: "Nepoznat model %{model} — upišite /model za prikaz dostupnog popisa."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/hu-HU.yml
+++ b/tools/wta/locales/hu-HU.yml
@@ -214,8 +214,17 @@ system.agent_switch_unavailable: "Az ügynökváltás nem érhető el a Windows 
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Válassza ki a modellt ehhez a panelhez (/model <id> a közvetlen váltáshoz)"  # {Locked="/model","<id>"}
+commands.config.summary: "Az ügynökmunkamenet konfigurálása"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "A lap ügynökpanelének áthelyezése (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Modell kiválasztása (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "A csatlakoztatott ügynök nem hirdetett meg kiválasztható modelleket."
 system.model_set: "A panel modellje erre állítva: %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Munkamenet-konfiguráció (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "A csatlakoztatott ügynök nem hirdetett meg konfigurálható munkamenet-beállításokat."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "A(z) %{option} frissítése sikertelen: %{error}"
 system.model_unknown: "Ismeretlen modell: %{model} — írja be a /model parancsot az elérhető lista megtekintéséhez."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/hy-AM.yml
+++ b/tools/wta/locales/hy-AM.yml
@@ -231,8 +231,17 @@ system.agent_switch_unavailable: "Գործակալի փոխարկումը հաս
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Ընտրեք մոդելն այս վահանակի համար (/model <id>՝ ուղղակիորեն փոխելու համար)"  # {Locked="/model","<id>"}
+commands.config.summary: "Կարգավորել գործակալի այս աշխատաշրջանը"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Տեղափոխել այս ներդիրի ագենտի վահանակը (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Ընտրեք մոդելը (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Միացված ագենտը չհայտարարեց ընտրելի մոդելների մասին։"
 system.model_set: "Այս վահանակի մոդելը սահմանվել է %{model}։"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Աշխատաշրջանի կարգավորում (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Միացված գործակալը չի հայտարարել աշխատաշրջանի կարգավորելի տարբերակներ:"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Չհաջողվեց թարմացնել %{option}-ը. %{error}"
 system.model_unknown: "Անհայտ մոդել %{model} — մուտքագրեք /model՝ հասանելի ցանկը տեսնելու համար։"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/id-ID.yml
+++ b/tools/wta/locales/id-ID.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Peralihan agen tidak tersedia di luar tab Wind
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Pilih model untuk panel ini (/model <id> untuk beralih langsung)"  # {Locked="/model","<id>"}
+commands.config.summary: "Konfigurasikan sesi agent ini"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Pindahkan panel agen tab ini (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Pilih model (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Agen yang terhubung tidak mengiklankan model apa pun yang dapat dipilih."
 system.model_set: "Model untuk panel ini diatur ke %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Konfigurasi sesi (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Agent yang terhubung tidak mengiklankan opsi sesi apa pun yang dapat dikonfigurasi."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Gagal memperbarui %{option}: %{error}"
 system.model_unknown: "Model tidak dikenal %{model} — ketik /model untuk melihat daftar yang tersedia."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/is-IS.yml
+++ b/tools/wta/locales/is-IS.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Ekki er hægt að skipta um fulltrúa utan Win
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Veldu líkanið fyrir þetta spjald (/model <id> til að skipta beint)"  # {Locked="/model","<id>"}
+commands.config.summary: "Stilla þessa fulltrúaotu"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Færa agentspjald þessa flipa (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Veldu líkan (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Tengdi agentinn auglýsti engin valanleg líkön."
 system.model_set: "Líkan fyrir þetta spjald stillt á %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Stilling lotu (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Tengdi fulltrúinn auglýsti enga stillanlega lotuvalkosti."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Tókst ekki að uppfæra %{option}: %{error}"
 system.model_unknown: "Óþekkt líkan %{model} — sláðu inn /model til að sjá tiltækan lista."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/it-IT.yml
+++ b/tools/wta/locales/it-IT.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "La commutazione dell'agente non è disponibile
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Scegli il modello per questo riquadro (/model <id> per cambiare direttamente)"  # {Locked="/model","<id>"}
+commands.config.summary: "Configura questa sessione dell’agente"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Sposta il riquadro agente di questa scheda (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Seleziona modello (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "L'agente connesso non ha annunciato alcun modello selezionabile."
 system.model_set: "Modello per questo riquadro impostato su %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Configurazione sessione (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "L’agente connesso non ha annunciato alcuna opzione di sessione configurabile."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Aggiornamento di %{option} non riuscito: %{error}"
 system.model_unknown: "Modello sconosciuto %{model} — digita /model per visualizzare l'elenco disponibile."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ja-JP.yml
+++ b/tools/wta/locales/ja-JP.yml
@@ -210,8 +210,17 @@ system.agent_switch_unavailable: "Windows Terminal タブの外ではエージ�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "このペインのモデルを選択（直接切り替えるには /model <id>）"  # {Locked="/model","<id>"}
+commands.config.summary: "このエージェント セッションを構成"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "このタブのエージェント ペインを移動 (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "モデルを選択 (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "接続中のエージェントは選択可能なモデルを通知しませんでした。"
 system.model_set: "このペインのモデルを %{model} に設定しました。"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "セッションの構成 (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "接続されているエージェントは、構成可能なセッション オプションを一切通知しませんでした。"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} の更新に失敗しました: %{error}"
 system.model_unknown: "不明なモデル %{model} — 利用可能な一覧を表示するには /model と入力してください。"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ka-GE.yml
+++ b/tools/wta/locales/ka-GE.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "აგენტის გადართვა
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "აირჩიეთ მოდელი ამ პანელისთვის (/model <id> პირდაპირ გადასართავად)"  # {Locked="/model","<id>"}
+commands.config.summary: "აგენტის ამ სესიის კონფიგურაცია"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "ამ ჩანართის აგენტის პანელის გადატანა (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "აირჩიეთ მოდელი (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "დაკავშირებულმა აგენტმა არცერთი ასარჩევი მოდელი არ გამოაცხადა."
 system.model_set: "ამ პანელის მოდელად დაყენდა %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "სესიის კონფიგურაცია (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "დაკავშირებულ აგენტს არ გამოუცხადებია სესიის კონფიგურირებადი პარამეტრები."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option}-ის განახლება ვერ შესრულდა: %{error}"
 system.model_unknown: "უცნობი მოდელი %{model} — აკრიფეთ /model ხელმისაწვდომი სიის სანახავად."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/kk-KZ.yml
+++ b/tools/wta/locales/kk-KZ.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Агентті ауыстыру Windows Termin
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Осы панель үшін модельді таңдаңыз (тікелей ауыстыру үшін /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "Осы агент сеансын конфигурациялау"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Осы қойындының агент панелін жылжыту (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Модельді таңдаңыз (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Қосылған агент таңдауға болатын ешбір модельді жарияламады."
 system.model_set: "Осы панельдің моделі %{model} етіп орнатылды."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Сеанс конфигурациясы (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Қосылған агент ешқандай бапталатын сеанс опцияларын жарияламады."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} жаңарту сәтсіз аяқталды: %{error}"
 system.model_unknown: "Белгісіз модель %{model} — қолжетімді тізімді көру үшін /model теріңіз."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/km-KH.yml
+++ b/tools/wta/locales/km-KH.yml
@@ -231,8 +231,17 @@ system.agent_switch_unavailable: "ការផ្លាស់ប្តូរភ�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "ជ្រើសរើសម៉ូដែលសម្រាប់ផ្តាំងនេះ (/model <id> ដើម្បីប្តូរដោយផ្ទាល់)"  # {Locked="/model","<id>"}
+commands.config.summary: "កំណត់រចនាសម្ព័ន្ធសម័យភ្នាក់ងារនេះ"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "ផ្លាស់ទីផ្ទាំងភ្នាក់ងារនៃផ្ទាំងនេះ (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "ជ្រើសរើសម៉ូដែល (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "AI អេជេន្ត់ដែលបានភ្ជាប់មិនបានប្រកាសម៉ូដែលណាមួយដែលអាចជ្រើសរើសបានទេ។"
 system.model_set: "ម៉ូដែលសម្រាប់ផ្តាំងនេះត្រូវបានកំណត់ទៅ %{model}។"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "ការកំណត់រចនាសម្ព័ន្ធសម័យ (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "ភ្នាក់ងារដែលបានភ្ជាប់មិនបានផ្សព្វផ្សាយជម្រើសសម័យដែលកែសម្រួលបានឡើយ។"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "បរាជ័យក្នុងការធ្វើបច្ចុប្បន្នភាព %{option}: %{error}"
 system.model_unknown: "មិនស្គាល់ម៉ូដែល %{model} — វាយ /model ដើម្បីមើលបញ្ជីដែលមាន។"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/kn-IN.yml
+++ b/tools/wta/locales/kn-IN.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "ವಿಂಡೋಸ್ ಟರ್ಮಿನಲ್
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "ಈ ಪೇನ್‌ಗಾಗಿ ಮಾದರಿಯನ್ನು ಆಯ್ಕೆಮಾಡಿ (ನೇರವಾಗಿ ಬದಲಾಯಿಸಲು /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "ಈ ಏಜೆಂಟ್ ಸೆಷನ್ ಸಂರಚಿಸಿ"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "ಈ ಟ್ಯಾಬ್‌ನ ಏಜೆಂ트 ಪೇನ್ ಅನ್ನು ಸರಿಸಿ (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "ಮಾದರಿ ಆಯ್ಕೆಮಾಡಿ (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "ಸಂಪರ್ಕಿತ ಏಜೆಂಟ್ ಯಾವುದೇ ಆಯ್ಕೆ ಮಾಡಬಹುದಾದ ಮಾದರಿಗಳನ್ನು ಪ್ರಕಟಿಸಲಿಲ್ಲ."
 system.model_set: "ಈ ಪೇನ್‌ಗಾಗಿ ಮಾದರಿಯನ್ನು %{model} ಗೆ ಹೊಂದಿಸಲಾಗಿದೆ."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "ಸೆಷನ್ ಸಂರಚನೆ (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "ಸಂಪರ್ಕಿತ ಏಜೆಂಟ್ ಯಾವುದೇ ಸಂರಚಿಸಬಹುದಾದ ಸೆಷನ್ ಆಯ್ಕೆಗಳನ್ನು ಜಾಹೀರಾತು ಮಾಡಿಲ್ಲ."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} ಅಪ್‌ಡೇಟ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: %{error}"
 system.model_unknown: "ಅಪರಿಚಿತ ಮಾದರಿ %{model} — ಲಭ್ಯವಿರುವ ಪಟ್ಟಿಯನ್ನು ನೋಡಲು /model ಟೈಪ್ ಮಾಡಿ."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ko-KR.yml
+++ b/tools/wta/locales/ko-KR.yml
@@ -210,8 +210,17 @@ system.agent_switch_unavailable: "Windows Terminal 탭 외부에서는 에이전
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "이 창의 모델 선택 (/model <id>로 바로 전환)"  # {Locked="/model","<id>"}
+commands.config.summary: "이 에이전트 세션 구성"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "이 탭의 에이전트 창 이동 (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "모델 선택 (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "연결된 에이전트가 선택 가능한 모델을 알리지 않았습니다."
 system.model_set: "이 창의 모델이 %{model}(으)로 설정되었습니다."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "세션 구성 (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "연결된 에이전트가 구성 가능한 세션 옵션을 알리지 않았습니다."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} 업데이트 실패: %{error}"
 system.model_unknown: "알 수 없는 모델 %{model} — 사용 가능한 목록을 보려면 /model을 입력하세요."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/kok-IN.yml
+++ b/tools/wta/locales/kok-IN.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "विंडोज टर्मिनल ट�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "ह्या पेना खातीर मॉडेल निवडात (थेट बदलपाक /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "ह्या एजंट सत्राचे संफिग्रेशन करा"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "ह्या टॅबाचें एजंट पेन हलायात (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "मॉडेल निवडात (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "जोडिल्ल्या एजंटान कसलेच निवडपायोग्य मॉडेल जाहीर केलें ना."
 system.model_set: "ह्या पेना खातीर मॉडेल %{model} चेर सेट केलें."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "सत्र संफिग्रेशन (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "जोडिल्ल्या एजंटान कसलेच संफिग्रेशन करपासारखे सत्र पर्याय सांगले नानात."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} अद्ययावत करपाक अपेस आले: %{error}"
 system.model_unknown: "अज्ञात मॉडेल %{model} — उपलब्ध वळेरी पळोवपाक /model टायप करात."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/lb-LU.yml
+++ b/tools/wta/locales/lb-LU.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "D'Agenten-Umschalten ass ausserhalb vun engem 
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Wielt de Modell fir dës Panell (/model <id> fir direkt ze wiesselen)"  # {Locked="/model","<id>"}
+commands.config.summary: "Dës Agent-Sessioun konfiguréieren"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Deen Agent-Panell vun dësem Tab réckelen (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Modell auswielen (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Den ugeschlossenen Agent huet keng auswielbar Modeller ugekënnegt."
 system.model_set: "De Modell fir dës Panell gouf op %{model} gesat."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Sessiounskonfiguratioun (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Den ugeschlossenen Agent huet keng konfiguréierbar Sessiounsoptiounen ugekënnegt."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} konnt net aktualiséiert ginn: %{error}"
 system.model_unknown: "Onbekannte Modell %{model} — tippt /model fir d'verfügbar Lëscht ze gesinn."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/lo-LA.yml
+++ b/tools/wta/locales/lo-LA.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "ການສະຫຼັບຕົວແທນ�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "ເລືອກແບບຈຳລອງສຳລັບ pane ນີ້ (/model <id> ເພື່ອປ່ຽນໂດຍກົງ)"  # {Locked="/model","<id>"}
+commands.config.summary: "ກຳນົດຄ່າເຊດຊັນຕົວແທນນີ້"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "ຍ້າຍແຜງຕົວແທນຂອງແທັບນີ້ (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "ເລືອກແບບຈຳລອງ (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "agent ທີ່ເຊື່ອມຕໍ່ບໍ່ໄດ້ປະກາດແບບຈຳລອງທີ່ສາມາດເລືອກໄດ້ໃດໆ."
 system.model_set: "ແບບຈຳລອງສຳລັບ pane ນີ້ຖືກຕັ້ງເປັນ %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "ການກຳນົດຄ່າເຊດຊັນ (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "ຕົວແທນທີ່เชื่อมຕໍ່ບໍ່ໄດ້ໂຄສະນາຕົວເລືອກເຊດຊັນທີ່ກຳນົດຄ່າໄດ້."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "ອັບເດດ %{option} ລົ້ມເຫຼວ: %{error}"
 system.model_unknown: "ບໍ່ຮູ້ຈັກແບບຈຳລອງ %{model} — ພິມ /model ເພື່ອເບິ່ງລາຍການທີ່ມີ."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/lo-LA.yml
+++ b/tools/wta/locales/lo-LA.yml
@@ -225,7 +225,7 @@ system.model_set: "ແບບຈຳລອງສຳລັບ pane ນີ້ຖື�
 # {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
 config_picker.title: "ການກຳນົດຄ່າເຊດຊັນ (↑ ↓ • Enter • Esc)"
 # Shown when /config is used but the AI agent exposed no ACP select options.
-system.no_config_options: "ຕົວແທນທີ່เชื่อมຕໍ່ບໍ່ໄດ້ໂຄສະນາຕົວເລືອກເຊດຊັນທີ່ກຳນົດຄ່າໄດ້."
+system.no_config_options: "ຕົວແທນທີ່ເຊື່ອມຕໍ່ບໍ່ໄດ້ໂຄສະນາຕົວເລືອກເຊດຊັນທີ່ກຳນົດຄ່າໄດ້."
 # {option} is an Agent-provided option name; {error} is the ACP error.
 system.config_update_failed: "ອັບເດດ %{option} ລົ້ມເຫຼວ: %{error}"
 system.model_unknown: "ບໍ່ຮູ້ຈັກແບບຈຳລອງ %{model} — ພິມ /model ເພື່ອເບິ່ງລາຍການທີ່ມີ."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/lt-LT.yml
+++ b/tools/wta/locales/lt-LT.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Agento perjungimas nepasiekiamas už „Window
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Pasirinkite šios srities modelį (/model <id> norėdami perjungti tiesiogiai)"  # {Locked="/model","<id>"}
+commands.config.summary: "Konfigūruoti šią agento sesiją"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Perkelti šios kortelės agento skydelį (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Pasirinkite modelį (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Prijungtas agentas nepaskelbė jokių pasirenkamų modelių."
 system.model_set: "Šios srities modelis nustatytas į %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Sesijos konfigūracija (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Prijungtas agentas nepaskelbė jokių konfigūruojamų sesijos parinkčių."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Nepavyko atnaujinti %{option}: %{error}"
 system.model_unknown: "Nežinomas modelis %{model} — įveskite /model, kad pamatytumėte galimų sąrašą."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/lv-LV.yml
+++ b/tools/wta/locales/lv-LV.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Aģenta pārslēgšana nav pieejama ārpus Win
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Izvēlieties šīs rūts modeli (/model <id>, lai pārslēgtu tieši)"  # {Locked="/model","<id>"}
+commands.config.summary: "Konfigurēt šo aģenta sesiju"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Pārvietot šīs cilnes aģenta paneli (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Izvēlieties modeli (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Pievienotais aģents nepaziņoja nevienu atlasāmu modeli."
 system.model_set: "Šīs rūts modelis iestatīts uz %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Sesijas konfigurācija (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Savienotais aģents nereklamēja nekādas konfigurējamas sesijas opcijas."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Neizdevās atjaunināt opciju %{option}: %{error}"
 system.model_unknown: "Nezināms modelis %{model} — ierakstiet /model, lai redzētu pieejamo sarakstu."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/mi-NZ.yml
+++ b/tools/wta/locales/mi-NZ.yml
@@ -214,8 +214,17 @@ system.agent_switch_unavailable: "Kāore i te wātea te whakawhiti māngai i wah
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Kōwhiria te tauira mō tēnei papa (/model <id> ki te huri tika)"  # {Locked="/model","<id>"}
+commands.config.summary: "Whirihorahia tēnei teho māngai"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Neke i te papa agent o tēnei ripa (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Kōwhiria te tauira (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Kāore te agent kua hono i pānui i tētahi tauira ka taea te kōwhiri."
 system.model_set: "Kua whakaritea te tauira mō tēnei papa ki %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Whirihoranga teho (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Kāore te māngai hono i pānui i ētahi kōwhiringa teho ka taea te whirihora."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "I rahua te updating %{option}: %{error}"
 system.model_unknown: "Tauira kāore e mōhiotia %{model} — patohia /model kia kite i te rārangi e wātea ana."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/mk-MK.yml
+++ b/tools/wta/locales/mk-MK.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Префрлањето на агент не е
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Изберете го моделот за овој панел (/model <id> за директно префрлување)"  # {Locked="/model","<id>"}
+commands.config.summary: "Конфигурирајте ја оваа сесија на агентот"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Премести го панелот на агентот за ова јазиче (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Изберете модел (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Поврзаниот агент не објави ниту еден модел што може да се избере."
 system.model_set: "Моделот за овој панел е поставен на %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Конфигурација на сесијата (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Поврзаниот агент не рекламираше никакви опции за сесија што може да се конфигурираат."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Не успеа да се ажурира %{option}: %{error}"
 system.model_unknown: "Непознат модел %{model} — внесете /model за да ја видите достапната листа."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ml-IN.yml
+++ b/tools/wta/locales/ml-IN.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "വിൻഡോസ് ടെർമിനൽ �
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "ഈ പേനിനായി മോഡൽ തിരഞ്ഞെടുക്കുക (നേരിട്ട് മാറാൻ /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "ഈ ഏജന്റ് സെഷൻ കോൺഫിഗർ ചെയ്യുക"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "ഈ ടാബിന്റെ ഏജന്റ് പേൻ നീക്കുക (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "മോഡൽ തിരഞ്ഞെടുക്കുക (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "കണക്റ്റുചെയ്‌ത agent തിരഞ്ഞെടുക്കാവുന്ന ഒരു മോഡലും പ്രഖ്യാപിച്ചില്ല."
 system.model_set: "ഈ പേനിനായുള്ള മോഡൽ %{model} ആയി സജ്ജമാക്കി."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "സെഷൻ കോൺഫിഗറേഷൻ (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "ബന്ധിപ്പിച്ച ഏജന്റ് കോൺഫിഗർ ചെയ്യാവുന്ന സെഷൻ ഓപ്ഷനുകളൊന്നും പരസ്യപ്പെടുത്തിയില്ല."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} അപ്‌ഡേറ്റ് ചെയ്യുന്നതിൽ പരാജയപ്പെട്ടു: %{error}"
 system.model_unknown: "അറിയാത്ത മോഡൽ %{model} — ലഭ്യമായ പട്ടിക കാണാൻ /model ടൈപ്പ് ചെയ്യുക."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/mr-IN.yml
+++ b/tools/wta/locales/mr-IN.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "विंडोज टर्मिनल ट�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "या पेनसाठी मॉडेल निवडा (थेट स्विच करण्यासाठी /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "हे एजंट सत्र कॉन्फिगर करा"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "या टॅबचे एजंट पेन हलवा (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "मॉडेल निवडा (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "कनेक्ट केलेल्या agent ने कोणतेही निवडण्यायोग्य मॉडेल जाहीर केले नाही."
 system.model_set: "या पेनसाठी मॉडेल %{model} वर सेट केले."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "सत्र कॉन्फिगरेशन (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "कनेक्ट केलेल्या एजंटने कोणतेही कॉन्फिगर करण्यायोग्य सत्र पर्याय घोषित केले नाहीत."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} अपडेट करण्यात अपयशी: %{error}"
 system.model_unknown: "अज्ञात मॉडेल %{model} — उपलब्ध यादी पाहण्यासाठी /model टाइप करा."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ms-MY.yml
+++ b/tools/wta/locales/ms-MY.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Peralihan ejen tidak tersedia di luar tab Wind
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Pilih model untuk anak tetingkap ini (/model <id> untuk menukar terus)"  # {Locked="/model","<id>"}
+commands.config.summary: "Konfigurasi sesi ejen ini"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Alihkan anak tetingkap ejen tab ini (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Pilih model (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Ejen yang disambungkan tidak mengiklankan sebarang model yang boleh dipilih."
 system.model_set: "Model untuk anak tetingkap ini ditetapkan kepada %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Konfigurasi sesi (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Ejen yang disambungkan tidak mengiklankan sebarang pilihan sesi yang boleh dikonfigurasi."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Gagal mengemas kini %{option}: %{error}"
 system.model_unknown: "Model tidak diketahui %{model} — taip /model untuk melihat senarai yang tersedia."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/mt-MT.yml
+++ b/tools/wta/locales/mt-MT.yml
@@ -214,8 +214,17 @@ system.agent_switch_unavailable: "L-iswiċċjar tal-aġent mhuwiex disponibbli b
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Agħżel il-mudell għal dan il-pannell (/model <id> biex tibdel direttament)"  # {Locked="/model","<id>"}
+commands.config.summary: "Ikkonfigura din is-sessjoni tal-aġent"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Mexxi l-pannell tal-aġent ta' dan it-tab (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Agħżel mudell (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "L-aġent konness ma rreklama l-ebda mudell li jista' jintgħażel."
 system.model_set: "Il-mudell għal dan il-pannell ġie ssettjat għal %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Konfigurazzjoni tas-sessjoni (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "L-aġent konness ma rreklama l-ebda għażla ta’ sessjoni konfigurabbli."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Naqas milli jaġġorna %{option}: %{error}"
 system.model_unknown: "Mudell mhux magħruf %{model} — ittajpja /model biex tara l-lista disponibbli."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/nb-NO.yml
+++ b/tools/wta/locales/nb-NO.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Agentskifting er ikke tilgjengelig utenfor en 
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Velg modellen for dette panelet (/model <id> for å bytte direkte)"  # {Locked="/model","<id>"}
+commands.config.summary: "Konfigurer denne agentsesjonen"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Flytt agentpanelet for denne fanen (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Velg modell (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Den tilkoblede agenten annonserte ingen valgbare modeller."
 system.model_set: "Modellen for dette panelet er satt til %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Sesjonskonfigurasjon (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Den tilkoblede agenten annonserte ingen konfigurerbare sesjonsalternativer."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Klarte ikke å oppdatere %{option}: %{error}"
 system.model_unknown: "Ukjent modell %{model} — skriv /model for å se den tilgjengelige listen."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ne-NP.yml
+++ b/tools/wta/locales/ne-NP.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "विन्डोज टर्मिनल �
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "यो पेनका लागि मोडेल छान्नुहोस् (सिधै बदल्न /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "यो एजेन्ट सत्र कन्फिगर गर्नुहोस्"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "यो ट्याबको एजेन्ट पेन सार्नुहोस् (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "मोडेल छान्नुहोस् (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "जोडिएको agent ले कुनै पनि छान्न मिल्ने मोडेल घोषणा गरेन।"
 system.model_set: "यो पेनका लागि मोडेल %{model} मा सेट गरियो।"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "सत्र कन्फिगरेसन (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "जอดिएको एजेन्टले कुनै कन्फिगर योग्य सत्र विकल्पहरू विज्ञापन गरेन।"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} अद्यावधिक गर्न असफल भयो: %{error}"
 system.model_unknown: "अज्ञात मोडेल %{model} — उपलब्ध सूची हेर्न /model टाइप गर्नुहोस्।"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/nl-NL.yml
+++ b/tools/wta/locales/nl-NL.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Schakelen tussen agents is niet beschikbaar bu
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Het model voor dit deelvenster kiezen (/model <id> om direct te wisselen)"  # {Locked="/model","<id>"}
+commands.config.summary: "Deze agentsessie configureren"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Het agentdeelvenster van dit tabblad verplaatsen (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Model selecteren (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "De verbonden agent heeft geen selecteerbare modellen aangekondigd."
 system.model_set: "Model voor dit deelvenster ingesteld op %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Sessieconfiguratie (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "De verbonden agent heeft geen configureerbare sessie-opties geadverteerd."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Bijwerken van %{option} is mislukt: %{error}"
 system.model_unknown: "Onbekend model %{model} — typ /model om de beschikbare lijst te zien."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/nn-NO.yml
+++ b/tools/wta/locales/nn-NO.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Agentskifting er ikkje tilgjengeleg utanfor ei
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Vel modellen for dette panelet (/model <id> for å byte direkte)"  # {Locked="/model","<id>"}
+commands.config.summary: "Konfigurer denne agentsesjonen"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Flytt agentpanelet for denne fana (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Vel modell (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Den tilkopla agenten annonserte ingen modellar som kan veljast."
 system.model_set: "Modell for dette panelet sett til %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Sesjonskonfigurasjon (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Den tilknytta agenten annonserte ingen konfigurerbare sesjonsalternativ."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Klarte ikkje å oppdatere %{option}: %{error}"
 system.model_unknown: "Ukjend modell %{model} — skriv /model for å sjå lista over tilgjengelege."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/or-IN.yml
+++ b/tools/wta/locales/or-IN.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "ୱିଣ୍ଡୋଜ୍ ଟର୍ମିନା
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "ଏହି ପେନ୍ ପାଇଁ ମଡେଲ ବାଛନ୍ତୁ (ସିଧାସଳଖ ବଦଳାଇବାକୁ /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "ଏହି ଏଜେଣ୍ଟ୍ ସେସନ୍ କନ୍ଫିଗର୍ କରନ୍ତୁ"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "ଏହି ଟ୍ୟାବ୍‌ର ଏଜେଣ୍ଟ୍ ପେନ୍‌କୁ ସ୍ଥានାନ୍ତର କରନ୍ତୁ (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "ମଡେଲ ବାଛନ୍ତୁ (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "ସଂଯୁକ୍ତ ଏଜେଣ୍ଟ କୌଣସି ଚୟନଯୋଗ୍ୟ ମଡେଲ ଘୋଷଣା କଲା ନାହିଁ।"
 system.model_set: "ଏହି ପେନ୍ ପାଇଁ ମଡେଲ %{model} କୁ ସେଟ୍ କରାଗଲା।"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "ସେସନ୍ କନ୍ଫିଗରେସନ୍ (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "ସଂଯୋଜିତ ଏଜେଣ୍ଟ୍ କୌଣସି କନ୍ଫିଗର୍-ଯୋଗ୍ୟ ସେସନ୍ ବିକଳ୍ପ ବିଜ୍ଞାପିତ କରିନାହିଁ।"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} ଅପଡେଟ୍ କରିବାରେ ବିଫଳ ହେଲା: %{error}"
 system.model_unknown: "ଅଜଣା ମଡେଲ %{model} — ଉପଲବ୍ଧ ତାଲିକା ଦେଖିବାକୁ /model ଟାଇପ୍ କରନ୍ତୁ।"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/pa-IN.yml
+++ b/tools/wta/locales/pa-IN.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "ਵਿੰਡੋਜ਼ ਟਰਮੀਨਲ ਟ�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "ਇਸ ਪੈਨ ਲਈ ਮਾਡਲ ਚੁਣੋ (ਸਿੱਧਾ ਬਦਲਣ ਲਈ /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "ਇਸ ਏਜੰਟ ਸੈਸ਼ਨ ਨੂੰ ਸੰਰਚਿਤ ਕਰੋ"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "ਇਸ ਟੈബ ਦੇ ਏਜੰट ਪੈਨ ਨੂੰ ਹਿਲਾਓ (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "ਮਾਡਲ ਚੁਣੋ (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "ਜੁੜੇ ਏਜੰਟ ਨੇ ਕੋਈ ਚੁਣਨਯੋਗ ਮਾਡਲ ਦਾ ਐਲਾਨ ਨਹੀਂ ਕੀਤਾ।"
 system.model_set: "ਇਸ ਪੈਨ ਲਈ ਮਾਡਲ %{model} 'ਤੇ ਸੈੱਟ ਕੀਤਾ ਗਿਆ।"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "ਸੈਸ਼ਨ ਸੰਰਚਨਾ (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "ਜੁੜੇ ਏਜੰਟ ਨੇ ਕੋਈ ਸੰਰਚਨਾਯੋਗ ਸੈਸ਼ਨ ਵਿਕਲਪਾਂ ਦਾ ਇਸ਼ਤਿਹਾਰ ਨਹੀਂ ਦਿੱਤਾ।"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} ਨੂੰ ਅੱਪਡੇਟ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: %{error}"
 system.model_unknown: "ਅਣਜਾਣ ਮਾਡਲ %{model} — ਉਪਲਬਧ ਸੂਚੀ ਵੇਖਣ ਲਈ /model ਟਾਈਪ ਕਰੋ।"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/pl-PL.yml
+++ b/tools/wta/locales/pl-PL.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Przełączanie agentów jest niedostępne poza
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Wybierz model dla tego panelu (/model <id>, aby przełączyć bezpośrednio)"  # {Locked="/model","<id>"}
+commands.config.summary: "Skonfiguruj tę sesję agenta"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Przenieś panel agenta tej karty (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Wybierz model (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Połączony agent nie ogłosił żadnych modeli do wyboru."
 system.model_set: "Model dla tego panelu ustawiono na %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Konfiguracja sesji (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Połączony agent nie zakomunikował żadnych konfigurowalnych opcji sesji."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Nie udało się zaktualizować opcji %{option}: %{error}"
 system.model_unknown: "Nieznany model %{model} — wpisz /model, aby zobaczyć dostępną listę."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/pt-BR.yml
+++ b/tools/wta/locales/pt-BR.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "A alternância de agente não está disponíve
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Escolha o modelo para este painel (/model <id> para trocar diretamente)"  # {Locked="/model","<id>"}
+commands.config.summary: "Configurar esta sessão do agente"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Mover o painel do agente desta guia (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Selecionar modelo (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "O agente conectado não anunciou nenhum modelo selecionável."
 system.model_set: "Modelo para este painel definido como %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Configuração da sessão (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "O agente conectado não anunciou nenhuma opção de sessão configurável."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Falha ao atualizar %{option}: %{error}"
 system.model_unknown: "Modelo desconhecido %{model} — digite /model para ver a lista disponível."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/pt-PT.yml
+++ b/tools/wta/locales/pt-PT.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "A alternância de agente não está disponíve
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Escolha o modelo para este painel (/model <id> para mudar diretamente)"  # {Locked="/model","<id>"}
+commands.config.summary: "Configurar esta sessão do agente"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Mover o painel do agente deste separador (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Selecionar modelo (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "O agente ligado não anunciou nenhum modelo selecionável."
 system.model_set: "Modelo para este painel definido como %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Configuração da sessão (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "O agente ligado não anunciou quaisquer opções de sessão configuráveis."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Falha ao atualizar %{option}: %{error}"
 system.model_unknown: "Modelo desconhecido %{model} — escreva /model para ver a lista disponível."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/qps-ploc.yml
+++ b/tools/wta/locales/qps-ploc.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "[Àğéñţ śŵïţçĥïñğ ïś ûñåṽ�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "[Ṗïçķ ţĥé ḿöďéĺ ƒöŕ ţĥïś ṗåñé (/model <id> ţö śŵïţçĥ ďïŕéçţĺÿ)!!!! !!!! !!!! !!!!]"  # {Locked="/model","<id>"}
+commands.config.summary: "[Çöñƒïğûŕé ţĥïś åğéñţ śéśśïöñ!!!! !!!! !!!! !!!!]"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "[Ḿöṽé ţĥïś ţåƀ'ś åğéñţ ṗåñé (/move <position>)!!!! !!!! !!!!]"  # {Locked="/move","<position>"}
 model_picker.title: "[Ŝéĺéçţ ḿöďéĺ (↑ ↓ • Enter • Esc)!!!! !!!!]"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "[Ţĥé çöññéçţéď åğéñţ ďïď ñöţ åďṽéŕţïśé åñÿ śéĺéçţåƀĺé ḿöďéĺś.!!!! !!!! !!!! !!!!]"
 system.model_set: "[Ḿöďéĺ ƒöŕ ţĥïś ṗåñé śéţ ţö %{model}.!!!! !!!! !!!!]"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "[Śéśśïöñ çöñƒïğûŕåţïöñ (↑ ↓ • Enter • Esc)!!!! !!!! !!!!]"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "[Ţĥé çöññéçţéď åğéñţ ďïď ñöţ åďṽéŕţïśé åñÿ çöñƒïğûŕåƀĺé śéśśïöñ öṗţïöñś.!!!! !!!! !!!! !!!! !!!!]"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "[ƒåïĺéď ţö ûṗďåţé %{option}: %{error}!!!! !!!! !!!!]"
 system.model_unknown: "[Ûñķñöŵñ ḿöďéĺ %{model} — ţÿṗé /model ţö śéé ţĥé åṽåïĺåƀĺé ĺïśţ.!!!! !!!! !!!! !!!!]"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/qps-ploca.yml
+++ b/tools/wta/locales/qps-ploca.yml
@@ -213,8 +213,17 @@ system.agent_switch_unavailable: "[!!_Agent switching is unavailable outside a W
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "[!!_Pick the model for this pane (/model <id> to switch directly)_!!]"  # {Locked="/model","<id>"}
+commands.config.summary: "[!!_Configure this agent session_!!]"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "[!!_Move this tab's agent pane (/move <position>)_!!]"  # {Locked="/move","<position>"}
 model_picker.title: "[!!_Select model (↑ ↓ • Enter • Esc)_!!]"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "[!!_The connected agent did not advertise any selectable models._!!]"
 system.model_set: "[!!_Model for this pane set to %{model}._!!]"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "[!!_Session configuration (↑ ↓ • Enter • Esc)_!!]"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "[!!_The connected agent did not advertise any configurable session options._!!]"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "[!!_Failed to update %{option}: %{error}_!!]"
 system.model_unknown: "[!!_Unknown model %{model} — type /model to see the available list._!!]"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/qps-plocm.yml
+++ b/tools/wta/locales/qps-plocm.yml
@@ -213,8 +213,17 @@ system.agent_switch_unavailable: "[!! Ag_ent switching is unavailable outside a 
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "[!! Pic_k the model for this pane (/model <id> to switch directly) !!]"  # {Locked="/model","<id>"}
+commands.config.summary: "[!! Con_figure this agent session !!]"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "[!! Mo_ve this tab's agent pane (/move <position>) !!]"  # {Locked="/move","<position>"}
 model_picker.title: "[!! Sel_ect model (↑ ↓ • Enter • Esc) !!]"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "[!! The_ connected agent did not advertise any selectable models. !!]"
 system.model_set: "[!! Mod_el for this pane set to %{model}. !!]"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "[!! Ses_sion configuration (↑ ↓ • Enter • Esc) !!]"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "[!! The_ connected agent did not advertise any configurable session options. !!]"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "[!! Fai_led to update %{option}: %{error} !!]"
 system.model_unknown: "[!! Unk_nown model %{model} — type /model to see the available list. !!]"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/quz-PE.yml
+++ b/tools/wta/locales/quz-PE.yml
@@ -214,8 +214,17 @@ system.agent_switch_unavailable: "Agente cambiaqkuna manam tarikunchu Windows Te
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Kay k'itipaq modelo akllay (/model <id> qillqay kikinmanta t'ikranapaq)"  # {Locked="/model","<id>"}
+commands.config.summary: "Kay agente nisqap t'inkinta allichay"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Kay hunt'a k'itipi agente k'itita astay (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Modelo akllay (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Tinkisqa agente mana ima akllana modelotapas willarqachu."
 system.model_set: "Kay k'itipaq modelo %{model} nisqaman churasqa."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "T'inki allichay (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "T'inkisqa agente mana ima allichana t'inki akllanatahpas riqsichimurqanchu."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} machkhapay pantarun: %{error}"
 system.model_unknown: "Mana riqsisqa modelo %{model} — akllana lista rikunaykipaq /model qillqay."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ro-RO.yml
+++ b/tools/wta/locales/ro-RO.yml
@@ -214,8 +214,17 @@ system.agent_switch_unavailable: "Comutarea agentului nu este disponibilă în a
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Alegeți modelul pentru acest panou (/model <id> pentru a comuta direct)"  # {Locked="/model","<id>"}
+commands.config.summary: "Configurați această sesiune del agent"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Mutați panoul agentului al acestei file (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Selectați modelul (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Agentul conectat nu a anunțat niciun model selectabil."
 system.model_set: "Modelul pentru acest panou a fost setat la %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Configurare sesiune (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Agentul conectat nu a anunțat nicio opțiune de sesiune configurabilă."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Nu s-a putut actualiza %{option}: %{error}"
 system.model_unknown: "Model necunoscut %{model} — tastați /model pentru a vedea lista disponibilă."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ru-RU.yml
+++ b/tools/wta/locales/ru-RU.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Переключение агентов нед
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Выберите модель для этой панели (/model <id> для прямого переключения)"  # {Locked="/model","<id>"}
+commands.config.summary: "Настроить этот сеанс агента"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Переместить панель агента этой вкладки (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Выбор модели (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Подключённый агент не объявил ни одной доступной для выбора модели."
 system.model_set: "Модель для этой панели установлена на %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Конфигурация сеанса (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Подключённый агент не объявил ни одного настраиваемого параметра сеанса."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Не удалось обновить %{option}: %{error}"
 system.model_unknown: "Неизвестная модель %{model} — введите /model, чтобы увидеть доступный список."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/sk-SK.yml
+++ b/tools/wta/locales/sk-SK.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Prepínanie agentov nie je k dispozícii mimo 
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Vyberte model pre túto tablu (/model <id> na priame prepnutie)"  # {Locked="/model","<id>"}
+commands.config.summary: "Nakonfigurujte tuto reláciu agenta"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Presunúť panel agenta pre túto kartu (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Vybrať model (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Pripojený agent neohlásil žiadne vybrateľné modely."
 system.model_set: "Model pre túto tablu je nastavený na %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Konfigurácia relácie (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Pripojený agent nenabídol žiadne konfigurateľné možnosti relácie."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Obnovenie %{option} zlyhalo: %{error}"
 system.model_unknown: "Neznámy model %{model} — zadaním /model zobrazíte dostupný zoznam."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/sl-SI.yml
+++ b/tools/wta/locales/sl-SI.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Preklapljanje agentov ni na voljo zunaj zavihk
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Izberite model za to podokno (/model <id> za neposreden preklop)"  # {Locked="/model","<id>"}
+commands.config.summary: "Konfigurirajte to sejo agenta"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Premakni podokno agenta za ta zavihek (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Izberi model (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Povezani agent ni oglaševal nobenega izbirljivega modela."
 system.model_set: "Model za to podokno je nastavljen na %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Konfiguracija seje (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Povezani agent ni objavil nobenih nastavljivih možnosti seje."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Posodobitev možnosti %{option} ni uspela: %{error}"
 system.model_unknown: "Neznan model %{model} — vnesite /model za prikaz razpoložljivega seznama."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/sq-AL.yml
+++ b/tools/wta/locales/sq-AL.yml
@@ -214,8 +214,17 @@ system.agent_switch_unavailable: "Ndryshimi i agjentit nuk është i disponuesh�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Zgjidhni modelin për këtë panel (/model <id> për të kaluar drejtpërdrejt)"  # {Locked="/model","<id>"}
+commands.config.summary: "Konfiguroni këtë seancë të agjentit"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Lëvizni panelin e agjentit të kësaj skede (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Zgjidhni modelin (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Agjenti i lidhur nuk shpalli asnjë model të zgjedhshëm."
 system.model_set: "Modeli për këtë panel u caktua në %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Konfigurimi i seancës (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Agjenti i lidhur nuk njoftoi asnjë opsion seance të konfigurueshëm."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Dështoi përditësimi i %{option}: %{error}"
 system.model_unknown: "Model i panjohur %{model} — shkruani /model për të parë listën e disponueshme."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/sr-Cyrl-BA.yml
+++ b/tools/wta/locales/sr-Cyrl-BA.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Промена агента није дост�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Изаберите модел за ово окно (/model <id> за директно пребацивање)"  # {Locked="/model","<id>"}
+commands.config.summary: "Конфигуришите ову сесију агента"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Преместите панел агента за ову картицу (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Изаберите модел (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Повезани агент није огласио ниједан модел који се може изабрати."
 system.model_set: "Модел за ово окно је подешен на %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Конфигурација сесије (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Повезани агент није рекламирао ниједну опцију сесије која се може конфигурисати."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Ажурирање опције %{option} није успело: %{error}"
 system.model_unknown: "Непознат модел %{model} — унесите /model да видите доступну листу."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/sr-Cyrl-RS.yml
+++ b/tools/wta/locales/sr-Cyrl-RS.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Промена агента није дост�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Изаберите модел за ово окно (/model <id> за директно пребацивање)"  # {Locked="/model","<id>"}
+commands.config.summary: "Конфигуришите ову сесију агента"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Преместите панел агента за ову картицу (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Изаберите модел (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Повезани агент није огласио ниједан модел који се може изабрати."
 system.model_set: "Модел за ово окно је подешен на %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Конфигурација сесије (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Повезани агент није рекламирао ниједну опцију сесије која се може конфигурисати."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Ажурирање опције %{option} није успело: %{error}"
 system.model_unknown: "Непознат модел %{model} — унесите /model да видите доступну листу."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/sr-Latn-RS.yml
+++ b/tools/wta/locales/sr-Latn-RS.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Promena agenta nije dostupna van kartice u apl
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Izaberite model za ovo okno (/model <id> za direktno prebacivanje)"  # {Locked="/model","<id>"}
+commands.config.summary: "Konfigurišite ovu sesiju agenta"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Premestite panel agenta za ovu karticu (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Izaberite model (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Povezani agent nije oglasio nijedan model koji se može izabrati."
 system.model_set: "Model za ovo okno je podešen na %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Konfiguracija sesije (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Povezani agent nije reklamirao nijednu opciju sesije koja se može konfigurisati."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Ažuriranje opcije %{option} nije uspelo: %{error}"
 system.model_unknown: "Nepoznat model %{model} — unesite /model da vidite dostupnu listu."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/sv-SE.yml
+++ b/tools/wta/locales/sv-SE.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Agentbyte är inte tillgängligt utanför en W
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Välj modellen för den här panelen (/model <id> för att växla direkt)"  # {Locked="/model","<id>"}
+commands.config.summary: "Konfigurera den här agentsessionen"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Flytta agentpanelen för den här fliken (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Välj modell (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Den anslutna agenten annonserade inga valbara modeller."
 system.model_set: "Modellen för den här panelen är inställd på %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Sessionskonfiguration (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Den anslutna agenten annonserade inga konfigurerbara sessionsalternativ."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Det gick inte att uppdatera %{option}: %{error}"
 system.model_unknown: "Okänd modell %{model} — skriv /model för att se den tillgängliga listan."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ta-IN.yml
+++ b/tools/wta/locales/ta-IN.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "விண்டோஸ் டெர்மின
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "இந்தப் பலகத்திற்கான மாதிரியைத் தேர்ந்தெடுக்கவும் (நேரடியாக மாற்ற /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "இந்த ஏஜென்ட் அமர்வை காண்ஃபிகர் செய்யவும்"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "இந்தத் தாவலின் ஏஜெண்ட் பலகத்தை நகர்த்தவும் (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "மாதிரியைத் தேர்ந்தெடுக்கவும் (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "இணைக்கப்பட்ட ஏஜெண்ட் தேர்ந்தெடுக்கக்கூடிய எந்த மாதிரியையும் அறிவிக்கவில்லை."
 system.model_set: "இந்தப் பலகத்திற்கான மாதிரி %{model} ஆக அமைக்கப்பட்டது."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "அமர்வு காண்ஃபிகரேஷன் (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "இணைக்கப்பட்ட ஏஜென்ட் எந்த உள்ளமைக்கக்கூடிய அமர்வு விருப்பங்களையும் விளம்பரம் செய்யவில்லை."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} ஐப் புதுப்பிப்பது தோல்வியடைந்தது: %{error}"
 system.model_unknown: "அறியப்படாத மாதிரி %{model} — கிடைக்கும் பட்டியலைக் காண /model எனத் தட்டச்சு செய்யவும்."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/te-IN.yml
+++ b/tools/wta/locales/te-IN.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "Windows Terminal ట్యాబ్ వెల�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "ఈ పేన్ కోసం మోడల్‌ను ఎంచుకోండి (నేరుగా మార్చడానికి /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "ఈ ఏజెంట్ సెషన్‌ను కాన్ఫిගర్ చేయండి"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "ఈ ట్యాబ్ యొక్క ఏజెంట్ పేన్‌ను తరలించండి (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "మోడల్‌ను ఎంచుకోండి (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "కనెక్ట్ అయిన ఏజెంట్ ఎంచుకోదగిన ఏ మోడల్‌ను కూడా ప్రకటించలేదు."
 system.model_set: "ఈ పేన్ కోసం మోడల్ %{model} గా సెట్ చేయబడింది."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "సెషన్ కాన్ఫిగరేషన్ (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "కనెక్ట్ చేయబడిన ఏజెంట్ కాన్ఫిగర్ చేయదగిన సెషన్ ఎంపికలను ప్రచారం చేయలేదు."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option}ను నవీకరించడం విఫలమైంది: %{error}"
 system.model_unknown: "తెలియని మోడల్ %{model} — అందుబాటులో ఉన్న జాబితాను చూడటానికి /model టైప్ చేయండి."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/th-TH.yml
+++ b/tools/wta/locales/th-TH.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "การสลับตัวแทนจะ�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "เลือกโมเดลสำหรับแผงนี้ (/model <id> เพื่อสลับโดยตรง)"  # {Locked="/model","<id>"}
+commands.config.summary: "กำหนดค่าเซสชันตัวแทนนี้"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "ย้ายแผงเอเจนต์ของแท็บนี้ (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "เลือกโมเดล (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "เอเจนต์ที่เชื่อมต่ออยู่ไม่ได้ประกาศโมเดลที่เลือกได้"
 system.model_set: "ตั้งค่าโมเดลสำหรับแผงนี้เป็น %{model} แล้ว"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "การกำหนดค่าเซสชัน (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "ตัวแทนที่เชื่อมต่อไม่ได้โฆษณาตัวเลือกเซสชันที่กำหนดค่าได้"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "อัปเดต %{option} ไม่สำเร็จ: %{error}"
 system.model_unknown: "ไม่รู้จักโมเดล %{model} — พิมพ์ /model เพื่อดูรายการที่มีอยู่"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/tr-TR.yml
+++ b/tools/wta/locales/tr-TR.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Aracı geçişi, bir Windows Terminal sekmesin
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Bu panel için modeli seçin (doğrudan geçmek için /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "Bu aracı oturumunu yapılandırın"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Bu sekmenin aracı panelini taşı (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Model seçin (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Bağlı aracı seçilebilir hiçbir model duyurmadı."
 system.model_set: "Bu panel için model %{model} olarak ayarlandı."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Oturum yapılandırması (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Bağlı aracı, yapılandırılabilir herhangi bir oturum seçeneği bildirmedi."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} güncelleştirilemedi: %{error}"
 system.model_unknown: "Bilinmeyen model %{model} — kullanılabilir listeyi görmek için /model yazın."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/tt-RU.yml
+++ b/tools/wta/locales/tt-RU.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Агентны күчерү Windows Terminal �
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Бу панель өчен модель сайлагыз (туры алыштыру өчен /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "Бу агент сессиясын көйләү"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Бу салынманың агент панелен күчерү (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Модель сайлагыз (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Тоташкан агент бер дә сайлап була торган модель игълан итмәде."
 system.model_set: "Бу панель өчен модель %{model} итеп билгеләнде."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Сессия конфигурациясе (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Тоташтырылган агент бернинде көйләп була торган сессия параметрларын белдермәде."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} яңарту уңышсыз булды: %{error}"
 system.model_unknown: "Билгесез модель %{model} — мөмкин булган исемлекне күрү өчен /model языгыз."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ug-CN.yml
+++ b/tools/wta/locales/ug-CN.yml
@@ -224,8 +224,17 @@ system.agent_switch_unavailable: "ۋاكالەتچى ئالماشتۇرۇشنى 
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "بۇ تاختا ئۈچۈن مودېل تاللاڭ (بىۋاسىتە الماشتۇرۇش ئۈچۈن /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "بۇ ۋاكالەتچى ئەڭگىمەسىنى سەپلەش"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "بۇ بەتنىڭ AI ئاگېنتى تاختىسىنى يۆتكەش (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "مودېل تاللاڭ (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "ئۇلانغان AI ئاگېنتى تاللىغىلى بولىدىغان ھېچقانداق مودېل ئېلان قىلمىدى."
 system.model_set: "بۇ تاختا ئۈچۈن مودېل %{model} قىلىپ بەلگىلەندى."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "ئەڭگىمە سەپلىمىسى (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "أۇلانغان ۋاكالەتچى ھېچقانداق سەپلىگىلى بولىدىغان ئەڭگىمە تاللانمىلىرىنى ئېلان قىلمىدى."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} نى يېڭىلاش مەغلۇپ بولدى: %{error}"
 system.model_unknown: "نامەلۇم مودېل %{model} — ئىشلەتكىلى بولىدىغان تىزىملىكنى كۆرۈش ئۈچۈن /model نى كىرگۈزۈڭ."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/uk-UA.yml
+++ b/tools/wta/locales/uk-UA.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Перемикання агентів недо
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Виберіть модель для цієї панелі (/model <id> для прямого перемикання)"  # {Locked="/model","<id>"}
+commands.config.summary: "Налаштувати цей сеанс агента"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Перемістити панель агента цієї вкладки (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Виберіть модель (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Підключений агент не оголосив жодної моделі, яку можна вибрати."
 system.model_set: "Модель для цієї панелі встановлено на %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Конфігурація сеансу (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Підключений агент не оголосив жодного налаштовуваного параметра сеансу."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Не вдалося оновити %{option}: %{error}"
 system.model_unknown: "Невідома модель %{model} — введіть /model, щоб переглянути доступний список."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ur-PK.yml
+++ b/tools/wta/locales/ur-PK.yml
@@ -216,8 +216,17 @@ system.agent_switch_unavailable: "ونڈوز ٹرمینل ٹیب سے باہر �
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "اس پین کے لیے ماڈل منتخب کریں (براہ راست تبدیل کرنے کے لیے /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "اس ایجنٹ سیشن کو ترتيب دیں"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "اس ٹیب کے ایجنٹ پین کو منتقل کریں (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "ماڈل منتخب کریں (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "منسلک ایجنٹ نے کوئی قابلِ انتخاب ماڈل ظاہر نہیں کیا۔"
 system.model_set: "اس پین کے لیے ماڈل %{model} پر سیٹ کر دیا گیا۔"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "سیشن کنفیگریشن (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "منسلک ایجنٹ نے کسی بھی قابل کنفیگر سیشن کے اختیارات ਦੀ تشہیر نہیں کی۔"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} کو اپ ڈیٹ کرنے میں ناکام: %{error}"
 system.model_unknown: "نامعلوم ماڈل %{model} — دستیاب فہرست دیکھنے کے لیے /model ٹائپ کریں۔"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/ur-PK.yml
+++ b/tools/wta/locales/ur-PK.yml
@@ -226,7 +226,7 @@ system.model_set: "اس پین کے لیے ماڈل %{model} پر سیٹ کر د
 # {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
 config_picker.title: "سیشن کنفیگریشن (↑ ↓ • Enter • Esc)"
 # Shown when /config is used but the AI agent exposed no ACP select options.
-system.no_config_options: "منسلک ایجنٹ نے کسی بھی قابل کنفیگر سیشن کے اختیارات ਦੀ تشہیر نہیں کی۔"
+system.no_config_options: "منسلک ایجنٹ نے کسی بھی قابل کنفیگر سیشن کے اختیارات کی تشہیر نہیں کی۔"
 # {option} is an Agent-provided option name; {error} is the ACP error.
 system.config_update_failed: "%{option} کو اپ ڈیٹ کرنے میں ناکام: %{error}"
 system.model_unknown: "نامعلوم ماڈل %{model} — دستیاب فہرست دیکھنے کے لیے /model ٹائپ کریں۔"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/uz-Latn-UZ.yml
+++ b/tools/wta/locales/uz-Latn-UZ.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Agentni almashtirish Windows Terminal ilovasid
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Bu panel uchun modelni tanlang (toʻgʻridan-toʻgʻri almashtirish uchun /model <id>)"  # {Locked="/model","<id>"}
+commands.config.summary: "Ushbu agent seansini sozlash"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Bu tabning agent panelini koʻchirish (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Modelni tanlang (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Ulangan agent hech qanday tanlanadigan modelni eʼlon qilmadi."
 system.model_set: "Bu panel uchun model %{model} ga oʻrnatildi."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Seans konfiguratsiyasi (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Ulanmagan agent hech qanday sozlanishi mumkin boʻlgan seans parametrlarini eʼlon qilmadi."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "%{option} yangilanmadi: %{error}"
 system.model_unknown: "Nomaʼlum model %{model} — mavjud roʻyxatni koʻrish uchun /model yozing."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/vi-VN.yml
+++ b/tools/wta/locales/vi-VN.yml
@@ -215,8 +215,17 @@ system.agent_switch_unavailable: "Tính năng chuyển đổi agent không khả
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "Chọn mô hình cho bảng này (/model <id> để chuyển trực tiếp)"  # {Locked="/model","<id>"}
+commands.config.summary: "Cấu hình phiên agent này"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "Di chuyển bảng tác nhân AI của tab này (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "Chọn mô hình (↑ ↓ • Enter • Esc)"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "Tác nhân AI đã kết nối không quảng bá bất kỳ mô hình nào có thể chọn."
 system.model_set: "Mô hình cho bảng này được đặt thành %{model}."  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "Cấu hình phiên (↑ ↓ • Enter • Esc)"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "Agent được kết nối không quảng cáo bất kỳ tùy chọn phiên nào có thể cấu hình."
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "Không thể cập nhật %{option}: %{error}"
 system.model_unknown: "Mô hình không xác định %{model} — nhập /model để xem danh sách khả dụng."  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/zh-CN.yml
+++ b/tools/wta/locales/zh-CN.yml
@@ -210,8 +210,17 @@ system.agent_switch_unavailable: "在 Windows Terminal 标签页之外，智能�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "为此窗格选择模型（使用 /model <id> 可直接切换）"  # {Locked="/model","<id>"}
+commands.config.summary: "配置此智能体会话"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "移动此标签页的智能体窗格 (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "选择模型（↑ ↓ • Enter • Esc）"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "已连接的智能体未公布任何可选模型。"
 system.model_set: "此窗格的模型已设置为 %{model}。"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "会话配置（↑ ↓ • Enter • Esc）"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "已连接的智能体未公布任何可配置的会话选项。"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "更新 %{option} 失败：%{error}"
 system.model_unknown: "未知模型 %{model} — 键入 /model 查看可用列表。"  # {Locked="%{model}","/model"}

--- a/tools/wta/locales/zh-TW.yml
+++ b/tools/wta/locales/zh-TW.yml
@@ -210,8 +210,17 @@ system.agent_switch_unavailable: "在 Windows Terminal 分頁之外，無法切�
 
 # ── Model picker (/model) ───────────────────────────────────────────────────
 commands.model.summary: "為此窗格選擇模型（使用 /model <id> 可直接切換）"  # {Locked="/model","<id>"}
+commands.config.summary: "設定此智能體工作階段"  # Agent means an AI coding agent; shown for the /config command. {Locked="/config"}
 commands.move.summary: "移動此分頁的智能體窗格 (/move <position>)"  # {Locked="/move","<position>"}
 model_picker.title: "選擇模型（↑ ↓ • Enter • Esc）"  # {Locked="↑","↓","Enter","Esc"}
 system.no_models: "已連線的智能體未公布任何可選取的模型。"
 system.model_set: "此窗格的模型已設定為 %{model}。"  # {Locked="%{model}"}
+
+# ── Session configuration picker (src/ui/config_popup.rs) ───────────────────
+# {Locked="↑","↓","Enter","Esc","ACP"} - key names and protocol name
+config_picker.title: "工作階段設定（↑ ↓ • Enter • Esc）"
+# Shown when /config is used but the AI agent exposed no ACP select options.
+system.no_config_options: "已連線的智能體未公布任何可設定的工作階段選項。"
+# {option} is an Agent-provided option name; {error} is the ACP error.
+system.config_update_failed: "更新 %{option} 失敗：%{error}"
 system.model_unknown: "未知模型 %{model} — 輸入 /model 查看可用清單。"  # {Locked="%{model}","/model"}

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -60,8 +60,9 @@ pub use crate::turn_context::TurnContext;
 use input_edit::{next_word_boundary, prev_word_boundary, INPUT_HISTORY_MAX_ENTRIES};
 pub(crate) use tab_state::DEFAULT_TAB_ID;
 pub use tab_state::{
-    ChatMessage, CompletedTurn, NoticeKind, PermissionState, RecommendationFocus, TabSession,
-    ToolCallContent, ToolCallKind, ToolCallLocation, ToolCallOutput, UserInputState, View,
+    ChatMessage, CompletedTurn, ConfigPickerState, NoticeKind, PermissionState,
+    RecommendationFocus, TabSession, ToolCallContent, ToolCallKind, ToolCallLocation,
+    ToolCallOutput, UserInputState, View,
 };
 pub use turn_state::{AutofixContext, ChunkKind, SubmittedPrompt, TurnOutcome, TurnState};
 
@@ -2006,7 +2007,7 @@ impl App {
     fn open_agent_picker(&mut self, selected: usize) {
         let tab = self.current_tab_mut();
         tab.model_picker_open = false;
-        tab.config_picker_open = false;
+        tab.config_picker = ConfigPickerState::Closed;
         tab.agent_picker_open = true;
         tab.agent_picker_selected = selected;
     }
@@ -2064,7 +2065,7 @@ impl App {
     // ── /config picker ──────────────────────────────────────────────────
 
     fn config_picker_visible(&self) -> bool {
-        self.current_tab().config_picker_open
+        self.current_tab().config_picker.is_open()
     }
 
     fn current_session_config_options(&self) -> &[crate::app_contracts::AcpSessionConfigOption] {
@@ -2095,10 +2096,7 @@ impl App {
         let tab = self.current_tab_mut();
         tab.agent_picker_open = false;
         tab.model_picker_open = false;
-        tab.config_picker_open = true;
-        tab.config_picker_selected = 0;
-        tab.config_picker_value_option_id = None;
-        tab.config_picker_returns_to_options = false;
+        tab.config_picker = ConfigPickerState::Options { selected: 0 };
     }
 
     fn open_config_value_picker(&mut self, config_id: String) {
@@ -2117,59 +2115,67 @@ impl App {
         let tab = self.current_tab_mut();
         tab.agent_picker_open = false;
         tab.model_picker_open = false;
-        tab.config_picker_open = true;
-        tab.config_picker_selected = selected;
-        tab.config_picker_value_option_id = Some(config_id);
-        tab.config_picker_returns_to_options = false;
-    }
-
-    fn close_config_picker(&mut self) {
-        let tab = self.current_tab_mut();
-        tab.config_picker_open = false;
-        tab.config_picker_value_option_id = None;
-        tab.config_picker_returns_to_options = false;
+        tab.config_picker = ConfigPickerState::Values {
+            option_id: config_id,
+            selected,
+            parent_selected: None,
+        };
     }
 
     fn config_picker_row_count(&self) -> usize {
         let options = self.current_session_config_options();
         self.current_tab()
-            .config_picker_value_option_id
-            .as_deref()
+            .config_picker
+            .option_id()
             .and_then(|config_id| options.iter().find(|option| option.id == config_id))
             .map(|option| option.values.len())
             .unwrap_or(options.len())
     }
 
     fn config_picker_up(&mut self) {
-        self.current_tab_mut().config_picker_selected =
-            self.current_tab().config_picker_selected.saturating_sub(1);
+        match &mut self.current_tab_mut().config_picker {
+            ConfigPickerState::Options { selected }
+            | ConfigPickerState::Values { selected, .. } => {
+                *selected = selected.saturating_sub(1);
+            }
+            ConfigPickerState::Closed => {}
+        }
     }
 
     fn config_picker_down(&mut self) {
         let max = self.config_picker_row_count().saturating_sub(1);
-        let selected = self.current_tab().config_picker_selected;
-        self.current_tab_mut().config_picker_selected = (selected + 1).min(max);
-    }
-
-    fn config_picker_escape(&mut self) {
-        if self.current_tab().config_picker_value_option_id.is_some()
-            && self.current_tab().config_picker_returns_to_options
-        {
-            let tab = self.current_tab_mut();
-            tab.config_picker_value_option_id = None;
-            tab.config_picker_selected = 0;
-            tab.config_picker_returns_to_options = false;
-        } else {
-            self.close_config_picker();
+        match &mut self.current_tab_mut().config_picker {
+            ConfigPickerState::Options { selected }
+            | ConfigPickerState::Values { selected, .. } => {
+                *selected = (*selected + 1).min(max);
+            }
+            ConfigPickerState::Closed => {}
         }
     }
 
+    fn config_picker_escape(&mut self) {
+        let next = match &self.current_tab().config_picker {
+            ConfigPickerState::Values {
+                parent_selected: Some(selected),
+                ..
+            } => ConfigPickerState::Options {
+                selected: *selected,
+            },
+            _ => ConfigPickerState::Closed,
+        };
+        self.current_tab_mut().config_picker = next;
+    }
+
     fn config_picker_enter(&mut self) {
-        let selected = self.current_tab().config_picker_selected;
-        let value_option_id = self.current_tab().config_picker_value_option_id.clone();
+        let picker = self.current_tab().config_picker.clone();
         let options = self.current_session_config_options();
 
-        if let Some(config_id) = value_option_id {
+        if let ConfigPickerState::Values {
+            option_id: config_id,
+            selected,
+            parent_selected,
+        } = picker
+        {
             let Some(option) = options.iter().find(|option| option.id == config_id) else {
                 self.config_picker_escape();
                 return;
@@ -2185,19 +2191,15 @@ impl App {
             let session_id = self.current_tab().session_id.clone();
             let config_id = option.id.clone();
             let value_id = value.id.clone();
-            let is_model = option.is_model();
-            if is_model {
-                self.close_config_picker();
-                self.apply_model_pick(value_id);
-            } else if let Some(session_id) = session_id {
+            if let Some(session_id) = session_id {
                 let tab = self.current_tab_mut();
                 if tab.config_pending_id.is_some() {
                     return;
                 }
                 tab.config_pending_id = Some(config_id.clone());
-                tab.config_picker_value_option_id = None;
-                tab.config_picker_selected = 0;
-                tab.config_picker_returns_to_options = false;
+                tab.config_picker = parent_selected
+                    .map(|selected| ConfigPickerState::Options { selected })
+                    .unwrap_or(ConfigPickerState::Closed);
                 let _ = self.master_request_tx.send(
                     crate::protocol::acp::client::MasterExtRequest::SetSessionConfigOption {
                         session_id: agent_client_protocol::schema::v1::SessionId::new(session_id),
@@ -2209,6 +2211,9 @@ impl App {
             return;
         }
 
+        let ConfigPickerState::Options { selected } = picker else {
+            return;
+        };
         let Some(option) = options.get(selected) else {
             return;
         };
@@ -2218,10 +2223,11 @@ impl App {
             .position(|value| value.id == option.current_value)
             .unwrap_or(0);
         let option_id = option.id.clone();
-        let tab = self.current_tab_mut();
-        tab.config_picker_value_option_id = Some(option_id);
-        tab.config_picker_selected = value_selected;
-        tab.config_picker_returns_to_options = true;
+        self.current_tab_mut().config_picker = ConfigPickerState::Values {
+            option_id,
+            selected: value_selected,
+            parent_selected: Some(selected),
+        };
     }
 
     // ── /model picker ───────────────────────────────────────────────────
@@ -2303,7 +2309,7 @@ impl App {
             .unwrap_or(0);
         let tab = self.current_tab_mut();
         tab.agent_picker_open = false;
-        tab.config_picker_open = false;
+        tab.config_picker = ConfigPickerState::Closed;
         tab.model_picker_open = true;
         tab.model_picker_selected = selected;
     }
@@ -3785,6 +3791,13 @@ impl App {
             .unwrap_or_else(|| DEFAULT_TAB_ID.to_string())
     }
 
+    fn bound_tab_for_session(&self, session_id: &str) -> Option<String> {
+        self.session_to_tab.get(session_id).cloned().or_else(|| {
+            (self.current_tab().session_id.as_deref() == Some(session_id))
+                .then(|| self.active_tab_key().to_string())
+        })
+    }
+
     /// Mutable view of the tab that owns the given session id. Lazily
     /// creates the `TabSession` if missing.
     pub fn session_tab_mut(&mut self, session_id: &str) -> &mut TabSession {
@@ -4631,7 +4644,7 @@ impl App {
 
     pub fn config_popup_state(&self) -> Option<crate::ui::ConfigPopupState<'_>> {
         let tab = self.current_tab();
-        if !tab.config_picker_open {
+        if !tab.config_picker.is_open() {
             return None;
         }
         let options = self.current_session_config_options();
@@ -4639,13 +4652,13 @@ impl App {
             return None;
         }
         let value_option = tab
-            .config_picker_value_option_id
-            .as_deref()
+            .config_picker
+            .option_id()
             .and_then(|config_id| options.iter().find(|option| option.id == config_id));
         Some(crate::ui::ConfigPopupState {
             options,
             value_option,
-            selected: tab.config_picker_selected,
+            selected: tab.config_picker.selected(),
             pending_config_id: tab.config_pending_id.as_deref(),
             pane_focused: self.pane_focused,
         })

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2098,6 +2098,7 @@ impl App {
         tab.config_picker_open = true;
         tab.config_picker_selected = 0;
         tab.config_picker_value_option_id = None;
+        tab.config_picker_returns_to_options = false;
     }
 
     fn open_config_value_picker(&mut self, config_id: String) {
@@ -2119,12 +2120,14 @@ impl App {
         tab.config_picker_open = true;
         tab.config_picker_selected = selected;
         tab.config_picker_value_option_id = Some(config_id);
+        tab.config_picker_returns_to_options = false;
     }
 
     fn close_config_picker(&mut self) {
         let tab = self.current_tab_mut();
         tab.config_picker_open = false;
         tab.config_picker_value_option_id = None;
+        tab.config_picker_returns_to_options = false;
     }
 
     fn config_picker_row_count(&self) -> usize {
@@ -2149,10 +2152,13 @@ impl App {
     }
 
     fn config_picker_escape(&mut self) {
-        if self.current_tab().config_picker_value_option_id.is_some() {
+        if self.current_tab().config_picker_value_option_id.is_some()
+            && self.current_tab().config_picker_returns_to_options
+        {
             let tab = self.current_tab_mut();
             tab.config_picker_value_option_id = None;
             tab.config_picker_selected = 0;
+            tab.config_picker_returns_to_options = false;
         } else {
             self.close_config_picker();
         }
@@ -2191,6 +2197,7 @@ impl App {
                 tab.config_pending_id = Some(config_id.clone());
                 tab.config_picker_value_option_id = None;
                 tab.config_picker_selected = 0;
+                tab.config_picker_returns_to_options = false;
                 let _ = self.master_request_tx.send(
                     crate::protocol::acp::client::MasterExtRequest::SetSessionConfigOption {
                         session_id: agent_client_protocol::schema::v1::SessionId::new(session_id),
@@ -2214,6 +2221,7 @@ impl App {
         let tab = self.current_tab_mut();
         tab.config_picker_value_option_id = Some(option_id);
         tab.config_picker_selected = value_selected;
+        tab.config_picker_returns_to_options = true;
     }
 
     // ── /model picker ───────────────────────────────────────────────────

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -914,6 +914,8 @@ pub struct App {
     /// Latest ACP model config for each session. Notifications can race ahead
     /// of the event that attaches their session to a tab.
     session_model_configs: HashMap<String, (Vec<AcpModelInfo>, Option<String>)>,
+    /// Complete ordered ACP select config options, keyed by SessionId.
+    session_config_options: HashMap<String, Vec<crate::app_contracts::AcpSessionConfigOption>>,
     pub prompt_name: Option<String>,
     pub session_id: String,
     #[allow(dead_code)]
@@ -1231,6 +1233,7 @@ impl App {
             model_picker_models: Vec::new(),
             current_model_id: None,
             session_model_configs: HashMap::new(),
+            session_config_options: HashMap::new(),
             prompt_name: None,
             session_id: String::new(),
             wt_connected,
@@ -2003,6 +2006,7 @@ impl App {
     fn open_agent_picker(&mut self, selected: usize) {
         let tab = self.current_tab_mut();
         tab.model_picker_open = false;
+        tab.config_picker_open = false;
         tab.agent_picker_open = true;
         tab.agent_picker_selected = selected;
     }
@@ -2057,6 +2061,161 @@ impl App {
         tab.scroll_to_bottom();
     }
 
+    // ── /config picker ──────────────────────────────────────────────────
+
+    fn config_picker_visible(&self) -> bool {
+        self.current_tab().config_picker_open
+    }
+
+    fn current_session_config_options(&self) -> &[crate::app_contracts::AcpSessionConfigOption] {
+        self.current_tab()
+            .session_id
+            .as_deref()
+            .and_then(|session_id| self.session_config_options.get(session_id))
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    fn cmd_config(&mut self) {
+        if self.current_session_config_options().is_empty() {
+            let tab = self.current_tab_mut();
+            tab.messages.push(ChatMessage::info(
+                t!("system.no_config_options").into_owned(),
+            ));
+            tab.scroll_to_bottom();
+            return;
+        }
+        self.open_config_picker();
+    }
+
+    fn open_config_picker(&mut self) {
+        if self.current_session_config_options().is_empty() {
+            return;
+        }
+        let tab = self.current_tab_mut();
+        tab.agent_picker_open = false;
+        tab.model_picker_open = false;
+        tab.config_picker_open = true;
+        tab.config_picker_selected = 0;
+        tab.config_picker_value_option_id = None;
+    }
+
+    fn open_config_value_picker(&mut self, config_id: String) {
+        let Some(option) = self
+            .current_session_config_options()
+            .iter()
+            .find(|option| option.id == config_id)
+        else {
+            return;
+        };
+        let selected = option
+            .values
+            .iter()
+            .position(|value| value.id == option.current_value)
+            .unwrap_or(0);
+        let tab = self.current_tab_mut();
+        tab.agent_picker_open = false;
+        tab.model_picker_open = false;
+        tab.config_picker_open = true;
+        tab.config_picker_selected = selected;
+        tab.config_picker_value_option_id = Some(config_id);
+    }
+
+    fn close_config_picker(&mut self) {
+        let tab = self.current_tab_mut();
+        tab.config_picker_open = false;
+        tab.config_picker_value_option_id = None;
+    }
+
+    fn config_picker_row_count(&self) -> usize {
+        let options = self.current_session_config_options();
+        self.current_tab()
+            .config_picker_value_option_id
+            .as_deref()
+            .and_then(|config_id| options.iter().find(|option| option.id == config_id))
+            .map(|option| option.values.len())
+            .unwrap_or(options.len())
+    }
+
+    fn config_picker_up(&mut self) {
+        self.current_tab_mut().config_picker_selected =
+            self.current_tab().config_picker_selected.saturating_sub(1);
+    }
+
+    fn config_picker_down(&mut self) {
+        let max = self.config_picker_row_count().saturating_sub(1);
+        let selected = self.current_tab().config_picker_selected;
+        self.current_tab_mut().config_picker_selected = (selected + 1).min(max);
+    }
+
+    fn config_picker_escape(&mut self) {
+        if self.current_tab().config_picker_value_option_id.is_some() {
+            let tab = self.current_tab_mut();
+            tab.config_picker_value_option_id = None;
+            tab.config_picker_selected = 0;
+        } else {
+            self.close_config_picker();
+        }
+    }
+
+    fn config_picker_enter(&mut self) {
+        let selected = self.current_tab().config_picker_selected;
+        let value_option_id = self.current_tab().config_picker_value_option_id.clone();
+        let options = self.current_session_config_options();
+
+        if let Some(config_id) = value_option_id {
+            let Some(option) = options.iter().find(|option| option.id == config_id) else {
+                self.config_picker_escape();
+                return;
+            };
+            let Some(value) = option.values.get(selected) else {
+                return;
+            };
+            if value.id == option.current_value {
+                self.config_picker_escape();
+                return;
+            }
+
+            let session_id = self.current_tab().session_id.clone();
+            let config_id = option.id.clone();
+            let value_id = value.id.clone();
+            let is_model = option.is_model();
+            if is_model {
+                self.close_config_picker();
+                self.apply_model_pick(value_id);
+            } else if let Some(session_id) = session_id {
+                let tab = self.current_tab_mut();
+                if tab.config_pending_id.is_some() {
+                    return;
+                }
+                tab.config_pending_id = Some(config_id.clone());
+                tab.config_picker_value_option_id = None;
+                tab.config_picker_selected = 0;
+                let _ = self.master_request_tx.send(
+                    crate::protocol::acp::client::MasterExtRequest::SetSessionConfigOption {
+                        session_id: agent_client_protocol::schema::v1::SessionId::new(session_id),
+                        config_id,
+                        value: value_id,
+                    },
+                );
+            }
+            return;
+        }
+
+        let Some(option) = options.get(selected) else {
+            return;
+        };
+        let value_selected = option
+            .values
+            .iter()
+            .position(|value| value.id == option.current_value)
+            .unwrap_or(0);
+        let option_id = option.id.clone();
+        let tab = self.current_tab_mut();
+        tab.config_picker_value_option_id = Some(option_id);
+        tab.config_picker_selected = value_selected;
+    }
+
     // ── /model picker ───────────────────────────────────────────────────
 
     /// True while the model picker modal is up for the active tab.
@@ -2069,6 +2228,17 @@ impl App {
     /// Crossing modes requires changing Settings and restarting the agent.
     fn cmd_model(&mut self, arg: String) {
         let arg = arg.trim().to_string();
+        let model_config_id = self
+            .current_session_config_options()
+            .iter()
+            .find(|option| option.is_model())
+            .map(|option| option.id.clone());
+        if arg.is_empty() {
+            if let Some(config_id) = model_config_id {
+                self.open_config_value_picker(config_id);
+                return;
+            }
+        }
         if self.model_picker_models.is_empty() {
             let tab = self.current_tab_mut();
             tab.messages
@@ -2125,6 +2295,7 @@ impl App {
             .unwrap_or(0);
         let tab = self.current_tab_mut();
         tab.agent_picker_open = false;
+        tab.config_picker_open = false;
         tab.model_picker_open = true;
         tab.model_picker_selected = selected;
     }
@@ -3796,6 +3967,9 @@ impl App {
             AppEvent::UsageReported { .. } => "usage_reported",
             AppEvent::UsageCleared { .. } => "usage_cleared",
             AppEvent::ModelConfigUpdated { .. } => "model_config_updated",
+            AppEvent::SessionConfigUpdated { .. } => "session_config_updated",
+            AppEvent::SessionConfigSetCompleted { .. } => "session_config_set_completed",
+            AppEvent::SessionConfigSetFailed { .. } => "session_config_set_failed",
             AppEvent::TabError { .. } => "tab_error",
             AppEvent::TabSystemMessage { .. } => "tab_system_message",
             AppEvent::AgentPasteTextReady { .. } => "agent_paste_text_ready",
@@ -4447,6 +4621,28 @@ impl App {
         })
     }
 
+    pub fn config_popup_state(&self) -> Option<crate::ui::ConfigPopupState<'_>> {
+        let tab = self.current_tab();
+        if !tab.config_picker_open {
+            return None;
+        }
+        let options = self.current_session_config_options();
+        if options.is_empty() {
+            return None;
+        }
+        let value_option = tab
+            .config_picker_value_option_id
+            .as_deref()
+            .and_then(|config_id| options.iter().find(|option| option.id == config_id));
+        Some(crate::ui::ConfigPopupState {
+            options,
+            value_option,
+            selected: tab.config_picker_selected,
+            pending_config_id: tab.config_pending_id.as_deref(),
+            pane_focused: self.pane_focused,
+        })
+    }
+
     pub fn agent_popup_state(&self) -> Option<crate::ui::AgentPopupState<'_>> {
         let tab = self.current_tab();
         if !tab.agent_picker_open || self.available_agents.is_empty() {
@@ -4609,6 +4805,7 @@ impl App {
             CommandKind::Restart => self.cmd_restart(),
             CommandKind::Agent => self.cmd_agent(cmd.rest),
             CommandKind::Model => self.cmd_model(cmd.rest),
+            CommandKind::Config => self.cmd_config(),
             CommandKind::Move => self.cmd_move(cmd.rest),
         }
     }
@@ -4672,6 +4869,7 @@ impl App {
             });
         if let Some(session_id) = self.current_tab().session_id.clone() {
             self.session_model_configs.remove(&session_id);
+            self.session_config_options.remove(&session_id);
         }
         let tab = self.current_tab_mut();
         tab.clear_chat_history();
@@ -4864,6 +5062,7 @@ impl App {
         self.state = ConnectionState::Connecting("Restarting agent...".to_string());
         self.session_to_tab.clear();
         self.session_model_configs.clear();
+        self.session_config_options.clear();
         self.session_id.clear();
         for (_, tab) in self.tab_sessions.iter_mut() {
             tab.clear_chat_history();
@@ -5032,6 +5231,7 @@ impl App {
         let removed = self.tab_sessions.remove(closed_tab_id);
         if let Some(session_id) = removed.as_ref().and_then(|tab| tab.session_id.as_ref()) {
             self.session_model_configs.remove(session_id);
+            self.session_config_options.remove(session_id);
         }
         self.session_to_tab.retain(|_, tab| tab != closed_tab_id);
 
@@ -5250,6 +5450,7 @@ impl App {
         }
         if let Some(session_id) = removed_session_id {
             self.session_model_configs.remove(&session_id);
+            self.session_config_options.remove(&session_id);
         }
 
         // Prune the reverse SessionId → tab routing so late ACP chunks for

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -312,6 +312,74 @@ pub(crate) struct PendingTerminalActionProposal {
     pub recommendations: super::RecommendationSet,
 }
 
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub enum ConfigPickerState {
+    #[default]
+    Closed,
+    Options {
+        selected: usize,
+    },
+    Values {
+        option_id: String,
+        selected: usize,
+        parent_selected: Option<usize>,
+    },
+}
+
+impl ConfigPickerState {
+    pub fn is_open(&self) -> bool {
+        !matches!(self, Self::Closed)
+    }
+
+    pub fn selected(&self) -> usize {
+        match self {
+            Self::Closed => 0,
+            Self::Options { selected } | Self::Values { selected, .. } => *selected,
+        }
+    }
+
+    pub fn option_id(&self) -> Option<&str> {
+        match self {
+            Self::Values { option_id, .. } => Some(option_id),
+            _ => None,
+        }
+    }
+
+    pub fn reconcile(&mut self, options: &[crate::app_contracts::AcpSessionConfigOption]) {
+        let next = match std::mem::take(self) {
+            Self::Closed => Self::Closed,
+            Self::Options { selected } if !options.is_empty() => Self::Options {
+                selected: selected.min(options.len() - 1),
+            },
+            Self::Values {
+                option_id,
+                selected,
+                parent_selected,
+            } => {
+                let value_count = options
+                    .iter()
+                    .find(|option| option.id == option_id)
+                    .map(|option| option.values.len());
+                match value_count {
+                    Some(value_count) if value_count > 0 => Self::Values {
+                        option_id,
+                        selected: selected.min(value_count - 1),
+                        parent_selected,
+                    },
+                    _ => parent_selected
+                        .filter(|_| !options.is_empty())
+                        .map(|selected| Self::Options {
+                            selected: selected.min(options.len() - 1),
+                        })
+                        .unwrap_or(Self::Closed),
+                }
+            }
+            Self::Options { .. } => Self::Closed,
+        };
+        *self = next;
+    }
+}
+
 /// Everything that conceptually belongs to one tab's conversation: the
 /// message history, the streaming buffer of the in-flight prompt, the
 /// pending tool calls, the recommendations panel state, etc.
@@ -418,14 +486,8 @@ pub struct TabSession {
     pub model_picker_open: bool,
     /// Highlighted row in the open model picker.
     pub model_picker_selected: usize,
-    /// True while the ACP session configuration picker is open.
-    pub config_picker_open: bool,
-    /// Highlighted option or value in the configuration picker.
-    pub config_picker_selected: usize,
-    /// Config option whose values are currently shown; `None` shows the option list.
-    pub config_picker_value_option_id: Option<String>,
-    /// Whether Esc from the value picker returns to the `/config` option list.
-    pub config_picker_returns_to_options: bool,
+    /// Navigation state for the ACP session configuration picker.
+    pub config_picker: ConfigPickerState,
     /// Config option currently awaiting a `session/set_config_option` response.
     pub config_pending_id: Option<String>,
     /// True while the `/agent` picker is open for this tab.
@@ -480,7 +542,7 @@ impl TabSession {
             && self.user_input.is_empty()
             && !self.paste_pending
             && !self.model_picker_open
-            && !self.config_picker_open
+            && !self.config_picker.is_open()
             && !self.agent_picker_open
     }
 

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -424,6 +424,8 @@ pub struct TabSession {
     pub config_picker_selected: usize,
     /// Config option whose values are currently shown; `None` shows the option list.
     pub config_picker_value_option_id: Option<String>,
+    /// Whether Esc from the value picker returns to the `/config` option list.
+    pub config_picker_returns_to_options: bool,
     /// Config option currently awaiting a `session/set_config_option` response.
     pub config_pending_id: Option<String>,
     /// True while the `/agent` picker is open for this tab.

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -418,6 +418,14 @@ pub struct TabSession {
     pub model_picker_open: bool,
     /// Highlighted row in the open model picker.
     pub model_picker_selected: usize,
+    /// True while the ACP session configuration picker is open.
+    pub config_picker_open: bool,
+    /// Highlighted option or value in the configuration picker.
+    pub config_picker_selected: usize,
+    /// Config option whose values are currently shown; `None` shows the option list.
+    pub config_picker_value_option_id: Option<String>,
+    /// Config option currently awaiting a `session/set_config_option` response.
+    pub config_pending_id: Option<String>,
     /// True while the `/agent` picker is open for this tab.
     pub agent_picker_open: bool,
     /// Highlighted row in `App::available_agents`.
@@ -470,6 +478,7 @@ impl TabSession {
             && self.user_input.is_empty()
             && !self.paste_pending
             && !self.model_picker_open
+            && !self.config_picker_open
             && !self.agent_picker_open
     }
 

--- a/tools/wta/src/app_contracts/config.rs
+++ b/tools/wta/src/app_contracts/config.rs
@@ -1,0 +1,30 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpSessionConfigValue {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpSessionConfigOption {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub category: Option<String>,
+    pub current_value: String,
+    pub values: Vec<AcpSessionConfigValue>,
+}
+
+impl AcpSessionConfigOption {
+    pub fn is_model(&self) -> bool {
+        self.category.as_deref() == Some("model") || self.id == "model"
+    }
+
+    pub fn current_value_name(&self) -> &str {
+        self.values
+            .iter()
+            .find(|value| value.id == self.current_value)
+            .map(|value| value.name.as_str())
+            .unwrap_or(&self.current_value)
+    }
+}

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -52,6 +52,8 @@ pub enum AppEvent {
     SessionConfigSetCompleted {
         session_id: String,
         config_id: String,
+        value: String,
+        model_compat: bool,
     },
     SessionConfigSetFailed {
         session_id: String,

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -1,6 +1,9 @@
 use crossterm::event::{KeyEvent, MouseEvent};
 
-use super::{AcpModelInfo, AvailableAgent, DebugMessage, PermOption, PlanEntry, PreflightResult};
+use super::{
+    AcpModelInfo, AcpSessionConfigOption, AvailableAgent, DebugMessage, PermOption, PlanEntry,
+    PreflightResult,
+};
 
 pub enum AppEvent {
     Key(KeyEvent),
@@ -41,6 +44,19 @@ pub enum AppEvent {
         session_id: String,
         available_models: Vec<AcpModelInfo>,
         current_model_id: Option<String>,
+    },
+    SessionConfigUpdated {
+        session_id: String,
+        options: Vec<AcpSessionConfigOption>,
+    },
+    SessionConfigSetCompleted {
+        session_id: String,
+        config_id: String,
+    },
+    SessionConfigSetFailed {
+        session_id: String,
+        config_id: String,
+        message: String,
     },
     TabError {
         tab_id: String,

--- a/tools/wta/src/app_contracts/mod.rs
+++ b/tools/wta/src/app_contracts/mod.rs
@@ -4,6 +4,7 @@
 //! boundaries. Mutable UI state remains owned by `app`.
 
 mod agent;
+mod config;
 mod diagnostics;
 mod event;
 mod model;
@@ -12,6 +13,7 @@ mod plan;
 mod preflight;
 
 pub use agent::AvailableAgent;
+pub use config::{AcpSessionConfigOption, AcpSessionConfigValue};
 pub use diagnostics::{DebugDir, DebugMessage};
 pub use event::AppEvent;
 pub use model::AcpModelInfo;

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -262,6 +262,7 @@ impl App {
                 for replaced_session_id in replaced_session_ids {
                     self.session_to_tab.remove(&replaced_session_id);
                     self.session_model_configs.remove(&replaced_session_id);
+                    self.session_config_options.remove(&replaced_session_id);
                 }
                 self.session_to_tab
                     .insert(session_id.clone(), tab_id.clone());
@@ -354,6 +355,95 @@ impl App {
                     self.rebuild_model_catalog_from_agent_state();
                     self.publish_agent_status();
                 }
+            }
+            AppEvent::SessionConfigUpdated {
+                session_id,
+                options,
+            } => {
+                self.session_config_options
+                    .insert(session_id.clone(), options);
+                let target_tab = self
+                    .session_to_tab
+                    .get(&session_id)
+                    .cloned()
+                    .or_else(|| {
+                        (self.current_tab().session_id.as_deref() == Some(session_id.as_str()))
+                            .then(|| self.active_tab_key().to_string())
+                    });
+                let Some(target_tab) = target_tab else {
+                    return;
+                };
+                let option_count = self
+                    .session_config_options
+                    .get(&session_id)
+                    .map(Vec::len)
+                    .unwrap_or(0);
+                let selected_option_id = self
+                    .tab_sessions
+                    .get(&target_tab)
+                    .and_then(|tab| tab.config_picker_value_option_id.clone());
+                let selected_option_exists = selected_option_id.as_deref().is_some_and(|id| {
+                    self.session_config_options
+                        .get(&session_id)
+                        .is_some_and(|options| options.iter().any(|option| option.id == id))
+                });
+                let row_count = selected_option_id
+                    .as_deref()
+                    .and_then(|id| {
+                        self.session_config_options
+                            .get(&session_id)
+                            .and_then(|options| options.iter().find(|option| option.id == id))
+                    })
+                    .map(|option| option.values.len())
+                    .unwrap_or(option_count);
+                let tab = self.tab_mut(&target_tab);
+                if option_count == 0 {
+                    tab.config_picker_open = false;
+                    tab.config_picker_selected = 0;
+                    tab.config_picker_value_option_id = None;
+                } else if !selected_option_exists && selected_option_id.is_some() {
+                    tab.config_picker_value_option_id = None;
+                    tab.config_picker_selected = 0;
+                } else {
+                    tab.config_picker_selected =
+                        tab.config_picker_selected.min(row_count.saturating_sub(1));
+                }
+            }
+            AppEvent::SessionConfigSetCompleted {
+                session_id,
+                config_id,
+            } => {
+                let target_tab = self.tab_for_session(&session_id);
+                let tab = self.tab_mut(&target_tab);
+                if tab.config_pending_id.as_deref() == Some(config_id.as_str()) {
+                    tab.config_pending_id = None;
+                }
+            }
+            AppEvent::SessionConfigSetFailed {
+                session_id,
+                config_id,
+                message,
+            } => {
+                let option_name = self
+                    .session_config_options
+                    .get(&session_id)
+                    .and_then(|options| options.iter().find(|option| option.id == config_id))
+                    .map(|option| option.name.clone())
+                    .unwrap_or(config_id.clone());
+                let target_tab = self.tab_for_session(&session_id);
+                let tab = self.tab_mut(&target_tab);
+                if tab.config_pending_id.as_deref() == Some(config_id.as_str()) {
+                    tab.config_pending_id = None;
+                }
+                tab.messages.push(ChatMessage::error(
+                    t!(
+                        "system.config_update_failed",
+                        option = option_name.as_str(),
+                        error = message.as_str()
+                    )
+                    .into_owned(),
+                ));
+                tab.scroll_to_bottom();
             }
             AppEvent::TabError { tab_id, message } => {
                 // Scoped error for a specific tab. Bypasses the global

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -385,15 +385,18 @@ impl App {
                 value,
                 model_compat,
             } => {
-                let value_name = self
+                let (option_name, value_name) = self
                     .session_config_options
                     .get_mut(&session_id)
                     .and_then(|options| options.iter_mut().find(|option| option.id == config_id))
                     .map(|option| {
                         option.current_value = value.clone();
-                        option.current_value_name().to_string()
+                        (
+                            option.name.clone(),
+                            option.current_value_name().to_string(),
+                        )
                     })
-                    .unwrap_or_else(|| value.clone());
+                    .unwrap_or_else(|| (config_id.clone(), value.clone()));
                 let target_tab = self.bound_tab_for_session(&session_id);
                 let Some(target_tab) = target_tab else {
                     return;
@@ -403,13 +406,14 @@ impl App {
                     if tab.config_pending_id.as_deref() == Some(config_id.as_str()) {
                         tab.config_pending_id = None;
                     }
-                    if model_compat {
+                    let message = if model_compat {
                         tab.model_override = Some(value.clone());
-                        tab.messages.push(ChatMessage::success(
-                            t!("system.model_set", model = value_name.as_str()).into_owned(),
-                        ));
-                        tab.scroll_to_bottom();
-                    }
+                        t!("system.model_set", model = value_name.as_str()).into_owned()
+                    } else {
+                        format!("{option_name}: {value_name}")
+                    };
+                    tab.messages.push(ChatMessage::success(message));
+                    tab.scroll_to_bottom();
                 }
                 if model_compat {
                     if let Some((_, current_model_id)) =

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -401,9 +401,11 @@ impl App {
                     tab.config_picker_open = false;
                     tab.config_picker_selected = 0;
                     tab.config_picker_value_option_id = None;
+                    tab.config_picker_returns_to_options = false;
                 } else if !selected_option_exists && selected_option_id.is_some() {
                     tab.config_picker_value_option_id = None;
                     tab.config_picker_selected = 0;
+                    tab.config_picker_returns_to_options = false;
                 } else {
                     tab.config_picker_selected =
                         tab.config_picker_selected.min(row_count.saturating_sub(1));

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -362,63 +362,66 @@ impl App {
             } => {
                 self.session_config_options
                     .insert(session_id.clone(), options);
-                let target_tab = self
-                    .session_to_tab
-                    .get(&session_id)
-                    .cloned()
-                    .or_else(|| {
-                        (self.current_tab().session_id.as_deref() == Some(session_id.as_str()))
-                            .then(|| self.active_tab_key().to_string())
-                    });
+                let target_tab = self.bound_tab_for_session(&session_id);
                 let Some(target_tab) = target_tab else {
                     return;
                 };
-                let option_count = self
+                let options = self
                     .session_config_options
                     .get(&session_id)
-                    .map(Vec::len)
-                    .unwrap_or(0);
-                let selected_option_id = self
+                    .map(Vec::as_slice)
+                    .unwrap_or_default();
+                let mut picker = self
                     .tab_sessions
                     .get(&target_tab)
-                    .and_then(|tab| tab.config_picker_value_option_id.clone());
-                let selected_option_exists = selected_option_id.as_deref().is_some_and(|id| {
-                    self.session_config_options
-                        .get(&session_id)
-                        .is_some_and(|options| options.iter().any(|option| option.id == id))
-                });
-                let row_count = selected_option_id
-                    .as_deref()
-                    .and_then(|id| {
-                        self.session_config_options
-                            .get(&session_id)
-                            .and_then(|options| options.iter().find(|option| option.id == id))
-                    })
-                    .map(|option| option.values.len())
-                    .unwrap_or(option_count);
-                let tab = self.tab_mut(&target_tab);
-                if option_count == 0 {
-                    tab.config_picker_open = false;
-                    tab.config_picker_selected = 0;
-                    tab.config_picker_value_option_id = None;
-                    tab.config_picker_returns_to_options = false;
-                } else if !selected_option_exists && selected_option_id.is_some() {
-                    tab.config_picker_value_option_id = None;
-                    tab.config_picker_selected = 0;
-                    tab.config_picker_returns_to_options = false;
-                } else {
-                    tab.config_picker_selected =
-                        tab.config_picker_selected.min(row_count.saturating_sub(1));
-                }
+                    .map(|tab| tab.config_picker.clone())
+                    .unwrap_or_default();
+                picker.reconcile(options);
+                self.tab_mut(&target_tab).config_picker = picker;
             }
             AppEvent::SessionConfigSetCompleted {
                 session_id,
                 config_id,
+                value,
+                model_compat,
             } => {
-                let target_tab = self.tab_for_session(&session_id);
-                let tab = self.tab_mut(&target_tab);
-                if tab.config_pending_id.as_deref() == Some(config_id.as_str()) {
-                    tab.config_pending_id = None;
+                let value_name = self
+                    .session_config_options
+                    .get_mut(&session_id)
+                    .and_then(|options| options.iter_mut().find(|option| option.id == config_id))
+                    .map(|option| {
+                        option.current_value = value.clone();
+                        option.current_value_name().to_string()
+                    })
+                    .unwrap_or_else(|| value.clone());
+                let target_tab = self.bound_tab_for_session(&session_id);
+                let Some(target_tab) = target_tab else {
+                    return;
+                };
+                {
+                    let tab = self.tab_mut(&target_tab);
+                    if tab.config_pending_id.as_deref() == Some(config_id.as_str()) {
+                        tab.config_pending_id = None;
+                    }
+                    if model_compat {
+                        tab.model_override = Some(value.clone());
+                        tab.messages.push(ChatMessage::success(
+                            t!("system.model_set", model = value_name.as_str()).into_owned(),
+                        ));
+                        tab.scroll_to_bottom();
+                    }
+                }
+                if model_compat {
+                    if let Some((_, current_model_id)) =
+                        self.session_model_configs.get_mut(&session_id)
+                    {
+                        *current_model_id = Some(value.clone());
+                    }
+                    if self.current_tab().session_id.as_deref() == Some(session_id.as_str()) {
+                        self.agent_current_model_id = Some(value);
+                        self.rebuild_model_catalog_from_agent_state();
+                        self.publish_agent_status();
+                    }
                 }
             }
             AppEvent::SessionConfigSetFailed {
@@ -432,7 +435,10 @@ impl App {
                     .and_then(|options| options.iter().find(|option| option.id == config_id))
                     .map(|option| option.name.clone())
                     .unwrap_or(config_id.clone());
-                let target_tab = self.tab_for_session(&session_id);
+                let target_tab = self.bound_tab_for_session(&session_id);
+                let Some(target_tab) = target_tab else {
+                    return;
+                };
                 let tab = self.tab_mut(&target_tab);
                 if tab.config_pending_id.as_deref() == Some(config_id.as_str()) {
                     tab.config_pending_id = None;

--- a/tools/wta/src/app_keys.rs
+++ b/tools/wta/src/app_keys.rs
@@ -519,6 +519,17 @@ impl App {
             return;
         }
 
+        if self.config_picker_visible() {
+            match key.code {
+                KeyCode::Up => self.config_picker_up(),
+                KeyCode::Down => self.config_picker_down(),
+                KeyCode::Enter => self.config_picker_enter(),
+                KeyCode::Esc => self.config_picker_escape(),
+                _ => {}
+            }
+            return;
+        }
+
         if self.current_tab().paste_pending {
             tracing::debug!(target: "agent_paste", "ignoring key while paste is pending");
             return;

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -6419,7 +6419,7 @@ fn render_config_picker_lists_options_and_current_values() {
             }],
         }],
     });
-    app.current_tab_mut().config_picker_open = true;
+    app.current_tab_mut().config_picker = ConfigPickerState::Options { selected: 0 };
 
     let text = render_to_text(&mut app, 120, 24);
     assert!(text.contains("ReasoningXYZ"), "rendered:\n{text}");

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -815,7 +815,7 @@ fn helper_agent_event_with_real_agent_session_id_still_publishes_to_master() {
     );
 }
 
-fn test_app_with_master_rx() -> (
+pub(super) fn test_app_with_master_rx() -> (
     App,
     tokio::sync::mpsc::UnboundedReceiver<crate::protocol::acp::client::MasterExtRequest>,
 ) {
@@ -6397,6 +6397,33 @@ fn render_model_picker_lists_models() {
         !text.contains('●'),
         "the model picker must not prefix the current model with a circle; rendered:\n{text}"
     );
+}
+
+#[test]
+fn render_config_picker_lists_options_and_current_values() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().session_id = Some("session-config".into());
+    app.handle_event(AppEvent::SessionConfigUpdated {
+        session_id: "session-config".into(),
+        options: vec![crate::app_contracts::AcpSessionConfigOption {
+            id: "reasoning".into(),
+            name: "ReasoningXYZ".into(),
+            description: Some("Controls depth".into()),
+            category: Some("thought_level".into()),
+            current_value: "high".into(),
+            values: vec![crate::app_contracts::AcpSessionConfigValue {
+                id: "high".into(),
+                name: "HighXYZ".into(),
+                description: Some("Think longer".into()),
+            }],
+        }],
+    });
+    app.current_tab_mut().config_picker_open = true;
+
+    let text = render_to_text(&mut app, 120, 24);
+    assert!(text.contains("ReasoningXYZ"), "rendered:\n{text}");
+    assert!(text.contains("HighXYZ"), "rendered:\n{text}");
 }
 
 #[test]

--- a/tools/wta/src/commands.rs
+++ b/tools/wta/src/commands.rs
@@ -51,6 +51,8 @@ pub enum CommandKind {
     /// models. Cloud/native models are intentionally omitted; model changes
     /// are made through Settings because they require an agent restart.
     Model,
+    /// Configure the current ACP session using Agent-provided config options.
+    Config,
     /// Move this tab's agent pane without changing the global pane-position
     /// setting or any other tab.
     Move,
@@ -124,6 +126,11 @@ pub const REGISTRY: &[CommandSpec] = &[
         summary_key: "commands.model.summary",
         // `/model <id>` switches directly; bare `/model` opens the picker.
         kind: CommandKind::Model,
+    },
+    CommandSpec {
+        name: "config",
+        summary_key: "commands.config.summary",
+        kind: CommandKind::Config,
     },
     CommandSpec {
         name: "move",

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1505,18 +1505,18 @@ impl WtaClient {
                 });
             }
             acp::schema::v1::SessionUpdate::ConfigOptionUpdate(update) => {
-                let _ = self.state.event_tx.send(AppEvent::SessionConfigUpdated {
-                    session_id: sid.clone(),
-                    options: crate::protocol::acp::session_config::select_options(
-                        &update.config_options,
-                    ),
-                });
                 let (available_models, current_model_id) =
                     crate::protocol::acp::model_select::models_from_config_options(
                         &sid,
                         &update.config_options,
                     )
                     .unwrap_or_default();
+                let _ = self.state.event_tx.send(AppEvent::SessionConfigUpdated {
+                    session_id: sid.clone(),
+                    options: crate::protocol::acp::session_config::select_options(
+                        &update.config_options,
+                    ),
+                });
                 let _ = self.state.event_tx.send(AppEvent::ModelConfigUpdated {
                     session_id: sid,
                     available_models,
@@ -2864,7 +2864,7 @@ pub async fn run_acp_client_over_pipe(
             .map(std::path::PathBuf::from)
             .unwrap_or_else(|| std::path::PathBuf::from("/")),
     };
-    let (session_id, available_models, current_model_id, session_config, has_bootstrap) =
+    let (session_id, mut available_models, mut current_model_id, mut session_config, has_bootstrap) =
         if let Some(load_sid) = initial_load_session_id.as_deref()
         {
             // No bootstrap. AgentConnected fires with the to-be-loaded
@@ -3000,10 +3000,22 @@ pub async fn run_acp_client_over_pipe(
             )
             .await;
             match model_result {
-                Ok(()) => startup_probe.log(&format!(
-                    "ACP session model set to {} (over pipe)",
-                    requested_model
-                )),
+                Ok(config_options) => {
+                    if let Some(config_options) = config_options {
+                        (available_models, current_model_id) =
+                            crate::protocol::acp::model_select::models_from_config_options(
+                                session_id.0.as_ref(),
+                                &config_options,
+                            )
+                            .unwrap_or_default();
+                        session_config =
+                            crate::protocol::acp::session_config::select_options(&config_options);
+                    }
+                    startup_probe.log(&format!(
+                        "ACP session model set to {} (over pipe)",
+                        requested_model
+                    ));
+                }
                 Err(error) if is_redundant_startup_model_error(&prompt_usage_identity, &error) => {
                     tracing::warn!(
                         target: "helper",
@@ -3395,12 +3407,32 @@ fn dispatch_master_ext_request(
                     )
                     .await
                     {
-                        Ok(_) => tracing::info!(
-                            target: "acp",
-                            session_id = %sid.0,
-                            model = %model,
-                            "acp-model hot-applied to live session"
-                        ),
+                        Ok(config_options) => {
+                            if let Some(config_options) = config_options {
+                                let (available_models, current_model_id) =
+                                    crate::protocol::acp::model_select::models_from_config_options(
+                                        sid.0.as_ref(),
+                                        &config_options,
+                                    )
+                                    .unwrap_or_default();
+                                publish_session_config_options(
+                                    &event_tx,
+                                    &sid,
+                                    Some(&config_options),
+                                );
+                                let _ = event_tx.send(AppEvent::ModelConfigUpdated {
+                                    session_id: sid.to_string(),
+                                    available_models,
+                                    current_model_id,
+                                });
+                            }
+                            tracing::info!(
+                                target: "acp",
+                                session_id = %sid.0,
+                                model = %model,
+                                "acp-model hot-applied to live session"
+                            );
+                        }
                         Err(err) => tracing::warn!(
                             target: "acp",
                             session_id = %sid.0,
@@ -3429,32 +3461,52 @@ fn dispatch_master_ext_request(
                     return;
                 }
 
-                let request = acp::schema::v1::SetSessionConfigOptionRequest::new(
-                    session_id.clone(),
-                    config_id.clone(),
-                    value.as_str(),
+                let model_compat = crate::protocol::acp::model_select::is_model_config(
+                    session_id.0.as_ref(),
+                    &config_id,
                 );
-                match conn.set_session_config_option(request).await {
-                    Ok(response) => {
-                        let (available_models, current_model_id) =
-                            crate::protocol::acp::model_select::models_from_config_options(
-                                session_id.0.as_ref(),
-                                &response.config_options,
-                            )
-                            .unwrap_or_default();
-                        publish_session_config_options(
-                            &event_tx,
-                            &session_id,
-                            Some(&response.config_options),
-                        );
-                        let _ = event_tx.send(AppEvent::ModelConfigUpdated {
-                            session_id: session_id.to_string(),
-                            available_models,
-                            current_model_id,
-                        });
+                let result = if model_compat {
+                    crate::protocol::acp::model_select::apply_session_model(
+                        &conn,
+                        session_id.clone(),
+                        value.clone(),
+                    )
+                    .await
+                } else {
+                    let request = acp::schema::v1::SetSessionConfigOptionRequest::new(
+                        session_id.clone(),
+                        config_id.clone(),
+                        value.as_str(),
+                    );
+                    conn.set_session_config_option(request)
+                        .await
+                        .map(|response| Some(response.config_options))
+                };
+                match result {
+                    Ok(config_options) => {
+                        if let Some(config_options) = config_options {
+                            let (available_models, current_model_id) =
+                                crate::protocol::acp::model_select::models_from_config_options(
+                                    session_id.0.as_ref(),
+                                    &config_options,
+                                )
+                                .unwrap_or_default();
+                            publish_session_config_options(
+                                &event_tx,
+                                &session_id,
+                                Some(&config_options),
+                            );
+                            let _ = event_tx.send(AppEvent::ModelConfigUpdated {
+                                session_id: session_id.to_string(),
+                                available_models,
+                                current_model_id,
+                            });
+                        }
                         let _ = event_tx.send(AppEvent::SessionConfigSetCompleted {
                             session_id: session_id.to_string(),
                             config_id,
+                            value,
+                            model_compat,
                         });
                     }
                     Err(error) => {

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -172,6 +172,25 @@ pub enum MasterExtRequest {
         session_id: Option<acp::schema::v1::SessionId>,
         model: String,
     },
+    SetSessionConfigOption {
+        session_id: acp::schema::v1::SessionId,
+        config_id: String,
+        value: String,
+    },
+}
+
+fn publish_session_config_options(
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+    session_id: &acp::schema::v1::SessionId,
+    options: Option<&[acp::schema::v1::SessionConfigOption]>,
+) {
+    let options = options
+        .map(crate::protocol::acp::session_config::select_options)
+        .unwrap_or_default();
+    let _ = event_tx.send(AppEvent::SessionConfigUpdated {
+        session_id: session_id.to_string(),
+        options,
+    });
 }
 
 /// User-initiated request to resume a historical agent session by calling
@@ -1486,6 +1505,12 @@ impl WtaClient {
                 });
             }
             acp::schema::v1::SessionUpdate::ConfigOptionUpdate(update) => {
+                let _ = self.state.event_tx.send(AppEvent::SessionConfigUpdated {
+                    session_id: sid.clone(),
+                    options: crate::protocol::acp::session_config::select_options(
+                        &update.config_options,
+                    ),
+                });
                 let (available_models, current_model_id) =
                     crate::protocol::acp::model_select::models_from_config_options(
                         &sid,
@@ -2266,6 +2291,7 @@ async fn handle_load_failure(
                 available_models,
                 current_model_id,
             });
+            publish_session_config_options(&event_tx, &new_sid, resp.config_options.as_deref());
         }
         Err(e) => {
             tracing::error!(
@@ -2838,9 +2864,9 @@ pub async fn run_acp_client_over_pipe(
             .map(std::path::PathBuf::from)
             .unwrap_or_else(|| std::path::PathBuf::from("/")),
     };
-    let (session_id, available_models, current_model_id, has_bootstrap) = if let Some(load_sid) =
-        initial_load_session_id.as_deref()
-    {
+    let (session_id, available_models, current_model_id, session_config, has_bootstrap) =
+        if let Some(load_sid) = initial_load_session_id.as_deref()
+        {
             // No bootstrap. AgentConnected fires with the to-be-loaded
             // sid as a placeholder so the App flips to Connected (and
             // binds session_id → owner_tab in `session_to_tab` early,
@@ -2862,6 +2888,7 @@ pub async fn run_acp_client_over_pipe(
                 acp::schema::v1::SessionId::new(load_sid.to_string()),
                 Vec::<AcpModelInfo>::new(),
                 None,
+                Vec::new(),
                 false,
             )
         } else {
@@ -2938,7 +2965,18 @@ pub async fn run_acp_client_over_pipe(
 
             let (available_models, current_model_id) =
                 crate::protocol::acp::model_select::models_from_new_session(&session);
-            (session_id, available_models, current_model_id, true)
+            let session_config = session
+                .config_options
+                .as_deref()
+                .map(crate::protocol::acp::session_config::select_options)
+                .unwrap_or_default();
+            (
+                session_id,
+                available_models,
+                current_model_id,
+                session_config,
+                true,
+            )
         };
 
     // Apply --acp-model if requested. Only valid when we actually have
@@ -3016,6 +3054,10 @@ pub async fn run_acp_client_over_pipe(
         current_model_id,
         load_session_supported,
         image_supported,
+    });
+    let _ = event_tx.send(AppEvent::SessionConfigUpdated {
+        session_id: session_id.to_string(),
+        options: session_config,
     });
     // Per-tab session cache. Only
     // prepopulate the owner-tab binding when we actually have a
@@ -3369,6 +3411,69 @@ fn dispatch_master_ext_request(
                     }
                 }
             }
+            MasterExtRequest::SetSessionConfigOption {
+                session_id,
+                config_id,
+                value,
+            } => {
+                let is_live = {
+                    let sessions = tab_to_session.lock().await;
+                    sessions.values().any(|known| known == &session_id)
+                };
+                if !is_live {
+                    let _ = event_tx.send(AppEvent::SessionConfigSetFailed {
+                        session_id: session_id.to_string(),
+                        config_id,
+                        message: "the session is no longer active".to_string(),
+                    });
+                    return;
+                }
+
+                let request = acp::schema::v1::SetSessionConfigOptionRequest::new(
+                    session_id.clone(),
+                    config_id.clone(),
+                    value.as_str(),
+                );
+                match conn.set_session_config_option(request).await {
+                    Ok(response) => {
+                        let (available_models, current_model_id) =
+                            crate::protocol::acp::model_select::models_from_config_options(
+                                session_id.0.as_ref(),
+                                &response.config_options,
+                            )
+                            .unwrap_or_default();
+                        publish_session_config_options(
+                            &event_tx,
+                            &session_id,
+                            Some(&response.config_options),
+                        );
+                        let _ = event_tx.send(AppEvent::ModelConfigUpdated {
+                            session_id: session_id.to_string(),
+                            available_models,
+                            current_model_id,
+                        });
+                        let _ = event_tx.send(AppEvent::SessionConfigSetCompleted {
+                            session_id: session_id.to_string(),
+                            config_id,
+                        });
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            target: "acp",
+                            session_id = %session_id,
+                            config_id,
+                            value,
+                            error = ?error,
+                            "session config update failed"
+                        );
+                        let _ = event_tx.send(AppEvent::SessionConfigSetFailed {
+                            session_id: session_id.to_string(),
+                            config_id,
+                            message: error.to_string(),
+                        });
+                    }
+                }
+            }
         }
     });
 }
@@ -3500,6 +3605,11 @@ fn dispatch_load_session(
                     available_models,
                     current_model_id,
                 });
+                publish_session_config_options(
+                    &event_tx,
+                    &session_id,
+                    resp.config_options.as_deref(),
+                );
             }
             Ok(Err(e)) => {
                 tracing::warn!(
@@ -3710,7 +3820,6 @@ fn dispatch_new_session(
         }
         let (available_models, current_model_id) =
             crate::protocol::acp::model_select::models_from_new_session(&new_session);
-
         {
             let mut g = tab_to_session.lock().await;
             g.insert(req.tab_id.clone(), new_sid.clone());
@@ -3722,6 +3831,7 @@ fn dispatch_new_session(
             available_models,
             current_model_id,
         });
+        publish_session_config_options(&event_tx, &new_sid, new_session.config_options.as_deref());
     });
 }
 
@@ -3998,6 +4108,11 @@ async fn dispatch_prompt_body(
                 available_models,
                 current_model_id,
             });
+            publish_session_config_options(
+                &event_tx_task,
+                &new_sid,
+                new_session.config_options.as_deref(),
+            );
             g.insert(tab_key_task.clone(), new_sid.clone());
             new_sid
         }

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -1901,6 +1901,18 @@ async fn session_notification_routes_model_config_update() {
         .unwrap();
 
     match rx.try_recv() {
+        Ok(AppEvent::SessionConfigUpdated {
+            session_id,
+            options,
+        }) => {
+            assert_eq!(session_id, "s1");
+            assert_eq!(options.len(), 1);
+            assert_eq!(options[0].id, "model");
+            assert_eq!(options[0].current_value, "gpt-5.6-sol");
+        }
+        _ => panic!("expected SessionConfigUpdated"),
+    }
+    match rx.try_recv() {
         Ok(AppEvent::ModelConfigUpdated {
             session_id,
             available_models,
@@ -2031,6 +2043,17 @@ async fn session_notification_clears_removed_model_config() {
         .await
         .unwrap();
 
+    match rx.try_recv() {
+        Ok(AppEvent::SessionConfigUpdated {
+            session_id,
+            options,
+        }) => {
+            assert_eq!(session_id, "s1");
+            assert_eq!(options.len(), 1);
+            assert_eq!(options[0].id, "mode");
+        }
+        _ => panic!("expected SessionConfigUpdated"),
+    }
     match rx.try_recv() {
         Ok(AppEvent::ModelConfigUpdated {
             session_id,

--- a/tools/wta/src/protocol/acp/mod.rs
+++ b/tools/wta/src/protocol/acp/mod.rs
@@ -6,6 +6,7 @@ pub mod probe;
 pub mod prompt;
 pub(crate) mod prompt_builder;
 pub(crate) mod prompt_context;
+pub(crate) mod session_config;
 pub(crate) mod session_list;
 pub mod soft_stop;
 pub(crate) mod spawn;

--- a/tools/wta/src/protocol/acp/model_select.rs
+++ b/tools/wta/src/protocol/acp/model_select.rs
@@ -122,7 +122,7 @@ enum ModelSwitchChannel {
     /// Legacy `session/set_model`.
     Legacy,
     /// Legacy after the agent rejected `session/set_config_option`.
-    LegacyFallback,
+    LegacyFallback { config_id: String },
     /// `session/set_config_option` carrying this config id (e.g. `"model"`).
     Config { config_id: String },
 }
@@ -145,7 +145,7 @@ fn record_loaded_channel_config(session_id: &str, config_id: &str) {
     let mut channels = MODEL_SWITCHES.write().unwrap();
     if !matches!(
         channels.get(session_id),
-        Some(ModelSwitchChannel::LegacyFallback)
+        Some(ModelSwitchChannel::LegacyFallback { .. })
     ) {
         channels.insert(
             session_id.to_string(),
@@ -154,6 +154,17 @@ fn record_loaded_channel_config(session_id: &str, config_id: &str) {
             },
         );
     }
+}
+
+pub(crate) fn is_model_config(session_id: &str, config_id: &str) -> bool {
+    matches!(
+        MODEL_SWITCHES.read().unwrap().get(session_id),
+        Some(ModelSwitchChannel::Config {
+            config_id: known_id
+        }) | Some(ModelSwitchChannel::LegacyFallback {
+            config_id: known_id
+        }) if known_id == config_id
+    )
 }
 
 pub(crate) fn forget_session(session_id: &str) {
@@ -188,7 +199,7 @@ pub(crate) fn models_from_load_session(
 ) -> (Vec<AcpModelInfo>, Option<String>) {
     let had_confirmed_fallback = matches!(
         MODEL_SWITCHES.read().unwrap().get(session_id),
-        Some(ModelSwitchChannel::LegacyFallback)
+        Some(ModelSwitchChannel::LegacyFallback { .. })
     );
     if !had_confirmed_fallback {
         forget_session(session_id);
@@ -280,7 +291,7 @@ pub(crate) async fn apply_session_model(
     conn: &crate::protocol::acp::conn::ClientLink,
     session_id: acp::schema::v1::SessionId,
     model_id: String,
-) -> acp::Result<()> {
+) -> acp::Result<Option<Vec<acp::schema::v1::SessionConfigOption>>> {
     // Snapshot under the read lock and release it before the await — the lock
     // guard isn't Send and must not be held across the suspension point.
     let session_key = session_id.to_string();
@@ -295,24 +306,28 @@ pub(crate) async fn apply_session_model(
             match conn
                 .set_session_config_option(acp::schema::v1::SetSessionConfigOptionRequest::new(
                     session_id.clone(),
-                    config_id,
+                    config_id.clone(),
                     model_id.as_str(),
                 ))
                 .await
             {
-                Ok(_) => Ok(()),
+                Ok(response) => Ok(Some(response.config_options)),
                 Err(e) if e.code == acp::ErrorCode::MethodNotFound => {
                     MODEL_SWITCHES
                         .write()
                         .unwrap()
-                        .insert(session_key, ModelSwitchChannel::LegacyFallback);
-                    apply_legacy_set_model(conn, session_id, model_id).await
+                        .insert(session_key, ModelSwitchChannel::LegacyFallback { config_id });
+                    apply_legacy_set_model(conn, session_id, model_id)
+                        .await
+                        .map(|()| None)
                 }
                 Err(e) => Err(e),
             }
         }
-        ModelSwitchChannel::Legacy | ModelSwitchChannel::LegacyFallback => {
-            apply_legacy_set_model(conn, session_id, model_id).await
+        ModelSwitchChannel::Legacy | ModelSwitchChannel::LegacyFallback { .. } => {
+            apply_legacy_set_model(conn, session_id, model_id)
+                .await
+                .map(|()| None)
         }
     }
 }
@@ -618,7 +633,9 @@ mod tests {
             );
             assert_eq!(
                 channel_for("s-fallback"),
-                ModelSwitchChannel::LegacyFallback,
+                ModelSwitchChannel::LegacyFallback {
+                    config_id: "model".into()
+                },
                 "MethodNotFound on set_config_option must flip the channel to Legacy"
             );
 
@@ -637,7 +654,9 @@ mod tests {
             let _ = models_from_load_session("s-fallback", &loaded);
             assert_eq!(
                 channel_for("s-fallback"),
-                ModelSwitchChannel::LegacyFallback,
+                ModelSwitchChannel::LegacyFallback {
+                    config_id: "model".into()
+                },
                 "loading a session must preserve a confirmed Legacy fallback"
             );
         });

--- a/tools/wta/src/protocol/acp/session_config.rs
+++ b/tools/wta/src/protocol/acp/session_config.rs
@@ -1,0 +1,112 @@
+use agent_client_protocol as acp;
+
+use crate::app_contracts::{AcpSessionConfigOption, AcpSessionConfigValue};
+
+pub(crate) fn select_options(
+    options: &[acp::schema::v1::SessionConfigOption],
+) -> Vec<AcpSessionConfigOption> {
+    options.iter().filter_map(select_option).collect()
+}
+
+fn select_option(option: &acp::schema::v1::SessionConfigOption) -> Option<AcpSessionConfigOption> {
+    let acp::schema::v1::SessionConfigKind::Select(select) = &option.kind else {
+        return None;
+    };
+
+    let values = match &select.options {
+        acp::schema::v1::SessionConfigSelectOptions::Ungrouped(values) => {
+            values.iter().map(normalize_value).collect()
+        }
+        acp::schema::v1::SessionConfigSelectOptions::Grouped(groups) => groups
+            .iter()
+            .flat_map(|group| group.options.iter().map(normalize_value))
+            .collect(),
+        _ => return None,
+    };
+
+    Some(AcpSessionConfigOption {
+        id: option.id.0.to_string(),
+        name: option.name.clone(),
+        description: option.description.clone(),
+        category: option
+            .category
+            .as_ref()
+            .and_then(|category| serde_json::to_value(category).ok())
+            .and_then(|category| category.as_str().map(str::to_owned)),
+        current_value: select.current_value.0.to_string(),
+        values,
+    })
+}
+
+fn normalize_value(value: &acp::schema::v1::SessionConfigSelectOption) -> AcpSessionConfigValue {
+    AcpSessionConfigValue {
+        id: value.value.0.to_string(),
+        name: value.name.clone(),
+        description: value.description.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_order_categories_and_current_values() {
+        let response: acp::schema::v1::NewSessionResponse =
+            serde_json::from_value(serde_json::json!({
+                "sessionId": "session-1",
+                "configOptions": [
+                    {
+                        "id": "mode",
+                        "name": "Mode",
+                        "description": "Controls agent behavior",
+                        "category": "mode",
+                        "type": "select",
+                        "currentValue": "code",
+                        "options": [
+                            {"value": "ask", "name": "Ask"},
+                            {"value": "code", "name": "Code", "description": "Write code"}
+                        ]
+                    },
+                    {
+                        "id": "reasoning",
+                        "name": "Reasoning",
+                        "category": "thought_level",
+                        "type": "select",
+                        "currentValue": "high",
+                        "options": [{"value": "high", "name": "High"}]
+                    }
+                ]
+            }))
+            .expect("valid response");
+
+        let options = select_options(response.config_options.as_deref().expect("config options"));
+
+        assert_eq!(options.len(), 2);
+        assert_eq!(options[0].id, "mode");
+        assert_eq!(options[0].category.as_deref(), Some("mode"));
+        assert_eq!(options[0].current_value_name(), "Code");
+        assert_eq!(
+            options[0].values[1].description.as_deref(),
+            Some("Write code")
+        );
+        assert_eq!(options[1].category.as_deref(), Some("thought_level"));
+    }
+
+    #[test]
+    fn ignores_unsupported_option_kinds() {
+        let response: acp::schema::v1::NewSessionResponse =
+            serde_json::from_value(serde_json::json!({
+                "sessionId": "session-1",
+                "configOptions": [{
+                    "id": "enabled",
+                    "name": "Enabled",
+                    "type": "boolean",
+                    "currentValue": true
+                }]
+            }))
+            .expect("valid response");
+
+        assert!(select_options(response.config_options.as_deref().unwrap()).is_empty());
+    }
+}

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -473,6 +473,8 @@ fn config_picker_select_sends_session_scoped_option_request() {
         "code"
     );
     assert!(app.current_tab().config_pending_id.is_none());
+    assert_eq!(last_notice(&app).0, NoticeKind::Success);
+    assert!(last_notice(&app).1.contains("Mode: Code"));
 }
 
 #[test]

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -280,7 +280,7 @@ fn slash_config_without_options_notes_none() {
 
     run_slash(&mut app, "config");
 
-    assert!(!app.current_tab().config_picker_open);
+    assert!(!app.current_tab().config_picker.is_open());
     assert_eq!(last_notice(&app).0, NoticeKind::Info);
 }
 
@@ -316,9 +316,9 @@ fn slash_model_opens_the_standard_model_config_option() {
     run_slash(&mut app, "model");
 
     assert!(!app.current_tab().model_picker_open);
-    assert!(app.current_tab().config_picker_open);
+    assert!(app.current_tab().config_picker.is_open());
     assert_eq!(
-        app.current_tab().config_picker_value_option_id.as_deref(),
+        app.current_tab().config_picker.option_id(),
         Some("agent-model")
     );
 }
@@ -335,7 +335,7 @@ fn escape_from_slash_model_closes_the_config_picker() {
     run_slash(&mut app, "model");
     app.config_picker_escape();
 
-    assert!(!app.current_tab().config_picker_open);
+    assert!(!app.current_tab().config_picker.is_open());
 }
 
 #[test]
@@ -351,8 +351,78 @@ fn escape_from_config_value_picker_returns_to_option_list() {
     app.config_picker_enter();
     app.config_picker_escape();
 
-    assert!(app.current_tab().config_picker_open);
-    assert!(app.current_tab().config_picker_value_option_id.is_none());
+    assert!(app.current_tab().config_picker.is_open());
+    assert!(app.current_tab().config_picker.option_id().is_none());
+}
+
+#[test]
+fn slash_model_selection_uses_the_generic_config_request_lifecycle() {
+    let (mut app, mut master_rx) = super::tests::test_app_with_master_rx();
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionConfigUpdated {
+        session_id: "session-1".into(),
+        options: vec![config_option("agent-model", "Model", "model", "ask")],
+    });
+
+    run_slash(&mut app, "model");
+    app.config_picker_down();
+    app.config_picker_enter();
+
+    match master_rx.try_recv().expect("model config update request") {
+        crate::protocol::acp::client::MasterExtRequest::SetSessionConfigOption {
+            session_id,
+            config_id,
+            value,
+        } => {
+            assert_eq!(session_id.to_string(), "session-1");
+            assert_eq!(config_id, "agent-model");
+            assert_eq!(value, "code");
+        }
+        other => panic!("expected SetSessionConfigOption, got {other:?}"),
+    }
+    assert!(!app.current_tab().config_picker.is_open());
+    assert_eq!(
+        app.current_tab().config_pending_id.as_deref(),
+        Some("agent-model")
+    );
+    assert!(app.current_tab().model_override.is_none());
+
+    app.handle_event(AppEvent::SessionConfigSetCompleted {
+        session_id: "session-1".into(),
+        config_id: "agent-model".into(),
+        value: "code".into(),
+        model_compat: true,
+    });
+
+    assert!(app.current_tab().config_pending_id.is_none());
+    assert_eq!(app.current_tab().model_override.as_deref(), Some("code"));
+    assert!(
+        app.config_popup_state().is_none(),
+        "the /model deep link remains closed after completion"
+    );
+}
+
+#[test]
+fn failed_model_config_selection_keeps_the_previous_model() {
+    let (mut app, _master_rx) = super::tests::test_app_with_master_rx();
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionConfigUpdated {
+        session_id: "session-1".into(),
+        options: vec![config_option("agent-model", "Model", "model", "ask")],
+    });
+
+    run_slash(&mut app, "model");
+    app.config_picker_down();
+    app.config_picker_enter();
+    app.handle_event(AppEvent::SessionConfigSetFailed {
+        session_id: "session-1".into(),
+        config_id: "agent-model".into(),
+        message: "rejected".into(),
+    });
+
+    assert!(app.current_tab().config_pending_id.is_none());
+    assert!(app.current_tab().model_override.is_none());
+    assert_eq!(last_notice(&app).0, NoticeKind::Error);
 }
 
 #[test]
@@ -367,7 +437,7 @@ fn config_picker_select_sends_session_scoped_option_request() {
 
     app.config_picker_enter();
     assert_eq!(
-        app.current_tab().config_picker_value_option_id.as_deref(),
+        app.current_tab().config_picker.option_id(),
         Some("mode")
     );
     app.config_picker_down();
@@ -394,6 +464,8 @@ fn config_picker_select_sends_session_scoped_option_request() {
     app.handle_event(AppEvent::SessionConfigSetCompleted {
         session_id: "session-1".into(),
         config_id: "mode".into(),
+        value: "code".into(),
+        model_compat: false,
     });
 
     assert_eq!(
@@ -418,8 +490,23 @@ fn unbound_background_config_update_does_not_close_current_picker() {
         options: Vec::new(),
     });
 
-    assert!(app.current_tab().config_picker_open);
+    assert!(app.current_tab().config_picker.is_open());
     assert_eq!(app.config_popup_state().unwrap().options[0].id, "mode");
+}
+
+#[test]
+fn unbound_background_config_failure_does_not_pollute_current_tab() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("current-session".into());
+    let message_count = app.current_tab().messages.len();
+
+    app.handle_event(AppEvent::SessionConfigSetFailed {
+        session_id: "closed-session".into(),
+        config_id: "mode".into(),
+        message: "the session is no longer active".into(),
+    });
+
+    assert_eq!(app.current_tab().messages.len(), message_count);
 }
 
 #[test]

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -247,14 +247,154 @@ fn slash_model_without_models_notes_none() {
     assert_eq!(last_notice(&app).0, NoticeKind::Info);
 }
 
+fn config_option(
+    id: &str,
+    name: &str,
+    category: &str,
+    current_value: &str,
+) -> crate::app_contracts::AcpSessionConfigOption {
+    crate::app_contracts::AcpSessionConfigOption {
+        id: id.into(),
+        name: name.into(),
+        description: Some(format!("Configure {name}")),
+        category: Some(category.into()),
+        current_value: current_value.into(),
+        values: vec![
+            crate::app_contracts::AcpSessionConfigValue {
+                id: "ask".into(),
+                name: "Ask".into(),
+                description: None,
+            },
+            crate::app_contracts::AcpSessionConfigValue {
+                id: "code".into(),
+                name: "Code".into(),
+                description: Some("Write code".into()),
+            },
+        ],
+    }
+}
+
+#[test]
+fn slash_config_without_options_notes_none() {
+    let mut app = test_app();
+
+    run_slash(&mut app, "config");
+
+    assert!(!app.current_tab().config_picker_open);
+    assert_eq!(last_notice(&app).0, NoticeKind::Info);
+}
+
+#[test]
+fn slash_config_opens_ordered_session_options() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionConfigUpdated {
+        session_id: "session-1".into(),
+        options: vec![
+            config_option("mode", "Mode", "mode", "ask"),
+            config_option("reasoning", "Reasoning", "thought_level", "code"),
+        ],
+    });
+
+    run_slash(&mut app, "config");
+
+    let state = app.config_popup_state().expect("config picker state");
+    assert_eq!(state.options[0].name, "Mode");
+    assert_eq!(state.options[1].name, "Reasoning");
+    assert!(state.value_option.is_none());
+}
+
+#[test]
+fn slash_model_opens_the_standard_model_config_option() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionConfigUpdated {
+        session_id: "session-1".into(),
+        options: vec![config_option("agent-model", "Model", "model", "ask")],
+    });
+
+    run_slash(&mut app, "model");
+
+    assert!(!app.current_tab().model_picker_open);
+    assert!(app.current_tab().config_picker_open);
+    assert_eq!(
+        app.current_tab().config_picker_value_option_id.as_deref(),
+        Some("agent-model")
+    );
+}
+
+#[test]
+fn config_picker_select_sends_session_scoped_option_request() {
+    let (mut app, mut master_rx) = super::tests::test_app_with_master_rx();
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionConfigUpdated {
+        session_id: "session-1".into(),
+        options: vec![config_option("mode", "Mode", "mode", "ask")],
+    });
+    run_slash(&mut app, "config");
+
+    app.config_picker_enter();
+    assert_eq!(
+        app.current_tab().config_picker_value_option_id.as_deref(),
+        Some("mode")
+    );
+    app.config_picker_down();
+    app.config_picker_enter();
+
+    match master_rx.try_recv().expect("config update request") {
+        crate::protocol::acp::client::MasterExtRequest::SetSessionConfigOption {
+            session_id,
+            config_id,
+            value,
+        } => {
+            assert_eq!(session_id.to_string(), "session-1");
+            assert_eq!(config_id, "mode");
+            assert_eq!(value, "code");
+        }
+        other => panic!("expected SetSessionConfigOption, got {other:?}"),
+    }
+    assert_eq!(app.current_tab().config_pending_id.as_deref(), Some("mode"));
+
+    app.handle_event(AppEvent::SessionConfigUpdated {
+        session_id: "session-1".into(),
+        options: vec![config_option("mode", "Mode", "mode", "code")],
+    });
+    app.handle_event(AppEvent::SessionConfigSetCompleted {
+        session_id: "session-1".into(),
+        config_id: "mode".into(),
+    });
+
+    assert_eq!(
+        app.config_popup_state().unwrap().options[0].current_value,
+        "code"
+    );
+    assert!(app.current_tab().config_pending_id.is_none());
+}
+
+#[test]
+fn unbound_background_config_update_does_not_close_current_picker() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("current-session".into());
+    app.handle_event(AppEvent::SessionConfigUpdated {
+        session_id: "current-session".into(),
+        options: vec![config_option("mode", "Mode", "mode", "ask")],
+    });
+    run_slash(&mut app, "config");
+
+    app.handle_event(AppEvent::SessionConfigUpdated {
+        session_id: "background-session".into(),
+        options: Vec::new(),
+    });
+
+    assert!(app.current_tab().config_picker_open);
+    assert_eq!(app.config_popup_state().unwrap().options[0].id, "mode");
+}
+
 #[test]
 fn slash_model_bare_opens_picker_when_models_present() {
     let mut app = test_app();
     let selected = "custom:provider:local";
-    app.set_custom_model_config(
-        vec![custom_model(selected, "local")],
-        Some(selected.into()),
-    );
+    app.set_custom_model_config(vec![custom_model(selected, "local")], Some(selected.into()));
 
     run_slash(&mut app, "model");
 
@@ -437,10 +577,7 @@ fn private_cloud_catalog_survives_bare_agent_model_response() {
 fn agent_and_model_pickers_are_mutually_exclusive() {
     let mut app = test_app();
     let selected = "custom:provider:local";
-    app.set_custom_model_config(
-        vec![custom_model(selected, "local")],
-        Some(selected.into()),
-    );
+    app.set_custom_model_config(vec![custom_model(selected, "local")], Some(selected.into()));
 
     app.open_model_picker();
     assert!(app.current_tab().model_picker_open);

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -324,6 +324,38 @@ fn slash_model_opens_the_standard_model_config_option() {
 }
 
 #[test]
+fn escape_from_slash_model_closes_the_config_picker() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionConfigUpdated {
+        session_id: "session-1".into(),
+        options: vec![config_option("agent-model", "Model", "model", "ask")],
+    });
+
+    run_slash(&mut app, "model");
+    app.config_picker_escape();
+
+    assert!(!app.current_tab().config_picker_open);
+}
+
+#[test]
+fn escape_from_config_value_picker_returns_to_option_list() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionConfigUpdated {
+        session_id: "session-1".into(),
+        options: vec![config_option("agent-model", "Model", "model", "ask")],
+    });
+
+    run_slash(&mut app, "config");
+    app.config_picker_enter();
+    app.config_picker_escape();
+
+    assert!(app.current_tab().config_picker_open);
+    assert!(app.current_tab().config_picker_value_option_id.is_none());
+}
+
+#[test]
 fn config_picker_select_sends_session_scoped_option_request() {
     let (mut app, mut master_rx) = super::tests::test_app_with_master_rx();
     app.current_tab_mut().session_id = Some("session-1".into());

--- a/tools/wta/src/ui/config_popup.rs
+++ b/tools/wta/src/ui/config_popup.rs
@@ -1,0 +1,84 @@
+//! Session configuration picker driven by ACP `configOptions`.
+
+use ratatui::prelude::*;
+use ratatui::widgets::{Clear, List, ListItem, ListState};
+
+use super::popup;
+use crate::app_contracts::AcpSessionConfigOption;
+use crate::theme;
+
+const POPUP_MAX_VISIBLE: usize = 8;
+
+pub struct ConfigPopupState<'a> {
+    pub options: &'a [AcpSessionConfigOption],
+    pub value_option: Option<&'a AcpSessionConfigOption>,
+    pub selected: usize,
+    pub pending_config_id: Option<&'a str>,
+    pub pane_focused: bool,
+}
+
+pub fn render_popup(frame: &mut Frame, state: ConfigPopupState<'_>, input_area: Rect) {
+    let row_count = state
+        .value_option
+        .map(|option| option.values.len())
+        .unwrap_or(state.options.len());
+    if row_count == 0 {
+        return;
+    }
+
+    let visible = row_count.min(POPUP_MAX_VISIBLE) as u16;
+    let area = popup::anchored_above(frame, input_area, visible);
+    frame.render_widget(Clear, area);
+
+    let (title, items) = match state.value_option {
+        Some(option) => {
+            let items: Vec<ListItem<'_>> = option
+                .values
+                .iter()
+                .map(|value| {
+                    let mut spans = vec![Span::styled(&value.name, theme::INPUT_TEXT)];
+                    if let Some(description) = value.description.as_deref() {
+                        spans.push(Span::styled(format!(" - {description}"), theme::DIM));
+                    }
+                    ListItem::new(Line::from(spans))
+                })
+                .collect();
+            (option.name.clone(), items)
+        }
+        None => {
+            let items: Vec<ListItem<'_>> = state
+                .options
+                .iter()
+                .map(|option| {
+                    let pending = state.pending_config_id == Some(option.id.as_str());
+                    let mut spans = vec![
+                        Span::styled(&option.name, theme::INPUT_TEXT),
+                        Span::raw("  "),
+                        Span::styled(option.current_value_name(), theme::DIM),
+                    ];
+                    if pending {
+                        spans.push(Span::styled(" ...", theme::IN_PROGRESS));
+                    } else if let Some(description) = option.description.as_deref() {
+                        spans.push(Span::styled(format!(" - {description}"), theme::DIM));
+                    }
+                    ListItem::new(Line::from(spans))
+                })
+                .collect();
+            (t!("config_picker.title").into_owned(), items)
+        }
+    };
+
+    let selected_style = if state.pane_focused {
+        theme::SELECTED
+    } else {
+        theme::SELECTED_INACTIVE
+    };
+    let list = List::new(items)
+        .block(popup::block(title))
+        .highlight_style(selected_style)
+        .highlight_symbol("> ");
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(state.selected.min(row_count - 1)));
+    frame.render_stateful_widget(list, area, &mut list_state);
+}

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -1,6 +1,7 @@
 use crate::app::{App, AppMode, View, DEFAULT_TAB_ID};
 use ratatui::prelude::*;
 
+use super::config_popup;
 use super::{
     action_panel, agent_popup, agents_view, auth, chat, command_popup, debug_panel, input,
     model_popup, permission, recommendations, setup, user_input,
@@ -272,6 +273,10 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     // command popup isn't visible while it's up.
     if let Some(model_state) = app.model_popup_state() {
         model_popup::render_popup(frame, model_state, chunks[7]);
+    }
+
+    if let Some(config_state) = app.config_popup_state() {
+        config_popup::render_popup(frame, config_state, chunks[7]);
     }
 
     if let Some(agent_state) = app.agent_popup_state() {

--- a/tools/wta/src/ui/mod.rs
+++ b/tools/wta/src/ui/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod card;
 pub(crate) mod chat;
 pub(crate) mod command_format;
 mod command_popup;
+mod config_popup;
 mod debug_panel;
 mod input;
 mod layout;
@@ -19,6 +20,7 @@ mod user_input;
 
 pub use agent_popup::AgentPopupState;
 pub use command_popup::{PopupCandidates, PopupState};
+pub use config_popup::ConfigPopupState;
 #[cfg(test)]
 pub(crate) use input::input_height;
 pub use layout::render;


### PR DESCRIPTION
## Summary

- preserve ordered ACP `configOptions` select entries per session across `session/new`, `session/load`, `session/update`, and `session/set_config_option`
- add a generic two-level `/config` picker for Agent-provided session options with pending/error handling
- route `/model` through the standard model config option when available while retaining the legacy model-switch fallback
- localize the new experience across all WTA locales and update the ACP v1 completion plan

## Validation

- `cargo test --manifest-path tools/wta/Cargo.toml` (1506 passed)
- hot-refreshed the Debug package and manually launched the new `wta.exe`
<img width="1555" height="296" alt="image" src="https://github.com/user-attachments/assets/05483ba5-3293-4adf-bd8c-d99c49a22fe4" />

<img width="1535" height="260" alt="image" src="https://github.com/user-attachments/assets/bde76000-900d-4ada-a281-7fcb8f63f7a5" />

<img width="1369" height="465" alt="image" src="https://github.com/user-attachments/assets/e05e9abe-b953-4df4-84ee-bfd8122ffdac" />
