### PR TITLE
Streamline agent development context

### DIFF
--- a/.github/instructions/localization.instructions.md
+++ b/.github/instructions/localization.instructions.md
@@ -202,10 +202,10 @@ Terms that should always be locked:
 |------|--------|
 | Hooks, Hook | Technical term (shell hooks) |
 | CLI | Technical acronym |
-| ACP | Technical acronym (Agent Control Protocol) |
+| ACP | Technical acronym (Agent Client Protocol) |
 | PATH | Environment variable |
 | PowerShell | Product name |
-| Copilot, Claude, Gemini | Brand names |
+| Copilot, Claude, Codex, Gemini, OpenCode | Brand names |
 | JSON, YAML, XML | Technical formats |
 
 ### Translator guidance comments

--- a/.github/instructions/rust-wta.instructions.md
+++ b/.github/instructions/rust-wta.instructions.md
@@ -1,64 +1,43 @@
 ---
-description: 'WTA (Windows Terminal Agent) Rust crate conventions — overrides and complements the generic rust.instructions.md'
+description: 'File-scoped conventions for the WTA Rust crate'
 applyTo: 'tools/wta/**/*.rs'
 ---
 
-# WTA Rust Conventions
+# WTA Rust conventions
 
-Project-specific Rust guidance for the WTA crate (`tools/wta/`). Applies **in addition to** `rust.instructions.md`; where the two conflict, this file wins.
+These rules complement `rust.instructions.md`. Architecture, build commands,
+and product behavior are defined in `AGENTS.md` and `tools/wta/AGENTS.md`.
 
-The repo contains multiple Rust crates (e.g. `installer/bootstrap/`); this file's conventions apply only to the WTA crate under `tools/wta/`. Other Rust code in the repo is governed by the generic `rust.instructions.md` only.
+## Toolchain and dependencies
 
-## Toolchain & Build
+- Keep `tools/wta/rust-toolchain.toml` pinned unless a toolchain update is the
+  explicit task.
+- New dependencies must build with the repo's static-CRT Windows MSVC
+  configuration.
+- Use the explicit Windows target from the repo-level build instructions; do
+  not mix host-target and explicit-target outputs.
+- When the shipped dependency graph changes, run
+  `build/scripts/Generate-WtaThirdPartyNotices.ps1` with PowerShell 7 and commit
+  both `tools/wta/cgmanifest.json` and `/NOTICE.md`.
 
-- **Toolchain is pinned.** `tools/wta/rust-toolchain.toml` pins the channel to `ms-prod-1.93` for CI reproducibility. Do not bump it casually.
-- **Static CRT on Windows.** The repo-root `.cargo/config.toml` forces `+crt-static` rustflags for all Windows MSVC targets (`x86_64`, `i686`, `aarch64`). Avoid dependencies that break under static CRT.
-- **Two supported build invocations — don't mix them.** Both of these are valid for WTA local dev:
+## Runtime behavior
 
-  ```bash
-  cargo build --manifest-path tools/wta/Cargo.toml                              # host target (bare target/)
-  cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml   # explicit target
-  ```
+- Resolve state through `runtime_paths::intelligent_terminal_root()` and logs
+  through `logging::log_dir()`. Never construct LocalAppData/package paths by
+  hand.
+- Use structured `tracing` targets and fields. Never log secrets, provider
+  credentials, or session MCP bearer capabilities.
+- Initialize logging once before substantive startup work and call
+  `logging::shutdown_flush()` before every `std::process::exit`.
+- Localize user-facing strings through `t!(...)`; follow
+  `rust-localization.instructions.md` for locale-file changes.
+- Preserve tab, window, helper, and ACP session identity across asynchronous
+  routing. Do not replace typed identities with loosely related strings.
 
-  Pick one and stay with it within a single dev session. The `CascadiaPackage.wapproj` deploy step prefers `tools/wta/target/x86_64-pc-windows-msvc/<profile>/wta.exe` over the bare `tools/wta/target/<profile>/wta.exe`, so if you build once with `--target` and later iterate with plain `cargo build`, the wapproj will silently keep deploying the stale explicit-target binary. See `tools/wta/README.md` and `tools/wta/AGENTS.md` for the host-target workflow.
+## Testing
 
-## Localization
-
-User-facing strings go through `t!(...)` (rust-i18n) — see `rust-localization.instructions.md` for the full pattern (locale YAML structure, `{Locked}` markers, fallback chain).
-
-## Logging
-
-- Use `tracing` with structured `target` + key=value fields.
-- Initialize **once** in `main()` via `logging::init(&process_label(&cli))` **before** any work — even arg-parsing failures should land on disk.
-- Call `logging::shutdown_flush()` on every exit path, **including before `std::process::exit`** (which otherwise skips the `WorkerGuard` drop and loses buffered records).
-- Default level: debug builds → `debug`, release → `info` (`logging::default_filter_directive`).
-- Override with `WTA_LOG` or `RUST_LOG` env vars.
-
-## Runtime Paths
-
-- Resolve all runtime data paths through `runtime_paths.rs`:
-  - `intelligent_terminal_root()` for state (`LocalState`)
-  - `logging::log_dir()` for logs (`LocalCache\Local`)
-- **Do not** hand-roll `%LOCALAPPDATA%\IntelligentTerminal` paths — the helper has to handle package-private (`Packages\<pfn>\LocalState`) vs unpackaged (bare `%LOCALAPPDATA%`) identity correctly.
-- All Rust log writers, the C++ `AgentPaneLog.h`, and PowerShell hooks share the same per-version dir `logs\<pkgver>\` so the bug-report zip captures everything.
-
-## Third-Party Dependency Notices
-
-`tools/wta/cgmanifest.json` (Component Governance manifest) and the `<!-- BEGIN wta-rust-deps -->` block in `/NOTICE.md` are **generated** from `cargo metadata`. Whenever you change the dependency graph — add/remove/upgrade a direct dep in `tools/wta/Cargo.toml`, run a `cargo update` that substantially shifts `Cargo.lock`, or flip a feature flag that pulls in/drops transitive crates — regenerate both and commit the diff alongside the Cargo change:
-
-```powershell
-$env:RUSTUP_TOOLCHAIN = 'stable'   # bypass the rust-toolchain.toml pin
-pwsh -File .\build\scripts\Generate-WtaThirdPartyNotices.ps1
-```
-
-Requires **PowerShell 7+** (`pwsh.exe`); fails fast under Windows PowerShell 5.1. Inspect the diff to both files and include them in the same commit. See `tools/wta/AGENTS.md` → "Third-party Rust crate attribution" for the full pipeline.
-
-## WTA-Specific Quality Checklist
-
-In addition to the generic checklist in `rust.instructions.md`:
-
-- [ ] **Logging**: New entry points call `logging::init` and ensure `shutdown_flush` runs before any `std::process::exit`
-- [ ] **Paths**: Runtime data paths go through `runtime_paths.rs` (no hand-rolled `%LOCALAPPDATA%`)
-- [ ] **Dep changes**: If `tools/wta/Cargo.toml` direct deps or `Cargo.lock` shift meaningfully, regenerate `cgmanifest.json` + `NOTICE.md` via `Generate-WtaThirdPartyNotices.ps1` and commit together
-- [ ] **Static CRT**: New deps build cleanly under `+crt-static` for `x86_64-pc-windows-msvc`
-- [ ] **Toolchain**: No changes to `rust-toolchain.toml` channel unless explicitly intended
+- Cover reducers and routing decisions with deterministic unit tests.
+- Use mock ACP and render harnesses for protocol/UI behavior instead of timing
+  sleeps or live services.
+- Run the explicit-target WTA test command from the repo-level `AGENTS.md`
+  before committing or pushing behavior changes.

--- a/.github/instructions/rust-wta.instructions.md
+++ b/.github/instructions/rust-wta.instructions.md
@@ -10,8 +10,10 @@ and product behavior are defined in `AGENTS.md` and `tools/wta/AGENTS.md`.
 
 ## Toolchain and dependencies
 
-- Keep `tools/wta/rust-toolchain.toml` pinned unless a toolchain update is the
-  explicit task.
+- Keep the CI `ms-prod-1.93` pin in `tools/wta/rust-toolchain.toml` unless a
+  toolchain update is the explicit task. Repo-root local commands use the
+  installed active toolchain, so do not rely on language or library features
+  newer than Rust 1.93.
 - New dependencies must build with the repo's static-CRT Windows MSVC
   configuration.
 - Use the explicit Windows target from the repo-level build instructions; do

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -26,8 +26,8 @@ pattern or dependency.
 
 - Return `Result` for recoverable failures and add context at I/O, process,
   parsing, and protocol boundaries.
-- Use the crate's existing error type and conventions; do not introduce
-  `anyhow`, `thiserror`, or another error crate solely for a local change.
+- Use the crate's existing error type and conventions; do not introduce a new
+  error-handling dependency solely for a local change.
 - Avoid `unwrap`, `expect`, and panics in production paths unless an invariant
   is both local and demonstrably impossible to violate.
 - Do not silently discard errors. Log, propagate, or explicitly document why

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -1,114 +1,52 @@
 ---
-description: 'Rust programming language coding conventions and best practices'
+description: 'Concise Rust coding conventions for this repository'
 applyTo: '**/*.rs'
 ---
 
-# Rust Coding Conventions and Best Practices
+# Rust conventions
 
-Follow idiomatic Rust practices and community standards when writing Rust code. 
+Follow the existing crate's architecture and style before introducing a new
+pattern or dependency.
 
-These instructions are based on [The Rust Book](https://doc.rust-lang.org/book/), [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/), [RFC 430 naming conventions](https://github.com/rust-lang/rfcs/blob/master/text/0430-finalizing-naming-conventions.md), and the broader Rust community at [users.rust-lang.org](https://users.rust-lang.org).
+## Implementation
 
-## General Instructions
+- Prefer clear ownership and borrowing over cloning or unnecessary allocation.
+- Use domain types and enums to make invalid states difficult to represent.
+- Accept `&str` or borrowed values when ownership is not required.
+- Keep iterators lazy when that improves clarity; use direct loops when they
+  are easier to read.
+- Keep async work non-blocking. Move blocking filesystem or process work to the
+  crate's established blocking boundary.
+- Avoid `unsafe`. When it is required, minimize its scope and document the
+  safety invariant.
+- Do not add abstraction, traits, builders, or dependencies without a concrete
+  need in the changed code.
 
-- Always prioritize readability, safety, and maintainability.
-- Use strong typing and leverage Rust's ownership system for memory safety.
-- Break down complex functions into smaller, more manageable functions.
-- For algorithm-related code, include explanations of the approach used.
-- Write code with good maintainability practices, including comments on why certain design decisions were made.
-- Handle errors gracefully using `Result<T, E>` and provide meaningful error messages.
-- For external dependencies, mention their usage and purpose in documentation.
-- Use consistent naming conventions following [RFC 430](https://github.com/rust-lang/rfcs/blob/master/text/0430-finalizing-naming-conventions.md).
-- Write idiomatic, safe, and efficient Rust code that follows the borrow checker's rules.
-- Ensure code compiles without warnings.
+## Errors
 
-## Patterns to Follow
+- Return `Result` for recoverable failures and add context at I/O, process,
+  parsing, and protocol boundaries.
+- Use the crate's existing error type and conventions; do not introduce
+  `anyhow`, `thiserror`, or another error crate solely for a local change.
+- Avoid `unwrap`, `expect`, and panics in production paths unless an invariant
+  is both local and demonstrably impossible to violate.
+- Do not silently discard errors. Log, propagate, or explicitly document why
+  an error is intentionally ignored.
 
-- Use modules (`mod`) and public interfaces (`pub`) to encapsulate logic.
-- Handle errors properly using `?`, `match`, or `if let`.
-- Use `serde` for serialization and `anyhow` for application errors.
-- Implement traits to abstract services or external dependencies.
-- Structure async code using `async/await` and `tokio`.
-- Prefer enums over flags and states for type safety.
-- Use builders for complex object creation.
-- Use iterators instead of index-based loops as they're often faster and safer.
-- Use `&str` instead of `String` for function parameters when you don't need ownership.
-- Prefer borrowing and zero-copy operations to avoid unnecessary allocations.
+## Documentation and tests
 
-### Ownership, Borrowing, and Lifetimes
+- Comment invariants, non-obvious concurrency, and compatibility constraints;
+  do not narrate straightforward code.
+- Add focused tests for behavior changes and regressions. Keep unit tests near
+  the code unless the crate already uses an integration-test boundary.
+- Do not require every private item to have documentation or every change to
+  introduce a new abstraction.
 
-- Prefer borrowing (`&T`) over cloning unless ownership transfer is necessary.
-- Use `&mut T` when you need to modify borrowed data.
-- Explicitly annotate lifetimes when the compiler cannot infer them.
-- Use `Rc<T>` for single-threaded reference counting and `Arc<T>` for thread-safe reference counting.
-- Use `RefCell<T>` for interior mutability in single-threaded contexts and `Mutex<T>` or `RwLock<T>` for multi-threaded contexts.
+## Validation
 
-## Patterns to Avoid
-
-- Don't use `unwrap()` or `expect()` unless absolutely necessary—prefer proper error handling.
-- Avoid panics in library code—return `Result` instead.
-- Don't rely on global mutable state—use dependency injection or thread-safe containers.
-- Avoid deeply nested logic—refactor with functions or combinators.
-- Don't ignore warnings—treat them as errors during CI.
-- Avoid `unsafe` unless required and fully documented.
-- Don't overuse `clone()`, use borrowing instead of cloning unless ownership transfer is needed.
-- Avoid premature `collect()`, keep iterators lazy until you actually need the collection.
-- Avoid unnecessary allocations—prefer borrowing and zero-copy operations.
-
-## Code Style and Formatting
-
-- Follow the Rust Style Guide and use `rustfmt` for automatic formatting.
-- Keep lines under 100 characters when possible.
-- Place function and struct documentation immediately before the item using `///`.
-- Use `cargo clippy` to catch common mistakes and enforce best practices.
-
-## Error Handling
-
-- Use `Result<T, E>` for recoverable errors and `panic!` only for unrecoverable errors.
-- Prefer `?` operator over `unwrap()` or `expect()` for error propagation.
-- Use `anyhow::Result<T>` with `.context(...)` for application-level errors.
-- Use `Option<T>` for values that may or may not exist.
-- Provide meaningful error messages and context.
-- Validate function arguments and return appropriate errors for invalid input.
-
-## API Design Guidelines
-
-### Common Traits Implementation
-Eagerly implement common traits where appropriate:
-- `Copy`, `Clone`, `Eq`, `PartialEq`, `Ord`, `PartialOrd`, `Hash`, `Debug`, `Display`, `Default`
-- Use standard conversion traits: `From`, `AsRef`, `AsMut`
-- Note: `Send` and `Sync` are auto-implemented by the compiler when safe; avoid manual implementation unless using `unsafe` code
-
-### Type Safety and Predictability
-- Use newtypes to provide static distinctions
-- Arguments should convey meaning through types; prefer specific types over generic `bool` parameters
-- Use `Option<T>` appropriately for truly optional values
-- Functions with a clear receiver should be methods
-- Only smart pointers should implement `Deref` and `DerefMut`
-
-## Testing and Documentation
-
-- Write comprehensive unit tests using `#[cfg(test)]` modules and `#[test]` annotations.
-- Use test modules alongside the code they test (`mod tests { ... }`).
-- Write integration tests in `tests/` directory with descriptive filenames.
-- Write clear and concise comments for each function, struct, enum, and complex logic.
-- Ensure functions have descriptive names and include comprehensive documentation.
-- Use module-level `//!` docs and inline `//` comments for non-obvious logic.
-- Document error conditions, panic scenarios, and safety considerations.
-- Examples should use `?` operator, not `unwrap()` or deprecated `try!` macro.
-
-## Quality Checklist
-
-Before reviewing Rust code, ensure:
-
-### Core Requirements
-- [ ] **Naming**: Follows RFC 430 naming conventions
-- [ ] **Traits**: Implements `Debug`, `Clone`, `PartialEq` where appropriate
-- [ ] **Error Handling**: Uses `Result<T, E>` / `anyhow::Result<T>` and provides meaningful error context
-- [ ] **Testing**: Comprehensive test coverage including edge cases
-
-### Safety and Quality
-- [ ] **Safety**: No unnecessary `unsafe` code, proper error handling
-- [ ] **Performance**: Efficient use of iterators, minimal allocations
-- [ ] **API Design**: Functions are predictable, flexible, and type-safe
-- [ ] **Tooling**: Code passes `cargo fmt`, `cargo clippy`, and `cargo test`
+- Run `cargo fmt` for changed Rust code.
+- Run the smallest relevant tests while iterating, then the crate's required
+  test command.
+- Run Clippy only when the crate already uses it or the task requires it; do
+  not perform unrelated cleanup.
+- Keep builds warning-free under the repository's configured toolchain.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ fork-specific context.
 ```
 WindowsTerminal.exe
   |-- TerminalProtocolComServer (COM, discovered through WT_COM_CLSID)
-  |-- SharedWta --> wta-master --> agent CLI (ACP over stdio)
+  |-- SharedWta --> wta-master --> agent CLI pool (ACP over stdio)
   +-- one wta-helper pane per tab
                        |
                        +-- helper/master ACP over a named pipe
@@ -20,8 +20,9 @@ Agent or human CLI --> wta/wtcli --> COM IProtocolServer --> Windows Terminal
 ```
 
 - **WTA** (`tools/wta/`) is the Rust orchestrator.
-- **ACP** means Agent Client Protocol. `wta-master` owns the single agent CLI
-  process; per-tab helpers multiplex sessions through it.
+- **ACP** means Agent Client Protocol. `wta-master` lazily owns a pool of agent
+  CLI processes keyed by agent identity, execution source, and command; helpers
+  using the same key share one process and multiplex sessions through it.
 - **WT Protocol** is the terminal-control boundary. `wtcli.exe` activates
   `IProtocolServer` through the package COM registration.
 - **Session MCP** exposes `request_terminal_actions` and `request_user_input`.
@@ -122,9 +123,9 @@ cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml
 
 Output: `tools/wta/target/x86_64-pc-windows-msvc/debug/wta.exe`.
 
-A live WTA process may lock the output. Stop only the exact process whose
-executable path matches the binary being rebuilt; never terminate every
-`wta.exe` or `WindowsTerminal.exe` by name.
+A live WTA process may lock the output. Stop only processes whose executable
+path exactly matches the binary being rebuilt; never terminate every `wta.exe`
+or `WindowsTerminal.exe` by name.
 
 ### Terminal
 
@@ -163,6 +164,7 @@ Primary logs are:
 - `wta-main_helper-{pid}.log`
 - `wta-cli.log`
 - `wta-delegate.log`
+- `wta-probe.log`
 - `wta-install-hooks.log`
 - `wta-ensure-host.log`
 - `wta-acp-debug.log`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,414 +1,182 @@
-# Intelligent Terminal (Windows Terminal Fork)
+# Intelligent Terminal
 
-AI-native Windows Terminal — agents (Copilot, Claude, Gemini, custom) can understand, fix, and automate terminal workflows.
+Intelligent Terminal is a Windows Terminal fork that adds first-class AI agent
+workflows. The inherited Windows Terminal build, architecture, and C++ conventions
+are documented in `.github/copilot-instructions.md`; this file contains only the
+fork-specific context.
 
-## Core Components
+## Architecture
 
-- **WTA** (Windows Terminal Agent) — orchestrator binary. Launches agents, passes Terminal Protocol connection info. Agents control WT via `wtcli`.
-  - Launch: `wta delegate --agent <agent> --delegate-agent <delegate> --cwd <cwd> "<prompt>"`
-- **WT Protocol** (`IProtocolServer`) — sole integration surface. WinRT IDL + COM out-of-process server (MBM marshaling, MTA thread). Discovery via `WT_COM_CLSID` env var.
-  - IDL: `src/cascadia/TerminalProtocol/TerminalProtocol.idl`
-  - Server: `src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp`
-- **WTCLI** — CLI client consuming `IProtocolServer` via `CoCreateInstance(CLSCTX_LOCAL_SERVER)`. Agents shell out to `wtcli list-panes`, `wtcli capture-pane`, etc.
-- **ACP** (Agent Control Protocol) — JSON-RPC 2.0 spoken inside the helper+master architecture. `wta-helper` ↔ `wta-master` over a named pipe; `wta-master` ↔ agent CLI subprocess over stdio. The C++ side no longer participates in ACP directly — agent panes are plain `ConptyConnection`s hosting a `wta-helper` child. See `doc/specs/Multi-window-agent-pane.md`.
+```
+WindowsTerminal.exe
+  |-- TerminalProtocolComServer (COM, discovered through WT_COM_CLSID)
+  |-- SharedWta --> wta-master --> agent CLI (ACP over stdio)
+  +-- one wta-helper pane per tab
+                       |
+                       +-- helper/master ACP over a named pipe
+                       +-- session-scoped MCP tools
 
-## UX
+Agent or human CLI --> wta/wtcli --> COM IProtocolServer --> Windows Terminal
+```
 
-| Trigger | Behavior |
-|---------|----------|
-| `>Toggle AI assistant` | Opens/toggles agent pane (`openAgentPane` action) |
-| `?<prompt>` | Delegates to hidden background WTA process |
-| `?` (empty) | No-op |
-| `&` | Background task mode (future, C9) |
+- **WTA** (`tools/wta/`) is the Rust orchestrator.
+- **ACP** means Agent Client Protocol. `wta-master` owns the single agent CLI
+  process; per-tab helpers multiplex sessions through it.
+- **WT Protocol** is the terminal-control boundary. `wtcli.exe` activates
+  `IProtocolServer` through the package COM registration.
+- **Session MCP** exposes `request_terminal_actions` and `request_user_input`.
+  It routes requests to the owning helper and never executes terminal actions
+  itself.
+- Agent panes are ordinary `ConptyConnection` panes hosting `wta-helper`; C++
+  does not speak ACP.
 
-Agent pane: position configurable (`bottom`/`right`/`top`/`left`). Color-coded VT output.
+See `doc/specs/Multi-window-agent-pane.md` for the detailed lifecycle and
+`tools/wta/AGENTS.md` for WTA-specific implementation rules.
 
-## Settings (`settings.json`)
+## Supported agents and settings
+
+Built-in ACP and delegation providers are Copilot, Claude, Codex, Gemini, and
+OpenCode. Custom providers use a `custom:<name>` ID plus the matching custom
+command setting.
 
 ```jsonc
 {
-    "acpAgent": "copilot",           // "copilot", "gemini", or "custom:<cmd>"
-    "acpModel": "",                  // Model override
-    "acpCustomCommand": "",          // Command for custom agent
-    "agentPanePosition": "bottom",
-    "delegateAgent": "copilot",      // Agent for ?<prompt> delegation
+    "acpAgent": "copilot",
+    "acpModel": "",
+    "acpCustomCommand": "",
+    "delegateAgent": "copilot",
     "delegateModel": "",
     "delegateCustomCommand": "",
-    "autoFixEnabled": true,
+    "agentPanePosition": "bottom",
+    "autoErrorDetectionEnabled": true,
+    "autoFixEnabled": false,
     "aiIntegration.coordinator.enabled": false,
     "aiIntegration.coordinator.commandline": "wta",
     "aiIntegration.coordinator.profile": "{fd19208a-412b-4857-8a2d-9ca592b4b16e}",
     "aiIntegration.confirmation.readOperations": "auto",
     "aiIntegration.confirmation.createOperations": "auto",
-    "aiIntegration.confirmation.inputOperations": "auto",
+    "aiIntegration.confirmation.inputOperations": "auto"
 }
 ```
 
-## Architecture
+The settings model is authoritative; check
+`src/cascadia/TerminalSettingsModel/MTSMSettings.h` and
+`src/cascadia/inc/AgentRegistry.h` before documenting defaults or providers.
 
-```
-WindowEmperor (one WT process, N AppHosts/windows)
-  |-- TerminalProtocolComServer (COM, MTA thread, WT_COM_CLSID)
-  |-- SharedWta (singleton) -- spawns --> wta-master ──► agent CLI (ACP/stdio)
-  |                                          ▲
-  |                                          │ ACP/JSON-RPC over named pipe
-  +-- AppHost[] → TerminalWindow → TerminalPage
-        |-- CommandPalette (? / & prefixes)
-        |-- Per-tab agent pane: ConptyConnection ───► wta-helper (conpty child)
-        |                                            (one helper per tab, pre-warmed)
-        +-- Protocol bridge (TerminalPage.Protocol.cpp)
+## User-facing behavior
 
-External: Agent → wtcli → COM (IProtocolServer) → TerminalProtocolComServer → WindowEmperor
-```
+| Trigger | Behavior |
+| --- | --- |
+| `>Toggle AI assistant` | Stash or restore the current tab's agent pane |
+| `?<prompt>` | Delegate a prompt through WTA |
+| `?` | No-op |
+| `&<prompt>` | Reserved background-task entry point; currently a no-op |
 
-**Per-tab + per-window routing.** Each agent pane has its own helper bound
-to an `owner_tab_id` (= WT tab StableId) and a `window_id`. All inbound
-events that mutate per-tab state (`set_agent_state`, `tab_changed`,
-`tab_closed`, `tab_renamed`) carry both ids; helpers filter by `window_id`
-and (for `tab_changed`) by owner-lock in `switch_tab_session`. Outbound
-helper events (`agent_state_changed`, `agent_status`, `autofix_state`,
-`close_agent_pane`) carry `tab_id` so C++ can route via
-`_FindTabByStableId` instead of fanning out across every pane / window.
-See `doc/specs/Multi-window-agent-pane.md` §7.
+Important invariants:
 
-**Helper is pre-warmed per tab.** Every new tab spawns a stashed agent
-pane on creation (`_InitializeTab` → `_AutoCreateHiddenAgentPaneShared`
-with `autoStash=true`, `--start-stashed`), so the helper is running and
-its ACP session connects in the background from the start — even if the
-user never opens the pane. This is what lets autofix work on a tab the
-user hasn't interacted with. The agent CLI itself is spawned once by
-`wta-master` at startup and shared across all helpers (each helper's
-`initialize` is a cached replay; only `session/new` round-trips to the
-CLI). `--start-stashed` only seeds `pane_open=false`; it does not defer
-the handshake. The pre-warm is skipped when wta is unavailable, GPO
-blocks all agents, or the tab arrived with an agent pane via cross-window
-drag-in (`agentLeavesSeen > 0`). See `TabManagement.cpp:366`.
+- Each eligible tab pre-warms one stashed helper. Skip pre-warm when WTA is
+  unavailable, policy blocks all agents, the tab has no active terminal, or a
+  dragged-in agent pane already exists.
+- Toggling an agent pane stashes/restores it; it does not destroy the helper,
+  ACP session, or chat history.
+- Per-tab events carry tab and window identity. Route responses to the owning
+  tab instead of broadcasting across panes or windows.
+- Autofix requires a connected helper session. Failures received before the
+  session connects are not replayed later.
+- Terminal mutation requested by an agent goes through the confirmation-gated
+  session MCP action path. Agent-owned shell tools are a separate execution
+  path.
 
-**Agent pane toggle = stash, not destroy.** `Ctrl+Shift+.` /
-`Ctrl+Shift+/` / the bottom-bar button toggle via
-`Tab::StashAgentPane`/`RestoreStashedAgentPane` (built on WT's
-`Pane::HidePane`/`RestorePane`). Helper + conpty + ACP session + chat
-history all survive the toggle. The pane is only destroyed on tab close
-or `Ctrl+C×2` in the TUI. See spec §8.
-
-## Key Files
+## Key files
 
 | Area | Path |
-|------|------|
-| Agent integration | `src/cascadia/TerminalApp/TerminalPage.cpp`, `TerminalPage.Protocol.cpp` |
-| Agent pane wrapper | `src/cascadia/TerminalApp/AgentPaneContent.cpp` (XAML chrome around the helper's `TermControl`) |
-| Tab-side stash | `src/cascadia/TerminalApp/Tab.cpp` (`StashAgentPane`, `RestoreStashedAgentPane`, `HasStashedAgentPane`) |
-| Command Palette | `src/cascadia/TerminalApp/CommandPalette.cpp` |
+| --- | --- |
+| Terminal integration | `src/cascadia/TerminalApp/TerminalPage.cpp` |
+| Protocol bridge | `src/cascadia/TerminalApp/TerminalPage.Protocol.cpp` |
+| Tab lifecycle and pre-warm | `src/cascadia/TerminalApp/TabManagement.cpp` |
+| Agent pane chrome | `src/cascadia/TerminalApp/AgentPaneContent.cpp` |
+| Stash/restore | `src/cascadia/TerminalApp/Tab.cpp` |
+| Shared WTA process | `src/cascadia/TerminalApp/SharedWta.cpp` |
+| COM server | `src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp` |
 | Protocol IDL | `src/cascadia/TerminalProtocol/TerminalProtocol.idl` |
-| COM Server | `src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp` |
-| Shared master spawn | `src/cascadia/TerminalApp/SharedWta.cpp` |
-| wta-master | `tools/wta/src/master/mod.rs` |
-| wta-helper / App | `tools/wta/src/app.rs`, `tools/wta/src/main.rs` |
-| Settings | `src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl`, `MTSMSettings.h` |
-| Settings UI | `src/cascadia/TerminalSettingsEditor/AIAgents.xaml` |
-| Process coord | `src/cascadia/WindowsTerminal/WindowEmperor.cpp` |
+| Agent registry | `src/cascadia/inc/AgentRegistry.h` |
+| Settings | `src/cascadia/TerminalSettingsModel/MTSMSettings.h` |
+| WTA master/helper | `tools/wta/src/master/mod.rs`, `tools/wta/src/helper/mod.rs` |
+| Runtime agent prompt | `tools/wta/prompts/terminal-agent.md` |
 
-## Autofix
+## Build and validation
 
-Detects command failures in other panes and auto-suggests fixes via the agent.
+WTA and Terminal use separate build systems. Build WTA before packaging changes
+that need a refreshed `wta.exe`.
 
-**Pipeline**: Shell emits `OSC 133;D;<exit_code>` → `TerminalPage` raises `ProtocolVtSequenceReceived` → COM server forwards to clients → WTA (via `wtcli listen --json`) classifies → `maybe_trigger_autofix()`.
+### WTA
 
-**Requirements**: PowerShell shell integration (OSC 133 marks), a helper
-whose ACP session has reached `Connected`, `wtcli` on PATH. The pane does
-**not** need to be visible — the per-tab pre-warmed helper (see
-Architecture) makes autofix work on a stashed pane. But a failure that
-lands before the helper's session connects (cold start of master/agent
-CLI, in-flight `session/new`, or a `Failed` agent) is **dropped**:
-`trigger_autofix_inner` early-returns when `state != Connected`
-(`app.rs:6820`). The bottom-bar notification banner still shows; only the
-autofix pill / LLM call is skipped, and the failure is not re-triggered
-once the session later connects.
+Always use the explicit Windows target. `CascadiaPackage.wapproj` prefers this
+output over the host-target fallback, so mixing target layouts can silently
+deploy a stale binary.
 
-**Key code**: `tools/wta/src/app.rs` (`classify_wt_event`, `maybe_trigger_autofix`), `TerminalPage.cpp:2650-2740` (event handlers), `TerminalProtocolComServer.cpp` (`_ensurePageEventsRegistered`).
-
-**Diag log**: `wta-ensure-host.log` in the WTA log directory — shows event flow, classification, and autofix triggers.
-
-## Hooks plugin auto-upgrade
-
-When IT is installed or upgraded, the bundled `wt-agent-hooks` plugin
-(`tools/wta/wt-agent-hooks/{copilot,claude,gemini-extension}/`) needs to
-re-land into any agent CLI the user already opted into (via Settings UI /
-FRE "Install hooks" or `wta hooks install`). This is handled silently by
-`agent_hooks_installer::upgrade_installed_hooks`, fired once per
-`wta-master` startup on a blocking-pool thread.
-
-**Trigger model — bundle version is the upgrade signal.** A tiny state
-file `<LocalCache>/IntelligentTerminal/hooks-upgrade-state.json` records
-the bundle version this wta process last saw per CLI. At startup we read
-each CLI's bundle `plugin.json` / `gemini-extension.json` (cheap, <5ms)
-and compare; if all match, we return immediately (no spawns, no IO
-beyond the cache compare). Only after the user installs / upgrades IT
-does the bundle version change → cache miss → per-CLI flow runs once,
-then the state file is rewritten and the fast path resumes.
-
-**Opt-in only.** Even on cache miss, CLIs that don't already have
-`wt-agent-hooks` installed are skipped. The auto-upgrade never installs
-into a CLI the user hasn't accepted. Disabled plugins are also skipped
-(`enabled: false` in Copilot's `config.json` / `claude plugin list`).
-
-**Per-CLI strategy.** Copilot and Claude use their `plugin update`
-subcommands; before invoking them we rewrite any stale marketplace
-`source.path` to the current bundle dir (Copilot: existing
-`cleanup_stale_copilot_marketplace`; Claude: new
-`cleanup_stale_claude_marketplace`). Gemini's `extensions update`
-silently returns `NOT_UPDATABLE` when the recorded install source no
-longer exists (typical after an MSIX version-dir bump), so we peek at
-`~/.gemini/extensions/wt-agent-hooks/.gemini-extension-install.json`
-first: if `type==local` AND `source` is still under the current bundle,
-run `extensions update` in place; otherwise fall back to
-uninstall+install while preserving the `isActive` flag.
-
-**Trigger-point caveat.** The agent CLI master spawns concurrently may
-already be past its plugin-load step by the time `plugin update` writes
-the new files — so the freshly upgraded hooks may not take effect until
-the next agent restart. Acceptable because blocking master startup on a
-Node-based `plugin update` (1-30s) would hurt every IT-upgrade boot.
-
-**Diag**: `wta-install-hooks.log` (existing) plus `target=agent_hooks`
-+ `target={copilot,gemini}_hooks` trace events in
-`wta-main_master.log` show every per-CLI decision (`upgrade decision`
-log line carries `installed_version`, `bundle_version`, `action`).
-
-## Logs & runtime data layout
-
-WTA runtime data lives under the **package-private** store, split by lifetime
-into two roots (both resolved in `runtime_paths.rs`, both falling back to the
-same bare path when the process has no package identity):
-
-```
-# Packaged (every production wta process — helper is a conpty child of the
-# packaged WindowsTerminal.exe, master is spawned in-package by SharedWta):
-
-  …\Packages\<PackageFamilyName>\LocalState\IntelligentTerminal\   <- STATE root
-      prompts\                      (prompt overrides)             intelligent_terminal_root()
-      agent-pane-sessions.jsonl     (session origin index)
-      master-pipe.txt               (helper↔master rendezvous)
-
-  …\Packages\<PackageFamilyName>\LocalCache\Local\IntelligentTerminal\  <- LOCAL/cache root
-      logs\<pkgver>\                (ALL logs for that build — Rust wta-*.log,
-                                     C++ terminal-agent-pane.log, PS hook-trace.log)
-      hook-bundle-staging\ …        (hook-installer staging)
-      hooks-upgrade-state.json      (per-CLI bundle version cache for the
-                                     hooks auto-upgrade fast-path)
-
-# Unpackaged (dev builds run straight out of the Cargo target dir, tests):
-# BOTH roots collapse to the legacy bare %LOCALAPPDATA%\IntelligentTerminal\.
-```
-
-Rationale for the split: **State** = persistent, must-survive, package-private
-data → `LocalState` (alongside the WT app's own `settings.json` / `state.json`).
-**Local/cache** = transient, regenerable diagnostics → `LocalCache\Local`, the
-cache store that doesn't roam / back up.
-
-Both roots are package-private — removed on uninstall and isolated between the
-dev-sideload family (`IntelligentTerminal_rd9vj3e6a2mbr`) and the store family
-(`Microsoft.IntelligentTerminal_8wekyb3d8bbwe`) — instead of sharing one bare
-`%LOCALAPPDATA%\IntelligentTerminal` directory. The family name comes from
-`GetCurrentPackageFamilyName` (windows-sys); the `Packages\<pfn>\LocalState` and
-`…\LocalCache\Local` paths are what WinRT `ApplicationData.Current.LocalFolder`
-/ `LocalCacheFolder` resolve to, so we construct them directly rather than
-pulling in the WinRT projection.
-
-**All three writers share one per-version dir** `logs\<pkgver>\`, where
-`<pkgver>` is the **package version** (`GetCurrentPackageId`, e.g. `0.8.0.2`) —
-read identically at runtime by Rust (`logging::package_version`) and C++
-(`IntelligentTerminal::PackageVersionDir`), so no build-time version sync is
-needed:
-- Rust wta processes → `logging::log_dir()` (`logs\<pkgver>\wta-*.log`).
-- C++ `AgentPaneLog.h` → `IntelligentTerminal::LogDirVersioned()` →
-  `terminal-agent-pane.log` (renamed from the old `wta-agent-pane.log`).
-- PowerShell hooks (`send-event.ps1`) → `hook-trace.log`, via the
-  `WTA_HOOK_LOG_DIR` env var set to `LogDirVersioned()` (C++ ConptyConnection
-  for shell panes; `spawn.rs` for agent-pane CLIs).
-
-`IntelligentTerminal::LogDir()` stays the **root** (`…\logs`, no version) and is
-used only by the bug-report-zip action so it archives every version at once.
-Unpackaged (dev-from-cargo / tests) has no package identity → all writers fall
-back to the flat bare `…\logs\`.
-
-> Earlier builds wrote everything to the bare `%LOCALAPPDATA%\IntelligentTerminal`
-> regardless of identity (the `LOCALAPPDATA` env var is **not** redirected into
-> the sandbox on Win10/11). There is no migration — old data is left in place
-> and simply ignored.
-
-**Log level** is controlled by the `WTA_LOG` (or `RUST_LOG`) env var. When
-unset, the default comes from the build: **debug builds default to `debug`,
-release builds default to `info`** (`logging::default_filter_directive`). Set
-`WTA_LOG=debug|trace` for the noisy traces, or `WTA_LOG=warn` to quiet a
-release build further.
-
-**Logging is initialized once** in `main()` immediately after arg parsing
-(`logging::init(&process_label(&cli))`), before locale/ETW setup, so even
-early-startup failures land on disk. The non-blocking appender's `WorkerGuard`
-lives in a global and is flushed via `logging::shutdown_flush()` on every exit
-path — including before each `std::process::exit` (which would otherwise skip
-the guard drop and lose buffered records). Every launch mode — including
-short-lived `wtcli`-style commands — now writes a log file (previously only 6
-entry points did).
-
-**Per-version storage + retention** (`logging::housekeeping`): each build's
-logs live in their own subdir, `logs\<pkgver>\` (the package version — see
-above). On every start, `prune_old_version_dirs` keeps **only the current
-version's dir** and deletes all other version dirs wholesale. The current
-version's dir is never a deletion target, so cleanup is **lock-free and
-concurrency-safe** (no process can delete a file another is writing). Within the
-current version's dir, per-PID helper logs older than **3 days** are pruned and
-`wta-cli.log` rotates daily keeping 3 days (`max_log_files`).
-
-### Log files in the helper+master architecture
-
-```
-wta-main_master.log        — wta-master process: agent CLI spawn, named pipe accept
-                              loop, per-helper routing, session_to_helper map updates,
-                              agent CLI exit detection, connection failures
-wta-main_helper-{pid}.log  — each wta-helper process (one file per PID, so concurrent
-                              per-tab helpers don't interleave): pipe connect, ACP
-                              initialize, session/new, prompts, agent responses,
-                              TUI lifecycle, connection failures
-wta-cli.log                — short-lived wtcli-style commands (list-*, capture-pane,
-                              listen, sessions, …); daily-rotated, 3-day retention
-wta-delegate.log           — `?<prompt>` delegation flow (separate from agent pane)
-wta-probe.log              — `probe-models` ACP model-list probe
-wta-install-hooks.log      — `hooks install` agent-hook bridge installation
-wta-ensure-host.log        — WT-side background ensure-running diagnostics (kept from
-                              M3-M6 era; remains useful for SharedWta lifecycle)
-wta-acp-debug.log          — low-level ACP JSON-RPC wire trace
-```
-
-Two files in the per-version dir are **not** written by the Rust wta binary —
-`hook-trace.log` (PowerShell hooks) and `terminal-agent-pane.log` (C++ side);
-see **All three writers share one per-version dir** above. They live in the
-same `logs\<pkgver>\` and so are cleaned together with the Rust logs when that
-version's dir ages out.
-
-### Tracking flows by `target` field
-
-All tracing uses structured `target` + key=value fields. Grep patterns for common
-scenarios:
-
-| Goal | Grep |
-|---|---|
-| Master process lifecycle | `target=master` (in `wta-main_master.log`) |
-| Who's connected to master right now | `live_helpers=` in `wta-main_master.log` (climbs on connect, drops on disconnect) |
-| Which helper owns a SessionId | `step="helper→agent" op="new_session" session_id=…` |
-| Trace one prompt end-to-end | grep `session_id="X"`, look for `step="helper→agent" op="prompt"` (sent) then `step="master→helper" op="session_notification"` (response chunks) |
-| Helper pipe lifecycle | `target=master helper_id=…` shows connect+exit |
-| Agent CLI failures | `target=agent_stderr` |
-| Connection failures (either side) | `"exiting with error"` — `target=master` in `wta-main_master.log`, `target=helper` in `wta-main_helper-{pid}.log`; plus inline `step="acp_initialize"` / `step="pipe_connect"` for the helper handshake |
-| Internal control routing | `target=internal_control` (legacy; mostly empty post-Z) |
-
-### Example: end-to-end trace of one user prompt
-
-```
-[helper] target=acp_client                — pipe connected to master
-[helper] target=acp_client                — ACP initialize sent
-[helper] target=acp_client                — session/new → session_id=abc-123
-[master] step=helper→agent op=new_session — registered abc-123 → helper_id=2
-[helper]                                  — user pressed Enter, sending prompt
-[master] step=helper→agent op=prompt      — forwarding to agent CLI (sid=abc-123)
-[master] step=agent→helper kind=agent_message_chunk — agent CLI streamed first chunk
-[master] step=master→helper               — wrote chunk back to helper_id=2 pipe
-[helper]                                  — chunk applied to TabSession.messages
-[master] step=helper→agent op=prompt elapsed_ms=842 stop_reason=…  — turn ended
-```
-
-If any step is missing, the failure is at the previous step.
-
-## Build
-
-There are two independent build systems. **Both must be built** before F5.
-
-### 1. WTA (Rust) — build first
-
-```bash
-# Kill stale WTA processes first
-taskkill //f //im wta.exe 2>/dev/null; true
-
+```powershell
 cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml
-# Output: tools/wta/target/x86_64-pc-windows-msvc/debug/wta.exe
-#
-# Always pass --target explicitly — the wapproj prefers
-# tools/wta/target/<triple>/<profile>/wta.exe over the bare target/<profile>
-# fallback, and a stale explicit-target binary will silently shadow your
-# fresh bare-target build.
+cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml
 ```
 
-### 2. Terminal (C++ / MSBuild)
+Output: `tools/wta/target/x86_64-pc-windows-msvc/debug/wta.exe`.
 
-**Command line (incremental):**
-```bash
-cmd.exe //c "tools\razzle.cmd && bcz no_clean"
-# Release: bcz rel no_clean
-# Output: bin/x64/Debug/
+A live WTA process may lock the output. Stop only the exact process whose
+executable path matches the binary being rebuilt; never terminate every
+`wta.exe` or `WindowsTerminal.exe` by name.
+
+### Terminal
+
+```cmd
+cmd.exe /c "tools\razzle.cmd && bcz no_clean"
 ```
 
-**Visual Studio F5 (debug):**
-- Set `CascadiaPackage` as startup project → F5
-- MSBuild copies `wta.exe` from Cargo output into the package layout
-  (via Content items in `CascadiaPackage.wapproj`)
-- The deployed `wta.exe` sits next to `WindowsTerminal.exe` in the
-  package directory, inheriting package identity for COM access
+For Release use `bcz rel no_clean`. For a project-local incremental build, enter
+the project directory in the same razzle CMD session and use `bx`.
 
-### Safe Debug deployment
-
-After a Debug Terminal build, use this wrapper to deploy C++, XAML, IDL,
-`wtcli`, manifest, resource, packaging, or mixed changes:
+After C++, XAML, IDL, packaging, resource, or mixed Debug changes, deploy with:
 
 ```powershell
 .\build\scripts\Invoke-IntelligentTerminalDebugDeployment.ps1 `
     -AppxRecipePath src\cascadia\CascadiaPackage\bin\x64\Debug\CascadiaPackage.build.appxrecipe
 ```
 
-The script validates the dev package and loose Debug layout, closes only exact
-PIDs running from that layout, deploys it, and reopens Intelligent Terminal if
-needed. It terminates IT panes and agent sessions but never ordinary Windows
-Terminal. Never stop `WindowsTerminal.exe` by name; use `-WhatIf -Verbose` when
-process selection is uncertain.
+Do not perform a full package deployment for a `wta.exe`-only change. Static
+assets such as `wt-agent-hooks` do require packaging.
 
-Do not use full deployment for `wta.exe`-only changes; use the WTA hot-refresh
-flow. Static assets such as `wt-agent-hooks` are not `wta.exe`-only changes.
+## Runtime data and diagnostics
 
-### Full rebuild flow (typical dev cycle)
+Packaged state and cache data are package-private:
 
-```bash
-# 1. Build WTA (always use --target — see note above)
-taskkill //f //im wta.exe 2>/dev/null; true
-cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml
+- State: `Packages\<PFN>\LocalState\IntelligentTerminal`
+- Cache/logs: `Packages\<PFN>\LocalCache\Local\IntelligentTerminal`
+- Logs: `logs\<package-version>\`
 
-# 2. Build & run Terminal from VS
-#    F5 in Visual Studio (CascadiaPackage project)
-#    — or from command line:
-cmd.exe //c "tools\razzle.cmd && bcz no_clean"
-```
+Unpackaged development falls back to
+`%LOCALAPPDATA%\IntelligentTerminal`. Resolve paths through the shared runtime
+path helpers; do not hard-code `%TEMP%` or a bare LocalAppData path.
 
-### Package identity & COM
+Primary logs are:
 
-The COM server (`TerminalProtocolComServer`) is registered under the
-Terminal's package identity. `wtcli.exe` and `wta.exe` must also have
-package identity to activate it via `CoCreateInstance`. This is why:
+- `wta-main_master.log`
+- `wta-main_helper-{pid}.log`
+- `wta-cli.log`
+- `wta-delegate.log`
+- `wta-install-hooks.log`
+- `wta-ensure-host.log`
+- `wta-acp-debug.log`
+- `terminal-agent-pane.log`
+- `hook-trace.log`
 
-- `wta.exe` is deployed **inside the package** (next to `WindowsTerminal.exe`)
-- `_DetectWtaPath()` prefers the co-located `wta.exe` over dev-build paths
-- Running `wta.exe` from `tools/wta/target/debug/` directly will fail with
-  `0x80073D54` (APPMODEL_ERROR_NO_PACKAGE) when calling COM methods
+Use `WTA_LOG=debug` or `WTA_LOG=trace` for additional Rust tracing. See
+`tools/wta/README.md` for current diagnostics and CLI usage.
 
-If autofix or the agent pane stops working after a debug launch, check
-`%TEMP%\wta-ensure-host.log` for the `0x80073D54` error — it means
-the wrong (unpackaged) `wta.exe` was used.
+## Focused design references
 
-## Installer
-
-See **[doc/building-installer.md](doc/building-installer.md)** for full details.
-
-Two distribution formats:
-
-| Format | Script | Output |
-|--------|--------|--------|
-| **MSIX ZIP** (packaged) | Manual assembly from MSBuild output | `artifacts/local-installer/*-msix.zip` |
-| **Self-extracting EXE** (unpackaged) | `build/scripts/New-WtaLocalInstaller.ps1` | `artifacts/local-installer/*-setup.exe` |
+- Multi-window helper/master lifecycle:
+  `doc/specs/Multi-window-agent-pane.md`
+- Session tracking: `doc/specs/hybrid-agent-session-tracking.md`
+- Security boundaries: `doc/security-model.md`
+- Installer: `doc/building-installer.md`
+- WTA customization: `tools/wta/CUSTOMIZATION.md`

--- a/doc/installing-dependencies.md
+++ b/doc/installing-dependencies.md
@@ -132,7 +132,7 @@ the other four are **bring-your-own** — install the CLI yourself
 (sub-sections below) before selecting it in the FRE.
 
 Intelligent Terminal talks to all five through the
-[**Agent Control Protocol (ACP)**](https://agentclientprotocol.com/get-started/agents).
+[**Agent Client Protocol (ACP)**](https://agentclientprotocol.com/get-started/agents).
 **Copilot**, **Gemini**, and **OpenCode** speak ACP natively, so no extra layer is
 required. **Claude Code** and **OpenAI Codex** do not speak ACP directly
 — Intelligent Terminal launches them through an `npx` wrapper that is
@@ -213,7 +213,7 @@ claude --version
 
 #### Step 3.2.3 — ACP wrapper (no install action required)
 
-Claude Code does not speak the Agent Control Protocol (ACP) directly, so
+Claude Code does not speak the Agent Client Protocol (ACP) directly, so
 Intelligent Terminal launches it through the
 [`@agentclientprotocol/claude-agent-acp`](https://www.npmjs.com/package/@agentclientprotocol/claude-agent-acp)
 wrapper. The wrapper is fetched on demand at run time with:
@@ -260,7 +260,7 @@ codex --version
 
 #### Step 3.3.3 — ACP wrapper (no install action required)
 
-Codex does not speak the Agent Control Protocol (ACP) directly, so
+Codex does not speak the Agent Client Protocol (ACP) directly, so
 Intelligent Terminal launches it through the
 [`@agentclientprotocol/codex-acp`](https://www.npmjs.com/package/@agentclientprotocol/codex-acp)
 wrapper. The wrapper is fetched on demand at run time with:
@@ -283,7 +283,7 @@ The first launch may take a few seconds while `npx` downloads the wrapper.
 
 **Status:** Supported, but **not installed by Intelligent Terminal**. You
 must install Google's Gemini CLI yourself before selecting Gemini in the
-FRE. Gemini speaks the Agent Control Protocol (ACP) natively, so no
+FRE. Gemini speaks the Agent Client Protocol (ACP) natively, so no
 wrapper is required at runtime, but the CLI itself is still distributed as
 an npm package.
 

--- a/doc/security-model.md
+++ b/doc/security-model.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 |---|---|
-| **Document status** | Draft v1.3 |
-| **Last updated** | 2026-05-21 |
+| **Document status** | Draft v1.4 |
+| **Last updated** | 2026-08-14 |
 | **Audience** | Microsoft internal security review |
 | **Component** | Windows Terminal fork with embedded AI agents (WT + WTA + WTCLI) |
 
@@ -35,7 +35,7 @@ Highest-priority residual risks:
 | **Create/split over COM** | `CreateTab` / `SplitPane` can spawn attacker-chosen commands as WT children. | Still exposed through COM and stock `wtcli.exe`. |
 | **Event broadcast disclosure** | Legacy `agent_event` envelopes are broadcast to every subscribed COM caller; a pane-context subscriber can passively observe other panes' agent prompts and tool calls. | No per-subscriber filtering; only observed platform COM activation behavior gates `Subscribe`. |
 | **Prompt injection** | COM access does not prove the LLM's requested action is safe. | Confirmation settings exist in the settings model, but they default to `auto` and the current implementation does not enforce them on the runtime operation paths reviewed here. |
-| **Autofix-triggered context disclosure** | Crafted OSC 133 failure marks can trigger automatic Autofix analysis that reads source-pane context and sends it to the Agent CLI / LLM before any fix-execution confirmation. | `autoFixEnabled` defaults to `true`; no first-run opt-in or analysis-time confirmation is implemented. |
+| **Autofix-triggered context disclosure** | When Autofix is enabled, crafted OSC 133 failure marks can trigger analysis that reads source-pane context and sends it to the Agent CLI / LLM before any fix-execution confirmation. | `autoFixEnabled` defaults to `false`, providing fresh-install opt-in. Once enabled, no per-event analysis confirmation is implemented. |
 | **Delegation context disclosure** | `wta delegate` / `?<prompt>` reads active-pane context and passes it to the delegate Agent CLI / LLM as startup prompt context. | No context-specific confirmation or redaction; the assembled delegate command line may also appear in process and diagnostic surfaces. |
 | **Scrollback/log disclosure** | Pane output and diagnostic logs may contain secrets, source code, prompts, or command output. | Redaction is not implemented. |
 | **Settings persistence via filesystem** | A process running as the user can overwrite `settings.json` and persistently change agent selection, Autofix behavior, or future AI policy knobs. | No meta-confirmation when WT reads policy-relevant settings and launches WTA / agent processes with those values. |
@@ -376,7 +376,7 @@ Delegation is an agent-launch and context-transfer path, not a direct shell-inpu
 | WTA binary substitution | Supply chain / EoP | High | Production intent is co-located packaged `wta.exe`, but `_DetectWtaPath()` also supports local dev and PATH fallbacks. Any resolved WTA binary runs with WTA's normal environment (`WT_COM_CLSID` etc.) and can drive WT over COM. |
 | Diagnostic logs may disclose sensitive data | Information disclosure | Medium | WTA and hook logs may contain command lines, event payload summaries, errors, and metadata. Raw user/agent content (prompts, responses, terminal output, typed input) is gated to `trace` level; the shipping `info` default and `debug` log lengths/ids/enums, not content. Known examples include `wta-main_*.log`, `wta-delegate.log`, `terminal-agent-pane.log`, `wta-install-hooks.log`, and `hook-trace.log` under `logs\<pkgver>\`. Retention is bounded (only the current version's dir kept, daily cli rotation, 3-day per-PID helper prune). |
 | Direct `settings.json` file write | Tampering | Critical for persistent AI-policy bypass; not OS privilege escalation | Inherits filesystem ACL behavior; no meta-confirmation for policy changes before WT honors the changed settings in future WTA / agent launches. |
-| Crafted OSC marks for Autofix | Information disclosure / Prompt injection / Tampering | High | OSC 133 is shell-controlled. With `autoFixEnabled=true` by default, a crafted failure mark can trigger WTA's Autofix analysis path to submit an agent prompt and read source-pane context via `wt_read_last_prompt` / `wt_read_pane_output` before any fix-execution confirmation. User interaction still gates applying a suggested fix, but pane-context disclosure and prompt-injection exposure can happen during analysis. |
+| Crafted OSC marks for Autofix | Information disclosure / Prompt injection / Tampering | High when Autofix is enabled | OSC 133 is shell-controlled. `autoFixEnabled` defaults to `false`, but after the user enables it a crafted failure mark can trigger WTA's Autofix analysis path to submit an agent prompt and read source-pane context via `wt_read_last_prompt` / `wt_read_pane_output` before any per-event confirmation. User interaction still gates applying a suggested fix, but pane-context disclosure and prompt-injection exposure can happen during analysis. |
 | Delegation context disclosure | Information disclosure / Prompt injection | High | `wta delegate` / `?<prompt>` reads the active pane's recent output (`ReadPaneOutput(..., 30)`) and appends it as terminal context to the delegate prompt. It then uses COM `CreateTab(commandline)` to have WT launch the delegate Agent CLI in a new tab, not `send_input`. Sensitive pane data can be disclosed to the Agent CLI / LLM and exposed through command-line or diagnostic surfaces without a separate context confirmation. |
 
 ### Scope boundary note
@@ -416,7 +416,7 @@ Same-user OS process introspection and handle-table attacks against WTA are inte
 | Per-turn rate limit for shell-input calls | Roadmap | Agent runaway / prompt-injection loops |
 | Pin or verify built-in Agent CLI binary identity and ACP adapter provenance | Partial — known-location / PATH resolution only; no signature pinning; `npx` adapter package versions / sources are not pinned or vendored | Agent CLI and adapter supply chain |
 | Pin or verify WTA binary identity and remove PATH fallback from production launches | Planned | WTA binary substitution |
-| Autofix opt-in / first-run hardening | Not implemented; `autoFixEnabled` defaults to `true` | Automatic pane-context disclosure, surprise background analysis, and prompt-injection exposure |
+| Autofix opt-in / first-run hardening | Implemented for fresh installs: `autoFixEnabled` defaults to `false`; no per-event analysis confirmation exists after opt-in | Reduces default pane-context disclosure; enabled Autofix remains exposed to crafted failure marks |
 | Delegation context confirmation and prompt transport hardening | Not implemented; delegate prompt is enriched with recent active-pane output and launched through startup command line | Pane-context disclosure to delegate Agent CLI / LLM and command-line/log surfaces |
 
 ---
@@ -446,7 +446,7 @@ Same-user OS process introspection and handle-table attacks against WTA are inte
 | **P1** | Add per-turn shell-input rate limiting. |
 | **P1** | Add source-pane / target-pane authorization for `SendInput`, or explicitly document that any COM-allowed caller may target any pane by session GUID. |
 | **P1** | Scope or authorize lower-impact COM mutations (`ClosePane`, `FocusPane`, `SetSessionVariable`) separately from process creation. |
-| **P1** | Autofix opt-in / first-run hardening — change `autoFixEnabled` default to `false` (or surface an analysis-time prompt) so pane context is not sent to the Agent CLI / LLM by surprise. |
+| **P1** | Add clear Autofix context-disclosure consent and consider per-event analysis confirmation or source validation for crafted OSC failure marks. |
 | **P1** | Add delegation context confirmation/redaction and avoid putting full pane context into delegate command lines or diagnostic logs. |
 | **P2** | Migrate read methods (`ReadPaneOutput`, `GetSettings`, topology reads) after mutation methods. |
 | **P2** | Tighten built-in Agent CLI resolution and binary identity checks, and pin/vendor/verify ACP adapter packages launched through package managers such as `npx -y`. |

--- a/doc/specs/Multi-window-agent-pane.md
+++ b/doc/specs/Multi-window-agent-pane.md
@@ -1,8 +1,8 @@
 # Multi-Window Behavior of the Agent Pane
 
 Author: kaitao@microsoft.com
-Date: 2026-05-26 (post-Z follow-ups: per-tab + per-window event routing
-hardening B12–B20; agent-pane stash/restore B4–B11)
+Date: 2026-08-14 (post-Z follow-ups: per-tab + per-window event routing,
+agent-pane stash/restore, and per-tab independent agent pooling)
 Branch: `dev/vanzue/window-management`
 Status: Helper + master architecture (Z-M1 through Z-M6) is shipped and
 default. Post-Z work tightened the multi-tab + multi-window event
@@ -14,19 +14,20 @@ See "Design history" for the rationale of the original pivot.
 - **Each agent pane runs as its own `wta-helper` process** spawned by
   Windows Terminal as a normal conpty child (same Win32 pattern as today's
   legacy mode and any other conpty-backed pane).
-- **One `wta-master` process per Terminal process** owns the single agent
-  CLI subprocess (claude / copilot / gemini).
+- **One `wta-master` process per Terminal process** lazily owns a pool of
+  agent CLI subprocesses keyed by agent identity, execution source, and
+  command line.
 - Helpers connect to the master via a **named pipe** and speak **ACP
-  JSON-RPC** — the master multiplexes per-tab `sessionId`s onto its single
-  ACP connection to the agent CLI.
+  JSON-RPC** — helpers with the same agent key share one ACP connection, and
+  the master routes every `sessionId` to its owning helper and agent instance.
 - TermControl ↔ helper communication is plain conpty (no custom protocol);
   helper ↔ master is plain ACP JSON-RPC over a pipe; master ↔ agent CLI is
   plain ACP JSON-RPC over stdio. **No bespoke wire format is invented.**
 
 ```
 WT (one process, N windows)
- └─ SharedWta singleton spawns ─► wta-master ◄──── ACP JSON-RPC ───► agent CLI
-                                       ▲                              (one child)
+ └─ SharedWta singleton spawns ─► wta-master ◄──── ACP JSON-RPC ───► agent CLI pool
+                                       ▲                         (one per active key)
                                        │ ACP JSON-RPC over named pipe
                                        │
  (per agent pane:)                     │
@@ -246,16 +247,16 @@ WindowsTerminal.exe (one process)
 ```
 
 - **`wta-master`**: singleton per Terminal process, spawned by
-  `SharedWta` on first agent-pane request. Headless (no UI). Owns the
-  single ACP connection to the agent CLI subprocess. Listens on a
-  named pipe for helper connections.
+  `SharedWta` on first agent-pane request. Headless (no UI). Lazily owns an
+  ACP connection per active agent key and listens on a named pipe for helper
+  connections.
 - **`wta-helper`**: one per agent pane. Conpty child of its
   TerminalControl. Runs the full Ratatui chat UI for one tab.
   Connects to master via named pipe; speaks ACP JSON-RPC as a
   client.
-- **`agent CLI`**: existing claude/copilot/gemini ACP-protocol
-  subprocess. One per master (= one per Terminal process). Owns N
-  ACP sessions internally, one per attached helper.
+- **`agent CLI`**: an ACP-protocol subprocess such as Copilot, Claude, Codex,
+  Gemini, or OpenCode. One warm process per distinct agent key owns the ACP
+  sessions for helpers sharing that key.
 
 ### 2. Per-pane attachment model
 
@@ -597,14 +598,14 @@ calls `Tab::StashAgentPane()`, `true` calls `Tab::RestoreStashedAgentPane`
 if the pane is stashed; otherwise `_AutoCreateHiddenAgentPaneShared`
 (first-open).
 
-### 9. Per-tab independent agents (future)
+### 9. Per-tab independent agents
 
-`AttachPaneParams.agent_id` is currently metadata-only because the
-master holds a single agent CLI subprocess shared across helpers.
-Future: master could maintain a pool of agent CLI subprocesses keyed
-by `agent_id`. Each helper requests sessions from the agent CLI
-matching its `agent_id`. Wire format is already extensible (see Z-R4
-risk below). Not in v1.
+The master maintains a lazy agent CLI pool keyed by the master-resolved agent
+identity, execution source, and command line. Each helper declares its agent ID
+during `initialize`; policy filtering and command reconstruction remain
+master-owned. Helpers with the same key reuse one process, while different keys
+can spawn in parallel. Dead processes are reaped from the pool and restarted
+on demand.
 
 ## What needs to change
 

--- a/doc/specs/per-cli-history-filtering.md
+++ b/doc/specs/per-cli-history-filtering.md
@@ -80,8 +80,9 @@ seeds selection on arrival.
 Filtering the history scan only drops **historical** (on-disk, dead) rows of
 other CLIs. Live rows do not come from `load_all`:
 
-- Sessions created through master are all the current CLI (master spawns a
-  single agent CLI).
+- Sessions created through master may span multiple CLIs because master owns
+  a per-agent pool. The helper's **view filter** narrows master's snapshot to
+  that helper's current CLI.
 - The hookless **watcher** discovers Class B shell sessions **machine-wide /
   cross-CLI** (`master/mod.rs` "the file watcher sees session files
   machine-wide"). Those are narrowed to the current CLI by the **view filter**

--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -8,9 +8,10 @@ Do not duplicate those facts here.
 
 WTA is a Rust binary with three launch modes:
 
-- **Master** (`--master <pipe>`): owns the single agent CLI subprocess and its
-  ACP stdio connection, accepts helper named-pipe connections, and routes each
-  ACP SessionId to its owning helper. Implementation: `src/master/mod.rs`.
+- **Master** (`--master <pipe>`): lazily owns a pool of agent CLI subprocesses
+  and their ACP stdio connections, accepts helper named-pipe connections, and
+  routes each ACP SessionId to its owning helper. Helpers with the same
+  master-derived agent key share a process. Implementation: `src/master/mod.rs`.
 - **Helper** (`--connect-master <pipe>`): one ratatui UI per agent pane. It is
   an ACP client of master and owns pane-local UI state and `ShellManager`.
   Implementation: `src/helper/mod.rs` and `src/app.rs`.
@@ -37,8 +38,9 @@ WTA does not own those processes or invent process controls for them.
 
 ### Session MCP
 
-Master creates a session-scoped loopback Streamable HTTP endpoint, with an
-on-demand relay for WSL sessions. It exposes:
+Master owns one loopback Streamable HTTP listener and publishes an independent
+server name and bearer capability for each eligible ACP session. WSL sessions
+use an on-demand distro-local relay to that listener. The endpoint exposes:
 
 - `request_terminal_actions`
 - `request_user_input`
@@ -107,9 +109,10 @@ Detailed tracking and resume behavior belongs in:
 
 ## Build and test
 
-Use the explicit-target commands in the repo-level `AGENTS.md`. Do not alternate
-between host-target and explicit-target Cargo outputs in one worktree because
-the package project prefers the explicit-target binary.
+Run the explicit-target commands in the repo-level `AGENTS.md` from the
+repository root. Do not alternate between host-target and explicit-target Cargo
+outputs in one worktree because the package project prefers the explicit-target
+binary.
 
 Run the WTA test suite for every behavior change covered by, or deserving,
 unit tests. A successful Cargo build or C++ build does not compile
@@ -121,14 +124,15 @@ Use the smallest relevant test while iterating, then run:
 cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml
 ```
 
-If a live process locks the output, stop only the PID whose executable path is
-the target being rebuilt. Do not kill all WTA processes by name.
+If live processes lock the output, stop only PIDs whose executable paths exactly
+match the target being rebuilt. Do not kill all WTA processes by name.
 
 ## Dependencies and generated notices
 
-WTA uses the pinned toolchain in `rust-toolchain.toml` and the repo's static-CRT
-Windows target configuration. Avoid dependencies that do not support static
-CRT.
+CI resolves the `ms-prod-1.93` pin in `rust-toolchain.toml` through MSRustup.
+The documented repo-root local commands use the installed active Rust toolchain
+while still loading the repo's static-CRT target configuration. Keep code
+compatible with Rust 1.93 and avoid dependencies that do not support static CRT.
 
 When `Cargo.toml`, Cargo features, or `Cargo.lock` changes the shipped
 dependency graph, regenerate and commit both `tools/wta/cgmanifest.json` and the

--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -1,560 +1,159 @@
-# WTA Agent Architecture
+# WTA development
 
-## What is WTA?
+These rules apply to `tools/wta/`. The repo-level `AGENTS.md` is the canonical
+source for build, deployment, supported providers, runtime paths, and log names.
+Do not duplicate those facts here.
 
-WTA (Windows Terminal Agent) is a Rust binary that bridges AI agent CLIs with
-Windows Terminal. It is built around a **helper + master** architecture (see
-`doc/specs/Multi-window-agent-pane.md`) and runs in one of three roles, selected
-at startup by flags / subcommands. There is no standalone agent / TUI mode;
-bare `wta` with neither a role flag nor a subcommand exits with an error.
+## Roles and ownership
 
-- **`wta-master`** (`--master <pipe>`, spawned once by the C++ `SharedWta`
-  singleton) -- the ACP **multiplexer**. Owns the *single* `ACP/stdio`
-  connection to the agent CLI subprocess (Copilot, Claude, Gemini, Codex, or a
-  custom command), listens on a named pipe, and fans per-helper ACP sessions
-  onto that one agent CLI. Implementation: `src/master/mod.rs`.
-- **`wta-helper`** (`--connect-master <pipe>`, spawned once per agent pane by
-  Windows Terminal) -- the per-pane **TUI**. Drives the ratatui chat UI (`app.rs`)
-  but, instead of spawning its own agent CLI, speaks ACP/JSON-RPC to master over
-  the pipe. *From the helper's perspective, master is the agent.* Entry:
-  `src/helper/mod.rs` → `run_default_tui_over_pipe`.
-- **CLI helpers** (`wta list-panes`, `wta capture-pane`, `wta resolve-command`,
-  `wta new-tab`,
-  `delegate`, `hooks`, `sessions`, …) -- one-shot WT-control commands for humans
-  and for agents that can shell out. Direct keystroke injection is not exposed by
-  the CLI. Dispatched in `src/main.rs`.
-- **Session MCP endpoint** (one ephemeral Windows-loopback Streamable HTTP
-  listener owned by `wta-master`, plus an on-demand loopback relay per WSL
-  distro) -- exposes `request_terminal_actions` and `request_user_input`. Each session receives an
-  independent public server name plus a bearer capability, preventing
-  name-keyed Agent caches from overwriting another session's header. The
-  capability resolves to ACP SessionId, then `session_to_helper` routes the
-  request over the existing master/helper pipe. Relays are bounded
-  master-lifetime services and exit when their master-owned stdin pipe closes.
-  Unexpected relay failure is restarted on the same port. Capabilities are
-  revoked when their exact Agent CLI instance dies. The endpoint never
-  executes terminal actions.
+WTA is a Rust binary with three launch modes:
 
-The helper side owns `ShellManager`, which services the agent CLI's ACP
-`create_terminal` / permission requests by routing to either a local subprocess
-or a Windows Terminal pane. WT pane operations use a `WtChannel` abstraction with
-a single implementation today:
+- **Master** (`--master <pipe>`): owns the single agent CLI subprocess and its
+  ACP stdio connection, accepts helper named-pipe connections, and routes each
+  ACP SessionId to its owning helper. Implementation: `src/master/mod.rs`.
+- **Helper** (`--connect-master <pipe>`): one ratatui UI per agent pane. It is
+  an ACP client of master and owns pane-local UI state and `ShellManager`.
+  Implementation: `src/helper/mod.rs` and `src/app.rs`.
+- **CLI command**: one-shot commands such as `list-panes`, `capture-pane`,
+  `resolve-command`, `delegate`, `hooks`, and `sessions`. Dispatch:
+  `src/cli/`.
 
-- `CliChannel` shells out to `wtcli.exe`, which calls WT's COM `IProtocolServer`.
-  All WT operations — including `send_input` (via `wtcli send-keys`) — go through
-  this path.
+Bare `wta` without a role flag or subcommand is invalid. The session MCP
+listener is a master-owned service, not a fourth launch mode.
 
-## System Diagram
+## Protocol boundaries
 
-```
-            Windows Terminal (WindowEmperor, one WT process)
-              |  spawns once (SharedWta)      |  spawns per agent pane
-              |  --master <pipe>              |  --connect-master <pipe>
-              v                               v
-        +--------------+   named pipe   +------------------+
-        | wta-master   |<-------------->| wta-helper       |  (one per pane)
-        | (singleton)  |  ACP/JSON-RPC  | TUI: app.rs +    |
-        | master/mod.rs|                | helper/mod.rs    |
-        +------+-------+                +--------+---------+
-               |  ACP/stdio                      |  ShellManager
-               v                                 |  (create_terminal /
-         Agent CLI                               |   permission)
-      (copilot/claude/                           |
-       gemini/codex)                             v
-               | per-session HTTP MCP             |
-               | capability                       |  CliChannel
-               v                                  |
-        master/WSL relay MCP -------------------> |
-         (existing ACP pipe routing)              |
-                                                 |
- Human / agent shell-out:                        v
-   wta <subcommand>  ----------------->  wtcli.exe -> COM IProtocolServer
-   (main.rs CLI helpers)                         |
-                                                 v
-                                    TerminalProtocolComServer
-                                                 |
-                                                 v
-                                         Windows Terminal
-```
+### ACP
 
-## Protocol Stack
+ACP means Agent Client Protocol and is used on two hops:
 
-### ACP (Agent Client Protocol)
+1. Master is the ACP client of the agent CLI over stdio.
+2. Helper is an ACP client of master over the named pipe; master acts as the
+   ACP agent and multiplexes requests.
 
-ACP (`agent-client-protocol = "1.3.0"`, JSON-RPC 2.0) is spoken on **two hops**,
-because of the helper+master split:
+The owning helper services ACP client requests such as permission and
+`terminal/*` operations. Ordinary agent-reported tool calls are display-only:
+WTA does not own those processes or invent process controls for them.
 
-- **master ↔ agent CLI** (stdio): master is the ACP **client** of the agent CLI
-  subprocess — the same role legacy single-process wta used to play. It spawns
-  the agent CLI and owns its stdin/stdout.
-- **helper ↔ master** (named pipe): master is an ACP **agent** (server) to each
-  helper, and the helper is the ACP **client**. Master forwards helper requests
-  to the agent CLI and routes inbound `session_notification`s back to the helper
-  that owns the session (`session_to_helper` map in `src/master/mod.rs`).
+### Session MCP
 
-Implementations: agent-CLI client + helper-side `WtaClient` in
-`src/protocol/acp/client.rs`; the master multiplexer in `src/master/mod.rs`.
+Master creates a session-scoped loopback Streamable HTTP endpoint, with an
+on-demand relay for WSL sessions. It exposes:
 
-The agent sends requests (`create_terminal`, `request_permission`, etc.) which
-ultimately land on the owning helper's `WtaClient`; session notifications
-(message chunks, tool calls, plans, status changes) flow agent CLI → master →
-helper.
+- `request_terminal_actions`
+- `request_user_input`
 
-Key ACP message types handled:
+Treat the bearer capability as the session identity. Revoke it when the exact
+agent CLI instance exits. Route requests through `session_to_helper`; the MCP
+endpoint must not execute terminal actions.
 
-- `session/update` -- agent message chunks, tool calls, plan entries
-- `request_permission` -- permission dialog with options (allow/reject)
-- `create_terminal` / `terminal_output` / `wait_for_terminal_exit` -- agent-managed shells
-- `release_terminal` / `kill_terminal` -- cleanup
+### WT protocol
 
-Agent-owned tool calls and ACP Client Terminals are distinct. For ordinary
-`tool_call` / `tool_call_update` notifications, WTA displays only the command,
-cwd, status, output, and exit information the Agent reports; it does not own
-the process or provide process controls. The `terminal/*` callbacks remain the
-separate v1 path where WTA owns execution. `request_terminal_actions` remains
-the user-owned, confirmation-gated pane mutation path.
+All Windows Terminal operations use `CliChannel`, which invokes `wtcli.exe`;
+`wtcli` activates the COM `IProtocolServer` discovered through `WT_COM_CLSID`.
 
-### WT COM Protocol
-
-All WT operations flow through `wtcli.exe` to WT's out-of-process COM server.
-
-- Client wrapper: `src/shell/wt_channel/cli_channel.rs`
-- CLI executable: `src/tools/wtcli/main.cpp`
+- WTA wrapper: `src/shell/wt_channel/cli_channel.rs`
+- CLI client: `src/tools/wtcli/main.cpp`
 - IDL: `src/cascadia/TerminalProtocol/TerminalProtocol.idl`
-- WT-side server: `src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp`
-- Discovery: `WT_COM_CLSID`, injected into panes by WT
+- COM server: `src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp`
 
-The COM surface exposes reads and mutations, including `list_*`, `read_pane_output`, `create_tab`, `split_pane`, `close_pane`, `focus_pane`, `send_input` (via `wtcli send-keys`), and event subscribe/publish.
+Do not treat `WT_COM_CLSID`, `pipe-id`, or `set-env` as security boundaries.
+The human-facing WTA CLI intentionally does not expose direct keystroke
+injection; internal `ShellManager::wt_send_input` uses `wtcli send-keys`.
 
-## Agent Integration
+## Agent commands
 
-### Copilot
+The Terminal settings layer resolves built-in IDs to ACP command lines.
+`src/cascadia/inc/AcpModelUtils.h` is authoritative for those commands and
+adapter versions; do not copy them into WTA code or documentation.
 
-```
-wta --agent "copilot --acp --stdio"
-```
+Custom agents arrive as a resolved `--agent` command plus their canonical
+`custom:<name>` ID. Do not re-parse a known ID from an adapter command when the
+host supplied `--agent-id`.
 
-Copilot speaks ACP directly (`--acp --stdio`). It is spawned by `wta-master`,
-not by the helper. Each eligible Host or WSL ACP session receives an HTTP MCP
-configuration for the master-owned proposal endpoint or its distro-local
-relay. Other Windows Terminal operations remain available through the `wta` /
-`wtcli` CLI helpers, which call WT's COM `IProtocolServer`.
+## State and routing invariants
 
-### Claude and Codex
+- `session_to_helper` is the authoritative ACP SessionId routing map.
+- Per-tab state mutations must preserve both tab and window identity.
+- Helper disconnect, agent exit, pane close, and master restart are distinct
+  lifecycle events; do not collapse them into one generic failure.
+- `ShellManager` owns ACP client terminals. Agent-reported ordinary tool calls
+  remain agent-owned.
+- Command resolution must preserve the active pane's cwd, host PATH, shell,
+  and PowerShell profile behavior. Return `exists`, `not_found`,
+  `indeterminate`, or `unsupported` precisely.
+- Runtime state and cache paths must go through `runtime_paths.rs`.
 
-Claude and Codex are launched through ACP adapters:
+## Session management
 
-```
-wta --agent "npx -y @agentclientprotocol/claude-agent-acp@0.65.0"
-wta --agent "npx -y @agentclientprotocol/codex-acp@1.1.13"
-```
+The registry models activity and liveness separately:
 
-The Terminal settings layer resolves the built-in agent IDs to these adapter commands.
+- Activity: `Idle`, `Working`, `Attention`, or `Error`
+- Liveness: `Live`, `Ended`, or `Historical`
 
-### Gemini
+Agent-pane and shell-pane sessions have different focus/resume behavior.
+Keep routing decisions in the pure `session_mgmt::decide_enter_action`
+boundary and side effects in its dispatch callers.
 
-```
-wta --agent "gemini --experimental-acp"
-```
+The picker currently defaults to shell-pane sessions through
+`MVP_SESSIONS_ORIGIN_FILTER`; `WTA_SESSIONS_SHOW_AGENT_PANE=1` is the debug
+override. Do not change that product behavior incidentally.
 
-### Custom agents
+Detailed tracking and resume behavior belongs in:
 
-Custom agents are configured through the Terminal settings (`custom:<cmd>` plus the stored custom command). WTA receives the resolved command line via `--agent`.
+- `doc/specs/hybrid-agent-session-tracking.md`
+- `doc/specs/per-cli-history-filtering.md`
+- `doc/specs/wsl-session-management.md`
 
-## CLI Helpers
+## Build and test
 
-Agents that can shell out, and humans debugging WTA, can use WTA as a small WT helper CLI:
+Use the explicit-target commands in the repo-level `AGENTS.md`. Do not alternate
+between host-target and explicit-target Cargo outputs in one worktree because
+the package project prefers the explicit-target binary.
 
-| Command | Alias | WT protocol method |
-|---|---|---|
-| `list-windows` | `lsw` | `list_windows` |
-| `list-tabs` | `lst` | `list_tabs` |
-| `list-panes` | `lsp` | `list_panes` |
-| `new-tab` | `neww` | `create_tab` |
-| `split-pane` | `splitw` | `split_pane` |
-| `capture-pane` | `capturep` | `read_pane_output` |
-| `kill-pane` | `killp` | `close_pane` |
-| `active-pane` | -- | `get_active_pane` |
-| `wait-for` | -- | delegated to `wtcli wait-for` |
-| `pane-status` | -- | `get_process_status` |
-| `listen` | `mon` | COM event subscribe |
+Run the WTA test suite for every behavior change covered by, or deserving,
+unit tests. A successful Cargo build or C++ build does not compile
+`#[cfg(test)]` code.
 
-`wta resolve-command <token> [--shell pwsh.exe] --json` is a local,
-profile-aware PowerShell command resolver. It does not call the WT protocol.
-It reports `exists`, `not_found`, `indeterminate`, or `unsupported`, replacing
-the former localhost MCP tool with the same machine-readable result shape.
-
-## Connection Discovery
-
-`CliChannel` uses `wtcli.exe`, and `wtcli.exe` discovers WT through `WT_COM_CLSID`. WT injects this environment variable into pane shells.
-
-`pipe-id` and `set-env` are diagnostic subcommands that surface the inherited `WT_COM_CLSID` value. They should not be described as a security boundary.
-
-## Pane Identity
-
-WTA discovers which WT pane it is running in by PID matching:
-
-1. Call `list_windows` -> `list_tabs` -> `list_panes` through `CliChannel`.
-2. Each pane has a `pid` field.
-3. Match against `std::process::id()`.
-4. Store `(pane_id, tab_id, window_id)` in app state.
-5. Display the identity in the status bar.
-
-## Logging
-
-WTA writes structured logs under the package-private log dir, in a per-version
-subfolder keyed by the package version:
-
-```
-…\Packages\<PFN>\LocalCache\Local\IntelligentTerminal\logs\<pkgver>\   (packaged)
-%LOCALAPPDATA%\IntelligentTerminal\logs\                                (unpackaged / dev)
-```
-
-Per-process logs in the helper+master architecture:
-
-- `wta-main_master.log` -- `wta-master`: agent CLI spawn, pipe accept loop,
-  per-helper routing, `session_to_helper` updates, session MCP call
-  receipt/routing/validation results, agent CLI exit detection
-- `wta-main_helper-{pid}.log` -- each `wta-helper` (one file per PID): pipe
-  connect, ACP initialize, `session/new`, prompts, agent responses, TUI lifecycle
-- `wta-cli.log` -- short-lived CLI helpers (`list-*`, `capture-pane`, `listen`,
-  `sessions`, …); daily-rotated, 3-day retention
-- `wta-delegate.log` -- `wta delegate` (`?<prompt>` delegation)
-- `wta-probe.log` -- `probe-models`
-- `wta-install-hooks.log` -- `hooks install` / uninstall
-- `wta-ensure-host.log` -- WT-side background ensure-running / SharedWta lifecycle
-- `wta-acp-debug.log` -- low-level ACP JSON-RPC wire trace
-
-Two files in the same dir are written by **non-Rust** producers:
-`terminal-agent-pane.log` (C++ `AgentPaneLog`) and `hook-trace.log` (PowerShell
-hooks). See the repo-level architecture notes for the full storage layout.
-
-The log level is controlled by `WTA_LOG` (or `RUST_LOG`); if unset, debug builds
-default to `debug` and release builds to `info` (`logging::default_filter_directive`).
-
-## Build Rule
-
-For normal local WTA development, always produce the binary at `tools/wta/target/debug/wta.exe`.
-
-- Before running `cargo build` for WTA, kill any active `wta.exe` processes first. A live shared-host session can keep `target/debug/wta.exe` locked and make the build fail with `Access is denied`.
-- Preferred PowerShell sequence:
-  - `Get-Process wta -ErrorAction SilentlyContinue | Stop-Process -Force`
-  - `cargo build --manifest-path tools/wta/Cargo.toml`
-- Do not switch to an alternate `--target-dir` just to work around a locked `wta.exe` unless that is explicitly the task. The default expectation is to refresh `tools/wta/target/debug/wta.exe`.
-
-## Test Rule
-
-For any WTA change that is covered by — or should be covered by — unit tests,
-**run the WTA test suite locally before committing/pushing.** `cargo build` and
-the C++ F5 / `bcz` flow do **not** compile or run the `#[cfg(test)]` code, so a
-green build says nothing about the tests.
-
-- Kill any live `wta.exe` first (same as the Build Rule), then run from the repo
-  root so the manifest's toolchain pin doesn't force the unavailable channel:
-  - `cargo test --manifest-path tools/wta/Cargo.toml`
-- All tests must pass before you push. CI runs the same `cargo test` and fails
-  the build on any failure
-  (`build/pipelines/templates-v2/job-build-project.yml`), so a local run just
-  catches it earlier.
-- Run the suite even when the change "looks trivial" — especially for tested
-  logic like `protocol/acp/client.rs`, `ui/chat.rs`, and permission handling.
-  The mock-ACP (`protocol/acp/mock_agent_tests.rs`) and render harnesses guard
-  real behavior and have caught real regressions.
-
-## Key Crates
-
-| Crate | Version | Purpose |
-|-------|---------|---------|
-| `agent-client-protocol` | 1.3.0 | ACP client library |
-| `tokio` | 1 | Async runtime |
-| `ratatui` | 0.30 | TUI rendering |
-| `crossterm` | 0.29 | Terminal I/O |
-| `clap` | 4 | CLI parsing |
-| `serde_json` | 1 | JSON handling |
-
----
-
-## Third-party Rust crate attribution
-
-`wta.exe` statically links many third-party crates. Their attribution lives
-in two generated artifacts:
-
-| Artifact | Purpose | Hand-maintained? |
-|---|---|---|
-| `tools/wta/cgmanifest.json` | Microsoft Component Governance manifest. CG tooling auto-discovers this file and ingests it for OSS compliance, vulnerability scanning, and IP review. Sits alongside the existing `oss/<name>/cgmanifest.json` files for the inherited C++ packages. | **No — generated.** |
-| The `<!-- BEGIN wta-rust-deps -->` block in `/NOTICE.md` | Human-facing third-party notice text (one bullet per `(name, version)` plus one canonical license-text section per unique atomic SPDX identifier). | **No — generated.** |
-
-Both artifacts are regenerated by a single PowerShell script that lives
-next to `Generate-ThirdPartyNotices.ps1` (the existing MD-to-HTML converter
-the build pipeline runs):
+Use the smallest relevant test while iterating, then run:
 
 ```powershell
-$env:RUSTUP_TOOLCHAIN = 'stable'   # bypass the repo's rust-toolchain.toml pin
+cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml
+```
+
+If a live process locks the output, stop only the PID whose executable path is
+the target being rebuilt. Do not kill all WTA processes by name.
+
+## Dependencies and generated notices
+
+WTA uses the pinned toolchain in `rust-toolchain.toml` and the repo's static-CRT
+Windows target configuration. Avoid dependencies that do not support static
+CRT.
+
+When `Cargo.toml`, Cargo features, or `Cargo.lock` changes the shipped
+dependency graph, regenerate and commit both `tools/wta/cgmanifest.json` and the
+generated WTA block in `/NOTICE.md`:
+
+```powershell
+$env:RUSTUP_TOOLCHAIN = 'stable'
 pwsh -File .\build\scripts\Generate-WtaThirdPartyNotices.ps1
 ```
 
-The script requires **PowerShell 7+** (`pwsh.exe`). It fails fast with a clear
-message under Windows PowerShell 5.1 because `ConvertFrom-Json` / `ConvertTo-Json`
-indent differently across versions and Windows PowerShell 5.1's `ConvertFrom-Json`
-caps payloads below the size of `cargo metadata` output for this dep tree.
+The generator requires PowerShell 7+. Generated artifacts are not edited by
+hand.
 
-The script:
+## Rust implementation conventions
 
-1. Runs `cargo metadata --filter-platform x86_64-pc-windows-msvc` against
-   `tools/wta/Cargo.toml` — cargo handles the target-cfg filtering, so the
-   script keeps no hand-rolled OS allow / deny list.
-2. Walks the resolved graph keeping only normal (non-dev, non-build) deps,
-   then attributes every reachable `(name, version)` package — both versions
-   of crates that appear in the lockfile twice (e.g. `syn` v1 + v2) are
-   included.
-3. Normalizes SPDX expressions (`X/Y` → `X OR Y`, sort tokens in pure-OR
-   expressions, decompose composites like `(MIT OR Apache-2.0) AND
-   Unicode-3.0` into atomic tokens so each required license text is
-   reproduced exactly once).
-4. Sources each license text from the local Cargo registry cache (extracted
-   `~/.cargo/registry/src/.../<crate>-<version>/`, then the gzipped `.crate`
-   tarball via bundled `tar.exe`), with a best-effort fall back to
-   `raw.githubusercontent.com/<owner>/<repo>/HEAD/LICENSE` when the upstream
-   tarball does not bundle one.
-5. Writes `tools/wta/cgmanifest.json` (Component Governance Cargo schema,
-   sorted alphabetically for stable diffs).
-6. Splices the regenerated block into `/NOTICE.md` between the
-   `<!-- BEGIN wta-rust-deps -->` and `<!-- END wta-rust-deps -->` markers,
-   atomically and preserving the file's CRLF line endings.
+- Localize user-facing strings through `t!(...)`.
+- Use structured `tracing` fields and stable targets; do not log credentials,
+  bearer capabilities, or full provider configuration.
+- Initialize logging once near process startup and flush it before any
+  `std::process::exit`.
+- Preserve explicit error context across async/process/protocol boundaries.
+- Add tests around reducers, routing decisions, protocol translation, and
+  parsing rather than testing private implementation details.
+- Format with `cargo fmt`; address relevant Clippy findings without broad,
+  unrelated cleanup.
 
-### When to re-run
-
-Re-run the generator and commit the result whenever any of the following
-changes the Rust dependency graph:
-
-- A direct dependency in `tools/wta/Cargo.toml` is added, removed, or
-  upgraded.
-- `cargo update` substantially shifts `tools/wta/Cargo.lock`.
-- Feature flags on a direct dependency change in a way that pulls in or
-  drops transitive crates.
-
-Inspect the diff to `tools/wta/cgmanifest.json` and `/NOTICE.md` and
-include both in the same commit as the underlying Cargo change.
-
-### Boundary with `oss/<name>/`
-
-The C / C++ packages under `oss/` are separately tracked source-code
-mirrors maintained by hand (see e.g. `oss/chromium/MAINTAINER_README.md`).
-Each has its own `cgmanifest.json` checked in alongside the imported
-source. This generator covers only the Rust crates that ship inside
-`wta.exe`; it does not touch the `oss/` tree.
-
----
-
-## Session liveness + Enter routing (session management view)
-
-The "Session management" view (a.k.a. `/sessions`) lists every
-agent session that WTA knows about — both currently connected ("Live")
-and replayed from on-disk history ("Historical" / "Ended"). Enter and
-Shift+Enter on a row are routed through a closed-form state machine
-that splits the legacy one-dimensional `AgentStatus` into a
-**two-dimensional** model.
-
-### The two axes
-
-* **Activity** — `Idle | Working | Attention | Error`. Surfaces what
-  the connected agent is *doing* right now. Driven by ACP
-  `session/update` (`ToolCall`, `ToolCallUpdate`) on Class A
-  sessions, and by shell-integration hooks on Class B.
-
-* **Liveness** — `Live { pane_session_id } | Ended | Historical`.
-  Surfaces whether the session is currently attached to a process.
-  `Historical` = reconstructed from disk only; `Ended` = was Live
-  in this WTA process at some point, then closed.
-
-The legacy `AgentStatus` field is still the storage; `activity()`
-and `liveness()` derive from it (see `agent_sessions.rs`).
-
-### Class A vs Class B
-
-* **Class A** (`SessionOrigin::AgentPane`) — created by WTA on behalf
-  of an Intelligent Terminal agent pane (recorded in
-  `agent-pane-sessions.jsonl`). For these rows the natural Enter
-  target is the *same* agent pane; the natural Resume target is ACP
-  `session/load` so the conversation rehydrates in-place.
-
-* **Class B** (`SessionOrigin::Unknown`) — user ran the CLI directly
-  (`copilot`, `claude`, `gemini`) in a normal pane. The natural
-  Enter target is to focus that pane; the natural Resume target is
-  the CLI's own `--resume` flag (because the CLI owns the
-  conversation, not WTA).
-
-### Liveness data sources (composite)
-
-* **Class A** is composite: `liveness = Live` requires *both*
-  `alive_mirror.lookup(sid).is_some()` (the master-pushed registry
-  mirror via `intellterm.wta/session_added|removed` ext
-  notifications) *and* no local `PaneClosed` tombstone. Local
-  pane-close events trump the mirror so the row flips to `Ended`
-  immediately, even if master's `session_removed` notification
-  hasn't landed yet.
-
-* **Class B** is tracked by hooks + #266 **born-bound** bindings, with the file
-  **watcher** as a **status-only fallback for born-bound rows** (full design:
-  [`doc/specs/hybrid-agent-session-tracking.md`](../../doc/specs/hybrid-agent-session-tracking.md)):
-  a real PowerShell **hook** owns a session outright; #266 **born-bound**
-  (delegate `?<prompt>` / `/sessions` resume) owns its pane binding; and the
-  watcher — which no longer discovers or pane-binds user-typed shell-pane
-  sessions (that required reading a foreign process's PEB, since removed) —
-  only supplies **status** for born-bound sessions that have no hook. The master
-  keeps two disjoint sets, `hook_owned` and `born_bound`, so hooks and the
-  watcher never double-track (`master/mod.rs`: `apply_watcher_event` /
-  `handle_session_hook`).
-
-### Status (Working / Idle / Attention) from the log
-
-When a born-bound Class-B session has no hook, the watcher derives status from
-the CLI's transcript (`session_watcher/classify_*.rs` -> `ToolStarting` = Working /
-`ToolCompleted` = Idle / `Notification` = Attention):
-
-* **Claude** — turn-based, keyed on `stop_reason` (a `user` record -> Working;
-  assistant `stop_reason:tool_use` -> Working, `AskUserQuestion` -> Attention;
-  `end_turn` -> Idle). Claude re-writes the same message id while streaming, so
-  keying on content would flicker — `stop_reason` is stable.
-* **Copilot / Codex** — turn-based over their append-only logs. Working is
-  bracketed by the turn boundary (`assistant.turn_start`/`turn_end` for Copilot,
-  `event_msg/task_started`/`task_complete` for Codex), not by the brief tool
-  windows; a user-input tool *or* an explicit permission/escalation record
-  (`permission.requested` / sandbox `require_escalated`) -> Attention.
-* **Gemini — Working-only (turn-based Idle deferred)**: Gemini's
-  `session-*.jsonl` is an append log (single-message records + `$set` ops),
-  read by byte offset like the others. `classify_record` **skips every `$set`
-  op** (crucially the start/resume `$set:messages` snapshot, so a resume can't
-  replay history) and maps each activity record to Working: a `user` record
-  (prompt or `functionResponse`), a `gemini` text record, or a `gemini` with
-  `toolCalls` (`ask_user` -> Attention). It **never emits Idle** — Gemini writes
-  no turn-completion signal and a completed `toolCall` doesn't mean the turn
-  ended, so a row stays Working until `PaneClosed`. A clean turn-based Idle is
-  deferred (needs a turn-end marker Gemini doesn't write).
-* **Limitation (permission / ask-for-input)**:
-  * **Claude** — no permission marker (only `permissionMode`), so a permission
-    prompt (`Bash`/`Edit` in default mode) is indistinguishable from a running
-    tool -> **Working** (only the explicit `AskUserQuestion` tool is Attention).
-  * **Gemini** — the transcript is written **post-completion** (every on-disk
-    `toolCall` is `status:success` with its result, and `ask_user` already holds
-    the answer), so the wait window shows **Working**; the `ask_user` ->
-    Attention mapping is kept but is typically superseded by the following result
-    record. Reliable wait-state Attention needs hooks.
-  * **Copilot / Codex** *do* surface permission waits as Attention via
-    `permission.requested` / `require_escalated`.
-
-### Cold-startup race
-
-History scan and alive-mirror bootstrap arrive in either order. Both
-paths post `AppEvent::AliveJoinUpgrade`, which calls
-`AgentSessionRegistry::apply_alive_session_join` to upgrade
-**Historical** rows whose ACP session_id is in the alive mirror to
-`LivenessState::Live`. **Ended** rows (locally tombstoned by a
-`PaneClosed` event in this process) are **not** upgraded — local
-tombstones are authoritative, so a stale `session_added` broadcast
-arriving after `PaneClosed` cannot resurrect a row that has no
-demotion path back. Live rows are never demoted — preserves
-tool/attention state. See `agent_sessions.rs::apply_alive_session_join`.
-
-### Steady-state alive-mirror updates
-
-Every `intellterm.wta/session_added` notification from master also
-runs the incremental join synchronously in `app.rs` (calls
-`apply_alive_session_join([(sid, pane)])` before the async mirror
-upsert), so a Historical row matched by an arriving alive broadcast
-becomes Live in the same tick. Every `intellterm.wta/session_removed`
-notification calls `apply_master_session_ended(sid)` — the
-counterpart of `apply_alive_pane_snapshot` for a single explicit
-disappearance — which demotes a Live row to Ended, clears the pane
-binding, and prunes `known_alive_panes`. Without these two
-synchronous reducer calls, session management rows would stay frozen at whatever
-state the last bootstrap snapshot saw.
-
-### Enter / Shift+Enter dispatch
-
-The pure-function core is `session_mgmt::decide_enter_action`. It
-takes a `RowSnapshot` (origin + liveness + cli + agent capabilities)
-and a `shift` boolean, and returns one of:
-
-* `Focus { pane_session_id }` — hand off to `wtcli focus-pane`
-  (which transparently restores a stashed agent pane after PR A).
-* `ResumeInAgentPane { key, cli }` — new tab + agent pane + ACP
-  `session/load(key)` (requires `loadSession` capability).
-* `ResumeCliFlag { key, cli }` — new tab + plain pane running
-  `<cli> --resume <key>` (requires the CLI to advertise a resume
-  flag — Codex doesn't).
-* `NotResumable { reason }` — surface a system message.
-
-The table (matching `session_mgmt.rs` and the plan):
-
-| Row state                  | Enter            | Shift+Enter      |
-| -------------------------- | ---------------- | ---------------- |
-| Any Live (Class A or B)    | Focus            | Focus (same)     |
-| Class A dead (Ended/Hist)  | ResumeInAgentPane| ResumeCliFlag    |
-| Class B dead (Ended/Hist)  | ResumeCliFlag    | ResumeInAgentPane|
-| Unknown CLI                | NotResumable     | NotResumable     |
-| Missing capability         | NotResumable     | NotResumable     |
-
-Shift on Live is intentionally identical to Enter — agents forbid two
-clients on one session, so any "force second copy" attempt would just
-error out. Shift is a safety alias there.
-
-### Dispatch boundary
-
-`App::activate_agent_session_with_shift` (`app.rs`) is the only
-caller of `decide_enter_action` from production code. It then
-dispatches into the existing helpers (`dispatch_focus_pane`,
-`dispatch_resume_in_agent_pane`, `dispatch_resume`) — those own
-all the side effects:
-
-* optimistic `SessionEvent::ResumeDispatched` state flip,
-* `resume_in_new_agent_tab` event publish (for the WT side to open
-  a new tab + reconcile the agent pane),
-* on-failure `PaneClosed` rebroadcast (so a stuck Live row
-  transitions to Ended after `wtcli focus-pane` returns NotFound).
-
-### MVP origin filter (session management picker shows shell-pane sessions only)
-
-The session management picker currently ships in MVP mode: it only surfaces
-**Class B** (shell-pane) sessions — the user manually ran `copilot`
-/ `claude` / `gemini` in a regular shell. **Class A** (agent-pane)
-sessions stay in the registry so Enter routing, alive-mirror
-reconciliation, `intellterm.wta/session_added|removed`, and
-`wta sessions list` all keep seeing every row; they just don't
-render in the picker and aren't reachable by the cursor.
-
-The gate is a single constant — `app.rs::MVP_SESSIONS_ORIGIN_FILTER` —
-threaded through `App::sessions_origin_filter` so that the two places
-that have to stay in sync read the same value:
-
-1. `App::agents_rows_for_tab` (cursor / Enter dispatch source of
-   truth) — applies the filter to both the snapshot path and the
-   registry-fallback path.
-2. `ui/agents_view::render` — applies the same retain to keep the
-   rendered rows lined up with the cursor model.
-
-`agent_sessions::OriginFilter` (`ShellOnly | AgentPaneOnly | All`)
-is the public surface; `iter_sorted_with_filters` is the registry
-API. `iter_sorted_filtered` is preserved as a thin wrapper
-(`origin = All`) so existing call sites keep their behavior.
-
-**Debug overrides** (no rebuild required):
-
-| Surface | How to see everything |
-|---|---|
-| session management picker, single helper | `WTA_SESSIONS_SHOW_AGENT_PANE=1` in that helper's env |
-| Out-of-band debug list | `wta sessions list` (defaults to `--origin all`) |
-| Slice to shell only | `wta sessions list --origin shell` |
-| Slice to agent-pane only | `wta sessions list --origin agent-pane` |
-
-`wta sessions list` always asks master for the full registry and
-filters client-side, so it can act as the eye-of-god view even
-while every helper's session management picker stays in `ShellOnly`. The table
-output gains an `ORIGIN` column (`Shell` / `AgentPane` / `-` for
-untagged legacy rows); JSON output is unchanged because the field
-was already serialized.
-
-**Removing MVP gate.** When agent-pane session management is
-ready, flip `MVP_SESSIONS_ORIGIN_FILTER` to `OriginFilter::All` and
-delete `WTA_SESSIONS_SHOW_AGENT_PANE` handling in
-`resolve_sessions_origin_filter`. No other call site needs to change.
+See `.github/instructions/rust-wta.instructions.md` for file-scoped coding
+rules and `tools/wta/README.md` for human-facing CLI and diagnostics.

--- a/tools/wta/OVERVIEW.md
+++ b/tools/wta/OVERVIEW.md
@@ -156,7 +156,7 @@ question tools.
 | Module | File | Responsibility |
 |------|------|------|
 | **Entry / CLI** | `src/main.rs` | clap parsing, role/subcommand dispatch, protocol discovery, locale normalization |
-| **Master** | `src/master/mod.rs` | ACP multiplexer singleton: spawns the agent CLI, serves helpers over the pipe, routes per-session notifications |
+| **Master** | `src/master/mod.rs` | ACP multiplexer singleton: owns the lazy agent CLI pool, serves helpers over the pipe, routes per-session notifications |
 | **Helper** | `src/helper/mod.rs` | Thin per-pane entry; reuses `run_default_tui_over_pipe` with the pipe as ACP transport |
 | **App / TUI** | `src/app.rs` (+ `src/app/*.rs`) | TUI state machine and event loop; per-tab sessions, autofix, permission, session-management view |
 | **ACP client** | `src/protocol/acp/client.rs` | Agent-CLI client + helper-side `WtaClient`; prompt templating, model select, probe, failure handling |
@@ -175,8 +175,8 @@ question tools.
 
 ACP (`agent-client-protocol = "1.3.0"`, JSON-RPC 2.0) is spoken on two hops:
 
-- **master ↔ agent CLI** (stdio): master is the ACP **client**; it spawns and
-  owns the agent CLI.
+- **master ↔ agent CLI** (stdio): master is the ACP **client**; it lazily
+  spawns and owns one process per distinct agent key.
 - **helper ↔ master** (named pipe): master is the ACP **agent** (server), the
   helper is the **client**. Master forwards helper requests to the agent CLI and
   fans notifications back to the owning helper.
@@ -257,16 +257,16 @@ liveness model, hooks auto-upgrade, third-party notice generation).
 | Process | Binary | Lifetime | Role |
 |------|-----------|---------|------|
 | **Windows Terminal** | `WindowsTerminal.exe` | User-launched, long-lived | Window manager + renderer; hosts `TerminalProtocolComServer`; spawns master + helpers |
-| **wta-master** | `wta.exe --master` | Spawned once by `SharedWta` | Owns the agent CLI; multiplexes ACP sessions for all helpers |
+| **wta-master** | `wta.exe --master` | Spawned once by `SharedWta` | Owns the agent CLI pool; multiplexes ACP sessions for all helpers |
 | **wta-helper** | `wta.exe --connect-master` | One per agent pane | TUI + per-pane side effects; ACP client of master |
-| **Agent CLI** | `copilot`, `claude`, `gemini`, `codex` | Spawned once by master | The AI "brain"; shared across all helpers |
+| **Agent CLI** | `copilot`, `claude`, `gemini`, `codex`, `opencode` | Spawned lazily by master | One warm process per agent key; shared by helpers using that key |
 | **wtcli** | `wtcli.exe` | Per call (or long-running for `listen`) | COM client for `IProtocolServer`; bridges wta → WT |
 | **Shell commands** | `pwsh`, `cargo`, `git`, … | Spawned by WT; exit when done | The actual tools doing the work |
 
 ### Key lifetime points
 
-- One agent CLI is shared by **all** panes/tabs (master multiplexes). A helper's
-  `session/new` round-trips to the CLI; `initialize` is a cached replay.
+- One agent CLI is shared by panes/tabs with the **same agent key**. A helper's
+  `session/new` round-trips to that CLI; `initialize` is cached per process.
 - Helpers are **pre-warmed per tab** at tab creation (`--start-stashed`), so the
   ACP session connects in the background even before the user opens the pane —
   this is what lets autofix work on a stashed pane.

--- a/tools/wta/PLAN.md
+++ b/tools/wta/PLAN.md
@@ -10,10 +10,10 @@
 ## Overview
 
 WTA is a Rust application. **Current model (see OVERVIEW.md):** it runs as a
-`wta-master` singleton (owns the agent CLI) plus one `wta-helper` TUI per agent
-pane (ACP over a named pipe), with stateless **CLI helpers** (`wta list-panes`,
-`wta capture-pane`, …) for one-shot WT control. There is no standalone TUI and no
-MCP server.
+`wta-master` singleton (owns a lazy agent CLI pool) plus one `wta-helper` TUI
+per agent pane (ACP over a named pipe), with stateless **CLI helpers**
+(`wta list-panes`, `wta capture-pane`, …) for one-shot WT control. There is no
+standalone TUI or standalone MCP server mode.
 
 *The historical description below predates that change:*
 

--- a/tools/wta/README.md
+++ b/tools/wta/README.md
@@ -64,7 +64,7 @@ wta list-windows --json                   # raw JSON output
 ```
 
 Short aliases are supported: `lsw`, `lst`, `lsp`, `neww`, `splitw`, `capturep`,
-`killp`, and `setenv`.
+`killp`, `setenv`, and `mon`.
 
 When `-t` (target pane) is omitted, the active pane is used automatically.
 

--- a/tools/wta/README.md
+++ b/tools/wta/README.md
@@ -9,6 +9,8 @@ Customization:
 
 ### Build
 
+From the repository root:
+
 ```bash
 cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml
 ```
@@ -21,10 +23,12 @@ fallback.
 ### How WTA runs
 
 WTA is normally launched **by Windows Terminal**, not by hand. WT spawns one
-`wta-master` singleton (owns the agent CLI) and one `wta-helper` per agent pane
-(renders this TUI and speaks ACP to master over a named pipe). Bare `wta` with no
-subcommand and neither `--master` nor `--connect-master` exits with an error —
-there is no standalone agent / TUI mode.
+`wta-master` singleton (owns a lazily populated agent CLI pool) and one
+`wta-helper` per agent pane (renders this TUI and speaks ACP to master over a
+named pipe). Helpers selecting the same agent identity, source, and command
+share one agent process. Bare `wta` with no subcommand and neither `--master`
+nor `--connect-master` exits with an error — there is no standalone agent / TUI
+mode.
 
 The default agent is Copilot; the agent and model come from Windows Terminal
 settings (`acpAgent` / `acpModel`) and are passed through to master via `--agent`
@@ -154,13 +158,16 @@ packaged (or bare `%LOCALAPPDATA%\IntelligentTerminal\logs\` unpackaged):
 
 | File | Contents |
 |------|----------|
-| `wta-main_master.log` | `wta-master`: agent CLI spawn, pipe accept loop, per-helper routing |
+| `wta-main_master.log` | `wta-master`: agent CLI pool, pipe accept loop, per-helper routing |
 | `wta-main_helper-{pid}.log` | each `wta-helper`: pipe connect, ACP init, prompts, agent responses, TUI lifecycle |
 | `wta-cli.log` | short-lived CLI helpers (`list-*`, `capture-pane`, `listen`, `sessions`) |
 | `terminal-agent-pane.log` | Agent-pane chrome (C++ TerminalApp side) |
 | `wta-ensure-host.log` | Background host startup / COM connection / SharedWta lifecycle |
 | `wta-acp-debug.log` | ACP protocol debug trace |
 | `wta-delegate.log` | `?<prompt>` delegation flow |
+| `wta-probe.log` | Agent/model/session capability probes |
+| `wta-install-hooks.log` | Hook installation and upgrade diagnostics |
+| `hook-trace.log` | Shell-hook event diagnostics |
 
 Set `WTA_LOG=debug` for verbose output (debug builds default to `debug`, release
 to `info`). The F12 debug panel in the TUI shows protocol traffic live without
@@ -171,7 +178,7 @@ tailing log files.
 ```
 tools/wta/src/
 +-- main.rs                    Entry point, role/CLI dispatch, protocol discovery
-+-- master/mod.rs             wta-master: owns the agent CLI, multiplexes helpers
++-- master/mod.rs             wta-master: owns the agent CLI pool, multiplexes helpers
 +-- helper/mod.rs             wta-helper: per-pane entry (reuses the TUI over a pipe)
 +-- app.rs                     TUI state machine, event loop, per-tab sessions
 |   +-- app/autofix.rs         Autofix detection + suggestion
@@ -206,6 +213,11 @@ tools/wta/src/
 - An ACP-compatible agent CLI (Copilot, Claude ACP adapter, etc.)
 
 ### Build and run
+
+Run these commands from the repository root. CI resolves the
+`tools/wta/rust-toolchain.toml` `ms-prod-1.93` pin through MSRustup; local
+repo-root commands use your installed active toolchain, so changes must remain
+compatible with Rust 1.93.
 
 ```bash
 # A live process may lock the output. Stop only a PID whose executable path

--- a/tools/wta/README.md
+++ b/tools/wta/README.md
@@ -10,11 +10,13 @@ Customization:
 ### Build
 
 ```bash
-cd tools/wta
-cargo build
+cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml
 ```
 
-The binary is output to `tools/wta/target/debug/wta.exe`.
+The binary is output to
+`tools/wta/target/x86_64-pc-windows-msvc/debug/wta.exe`. Always use the explicit
+target in this repo: the package project prefers that output over the host-target
+fallback.
 
 ### How WTA runs
 
@@ -61,7 +63,8 @@ wta resolve-command which --cwd . --json  # resolve from cwd + PATH + shell-spec
 wta list-windows --json                   # raw JSON output
 ```
 
-Short aliases are supported: `lsw`, `lst`, `lsp`, `neww`, `splitw`, `send`, `capturep`, `killp`, `setenv`.
+Short aliases are supported: `lsw`, `lst`, `lsp`, `neww`, `splitw`, `capturep`,
+`killp`, and `setenv`.
 
 When `-t` (target pane) is omitted, the active pane is used automatically.
 
@@ -103,7 +106,7 @@ shell, so any pane-launched process — including wta and wtcli — inherits it.
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `WT_COM_CLSID` | Yes* | Stringified GUID of WT's `TerminalProtocolComServer` COM class |
-| `WTA_DEBUG_LOG` | No | Set to `0` to disable `wta-pipe-debug.log` |
+| `WTA_LOG` | No | Rust tracing filter, such as `debug` or `trace` |
 
 \* Set automatically by WT when it spawns a conpty child. If you launch `wta` from outside WT, run `eval "$(wta set-env)"` to copy the value over (only useful when you've previously captured it from a WT shell).
 
@@ -205,19 +208,17 @@ tools/wta/src/
 ### Build and run
 
 ```bash
-cd tools/wta
+# A live process may lock the output. Stop only a PID whose executable path
+# matches this target; do not kill every wta.exe by name.
+cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml
 
-# Kill any live wta.exe first (a running shared-host locks target/debug/wta.exe):
-#   Get-Process wta -ErrorAction SilentlyContinue | Stop-Process -Force
-cargo build
-
-# Run the test suite (cargo build does NOT compile #[cfg(test)] code):
-cargo test
+# cargo build does not compile #[cfg(test)] code.
+cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml
 ```
 
 The TUI (master + helper) is launched by Windows Terminal as an agent pane — see
 the C++ F5 / `bcz` flow in the repo `AGENTS.md`. From a WT pane you can exercise
-the CLI helpers directly: `target/debug/wta.exe list-windows`, `… capture-pane`, etc.
+the CLI helpers directly with the packaged `wta` app execution alias.
 
 ### Development workflow
 
@@ -244,4 +245,3 @@ the CLI helpers directly: `target/debug/wta.exe list-windows`, `… capture-pane
 - **Protocol discovery**: `WT_COM_CLSID` env var, inherited from the WT-spawned conpty
 - **CLI subcommands** call `CliChannel::connect()` directly; no ShellManager needed
 - **Pane identity** is discovered at startup via PID matching (list all panes, find ours)
-- **Graceful degradation**: if the WT protocol is unavailable, WTA falls back to local-only mode (no WT tools, just local shell operations)

--- a/tools/wta/rust-toolchain.toml
+++ b/tools/wta/rust-toolchain.toml
@@ -1,6 +1,7 @@
 # Pin Rust version for CI reproducibility.
 # The ms-prod channel is resolved by MSRustup (RustInstaller ADO task).
-# Local dev with standard rustup ignores the ms-prod- prefix and uses
-# the latest stable toolchain instead.
+# Standard rustup treats this as a custom toolchain and may not have it
+# installed. Documented local builds run from the repository root, outside
+# this directory override, and must remain compatible with this CI version.
 [toolchain]
 channel = "ms-prod-1.93"


### PR DESCRIPTION
## Summary
- reduce always-loaded agent guidance by about 72% while preserving stable architecture and safety invariants
- establish one explicit-target WTA build workflow and remove broad process-kill guidance
- correct ACP terminology, supported providers, Autofix defaults, log locations, and related security documentation
- remove stale and duplicated Rust, session-management, logging, and dependency guidance

## Validation
- checked Markdown diffs for whitespace errors
- verified referenced files and current settings/provider defaults

<img width="826" height="306" alt="image" src="https://github.com/user-attachments/assets/82477aba-017c-40f8-86b4-e0681617d2cf" />

<img width="817" height="291" alt="image" src="https://github.com/user-attachments/assets/9d8ddf17-e89c-44f1-a755-e12f704e7eed" />

7.9k ->  4.1k