### PR TITLE
Show model in agent pane title bar

### DIFF
--- a/src/cascadia/TerminalApp/AgentPaneContent.cpp
+++ b/src/cascadia/TerminalApp/AgentPaneContent.cpp
@@ -112,7 +112,7 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Swap the bar between two modes:
-    //   * chat / connecting / etc. (active=false) — agent logo + "<name> <version>"
+    //   * chat / connecting / etc. (active=false) — agent logo + agent/model label
     //   * session management view (active=true)  — no logo, "Agent sessions"
     // Idempotent so callers don't need to dedupe.
     void AgentPaneContent::SetSessionsView(bool active)
@@ -248,9 +248,9 @@ namespace winrt::TerminalApp::implementation
                 text += L" ";
                 text += _agentVersion;
             }
-            else if (!_agentModel.empty())
+            if (!_agentModel.empty())
             {
-                text += L" ";
+                text += L" \u00B7 ";
                 text += _agentModel;
             }
         }

--- a/src/cascadia/TerminalApp/AgentPaneContent.cpp
+++ b/src/cascadia/TerminalApp/AgentPaneContent.cpp
@@ -248,7 +248,7 @@ namespace winrt::TerminalApp::implementation
                 text += L" ";
                 text += _agentVersion;
             }
-            if (!_agentModel.empty())
+            if (_agentState == L"connected" && !_agentModel.empty())
             {
                 text += L" \u00B7 ";
                 text += _agentModel;

--- a/src/cascadia/TerminalApp/AgentPaneContent.h
+++ b/src/cascadia/TerminalApp/AgentPaneContent.h
@@ -152,7 +152,7 @@ namespace winrt::TerminalApp::implementation
         winrt::hstring _agentState{};
         winrt::hstring _agentBackend{};
 
-        // When true, the bar replaces "<agent> <version>" with "Agent sessions"
+        // When true, the bar replaces the agent/model label with "Agent sessions"
         // and hides the agent logo. Driven by TerminalPage::OnAgentStateChanged
         // (the single writer for view-derived UI state).
         bool _isSessionsView{ false };

--- a/src/cascadia/TerminalApp/AgentPaneContent.idl
+++ b/src/cascadia/TerminalApp/AgentPaneContent.idl
@@ -19,7 +19,7 @@ namespace TerminalApp
         // state is one of "connecting" | "connected" | "failed" | "disconnected".
         void UpdateAgentStatus(String name, String version, String model, String state, String backend);
 
-        // Toggle the bar's "agent name + version" header into a "Agent sessions"
+        // Toggle the bar's agent/model header into an "Agent sessions"
         // label (and hide the agent logo) while wta's session management view is
         // active. Driven by TerminalPage whenever the wta view changes.
         void SetSessionsView(Boolean active);

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1823,7 +1823,12 @@ impl App {
     /// this helper owns. No-op on an empty/whitespace model — an empty
     /// override means "agent default", which `set_session_model` can't
     /// express.
-    fn send_session_model(&self, session_id: Option<String>, model: String) {
+    fn send_session_model(
+        &self,
+        session_id: Option<String>,
+        model: String,
+        pane_override: bool,
+    ) {
         if model.trim().is_empty() {
             return;
         }
@@ -1831,6 +1836,7 @@ impl App {
             crate::protocol::acp::client::MasterExtRequest::SetSessionModel {
                 session_id: session_id.map(agent_client_protocol::schema::v1::SessionId::new),
                 model,
+                pane_override,
             },
         );
     }
@@ -1857,7 +1863,7 @@ impl App {
                 continue;
             }
             if let Some(sid) = tab.session_id.clone() {
-                self.send_session_model(Some(sid), model.clone());
+                self.send_session_model(Some(sid), model.clone(), false);
             }
         }
     }
@@ -1875,7 +1881,6 @@ impl App {
         }
 
         self.acp_model = new_model.filter(|s| !s.trim().is_empty());
-        self.recompute_current_model_id();
         self.send_acp_model_update();
         self.publish_agent_status();
         true
@@ -2386,26 +2391,21 @@ impl App {
             return;
         }
 
-        let name = self
-            .available_models
-            .iter()
-            .find(|m| m.id == model_id)
-            .map(|m| m.name.clone())
-            .unwrap_or_else(|| model_id.clone());
-        let session_id = {
-            let tab = self.current_tab_mut();
-            tab.model_override = Some(model_id.clone());
-            tab.messages.push(ChatMessage::success(
-                t!("system.model_set", model = name.as_str()).into_owned(),
-            ));
-            tab.scroll_to_bottom();
-            tab.session_id.clone()
-        };
-        self.current_model_id = Some(model_id.clone());
-        self.agent_current_model_id = Some(model_id.clone());
+        let session_id = self.current_tab().session_id.clone();
         if let Some(session_id) = session_id {
-            self.send_session_model(Some(session_id), model_id);
+            self.send_session_model(Some(session_id), model_id, true);
+            return;
         }
+
+        let name = self.model_display_name(&model_id);
+        let tab = self.current_tab_mut();
+        tab.model_override = Some(model_id.clone());
+        tab.messages.push(ChatMessage::success(
+            t!("system.model_set", model = name.as_str()).into_owned(),
+        ));
+        tab.scroll_to_bottom();
+        self.current_model_id = Some(model_id.clone());
+        self.agent_current_model_id = Some(model_id);
         self.publish_agent_status();
     }
 
@@ -4011,6 +4011,8 @@ impl App {
             AppEvent::UsageReported { .. } => "usage_reported",
             AppEvent::UsageCleared { .. } => "usage_cleared",
             AppEvent::ModelConfigUpdated { .. } => "model_config_updated",
+            AppEvent::ModelSetCompleted { .. } => "model_set_completed",
+            AppEvent::ModelSetFailed { .. } => "model_set_failed",
             AppEvent::SessionConfigUpdated { .. } => "session_config_updated",
             AppEvent::SessionConfigSetCompleted { .. } => "session_config_set_completed",
             AppEvent::SessionConfigSetFailed { .. } => "session_config_set_failed",
@@ -4595,13 +4597,27 @@ impl App {
             .or_else(|| self.current_model_id.clone())
             .or_else(|| self.acp_model.clone())
             .filter(|s| !s.trim().is_empty())?;
-        let name = self
-            .available_models
+        Some(self.model_display_name(&id))
+    }
+
+    fn confirmed_model_display(&self) -> Option<String> {
+        let id = self
+            .current_tab()
+            .model_override
+            .as_deref()
+            .or(self.agent_current_model_id.as_deref())
+            .or_else(|| self.selected_custom_model_id())
+            .map(str::trim)
+            .filter(|id| !id.is_empty())?;
+        Some(self.model_display_name(id))
+    }
+
+    fn model_display_name(&self, id: &str) -> String {
+        self.available_models
             .iter()
-            .find(|m| m.id == id)
-            .map(|m| m.name.clone())
-            .unwrap_or(id);
-        Some(name)
+            .find(|model| model.id == id)
+            .map(|model| model.name.clone())
+            .unwrap_or_else(|| id.to_string())
     }
 
     /// Whether the command popup is *effectively* visible — i.e. actually
@@ -5282,6 +5298,7 @@ impl App {
         self.agent_models = models;
         self.agent_current_model_id = current;
         self.rebuild_model_catalog_from_agent_state();
+        self.publish_agent_status();
 
         // The new active tab's `current_view` (and autofix bar) is now
         // authoritative for the shared C++ agent pane. Re-emit so the bar

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -45,6 +45,17 @@ pub enum AppEvent {
         available_models: Vec<AcpModelInfo>,
         current_model_id: Option<String>,
     },
+    ModelSetCompleted {
+        session_id: String,
+        model: String,
+        pane_override: bool,
+    },
+    ModelSetFailed {
+        session_id: String,
+        model: String,
+        pane_override: bool,
+        message: String,
+    },
     SessionConfigUpdated {
         session_id: String,
         options: Vec<AcpSessionConfigOption>,

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -447,7 +447,7 @@ impl App {
                 // already model-applied by the client at startup.
                 if !is_load_target {
                     if let Some(model) = self.effective_model_for_tab(&tab_id) {
-                        self.send_session_model(Some(session_id.clone()), model);
+                        self.send_session_model(Some(session_id.clone()), model, false);
                     }
                 }
                 self.publish_agent_status();
@@ -487,6 +487,59 @@ impl App {
                     self.agent_current_model_id = current_model_id;
                     self.rebuild_model_catalog_from_agent_state();
                     self.publish_agent_status();
+                }
+            }
+            AppEvent::ModelSetCompleted {
+                session_id,
+                model,
+                pane_override,
+            } => {
+                let target_tab = self.bound_tab_for_session(&session_id);
+                let Some(target_tab) = target_tab else {
+                    return;
+                };
+                if let Some((_, current_model_id)) =
+                    self.session_model_configs.get_mut(&session_id)
+                {
+                    *current_model_id = Some(model.clone());
+                }
+                if pane_override {
+                    let name = self.model_display_name(&model);
+                    let tab = self.tab_mut(&target_tab);
+                    tab.model_override = Some(model.clone());
+                    tab.messages.push(ChatMessage::success(
+                        t!("system.model_set", model = name.as_str()).into_owned(),
+                    ));
+                    tab.scroll_to_bottom();
+                }
+                if self.current_tab().session_id.as_deref() == Some(session_id.as_str()) {
+                    self.agent_current_model_id = Some(model);
+                    self.rebuild_model_catalog_from_agent_state();
+                    self.publish_agent_status();
+                }
+            }
+            AppEvent::ModelSetFailed {
+                session_id,
+                model,
+                pane_override,
+                message,
+            } => {
+                let target_tab = self.bound_tab_for_session(&session_id);
+                let Some(target_tab) = target_tab else {
+                    return;
+                };
+                if pane_override {
+                    let name = self.model_display_name(&model);
+                    let tab = self.tab_mut(&target_tab);
+                    tab.messages.push(ChatMessage::error(
+                        t!(
+                            "system.config_update_failed",
+                            option = name.as_str(),
+                            error = message.as_str()
+                        )
+                        .into_owned(),
+                    ));
+                    tab.scroll_to_bottom();
                 }
             }
             AppEvent::SessionConfigUpdated {

--- a/tools/wta/src/app_status_projection.rs
+++ b/tools/wta/src/app_status_projection.rs
@@ -29,7 +29,7 @@ impl App {
             None
         };
         let display_model = self
-            .current_model_display()
+            .confirmed_model_display()
             .or_else(|| self.agent_model.clone());
         let mut params = serde_json::json!({
             "agent_id": self.current_agent_id,

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -2228,6 +2228,26 @@ fn slash_model_hot_applies_cloud_model_to_live_session() {
 
     app.cmd_model("gpt-5.4".into());
 
+    assert_eq!(app.current_tab().model_override, None);
+    match master_rx.try_recv().expect("live model switch request") {
+        crate::protocol::acp::client::MasterExtRequest::SetSessionModel {
+            session_id,
+            model,
+            pane_override,
+        } => {
+            assert_eq!(session_id.expect("target session").0.as_ref(), "sid-1");
+            assert_eq!(model, "gpt-5.4");
+            assert!(pane_override);
+        }
+        other => panic!("expected SetSessionModel, got {other:?}"),
+    }
+
+    app.handle_event(AppEvent::ModelSetCompleted {
+        session_id: "sid-1".into(),
+        model: "gpt-5.4".into(),
+        pane_override: true,
+    });
+
     assert_eq!(app.current_tab().model_override.as_deref(), Some("gpt-5.4"));
     assert!(matches!(
         app.current_tab().messages.last(),
@@ -2236,13 +2256,62 @@ fn slash_model_hot_applies_cloud_model_to_live_session() {
             ..
         })
     ));
-    match master_rx.try_recv().expect("live model switch request") {
-        crate::protocol::acp::client::MasterExtRequest::SetSessionModel { session_id, model } => {
-            assert_eq!(session_id.expect("target session").0.as_ref(), "sid-1");
-            assert_eq!(model, "gpt-5.4");
-        }
-        other => panic!("expected SetSessionModel, got {other:?}"),
-    }
+}
+
+#[test]
+fn failed_legacy_model_pick_preserves_confirmed_model() {
+    let (mut app, mut master_rx) = test_app_with_master_rx();
+    app.set_cloud_models(vec![model_info("gpt-5.5"), model_info("gpt-5.4")]);
+    app.current_model_id = Some("gpt-5.5".into());
+    app.current_tab_mut().session_id = Some("sid-1".into());
+
+    app.cmd_model("gpt-5.4".into());
+    let _ = master_rx.try_recv().expect("live model switch request");
+    app.handle_event(AppEvent::ModelSetFailed {
+        session_id: "sid-1".into(),
+        model: "gpt-5.4".into(),
+        pane_override: true,
+        message: "rejected".into(),
+    });
+
+    assert_eq!(app.current_tab().model_override, None);
+    assert_eq!(app.current_model_id.as_deref(), Some("gpt-5.5"));
+    assert!(matches!(
+        app.current_tab().messages.last(),
+        Some(ChatMessage::Notice {
+            kind: NoticeKind::Error,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn status_model_ignores_unconfirmed_global_selection() {
+    let mut app = test_app();
+    app.available_models = vec![model_info("confirmed"), model_info("requested")];
+    app.agent_current_model_id = Some("confirmed".into());
+    app.current_model_id = Some("requested".into());
+    app.acp_model = Some("requested".into());
+
+    assert_eq!(app.confirmed_model_display().as_deref(), Some("CONFIRMED"));
+}
+
+#[test]
+fn connected_byok_selection_is_available_for_status() {
+    let mut app = test_app();
+    app.set_custom_model_config(
+        vec![CustomModelCatalogEntry {
+            selection_id: "custom:provider:qwen".into(),
+            model_id: "qwen".into(),
+            ..Default::default()
+        }],
+        Some("custom:provider:qwen".into()),
+    );
+
+    assert_eq!(
+        app.confirmed_model_display().as_deref(),
+        Some("qwen (BYOK)")
+    );
 }
 
 /// A pane-local `/model` pick remains authoritative when the matching global
@@ -2338,9 +2407,14 @@ fn fresh_session_model_does_not_replace_global_override() {
         .try_recv()
         .expect("the global override must be re-applied to the fresh session")
     {
-        MasterExtRequest::SetSessionModel { session_id, model } => {
+        MasterExtRequest::SetSessionModel {
+            session_id,
+            model,
+            pane_override,
+        } => {
             assert_eq!(session_id.unwrap().0.to_string(), "sid-fresh");
             assert_eq!(model, "global");
+            assert!(!pane_override);
         }
         other => panic!("expected SetSessionModel, got {other:?}"),
     }
@@ -2371,9 +2445,14 @@ fn fresh_session_model_does_not_replace_pane_override_on_new() {
         .try_recv()
         .expect("the pane override must be re-applied to the /new session")
     {
-        MasterExtRequest::SetSessionModel { session_id, model } => {
+        MasterExtRequest::SetSessionModel {
+            session_id,
+            model,
+            pane_override,
+        } => {
             assert_eq!(session_id.unwrap().0.to_string(), "sid-new");
             assert_eq!(model, "pane-picked");
+            assert!(!pane_override);
         }
         other => panic!("expected SetSessionModel, got {other:?}"),
     }
@@ -2419,9 +2498,14 @@ fn non_overridden_pane_follows_global_model() {
         .try_recv()
         .expect("non-overridden pane follows global")
     {
-        MasterExtRequest::SetSessionModel { session_id, model } => {
+        MasterExtRequest::SetSessionModel {
+            session_id,
+            model,
+            pane_override,
+        } => {
             assert_eq!(model, "global");
             assert_eq!(session_id.unwrap().0.to_string(), "sid-1");
+            assert!(!pane_override);
         }
         other => panic!("expected SetSessionModel, got {other:?}"),
     }
@@ -2480,9 +2564,14 @@ fn global_model_hot_update_is_scoped_to_matching_global_followers() {
         .try_recv()
         .expect("matching global-following helper should receive the model")
     {
-        MasterExtRequest::SetSessionModel { session_id, model } => {
+        MasterExtRequest::SetSessionModel {
+            session_id,
+            model,
+            pane_override,
+        } => {
             assert_eq!(session_id.unwrap().0.to_string(), "gemini-session");
             assert_eq!(model, "copilot-only-model");
+            assert!(!pane_override);
         }
         other => panic!("expected SetSessionModel, got {other:?}"),
     }

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -171,6 +171,7 @@ pub enum MasterExtRequest {
     SetSessionModel {
         session_id: Option<acp::schema::v1::SessionId>,
         model: String,
+        pane_override: bool,
     },
     SetSessionConfigOption {
         session_id: acp::schema::v1::SessionId,
@@ -3385,7 +3386,11 @@ fn dispatch_master_ext_request(
                 }
                 let _ = event_tx.send(AppEvent::MasterMutationCompleted { request_id });
             }
-            MasterExtRequest::SetSessionModel { session_id, model } => {
+            MasterExtRequest::SetSessionModel {
+                session_id,
+                model,
+                pane_override,
+            } => {
                 // Apply to the targeted session, or to every live session
                 // this helper owns when no target is given (normally just the
                 // one bound to its owner tab). Best-effort: a failure on one
@@ -3410,6 +3415,12 @@ fn dispatch_master_ext_request(
                             model = %model,
                             "set_session_model targeted an unknown/stale session; no live session updated"
                         );
+                        let _ = event_tx.send(AppEvent::ModelSetFailed {
+                            session_id: target.to_string(),
+                            model: model.clone(),
+                            pane_override,
+                            message: "the session is no longer active".to_string(),
+                        });
                     }
                 }
                 for sid in sessions {
@@ -3439,6 +3450,11 @@ fn dispatch_master_ext_request(
                                     current_model_id,
                                 });
                             }
+                            let _ = event_tx.send(AppEvent::ModelSetCompleted {
+                                session_id: sid.to_string(),
+                                model: model.clone(),
+                                pane_override,
+                            });
                             tracing::info!(
                                 target: "acp",
                                 session_id = %sid.0,
@@ -3446,13 +3462,21 @@ fn dispatch_master_ext_request(
                                 "acp-model hot-applied to live session"
                             );
                         }
-                        Err(err) => tracing::warn!(
-                            target: "acp",
-                            session_id = %sid.0,
-                            model = %model,
-                            error = ?err,
-                            "model hot-update failed"
-                        ),
+                        Err(err) => {
+                            tracing::warn!(
+                                target: "acp",
+                                session_id = %sid.0,
+                                model = %model,
+                                error = ?err,
+                                "model hot-update failed"
+                            );
+                            let _ = event_tx.send(AppEvent::ModelSetFailed {
+                                session_id: sid.to_string(),
+                                model: model.clone(),
+                                pane_override,
+                                message: err.to_string(),
+                            });
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- always include the active model at the end of the connected agent pane title
- reuse the existing model display label, including the existing `(BYOK)` suffix for custom models
- publish only confirmed model state: live `/model` changes update the title after ACP accepts them, and failures preserve the previous model
- republish per-tab model state when switching tabs and hide stale model labels while disconnected

## Validation
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml` (1546 passed)
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- `cmd.exe /c "tools\razzle.cmd && bcz no_clean"`
- deployed the Debug package from this worktree and launched it successfully

<img width="1420" height="364" alt="Agent pane title showing the BYOK model" src="https://github.com/user-attachments/assets/b878aea8-81a3-47c1-b2e1-822ad3ab29ae" />
