### PR TITLE
Align AI disclaimer with Copilot

### DIFF
--- a/tools/wta/locales/af-ZA.yml
+++ b/tools/wta/locales/af-ZA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Druk Enter om weer te probeer, of Esc om teru
 chat.activity_thinking: "Dink na…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Welkom by Intelligente Terminaal!"
-chat.welcome_disclaimer: "Intelligente Terminaal gebruik AI. Kyk vir foute."
+chat.welcome_disclaimer: "Intelligente Terminaal gebruik AI"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/af-ZA.yml
+++ b/tools/wta/locales/af-ZA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Druk Enter om weer te probeer, of Esc om teru
 chat.activity_thinking: "Dink na…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Welkom by Intelligente Terminaal!"
-chat.welcome_disclaimer: "Intelligente Terminaal gebruik AI"
+chat.welcome_disclaimer: "Intelligente Terminaal gebruik AI."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/am-ET.yml
+++ b/tools/wta/locales/am-ET.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  እንደገና ለመሞከር Enter ይጫ�
 chat.activity_thinking: "በማሰብ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "እንኳን ወደ ብልህ ተርሚናል በደህና መጡ!"
-chat.welcome_disclaimer: "ብልህ ተርሚናል AI ይጠቀማል። ስህተቶችን ያረጋግጡ።"
+chat.welcome_disclaimer: "ብልህ ተርሚናል AI ይጠቀማል"
 chat.plan_header: "እቅድ፡"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/am-ET.yml
+++ b/tools/wta/locales/am-ET.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  እንደገና ለመሞከር Enter ይጫ�
 chat.activity_thinking: "በማሰብ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "እንኳን ወደ ብልህ ተርሚናል በደህና መጡ!"
-chat.welcome_disclaimer: "ብልህ ተርሚናል AI ይጠቀማል"
+chat.welcome_disclaimer: "ብልህ ተርሚናል AI ይጠቀማል።"
 chat.plan_header: "እቅድ፡"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ar-SA.yml
+++ b/tools/wta/locales/ar-SA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  اضغط على Enter لإعادة المحا
 chat.activity_thinking: "جارٍ التفكير…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "مرحبًا بك في الوحدة الطرفية الذكية!"
-chat.welcome_disclaimer: "يستخدم الوحدة الطرفية الذكية الذكاء الاصطناعي. تحقق من الأخطاء."
+chat.welcome_disclaimer: "يستخدم الوحدة الطرفية الذكية الذكاء الاصطناعي"
 chat.plan_header: "الخطة:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ar-SA.yml
+++ b/tools/wta/locales/ar-SA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  اضغط على Enter لإعادة المحا
 chat.activity_thinking: "جارٍ التفكير…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "مرحبًا بك في الوحدة الطرفية الذكية!"
-chat.welcome_disclaimer: "يستخدم الوحدة الطرفية الذكية الذكاء الاصطناعي"
+chat.welcome_disclaimer: "يستخدم الوحدة الطرفية الذكية الذكاء الاصطناعي."
 chat.plan_header: "الخطة:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/as-IN.yml
+++ b/tools/wta/locales/as-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  পুনৰ চেষ্টা কৰিব�
 chat.activity_thinking: "চিন্তা কৰি আছে…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ইন্টেলিজেন্ট টাৰ্মিনেল লৈ স্বাগতম!"
-chat.welcome_disclaimer: "ইন্টেলিজেন্ট টাৰ্মিনেল-এ AI ব্যৱহাৰ কৰে"
+chat.welcome_disclaimer: "ইন্টেলিজেন্ট টাৰ্মিনেল-এ AI ব্যৱহাৰ কৰে।"
 chat.plan_header: "পৰিকল্পনা:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/as-IN.yml
+++ b/tools/wta/locales/as-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  পুনৰ চেষ্টা কৰিব�
 chat.activity_thinking: "চিন্তা কৰি আছে…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ইন্টেলিজেন্ট টাৰ্মিনেল লৈ স্বাগতম!"
-chat.welcome_disclaimer: "ইন্টেলিজেন্ট টাৰ্মিনেল-এ AI ব্যৱহাৰ কৰে। ভুলৰ বাবে পৰীক্ষা কৰক।"
+chat.welcome_disclaimer: "ইন্টেলিজেন্ট টাৰ্মিনেল-এ AI ব্যৱহাৰ কৰে"
 chat.plan_header: "পৰিকল্পনা:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/az-Latn-AZ.yml
+++ b/tools/wta/locales/az-Latn-AZ.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Yenidən cəhd etmək üçün Enter basın, y
 chat.activity_thinking: "Düşünür…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Ağıllı Terminal-a xoş gəlmisiniz!"
-chat.welcome_disclaimer: "Ağıllı Terminal AI istifadə edir. Səhvləri yoxlayın."
+chat.welcome_disclaimer: "Ağıllı Terminal AI istifadə edir"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/az-Latn-AZ.yml
+++ b/tools/wta/locales/az-Latn-AZ.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Yenidən cəhd etmək üçün Enter basın, y
 chat.activity_thinking: "Düşünür…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Ağıllı Terminal-a xoş gəlmisiniz!"
-chat.welcome_disclaimer: "Ağıllı Terminal AI istifadə edir"
+chat.welcome_disclaimer: "Ağıllı Terminal AI istifadə edir."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/bg-BG.yml
+++ b/tools/wta/locales/bg-BG.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Натиснете Enter, за да опит�
 chat.activity_thinking: "Мисля..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Добре дошли в Интелигентен Терминал!"
-chat.welcome_disclaimer: "Интелигентен Терминал използва AI"
+chat.welcome_disclaimer: "Интелигентен Терминал използва AI."
 chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/bg-BG.yml
+++ b/tools/wta/locales/bg-BG.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Натиснете Enter, за да опит�
 chat.activity_thinking: "Мисля..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Добре дошли в Интелигентен Терминал!"
-chat.welcome_disclaimer: "Интелигентен Терминал използва AI. Проверявайте за грешки."
+chat.welcome_disclaimer: "Интелигентен Терминал използва AI"
 chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/bn-IN.yml
+++ b/tools/wta/locales/bn-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  আবার চেষ্টা করতে 
 chat.activity_thinking: "ভাবছে…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ইন্টেলিজেন্ট টার্মিনাল-এ স্বাগতম!"
-chat.welcome_disclaimer: "ইন্টেলিজেন্ট টার্মিনাল AI ব্যবহার করে"
+chat.welcome_disclaimer: "ইন্টেলিজেন্ট টার্মিনাল AI ব্যবহার করে।"
 chat.plan_header: "পরিকল্পনা:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/bn-IN.yml
+++ b/tools/wta/locales/bn-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  আবার চেষ্টা করতে 
 chat.activity_thinking: "ভাবছে…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ইন্টেলিজেন্ট টার্মিনাল-এ স্বাগতম!"
-chat.welcome_disclaimer: "ইন্টেলিজেন্ট টার্মিনাল AI ব্যবহার করে। ভুলের জন্য পরীক্ষা করুন।"
+chat.welcome_disclaimer: "ইন্টেলিজেন্ট টার্মিনাল AI ব্যবহার করে"
 chat.plan_header: "পরিকল্পনা:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/bs-Latn-BA.yml
+++ b/tools/wta/locales/bs-Latn-BA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pritisnite Enter da pokušate ponovo ili Esc 
 chat.activity_thinking: "Razmišljam…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Dobrodošli u Inteligentni Terminal!"
-chat.welcome_disclaimer: "Inteligentni Terminal koristi AI. Provjerite greške."
+chat.welcome_disclaimer: "Inteligentni Terminal koristi AI"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/bs-Latn-BA.yml
+++ b/tools/wta/locales/bs-Latn-BA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pritisnite Enter da pokušate ponovo ili Esc 
 chat.activity_thinking: "Razmišljam…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Dobrodošli u Inteligentni Terminal!"
-chat.welcome_disclaimer: "Inteligentni Terminal koristi AI"
+chat.welcome_disclaimer: "Inteligentni Terminal koristi AI."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ca-ES.yml
+++ b/tools/wta/locales/ca-ES.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Premeu Enter per tornar-ho a provar, o Esc pe
 chat.activity_thinking: "Pensant…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Us donem la benvinguda a l'Terminal Intel·ligent!"
-chat.welcome_disclaimer: "Terminal Intel·ligent utilitza IA. Comproveu si hi ha errors."
+chat.welcome_disclaimer: "Terminal Intel·ligent utilitza IA"
 chat.plan_header: "Pla:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ca-ES.yml
+++ b/tools/wta/locales/ca-ES.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Premeu Enter per tornar-ho a provar, o Esc pe
 chat.activity_thinking: "Pensant…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Us donem la benvinguda a l'Terminal Intel·ligent!"
-chat.welcome_disclaimer: "Terminal Intel·ligent utilitza IA"
+chat.welcome_disclaimer: "Terminal Intel·ligent utilitza IA."
 chat.plan_header: "Pla:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ca-Es-VALENCIA.yml
+++ b/tools/wta/locales/ca-Es-VALENCIA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Premeu Enter per a tornar-ho a provar, o Esc 
 chat.activity_thinking: "Pensant…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Vos donem la benvinguda a l'Terminal Intel·ligent!"
-chat.welcome_disclaimer: "Terminal Intel·ligent utilitza IA. Comproveu si hi ha errors."
+chat.welcome_disclaimer: "Terminal Intel·ligent utilitza IA"
 chat.plan_header: "Pla:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ca-Es-VALENCIA.yml
+++ b/tools/wta/locales/ca-Es-VALENCIA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Premeu Enter per a tornar-ho a provar, o Esc 
 chat.activity_thinking: "Pensant…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Vos donem la benvinguda a l'Terminal Intel·ligent!"
-chat.welcome_disclaimer: "Terminal Intel·ligent utilitza IA"
+chat.welcome_disclaimer: "Terminal Intel·ligent utilitza IA."
 chat.plan_header: "Pla:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/cs-CZ.yml
+++ b/tools/wta/locales/cs-CZ.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Stisknutím Enter to zkuste znovu, nebo Esc p
 chat.activity_thinking: "Přemýšlím..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Vítejte v Inteligentní Terminál!"
-chat.welcome_disclaimer: "Inteligentní Terminál používá AI"
+chat.welcome_disclaimer: "Inteligentní Terminál používá AI."
 chat.plan_header: "Plán:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/cs-CZ.yml
+++ b/tools/wta/locales/cs-CZ.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Stisknutím Enter to zkuste znovu, nebo Esc p
 chat.activity_thinking: "Přemýšlím..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Vítejte v Inteligentní Terminál!"
-chat.welcome_disclaimer: "Inteligentní Terminál používá AI. Kontrolujte chyby."
+chat.welcome_disclaimer: "Inteligentní Terminál používá AI"
 chat.plan_header: "Plán:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/cy-GB.yml
+++ b/tools/wta/locales/cy-GB.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pwyswch Enter i roi cynnig arall, neu Esc i f
 chat.activity_thinking: "Yn meddwl…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Croeso i Terfynell Ddeallus!"
-chat.welcome_disclaimer: "Mae Terfynell Ddeallus yn defnyddio AI. Gwiriwch am gamgymeriadau."
+chat.welcome_disclaimer: "Mae Terfynell Ddeallus yn defnyddio AI"
 chat.plan_header: "Cynllun:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/cy-GB.yml
+++ b/tools/wta/locales/cy-GB.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pwyswch Enter i roi cynnig arall, neu Esc i f
 chat.activity_thinking: "Yn meddwl…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Croeso i Terfynell Ddeallus!"
-chat.welcome_disclaimer: "Mae Terfynell Ddeallus yn defnyddio AI"
+chat.welcome_disclaimer: "Mae Terfynell Ddeallus yn defnyddio AI."
 chat.plan_header: "Cynllun:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/da-DK.yml
+++ b/tools/wta/locales/da-DK.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Tryk på Enter for at prøve igen, eller Esc 
 chat.activity_thinking: "Tænker..."
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "Velkommen til Intelligent Terminal!"
-chat.welcome_disclaimer: "Intelligent Terminal bruger AI. Tjek for fejl."
+chat.welcome_disclaimer: "Intelligent Terminal bruger AI"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/da-DK.yml
+++ b/tools/wta/locales/da-DK.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Tryk på Enter for at prøve igen, eller Esc 
 chat.activity_thinking: "Tænker..."
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "Velkommen til Intelligent Terminal!"
-chat.welcome_disclaimer: "Intelligent Terminal bruger AI"
+chat.welcome_disclaimer: "Intelligent Terminal bruger AI."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/de-DE.yml
+++ b/tools/wta/locales/de-DE.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Drücken Sie Enter, um es erneut zu versuchen
 chat.activity_thinking: "Denke nach…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Willkommen bei Intelligentes Terminal!"
-chat.welcome_disclaimer: "Intelligentes Terminal verwendet KI"
+chat.welcome_disclaimer: "Intelligentes Terminal verwendet KI."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/de-DE.yml
+++ b/tools/wta/locales/de-DE.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Drücken Sie Enter, um es erneut zu versuchen
 chat.activity_thinking: "Denke nach…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Willkommen bei Intelligentes Terminal!"
-chat.welcome_disclaimer: "Intelligentes Terminal verwendet KI. Auf Fehler prüfen."
+chat.welcome_disclaimer: "Intelligentes Terminal verwendet KI"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/el-GR.yml
+++ b/tools/wta/locales/el-GR.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Πατήστε Enter για να δοκιμά
 chat.activity_thinking: "Σκέφτομαι…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Καλώς ήρθατε στο Έξυπνο Τερματικό!"
-chat.welcome_disclaimer: "Το Έξυπνο Τερματικό χρησιμοποιεί AI. Ελέγξτε για σφάλματα."
+chat.welcome_disclaimer: "Το Έξυπνο Τερματικό χρησιμοποιεί AI"
 chat.plan_header: "Σχέδιο:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/el-GR.yml
+++ b/tools/wta/locales/el-GR.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Πατήστε Enter για να δοκιμά
 chat.activity_thinking: "Σκέφτομαι…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Καλώς ήρθατε στο Έξυπνο Τερματικό!"
-chat.welcome_disclaimer: "Το Έξυπνο Τερματικό χρησιμοποιεί AI"
+chat.welcome_disclaimer: "Το Έξυπνο Τερματικό χρησιμοποιεί AI."
 chat.plan_header: "Σχέδιο:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/en-GB.yml
+++ b/tools/wta/locales/en-GB.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Press Enter to retry, or Esc to go back."  # 
 chat.activity_thinking: "Thinking…"
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "Welcome to Intelligent Terminal!"
-chat.welcome_disclaimer: "Intelligent Terminal uses AI. Check for mistakes."
+chat.welcome_disclaimer: "Intelligent Terminal uses AI"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/en-GB.yml
+++ b/tools/wta/locales/en-GB.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Press Enter to retry, or Esc to go back."  # 
 chat.activity_thinking: "Thinking…"
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "Welcome to Intelligent Terminal!"
-chat.welcome_disclaimer: "Intelligent Terminal uses AI"
+chat.welcome_disclaimer: "Intelligent Terminal uses AI."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/en-US.yml
+++ b/tools/wta/locales/en-US.yml
@@ -44,7 +44,7 @@ auth.login_failed_help_default: "  Press Enter to retry, or Esc to go back."  # 
 # ── Chat view (src/ui/chat.rs) ──────────────────────────────────────────────
 chat.activity_thinking: "Thinking…"
 chat.welcome_title: "Welcome to Intelligent Terminal!"
-chat.welcome_disclaimer: "Intelligent Terminal uses AI. Check for mistakes."
+chat.welcome_disclaimer: "Intelligent Terminal uses AI"  # {Locked="AI"}
 # Header label for the AI agent's step-by-step plan section
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}

--- a/tools/wta/locales/en-US.yml
+++ b/tools/wta/locales/en-US.yml
@@ -44,7 +44,7 @@ auth.login_failed_help_default: "  Press Enter to retry, or Esc to go back."  # 
 # ── Chat view (src/ui/chat.rs) ──────────────────────────────────────────────
 chat.activity_thinking: "Thinking…"
 chat.welcome_title: "Welcome to Intelligent Terminal!"
-chat.welcome_disclaimer: "Intelligent Terminal uses AI"  # {Locked="AI"}
+chat.welcome_disclaimer: "Intelligent Terminal uses AI."  # {Locked="AI"}
 # Header label for the AI agent's step-by-step plan section
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}

--- a/tools/wta/locales/es-ES.yml
+++ b/tools/wta/locales/es-ES.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pulse Enter para reintentar, o Esc para volve
 chat.activity_thinking: "Pensando…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "¡Bienvenido a Terminal Inteligente!"
-chat.welcome_disclaimer: "Terminal Inteligente usa IA"
+chat.welcome_disclaimer: "Terminal Inteligente usa IA."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/es-ES.yml
+++ b/tools/wta/locales/es-ES.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pulse Enter para reintentar, o Esc para volve
 chat.activity_thinking: "Pensando…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "¡Bienvenido a Terminal Inteligente!"
-chat.welcome_disclaimer: "Terminal Inteligente usa IA. Compruebe si hay errores."
+chat.welcome_disclaimer: "Terminal Inteligente usa IA"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/es-MX.yml
+++ b/tools/wta/locales/es-MX.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Presiona Enter para reintentar, o Esc para re
 chat.activity_thinking: "Pensando…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "¡Bienvenido a Terminal Inteligente!"
-chat.welcome_disclaimer: "Terminal Inteligente usa IA"
+chat.welcome_disclaimer: "Terminal Inteligente usa IA."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/es-MX.yml
+++ b/tools/wta/locales/es-MX.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Presiona Enter para reintentar, o Esc para re
 chat.activity_thinking: "Pensando…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "¡Bienvenido a Terminal Inteligente!"
-chat.welcome_disclaimer: "Terminal Inteligente usa IA. Compruebe si hay errores."
+chat.welcome_disclaimer: "Terminal Inteligente usa IA"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/et-EE.yml
+++ b/tools/wta/locales/et-EE.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Vajutage Enter uuesti proovimiseks või Esc t
 chat.activity_thinking: "Mõtleb..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Tere tulemast Nutikas Terminali!"
-chat.welcome_disclaimer: "Nutikas Terminal kasutab AI-d. Kontrollige vigu."
+chat.welcome_disclaimer: "Nutikas Terminal kasutab AI-d"
 chat.plan_header: "Plaan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/et-EE.yml
+++ b/tools/wta/locales/et-EE.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Vajutage Enter uuesti proovimiseks või Esc t
 chat.activity_thinking: "Mõtleb..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Tere tulemast Nutikas Terminali!"
-chat.welcome_disclaimer: "Nutikas Terminal kasutab AI-d"
+chat.welcome_disclaimer: "Nutikas Terminal kasutab AI-d."
 chat.plan_header: "Plaan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/eu-ES.yml
+++ b/tools/wta/locales/eu-ES.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Sakatu Enter berriro saiatzeko, edo Esc atzer
 chat.activity_thinking: "Pentsatzen…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Ongi etorri Terminal Adimenduna-era!"
-chat.welcome_disclaimer: "Terminal Adimenduna-ek AI erabiltzen du. Egiaztatu akatsak."
+chat.welcome_disclaimer: "Terminal Adimenduna-ek AI erabiltzen du"
 chat.plan_header: "Plana:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/eu-ES.yml
+++ b/tools/wta/locales/eu-ES.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Sakatu Enter berriro saiatzeko, edo Esc atzer
 chat.activity_thinking: "Pentsatzen…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Ongi etorri Terminal Adimenduna-era!"
-chat.welcome_disclaimer: "Terminal Adimenduna-ek AI erabiltzen du"
+chat.welcome_disclaimer: "Terminal Adimenduna-ek AI erabiltzen du."
 chat.plan_header: "Plana:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/fa-IR.yml
+++ b/tools/wta/locales/fa-IR.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  برای تلاش دوباره Enter را ف�
 chat.activity_thinking: "در حال فکر کردن…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "به پایانه هوشمند خوش آمدید!"
-chat.welcome_disclaimer: "پایانه هوشمند از AI استفاده می‌کند. خطاها را بررسی کنید."
+chat.welcome_disclaimer: "پایانه هوشمند از AI استفاده می‌کند"
 chat.plan_header: "طرح:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/fa-IR.yml
+++ b/tools/wta/locales/fa-IR.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  برای تلاش دوباره Enter را ف�
 chat.activity_thinking: "در حال فکر کردن…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "به پایانه هوشمند خوش آمدید!"
-chat.welcome_disclaimer: "پایانه هوشمند از AI استفاده می‌کند"
+chat.welcome_disclaimer: "پایانه هوشمند از AI استفاده می‌کند."
 chat.plan_header: "طرح:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/fi-FI.yml
+++ b/tools/wta/locales/fi-FI.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Paina Enter yrittääksesi uudelleen tai Esc 
 chat.activity_thinking: "Ajattelee..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Tervetuloa Älykäs Pääteiin!"
-chat.welcome_disclaimer: "Älykäs Pääte käyttää tekoälyä. Tarkista virheet."
+chat.welcome_disclaimer: "Älykäs Pääte käyttää tekoälyä"
 chat.plan_header: "Suunnitelma:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/fi-FI.yml
+++ b/tools/wta/locales/fi-FI.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Paina Enter yrittääksesi uudelleen tai Esc 
 chat.activity_thinking: "Ajattelee..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Tervetuloa Älykäs Pääteiin!"
-chat.welcome_disclaimer: "Älykäs Pääte käyttää tekoälyä"
+chat.welcome_disclaimer: "Älykäs Pääte käyttää tekoälyä."
 chat.plan_header: "Suunnitelma:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/fil-PH.yml
+++ b/tools/wta/locales/fil-PH.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pindutin ang Enter para subukang muli, o Esc 
 chat.activity_thinking: "Nag-iisip…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Maligayang pagdating sa Matalinong Terminal!"
-chat.welcome_disclaimer: "Gumagamit ang Matalinong Terminal ng AI"
+chat.welcome_disclaimer: "Gumagamit ang Matalinong Terminal ng AI."
 chat.plan_header: "Plano:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/fil-PH.yml
+++ b/tools/wta/locales/fil-PH.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pindutin ang Enter para subukang muli, o Esc 
 chat.activity_thinking: "Nag-iisip…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Maligayang pagdating sa Matalinong Terminal!"
-chat.welcome_disclaimer: "Gumagamit ang Matalinong Terminal ng AI. Suriin ang mga pagkakamali."
+chat.welcome_disclaimer: "Gumagamit ang Matalinong Terminal ng AI"
 chat.plan_header: "Plano:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/fr-CA.yml
+++ b/tools/wta/locales/fr-CA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Appuyez sur Enter pour réessayer, ou sur Esc
 chat.activity_thinking: "Réflexion en cours…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Bienvenue dans Terminal Intelligent !"
-chat.welcome_disclaimer: "Terminal Intelligent utilise l'IA. Vérifiez les erreurs."
+chat.welcome_disclaimer: "Terminal Intelligent utilise l'IA"
 chat.plan_header: "Plan :"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/fr-CA.yml
+++ b/tools/wta/locales/fr-CA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Appuyez sur Enter pour réessayer, ou sur Esc
 chat.activity_thinking: "Réflexion en cours…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Bienvenue dans Terminal Intelligent !"
-chat.welcome_disclaimer: "Terminal Intelligent utilise l'IA"
+chat.welcome_disclaimer: "Terminal Intelligent utilise l'IA."
 chat.plan_header: "Plan :"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/fr-FR.yml
+++ b/tools/wta/locales/fr-FR.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Appuyez sur Enter pour réessayer, ou sur Esc
 chat.activity_thinking: "Réflexion en cours…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Bienvenue dans Terminal Intelligent !"
-chat.welcome_disclaimer: "Terminal Intelligent utilise l'IA. Vérifiez les erreurs."
+chat.welcome_disclaimer: "Terminal Intelligent utilise l'IA"
 chat.plan_header: "Plan :"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/fr-FR.yml
+++ b/tools/wta/locales/fr-FR.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Appuyez sur Enter pour réessayer, ou sur Esc
 chat.activity_thinking: "Réflexion en cours…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Bienvenue dans Terminal Intelligent !"
-chat.welcome_disclaimer: "Terminal Intelligent utilise l'IA"
+chat.welcome_disclaimer: "Terminal Intelligent utilise l'IA."
 chat.plan_header: "Plan :"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ga-IE.yml
+++ b/tools/wta/locales/ga-IE.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Brúigh Enter chun triail a bhaint as arís, 
 chat.activity_thinking: "Ag smaoineamh…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Fáilte go Teirminéal Cliste!"
-chat.welcome_disclaimer: "Úsáideann Teirminéal Cliste AI"
+chat.welcome_disclaimer: "Úsáideann Teirminéal Cliste AI."
 chat.plan_header: "Plean:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ga-IE.yml
+++ b/tools/wta/locales/ga-IE.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Brúigh Enter chun triail a bhaint as arís, 
 chat.activity_thinking: "Ag smaoineamh…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Fáilte go Teirminéal Cliste!"
-chat.welcome_disclaimer: "Úsáideann Teirminéal Cliste AI. Seiceáil le haghaidh botúin."
+chat.welcome_disclaimer: "Úsáideann Teirminéal Cliste AI"
 chat.plan_header: "Plean:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/gd-gb.yml
+++ b/tools/wta/locales/gd-gb.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Brùth Enter airson feuchainn ris a-rithist, 
 chat.activity_thinking: "A' smaoineachadh…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Fàilte gu Tèirmineal Glic!"
-chat.welcome_disclaimer: "Bidh Tèirmineal Glic a' cleachdadh AI"
+chat.welcome_disclaimer: "Bidh Tèirmineal Glic a' cleachdadh AI."
 chat.plan_header: "Plana:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/gd-gb.yml
+++ b/tools/wta/locales/gd-gb.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Brùth Enter airson feuchainn ris a-rithist, 
 chat.activity_thinking: "A' smaoineachadh…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Fàilte gu Tèirmineal Glic!"
-chat.welcome_disclaimer: "Bidh Tèirmineal Glic a' cleachdadh AI. Thoir sùil airson mearachdan."
+chat.welcome_disclaimer: "Bidh Tèirmineal Glic a' cleachdadh AI"
 chat.plan_header: "Plana:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/gl-ES.yml
+++ b/tools/wta/locales/gl-ES.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Preme Enter para tentalo de novo, ou Esc para
 chat.activity_thinking: "Pensando…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Benvido a Terminal Intelixente!"
-chat.welcome_disclaimer: "Terminal Intelixente usa IA. Comprobe se hai erros."
+chat.welcome_disclaimer: "Terminal Intelixente usa IA"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/gl-ES.yml
+++ b/tools/wta/locales/gl-ES.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Preme Enter para tentalo de novo, ou Esc para
 chat.activity_thinking: "Pensando…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Benvido a Terminal Intelixente!"
-chat.welcome_disclaimer: "Terminal Intelixente usa IA"
+chat.welcome_disclaimer: "Terminal Intelixente usa IA."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/gu-IN.yml
+++ b/tools/wta/locales/gu-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  ફરી પ્રયાસ કરવા Ent
 chat.activity_thinking: "વિચારી રહ્યું છે…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ઇન્ટેલિજન્ટ ટર્મિનલ માં આપનું સ્વાગત છે!"
-chat.welcome_disclaimer: "ઇન્ટેલિજન્ટ ટર્મિનલ AI નો ઉપયોગ કરે છે"
+chat.welcome_disclaimer: "ઇન્ટેલિજન્ટ ટર્મિનલ AI નો ઉપયોગ કરે છે."
 chat.plan_header: "યોજના:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/gu-IN.yml
+++ b/tools/wta/locales/gu-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  ફરી પ્રયાસ કરવા Ent
 chat.activity_thinking: "વિચારી રહ્યું છે…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ઇન્ટેલિજન્ટ ટર્મિનલ માં આપનું સ્વાગત છે!"
-chat.welcome_disclaimer: "ઇન્ટેલિજન્ટ ટર્મિનલ AI નો ઉપયોગ કરે છે. ભૂલો માટે તપાસો."
+chat.welcome_disclaimer: "ઇન્ટેલિજન્ટ ટર્મિનલ AI નો ઉપયોગ કરે છે"
 chat.plan_header: "યોજના:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/he-IL.yml
+++ b/tools/wta/locales/he-IL.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  הקש Enter כדי לנסות שוב, או E
 chat.activity_thinking: "חושב…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ברוכים הבאים ל-מסוף חכם!"
-chat.welcome_disclaimer: "מסוף חכם משתמש ב-AI. בדוק אם יש שגיאות."
+chat.welcome_disclaimer: "מסוף חכם משתמש ב-AI"
 chat.plan_header: "תוכנית:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/he-IL.yml
+++ b/tools/wta/locales/he-IL.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  הקש Enter כדי לנסות שוב, או E
 chat.activity_thinking: "חושב…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ברוכים הבאים ל-מסוף חכם!"
-chat.welcome_disclaimer: "מסוף חכם משתמש ב-AI"
+chat.welcome_disclaimer: "מסוף חכם משתמש ב-AI."
 chat.plan_header: "תוכנית:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/hi-IN.yml
+++ b/tools/wta/locales/hi-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  फिर से प्रयास करन
 chat.activity_thinking: "सोच रहा है…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "इंटेलिजेंट टर्मिनल में आपका स्वागत है!"
-chat.welcome_disclaimer: "इंटेलिजेंट टर्मिनल AI का उपयोग करता है। गलतियों की जाँच करें।"
+chat.welcome_disclaimer: "इंटेलिजेंट टर्मिनल AI का उपयोग करता है"
 chat.plan_header: "योजना:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/hi-IN.yml
+++ b/tools/wta/locales/hi-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  फिर से प्रयास करन
 chat.activity_thinking: "सोच रहा है…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "इंटेलिजेंट टर्मिनल में आपका स्वागत है!"
-chat.welcome_disclaimer: "इंटेलिजेंट टर्मिनल AI का उपयोग करता है"
+chat.welcome_disclaimer: "इंटेलिजेंट टर्मिनल AI का उपयोग करता है।"
 chat.plan_header: "योजना:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/hr-HR.yml
+++ b/tools/wta/locales/hr-HR.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pritisnite Enter za ponovni pokušaj ili Esc 
 chat.activity_thinking: "Razmišljam..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Dobro došli u Inteligentni Terminal!"
-chat.welcome_disclaimer: "Inteligentni Terminal koristi AI. Provjerite pogreške."
+chat.welcome_disclaimer: "Inteligentni Terminal koristi AI"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/hr-HR.yml
+++ b/tools/wta/locales/hr-HR.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pritisnite Enter za ponovni pokušaj ili Esc 
 chat.activity_thinking: "Razmišljam..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Dobro došli u Inteligentni Terminal!"
-chat.welcome_disclaimer: "Inteligentni Terminal koristi AI"
+chat.welcome_disclaimer: "Inteligentni Terminal koristi AI."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/hu-HU.yml
+++ b/tools/wta/locales/hu-HU.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Nyomja meg az Enter billentyűt az újraprób
 chat.activity_thinking: "Gondolkodás..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Üdvözli az Intelligens Terminál!"
-chat.welcome_disclaimer: "Az Intelligens Terminál AI-t használ"
+chat.welcome_disclaimer: "Az Intelligens Terminál AI-t használ."
 chat.plan_header: "Terv:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/hu-HU.yml
+++ b/tools/wta/locales/hu-HU.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Nyomja meg az Enter billentyűt az újraprób
 chat.activity_thinking: "Gondolkodás..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Üdvözli az Intelligens Terminál!"
-chat.welcome_disclaimer: "Az Intelligens Terminál AI-t használ. Ellenőrizze a hibákat."
+chat.welcome_disclaimer: "Az Intelligens Terminál AI-t használ"
 chat.plan_header: "Terv:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/hy-AM.yml
+++ b/tools/wta/locales/hy-AM.yml
@@ -43,7 +43,7 @@ auth.login_failed_help_default: "  Սեղմեք Enter՝ նորից փորձել�
 # ── Chat view (src/ui/chat.rs) ──────────────────────────────────────────────────────────────────────
 chat.activity_thinking: "Մտածում եմ…"
 chat.welcome_title: "Բարի գալուստ Խելացի տերմինալ!"
-chat.welcome_disclaimer: "Խելացի տերմինալ-ը օգտագործում է AI: Ստուգեք սխալները."
+chat.welcome_disclaimer: "Խելացի տերմինալ-ը օգտագործում է AI"
 # Header label for the AI agent's step-by-step plan section
 chat.plan_header: "Պլան՝"
 chat.plan_marker_completed: "[x]"  # {Locked}

--- a/tools/wta/locales/hy-AM.yml
+++ b/tools/wta/locales/hy-AM.yml
@@ -43,7 +43,7 @@ auth.login_failed_help_default: "  Սեղմեք Enter՝ նորից փորձել�
 # ── Chat view (src/ui/chat.rs) ──────────────────────────────────────────────────────────────────────
 chat.activity_thinking: "Մտածում եմ…"
 chat.welcome_title: "Բարի գալուստ Խելացի տերմինալ!"
-chat.welcome_disclaimer: "Խելացի տերմինալ-ը օգտագործում է AI"
+chat.welcome_disclaimer: "Խելացի տերմինալ-ը օգտագործում է AI."
 # Header label for the AI agent's step-by-step plan section
 chat.plan_header: "Պլան՝"
 chat.plan_marker_completed: "[x]"  # {Locked}

--- a/tools/wta/locales/id-ID.yml
+++ b/tools/wta/locales/id-ID.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Tekan Enter untuk mencoba lagi, atau Esc untu
 chat.activity_thinking: "Berpikir…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Selamat datang di Terminal Cerdas!"
-chat.welcome_disclaimer: "Terminal Cerdas menggunakan AI"
+chat.welcome_disclaimer: "Terminal Cerdas menggunakan AI."
 chat.plan_header: "Rencana:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/id-ID.yml
+++ b/tools/wta/locales/id-ID.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Tekan Enter untuk mencoba lagi, atau Esc untu
 chat.activity_thinking: "Berpikir…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Selamat datang di Terminal Cerdas!"
-chat.welcome_disclaimer: "Terminal Cerdas menggunakan AI. Periksa kesalahan."
+chat.welcome_disclaimer: "Terminal Cerdas menggunakan AI"
 chat.plan_header: "Rencana:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/is-IS.yml
+++ b/tools/wta/locales/is-IS.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Ýttu á Enter til að reyna aftur eða Esc t
 chat.activity_thinking: "Hugsa..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Velkomin í Snjallútstöð!"
-chat.welcome_disclaimer: "Snjallútstöð notar AI. Athugaðu hvort villur séu."
+chat.welcome_disclaimer: "Snjallútstöð notar AI"
 chat.plan_header: "Áætlun:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/is-IS.yml
+++ b/tools/wta/locales/is-IS.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Ýttu á Enter til að reyna aftur eða Esc t
 chat.activity_thinking: "Hugsa..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Velkomin í Snjallútstöð!"
-chat.welcome_disclaimer: "Snjallútstöð notar AI"
+chat.welcome_disclaimer: "Snjallútstöð notar AI."
 chat.plan_header: "Áætlun:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/it-IT.yml
+++ b/tools/wta/locales/it-IT.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Premi Enter per riprovare, oppure Esc per tor
 chat.activity_thinking: "Elaborazione in corso…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Benvenuto in Terminale Intelligente!"
-chat.welcome_disclaimer: "Terminale Intelligente usa l'IA. Verifica la presenza di errori."
+chat.welcome_disclaimer: "Terminale Intelligente usa l'IA"
 chat.plan_header: "Piano:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/it-IT.yml
+++ b/tools/wta/locales/it-IT.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Premi Enter per riprovare, oppure Esc per tor
 chat.activity_thinking: "Elaborazione in corso…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Benvenuto in Terminale Intelligente!"
-chat.welcome_disclaimer: "Terminale Intelligente usa l'IA"
+chat.welcome_disclaimer: "Terminale Intelligente usa l'IA."
 chat.plan_header: "Piano:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ja-JP.yml
+++ b/tools/wta/locales/ja-JP.yml
@@ -37,7 +37,7 @@ auth.login_failed_help_default: "  Enter を押して再試行するか、Esc �
 # ── チャット ビュー (src/ui/chat.rs) ──────────────────────────────────────────────
 chat.activity_thinking: "考え中…"
 chat.welcome_title: "インテリジェント ターミナルへようこそ！"
-chat.welcome_disclaimer: "インテリジェント ターミナルは AI を使用しています。誤りがないか確認してください。"
+chat.welcome_disclaimer: "インテリジェント ターミナルは AI を使用しています"
 chat.plan_header: "プラン:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ja-JP.yml
+++ b/tools/wta/locales/ja-JP.yml
@@ -37,7 +37,7 @@ auth.login_failed_help_default: "  Enter を押して再試行するか、Esc �
 # ── チャット ビュー (src/ui/chat.rs) ──────────────────────────────────────────────
 chat.activity_thinking: "考え中…"
 chat.welcome_title: "インテリジェント ターミナルへようこそ！"
-chat.welcome_disclaimer: "インテリジェント ターミナルは AI を使用しています"
+chat.welcome_disclaimer: "インテリジェント ターミナルは AI を使用しています。"
 chat.plan_header: "プラン:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ka-GE.yml
+++ b/tools/wta/locales/ka-GE.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  დააჭირეთ Enter-ს ხელ�
 chat.activity_thinking: "ვფიქრობ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ჭკვიანი ტერმინალი-ში მოგესალმებით!"
-chat.welcome_disclaimer: "ჭკვიანი ტერმინალი იყენებს AI-ს. შეამოწმეთ შეცდომები."
+chat.welcome_disclaimer: "ჭკვიანი ტერმინალი იყენებს AI-ს"
 chat.plan_header: "გეგმა:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ka-GE.yml
+++ b/tools/wta/locales/ka-GE.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  დააჭირეთ Enter-ს ხელ�
 chat.activity_thinking: "ვფიქრობ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ჭკვიანი ტერმინალი-ში მოგესალმებით!"
-chat.welcome_disclaimer: "ჭკვიანი ტერმინალი იყენებს AI-ს"
+chat.welcome_disclaimer: "ჭკვიანი ტერმინალი იყენებს AI-ს."
 chat.plan_header: "გეგმა:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/kk-KZ.yml
+++ b/tools/wta/locales/kk-KZ.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Қайталау үшін Enter пернес�
 chat.activity_thinking: "Ойланып жатырмын…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Зияткер терминал-ға қош келдіңіз!"
-chat.welcome_disclaimer: "Зияткер терминал AI пайдаланады"
+chat.welcome_disclaimer: "Зияткер терминал AI пайдаланады."
 chat.plan_header: "Жоспар:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/kk-KZ.yml
+++ b/tools/wta/locales/kk-KZ.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Қайталау үшін Enter пернес�
 chat.activity_thinking: "Ойланып жатырмын…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Зияткер терминал-ға қош келдіңіз!"
-chat.welcome_disclaimer: "Зияткер терминал AI пайдаланады. Қателерді тексеріңіз."
+chat.welcome_disclaimer: "Зияткер терминал AI пайдаланады"
 chat.plan_header: "Жоспар:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/km-KH.yml
+++ b/tools/wta/locales/km-KH.yml
@@ -43,7 +43,7 @@ auth.login_failed_help_default: "  ចុច Enter ដើម្បីព្យ�
 chat.activity_thinking: "កំពុងគិត…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "សូមស្វាគមន៍មកកាន់ ស្ថានីយឆ្លាតវៃ!"
-chat.welcome_disclaimer: "ស្ថានីយឆ្លាតវៃ ប្រើ AI"
+chat.welcome_disclaimer: "ស្ថានីយឆ្លាតវៃ ប្រើ AI។"
 # Header label for the AI agent’s step-by-step plan section
 chat.plan_header: "ផែនការ:"
 chat.plan_marker_completed: "[x]"  # {Locked}

--- a/tools/wta/locales/km-KH.yml
+++ b/tools/wta/locales/km-KH.yml
@@ -43,7 +43,7 @@ auth.login_failed_help_default: "  ចុច Enter ដើម្បីព្យ�
 chat.activity_thinking: "កំពុងគិត…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "សូមស្វាគមន៍មកកាន់ ស្ថានីយឆ្លាតវៃ!"
-chat.welcome_disclaimer: "ស្ថានីយឆ្លាតវៃ ប្រើ AI។ ពិនិត្យមើលកំហុស។"
+chat.welcome_disclaimer: "ស្ថានីយឆ្លាតវៃ ប្រើ AI"
 # Header label for the AI agent’s step-by-step plan section
 chat.plan_header: "ផែនការ:"
 chat.plan_marker_completed: "[x]"  # {Locked}

--- a/tools/wta/locales/kn-IN.yml
+++ b/tools/wta/locales/kn-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  ಮತ್ತೆ ಪ್ರಯತ್ನಿಸ�
 chat.activity_thinking: "ಯೋಚಿಸುತ್ತಿದೆ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ಇಂಟೆಲಿಜೆಂಟ್ ಟರ್ಮಿನಲ್-ಗೆ ಸ್ವಾಗತ!"
-chat.welcome_disclaimer: "ಇಂಟೆಲಿಜೆಂಟ್ ಟರ್ಮಿನಲ್ AI ಬಳಸುತ್ತದೆ. ತಪ್ಪುಗಳನ್ನು ಪರಿಶೀಲಿಸಿ."
+chat.welcome_disclaimer: "ಇಂಟೆಲಿಜೆಂಟ್ ಟರ್ಮಿನಲ್ AI ಬಳಸುತ್ತದೆ"
 chat.plan_header: "ಯೋಜನೆ:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/kn-IN.yml
+++ b/tools/wta/locales/kn-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  ಮತ್ತೆ ಪ್ರಯತ್ನಿಸ�
 chat.activity_thinking: "ಯೋಚಿಸುತ್ತಿದೆ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ಇಂಟೆಲಿಜೆಂಟ್ ಟರ್ಮಿನಲ್-ಗೆ ಸ್ವಾಗತ!"
-chat.welcome_disclaimer: "ಇಂಟೆಲಿಜೆಂಟ್ ಟರ್ಮಿನಲ್ AI ಬಳಸುತ್ತದೆ"
+chat.welcome_disclaimer: "ಇಂಟೆಲಿಜೆಂಟ್ ಟರ್ಮಿನಲ್ AI ಬಳಸುತ್ತದೆ."
 chat.plan_header: "ಯೋಜನೆ:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ko-KR.yml
+++ b/tools/wta/locales/ko-KR.yml
@@ -37,7 +37,7 @@ auth.login_failed_help_default: "  Enter 키를 눌러 다시 시도하거나 Es
 # ── 채팅 보기 (src/ui/chat.rs) ──────────────────────────────────────────────
 chat.activity_thinking: "생각 중…"
 chat.welcome_title: "지능형 터미널에 오신 것을 환영합니다!"
-chat.welcome_disclaimer: "지능형 터미널은 AI를 사용합니다"
+chat.welcome_disclaimer: "지능형 터미널은 AI를 사용합니다."
 chat.plan_header: "계획:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ko-KR.yml
+++ b/tools/wta/locales/ko-KR.yml
@@ -37,7 +37,7 @@ auth.login_failed_help_default: "  Enter 키를 눌러 다시 시도하거나 Es
 # ── 채팅 보기 (src/ui/chat.rs) ──────────────────────────────────────────────
 chat.activity_thinking: "생각 중…"
 chat.welcome_title: "지능형 터미널에 오신 것을 환영합니다!"
-chat.welcome_disclaimer: "지능형 터미널은 AI를 사용합니다. 실수가 있는지 확인하세요."
+chat.welcome_disclaimer: "지능형 터미널은 AI를 사용합니다"
 chat.plan_header: "계획:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/kok-IN.yml
+++ b/tools/wta/locales/kok-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  परत यत्न करपाक Enter 
 chat.activity_thinking: "विचार करता…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "इंटेलिजंट टर्मिनल ंत आपलें स्वागत!"
-chat.welcome_disclaimer: "इंटेलिजंट टर्मिनल AI वापरता. चुकांची तपासणी करात."
+chat.welcome_disclaimer: "इंटेलिजंट टर्मिनल AI वापरता"
 chat.plan_header: "योजना:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/kok-IN.yml
+++ b/tools/wta/locales/kok-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  परत यत्न करपाक Enter 
 chat.activity_thinking: "विचार करता…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "इंटेलिजंट टर्मिनल ंत आपलें स्वागत!"
-chat.welcome_disclaimer: "इंटेलिजंट टर्मिनल AI वापरता"
+chat.welcome_disclaimer: "इंटेलिजंट टर्मिनल AI वापरता."
 chat.plan_header: "योजना:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/lb-LU.yml
+++ b/tools/wta/locales/lb-LU.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Dréckt Enter fir nach eng Kéier ze probéie
 chat.activity_thinking: "Denkt no…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Wëllkomm am Intelligenten Terminal!"
-chat.welcome_disclaimer: "Intelligenten Terminal benotzt KI. Kuckt no Feeler."
+chat.welcome_disclaimer: "Intelligenten Terminal benotzt KI"
 chat.plan_header: "Plang:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/lb-LU.yml
+++ b/tools/wta/locales/lb-LU.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Dréckt Enter fir nach eng Kéier ze probéie
 chat.activity_thinking: "Denkt no…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Wëllkomm am Intelligenten Terminal!"
-chat.welcome_disclaimer: "Intelligenten Terminal benotzt KI"
+chat.welcome_disclaimer: "Intelligenten Terminal benotzt KI."
 chat.plan_header: "Plang:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/lo-LA.yml
+++ b/tools/wta/locales/lo-LA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  ກົດ Enter ເພື່ອລອງໃ�
 chat.activity_thinking: "ກຳລັງຄິດ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ຍິນດີຕ້ອນຮັບສູ່ ເທອຮ໌ມິນັລອັດຊະລິຍະ!"
-chat.welcome_disclaimer: "ເທອຮ໌ມິນັລອັດຊະລິຍະ ໃຊ້ AI. ກວດເບິ່ງຂໍ້ຜິດພາດ."
+chat.welcome_disclaimer: "ເທອຮ໌ມິນັລອັດຊະລິຍະ ໃຊ້ AI"
 chat.plan_header: "ແຜນການ:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/lo-LA.yml
+++ b/tools/wta/locales/lo-LA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  ກົດ Enter ເພື່ອລອງໃ�
 chat.activity_thinking: "ກຳລັງຄິດ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ຍິນດີຕ້ອນຮັບສູ່ ເທອຮ໌ມິນັລອັດຊະລິຍະ!"
-chat.welcome_disclaimer: "ເທອຮ໌ມິນັລອັດຊະລິຍະ ໃຊ້ AI"
+chat.welcome_disclaimer: "ເທອຮ໌ມິນັລອັດຊະລິຍະ ໃຊ້ AI."
 chat.plan_header: "ແຜນການ:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/lt-LT.yml
+++ b/tools/wta/locales/lt-LT.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Paspauskite Enter, kad bandytumėte dar kart�
 chat.activity_thinking: "Mąsto..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Sveiki atvykę į Išmanusis Terminalas!"
-chat.welcome_disclaimer: "Išmanusis Terminalas naudoja AI"
+chat.welcome_disclaimer: "Išmanusis Terminalas naudoja AI."
 chat.plan_header: "Planas:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/lt-LT.yml
+++ b/tools/wta/locales/lt-LT.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Paspauskite Enter, kad bandytumėte dar kart�
 chat.activity_thinking: "Mąsto..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Sveiki atvykę į Išmanusis Terminalas!"
-chat.welcome_disclaimer: "Išmanusis Terminalas naudoja AI. Tikrinkite klaidas."
+chat.welcome_disclaimer: "Išmanusis Terminalas naudoja AI"
 chat.plan_header: "Planas:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/lv-LV.yml
+++ b/tools/wta/locales/lv-LV.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Nospiediet Enter, lai mēģinātu vēlreiz, v
 chat.activity_thinking: "Domā..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Laipni lūdzam Viedais Terminālis!"
-chat.welcome_disclaimer: "Viedais Terminālis izmanto AI. Pārbaudiet kļūdas."
+chat.welcome_disclaimer: "Viedais Terminālis izmanto AI"
 chat.plan_header: "Plāns:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/lv-LV.yml
+++ b/tools/wta/locales/lv-LV.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Nospiediet Enter, lai mēģinātu vēlreiz, v
 chat.activity_thinking: "Domā..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Laipni lūdzam Viedais Terminālis!"
-chat.welcome_disclaimer: "Viedais Terminālis izmanto AI"
+chat.welcome_disclaimer: "Viedais Terminālis izmanto AI."
 chat.plan_header: "Plāns:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/mi-NZ.yml
+++ b/tools/wta/locales/mi-NZ.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pēhia Enter hei ngana anō, Esc rānei hei h
 chat.activity_thinking: "E whakaaro ana..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Nau mai ki Iho Atamai!"
-chat.welcome_disclaimer: "Ka whakamahia e Iho Atamai te AI"
+chat.welcome_disclaimer: "Ka whakamahia e Iho Atamai te AI."
 chat.plan_header: "Mahere:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/mi-NZ.yml
+++ b/tools/wta/locales/mi-NZ.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pēhia Enter hei ngana anō, Esc rānei hei h
 chat.activity_thinking: "E whakaaro ana..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Nau mai ki Iho Atamai!"
-chat.welcome_disclaimer: "Ka whakamahia e Iho Atamai te AI. Tirohia ngā hapa."
+chat.welcome_disclaimer: "Ka whakamahia e Iho Atamai te AI"
 chat.plan_header: "Mahere:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/mk-MK.yml
+++ b/tools/wta/locales/mk-MK.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Притиснете Enter за да се о�
 chat.activity_thinking: "Размислувам..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Добредојдовте во Интелигентен Терминал!"
-chat.welcome_disclaimer: "Интелигентен Терминал користи AI"
+chat.welcome_disclaimer: "Интелигентен Терминал користи AI."
 chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/mk-MK.yml
+++ b/tools/wta/locales/mk-MK.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Притиснете Enter за да се о�
 chat.activity_thinking: "Размислувам..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Добредојдовте во Интелигентен Терминал!"
-chat.welcome_disclaimer: "Интелигентен Терминал користи AI. Проверете за грешки."
+chat.welcome_disclaimer: "Интелигентен Терминал користи AI"
 chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ml-IN.yml
+++ b/tools/wta/locales/ml-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  വീണ്ടും ശ്രമിക്�
 chat.activity_thinking: "ചിന്തിക്കുന്നു…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ഇന്റലിജന്റ് ടെർമിനൽ-ലേക്ക് സ്വാഗതം!"
-chat.welcome_disclaimer: "ഇന്റലിജന്റ് ടെർമിനൽ AI ഉപയോഗിക്കുന്നു. തെറ്റുകൾ പരിശോധിക്കുക."
+chat.welcome_disclaimer: "ഇന്റലിജന്റ് ടെർമിനൽ AI ഉപയോഗിക്കുന്നു"
 chat.plan_header: "പദ്ധതി:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ml-IN.yml
+++ b/tools/wta/locales/ml-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  വീണ്ടും ശ്രമിക്�
 chat.activity_thinking: "ചിന്തിക്കുന്നു…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ഇന്റലിജന്റ് ടെർമിനൽ-ലേക്ക് സ്വാഗതം!"
-chat.welcome_disclaimer: "ഇന്റലിജന്റ് ടെർമിനൽ AI ഉപയോഗിക്കുന്നു"
+chat.welcome_disclaimer: "ഇന്റലിജന്റ് ടെർമിനൽ AI ഉപയോഗിക്കുന്നു."
 chat.plan_header: "പദ്ധതി:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/mr-IN.yml
+++ b/tools/wta/locales/mr-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  पुन्हा प्रयत्न क�
 chat.activity_thinking: "विचार करत आहे…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "इंटेलिजंट टर्मिनल मध्ये आपले स्वागत आहे!"
-chat.welcome_disclaimer: "इंटेलिजंट टर्मिनल AI वापरते"
+chat.welcome_disclaimer: "इंटेलिजंट टर्मिनल AI वापरते."
 chat.plan_header: "योजना:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/mr-IN.yml
+++ b/tools/wta/locales/mr-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  पुन्हा प्रयत्न क�
 chat.activity_thinking: "विचार करत आहे…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "इंटेलिजंट टर्मिनल मध्ये आपले स्वागत आहे!"
-chat.welcome_disclaimer: "इंटेलिजंट टर्मिनल AI वापरते. चुकांची तपासणी करा."
+chat.welcome_disclaimer: "इंटेलिजंट टर्मिनल AI वापरते"
 chat.plan_header: "योजना:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ms-MY.yml
+++ b/tools/wta/locales/ms-MY.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Tekan Enter untuk mencuba semula, atau Esc un
 chat.activity_thinking: "Sedang berfikir…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Selamat datang ke Terminal Pintar!"
-chat.welcome_disclaimer: "Terminal Pintar menggunakan AI. Semak kesilapan."
+chat.welcome_disclaimer: "Terminal Pintar menggunakan AI"
 chat.plan_header: "Pelan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ms-MY.yml
+++ b/tools/wta/locales/ms-MY.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Tekan Enter untuk mencuba semula, atau Esc un
 chat.activity_thinking: "Sedang berfikir…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Selamat datang ke Terminal Pintar!"
-chat.welcome_disclaimer: "Terminal Pintar menggunakan AI"
+chat.welcome_disclaimer: "Terminal Pintar menggunakan AI."
 chat.plan_header: "Pelan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/mt-MT.yml
+++ b/tools/wta/locales/mt-MT.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Agħfas Enter biex terġa' tipprova, jew Esc 
 chat.activity_thinking: "Qed jaħseb…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Merħba fl-Terminal Intelliġenti!"
-chat.welcome_disclaimer: "Terminal Intelliġenti juża l-AI"
+chat.welcome_disclaimer: "Terminal Intelliġenti juża l-AI."
 chat.plan_header: "Pjan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/mt-MT.yml
+++ b/tools/wta/locales/mt-MT.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Agħfas Enter biex terġa' tipprova, jew Esc 
 chat.activity_thinking: "Qed jaħseb…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Merħba fl-Terminal Intelliġenti!"
-chat.welcome_disclaimer: "Terminal Intelliġenti juża l-AI. Iċċekkja għall-iżbalji."
+chat.welcome_disclaimer: "Terminal Intelliġenti juża l-AI"
 chat.plan_header: "Pjan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/nb-NO.yml
+++ b/tools/wta/locales/nb-NO.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Trykk Enter for å prøve på nytt, eller Esc
 chat.activity_thinking: "Tenker..."
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "Velkommen til Intelligent Terminal!"
-chat.welcome_disclaimer: "Intelligent Terminal bruker AI. Se etter feil."
+chat.welcome_disclaimer: "Intelligent Terminal bruker AI"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/nb-NO.yml
+++ b/tools/wta/locales/nb-NO.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Trykk Enter for å prøve på nytt, eller Esc
 chat.activity_thinking: "Tenker..."
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "Velkommen til Intelligent Terminal!"
-chat.welcome_disclaimer: "Intelligent Terminal bruker AI"
+chat.welcome_disclaimer: "Intelligent Terminal bruker AI."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ne-NP.yml
+++ b/tools/wta/locales/ne-NP.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  फेरि प्रयास गर्न 
 chat.activity_thinking: "सोचिरहेको छ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "इन्टेलिजेन्ट टर्मिनल मा स्वागत छ!"
-chat.welcome_disclaimer: "इन्टेलिजेन्ट टर्मिनल ले AI प्रयोग गर्छ"
+chat.welcome_disclaimer: "इन्टेलिजेन्ट टर्मिनल ले AI प्रयोग गर्छ।"
 chat.plan_header: "योजना:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ne-NP.yml
+++ b/tools/wta/locales/ne-NP.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  फेरि प्रयास गर्न 
 chat.activity_thinking: "सोचिरहेको छ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "इन्टेलिजेन्ट टर्मिनल मा स्वागत छ!"
-chat.welcome_disclaimer: "इन्टेलिजेन्ट टर्मिनल ले AI प्रयोग गर्छ। गल्तीहरू जाँच गर्नुहोस्।"
+chat.welcome_disclaimer: "इन्टेलिजेन्ट टर्मिनल ले AI प्रयोग गर्छ"
 chat.plan_header: "योजना:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/nl-NL.yml
+++ b/tools/wta/locales/nl-NL.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Druk op Enter om het opnieuw te proberen, of 
 chat.activity_thinking: "Bezig met nadenken…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Welkom bij Intelligente Terminal!"
-chat.welcome_disclaimer: "Intelligente Terminal maakt gebruik van AI. Controleer op fouten."
+chat.welcome_disclaimer: "Intelligente Terminal maakt gebruik van AI"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/nl-NL.yml
+++ b/tools/wta/locales/nl-NL.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Druk op Enter om het opnieuw te proberen, of 
 chat.activity_thinking: "Bezig met nadenken…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Welkom bij Intelligente Terminal!"
-chat.welcome_disclaimer: "Intelligente Terminal maakt gebruik van AI"
+chat.welcome_disclaimer: "Intelligente Terminal maakt gebruik van AI."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/nn-NO.yml
+++ b/tools/wta/locales/nn-NO.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Trykk Enter for å prøve på nytt, eller Esc
 chat.activity_thinking: "Tenkjer..."
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "Velkomen til Intelligent Terminal!"
-chat.welcome_disclaimer: "Intelligent Terminal brukar AI. Sjå etter feil."
+chat.welcome_disclaimer: "Intelligent Terminal brukar AI"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/nn-NO.yml
+++ b/tools/wta/locales/nn-NO.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Trykk Enter for å prøve på nytt, eller Esc
 chat.activity_thinking: "Tenkjer..."
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "Velkomen til Intelligent Terminal!"
-chat.welcome_disclaimer: "Intelligent Terminal brukar AI"
+chat.welcome_disclaimer: "Intelligent Terminal brukar AI."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/or-IN.yml
+++ b/tools/wta/locales/or-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  ପୁଣି ଚେଷ୍ଟା କରିବ�
 chat.activity_thinking: "ଚିନ୍ତା କରୁଛି…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନାଲ କୁ ସ୍ୱାଗତ!"
-chat.welcome_disclaimer: "ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନାଲ AI ବ୍ୟବହାର କରେ"
+chat.welcome_disclaimer: "ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନାଲ AI ବ୍ୟବହାର କରେ।"
 chat.plan_header: "ଯୋଜନା:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/or-IN.yml
+++ b/tools/wta/locales/or-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  ପୁଣି ଚେଷ୍ଟା କରିବ�
 chat.activity_thinking: "ଚିନ୍ତା କରୁଛି…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନାଲ କୁ ସ୍ୱାଗତ!"
-chat.welcome_disclaimer: "ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନାଲ AI ବ୍ୟବହାର କରେ। ଭୁଲ ଯାଞ୍ଚ କରନ୍ତୁ।"
+chat.welcome_disclaimer: "ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନାଲ AI ବ୍ୟବହାର କରେ"
 chat.plan_header: "ଯୋଜନା:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/pa-IN.yml
+++ b/tools/wta/locales/pa-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  ਮੁੜ ਕੋਸ਼ਿਸ਼ ਕਰਨ ਲ
 chat.activity_thinking: "ਸੋਚ ਰਿਹਾ ਹੈ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ਇੰਟੈਲੀਜੈਂਟ ਟਰਮੀਨਲ ਵਿੱਚ ਤੁਹਾਡਾ ਸੁਆਗਤ ਹੈ!"
-chat.welcome_disclaimer: "ਇੰਟੈਲੀਜੈਂਟ ਟਰਮੀਨਲ AI ਦੀ ਵਰਤੋਂ ਕਰਦਾ ਹੈ। ਗਲਤੀਆਂ ਦੀ ਜਾਂਚ ਕਰੋ।"
+chat.welcome_disclaimer: "ਇੰਟੈਲੀਜੈਂਟ ਟਰਮੀਨਲ AI ਦੀ ਵਰਤੋਂ ਕਰਦਾ ਹੈ"
 chat.plan_header: "ਯੋਜਨਾ:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/pa-IN.yml
+++ b/tools/wta/locales/pa-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  ਮੁੜ ਕੋਸ਼ਿਸ਼ ਕਰਨ ਲ
 chat.activity_thinking: "ਸੋਚ ਰਿਹਾ ਹੈ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ਇੰਟੈਲੀਜੈਂਟ ਟਰਮੀਨਲ ਵਿੱਚ ਤੁਹਾਡਾ ਸੁਆਗਤ ਹੈ!"
-chat.welcome_disclaimer: "ਇੰਟੈਲੀਜੈਂਟ ਟਰਮੀਨਲ AI ਦੀ ਵਰਤੋਂ ਕਰਦਾ ਹੈ"
+chat.welcome_disclaimer: "ਇੰਟੈਲੀਜੈਂਟ ਟਰਮੀਨਲ AI ਦੀ ਵਰਤੋਂ ਕਰਦਾ ਹੈ।"
 chat.plan_header: "ਯੋਜਨਾ:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/pl-PL.yml
+++ b/tools/wta/locales/pl-PL.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Naciśnij Enter, aby spróbować ponownie, lu
 chat.activity_thinking: "Myślenie..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Witamy w Inteligentny Terminal!"
-chat.welcome_disclaimer: "Inteligentny Terminal korzysta z AI. Sprawdź, czy nie ma błędów."
+chat.welcome_disclaimer: "Inteligentny Terminal korzysta z AI"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/pl-PL.yml
+++ b/tools/wta/locales/pl-PL.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Naciśnij Enter, aby spróbować ponownie, lu
 chat.activity_thinking: "Myślenie..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Witamy w Inteligentny Terminal!"
-chat.welcome_disclaimer: "Inteligentny Terminal korzysta z AI"
+chat.welcome_disclaimer: "Inteligentny Terminal korzysta z AI."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/pt-BR.yml
+++ b/tools/wta/locales/pt-BR.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pressione Enter para tentar novamente, ou Esc
 chat.activity_thinking: "Pensando…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Bem-vindo ao Terminal Inteligente!"
-chat.welcome_disclaimer: "O Terminal Inteligente usa IA. Verifique se há erros."
+chat.welcome_disclaimer: "O Terminal Inteligente usa IA"
 chat.plan_header: "Plano:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/pt-BR.yml
+++ b/tools/wta/locales/pt-BR.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pressione Enter para tentar novamente, ou Esc
 chat.activity_thinking: "Pensando…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Bem-vindo ao Terminal Inteligente!"
-chat.welcome_disclaimer: "O Terminal Inteligente usa IA"
+chat.welcome_disclaimer: "O Terminal Inteligente usa IA."
 chat.plan_header: "Plano:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/pt-PT.yml
+++ b/tools/wta/locales/pt-PT.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Prima Enter para tentar novamente, ou Esc par
 chat.activity_thinking: "A pensar…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Bem-vindo ao Terminal Inteligente!"
-chat.welcome_disclaimer: "O Terminal Inteligente utiliza IA. Verifique se existem erros."
+chat.welcome_disclaimer: "O Terminal Inteligente utiliza IA"
 chat.plan_header: "Plano:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/pt-PT.yml
+++ b/tools/wta/locales/pt-PT.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Prima Enter para tentar novamente, ou Esc par
 chat.activity_thinking: "A pensar…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Bem-vindo ao Terminal Inteligente!"
-chat.welcome_disclaimer: "O Terminal Inteligente utiliza IA"
+chat.welcome_disclaimer: "O Terminal Inteligente utiliza IA."
 chat.plan_header: "Plano:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/qps-ploc.yml
+++ b/tools/wta/locales/qps-ploc.yml
@@ -43,7 +43,7 @@ chat.activity_thinking: "[Ţĥïñķïñğ…!!]"
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "[Ŵéĺçöḿé ţö Intelligent Terminal!!]"
 # {Locked="Intelligent Terminal","AI"} - product name and acronym, do not translate
-chat.welcome_disclaimer: "[Intelligent Terminal ûśéś AI. Çĥéçķ ƒöŕ ḿïśţåķéś.!!]"
+chat.welcome_disclaimer: "[Intelligent Terminal ûśéś AI!!]"
 chat.plan_header: "[Ṗĺåñ:!!]"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/qps-ploc.yml
+++ b/tools/wta/locales/qps-ploc.yml
@@ -43,7 +43,7 @@ chat.activity_thinking: "[Ţĥïñķïñğ…!!]"
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "[Ŵéĺçöḿé ţö Intelligent Terminal!!]"
 # {Locked="Intelligent Terminal","AI"} - product name and acronym, do not translate
-chat.welcome_disclaimer: "[Intelligent Terminal ûśéś AI!!]"
+chat.welcome_disclaimer: "[Intelligent Terminal ûśéś AI.!!]"
 chat.plan_header: "[Ṗĺåñ:!!]"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/qps-ploca.yml
+++ b/tools/wta/locales/qps-ploca.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Press Enter to retry, or Esc to go back."  # 
 chat.activity_thinking: "[!!_Thinking..._!!]"
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "[!!_Welcome to Intelligent Terminal!_!!]"
-chat.welcome_disclaimer: "[!!_Intelligent Terminal uses AI_!!]"
+chat.welcome_disclaimer: "[!!_Intelligent Terminal uses AI._!!]"
 chat.plan_header: "[!!_Plan:_!!]"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/qps-ploca.yml
+++ b/tools/wta/locales/qps-ploca.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Press Enter to retry, or Esc to go back."  # 
 chat.activity_thinking: "[!!_Thinking..._!!]"
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "[!!_Welcome to Intelligent Terminal!_!!]"
-chat.welcome_disclaimer: "[!!_Intelligent Terminal uses AI. Check for mistakes._!!]"
+chat.welcome_disclaimer: "[!!_Intelligent Terminal uses AI_!!]"
 chat.plan_header: "[!!_Plan:_!!]"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/qps-plocm.yml
+++ b/tools/wta/locales/qps-plocm.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Press Enter to retry, or Esc to go back."  # 
 chat.activity_thinking: "[!! Thi_nking... !!]"
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "[!! Welco_me to Intelligent Terminal! !!]"
-chat.welcome_disclaimer: "[!! Inte_lligent Terminal uses AI. Check for mistakes. !!]"
+chat.welcome_disclaimer: "[!! Inte_lligent Terminal uses AI !!]"
 chat.plan_header: "[!! Pla_n: !!]"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/qps-plocm.yml
+++ b/tools/wta/locales/qps-plocm.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Press Enter to retry, or Esc to go back."  # 
 chat.activity_thinking: "[!! Thi_nking... !!]"
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "[!! Welco_me to Intelligent Terminal! !!]"
-chat.welcome_disclaimer: "[!! Inte_lligent Terminal uses AI !!]"
+chat.welcome_disclaimer: "[!! Inte_lligent Terminal uses AI. !!]"
 chat.plan_header: "[!! Pla_n: !!]"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/quz-PE.yml
+++ b/tools/wta/locales/quz-PE.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Watiqmanta ruwanapaq Enter ñit'iy, utaq kuti
 chat.activity_thinking: "Yuyachkan..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Allillanchu Yuyaysapa Terminal!"
-chat.welcome_disclaimer: "Yuyaysapa Terminal AI-ta llamk'achin"
+chat.welcome_disclaimer: "Yuyaysapa Terminal AI-ta llamk'achin."
 chat.plan_header: "Ruwana:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/quz-PE.yml
+++ b/tools/wta/locales/quz-PE.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Watiqmanta ruwanapaq Enter ñit'iy, utaq kuti
 chat.activity_thinking: "Yuyachkan..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Allillanchu Yuyaysapa Terminal!"
-chat.welcome_disclaimer: "Yuyaysapa Terminal AI-ta llamk'achin. Pantaykunata qhaway."
+chat.welcome_disclaimer: "Yuyaysapa Terminal AI-ta llamk'achin"
 chat.plan_header: "Ruwana:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ro-RO.yml
+++ b/tools/wta/locales/ro-RO.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Apăsați Enter pentru a încerca din nou, sa
 chat.activity_thinking: "Se gândește..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Bun venit la Terminal Inteligent!"
-chat.welcome_disclaimer: "Terminal Inteligent folosește AI. Verificați erorile."
+chat.welcome_disclaimer: "Terminal Inteligent folosește AI"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ro-RO.yml
+++ b/tools/wta/locales/ro-RO.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Apăsați Enter pentru a încerca din nou, sa
 chat.activity_thinking: "Se gândește..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Bun venit la Terminal Inteligent!"
-chat.welcome_disclaimer: "Terminal Inteligent folosește AI"
+chat.welcome_disclaimer: "Terminal Inteligent folosește AI."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ru-RU.yml
+++ b/tools/wta/locales/ru-RU.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Нажмите Enter, чтобы повтор
 chat.activity_thinking: "Думаю…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Добро пожаловать в Интеллектуальный Терминал!"
-chat.welcome_disclaimer: "Интеллектуальный Терминал использует AI. Проверяйте ошибки."
+chat.welcome_disclaimer: "Интеллектуальный Терминал использует AI"
 chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ru-RU.yml
+++ b/tools/wta/locales/ru-RU.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Нажмите Enter, чтобы повтор
 chat.activity_thinking: "Думаю…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Добро пожаловать в Интеллектуальный Терминал!"
-chat.welcome_disclaimer: "Интеллектуальный Терминал использует AI"
+chat.welcome_disclaimer: "Интеллектуальный Терминал использует AI."
 chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/sk-SK.yml
+++ b/tools/wta/locales/sk-SK.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Stlačením Enter to skúste znova alebo Esc 
 chat.activity_thinking: "Premýšľam..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Vitajte v Inteligentný Terminál!"
-chat.welcome_disclaimer: "Inteligentný Terminál používa AI"
+chat.welcome_disclaimer: "Inteligentný Terminál používa AI."
 chat.plan_header: "Plán:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/sk-SK.yml
+++ b/tools/wta/locales/sk-SK.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Stlačením Enter to skúste znova alebo Esc 
 chat.activity_thinking: "Premýšľam..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Vitajte v Inteligentný Terminál!"
-chat.welcome_disclaimer: "Inteligentný Terminál používa AI. Skontrolujte chyby."
+chat.welcome_disclaimer: "Inteligentný Terminál používa AI"
 chat.plan_header: "Plán:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/sl-SI.yml
+++ b/tools/wta/locales/sl-SI.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pritisnite Enter za ponovni poskus ali Esc za
 chat.activity_thinking: "Razmišljam..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Dobrodošli v Inteligentni Terminal!"
-chat.welcome_disclaimer: "Inteligentni Terminal uporablja AI. Preverite napake."
+chat.welcome_disclaimer: "Inteligentni Terminal uporablja AI"
 chat.plan_header: "Načrt:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/sl-SI.yml
+++ b/tools/wta/locales/sl-SI.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pritisnite Enter za ponovni poskus ali Esc za
 chat.activity_thinking: "Razmišljam..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Dobrodošli v Inteligentni Terminal!"
-chat.welcome_disclaimer: "Inteligentni Terminal uporablja AI"
+chat.welcome_disclaimer: "Inteligentni Terminal uporablja AI."
 chat.plan_header: "Načrt:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/sq-AL.yml
+++ b/tools/wta/locales/sq-AL.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Shtypni Enter për të riprovuar, ose Esc pë
 chat.activity_thinking: "Po mendoj..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Mirë se vini në Terminali inteligjent!"
-chat.welcome_disclaimer: "Terminali inteligjent përdor AI"
+chat.welcome_disclaimer: "Terminali inteligjent përdor AI."
 chat.plan_header: "Plani:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/sq-AL.yml
+++ b/tools/wta/locales/sq-AL.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Shtypni Enter për të riprovuar, ose Esc pë
 chat.activity_thinking: "Po mendoj..."
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Mirë se vini në Terminali inteligjent!"
-chat.welcome_disclaimer: "Terminali inteligjent përdor AI. Kontrolloni për gabime."
+chat.welcome_disclaimer: "Terminali inteligjent përdor AI"
 chat.plan_header: "Plani:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/sr-Cyrl-BA.yml
+++ b/tools/wta/locales/sr-Cyrl-BA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Притисните Enter да бисте п
 chat.activity_thinking: "Размишљам…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Добродошли у Интелигентни Терминал!"
-chat.welcome_disclaimer: "Интелигентни Терминал користи AI. Проверите грешке."
+chat.welcome_disclaimer: "Интелигентни Терминал користи AI"
 chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/sr-Cyrl-BA.yml
+++ b/tools/wta/locales/sr-Cyrl-BA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Притисните Enter да бисте п
 chat.activity_thinking: "Размишљам…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Добродошли у Интелигентни Терминал!"
-chat.welcome_disclaimer: "Интелигентни Терминал користи AI"
+chat.welcome_disclaimer: "Интелигентни Терминал користи AI."
 chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/sr-Cyrl-RS.yml
+++ b/tools/wta/locales/sr-Cyrl-RS.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Притисните Enter да бисте п
 chat.activity_thinking: "Размишљам…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Добродошли у Интелигентни Терминал!"
-chat.welcome_disclaimer: "Интелигентни Терминал користи AI. Проверите грешке."
+chat.welcome_disclaimer: "Интелигентни Терминал користи AI"
 chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/sr-Cyrl-RS.yml
+++ b/tools/wta/locales/sr-Cyrl-RS.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Притисните Enter да бисте п
 chat.activity_thinking: "Размишљам…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Добродошли у Интелигентни Терминал!"
-chat.welcome_disclaimer: "Интелигентни Терминал користи AI"
+chat.welcome_disclaimer: "Интелигентни Терминал користи AI."
 chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/sr-Latn-RS.yml
+++ b/tools/wta/locales/sr-Latn-RS.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pritisnite Enter da biste pokušali ponovo il
 chat.activity_thinking: "Razmišljam…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Dobrodošli u Inteligentni Terminal!"
-chat.welcome_disclaimer: "Inteligentni Terminal koristi AI"
+chat.welcome_disclaimer: "Inteligentni Terminal koristi AI."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/sr-Latn-RS.yml
+++ b/tools/wta/locales/sr-Latn-RS.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Pritisnite Enter da biste pokušali ponovo il
 chat.activity_thinking: "Razmišljam…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Dobrodošli u Inteligentni Terminal!"
-chat.welcome_disclaimer: "Inteligentni Terminal koristi AI. Proverite greške."
+chat.welcome_disclaimer: "Inteligentni Terminal koristi AI"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/sv-SE.yml
+++ b/tools/wta/locales/sv-SE.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Tryck på Enter för att försöka igen, elle
 chat.activity_thinking: "Tänker..."
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "Välkommen till Intelligent Terminal!"
-chat.welcome_disclaimer: "Intelligent Terminal använder AI"
+chat.welcome_disclaimer: "Intelligent Terminal använder AI."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/sv-SE.yml
+++ b/tools/wta/locales/sv-SE.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Tryck på Enter för att försöka igen, elle
 chat.activity_thinking: "Tänker..."
 # {Locked="Intelligent Terminal"} - product name, do not translate
 chat.welcome_title: "Välkommen till Intelligent Terminal!"
-chat.welcome_disclaimer: "Intelligent Terminal använder AI. Kontrollera om det finns fel."
+chat.welcome_disclaimer: "Intelligent Terminal använder AI"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ta-IN.yml
+++ b/tools/wta/locales/ta-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  மீண்டும் முயற்ச�
 chat.activity_thinking: "யோசிக்கிறது…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "அறிவாண் முனையம்-க்கு வரவேற்கிறோம்!"
-chat.welcome_disclaimer: "அறிவாண் முனையம் AI-ஐப் பயன்படுத்துகிறது"
+chat.welcome_disclaimer: "அறிவாண் முனையம் AI-ஐப் பயன்படுத்துகிறது."
 chat.plan_header: "திட்டம்:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ta-IN.yml
+++ b/tools/wta/locales/ta-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  மீண்டும் முயற்ச�
 chat.activity_thinking: "யோசிக்கிறது…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "அறிவாண் முனையம்-க்கு வரவேற்கிறோம்!"
-chat.welcome_disclaimer: "அறிவாண் முனையம் AI-ஐப் பயன்படுத்துகிறது. பிழைகளைச் சரிபார்க்கவும்."
+chat.welcome_disclaimer: "அறிவாண் முனையம் AI-ஐப் பயன்படுத்துகிறது"
 chat.plan_header: "திட்டம்:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/te-IN.yml
+++ b/tools/wta/locales/te-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  మళ్లీ ప్రయత్నిం�
 chat.activity_thinking: "ఆలోచిస్తోంది…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ఇంటెలిజెంట్ టెర్మినల్-కు స్వాగతం!"
-chat.welcome_disclaimer: "ఇంటెలిజెంట్ టెర్మినల్ AI ఉపయోగిస్తుంది. తప్పులు ఉన్నాయా తనిఖీ చేయండి."
+chat.welcome_disclaimer: "ఇంటెలిజెంట్ టెర్మినల్ AI ఉపయోగిస్తుంది"
 chat.plan_header: "ప్లాన్:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/te-IN.yml
+++ b/tools/wta/locales/te-IN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  మళ్లీ ప్రయత్నిం�
 chat.activity_thinking: "ఆలోచిస్తోంది…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ఇంటెలిజెంట్ టెర్మినల్-కు స్వాగతం!"
-chat.welcome_disclaimer: "ఇంటెలిజెంట్ టెర్మినల్ AI ఉపయోగిస్తుంది"
+chat.welcome_disclaimer: "ఇంటెలిజెంట్ టెర్మినల్ AI ఉపయోగిస్తుంది."
 chat.plan_header: "ప్లాన్:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/th-TH.yml
+++ b/tools/wta/locales/th-TH.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  กด Enter เพื่อลองอี�
 chat.activity_thinking: "กำลังคิด…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ยินดีต้อนรับสู่ เทอร์มินัลอัจฉริยะ!"
-chat.welcome_disclaimer: "เทอร์มินัลอัจฉริยะ ใช้ AI ตรวจสอบข้อผิดพลาด."
+chat.welcome_disclaimer: "เทอร์มินัลอัจฉริยะ ใช้ AI"
 chat.plan_header: "แผน:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/th-TH.yml
+++ b/tools/wta/locales/th-TH.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  กด Enter เพื่อลองอี�
 chat.activity_thinking: "กำลังคิด…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ยินดีต้อนรับสู่ เทอร์มินัลอัจฉริยะ!"
-chat.welcome_disclaimer: "เทอร์มินัลอัจฉริยะ ใช้ AI"
+chat.welcome_disclaimer: "เทอร์มินัลอัจฉริยะ ใช้ AI."
 chat.plan_header: "แผน:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/tr-TR.yml
+++ b/tools/wta/locales/tr-TR.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Yeniden denemek için Enter tuşuna veya geri
 chat.activity_thinking: "Düşünüyor…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Akıllı Terminal'e hoş geldiniz!"
-chat.welcome_disclaimer: "Akıllı Terminal, AI kullanır. Hataları kontrol edin."
+chat.welcome_disclaimer: "Akıllı Terminal, AI kullanır"
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/tr-TR.yml
+++ b/tools/wta/locales/tr-TR.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Yeniden denemek için Enter tuşuna veya geri
 chat.activity_thinking: "Düşünüyor…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Akıllı Terminal'e hoş geldiniz!"
-chat.welcome_disclaimer: "Akıllı Terminal, AI kullanır"
+chat.welcome_disclaimer: "Akıllı Terminal, AI kullanır."
 chat.plan_header: "Plan:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/tt-RU.yml
+++ b/tools/wta/locales/tt-RU.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Кабатлап карау өчен Enter т
 chat.activity_thinking: "Уйлыйм…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Акыллы терминал-га рәхим итегез!"
-chat.welcome_disclaimer: "Акыллы терминал AI куллана. Хаталарны тикшерегез."
+chat.welcome_disclaimer: "Акыллы терминал AI куллана"
 chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/tt-RU.yml
+++ b/tools/wta/locales/tt-RU.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Кабатлап карау өчен Enter т
 chat.activity_thinking: "Уйлыйм…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Акыллы терминал-га рәхим итегез!"
-chat.welcome_disclaimer: "Акыллы терминал AI куллана"
+chat.welcome_disclaimer: "Акыллы терминал AI куллана."
 chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ug-CN.yml
+++ b/tools/wta/locales/ug-CN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  قايتا سىناش ئۈچۈن Enter نى �
 chat.activity_thinking: "ئويلىنىۋاتىدۇ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ئەقلىي تېرمىنال ھە خوش كەلدىڭىز!"
-chat.welcome_disclaimer: "ئەقلىي تېرمىنال AI ئىشلىتىدۇ. خاتالىقلارنى تەكشۈرۈڭ."
+chat.welcome_disclaimer: "ئەقلىي تېرمىنال AI ئىشلىتىدۇ"
 chat.plan_header: "پىلان:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/ug-CN.yml
+++ b/tools/wta/locales/ug-CN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  قايتا سىناش ئۈچۈن Enter نى �
 chat.activity_thinking: "ئويلىنىۋاتىدۇ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "ئەقلىي تېرمىنال ھە خوش كەلدىڭىز!"
-chat.welcome_disclaimer: "ئەقلىي تېرمىنال AI ئىشلىتىدۇ"
+chat.welcome_disclaimer: "ئەقلىي تېرمىنال AI ئىشلىتىدۇ."
 chat.plan_header: "پىلان:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/uk-UA.yml
+++ b/tools/wta/locales/uk-UA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Натисніть Enter, щоб спробу
 chat.activity_thinking: "Думаю…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Ласкаво просимо до Інтелектуальний Термінал!"
-chat.welcome_disclaimer: "Інтелектуальний Термінал використовує AI"
+chat.welcome_disclaimer: "Інтелектуальний Термінал використовує AI."
 chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/uk-UA.yml
+++ b/tools/wta/locales/uk-UA.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Натисніть Enter, щоб спробу
 chat.activity_thinking: "Думаю…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Ласкаво просимо до Інтелектуальний Термінал!"
-chat.welcome_disclaimer: "Інтелектуальний Термінал використовує AI. Перевіряйте помилки."
+chat.welcome_disclaimer: "Інтелектуальний Термінал використовує AI"
 chat.plan_header: "План:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/uz-Latn-UZ.yml
+++ b/tools/wta/locales/uz-Latn-UZ.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Qayta urinish uchun Enter tugmasini bosing yo
 chat.activity_thinking: "Oʻylayapman…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Aqlli terminal-ga xush kelibsiz!"
-chat.welcome_disclaimer: "Aqlli terminal AI-dan foydalanadi. Xatolarni tekshiring."
+chat.welcome_disclaimer: "Aqlli terminal AI-dan foydalanadi"
 chat.plan_header: "Reja:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/uz-Latn-UZ.yml
+++ b/tools/wta/locales/uz-Latn-UZ.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Qayta urinish uchun Enter tugmasini bosing yo
 chat.activity_thinking: "Oʻylayapman…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Aqlli terminal-ga xush kelibsiz!"
-chat.welcome_disclaimer: "Aqlli terminal AI-dan foydalanadi"
+chat.welcome_disclaimer: "Aqlli terminal AI-dan foydalanadi."
 chat.plan_header: "Reja:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/vi-VN.yml
+++ b/tools/wta/locales/vi-VN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Nhấn Enter để thử lại hoặc Esc đ�
 chat.activity_thinking: "Đang suy nghĩ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Chào mừng bạn đến Đầu cuối thông minh!"
-chat.welcome_disclaimer: "Đầu cuối thông minh sử dụng AI. Hãy kiểm tra lỗi."
+chat.welcome_disclaimer: "Đầu cuối thông minh sử dụng AI"
 chat.plan_header: "Kế hoạch:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/vi-VN.yml
+++ b/tools/wta/locales/vi-VN.yml
@@ -41,7 +41,7 @@ auth.login_failed_help_default: "  Nhấn Enter để thử lại hoặc Esc đ�
 chat.activity_thinking: "Đang suy nghĩ…"
 # {Locked=qps-ploc,qps-ploca,qps-plocm}
 chat.welcome_title: "Chào mừng bạn đến Đầu cuối thông minh!"
-chat.welcome_disclaimer: "Đầu cuối thông minh sử dụng AI"
+chat.welcome_disclaimer: "Đầu cuối thông minh sử dụng AI."
 chat.plan_header: "Kế hoạch:"
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/zh-CN.yml
+++ b/tools/wta/locales/zh-CN.yml
@@ -37,7 +37,7 @@ auth.login_failed_help_default: "  按 Enter 重试,或按 Esc 返回。"  # {Lo
 # ── 聊天视图 (src/ui/chat.rs) ──────────────────────────────────────────────
 chat.activity_thinking: "思考中…"
 chat.welcome_title: "欢迎使用智能终端！"
-chat.welcome_disclaimer: "智能终端使用 AI"
+chat.welcome_disclaimer: "智能终端使用 AI。"
 chat.plan_header: "计划："
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/zh-CN.yml
+++ b/tools/wta/locales/zh-CN.yml
@@ -37,7 +37,7 @@ auth.login_failed_help_default: "  按 Enter 重试,或按 Esc 返回。"  # {Lo
 # ── 聊天视图 (src/ui/chat.rs) ──────────────────────────────────────────────
 chat.activity_thinking: "思考中…"
 chat.welcome_title: "欢迎使用智能终端！"
-chat.welcome_disclaimer: "智能终端使用 AI。请检查是否有误。"
+chat.welcome_disclaimer: "智能终端使用 AI"
 chat.plan_header: "计划："
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/zh-TW.yml
+++ b/tools/wta/locales/zh-TW.yml
@@ -37,7 +37,7 @@ auth.login_failed_help_default: "  按 Enter 重試，或按 Esc 返回。"  # {
 # ── 聊天檢視 (src/ui/chat.rs) ──────────────────────────────────────────────
 chat.activity_thinking: "思考中…"
 chat.welcome_title: "歡迎使用智能終端！"
-chat.welcome_disclaimer: "智能終端使用 AI"
+chat.welcome_disclaimer: "智能終端使用 AI。"
 chat.plan_header: "計畫："
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/locales/zh-TW.yml
+++ b/tools/wta/locales/zh-TW.yml
@@ -37,7 +37,7 @@ auth.login_failed_help_default: "  按 Enter 重試，或按 Esc 返回。"  # {
 # ── 聊天檢視 (src/ui/chat.rs) ──────────────────────────────────────────────
 chat.activity_thinking: "思考中…"
 chat.welcome_title: "歡迎使用智能終端！"
-chat.welcome_disclaimer: "智能終端使用 AI。請檢查是否有誤。"
+chat.welcome_disclaimer: "智能終端使用 AI"
 chat.plan_header: "計畫："
 chat.plan_marker_completed: "[x]"  # {Locked}
 chat.plan_marker_in_progress: "[>]"  # {Locked}

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -116,7 +116,7 @@ pub enum ChatMessage {
     /// codes, OSC sequences). Distinct from `Error` so we can theme it
     /// differently and skip autofix wiring.
     AgentEvent(String),
-    /// "Intelligent Terminal uses AI" disclaimer.
+    /// "Intelligent Terminal uses AI." disclaimer.
     /// Pushed on every agent-pane startup,
     /// no persistence gating — getting cleared by the next turn is fine,
     /// the next pane startup re-pushes it.

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -116,7 +116,7 @@ pub enum ChatMessage {
     /// codes, OSC sequences). Distinct from `Error` so we can theme it
     /// differently and skip autofix wiring.
     AgentEvent(String),
-    /// "Intelligent Terminal uses AI. Check for mistakes" disclaimer.
+    /// "Intelligent Terminal uses AI" disclaimer.
     /// Pushed on every agent-pane startup,
     /// no persistence gating — getting cleared by the next turn is fine,
     /// the next pane startup re-pushes it.

--- a/tools/wta/src/theme.rs
+++ b/tools/wta/src/theme.rs
@@ -10,6 +10,7 @@ pub const ATTACHMENT_TOKEN: Style = Style::new().fg(Color::Cyan);
 // pane's color scheme — light text on dark schemes, dark text on light
 // schemes. A hardcoded white was invisible on light color schemes (#234).
 pub const AGENT_TEXT: Style = Style::new().fg(Color::Reset);
+pub const DISCLAIMER_TEXT: Style = Style::new().fg(Color::Reset).add_modifier(Modifier::DIM);
 pub const SYSTEM_TEXT: Style = Style::new().fg(Color::Cyan);
 pub const NOTICE_SUCCESS: Style = Style::new().fg(Color::Green);
 pub const NOTICE_INFO: Style = Style::new().fg(Color::Cyan);

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -1044,7 +1044,7 @@ fn build_message_lines_with_details<'a>(
                 Span::raw("  "),
                 Span::styled(
                     t!("chat.welcome_disclaimer").into_owned(),
-                    Style::new().fg(Color::Reset).add_modifier(Modifier::BOLD),
+                    theme::DISCLAIMER_TEXT,
                 ),
             ]));
         }


### PR DESCRIPTION
## Summary
- shorten the agent-pane disclaimer to “Intelligent Terminal uses AI”
- update all 89 WTA locales
- use a theme-aware muted, non-bold style matching Copilot

## Validation
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`