### PR TITLE
Prevent duplicate windows during ItE2E startup

### DIFF
--- a/test/e2e/ItE2E/Public/Harness.ps1
+++ b/test/e2e/ItE2E/Public/Harness.ps1
@@ -286,6 +286,16 @@ function Start-Terminal {
     }
     Write-ItLog -Level INFO -Message "WindowsTerminal pid=$($app.Pid) launched=$($app.Launched)"
 
+    # Wait until shell activation has created the first real window before probing COM.
+    # An immediate COM activation while the process exists but has no HWND races startup
+    # and can create a second logical window in the same WindowsTerminal process.
+    $hwnd = Wait-Until -TimeoutSec 20 -IntervalSec 1 -Quiet -Because "WT window HWND" -Condition {
+        $w = Get-WtWindowHwnds -App $app | Where-Object { [int]$_.pid -eq [int]$app.Pid } | Select-Object -First 1
+        if ($w) { $w.hwnd } else { $null }
+    }
+    if ($hwnd) { $app.Hwnd = $hwnd; Write-ItLog -Level INFO -Message "WT window hwnd=$hwnd" }
+    else { Write-ItLog -Level WARN -Message "Could not resolve WT HWND; UI primitives will fall back to -a pid." }
+
     # Bring COM online and resolve the brand CLSID. Best-effort while the FRE overlay is up
     # (the overlay replaces the window content, so the COM tab/pane surface may not be ready).
     if ($ShowFre) {
@@ -295,14 +305,6 @@ function Start-Terminal {
     else {
         Resolve-WtComClsid -App $app -TimeoutSec $TimeoutSec | Out-Null
     }
-
-    # Resolve the window HWND for this pid (for winapp ui targeting).
-    $hwnd = Wait-Until -TimeoutSec 20 -IntervalSec 1 -Quiet -Because "WT window HWND" -Condition {
-        $w = Get-WtWindowHwnds -App $app | Where-Object { [int]$_.pid -eq [int]$app.Pid } | Select-Object -First 1
-        if ($w) { $w.hwnd } else { $null }
-    }
-    if ($hwnd) { $app.Hwnd = $hwnd; Write-ItLog -Level INFO -Message "WT window hwnd=$hwnd" }
-    else { Write-ItLog -Level WARN -Message "Could not resolve WT HWND; UI primitives will fall back to -a pid." }
 
     # Capture the WT logical window id (informational; agent panes are XAML chrome and never
     # appear in list-panes, so window scoping of the agent pane itself relies on the

--- a/test/e2e/selftests/ItE2E.Unit.Tests.ps1
+++ b/test/e2e/selftests/ItE2E.Unit.Tests.ps1
@@ -119,3 +119,46 @@ Describe 'Resolve-ItApp' -Tag 'Unit' {
         $app.WtcliPath | Should -Not -BeNullOrEmpty
     }
 }
+
+Describe 'Start-Terminal startup ordering' -Tag 'Unit' {
+    It 'waits for the first window before probing COM' {
+        InModuleScope ItE2E {
+            $script:startupOrder = @()
+            $root = Join-Path $env:TEMP "ite2e-startup-order-$PID"
+            $fakeApp = [pscustomobject]@{
+                Package = 'IntelligentTerminal_rd9vj3e6a2mbr'
+                Version = '0.0.0.0'
+                WtcliPath = 'wtcli.exe'
+                LocalStateDir = $root
+                SettingsPath = Join-Path $root 'settings.json'
+                StatePath = Join-Path $root 'state.json'
+                AppUserModelId = 'IntelligentTerminal_rd9vj3e6a2mbr!App'
+                LaunchAlias = $null
+                ComClsid = $null
+                Pid = $null
+                Hwnd = $null
+            }
+
+            Mock Resolve-ItApp { $fakeApp }
+            Mock Stop-StaleItInstances
+            Mock Get-WtProcessesForApp { [pscustomobject]@{ Id = 4242 } }
+            Mock Start-Process
+            Mock Get-WtWindowHwnds {
+                $script:startupOrder += 'hwnd'
+                [pscustomobject]@{ pid = 4242; hwnd = 9001; title = 'PowerShell' }
+            }
+            Mock Resolve-WtComClsid {
+                $script:startupOrder += 'com'
+                '{D5B7C9E1-4F6A-4B8C-D9E0-F1A2B3C4D5E6}'
+            }
+            Mock Get-ActivePane { [pscustomobject]@{ window_id = 1 } }
+            Mock Initialize-LogOffsets
+            Mock Write-ItLog
+
+            $app = Start-Terminal -Package Dev -PassFre $false -Backup $false -CleanSettings $false
+
+            $app.Hwnd | Should -Be 9001
+            $script:startupOrder | Should -Be @('hwnd', 'com')
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the Pull Request
- Waits for the first Terminal HWND before probing COM.
- Prevents an early startup race from creating a second window.
- Adds regression coverage for startup ordering.


## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
- Verified with unit and live ItE2E tests.

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
