### PR TITLE
Agent pane: Support ACP slash commands

### DIFF
--- a/doc/specs/acp-v1-support-completion-plan.md
+++ b/doc/specs/acp-v1-support-completion-plan.md
@@ -1,10 +1,10 @@
 # ACP v1 Support Completion Plan
 
-**Status**: Implementation in progress; Phase 1 core tool details are on `main`;
-Phase 4 select-option support is implemented locally
+**Status**: Implementation in progress; Phase 1 core tool details and Phase 4
+select-option support are on `main`; Phase 4 Agent Commands are implemented locally
 **Scope**: `tools/wta`, the agent-pane TUI, and the helper/master ACP bridge  
 **Baseline**: ACP wire `protocolVersion: 1`  
-**Last updated**: 2026-08-12
+**Last updated**: 2026-08-14
 
 ## Summary
 
@@ -56,7 +56,7 @@ additional ACP v1 work after PR #601.
 | Client Terminals | Commands can run in a WT pane or local subprocess. | `outputByteLimit`, retained-output semantics, accurate truncation, final output after kill, and display retention after release. |
 | Session lifecycle | New, load, cancel, and partial list flows exist. | Capability-gated resume, close, delete, list pagination/filtering, and `session_info_update`. |
 | Session config | Model select options are extracted. | Generic select options, boolean options, mode/reasoning/model-config categories, ordering, and dependent option updates. |
-| Agent commands | WTA has its own slash commands. | `available_commands_update` is ignored instead of contributing session-scoped Agent commands. |
+| Agent commands | Session-scoped Agent commands are merged into the slash-command popup. | No remaining stable ACP v1 gap in the current unstructured command surface. |
 | Authentication | CLI-specific login plus first-method post-login authenticate. | Auth-method selection, standard logout, and clearer capability-driven state. |
 | Cancellation | `session/cancel` stops the active prompt locally and notifies the Agent. | Stable request-ID `$/cancel_request` and consistent cancellation of pending reverse requests. |
 | Structured input | Permission cards handle approval choices. | Stable ACP elicitation form and URL modes. |
@@ -203,11 +203,14 @@ not currently have a safe file-handler selection model.
 
 ### Phase 4: Generic config options and Agent commands
 
-**Implementation status**: The first Config Options slice is implemented
-locally. WTA preserves ordered select options per Session, replaces complete
+**Implementation status**: The first Config Options slice is on `main`. WTA
+preserves ordered select options per Session, replaces complete
 snapshots from new/load/update/set responses, exposes a generic `/config`
 two-level picker, and routes `/model` through the standard model option when
-one exists. Boolean options and Agent commands remain follow-ups.
+one exists. Agent Commands are implemented locally: complete Session-scoped
+snapshots are merged after WTA-reserved commands, reserved-name collisions stay
+client-owned, and commands removed by later snapshots disappear. Boolean
+options remain a follow-up.
 
 1. Store the complete ordered `configOptions` collection per session.
 2. Render all supported select options, not only the `model` category.

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -107,8 +107,8 @@ pub fn resolve_sessions_origin_filter() -> crate::agent_sessions::OriginFilter {
 }
 
 pub use crate::app_contracts::{
-    AcpModelInfo, AppEvent, AvailableAgent, CheckStatus, DebugDir, DebugMessage, PlanEntryStatus,
-    PreflightResult,
+    AcpModelInfo, AcpSessionCommand, AppEvent, AvailableAgent, CheckStatus, DebugDir, DebugMessage,
+    PlanEntryStatus, PreflightResult,
 };
 use crate::commands::{self, CommandKind, ParseOutcome, ParsedCommand};
 use crate::coordinator::{recommended_choice_index, RecommendationChoice, RecommendationSet};
@@ -917,6 +917,8 @@ pub struct App {
     session_model_configs: HashMap<String, (Vec<AcpModelInfo>, Option<String>)>,
     /// Complete ordered ACP select config options, keyed by SessionId.
     session_config_options: HashMap<String, Vec<crate::app_contracts::AcpSessionConfigOption>>,
+    /// Complete ordered Agent command snapshots, keyed by SessionId.
+    session_commands: HashMap<String, Vec<AcpSessionCommand>>,
     pub prompt_name: Option<String>,
     pub session_id: String,
     #[allow(dead_code)]
@@ -1235,6 +1237,7 @@ impl App {
             current_model_id: None,
             session_model_configs: HashMap::new(),
             session_config_options: HashMap::new(),
+            session_commands: HashMap::new(),
             prompt_name: None,
             session_id: String::new(),
             wt_connected,
@@ -3989,6 +3992,7 @@ impl App {
             AppEvent::UsageCleared { .. } => "usage_cleared",
             AppEvent::ModelConfigUpdated { .. } => "model_config_updated",
             AppEvent::SessionConfigUpdated { .. } => "session_config_updated",
+            AppEvent::SessionCommandsUpdated { .. } => "session_commands_updated",
             AppEvent::SessionConfigSetCompleted { .. } => "session_config_set_completed",
             AppEvent::SessionConfigSetFailed { .. } => "session_config_set_failed",
             AppEvent::TabError { .. } => "tab_error",
@@ -4469,6 +4473,49 @@ impl App {
             .map(|n| (n.summary.as_str(), &n.severity))
     }
 
+    fn current_session_commands(&self) -> &[AcpSessionCommand] {
+        self.current_tab()
+            .session_id
+            .as_deref()
+            .and_then(|session_id| self.session_commands.get(session_id))
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    fn agent_slash_command_candidates(&self) -> Vec<&AcpSessionCommand> {
+        let input = self.current_tab().input.trim_start();
+        if !commands::is_command_prefix(input) {
+            return Vec::new();
+        }
+        let query = input
+            .strip_prefix('/')
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        let (prefix, contains): (Vec<_>, Vec<_>) = self
+            .current_session_commands()
+            .iter()
+            .filter(|command| {
+                commands::lookup(&command.name).is_none()
+                    && command.name.to_ascii_lowercase().contains(&query)
+            })
+            .partition(|command| command.name.to_ascii_lowercase().starts_with(&query));
+        prefix.into_iter().chain(contains).collect()
+    }
+
+    fn slash_command_candidates(&self) -> Vec<crate::ui::CommandCandidate<'_>> {
+        self.current_tab()
+            .command_popup_candidates
+            .iter()
+            .copied()
+            .map(crate::ui::CommandCandidate::Client)
+            .chain(
+                self.agent_slash_command_candidates()
+                    .into_iter()
+                    .map(crate::ui::CommandCandidate::Agent),
+            )
+            .collect()
+    }
+
     /// Visible popup state for the renderer. Returns `None` when the
     /// popup should not be drawn this frame. Reads from the active tab.
     pub fn command_popup_state(&self) -> Option<crate::ui::PopupState<'_>> {
@@ -4483,26 +4530,25 @@ impl App {
         // it, e.g. "/new"), and the Enter handler surfaces the reconnect hint.
         // Static command and move candidates borrow the tab's lists. Agent
         // candidates are filtered from the small cached available-agent list.
-        let agent_candidates: Vec<_> = self.agent_command_candidates().collect();
+        let agent_candidates: Vec<_> =
+            self.available_agent_command_candidates().collect();
         let candidates = if self.transport_lost {
-            let filtered: Vec<&'static crate::commands::CommandSpec> = tab
-                .command_popup_candidates
+            let filtered: Vec<_> = tab.command_popup_candidates
                 .iter()
                 .copied()
                 .filter(|s| s.kind == crate::commands::CommandKind::Restart)
+                .map(crate::ui::CommandCandidate::Client)
                 .collect();
             if filtered.is_empty() {
                 return None;
             }
-            crate::ui::PopupCandidates::Commands(std::borrow::Cow::Owned(filtered))
+            crate::ui::PopupCandidates::Commands(filtered)
         } else if !agent_candidates.is_empty() {
             crate::ui::PopupCandidates::Agents(agent_candidates)
         } else if !tab.move_position_candidates.is_empty() {
             crate::ui::PopupCandidates::MovePositions(tab.move_position_candidates.as_slice())
         } else {
-            crate::ui::PopupCandidates::Commands(std::borrow::Cow::Borrowed(
-                tab.command_popup_candidates.as_slice(),
-            ))
+            crate::ui::PopupCandidates::Commands(self.slash_command_candidates())
         };
         Some(crate::ui::PopupState {
             candidates,
@@ -4514,6 +4560,11 @@ impl App {
                 .strip_prefix('/')
                 .unwrap_or_default(),
             current_model: self.current_model_display(),
+            agent_label: if self.agent_name.is_empty() {
+                self.current_agent_id.as_str()
+            } else {
+                self.agent_name.as_str()
+            },
         })
     }
 
@@ -4553,7 +4604,8 @@ impl App {
     /// invisible popup.
     pub(super) fn command_popup_visible(&self) -> bool {
         if !self.current_tab().command_popup_visible()
-            && self.agent_command_candidates().next().is_none()
+            && self.available_agent_command_candidates().next().is_none()
+            && self.agent_slash_command_candidates().is_empty()
         {
             return false;
         }
@@ -4569,7 +4621,7 @@ impl App {
         true
     }
 
-    fn agent_command_candidates(&self) -> impl Iterator<Item = &AvailableAgent> {
+    fn available_agent_command_candidates(&self) -> impl Iterator<Item = &AvailableAgent> {
         let prefix = if self.transport_lost {
             None
         } else {
@@ -4587,18 +4639,45 @@ impl App {
 
     fn selected_agent_command_candidate(&self) -> Option<&AvailableAgent> {
         let selected = self.current_tab().command_popup_selected;
-        self.agent_command_candidates()
+        self.available_agent_command_candidates()
             .take(selected.saturating_add(1))
             .last()
     }
 
+    fn selected_slash_command_candidate(&self) -> Option<crate::ui::CommandCandidate<'_>> {
+        let candidates = self.slash_command_candidates();
+        let selected = self
+            .current_tab()
+            .command_popup_selected
+            .min(candidates.len().saturating_sub(1));
+        candidates.get(selected).copied()
+    }
+
+    fn agent_command_for_input(&self, input: &str) -> Option<&AcpSessionCommand> {
+        let rest = input.trim_start().strip_prefix('/')?;
+        if rest.starts_with('/') {
+            return None;
+        }
+        let name = rest.split_whitespace().next()?;
+        if commands::lookup(name).is_some() {
+            return None;
+        }
+        self.current_session_commands()
+            .iter()
+            .find(|command| command.name.eq_ignore_ascii_case(name))
+    }
+
     fn command_popup_candidate_count(&self) -> usize {
-        let agent_count = self.agent_command_candidates().count();
+        let agent_count = self.available_agent_command_candidates().count();
         if agent_count > 0 {
             agent_count
         } else {
             let tab = self.current_tab();
-            tab.command_popup_candidates.len() + tab.move_position_candidates.len()
+            if !tab.move_position_candidates.is_empty() {
+                tab.move_position_candidates.len()
+            } else {
+                self.slash_command_candidates().len()
+            }
         }
     }
 
@@ -4619,12 +4698,21 @@ impl App {
         if tab.cursor_pos != tab.input.len() {
             return None;
         }
-        let prefix = commands::agent_id_prefix(&tab.input)?;
+        if let Some(prefix) = commands::agent_id_prefix(&tab.input) {
         let candidate = self.selected_agent_command_candidate()?;
-        candidate
+            return candidate
             .id
             .get(prefix.len()..)
-            .filter(|suffix| !suffix.is_empty())
+                .filter(|suffix| !suffix.is_empty());
+        }
+        let command = self.agent_command_for_input(&tab.input)?;
+        let rest = tab.input.trim_start().strip_prefix('/')?;
+        let name = rest.split_whitespace().next()?;
+        let after_name = rest.get(name.len()..)?;
+        (after_name.chars().all(char::is_whitespace) && !after_name.is_empty())
+            .then_some(command.input_hint.as_deref())
+            .flatten()
+            .filter(|hint| !hint.is_empty())
     }
 
     /// Per-frame state for the `/model` picker modal, or `None` when it's not
@@ -4725,6 +4813,21 @@ impl App {
                     self.handle_slash_command(parsed);
                     return true;
                 }
+                if let Some(crate::ui::CommandCandidate::Agent(command)) =
+                    self.selected_slash_command_candidate()
+                {
+                    let needs_input = command.input_hint.is_some();
+                    let input = if needs_input {
+                        format!("/{} ", command.name)
+                    } else {
+                        format!("/{}", command.name)
+                    };
+                    let tab = self.current_tab_mut();
+                    tab.input = input;
+                    tab.cursor_pos = tab.input.len();
+                    tab.refresh_command_popup();
+                    return needs_input;
+                }
             }
 
             let spec = if self.transport_lost {
@@ -4774,6 +4877,12 @@ impl App {
                 true
             }
             ParseOutcome::Unknown(name) => {
+                if self
+                    .agent_command_for_input(&self.current_tab().input)
+                    .is_some()
+                {
+                    return false;
+                }
                 // Warn but fall through: the raw line (leading `/` intact) is
                 // still sent so the user doesn't lose what they typed.
                 let tab = self.current_tab_mut();
@@ -4879,8 +4988,9 @@ impl App {
     fn cmd_new(&mut self, in_flight: bool) {
         if in_flight {
             let tab = self.current_tab_mut();
-            tab.messages
-                .push(ChatMessage::warning(t!("system.busy_use_stop").into_owned()));
+            tab.messages.push(ChatMessage::warning(
+                t!("system.busy_use_stop").into_owned(),
+            ));
             tab.scroll_to_bottom();
             return;
         }
@@ -4895,6 +5005,7 @@ impl App {
         if let Some(session_id) = self.current_tab().session_id.clone() {
             self.session_model_configs.remove(&session_id);
             self.session_config_options.remove(&session_id);
+            self.session_commands.remove(&session_id);
         }
         let tab = self.current_tab_mut();
         tab.clear_chat_history();
@@ -4925,8 +5036,9 @@ impl App {
     fn cmd_fix(&mut self, in_flight: bool, hint: String) {
         if in_flight {
             let tab = self.current_tab_mut();
-            tab.messages
-                .push(ChatMessage::warning(t!("system.busy_use_stop").into_owned()));
+            tab.messages.push(ChatMessage::warning(
+                t!("system.busy_use_stop").into_owned(),
+            ));
             tab.scroll_to_bottom();
             return;
         }
@@ -5087,6 +5199,7 @@ impl App {
         self.session_to_tab.clear();
         self.session_model_configs.clear();
         self.session_config_options.clear();
+        self.session_commands.clear();
         self.session_id.clear();
         for (_, tab) in self.tab_sessions.iter_mut() {
             tab.clear_chat_history();
@@ -5154,8 +5267,7 @@ impl App {
                 let offset = self.current_tab().rec_scroll.offset;
                 // `card_h` includes the inter-card gap, so subtracting it
                 // yields the rendered card's exclusive bottom row.
-                let rendered_bottom_exclusive =
-                    line_top.saturating_add(card_h.saturating_sub(1));
+                let rendered_bottom_exclusive = line_top.saturating_add(card_h.saturating_sub(1));
                 let viewport_bottom = offset.saturating_add(viewport_height);
                 if line_top < offset || rendered_bottom_exclusive > viewport_bottom {
                     self.current_tab_mut().rec_scroll.set(line_top);
@@ -5255,6 +5367,7 @@ impl App {
         if let Some(session_id) = removed.as_ref().and_then(|tab| tab.session_id.as_ref()) {
             self.session_model_configs.remove(session_id);
             self.session_config_options.remove(session_id);
+            self.session_commands.remove(session_id);
         }
         self.session_to_tab.retain(|_, tab| tab != closed_tab_id);
 
@@ -5473,6 +5586,7 @@ impl App {
         if let Some(session_id) = removed_session_id {
             self.session_model_configs.remove(&session_id);
             self.session_config_options.remove(&session_id);
+            self.session_commands.remove(&session_id);
         }
 
         // Prune the reverse SessionId → tab routing so late ACP chunks for

--- a/tools/wta/src/app_contracts/command.rs
+++ b/tools/wta/src/app_contracts/command.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpSessionCommand {
+    pub name: String,
+    pub description: String,
+    pub input_hint: Option<String>,
+}

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -1,8 +1,8 @@
 use crossterm::event::{KeyEvent, MouseEvent};
 
 use super::{
-    AcpModelInfo, AcpSessionConfigOption, AvailableAgent, DebugMessage, PermOption, PlanEntry,
-    PreflightResult,
+    AcpModelInfo, AcpSessionCommand, AcpSessionConfigOption, AvailableAgent, DebugMessage,
+    PermOption, PlanEntry, PreflightResult,
 };
 
 pub enum AppEvent {
@@ -48,6 +48,10 @@ pub enum AppEvent {
     SessionConfigUpdated {
         session_id: String,
         options: Vec<AcpSessionConfigOption>,
+    },
+    SessionCommandsUpdated {
+        session_id: String,
+        commands: Vec<AcpSessionCommand>,
     },
     SessionConfigSetCompleted {
         session_id: String,

--- a/tools/wta/src/app_contracts/mod.rs
+++ b/tools/wta/src/app_contracts/mod.rs
@@ -4,6 +4,7 @@
 //! boundaries. Mutable UI state remains owned by `app`.
 
 mod agent;
+mod command;
 mod config;
 mod diagnostics;
 mod event;
@@ -13,6 +14,7 @@ mod plan;
 mod preflight;
 
 pub use agent::AvailableAgent;
+pub use command::AcpSessionCommand;
 pub use config::{AcpSessionConfigOption, AcpSessionConfigValue};
 pub use diagnostics::{DebugDir, DebugMessage};
 pub use event::AppEvent;

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -263,6 +263,7 @@ impl App {
                     self.session_to_tab.remove(&replaced_session_id);
                     self.session_model_configs.remove(&replaced_session_id);
                     self.session_config_options.remove(&replaced_session_id);
+                    self.session_commands.remove(&replaced_session_id);
                 }
                 self.session_to_tab
                     .insert(session_id.clone(), tab_id.clone());
@@ -379,6 +380,12 @@ impl App {
                 picker.reconcile(options);
                 self.tab_mut(&target_tab).config_picker = picker;
             }
+            AppEvent::SessionCommandsUpdated {
+                session_id,
+                commands,
+            } => {
+                self.session_commands.insert(session_id, commands);
+            }
             AppEvent::SessionConfigSetCompleted {
                 session_id,
                 config_id,
@@ -391,10 +398,7 @@ impl App {
                     .and_then(|options| options.iter_mut().find(|option| option.id == config_id))
                     .map(|option| {
                         option.current_value = value.clone();
-                        (
-                            option.name.clone(),
-                            option.current_value_name().to_string(),
-                        )
+                        (option.name.clone(), option.current_value_name().to_string())
                     })
                     .unwrap_or_else(|| (config_id.clone(), value.clone()));
                 let target_tab = self.bound_tab_for_session(&session_id);

--- a/tools/wta/src/app_keys.rs
+++ b/tools/wta/src/app_keys.rs
@@ -265,14 +265,14 @@ impl App {
                             .modifiers
                             .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
                     {
-                        self.current_tab_mut().agents_view.search_query.push(*character);
+                        self.current_tab_mut()
+                            .agents_view
+                            .search_query
+                            .push(*character);
                         self.reset_agents_search_selection(&tab_id);
                         return;
                     }
-                    KeyCode::Up
-                    | KeyCode::Down
-                    | KeyCode::Enter
-                    | KeyCode::F(5) => {}
+                    KeyCode::Up | KeyCode::Down | KeyCode::Enter | KeyCode::F(5) => {}
                     _ => return,
                 }
             }
@@ -395,8 +395,8 @@ impl App {
                         request.selected = request.selected.saturating_sub(1);
                     }
                     KeyCode::Down => {
-                        request.selected = (request.selected + 1)
-                            .min(request.selection_count().saturating_sub(1));
+                        request.selected =
+                            (request.selected + 1).min(request.selection_count().saturating_sub(1));
                     }
                     KeyCode::Char(character)
                         if request.request.allow_freeform
@@ -420,9 +420,7 @@ impl App {
                                     selected_index: None,
                                 });
                             }
-                        } else if let Some(answer) =
-                            request.request.choices.get(request.selected)
-                        {
+                        } else if let Some(answer) = request.request.choices.get(request.selected) {
                             resolved = Some(UserInputResponse::Answered {
                                 answer: answer.clone(),
                                 selected_index: Some(request.selected),
@@ -536,8 +534,7 @@ impl App {
         }
 
         match key.code {
-            KeyCode::Up if self.current_tab().turn.recommendations().is_some() =>
-            {
+            KeyCode::Up if self.current_tab().turn.recommendations().is_some() => {
                 if self.current_tab().recommendation_focus == RecommendationFocus::Input {
                     let choices_len = self
                         .current_tab()
@@ -566,8 +563,7 @@ impl App {
                     self.recompute_chip_override(&tab_id);
                 }
             }
-            KeyCode::Down if self.current_tab().turn.recommendations().is_some() =>
-            {
+            KeyCode::Down if self.current_tab().turn.recommendations().is_some() => {
                 let choices_len = self
                     .current_tab()
                     .turn
@@ -597,8 +593,7 @@ impl App {
             }
             KeyCode::Right
                 if self.current_tab().turn.recommendations().is_some()
-                    && self.current_tab().recommendation_focus
-                        == RecommendationFocus::Button =>
+                    && self.current_tab().recommendation_focus == RecommendationFocus::Button =>
             {
                 self.focus_next_recommendation_action();
             }
@@ -629,8 +624,7 @@ impl App {
             }
             KeyCode::Left
                 if self.current_tab().turn.recommendations().is_some()
-                    && self.current_tab().recommendation_focus
-                        == RecommendationFocus::Button =>
+                    && self.current_tab().recommendation_focus == RecommendationFocus::Button =>
             {
                 self.focus_previous_recommendation_action();
             }
@@ -871,6 +865,9 @@ impl App {
                         tab.scroll_to_bottom();
                         return;
                     }
+                    let is_agent_command = self
+                        .agent_command_for_input(&self.current_tab().input)
+                        .is_some();
                     let tab = self.current_tab_mut();
                     let display_text = std::mem::take(&mut tab.input);
                     let (text, images) = tab.attachments.take_for_submission(display_text.clone());
@@ -896,8 +893,12 @@ impl App {
                         cwd: self.source_cwd.clone(),
                         source_pane_id: self.source_session_id.clone(),
                     };
-                    let prompt =
-                        PromptSubmission::new(text.clone(), Some(pane_context)).with_images(images);
+                    let prompt = if is_agent_command {
+                        PromptSubmission::new_agent_command(text.clone(), Some(pane_context))
+                    } else {
+                        PromptSubmission::new(text.clone(), Some(pane_context))
+                    }
+                    .with_images(images);
                     prompt_timing_log(
                         prompt.id,
                         prompt.submitted_at_unix_s,

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -78,6 +78,9 @@ pub struct PromptSubmission {
     /// inputs. Automatic summaries are untrusted diagnostic context, while
     /// text supplied to `/fix` is user intent.
     pub autofix_text_kind: Option<AutofixTextKind>,
+    /// An Agent-advertised slash command. ACP requires this text to reach
+    /// `session/prompt` verbatim, without planner templates or runtime context.
+    pub agent_command: bool,
     /// Images pasted into the input via Alt+V. Sent to the agent as ACP
     /// `ContentBlock::Image` blocks appended after the text block (only when
     /// the agent advertised `promptCapabilities.image`). Empty for the common
@@ -261,6 +264,12 @@ impl PromptSubmission {
         Self::new_with_kind(text, pane_context, Some(AutofixTextKind::FailureSummary))
     }
 
+    pub fn new_agent_command(text: String, pane_context: Option<PaneContext>) -> Self {
+        let mut prompt = Self::new_with_kind(text, pane_context, None);
+        prompt.agent_command = true;
+        prompt
+    }
+
     fn new_with_kind(
         text: String,
         pane_context: Option<PaneContext>,
@@ -273,12 +282,17 @@ impl PromptSubmission {
             pane_context,
             submitted_at_unix_s: now_unix_s(),
             autofix_text_kind,
+            agent_command: false,
             images: Vec::new(),
         }
     }
 
     pub fn is_autofix(&self) -> bool {
         self.autofix_text_kind.is_some()
+    }
+
+    pub fn is_agent_command(&self) -> bool {
+        self.agent_command
     }
 
     /// Attach pasted images (Alt+V) to a human-entered prompt.
@@ -822,6 +836,9 @@ fn session_update_kind(update: &acp::schema::v1::SessionUpdate) -> &'static str 
         acp::schema::v1::SessionUpdate::ToolCall(_) => "tool_call",
         acp::schema::v1::SessionUpdate::ToolCallUpdate(_) => "tool_call_update",
         acp::schema::v1::SessionUpdate::Plan(_) => "plan",
+        acp::schema::v1::SessionUpdate::AvailableCommandsUpdate(_) => {
+            "available_commands_update"
+        }
         acp::schema::v1::SessionUpdate::UsageUpdate(_) => "usage_update",
         _ => "other",
     }
@@ -1502,6 +1519,14 @@ impl WtaClient {
                 let _ = self.state.event_tx.send(AppEvent::UsageReported {
                     session_id: sid,
                     snapshot,
+                });
+            }
+            acp::schema::v1::SessionUpdate::AvailableCommandsUpdate(update) => {
+                let commands =
+                    crate::protocol::acp::session_commands::normalize(&update.available_commands);
+                let _ = self.state.event_tx.send(AppEvent::SessionCommandsUpdated {
+                    session_id: sid,
+                    commands,
                 });
             }
             acp::schema::v1::SessionUpdate::ConfigOptionUpdate(update) => {
@@ -4176,9 +4201,13 @@ async fn dispatch_prompt_body(
     } else {
         TemplateKind::Planner
     };
-    let include_template = template_memo
-        .should_ship(&prompt_session_id_str, kind)
-        .await;
+    let include_template = if prompt.is_agent_command() {
+        false
+    } else {
+        template_memo
+            .should_ship(&prompt_session_id_str, kind)
+            .await
+    };
 
     prompt_timing_task.activate(
         &prompt_session_id_str,
@@ -4186,17 +4215,23 @@ async fn dispatch_prompt_body(
         &prompt.text,
         prompt.submitted_at_unix_s,
     );
-    let (text, prompt_source, prompt_name, resolved_target_pane) = build_prompt_text(
-        prompt.id,
-        prompt.submitted_at_unix_s,
-        &prompt.text,
-        prompt.autofix_text_kind,
-        include_template,
-        &shell_mgr_task,
-        wt_connected,
-        prompt.pane_context.as_ref(),
-    )
-    .await;
+    let (text, prompt_source, resolved_target_pane) = if prompt.is_agent_command() {
+        (prompt.text.clone(), "agent_command".to_string(), None)
+    } else {
+        let (text, source, name, target) = build_prompt_text(
+            prompt.id,
+            prompt.submitted_at_unix_s,
+            &prompt.text,
+            prompt.autofix_text_kind,
+            include_template,
+            &shell_mgr_task,
+            wt_connected,
+            prompt.pane_context.as_ref(),
+        )
+        .await;
+        let _ = event_tx_task.send(AppEvent::PromptTemplateLoaded { name });
+        (text, source, target)
+    };
     if proposal_commands_supported {
         match proposal_channels.issue(
             prompt_session_id_str.clone(),
@@ -4224,7 +4259,6 @@ async fn dispatch_prompt_body(
             pane_id,
         });
     }
-    let _ = event_tx_task.send(AppEvent::PromptTemplateLoaded { name: prompt_name });
     prompt_timing_task.mark_context_ready(&prompt_session_id_str, text.len());
     acp_log_built_prompt(
         &prompt.text,
@@ -4232,13 +4266,23 @@ async fn dispatch_prompt_body(
         &prompt_source,
         &text,
     );
-    log_turn_trace(
-        prompt.id,
-        &prompt_session_id_str,
-        kind,
-        include_template,
-        &text,
-    );
+    if prompt.is_agent_command() {
+        tracing::info!(
+            target: "acp",
+            prompt_id = prompt.id,
+            session_id = %prompt_session_id_str,
+            prompt_len = text.len(),
+            "sending Agent command verbatim"
+        );
+    } else {
+        log_turn_trace(
+            prompt.id,
+            &prompt_session_id_str,
+            kind,
+            include_template,
+            &text,
+        );
+    }
     prompt_timing_task.mark_prompt_sent(&prompt_session_id_str);
 
     // Telemetry: prompt dispatched over ACP. WTA emits `AgentPromptSent`
@@ -4251,6 +4295,7 @@ async fn dispatch_prompt_body(
         prompt.is_autofix(),
         match kind {
             TemplateKind::Autofix => "Autofix",
+            TemplateKind::Planner if prompt.is_agent_command() => "AgentCommand",
             TemplateKind::Planner => "Planner",
         },
     );

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -742,6 +742,7 @@ fn test_prompt(id: u64, text: &str, is_autofix: bool) -> PromptSubmission {
         pane_context: None,
         submitted_at_unix_s: 0.0,
         autofix_text_kind: is_autofix.then_some(AutofixTextKind::UserRequest),
+        agent_command: false,
         images: Vec::new(),
     }
 }
@@ -881,6 +882,51 @@ async fn dispatch_prompt_round_trips_through_agent() {
             assert!(
                 in_flight.lock().unwrap().is_empty(),
                 "single-flight slot must be released when the turn completes"
+            );
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn dispatch_agent_command_reaches_agent_verbatim() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let mut h = connect_for_dispatch(MockBehavior::Reply);
+            h.conn
+                .initialize(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .await
+                .expect("initialize failed");
+
+            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let mut prompt = test_prompt(1, "/usage", false);
+            prompt.agent_command = true;
+
+            dispatch_prompt(
+                prompt,
+                &h.conn,
+                &tab_to_session,
+                &memo,
+                &in_flight,
+                &cancel_signals,
+                &h.event_tx,
+                &h.shell_mgr,
+                &h.prompt_timing,
+                &h.client,
+                &PromptUsageIdentity::default(),
+                false,
+                false,
+                true,
+                &h.proposal_channels,
+            );
+
+            let _ = next_agent_chunk(&mut h.event_rx).await;
+            assert_eq!(
+                h.seen_prompts.lock().unwrap().as_slice(),
+                ["/usage"],
+                "Agent commands must bypass terminal templates and runtime context"
             );
         })
         .await;
@@ -2687,6 +2733,53 @@ async fn session_notification_routes_plan_with_status_mapping() {
             );
         }
         _ => panic!("expected Plan"),
+    }
+}
+
+#[tokio::test]
+async fn session_notification_routes_complete_available_command_snapshot() {
+    let (client, mut rx) = bare_client();
+    let commands = vec![
+        acp::schema::v1::AvailableCommand::new("plan", "Build a plan"),
+        acp::schema::v1::AvailableCommand::new("review", "Review changes").input(
+            acp::schema::v1::AvailableCommandInput::Unstructured(
+                acp::schema::v1::UnstructuredCommandInput::new("focus area"),
+            ),
+        ),
+    ];
+    client
+        .session_notification(notif(
+            "s1",
+            acp::schema::v1::SessionUpdate::AvailableCommandsUpdate(
+                acp::schema::v1::AvailableCommandsUpdate::new(commands),
+            ),
+        ))
+        .await
+        .unwrap();
+
+    match rx.try_recv() {
+        Ok(AppEvent::SessionCommandsUpdated {
+            session_id,
+            commands,
+        }) => {
+            assert_eq!(session_id, "s1");
+            assert_eq!(
+                commands,
+                vec![
+                    crate::app_contracts::AcpSessionCommand {
+                        name: "plan".into(),
+                        description: "Build a plan".into(),
+                        input_hint: None,
+                    },
+                    crate::app_contracts::AcpSessionCommand {
+                        name: "review".into(),
+                        description: "Review changes".into(),
+                        input_hint: Some("focus area".into()),
+                    },
+                ]
+            );
+        }
+        _ => panic!("expected SessionCommandsUpdated"),
     }
 }
 

--- a/tools/wta/src/protocol/acp/mod.rs
+++ b/tools/wta/src/protocol/acp/mod.rs
@@ -7,6 +7,7 @@ pub mod prompt;
 pub(crate) mod prompt_builder;
 pub(crate) mod prompt_context;
 pub(crate) mod session_config;
+pub(crate) mod session_commands;
 pub(crate) mod session_list;
 pub mod soft_stop;
 pub(crate) mod spawn;

--- a/tools/wta/src/protocol/acp/session_commands.rs
+++ b/tools/wta/src/protocol/acp/session_commands.rs
@@ -1,0 +1,73 @@
+use agent_client_protocol::schema::v1::{AvailableCommand, AvailableCommandInput};
+use std::collections::HashSet;
+
+use crate::app_contracts::AcpSessionCommand;
+
+pub(crate) fn normalize(commands: &[AvailableCommand]) -> Vec<AcpSessionCommand> {
+    let mut seen = HashSet::new();
+    commands
+        .iter()
+        .filter_map(|command| {
+            let name = command.name.trim().trim_start_matches('/');
+            if name.is_empty()
+                || name.chars().any(char::is_whitespace)
+                || !seen.insert(name.to_ascii_lowercase())
+            {
+                return None;
+            }
+            let input_hint = match command.input.as_ref() {
+                Some(AvailableCommandInput::Unstructured(input)) => {
+                    Some(input.hint.trim().to_string())
+                }
+                _ => None,
+            };
+            Some(AcpSessionCommand {
+                name: name.to_string(),
+                description: command.description.trim().to_string(),
+                input_hint,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalization_preserves_order_and_drops_unusable_duplicates() {
+        let commands = vec![
+            AvailableCommand::new(" plan ", " Build a plan "),
+            AvailableCommand::new("/review", "Review changes"),
+            AvailableCommand::new("explain", "Explain code").input(
+                AvailableCommandInput::Unstructured(
+                    agent_client_protocol::schema::v1::UnstructuredCommandInput::new(""),
+                ),
+            ),
+            AvailableCommand::new("PLAN", "Duplicate"),
+            AvailableCommand::new("two words", "Unaddressable"),
+            AvailableCommand::new("", "Empty"),
+        ];
+
+        assert_eq!(
+            normalize(&commands),
+            vec![
+                AcpSessionCommand {
+                    name: "plan".into(),
+                    description: "Build a plan".into(),
+                    input_hint: None,
+                },
+                AcpSessionCommand {
+                    name: "review".into(),
+                    description: "Review changes".into(),
+                    input_hint: None,
+                },
+                AcpSessionCommand {
+                    name: "explain".into(),
+                    description: "Explain code".into(),
+                    input_hint: Some(String::new()),
+                },
+            ]
+        );
+    }
+}

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -36,6 +36,31 @@ fn last_notice(app: &App) -> (NoticeKind, &str) {
     }
 }
 
+fn session_command(
+    name: &str,
+    description: &str,
+    input_hint: Option<&str>,
+) -> crate::app_contracts::AcpSessionCommand {
+    crate::app_contracts::AcpSessionCommand {
+        name: name.into(),
+        description: description.into(),
+        input_hint: input_hint.map(str::to_string),
+    }
+}
+
+fn popup_command_names(app: &App) -> Vec<String> {
+    match app.command_popup_state().expect("command popup").candidates {
+        crate::ui::PopupCandidates::Commands(candidates) => candidates
+            .into_iter()
+            .map(|candidate| match candidate {
+                crate::ui::CommandCandidate::Client(spec) => spec.name.to_string(),
+                crate::ui::CommandCandidate::Agent(command) => command.name.clone(),
+            })
+            .collect(),
+        _ => panic!("expected slash-command candidates"),
+    }
+}
+
 // ---- commands::classify — the pure input → intent mapping ----
 
 #[test]
@@ -84,6 +109,122 @@ fn classify_not_a_command() {
         commands::classify("run cmd /flag"),
         ParseOutcome::NotCommand
     );
+}
+
+#[test]
+fn agent_commands_merge_after_reserved_commands_and_replace_by_session() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionCommandsUpdated {
+        session_id: "session-1".into(),
+        commands: vec![
+            session_command("plan", "Build a plan", None),
+            session_command("clear", "Agent collision", None),
+        ],
+    });
+    app.handle_event(AppEvent::SessionCommandsUpdated {
+        session_id: "session-2".into(),
+        commands: vec![session_command("research", "Research", None)],
+    });
+    type_input(&mut app, "/");
+
+    let names = popup_command_names(&app);
+    assert_eq!(&names[..commands::REGISTRY.len()], {
+        &commands::REGISTRY
+            .iter()
+            .map(|spec| spec.name.to_string())
+            .collect::<Vec<_>>()[..]
+    });
+    assert_eq!(
+        names.iter().filter(|name| name.as_str() == "clear").count(),
+        1,
+        "an Agent command must not shadow a reserved WTA command"
+    );
+    assert!(names.contains(&"plan".to_string()));
+    assert!(!names.contains(&"research".to_string()));
+
+    app.current_tab_mut().clear_input();
+    app.handle_event(AppEvent::SessionCommandsUpdated {
+        session_id: "session-1".into(),
+        commands: vec![session_command("review", "Review changes", None)],
+    });
+    type_input(&mut app, "/");
+    let names = popup_command_names(&app);
+    assert!(!names.contains(&"plan".to_string()));
+    assert!(names.contains(&"review".to_string()));
+}
+
+#[test]
+fn agent_command_without_input_submits_as_a_normal_prompt() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionCommandsUpdated {
+        session_id: "session-1".into(),
+        commands: vec![session_command("plan", "Build a plan", None)],
+    });
+    type_input(&mut app, "/pla");
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert!(app.current_tab().input.is_empty());
+    assert!(app.current_tab().turn.is_in_flight());
+    assert!(!app.current_tab().messages.iter().any(|message| matches!(
+        message,
+        ChatMessage::Notice {
+            kind: NoticeKind::Warning,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn agent_command_with_input_hint_enters_argument_mode() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionCommandsUpdated {
+        session_id: "session-1".into(),
+        commands: vec![session_command(
+            "review",
+            "Review changes",
+            Some("focus area"),
+        )],
+    });
+    type_input(&mut app, "/rev");
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert_eq!(app.current_tab().input, "/review ");
+    assert_eq!(app.command_ghost_suffix(), Some("focus area"));
+    assert!(app.current_tab().turn.is_idle());
+}
+
+#[test]
+fn typed_agent_command_with_arguments_has_no_unknown_warning() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionCommandsUpdated {
+        session_id: "session-1".into(),
+        commands: vec![session_command(
+            "review",
+            "Review changes",
+            Some("focus area"),
+        )],
+    });
+    type_input(&mut app, "/review parser");
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert!(app.current_tab().turn.is_in_flight());
+    assert!(!app.current_tab().messages.iter().any(|message| matches!(
+        message,
+        ChatMessage::Notice {
+            kind: NoticeKind::Warning,
+            ..
+        }
+    )));
 }
 
 // ---- App dispatch — state effects via handle_slash_command ----
@@ -436,10 +577,7 @@ fn config_picker_select_sends_session_scoped_option_request() {
     run_slash(&mut app, "config");
 
     app.config_picker_enter();
-    assert_eq!(
-        app.current_tab().config_picker.option_id(),
-        Some("mode")
-    );
+    assert_eq!(app.current_tab().config_picker.option_id(), Some("mode"));
     app.config_picker_down();
     app.config_picker_enter();
 

--- a/tools/wta/src/ui/command_popup.rs
+++ b/tools/wta/src/ui/command_popup.rs
@@ -5,17 +5,18 @@
 //! a filtered list of `CommandSpec`s. `/help` opens a centered overlay that
 //! lists every command with full descriptions.
 
-use std::borrow::Cow;
-
 use ratatui::prelude::*;
 use ratatui::widgets::{Clear, List, ListItem, ListState, Paragraph};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::popup;
 use crate::app::{App, AvailableAgent};
+use crate::app_contracts::AcpSessionCommand;
 use crate::commands::{CommandSpec, MovePositionSpec, REGISTRY};
 use crate::theme;
 
 const POPUP_MAX_VISIBLE: usize = 6;
+const SOURCE_LABEL_MAX_WIDTH: usize = 12;
 
 /// Per-frame state captured from the [`App`] so callers don't need to know
 /// the popup internals.
@@ -31,12 +32,21 @@ pub struct PopupState<'a> {
     /// they're currently on while typing the command. `None` when no model
     /// is known yet.
     pub current_model: Option<String>,
+    /// Friendly name of the connected Agent, used to identify commands
+    /// advertised through ACP.
+    pub agent_label: &'a str,
 }
 
 pub enum PopupCandidates<'a> {
-    Commands(Cow<'a, [&'static CommandSpec]>),
+    Commands(Vec<CommandCandidate<'a>>),
     MovePositions(&'a [&'static MovePositionSpec]),
     Agents(Vec<&'a AvailableAgent>),
+}
+
+#[derive(Clone, Copy)]
+pub enum CommandCandidate<'a> {
+    Client(&'static CommandSpec),
+    Agent(&'a AcpSessionCommand),
 }
 
 /// Render the autocomplete popup just above `input_area`. If there isn't
@@ -59,30 +69,49 @@ pub fn render_popup(frame: &mut Frame, state: PopupState<'_>, input_area: Rect) 
     frame.render_widget(Clear, area);
 
     let items: Vec<ListItem> = match &state.candidates {
-        PopupCandidates::Commands(candidates) => candidates
-            .iter()
-            .map(|spec| {
-                let mut spans = command_name_spans(spec.name, state.command_query);
-                spans.push(Span::styled(spec.summary(), theme::DIM));
-                // The `/model` row shows the pane's current model so the user can
-                // see what they're on before opening the picker.
-                if spec.name == "model" {
-                    if let Some(model) = state.current_model.as_deref() {
-                        spans.push(Span::styled("  → ", theme::DIM));
-                        spans.push(Span::styled(model, theme::INPUT_TEXT));
+        PopupCandidates::Commands(candidates) => {
+            let agent_label = truncate_source_label(state.agent_label);
+            let source_width = candidates
+                .iter()
+                .map(|candidate| match candidate {
+                    CommandCandidate::Client(_) => UnicodeWidthStr::width("IT"),
+                    CommandCandidate::Agent(_) => UnicodeWidthStr::width(agent_label.as_str()),
+                })
+                .max()
+                .unwrap_or_default();
+            candidates
+                .iter()
+                .map(|candidate| {
+                    let (name, summary) = match candidate {
+                        CommandCandidate::Client(spec) => (spec.name, spec.summary()),
+                        CommandCandidate::Agent(command) => {
+                            (command.name.as_str(), command.description.clone().into())
+                        }
+                    };
+                    let mut spans = command_name_spans(name, state.command_query);
+                    spans.push(source_badge_span(
+                        candidate,
+                        agent_label.as_str(),
+                        source_width,
+                    ));
+                    spans.push(Span::styled(summary, theme::DIM));
+                    // The `/model` row shows the pane's current model so the user can
+                    // see what they're on before opening the picker.
+                    if matches!(candidate, CommandCandidate::Client(spec) if spec.name == "model") {
+                        if let Some(model) = state.current_model.as_deref() {
+                            spans.push(Span::styled("  → ", theme::DIM));
+                            spans.push(Span::styled(model, theme::INPUT_TEXT));
+                        }
                     }
-                }
-                ListItem::new(Line::from(spans))
-            })
-            .collect(),
+                    ListItem::new(Line::from(spans))
+                })
+                .collect()
+        }
         PopupCandidates::MovePositions(candidates) => candidates
             .iter()
             .map(|position| {
                 ListItem::new(Line::from(vec![
-                    Span::styled(
-                        format!(" /move {:<6} ", position.name),
-                        theme::INPUT_TEXT,
-                    ),
+                    Span::styled(format!(" /move {:<6} ", position.name), theme::INPUT_TEXT),
                     Span::styled(format!("({})", position.alias), theme::DIM),
                 ]))
             })
@@ -114,6 +143,41 @@ pub fn render_popup(frame: &mut Frame, state: PopupState<'_>, input_area: Rect) 
     frame.render_stateful_widget(list, area, &mut list_state);
 }
 
+fn source_badge_span(
+    candidate: &CommandCandidate<'_>,
+    agent_label: &str,
+    column_width: usize,
+) -> Span<'static> {
+    let label = match candidate {
+        CommandCandidate::Client(_) => "IT",
+        CommandCandidate::Agent(_) => agent_label,
+    };
+    let padding = column_width.saturating_sub(UnicodeWidthStr::width(label));
+    Span::styled(format!("[{label}]{}  ", " ".repeat(padding)), theme::DIM)
+}
+
+fn truncate_source_label(label: &str) -> String {
+    let label = label.trim();
+    let label = if label.is_empty() { "Agent" } else { label };
+    if UnicodeWidthStr::width(label) <= SOURCE_LABEL_MAX_WIDTH {
+        return label.to_string();
+    }
+
+    let budget = SOURCE_LABEL_MAX_WIDTH - 1;
+    let mut truncated = String::new();
+    let mut width = 0;
+    for character in label.chars() {
+        let character_width = UnicodeWidthChar::width(character).unwrap_or(0);
+        if width + character_width > budget {
+            break;
+        }
+        truncated.push(character);
+        width += character_width;
+    }
+    truncated.push('…');
+    truncated
+}
+
 fn command_name_spans(name: &str, query: &str) -> Vec<Span<'static>> {
     let padded_name = format!("{name:<8} ");
     let needle = query.trim().to_ascii_lowercase();
@@ -121,10 +185,7 @@ fn command_name_spans(name: &str, query: &str) -> Vec<Span<'static>> {
         .then(|| name.to_ascii_lowercase().find(&needle))
         .flatten()
     else {
-        return vec![Span::styled(
-            format!(" /{padded_name}"),
-            theme::INPUT_TEXT,
-        )];
+        return vec![Span::styled(format!(" /{padded_name}"), theme::INPUT_TEXT)];
     };
     let end = start + needle.len();
 
@@ -143,10 +204,7 @@ fn command_name_spans(name: &str, query: &str) -> Vec<Span<'static>> {
 /// needs no special handling here — the App pre-filters the candidate list to
 /// just `/restart`, so the normal clamp lands on it. Pure so it can be
 /// unit-tested without a render frame.
-pub(crate) fn popup_highlight(
-    candidate_count: usize,
-    selected: usize,
-) -> Option<usize> {
+pub(crate) fn popup_highlight(candidate_count: usize, selected: usize) -> Option<usize> {
     if candidate_count == 0 {
         return None;
     }
@@ -197,9 +255,14 @@ pub fn render_help_overlay(frame: &mut Frame, app: &App, area: Rect) {
 
 #[cfg(test)]
 mod tests {
-    use super::{command_name_spans, popup_highlight};
+    use super::{
+        command_name_spans, popup_highlight, source_badge_span, truncate_source_label,
+        CommandCandidate,
+    };
+    use crate::app_contracts::AcpSessionCommand;
     use crate::commands;
     use crate::theme;
+    use unicode_width::UnicodeWidthStr;
 
     fn spec(name: &str) -> &'static commands::CommandSpec {
         commands::lookup(name).expect("registered command")
@@ -242,5 +305,32 @@ mod tests {
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].content, " /clear    ");
         assert_eq!(spans[0].style, theme::INPUT_TEXT);
+    }
+
+    #[test]
+    fn source_badges_distinguish_client_and_agent_commands() {
+        let client = CommandCandidate::Client(spec("model"));
+        let agent_command = AcpSessionCommand {
+            name: "usage".into(),
+            description: "Show usage".into(),
+            input_hint: None,
+        };
+        let agent = CommandCandidate::Agent(&agent_command);
+
+        assert_eq!(
+            source_badge_span(&client, "Copilot", 7).content,
+            "[IT]       "
+        );
+        assert_eq!(
+            source_badge_span(&agent, "Copilot", 7).content,
+            "[Copilot]  "
+        );
+    }
+
+    #[test]
+    fn source_label_is_width_limited() {
+        let label = truncate_source_label("Very Long Agent Name");
+        assert_eq!(label, "Very Long A…");
+        assert!(UnicodeWidthStr::width(label.as_str()) <= 12);
     }
 }

--- a/tools/wta/src/ui/mod.rs
+++ b/tools/wta/src/ui/mod.rs
@@ -19,7 +19,7 @@ pub mod shimmer;
 mod user_input;
 
 pub use agent_popup::AgentPopupState;
-pub use command_popup::{PopupCandidates, PopupState};
+pub use command_popup::{CommandCandidate, PopupCandidates, PopupState};
 pub use config_popup::ConfigPopupState;
 #[cfg(test)]
 pub(crate) use input::input_height;


### PR DESCRIPTION
## Summary
- consume session-scoped ACP `available_commands_update` snapshots and merge Agent commands into slash-command completion
- preserve WTA command precedence, Agent ordering, input hints, and per-session isolation
- send advertised Agent commands verbatim through `session/prompt` without planner templates or terminal context
- label command origins in the popup with `[IT]` and the connected Agent name

## Validation
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- deployed the Debug AppX binary and manually exercised Agent slash-command discovery and `/usage`