### PR TITLE
Fix BYOK model dropdown recovery

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -172,10 +172,18 @@
             <local:SettingContainer x:Name="EmptyCustomModelProviders"
                                     x:Uid="AIAgents_CustomModels"
                                     Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(ViewModel.ShowCustomModelProvidersExpander), Mode=OneWay}">
-                <Button x:Uid="AIAgents_CustomProviderAdd"
-                        VerticalAlignment="Center"
-                        Click="{x:Bind ViewModel.AddCustomModelProvider}"
-                        Style="{StaticResource AccentButtonStyle}" />
+                <StackPanel MaxWidth="400"
+                            HorizontalAlignment="Right"
+                            Spacing="8">
+                    <Button x:Uid="AIAgents_CustomProviderAdd"
+                            HorizontalAlignment="Right"
+                            Click="{x:Bind ViewModel.AddCustomModelProvider}"
+                            Style="{StaticResource AccentButtonStyle}" />
+                    <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Text="{x:Bind ViewModel.CustomModelProviderUnsupportedMessage, Mode=OneWay}"
+                               TextWrapping="Wrap"
+                               Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(ViewModel.CustomModelProviderUnsupportedMessage), Mode=OneWay}" />
+                </StackPanel>
             </local:SettingContainer>
 
             <local:SettingContainer x:Name="CustomModelProvidersExpander"

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -169,10 +169,20 @@
                 </Grid>
             </local:SettingContainer>
 
+            <local:SettingContainer x:Name="EmptyCustomModelProviders"
+                                    x:Uid="AIAgents_CustomModels"
+                                    Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(ViewModel.ShowCustomModelProvidersExpander), Mode=OneWay}">
+                <Button x:Uid="AIAgents_CustomProviderAdd"
+                        VerticalAlignment="Center"
+                        Click="{x:Bind ViewModel.AddCustomModelProvider}"
+                        Style="{StaticResource AccentButtonStyle}" />
+            </local:SettingContainer>
+
             <local:SettingContainer x:Name="CustomModelProvidersExpander"
                                     x:Uid="AIAgents_CustomModels"
                                     StartExpanded="{x:Bind ViewModel.IsCustomModelProvidersExpanded, Mode=TwoWay}"
-                                    Style="{StaticResource ExpanderSettingContainerStyleWithComplexPreview}">
+                                    Style="{StaticResource ExpanderSettingContainerStyleWithComplexPreview}"
+                                    Visibility="{x:Bind ViewModel.ShowCustomModelProvidersExpander, Mode=OneWay}">
                 <local:SettingContainer.CurrentValue>
                     <Button x:Uid="AIAgents_CustomProviderAdd"
                             VerticalAlignment="Center"

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
@@ -1482,12 +1482,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _acpProbing = true;
         _RebuildAcpModelListFromCache();
         const auto cacheRevision = Model::AcpRuntimeState::Current().Revision(agentId);
+        const auto telemetryAgentId = _StartsWithCustom(agentId) ? winrt::hstring{ L"custom" } : agentId;
         TraceLoggingWrite(
             g_hTerminalSettingsEditorProvider,
             "AcpModelProbeStarted",
             TraceLoggingDescription("A clean ACP model catalog probe started"),
             TraceLoggingLevel(WINEVENT_LEVEL_INFO),
-            TraceLoggingWideString(agentId.c_str(), "AgentId"),
+            TraceLoggingWideString(telemetryAgentId.c_str(), "AgentId"),
             TraceLoggingUInt64(cacheRevision, "CacheRevision"),
             TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         _RunAcpModelProbeAsync(agentId, cmdline, _acpProbeGeneration, cacheRevision);
@@ -1542,6 +1543,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         co_await wil::resume_foreground(dispatcher);
 
+        const auto telemetryAgentId = _StartsWithCustom(agentId) ? winrt::hstring{ L"custom" } : agentId;
+
         // Drop stale results — a newer probe is already in flight
         // for a different agent and we'd clobber its eventual write.
         if (generation != _acpProbeGeneration)
@@ -1551,7 +1554,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 "AcpModelProbeDiscarded",
                 TraceLoggingDescription("An ACP model catalog probe result was superseded"),
                 TraceLoggingLevel(WINEVENT_LEVEL_INFO),
-                TraceLoggingWideString(agentId.c_str(), "AgentId"),
+                TraceLoggingWideString(telemetryAgentId.c_str(), "AgentId"),
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
             co_return;
         }
@@ -1563,7 +1566,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             "AcpModelProbeCompleted",
             TraceLoggingDescription("A clean ACP model catalog probe completed"),
             TraceLoggingLevel(WINEVENT_LEVEL_INFO),
-            TraceLoggingWideString(agentId.c_str(), "AgentId"),
+            TraceLoggingWideString(telemetryAgentId.c_str(), "AgentId"),
             TraceLoggingBool(probeSucceeded, "Succeeded"),
             TraceLoggingUInt32(gsl::narrow_cast<uint32_t>(parsed.size()), "ModelCount"),
             TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
@@ -324,10 +324,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _GlobalSettings.CustomModelProviders(providers);
         _originalCustomModelProviders = std::move(mergedProviders);
 
-        // The clean cloud catalog is independent of configured BYOK providers.
-        // Rebuild the combined list without launching another agent process.
-        _RebuildAcpModelListFromCache();
-        _NotifyChanges(L"CustomModelProviders");
+        // Refresh the clean cloud catalog after adding or removing a provider.
+        _TriggerAcpModelProbe();
+        _NotifyChanges(L"CustomModelProviders", L"ShowCustomModelProvidersExpander");
     }
 
     void AIAgentsViewModel::_RemoveCustomModelProvider(const winrt::hstring& id)
@@ -390,7 +389,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         IsCustomModelProvidersExpanded(true);
         _isAddingCustomModelProvider = true;
-        _NotifyChanges(L"IsAddingCustomModelProvider");
+        _NotifyChanges(L"IsAddingCustomModelProvider", L"ShowCustomModelProvidersExpander");
     }
 
     bool AIAgentsViewModel::_HasNonWhitespace(const std::wstring_view value) noexcept
@@ -482,6 +481,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _newCustomModelProviderApiKey.clear();
         _NotifyChanges(
             L"IsAddingCustomModelProvider",
+            L"ShowCustomModelProvidersExpander",
             L"NewCustomModelProviderBaseUrl",
             L"NewCustomModelId",
             L"NewCustomModelProviderApiKey",
@@ -1482,6 +1482,14 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _acpProbing = true;
         _RebuildAcpModelListFromCache();
         const auto cacheRevision = Model::AcpRuntimeState::Current().Revision(agentId);
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "AcpModelProbeStarted",
+            TraceLoggingDescription("A clean ACP model catalog probe started"),
+            TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+            TraceLoggingWideString(agentId.c_str(), "AgentId"),
+            TraceLoggingUInt64(cacheRevision, "CacheRevision"),
+            TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         _RunAcpModelProbeAsync(agentId, cmdline, _acpProbeGeneration, cacheRevision);
     }
 
@@ -1538,12 +1546,29 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // for a different agent and we'd clobber its eventual write.
         if (generation != _acpProbeGeneration)
         {
+            TraceLoggingWrite(
+                g_hTerminalSettingsEditorProvider,
+                "AcpModelProbeDiscarded",
+                TraceLoggingDescription("An ACP model catalog probe result was superseded"),
+                TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+                TraceLoggingWideString(agentId.c_str(), "AgentId"),
+                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
             co_return;
         }
 
         _acpProbing = false;
+        const auto probeSucceeded = catalog && !parsed.empty();
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "AcpModelProbeCompleted",
+            TraceLoggingDescription("A clean ACP model catalog probe completed"),
+            TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+            TraceLoggingWideString(agentId.c_str(), "AgentId"),
+            TraceLoggingBool(probeSucceeded, "Succeeded"),
+            TraceLoggingUInt32(gsl::narrow_cast<uint32_t>(parsed.size()), "ModelCount"),
+            TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
 
-        if (catalog && !parsed.empty())
+        if (probeSucceeded)
         {
             auto view = winrt::single_threaded_vector(std::move(parsed)).GetView();
             if (!Model::AcpRuntimeState::Current().TrySetAvailableModels(agentId, cacheRevision, view, currentId))

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.h
@@ -131,6 +131,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void CurrentAcpModelEntry(const Editor::AcpModelEntry& value);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AcpModel);
         winrt::Windows::Foundation::Collections::IObservableVector<Editor::CustomModelProviderEntry> CustomModelProviders() const { return _customModelProviders; }
+        bool ShowCustomModelProvidersExpander() const { return _isAddingCustomModelProvider || _customModelProviders.Size() != 0; }
         bool IsCustomModelProvidersExpanded() const { return _isCustomModelProvidersExpanded; }
         void IsCustomModelProvidersExpanded(bool value);
         bool IsAddingCustomModelProvider() const { return _isAddingCustomModelProvider; }

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.idl
@@ -83,6 +83,7 @@ namespace Microsoft.Terminal.Settings.Editor
         AcpModelEntry CurrentAcpModelEntry;
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(String, AcpModel);
         Windows.Foundation.Collections.IObservableVector<CustomModelProviderEntry> CustomModelProviders { get; };
+        Boolean ShowCustomModelProvidersExpander { get; };
         Boolean IsCustomModelProvidersExpanded;
         Boolean IsAddingCustomModelProvider { get; };
         String NewCustomModelProviderBaseUrl;


### PR DESCRIPTION
## Summary
- hide the BYOK expander affordance until a provider exists or is being added
- rerun the clean model catalog probe after adding or removing a BYOK provider
- add info-level telemetry for model probe start, completion, and superseded results

## Validation
- built TerminalSettingsEditor with `bx`
- deployed the Debug package and manually launched Intelligent Terminal