### PR TITLE
Show hook plugin versions in `wta hooks status`

### DIFF
--- a/build/scripts/Verify-AgentHooks.ps1
+++ b/build/scripts/Verify-AgentHooks.ps1
@@ -176,12 +176,15 @@ function Get-AgentHooksStatus {
     return $report
 }
 
-# v4 (#N): render the installed hook version, and the bundle version alongside
-# it when the two disagree. Every other column answers "are hooks installed?";
+# v4: render the installed hook version, and the bundle version alongside it
+# when the two disagree. Every other column answers "are hooks installed?";
 # this one answers "are they the hooks this wta ships?" — the question a
 # marketplace registered against a stale worktree leaves wrong while all the
-# boolean columns still read healthy. Older payloads omit the fields, which
-# renders as an empty column rather than an error.
+# boolean columns still read healthy.
+#
+# Both fields are optional *within* v4: wta omits them when it cannot establish
+# a version, so absence means "unknown here", not "older payload" — anything
+# below v4 was already rejected outright by Get-AgentHooksStatus.
 function Get-AgentHookVersionLabel {
     [CmdletBinding()]
     param(

--- a/build/scripts/Verify-AgentHooks.ps1
+++ b/build/scripts/Verify-AgentHooks.ps1
@@ -75,7 +75,7 @@ Set-StrictMode -Version Latest
 # Schema version this script understands. Mirrors STATUS_SCHEMA_VERSION
 # in tools/wta/src/agent_hooks_installer.rs and SupportedStatusSchemaVersion
 # in src/cascadia/inc/AgentHooksStatus.h. Bump in lockstep.
-$script:SupportedStatusSchemaVersion = 3
+$script:SupportedStatusSchemaVersion = 4
 
 $script:CliDisplayNames = @{
     copilot = 'Copilot CLI'
@@ -176,20 +176,54 @@ function Get-AgentHooksStatus {
     return $report
 }
 
+# v4 (#N): render the installed hook version, and the bundle version alongside
+# it when the two disagree. Every other column answers "are hooks installed?";
+# this one answers "are they the hooks this wta ships?" — the question a
+# marketplace registered against a stale worktree leaves wrong while all the
+# boolean columns still read healthy. Older payloads omit the fields, which
+# renders as an empty column rather than an error.
+function Get-AgentHookVersionLabel {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][psobject]$Cli,
+        [Parameter(Mandatory)][bool]$PluginInstalled
+    )
+
+    if (-not $PluginInstalled) { return '' }
+
+    $installed = $null
+    if (Get-Member -InputObject $Cli -Name installed_version -ErrorAction SilentlyContinue) {
+        $installed = $Cli.installed_version
+    }
+    # "Installed but won't say which build" is a real state (fs-fallback
+    # detection), and it is not the same as "nothing installed".
+    if (-not $installed) { return 'v?' }
+
+    $bundle = $null
+    if (Get-Member -InputObject $Cli -Name bundle_version -ErrorAction SilentlyContinue) {
+        $bundle = $Cli.bundle_version
+    }
+    if ($bundle -and $bundle -ne $installed) {
+        return "v$installed (bundle v$bundle)"
+    }
+    return "v$installed"
+}
+
 # Render one row of the table as a hashtable (consumed by Format-Table /
 # Write-Host). Returns:
-#   @{ CLI = 'copilot'; OnPath = $true; State = 'installed'; Color = 'Green'; Detail = '...' }
+#   @{ CLI = 'copilot'; OnPath = $true; State = 'installed'; Color = 'Green'; Detail = '...'; Version = 'v0.1.5' }
 function Get-AgentHookCliRow {
     [CmdletBinding()]
     param([Parameter(Mandatory)][psobject]$Cli)
 
     if (-not $Cli.binary_on_path) {
         return @{
-            CLI    = $Cli.name
-            OnPath = $false
-            State  = 'CLI not on PATH'
-            Color  = 'DarkGray'
-            Detail = ''
+            CLI     = $Cli.name
+            OnPath  = $false
+            State   = 'CLI not on PATH'
+            Color   = 'DarkGray'
+            Detail  = ''
+            Version = ''
         }
     }
 
@@ -223,11 +257,12 @@ function Get-AgentHookCliRow {
     }
 
     $row = @{
-        CLI    = $Cli.name
-        OnPath = $true
-        State  = $state
-        Color  = $color
-        Detail = if ($state -eq 'PARTIAL') { $detail } else { '' }
+        CLI     = $Cli.name
+        OnPath  = $true
+        State   = $state
+        Color   = $color
+        Detail  = if ($state -eq 'PARTIAL') { $detail } else { '' }
+        Version = Get-AgentHookVersionLabel -Cli $Cli -PluginInstalled $plugin
     }
 
     if ((Get-Member -InputObject $Cli -Name detection_fallback -ErrorAction SilentlyContinue) -and $Cli.detection_fallback) {
@@ -261,7 +296,10 @@ function Format-AgentHooksTable {
     foreach ($cli in $Report.clis) {
         $row = Get-AgentHookCliRow -Cli $cli
         $name = if ($script:CliDisplayNames.ContainsKey($row.CLI)) { $script:CliDisplayNames[$row.CLI] } else { $row.CLI }
-        $line = '  {0,-13} {1}' -f $name, $row.State
+        $line = '  {0,-13} {1,-16}' -f $name, $row.State
+        if ($row.Version) {
+            $line += "  $($row.Version)"
+        }
         if ($row.Detail) {
             $line += "  ($($row.Detail))"
         }

--- a/doc/installing-dependencies.md
+++ b/doc/installing-dependencies.md
@@ -422,7 +422,12 @@ Check the status report to confirm each agent CLI is wired up:
 wta hooks status
 ```
 
-You should see `installed` for the agent you selected. Then, back in
+You should see `installed` for the agent you selected, followed by the
+installed hook version (for example `v0.1.5`). When a CLI's hooks were
+registered by a different build, the row also names the version this
+Intelligent Terminal ships — `v0.1.4 (bundle v0.1.5)` means the CLI is
+loading older hooks and should be reinstalled with `wta hooks install`.
+Then, back in
 **Settings → AI Agents**, turn **Session management** back on (the FRE
 turns it off when hooks installation fails so you can save and continue
 without it) and restart Intelligent Terminal once.

--- a/src/cascadia/inc/AgentHooksStatus.h
+++ b/src/cascadia/inc/AgentHooksStatus.h
@@ -27,14 +27,19 @@
 namespace Microsoft::Terminal::AgentHooks
 {
     // Major schema version this code understands. The wta-side type is
-    // pinned at 3 (see STATUS_SCHEMA_VERSION in agent_hooks_installer.rs);
+    // pinned at 4 (see STATUS_SCHEMA_VERSION in agent_hooks_installer.rs);
     // mismatch produces a parse failure rather than silent mis-render.
+    //
+    // v4 added `installed_version` / `bundle_version` per CLI — the boolean
+    // flags say whether hooks are installed, these say *which build*, which
+    // is the part a stale marketplace path or a skipped upgrade leaves
+    // wrong while every other field still reads healthy.
     //
     // v3 added `marketplace_path` and `marketplace_path_valid` per CLI
     // (#25) — `marketplace_registered: true` no longer implies the
     // registered `source.path` actually exists on disk; consumers should
     // consult `marketplacePathValid` for that.
-    inline constexpr uint32_t SupportedStatusSchemaVersion = 3;
+    inline constexpr uint32_t SupportedStatusSchemaVersion = 4;
 
     // One entry of `clis[]` from the JSON report.
     struct CliStatus
@@ -54,6 +59,14 @@ namespace Microsoft::Terminal::AgentHooks
         bool marketplacePathValid{ false };
         bool pluginInstalled{ false };
         bool pluginEnabled{ false };
+        // v4: `MAJOR.MINOR.PATCH` of the hook plugin the CLI currently has
+        // installed. Absent when nothing is installed, or when neither the
+        // CLI nor its on-disk records name a version — "unknown version" is
+        // an ordinary state, not an error.
+        std::optional<std::string> installedVersion;
+        // v4: `MAJOR.MINOR.PATCH` the wta that produced this report would
+        // install. Absent when its hook bundle is unresolvable.
+        std::optional<std::string> bundleVersion;
         std::optional<std::string> detectionFallback; // e.g. "fs"
     };
 
@@ -141,6 +154,14 @@ namespace Microsoft::Terminal::AgentHooks
             if (entry.isMember("marketplace_path") && entry["marketplace_path"].isString())
             {
                 cli.marketplacePath = entry["marketplace_path"].asString();
+            }
+            if (entry.isMember("installed_version") && entry["installed_version"].isString())
+            {
+                cli.installedVersion = entry["installed_version"].asString();
+            }
+            if (entry.isMember("bundle_version") && entry["bundle_version"].isString())
+            {
+                cli.bundleVersion = entry["bundle_version"].asString();
             }
             if (entry.isMember("detection_fallback") && entry["detection_fallback"].isString())
             {

--- a/src/cascadia/ut_app/AgentHooksStatusTests.cpp
+++ b/src/cascadia/ut_app/AgentHooksStatusTests.cpp
@@ -36,6 +36,7 @@ namespace TerminalAppUnitTests
         TEST_METHOD(ParsesEmptyClisArray);
         TEST_METHOD(ParsesDetectionFallback);
         TEST_METHOD(ParsesBundleSourceNone);
+        TEST_METHOD(ParsesVersions);
         TEST_METHOD(IgnoresUnknownExtraFields);
 
         TEST_METHOD(FormatsCliNotOnPath);
@@ -57,19 +58,22 @@ namespace TerminalAppUnitTests
     };
 
     static constexpr std::string_view kHappyPathJson = R"({
-        "schema_version": 3,
+        "schema_version": 4,
         "clis": [
             { "name": "copilot", "binary_on_path": true,  "binary_path": "C:\\copilot.cmd",
               "marketplace_registered": true, "marketplace_path": "C:\\repo\\hooks\\copilot",
               "marketplace_path_valid": true,
-              "plugin_installed": true, "plugin_enabled": true },
+              "plugin_installed": true, "plugin_enabled": true,
+              "installed_version": "0.1.5", "bundle_version": "0.1.5" },
             { "name": "claude",  "binary_on_path": true,  "binary_path": "C:\\claude.exe",
               "marketplace_registered": true, "marketplace_path": "C:\\repo\\hooks\\claude",
               "marketplace_path_valid": true,
-              "plugin_installed": true, "plugin_enabled": true },
+              "plugin_installed": true, "plugin_enabled": true,
+              "installed_version": "0.1.4", "bundle_version": "0.1.5" },
             { "name": "gemini",  "binary_on_path": false,
               "marketplace_registered": false, "marketplace_path_valid": false,
-              "plugin_installed": false, "plugin_enabled": false },
+              "plugin_installed": false, "plugin_enabled": false,
+              "bundle_version": "0.1.5" },
             { "name": "opencode", "binary_on_path": true,
                "marketplace_registered": true, "marketplace_path": "C:\\Users\\test\\.config\\opencode\\plugins",
                "marketplace_path_valid": true,
@@ -82,7 +86,7 @@ namespace TerminalAppUnitTests
     {
         const auto report = ParseStatusJson(kHappyPathJson);
         VERIFY_IS_TRUE(report.has_value());
-        VERIFY_ARE_EQUAL(3u, report->schemaVersion);
+        VERIFY_ARE_EQUAL(4u, report->schemaVersion);
         VERIFY_ARE_EQUAL(size_t{ 4 }, report->clis.size());
 
         const auto* copilot = FindCli(*report, "copilot");
@@ -170,7 +174,7 @@ namespace TerminalAppUnitTests
     void AgentHooksStatusTests::RejectsMissingClis()
     {
         constexpr std::string_view js = R"({
-            "schema_version": 3,
+            "schema_version": 4,
             "bundle_source": { "kind": "none" }
         })";
         VERIFY_IS_FALSE(ParseStatusJson(js).has_value());
@@ -179,7 +183,7 @@ namespace TerminalAppUnitTests
     void AgentHooksStatusTests::RejectsMissingBundleSource()
     {
         constexpr std::string_view js = R"({
-            "schema_version": 3,
+            "schema_version": 4,
             "clis": []
         })";
         VERIFY_IS_FALSE(ParseStatusJson(js).has_value());
@@ -188,7 +192,7 @@ namespace TerminalAppUnitTests
     void AgentHooksStatusTests::ParsesEmptyClisArray()
     {
         constexpr std::string_view js = R"({
-            "schema_version": 3,
+            "schema_version": 4,
             "clis": [],
             "bundle_source": { "kind": "none" }
         })";
@@ -203,7 +207,7 @@ namespace TerminalAppUnitTests
     void AgentHooksStatusTests::ParsesDetectionFallback()
     {
         constexpr std::string_view js = R"({
-            "schema_version": 3,
+            "schema_version": 4,
             "clis": [
                 { "name": "copilot", "binary_on_path": true,
                   "marketplace_registered": true, "marketplace_path_valid": true,
@@ -221,7 +225,7 @@ namespace TerminalAppUnitTests
     void AgentHooksStatusTests::ParsesBundleSourceNone()
     {
         constexpr std::string_view js = R"({
-            "schema_version": 3,
+            "schema_version": 4,
             "clis": [],
             "bundle_source": { "kind": "none" }
         })";
@@ -231,13 +235,52 @@ namespace TerminalAppUnitTests
         VERIFY_IS_FALSE(r->bundlePath.has_value());
     }
 
+    // v4: the version pair is the only part of the report that distinguishes
+    // "hooks are installed" from "the hooks this build ships are installed",
+    // so both halves must survive the parse — including the asymmetric case
+    // where a CLI has nothing installed but the bundle still has a version to
+    // offer.
+    void AgentHooksStatusTests::ParsesVersions()
+    {
+        const auto report = ParseStatusJson(kHappyPathJson);
+        VERIFY_IS_TRUE(report.has_value());
+
+        const auto* copilot = FindCli(*report, "copilot");
+        VERIFY_IS_NOT_NULL(copilot);
+        VERIFY_IS_TRUE(copilot->installedVersion.has_value());
+        VERIFY_ARE_EQUAL(std::string{ "0.1.5" }, *copilot->installedVersion);
+        VERIFY_IS_TRUE(copilot->bundleVersion.has_value());
+        VERIFY_ARE_EQUAL(std::string{ "0.1.5" }, *copilot->bundleVersion);
+
+        // Installed, but a build behind the bundle.
+        const auto* claude = FindCli(*report, "claude");
+        VERIFY_IS_NOT_NULL(claude);
+        VERIFY_ARE_EQUAL(std::string{ "0.1.4" }, *claude->installedVersion);
+        VERIFY_ARE_EQUAL(std::string{ "0.1.5" }, *claude->bundleVersion);
+
+        // Nothing installed: no installed version to report, but the bundle
+        // still names what an install would produce.
+        const auto* gemini = FindCli(*report, "gemini");
+        VERIFY_IS_NOT_NULL(gemini);
+        VERIFY_IS_FALSE(gemini->installedVersion.has_value());
+        VERIFY_IS_TRUE(gemini->bundleVersion.has_value());
+        VERIFY_ARE_EQUAL(std::string{ "0.1.5" }, *gemini->bundleVersion);
+
+        // wta omits both fields when it can't establish them; that must read
+        // as "unknown", not as a malformed report.
+        const auto* openCode = FindCli(*report, "opencode");
+        VERIFY_IS_NOT_NULL(openCode);
+        VERIFY_IS_FALSE(openCode->installedVersion.has_value());
+        VERIFY_IS_FALSE(openCode->bundleVersion.has_value());
+    }
+
     void AgentHooksStatusTests::IgnoresUnknownExtraFields()
     {
         // Forward compatibility: wta may add fields in a future minor
         // bump. We must not reject them as long as schema_version still
         // matches the supported major.
         constexpr std::string_view js = R"({
-            "schema_version": 3,
+            "schema_version": 4,
             "future_field": "ignore me",
             "clis": [
                 { "name": "copilot", "binary_on_path": true,
@@ -382,7 +425,7 @@ namespace TerminalAppUnitTests
     void AgentHooksStatusTests::AnyBinaryOnPathFalseWhenNone()
     {
         constexpr std::string_view js = R"({
-            "schema_version": 3,
+            "schema_version": 4,
             "clis": [
                 { "name": "copilot", "binary_on_path": false,
                   "marketplace_registered": false, "marketplace_path_valid": false,

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -145,7 +145,13 @@ const OPENCODE_MANIFEST_MANAGED_BY: &str = "Intelligent Terminal: wt-agent-hooks
 /// Schema version of the JSON returned by [`status`]. Bumped when the shape
 /// or the set of possible string-enum values changes.
 ///
-/// v3 (this version): added `marketplace_path` and `marketplace_path_valid`
+/// v4 (this version): added the per-CLI `installed_version` and
+/// `bundle_version` fields. Every other field answers "is something
+/// installed?"; neither answered "is it the build this wta ships?", which is
+/// the question a half-finished upgrade or a marketplace pointed at a stale
+/// worktree actually leaves open. Both are omitted when unknown.
+///
+/// v3: added `marketplace_path` and `marketplace_path_valid`
 /// per-CLI fields (#25). `marketplace_registered: true` no longer implies the
 /// registered `source.path` actually exists on disk; consumers should consult
 /// `marketplace_path_valid` for that.
@@ -153,7 +159,7 @@ const OPENCODE_MANIFEST_MANAGED_BY: &str = "Intelligent Terminal: wt-agent-hooks
 /// v2: `bundle_source.kind` no longer includes `"embedded"` (the embedded
 /// `include_str!` fallback was removed in #20). Possible kinds are
 /// `env` / `exe-sibling` / `dev-tree` / `none`.
-const STATUS_SCHEMA_VERSION: u32 = 3;
+const STATUS_SCHEMA_VERSION: u32 = 4;
 
 /// Schema version of the JSON returned by [`uninstall`].
 ///
@@ -191,6 +197,8 @@ fn opencode_status(on_path: bool, bin_path: Option<String>, home: Option<&Path>)
         marketplace_path_valid: false,
         plugin_installed: false,
         plugin_enabled: false,
+        installed_version: None,
+        bundle_version: None,
         detection_fallback: None,
     };
     let Some(home) = home else { return out };
@@ -310,6 +318,11 @@ impl CliScope {
 ///     valid (validity isn't local-filesystem-shaped). `false` when no entry
 ///     was found or the directory has been pruned out from under us
 ///     (the #21 staleness symptom this field exists to catch).
+///
+/// `installed_version` / `bundle_version` (schema v4) are the two halves of
+/// "is the CLI running the hooks this wta ships?". They are deliberately
+/// separate from the boolean flags: a CLI can be fully, validly installed and
+/// still be a release behind, which every other field reports as healthy.
 #[derive(Debug, Clone, Serialize)]
 pub struct CliStatus {
     pub name: &'static str,
@@ -322,6 +335,17 @@ pub struct CliStatus {
     pub marketplace_path_valid: bool,
     pub plugin_installed: bool,
     pub plugin_enabled: bool,
+    /// `MAJOR.MINOR.PATCH` of the hook plugin the CLI currently has
+    /// installed. `None` when nothing is installed, or when the CLI and its
+    /// on-disk records both decline to say — "unknown version" is a normal
+    /// state here, never an error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub installed_version: Option<String>,
+    /// `MAJOR.MINOR.PATCH` this wta's own hook bundle would install for the
+    /// CLI. `None` when the bundle is unresolvable (`bundle_source.kind ==
+    /// "none"`) or its manifest carries no parseable version.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bundle_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detection_fallback: Option<&'static str>,
 }
@@ -342,6 +366,8 @@ impl CliStatus {
             marketplace_path_valid: false,
             plugin_installed: false,
             plugin_enabled: false,
+            installed_version: None,
+            bundle_version: None,
             detection_fallback: None,
         }
     }
@@ -1273,13 +1299,85 @@ pub fn status_scoped(scope: CliScope) -> StatusReport {
 
 fn status_for(cli: CliKind, home: Option<&Path>) -> CliStatus {
     let (on_path, bin_path) = locate_binary(cli);
-    match cli {
+    let mut out = match cli {
         CliKind::Copilot => copilot_status(on_path, bin_path, home),
         CliKind::Claude => claude_status(on_path, bin_path, home),
         CliKind::Gemini => gemini_status(on_path, bin_path, home),
         CliKind::Codex => codex_status(on_path, bin_path, home),
         CliKind::OpenCode => opencode_status(on_path, bin_path, home),
+    };
+    // Read unconditionally: the bundle version is the only half of the
+    // comparison that still means something when nothing is installed
+    // ("`hooks install` would give you 0.1.5").
+    out.bundle_version = read_bundled_version(cli).map(|v| v.to_string());
+    // The per-CLI query above already answered this for the CLIs whose
+    // listing carries a version. For the rest — and for every path that fell
+    // back to fs heuristics because the CLI wouldn't answer — read it off
+    // disk instead of spawning the CLI a second time.
+    if out.plugin_installed && out.installed_version.is_none() {
+        out.installed_version = installed_version_from_disk(cli, home).map(|v| v.to_string());
     }
+    out
+}
+
+/// Read the installed hook version from the CLI's own on-disk records.
+///
+/// Spawn-free by design. `status` already pays for one CLI query per CLI
+/// (~1-3s of Node startup for Claude/Copilot/Gemini); a second query issued
+/// purely to learn a version number would roughly double the wall-clock of
+/// `wta hooks status`, which is the command people run *because* something is
+/// already slow or broken.
+///
+/// `None` whenever the version can't be established — callers render that as
+/// "unknown", never as an error.
+fn installed_version_from_disk(cli: CliKind, home: Option<&Path>) -> Option<Version> {
+    let home = home?;
+    match cli {
+        CliKind::Copilot => read_installed_copilot(home).ok().flatten()?.version,
+        CliKind::Gemini => read_installed_gemini(home).ok().flatten()?.version,
+        CliKind::OpenCode => read_installed_opencode(home).ok().flatten()?.version,
+        // Claude and Codex both unpack into `<cache>/<plugin>/<version>/`.
+        CliKind::Claude => newest_live_cached_version(&claude_plugin_cache_dir(home)),
+        CliKind::Codex => newest_live_cached_version(&codex_plugin_cache_dir(home)),
+    }
+}
+
+/// Highest version directory under a plugin cache root that is still live.
+///
+/// Superseded versions are not deleted at upgrade time — Claude leaves the old
+/// directory in place and drops an `.orphaned_at` marker inside it. Taking the
+/// plain maximum would therefore keep reporting a version the CLI stopped
+/// loading (a real machine here had 0.1.4 through 0.1.7 side by side, three of
+/// them orphaned).
+fn newest_live_cached_version(plugin_cache_dir: &Path) -> Option<Version> {
+    let entries = fs::read_dir(plugin_cache_dir).ok()?;
+    entries
+        .flatten()
+        .filter(|e| {
+            let path = e.path();
+            path.is_dir() && !path.join(".orphaned_at").exists()
+        })
+        .filter_map(|e| {
+            let name = e.file_name();
+            name.to_str()?.parse::<Version>().ok()
+        })
+        .max()
+}
+
+fn claude_plugin_cache_dir(home: &Path) -> PathBuf {
+    home.join(".claude")
+        .join("plugins")
+        .join("cache")
+        .join(MARKETPLACE_NAME)
+        .join(PLUGIN_NAME)
+}
+
+fn codex_plugin_cache_dir(home: &Path) -> PathBuf {
+    home.join(".codex")
+        .join("plugins")
+        .join("cache")
+        .join(MARKETPLACE_NAME)
+        .join(PLUGIN_NAME)
 }
 
 fn locate_binary(cli: CliKind) -> (bool, Option<String>) {
@@ -1299,6 +1397,8 @@ fn copilot_status(on_path: bool, bin_path: Option<String>, home: Option<&Path>) 
         marketplace_path_valid: false,
         plugin_installed: false,
         plugin_enabled: false,
+        installed_version: None,
+        bundle_version: None,
         detection_fallback: None,
     };
     if !on_path {
@@ -1497,6 +1597,8 @@ fn claude_status(on_path: bool, bin_path: Option<String>, home: Option<&Path>) -
         marketplace_path_valid: false,
         plugin_installed: false,
         plugin_enabled: false,
+        installed_version: None,
+        bundle_version: None,
         detection_fallback: None,
     };
     if !on_path {
@@ -1533,6 +1635,7 @@ fn claude_status(on_path: bool, bin_path: Option<String>, home: Option<&Path>) -
     if let (Some(p), Some(m)) = (plugin_json, mkt_json) {
         out.plugin_installed = p.installed;
         out.plugin_enabled = p.enabled;
+        out.installed_version = p.version.map(|v| v.to_string());
         out.marketplace_registered = m;
     } else {
         claude_fs_fallback(&mut out, home);
@@ -1556,12 +1659,7 @@ fn claude_fs_fallback(out: &mut CliStatus, home: Option<&Path>) {
     // Claude copies the plugin into ~/.claude/plugins/cache/<marketplace>/
     // <plugin>/<version>/ at install time; presence of any version dir is
     // a good fs-only "is installed" signal.
-    let plugin_cache_root = home
-        .join(".claude")
-        .join("plugins")
-        .join("cache")
-        .join(MARKETPLACE_NAME)
-        .join(PLUGIN_NAME);
+    let plugin_cache_root = claude_plugin_cache_dir(home);
     let plugin_dir_exists = plugin_cache_root
         .read_dir()
         .map(|mut iter| iter.next().is_some())
@@ -1585,6 +1683,8 @@ fn gemini_status(on_path: bool, bin_path: Option<String>, home: Option<&Path>) -
         marketplace_path_valid: false,
         plugin_installed: false,
         plugin_enabled: false,
+        installed_version: None,
+        bundle_version: None,
         detection_fallback: None,
     };
     if !on_path {
@@ -1606,6 +1706,7 @@ fn gemini_status(on_path: bool, bin_path: Option<String>, home: Option<&Path>) -
             if let Some(p) = parse_gemini_extensions_list_json(payload) {
                 out.plugin_installed = p.installed;
                 out.plugin_enabled = p.enabled;
+                out.installed_version = p.version.map(|v| v.to_string());
                 out.marketplace_registered = p.installed;
                 populate_marketplace_path(&mut out, CliKind::Gemini, home);
                 return out;
@@ -1789,6 +1890,10 @@ fn parse_copilot_plugin_list(stdout: &str) -> PluginPresence {
     PluginPresence {
         installed: entry.is_some(),
         enabled: entry.is_some_and(|line| !line.to_ascii_lowercase().contains("[disabled]")),
+        // Copilot CLI 1.0.44-2 prints no version column here; the version
+        // comes from `~/.copilot/config.json` instead, which is a plain file
+        // read and therefore cheaper than a second `copilot` invocation.
+        version: None,
     }
 }
 
@@ -1824,6 +1929,11 @@ fn parse_copilot_marketplace_list(stdout: &str) -> bool {
 struct PluginPresence {
     installed: bool,
     enabled: bool,
+    /// Version the CLI itself reported, when its listing carries one.
+    /// `None` means "this CLI's list output doesn't say" (Copilot's plain-text
+    /// listing) — the caller falls back to the CLI's on-disk records rather
+    /// than paying a second spawn just to learn a version number.
+    version: Option<Version>,
 }
 
 /// Parse `claude plugin list --json` output. Returns `None` if the JSON
@@ -1846,12 +1956,17 @@ fn parse_claude_plugin_list_json(stdout: &str) -> Option<PluginPresence> {
             return Some(PluginPresence {
                 installed: true,
                 enabled,
+                version: entry
+                    .get("version")
+                    .and_then(|x| x.as_str())
+                    .and_then(|s| s.parse::<Version>().ok()),
             });
         }
     }
     Some(PluginPresence {
         installed: false,
         enabled: false,
+        version: None,
     })
 }
 
@@ -1882,12 +1997,17 @@ fn parse_gemini_extensions_list_json(stdout: &str) -> Option<PluginPresence> {
             return Some(PluginPresence {
                 installed: true,
                 enabled,
+                version: entry
+                    .get("version")
+                    .and_then(|x| x.as_str())
+                    .and_then(|s| s.parse::<Version>().ok()),
             });
         }
     }
     Some(PluginPresence {
         installed: false,
         enabled: false,
+        version: None,
     })
 }
 
@@ -3152,6 +3272,8 @@ fn codex_status(on_path: bool, bin_path: Option<String>, home: Option<&Path>) ->
         marketplace_path_valid: false,
         plugin_installed: false,
         plugin_enabled: false,
+        installed_version: None,
+        bundle_version: None,
         detection_fallback: None,
     };
     if !on_path {
@@ -3186,16 +3308,24 @@ fn codex_status(on_path: bool, bin_path: Option<String>, home: Option<&Path>) ->
         &["plugin", "list", "--marketplace", MARKETPLACE_NAME],
     )
     .filter(|o| o.success)
-    .map(|o| parse_codex_plugin_list(&o.stdout));
+    .map(|o| {
+        // Two views of the same stdout: the boolean the install verifier has
+        // always used, and the richer row that carries the version column.
+        (
+            parse_codex_plugin_list(&o.stdout),
+            parse_codex_plugin_list_entry(&o.stdout).and_then(|i| i.version),
+        )
+    });
 
     match (mkt, plugin) {
-        (Some((registered, path)), Some(installed)) => {
+        (Some((registered, path)), Some((installed, version))) => {
             out.marketplace_registered = registered;
             if path.is_some() {
                 out.marketplace_path = path;
             }
             out.plugin_installed = installed;
             out.plugin_enabled = installed;
+            out.installed_version = version.map(|v| v.to_string());
         }
         _ => {
             codex_fs_fallback(&mut out, home);
@@ -3219,7 +3349,7 @@ fn codex_fs_fallback(out: &mut CliStatus, home: Option<&Path>) {
     // a prior remove should not count.
     out.marketplace_registered = dir_has_entries(&cache_root);
 
-    let plugin_root = cache_root.join(PLUGIN_NAME);
+    let plugin_root = codex_plugin_cache_dir(home);
     let installed = dir_has_entries(&plugin_root);
     out.plugin_installed = installed;
     out.plugin_enabled = installed; // Codex has no separate enable flag.

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -2043,8 +2043,82 @@ fn bundle_resolve_source_returns_none_when_nothing_resolves() {
 /// as a test failure.
 #[test]
 fn schema_versions_are_pinned() {
-    assert_eq!(STATUS_SCHEMA_VERSION, 3);
+    assert_eq!(STATUS_SCHEMA_VERSION, 4);
     assert_eq!(UNINSTALL_SCHEMA_VERSION, 2);
+}
+
+// ---- installed-version reporting ------------------------------------
+
+/// Claude and Codex keep every version they have ever unpacked and mark the
+/// superseded ones with `.orphaned_at`. Reporting the plain maximum would
+/// claim an upgrade the CLI never actually loaded.
+#[test]
+fn newest_live_cached_version_ignores_orphaned_directories() {
+    let root = unique_dir("cached-version");
+    for v in ["0.1.4", "0.1.5", "0.1.6"] {
+        fs::create_dir_all(root.join(v)).unwrap();
+    }
+    // 0.1.5 and 0.1.6 were superseded; only 0.1.4 is still loaded.
+    fs::write(root.join("0.1.5").join(".orphaned_at"), "x").unwrap();
+    fs::write(root.join("0.1.6").join(".orphaned_at"), "x").unwrap();
+
+    assert_eq!(
+        newest_live_cached_version(&root).map(|v| v.to_string()),
+        Some("0.1.4".to_string()),
+    );
+}
+
+/// Highest wins among live directories, and non-semver junk in the cache
+/// (lock files, stray marker files) must not abort the scan.
+#[test]
+fn newest_live_cached_version_picks_the_highest_live_directory() {
+    let root = unique_dir("cached-version-max");
+    for v in ["0.1.4", "0.2.0", "0.1.9", "not-a-version"] {
+        fs::create_dir_all(root.join(v)).unwrap();
+    }
+    fs::write(root.join("stray-file"), "x").unwrap();
+
+    assert_eq!(
+        newest_live_cached_version(&root).map(|v| v.to_string()),
+        Some("0.2.0".to_string()),
+    );
+}
+
+/// A missing cache directory is the normal "never installed" state, not an
+/// error the caller has to handle.
+#[test]
+fn newest_live_cached_version_is_none_when_nothing_is_cached() {
+    let root = unique_dir("cached-version-empty");
+    assert!(newest_live_cached_version(&root.join("absent")).is_none());
+    assert!(newest_live_cached_version(&root).is_none());
+}
+
+/// The version rides along in the listing Claude already gives us, so status
+/// never has to spawn the CLI a second time just to learn it.
+#[test]
+fn claude_plugin_list_json_parser_reports_the_installed_version() {
+    let json = r#"[{"id":"wt-agent-hooks@wt-local","version":"0.1.7","enabled":true}]"#;
+    let parsed = parse_claude_plugin_list_json(json).expect("parses");
+    assert!(parsed.installed);
+    assert_eq!(parsed.version.map(|v| v.to_string()), Some("0.1.7".into()));
+}
+
+/// A listing without a parseable version must still report the install, with
+/// the version left unknown rather than defaulting to something invented.
+#[test]
+fn claude_plugin_list_json_parser_tolerates_a_missing_version() {
+    let json = r#"[{"id":"wt-agent-hooks@wt-local","enabled":true}]"#;
+    let parsed = parse_claude_plugin_list_json(json).expect("parses");
+    assert!(parsed.installed);
+    assert!(parsed.version.is_none());
+}
+
+#[test]
+fn gemini_extensions_list_json_parser_reports_the_installed_version() {
+    let json = r#"[{"name":"wt-agent-hooks","version":"0.1.5","isActive":true}]"#;
+    let parsed = parse_gemini_extensions_list_json(json).expect("parses");
+    assert!(parsed.installed);
+    assert_eq!(parsed.version.map(|v| v.to_string()), Some("0.1.5".into()));
 }
 
 // ---- run_plugin_cli idempotency (#17) -------------------------------
@@ -2479,6 +2553,8 @@ fn populate_marketplace_path_noop_without_home() {
         marketplace_path_valid: false,
         plugin_installed: false,
         plugin_enabled: false,
+        installed_version: None,
+        bundle_version: None,
         detection_fallback: None,
     };
     populate_marketplace_path(&mut s, CliKind::Copilot, None);
@@ -2499,6 +2575,8 @@ fn cli_status_serializes_new_fields() {
         marketplace_path_valid: true,
         plugin_installed: true,
         plugin_enabled: true,
+        installed_version: None,
+        bundle_version: None,
         detection_fallback: None,
     };
     let v = serde_json::to_value(&s).unwrap();
@@ -2685,6 +2763,8 @@ fn codex_fs_fallback_detects_install_dirs() {
         marketplace_path_valid: false,
         plugin_installed: false,
         plugin_enabled: false,
+        installed_version: None,
+        bundle_version: None,
         detection_fallback: None,
     };
     codex_fs_fallback(&mut s, Some(&tmp_root));

--- a/tools/wta/src/cli/hooks.rs
+++ b/tools/wta/src/cli/hooks.rs
@@ -190,17 +190,21 @@ fn format_status_human(r: &crate::agent_hooks_installer::StatusReport) {
     }
 }
 
-/// The single version this wta's bundle ships, or `None` when the per-CLI
-/// bundles disagree.
+/// The single version this wta's bundle ships, or `None` unless every CLI
+/// reports the same one.
 ///
-/// Every CLI subtree carries its own manifest, so a mixed bundle is
-/// representable. Claiming one number for the whole bundle in that case would
-/// be a lie, and the per-CLI column already tells the true story — so we say
-/// nothing on the header line instead.
+/// Every CLI subtree carries its own manifest, so both a mixed bundle and a
+/// partially-readable one are representable. Summarizing either as a single
+/// number would be a lie — and the more dangerous case is the partial one,
+/// because a CLI whose manifest we couldn't read shows no bundle suffix on its
+/// row, which reads exactly like "matches the bundle". Staying silent on the
+/// header line keeps the per-CLI column the only claim being made.
 fn unique_bundle_version(clis: &[crate::agent_hooks_installer::CliStatus]) -> Option<String> {
-    let mut versions = clis.iter().filter_map(|c| c.bundle_version.as_deref());
-    let first = versions.next()?;
-    versions.all(|v| v == first).then(|| format!("v{}", first))
+    let mut versions = clis.iter().map(|c| c.bundle_version.as_deref());
+    let first = versions.next()??;
+    versions
+        .all(|v| v == Some(first))
+        .then(|| format!("v{}", first))
 }
 
 fn format_bundle_source(kind: &str, version: Option<String>) -> String {
@@ -379,7 +383,7 @@ mod tests {
 
     /// "Installed but the version is unreadable" and "nothing installed" are
     /// different problems; collapsing them would hide the first one, which is
-    /// what an fs-fallback detection path actually produces.
+    /// what the fs-fallback detection path actually produces.
     #[test]
     fn version_column_distinguishes_unknown_from_absent() {
         assert_eq!(format_version_column(None, Some("0.1.5"), true), "v?");
@@ -417,6 +421,28 @@ mod tests {
 
         let unknown = [cli_with_bundle("copilot", None)];
         assert_eq!(super::unique_bundle_version(&unknown), None);
+    }
+
+    /// One unreadable manifest is enough to disqualify the header claim. This
+    /// is the dangerous case: the CLI we know nothing about shows no bundle
+    /// suffix on its row, which reads just like "matches the bundle", so a
+    /// confident header version would compound the error rather than expose it.
+    #[test]
+    fn one_unknown_bundle_version_suppresses_the_header_claim() {
+        let partial = [
+            cli_with_bundle("copilot", Some("0.1.5")),
+            cli_with_bundle("claude", None),
+        ];
+        assert_eq!(super::unique_bundle_version(&partial), None);
+
+        // Order must not matter — the unknown may come first.
+        let partial_reversed = [
+            cli_with_bundle("copilot", None),
+            cli_with_bundle("claude", Some("0.1.5")),
+        ];
+        assert_eq!(super::unique_bundle_version(&partial_reversed), None);
+
+        assert_eq!(super::unique_bundle_version(&[]), None);
     }
 
     /// An unresolvable bundle must still print its `kind`, because that is the

--- a/tools/wta/src/cli/hooks.rs
+++ b/tools/wta/src/cli/hooks.rs
@@ -145,7 +145,10 @@ fn format_status_human(r: &crate::agent_hooks_installer::StatusReport) {
         "{}",
         t!(
             "hooks.bundle_source",
-            source = r.bundle_source.kind,
+            // The version rides inside the already-interpolated source value
+            // rather than in a placeholder of its own, so surfacing it costs
+            // no re-translation across the locale set.
+            source = format_bundle_source(r.bundle_source.kind, unique_bundle_version(&r.clis)),
             path_suffix = path_suffix,
         )
     );
@@ -172,10 +175,66 @@ fn format_status_human(r: &crate::agent_hooks_installer::StatusReport) {
                 .map(|m| format!(", detection={}", m))
                 .unwrap_or_default(),
         );
-        println!("  {:<10} {:<28}  ({})", c.name, summary, detail);
+        let version = format_version_column(
+            c.installed_version.as_deref(),
+            c.bundle_version.as_deref(),
+            c.plugin_installed,
+        );
+        println!(
+            "  {:<10} {:<28}  {:<24}  ({})",
+            c.name, summary, version, detail
+        );
         if let Some(p) = c.marketplace_path.as_deref() {
             println!("    path: {}", p);
         }
+    }
+}
+
+/// The single version this wta's bundle ships, or `None` when the per-CLI
+/// bundles disagree.
+///
+/// Every CLI subtree carries its own manifest, so a mixed bundle is
+/// representable. Claiming one number for the whole bundle in that case would
+/// be a lie, and the per-CLI column already tells the true story — so we say
+/// nothing on the header line instead.
+fn unique_bundle_version(clis: &[crate::agent_hooks_installer::CliStatus]) -> Option<String> {
+    let mut versions = clis.iter().filter_map(|c| c.bundle_version.as_deref());
+    let first = versions.next()?;
+    versions.all(|v| v == first).then(|| format!("v{}", first))
+}
+
+fn format_bundle_source(kind: &str, version: Option<String>) -> String {
+    match version {
+        Some(v) => format!("{kind} {v}"),
+        None => kind.to_string(),
+    }
+}
+
+/// Render the per-CLI version column.
+///
+/// The question this column exists to answer is "is the CLI running the hooks
+/// this wta ships?", so the bundle version only appears when it disagrees with
+/// what's installed; printing both on every row would bury the one row that
+/// needs attention. It is labelled rather than arrowed because the mismatch
+/// runs both ways in practice — a CLI registered against another worktree is
+/// routinely *newer* than the bundle, and an arrow would read as a pending
+/// upgrade. The header line carries the bundle version for the matching case.
+fn format_version_column(
+    installed: Option<&str>,
+    bundle: Option<&str>,
+    plugin_installed: bool,
+) -> String {
+    if !plugin_installed {
+        return "-".to_string();
+    }
+    // "Installed but won't say which build" is a different problem from "not
+    // installed", and the fs-fallback detection paths can genuinely land here.
+    let Some(installed) = installed else {
+        return "v?".to_string();
+    };
+    match bundle {
+        Some(b) if b != installed => format!("v{installed} (bundle v{b})"),
+        _ => format!("v{installed}"),
     }
 }
 
@@ -220,8 +279,8 @@ fn yn(b: bool) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::format_install_failure;
-    use crate::agent_hooks_installer::InstallFailure;
+    use super::{format_bundle_source, format_install_failure, format_version_column};
+    use crate::agent_hooks_installer::{CliStatus, InstallFailure};
 
     fn failure(cli: &'static str, reason: &str) -> InstallFailure {
         InstallFailure {
@@ -283,5 +342,91 @@ mod tests {
             "hooks installation failed for: copilot",
             "the summary line must not repeat the CLI: {message}"
         );
+    }
+
+    fn cli_with_bundle(name: &'static str, bundle: Option<&str>) -> CliStatus {
+        CliStatus {
+            name,
+            binary_on_path: true,
+            binary_path: None,
+            marketplace_registered: true,
+            marketplace_path: None,
+            marketplace_path_valid: true,
+            plugin_installed: true,
+            plugin_enabled: true,
+            installed_version: None,
+            bundle_version: bundle.map(str::to_string),
+            detection_fallback: None,
+        }
+    }
+
+    /// The whole point of the column: a CLI running a different build than the
+    /// bundle must not read as plain "installed". The mismatch is labelled,
+    /// not arrowed, because installed is routinely the *newer* side when the
+    /// marketplace points at another worktree.
+    #[test]
+    fn version_column_shows_the_bundle_version_only_when_it_differs() {
+        assert_eq!(
+            format_version_column(Some("0.1.6"), Some("0.1.5"), true),
+            "v0.1.6 (bundle v0.1.5)"
+        );
+        assert_eq!(
+            format_version_column(Some("0.1.5"), Some("0.1.5"), true),
+            "v0.1.5",
+            "matching versions must not carry redundant bundle noise"
+        );
+    }
+
+    /// "Installed but the version is unreadable" and "nothing installed" are
+    /// different problems; collapsing them would hide the first one, which is
+    /// what an fs-fallback detection path actually produces.
+    #[test]
+    fn version_column_distinguishes_unknown_from_absent() {
+        assert_eq!(format_version_column(None, Some("0.1.5"), true), "v?");
+        assert_eq!(format_version_column(None, Some("0.1.5"), false), "-");
+    }
+
+    /// A CLI whose bundle manifest is unreadable still installed a real
+    /// version; the missing half must not erase the known half.
+    #[test]
+    fn version_column_survives_an_unknown_bundle_version() {
+        assert_eq!(format_version_column(Some("0.1.5"), None, true), "v0.1.5");
+    }
+
+    /// The header line may only claim one bundle version when there is one.
+    #[test]
+    fn bundle_version_is_summarized_only_when_every_cli_agrees() {
+        let agreeing = [
+            cli_with_bundle("copilot", Some("0.1.5")),
+            cli_with_bundle("claude", Some("0.1.5")),
+        ];
+        assert_eq!(
+            super::unique_bundle_version(&agreeing).as_deref(),
+            Some("v0.1.5")
+        );
+
+        let mixed = [
+            cli_with_bundle("copilot", Some("0.1.5")),
+            cli_with_bundle("claude", Some("0.1.4")),
+        ];
+        assert_eq!(
+            super::unique_bundle_version(&mixed),
+            None,
+            "a mixed bundle must not be summarized as a single version"
+        );
+
+        let unknown = [cli_with_bundle("copilot", None)];
+        assert_eq!(super::unique_bundle_version(&unknown), None);
+    }
+
+    /// An unresolvable bundle must still print its `kind`, because that is the
+    /// field that explains *why* there's no version to show.
+    #[test]
+    fn bundle_source_label_degrades_to_the_bare_kind() {
+        assert_eq!(
+            format_bundle_source("exe-sibling", Some("v0.1.5".to_string())),
+            "exe-sibling v0.1.5"
+        );
+        assert_eq!(format_bundle_source("none", None), "none");
     }
 }


### PR DESCRIPTION
## Summary

`wta hooks status` reported *whether* hooks were installed but never *which build*. A CLI whose marketplace points at a different worktree — or one left behind by a failed upgrade — reads as fully healthy (`✓ installed`, `path_valid=yes`) while loading stale hooks. There was no way to tell short of digging through `wta-install-hooks.log`.

This adds the installed hook version to the status output, plus the bundle version when the two disagree.

### Before

```text
bundle source: dev-tree (C:\...\tools\wta\wt-agent-hooks)

  copilot    ✓ installed                   (marketplace=yes, path_valid=yes, plugin=yes, enabled=yes)
  claude     ✓ installed                   (marketplace=yes, path_valid=yes, plugin=yes, enabled=yes)
  codex      ✓ installed                   (marketplace=yes, path_valid=yes, plugin=yes, enabled=yes)
```

### After

```text
bundle source: dev-tree v0.1.5 (C:\...\tools\wta\wt-agent-hooks)

  copilot    ✓ installed                   v0.1.6 (bundle v0.1.5)    (marketplace=yes, path_valid=yes, plugin=yes, enabled=yes)
  claude     ✓ installed                   v0.1.7 (bundle v0.1.5)    (marketplace=yes, path_valid=yes, plugin=yes, enabled=yes)
  codex      ✓ installed                   v0.1.5                    (marketplace=yes, path_valid=yes, plugin=yes, enabled=yes)
  opencode   ✗ not installed               -                         (marketplace=no, path_valid=no, plugin=no, enabled=no)
```

On a real machine this immediately exposed three CLIs loading hooks registered against *other* worktrees, all newer than the bundle under test — the exact drift the boolean columns cannot represent.

## Design notes

**No extra CLI spawns.** `status` already pays ~1-3s of Node startup per CLI; issuing a second query purely to learn a version number would roughly double the wall-clock of the command people run *because* something is already slow. Claude and Codex already return a version in the listing `status` parses, so it is read from that same stdout. Copilot, Gemini and OpenCode come from their own on-disk records, which are plain file reads.

**Orphaned version directories.** Claude and Codex unpack into `<cache>/<plugin>/<version>/` and leave superseded versions behind tagged with `.orphaned_at` (one machine here had `0.1.4` through `0.1.7` side by side, three of them orphaned). The fs path therefore picks the newest *live* directory rather than the plain maximum, which would report a version the CLI stopped loading.

**Labelled, not arrowed.** The bundle version only repeats on a row when it disagrees with what is installed — printing both on every row buries the one row that needs attention. It reads `v0.1.6 (bundle v0.1.5)` rather than `v0.1.6 → v0.1.5` because the mismatch runs both ways in practice: a CLI registered against another worktree is routinely *newer* than the bundle, and an arrow would read as a pending upgrade.

**`v?` vs `-`.** "Installed but won't say which build" (what an fs-fallback detection path produces) is a different problem from "nothing installed"; collapsing them would hide the first.

**No new locale keys.** The bundle version rides inside the already-interpolated `source` value of `hooks.bundle_source`, the same trick `hooks.install_succeeded` uses, so this costs no re-translation across the 88-locale set.

## Contract change

Status JSON schema **v3 → v4**, adding two optional per-CLI fields:

```jsonc
{
  "name": "copilot",
  "plugin_installed": true,
  "installed_version": "0.1.6",   // omitted when unknown
  "bundle_version": "0.1.5"       // omitted when the bundle is unresolvable
}
```

Both consumers that pin the version are bumped in lockstep:

- `src/cascadia/inc/AgentHooksStatus.h` — `SupportedStatusSchemaVersion`, plus the two fields parsed into `CliStatus`. Settings UI strings are unchanged.
- `build/scripts/Verify-AgentHooks.ps1` — `$script:SupportedStatusSchemaVersion`, and the version now renders in its table too.

## Validation

- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml` — **1577 passed, 0 failed** (13 new tests covering the version column, bundle-version summarization, orphan-aware cache scanning, and the Claude/Gemini listing parsers).
- Live `wta hooks status` and `wta hooks status --json` verified against a machine with genuine version drift.
- `AgentHooksStatus.h` compiled and asserted standalone (v4 accepted, v3 rejected, absent fields read as unknown) — this worktree's `obj` cache has pre-existing stale-PCH errors in `TerminalControlLib` unrelated to this change.
- `Verify-AgentHooks.ps1` run end-to-end under PowerShell 7 with live status JSON.
- Both C++ files are clang-format clean.
