### PR TITLE
Fix the OpenCode hook row and name the CLIs that fail to install

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -435,8 +435,8 @@
                         </StackPanel>
                     </Border>
                     <!--  Per-CLI rows surface installed or partial hook state.
-                          OpenCode also appears when its CLI is detected so new
-                          users can see that hook integration is supported.  -->
+                          A row disappears once its hooks are removed, so the
+                          Remove button is never shown with nothing to remove.  -->
                     <Border Visibility="{x:Bind ViewModel.ShowCopilotHookRow, Mode=OneWay}"
                             BorderThickness="0,1,0,0"
                             BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
@@ -568,7 +568,7 @@
                             <Button Grid.Column="1"
                                     x:Uid="AIAgents_HooksRemoveButton"
                                     Click="{x:Bind ViewModel.RemoveOpenCodeHooks}"
-                                    IsEnabled="{x:Bind ViewModel.CanRemoveOpenCodeHooks, Mode=OneWay}"
+                                    IsEnabled="{x:Bind ViewModel.CanRemoveAgentHooks, Mode=OneWay}"
                                     MinWidth="120" />
                        </Grid>
                     </Border>

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
@@ -1391,9 +1391,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const std::wstring hooksRemovedSummary{ RS_(L"AIAgents_HooksRemovedSummary") };
         const std::wstring hooksInstalledSummary{ RS_(L"AIAgents_HooksInstalledSummary") };
         const auto hooksLogDir = ::IntelligentTerminal::LogDirVersioned();
+        const auto hooksInstallLogPath = (hooksLogDir / L"wta-install-hooks.log").wstring();
         const std::wstring hooksRemovalFailedSummary{ RS_fmt(L"AIAgents_HooksRemovalFailedSummary", hooksLogDir.wstring()) };
         const std::wstring hooksInstallationFailedSummary{
-            RS_fmt(L"AIAgents_HooksInstallationFailedSummary", (hooksLogDir / L"wta-install-hooks.log").wstring())
+            RS_fmt(L"AIAgents_HooksInstallationFailedSummary", hooksInstallLogPath)
         };
         std::wstring summary;
         bool ok = false;
@@ -1405,16 +1406,37 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         {
             summary = locateWtaFailedSummary;
         }
-        else
+        else if (isUninstall)
         {
             ok = ::Microsoft::Terminal::WtaProcess::RunWtaAndWait(wtaPath, wtaArgs, 60'000);
+            summary = ok ? hooksRemovedSummary : hooksRemovalFailedSummary;
+        }
+        else
+        {
+            // Ask for the structured report so a failure can name the CLIs
+            // that failed. wta prints it and *then* exits non-zero, so we
+            // capture output independently of the exit code.
+            const auto run = ::Microsoft::Terminal::WtaProcess::RunWtaCapture(wtaPath, wtaArgs + L" --json", 60'000);
+            ok = run.completed && run.exitCode == 0;
             if (ok)
             {
-                summary = isUninstall ? hooksRemovedSummary : hooksInstalledSummary;
+                summary = hooksInstalledSummary;
             }
             else
             {
-                summary = isUninstall ? hooksRemovalFailedSummary : hooksInstallationFailedSummary;
+                // Fall back to the unattributed message whenever the report
+                // is unreadable or blames no particular CLI — a timeout, a
+                // crash before the report was written, or a failure that
+                // isn't per-CLI all land here.
+                summary = hooksInstallationFailedSummary;
+                if (const auto report = ::Microsoft::Terminal::AgentHooks::ParseInstallReportJson(run.output))
+                {
+                    const auto failed = ::Microsoft::Terminal::AgentHooks::FormatFailedCliList(*report);
+                    if (!failed.empty())
+                    {
+                        summary = RS_fmt(L"AIAgents_HooksInstallationFailedForSummary", failed, hooksInstallLogPath);
+                    }
+                }
             }
         }
 

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
@@ -1237,7 +1237,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             _showGeminiHookRow = false;
             _showCodexHookRow = false;
             _showOpenCodeHookRow = false;
-            _openCodeHooksPresent = false;
             _copilotHooksSubtitle = {};
             _claudeHooksSubtitle = {};
             _geminiHooksSubtitle = {};
@@ -1262,8 +1261,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             _showClaudeHookRow = AgentHooks::HasHookState(claude);
             _showGeminiHookRow = AgentHooks::HasHookState(gemini);
             _showCodexHookRow = AgentHooks::HasHookState(codex);
-            _openCodeHooksPresent = AgentHooks::HasHookState(openCode);
-            _showOpenCodeHookRow = AgentHooks::ShouldShowDetectedOrConfiguredHookRow(openCode);
+            _showOpenCodeHookRow = AgentHooks::HasHookState(openCode);
 
             _copilotHooksSubtitle = _ComputeHooksSubtitle(copilot);
             _claudeHooksSubtitle = _ComputeHooksSubtitle(claude);
@@ -1280,7 +1278,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                        L"IsAnyAgentCliDetected",
                        L"CanInstallAgentHooks",
                        L"CanRemoveAgentHooks",
-                       L"CanRemoveOpenCodeHooks",
                        L"ShowCopilotHookRow",
                        L"ShowClaudeHookRow",
                        L"ShowGeminiHookRow",

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
@@ -1257,11 +1257,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             _codexCliDetected = codex && codex->binaryOnPath;
             _openCodeCliDetected = openCode && openCode->binaryOnPath;
 
-            _showCopilotHookRow = AgentHooks::HasHookState(copilot);
-            _showClaudeHookRow = AgentHooks::HasHookState(claude);
-            _showGeminiHookRow = AgentHooks::HasHookState(gemini);
-            _showCodexHookRow = AgentHooks::HasHookState(codex);
-            _showOpenCodeHookRow = AgentHooks::HasHookState(openCode);
+            _showCopilotHookRow = AgentHooks::ShouldShowHookRow(copilot);
+            _showClaudeHookRow = AgentHooks::ShouldShowHookRow(claude);
+            _showGeminiHookRow = AgentHooks::ShouldShowHookRow(gemini);
+            _showCodexHookRow = AgentHooks::ShouldShowHookRow(codex);
+            _showOpenCodeHookRow = AgentHooks::ShouldShowHookRow(openCode);
 
             _copilotHooksSubtitle = _ComputeHooksSubtitle(copilot);
             _claudeHooksSubtitle = _ComputeHooksSubtitle(claude);
@@ -1415,8 +1415,14 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         {
             // Ask for the structured report so a failure can name the CLIs
             // that failed. wta prints it and *then* exits non-zero, so we
-            // capture output independently of the exit code.
-            const auto run = ::Microsoft::Terminal::WtaProcess::RunWtaCapture(wtaPath, wtaArgs + L" --json", 60'000);
+            // capture output independently of the exit code — and keep
+            // stderr out of it, since the failing run also writes an
+            // `Error: ...` line there that would break the JSON parse.
+            const auto run = ::Microsoft::Terminal::WtaProcess::RunWtaCapture(wtaPath,
+                                                                             wtaArgs + L" --json",
+                                                                             60'000,
+                                                                             nullptr,
+                                                                             /* mergeStderr */ false);
             ok = run.completed && run.exitCode == 0;
             if (ok)
             {

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.h
@@ -179,9 +179,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         {
             return _copilotCliDetected || _claudeCliDetected || _geminiCliDetected || _codexCliDetected || _openCodeCliDetected;
         }
-        // Per-CLI "row visible" flags. Existing integrations appear when they
-        // have hook state. OpenCode also appears when its CLI is detected so
-        // users can discover and install the newly supported integration.
+        // Per-CLI "row visible" flags. A CLI's row appears only while it has
+        // hook state (fully or partially installed), so removing hooks makes
+        // the row disappear — uniformly, for every CLI.
         bool ShowCopilotHookRow() const noexcept { return _showCopilotHookRow; }
         bool ShowClaudeHookRow() const noexcept { return _showClaudeHookRow; }
         bool ShowGeminiHookRow() const noexcept { return _showGeminiHookRow; }
@@ -206,10 +206,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         bool CanRemoveAgentHooks() const noexcept
         {
             return !IsAgentSessionHooksPolicyLocked();
-        }
-        bool CanRemoveOpenCodeHooks() const noexcept
-        {
-            return _openCodeHooksPresent && !IsAgentSessionHooksPolicyLocked();
         }
         bool IsInstallingAgentHooks() const noexcept { return _installingAgentHooks; }
         winrt::hstring AgentHooksInstallSummary() const { return _agentHooksInstallSummary; }
@@ -290,13 +286,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         bool _geminiCliDetected{ false };
         bool _codexCliDetected{ false };
         bool _openCodeCliDetected{ false };
-        // Row visibility. OpenCode additionally appears when its CLI is detected.
+        // Row visibility — a CLI's row shows only while it has hook state.
         bool _showCopilotHookRow{ false };
         bool _showClaudeHookRow{ false };
         bool _showGeminiHookRow{ false };
         bool _showCodexHookRow{ false };
         bool _showOpenCodeHookRow{ false };
-        bool _openCodeHooksPresent{ false };
         // Subtitle text per CLI; empty for fully-installed CLIs.
         winrt::hstring _copilotHooksSubtitle;
         winrt::hstring _claudeHooksSubtitle;

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.idl
@@ -157,7 +157,6 @@ namespace Microsoft.Terminal.Settings.Editor
         Boolean ShowOpenCodeHooksSubtitle { get; };
         Boolean CanInstallAgentHooks { get; };
         Boolean CanRemoveAgentHooks { get; };
-        Boolean CanRemoveOpenCodeHooks { get; };
         Boolean IsInstallingAgentHooks { get; };
         String AgentHooksInstallSummary { get; };
         // True iff AgentHooksInstallSummary is non-empty — gates the

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -2914,6 +2914,10 @@
     <value>Hooks-Installation fehlgeschlagen. Überprüfen Sie {0} auf Details.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>Hooks-Installation für {0} fehlgeschlagen. Überprüfen Sie {1} auf Details.</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Automatische Fehlererkennung</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -3035,6 +3035,10 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Hooks installation failed. Check {0} for details.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>Hooks installation failed for {0}. Check {1} for details.</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_CustomModels.Header" xml:space="preserve">
     <value>BYOK (bring your own key) providers</value>
     <comment>Section header for user-configured model providers. {Locked="BYOK"}</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -2914,6 +2914,10 @@
     <value>Error de instalación de Hooks. Consulte {0} para obtener detalles.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>Error de instalación de Hooks para {0}. Consulte {1} para obtener detalles.</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Detección automática de errores</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -2915,6 +2915,10 @@
     <value>Échec de l’installation Hooks. Consultez {0} pour plus de détails.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>Échec de l’installation Hooks pour {0}. Consultez {1} pour plus de détails.</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Détection automatique des erreurs</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -2914,6 +2914,10 @@
     <value>Installazione di Hooks non riuscita. Controllare {0} per i dettagli.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>Installazione di Hooks per {0} non riuscita. Controllare {1} per i dettagli.</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Rilevamento automatico degli errori</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -2914,6 +2914,10 @@
     <value>Hooks のインストールに失敗しました。詳細については {0} を確認してください。</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>{0} の Hooks のインストールに失敗しました。詳細については {1} を確認してください。</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>エラーの自動検出</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -2974,6 +2974,10 @@
     <value>Hooks 설치에 실패했습니다. 자세한 내용은 {0}를 확인하세요.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>{0}의 Hooks 설치에 실패했습니다. 자세한 내용은 {1}를 확인하세요.</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>자동 오류 검색</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -2957,6 +2957,10 @@
     <value>Falha na instalação de Hooks. Confira {0} para obter detalhes.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>Falha na instalação de Hooks para {0}. Confira {1} para obter detalhes.</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Detecção automática de erros</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -2905,6 +2905,10 @@
     <value>Hooks installation failed. Check {0} for details.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>Hooks installation failed for {0}. Check {1} for details.</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Automatic error detection</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -2905,6 +2905,10 @@
     <value>Hooks installation failed. Check {0} for details.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>Hooks installation failed for {0}. Check {1} for details.</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Automatic error detection</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -2905,6 +2905,10 @@
     <value>Hooks installation failed. Check {0} for details.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>Hooks installation failed for {0}. Check {1} for details.</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Automatic error detection</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -2957,6 +2957,10 @@
     <value>Не удалось установить Hooks. Подробности см. в {0}.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>Не удалось установить Hooks для {0}. Подробности см. в {1}.</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Автоматическое обнаружение ошибок</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -2972,6 +2972,10 @@
     <value>Инсталација Hooks није успела. Детаље потражите у {0}.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>Инсталација Hooks за {0} није успела. Детаље потражите у {1}.</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Аутоматско откривање грешака</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -2618,6 +2618,10 @@
     <value>Не вдалося встановити Hooks. Докладні відомості див. у {0}.</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>Не вдалося встановити Hooks для {0}. Докладні відомості див. у {1}.</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>Автоматичне виявлення помилок</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -2974,6 +2974,10 @@
     <value>Hooks 安装失败。请查看 {0} 获取详细信息。</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>{0} 的 Hooks 安装失败。请查看 {1} 获取详细信息。</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>自动错误检测</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -2914,6 +2914,10 @@
     <value>Hooks 安裝失敗。請查看 {0} 以取得詳細資料。</value>
     <comment>Failure summary shown when installing agent session tracking hooks fails. {Locked="Hooks","{0}"} {0} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
   </data>
+  <data name="AIAgents_HooksInstallationFailedForSummary" xml:space="preserve">
+    <value>{0} 的 Hooks 安裝失敗。請查看 {1} 以取得詳細資料。</value>
+    <comment>Failure summary shown when installing agent session tracking hooks fails for specific CLIs. {Locked="Hooks","{0}","{1}"} {0} is replaced with a comma-separated list of CLI names (brand names, never translated); {1} is replaced with the package-aware, versioned wta-install-hooks.log path at runtime.</comment>
+  </data>
   <data name="AIAgents_AutoErrorDetectionTitle.Text" xml:space="preserve">
     <value>自動錯誤偵測</value>
   </data>

--- a/src/cascadia/inc/AgentHooksStatus.h
+++ b/src/cascadia/inc/AgentHooksStatus.h
@@ -214,6 +214,20 @@ namespace Microsoft::Terminal::AgentHooks
         return cli && (cli->marketplaceRegistered || cli->pluginInstalled);
     }
 
+    // The row-visibility decision itself, named so the five call sites in
+    // AIAgentsViewModel share one predicate instead of each re-deriving it.
+    //
+    // Deliberately NOT `cli->binaryOnPath || HasHookState(cli)`. OpenCode
+    // used to be special-cased that way so new users could discover the
+    // integration, which left its row on screen after an uninstall with a
+    // permanently disabled Remove button — the only per-row action there is.
+    // Keep this as the single seam so that regression stays covered by
+    // ShouldShowHookRow's tests.
+    inline bool ShouldShowHookRow(const CliStatus* cli)
+    {
+        return HasHookState(cli);
+    }
+
     // True when at least one CLI binary is on PATH — drives the
     // "Install hooks" button enabled state.
     inline bool AnyBinaryOnPath(const StatusReport& report)

--- a/src/cascadia/inc/AgentHooksStatus.h
+++ b/src/cascadia/inc/AgentHooksStatus.h
@@ -203,14 +203,14 @@ namespace Microsoft::Terminal::AgentHooks
         return nullptr;
     }
 
+    // Drives per-CLI row visibility in Settings. A row exists only while the
+    // CLI has hook state to act on, so "Remove" is never offered against a
+    // CLI that has nothing installed. Merely having the CLI on PATH is not
+    // enough — installation is driven by the single "Install hooks" button,
+    // not per-row, so a detected-but-uninstalled row would carry no action.
     inline bool HasHookState(const CliStatus* cli)
     {
         return cli && (cli->marketplaceRegistered || cli->pluginInstalled);
-    }
-
-    inline bool ShouldShowDetectedOrConfiguredHookRow(const CliStatus* cli)
-    {
-        return cli && (cli->binaryOnPath || HasHookState(cli));
     }
 
     // True when at least one CLI binary is on PATH — drives the

--- a/src/cascadia/inc/AgentHooksStatus.h
+++ b/src/cascadia/inc/AgentHooksStatus.h
@@ -3,9 +3,10 @@
 //
 // AgentHooksStatus.h
 //
-// Pure parser + formatter for the JSON contract emitted by
-// `wta hooks status --json` (see tools/wta/src/agent_hooks_installer.rs ::
-// StatusReport). Lives in src/cascadia/inc/ so the Settings UI
+// Pure parser + formatter for the JSON contracts emitted by
+// `wta hooks status --json` and `wta hooks install --json` (see
+// tools/wta/src/agent_hooks_installer.rs :: StatusReport / InstallReport).
+// Lives in src/cascadia/inc/ so the Settings UI
 // (TerminalSettingsEditor::AIAgentsViewModel) and the unit tests in
 // ut_app can both consume it without a project-reference cycle.
 //
@@ -308,5 +309,139 @@ namespace Microsoft::Terminal::AgentHooks
             text += L" (filesystem fallback)";
         }
         return text;
+    }
+
+    // -----------------------------------------------------------------------
+    // `wta hooks install --json`
+    // -----------------------------------------------------------------------
+
+    // Major schema version of the install report this code understands.
+    // Pinned against INSTALL_SCHEMA_VERSION in agent_hooks_installer.rs.
+    inline constexpr uint32_t SupportedInstallSchemaVersion = 1;
+
+    inline constexpr std::string_view InstallOutcomeFailed = "failed";
+
+    // One entry of `clis[]` from the install report.
+    struct CliInstallResult
+    {
+        std::string name;
+        // "installed" | "skipped" | "failed". Compared as a string rather
+        // than mapped to an enum so a value added on the wta side lands as
+        // "not a failure" instead of failing the whole parse.
+        std::string outcome;
+        // Only present for failures, and only when wta has a specific
+        // reason beyond "nothing got registered".
+        std::optional<std::string> reason;
+    };
+
+    struct InstallReport
+    {
+        uint32_t schemaVersion{ 0 };
+        std::vector<CliInstallResult> clis;
+    };
+
+    // Returns nullopt on malformed JSON, a missing `clis` array, or an
+    // unsupported schema_version. Note that `wta hooks install --json`
+    // prints this report and *then* exits non-zero on failure, so callers
+    // must capture output independently of the exit code.
+    inline std::optional<InstallReport> ParseInstallReportJson(std::string_view json)
+    {
+        if (json.empty())
+        {
+            return std::nullopt;
+        }
+
+        Json::Value root;
+        {
+            Json::CharReaderBuilder rb;
+            const std::unique_ptr<Json::CharReader> reader{ rb.newCharReader() };
+            std::string errs;
+            if (!reader->parse(json.data(), json.data() + json.size(), &root, &errs))
+            {
+                return std::nullopt;
+            }
+        }
+        if (!root.isObject())
+        {
+            return std::nullopt;
+        }
+
+        InstallReport out;
+        if (!root.isMember("schema_version") || !root["schema_version"].isUInt())
+        {
+            return std::nullopt;
+        }
+        out.schemaVersion = root["schema_version"].asUInt();
+        if (out.schemaVersion != SupportedInstallSchemaVersion)
+        {
+            return std::nullopt;
+        }
+
+        if (!root.isMember("clis") || !root["clis"].isArray())
+        {
+            return std::nullopt;
+        }
+        for (const auto& entry : root["clis"])
+        {
+            if (!entry.isObject())
+            {
+                return std::nullopt;
+            }
+            CliInstallResult cli;
+            if (!entry.isMember("name") || !entry["name"].isString())
+            {
+                return std::nullopt;
+            }
+            cli.name = entry["name"].asString();
+            if (entry.isMember("outcome") && entry["outcome"].isString())
+            {
+                cli.outcome = entry["outcome"].asString();
+            }
+            if (entry.isMember("reason") && entry["reason"].isString())
+            {
+                cli.reason = entry["reason"].asString();
+            }
+            out.clis.push_back(std::move(cli));
+        }
+
+        return out;
+    }
+
+    // Display name for a CLI id. Mirrors the per-row titles in
+    // AIAgents.xaml so the failure summary names each CLI exactly the way
+    // the list above it does. All five are brand names, so none of them
+    // are translated. An unrecognized id falls through to its raw name
+    // rather than being dropped — a CLI wta knows about but this build
+    // doesn't should still be reportable.
+    inline std::wstring CliDisplayName(std::string_view name)
+    {
+        if (name == "copilot") return L"GitHub Copilot";
+        if (name == "claude") return L"Claude Code";
+        if (name == "gemini") return L"Gemini CLI";
+        if (name == "codex") return L"Codex CLI";
+        if (name == "opencode") return L"OpenCode";
+        return std::wstring{ name.begin(), name.end() };
+    }
+
+    // Comma-joined display names of every CLI that failed to install.
+    // Empty when nothing failed, which the caller treats as "the run failed
+    // for a reason the report doesn't attribute to any one CLI" and falls
+    // back to the generic message.
+    inline std::wstring FormatFailedCliList(const InstallReport& report)
+    {
+        std::wstring out;
+        for (const auto& cli : report.clis)
+        {
+            if (cli.outcome != InstallOutcomeFailed)
+            {
+                continue;
+            }
+            if (!out.empty())
+            {
+                out += L", ";
+            }
+            out += CliDisplayName(cli.name);
+        }
+        return out;
     }
 }

--- a/src/cascadia/inc/WtaProcess.h
+++ b/src/cascadia/inc/WtaProcess.h
@@ -81,8 +81,8 @@ namespace Microsoft::Terminal::WtaProcess
         std::string output;
     };
 
-    // Spawn `wta.exe <argsAfterExe>` and capture its combined stdout+stderr
-    // regardless of exit code. Synchronous — call from a background thread.
+    // Spawn `wta.exe <argsAfterExe>` and capture its output regardless of
+    // exit code. Synchronous — call from a background thread.
     // Optionally accepts a custom environment block (double-null-terminated
     // wide string); pass nullptr to inherit the current environment.
     //
@@ -90,10 +90,21 @@ namespace Microsoft::Terminal::WtaProcess
     // produced by a *failing* run: `wta hooks install --json` prints its
     // per-CLI report and then exits non-zero, so the exit-0-only helper
     // would throw away the very breakdown the caller needs.
+    //
+    // `mergeStderr` controls whether the child's stderr joins stdout in the
+    // captured text. Pass false when parsing machine-readable stdout: a wta
+    // subcommand that fails prints its report to stdout and then lets
+    // `main()` return Err, which makes the Rust runtime write `Error: ...`
+    // to stderr. Merged, that trails (or, depending on flush order, leads)
+    // the JSON and defeats the parse. Non-merged stderr goes to NUL rather
+    // than a second pipe — it would otherwise need its own drain to avoid
+    // deadlocking a chatty child, and every wta subcommand already mirrors
+    // its diagnostics into the wta logs.
     inline CaptureResult RunWtaCapture(const std::wstring& wtaPath,
                                        const std::wstring& argsAfterExe,
                                        DWORD timeoutMs,
-                                       wchar_t* envBlock = nullptr)
+                                       wchar_t* envBlock = nullptr,
+                                       bool mergeStderr = true)
     {
         CaptureResult result;
         if (wtaPath.empty())
@@ -121,8 +132,28 @@ namespace Microsoft::Terminal::WtaProcess
         si.dwFlags = STARTF_USESHOWWINDOW | STARTF_USESTDHANDLES;
         si.wShowWindow = SW_HIDE;
         si.hStdOutput = writeHandle.get();
-        si.hStdError = writeHandle.get();
         si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+
+        wil::unique_handle nullHandle;
+        if (mergeStderr)
+        {
+            si.hStdError = writeHandle.get();
+        }
+        else
+        {
+            nullHandle.reset(CreateFileW(L"NUL",
+                                         GENERIC_WRITE,
+                                         FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                         &sa,
+                                         OPEN_EXISTING,
+                                         0,
+                                         nullptr));
+            if (!nullHandle)
+            {
+                return result;
+            }
+            si.hStdError = nullHandle.get();
+        }
 
         std::wstring cmdline = L"\"" + wtaPath + L"\" " + argsAfterExe;
         std::wstring mutableCmd = cmdline;

--- a/src/cascadia/inc/WtaProcess.h
+++ b/src/cascadia/inc/WtaProcess.h
@@ -71,18 +71,34 @@ namespace Microsoft::Terminal::WtaProcess
         return {};
     }
 
-    // Spawn `wta.exe <argsAfterExe>` and return its stdout on exit-0;
-    // empty string otherwise. Synchronous — call from a background thread.
+    // Result of a captured wta run. `completed` is false when the process
+    // could not be launched or had to be killed on timeout — in that case
+    // `output` and `exitCode` carry nothing meaningful.
+    struct CaptureResult
+    {
+        bool completed{ false };
+        DWORD exitCode{ 1 };
+        std::string output;
+    };
+
+    // Spawn `wta.exe <argsAfterExe>` and capture its combined stdout+stderr
+    // regardless of exit code. Synchronous — call from a background thread.
     // Optionally accepts a custom environment block (double-null-terminated
     // wide string); pass nullptr to inherit the current environment.
-    inline std::string RunWtaCaptureStdout(const std::wstring& wtaPath,
-                                           const std::wstring& argsAfterExe,
-                                           DWORD timeoutMs,
-                                           wchar_t* envBlock = nullptr)
+    //
+    // Prefer this over RunWtaCaptureStdout when the interesting payload is
+    // produced by a *failing* run: `wta hooks install --json` prints its
+    // per-CLI report and then exits non-zero, so the exit-0-only helper
+    // would throw away the very breakdown the caller needs.
+    inline CaptureResult RunWtaCapture(const std::wstring& wtaPath,
+                                       const std::wstring& argsAfterExe,
+                                       DWORD timeoutMs,
+                                       wchar_t* envBlock = nullptr)
     {
+        CaptureResult result;
         if (wtaPath.empty())
         {
-            return {};
+            return result;
         }
 
         SECURITY_ATTRIBUTES sa{};
@@ -93,11 +109,11 @@ namespace Microsoft::Terminal::WtaProcess
         wil::unique_handle writeHandle;
         if (!CreatePipe(readHandle.addressof(), writeHandle.addressof(), &sa, 0))
         {
-            return {};
+            return result;
         }
         if (!SetHandleInformation(readHandle.get(), HANDLE_FLAG_INHERIT, 0))
         {
-            return {};
+            return result;
         }
 
         STARTUPINFOW si{};
@@ -131,7 +147,7 @@ namespace Microsoft::Terminal::WtaProcess
             &pi);
         if (!launched)
         {
-            return {};
+            return result;
         }
         wil::unique_handle proc{ pi.hProcess };
         wil::unique_handle thread{ pi.hThread };
@@ -172,16 +188,30 @@ namespace Microsoft::Terminal::WtaProcess
             {
                 TerminateProcess(proc.get(), 1);
                 WaitForSingleObject(proc.get(), 1000);
-                return {};
+                return result;
             }
         }
-        DWORD exitCode = 1;
-        GetExitCodeProcess(proc.get(), &exitCode);
-        if (exitCode != 0)
+        GetExitCodeProcess(proc.get(), &result.exitCode);
+        result.completed = true;
+        result.output = std::move(captured);
+        return result;
+    }
+
+    // Spawn `wta.exe <argsAfterExe>` and return its stdout on exit-0;
+    // empty string otherwise. Synchronous — call from a background thread.
+    // Optionally accepts a custom environment block (double-null-terminated
+    // wide string); pass nullptr to inherit the current environment.
+    inline std::string RunWtaCaptureStdout(const std::wstring& wtaPath,
+                                           const std::wstring& argsAfterExe,
+                                           DWORD timeoutMs,
+                                           wchar_t* envBlock = nullptr)
+    {
+        auto result = RunWtaCapture(wtaPath, argsAfterExe, timeoutMs, envBlock);
+        if (!result.completed || result.exitCode != 0)
         {
             return {};
         }
-        return captured;
+        return std::move(result.output);
     }
 
     // Build an environment block that extends PATH with WinGet Links and npm

--- a/src/cascadia/inc/WtaProcess.h
+++ b/src/cascadia/inc/WtaProcess.h
@@ -134,7 +134,10 @@ namespace Microsoft::Terminal::WtaProcess
         si.hStdOutput = writeHandle.get();
         si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
 
-        wil::unique_handle nullHandle;
+        // unique_hfile, not unique_handle: CreateFileW signals failure with
+        // INVALID_HANDLE_VALUE, which unique_handle (whose invalid value is
+        // nullptr) would happily treat as a live handle.
+        wil::unique_hfile nullHandle;
         if (mergeStderr)
         {
             si.hStdError = writeHandle.get();

--- a/src/cascadia/ut_app/AgentHooksStatusTests.cpp
+++ b/src/cascadia/ut_app/AgentHooksStatusTests.cpp
@@ -54,6 +54,7 @@ namespace TerminalAppUnitTests
         TEST_METHOD(FindCliReturnsNullptrForMissing);
         TEST_METHOD(HidesDetectedCliWithoutHooks);
         TEST_METHOD(ShowsHookStateWithoutCli);
+        TEST_METHOD(ShowsPartiallyInstalledCli);
         TEST_METHOD(HidesAbsentCliWithoutHooks);
 
         TEST_METHOD(ParsesInstallReport);
@@ -130,7 +131,9 @@ namespace TerminalAppUnitTests
     // A CLI that's merely installed on the machine gets no row: the row only
     // exists to carry the per-CLI Remove action, and there's nothing to
     // remove. Regression guard for the OpenCode row that used to linger with
-    // a permanently-disabled Remove button after its hooks were uninstalled.
+    // a permanently-disabled Remove button after its hooks were uninstalled —
+    // asserted against ShouldShowHookRow, the predicate the ViewModel calls,
+    // so reintroducing the `binaryOnPath ||` term fails here.
     void AgentHooksStatusTests::HidesDetectedCliWithoutHooks()
     {
         CliStatus openCode{};
@@ -138,6 +141,7 @@ namespace TerminalAppUnitTests
         openCode.binaryOnPath = true;
 
         VERIFY_IS_FALSE(HasHookState(&openCode));
+        VERIFY_IS_FALSE(ShouldShowHookRow(&openCode));
     }
 
     void AgentHooksStatusTests::ShowsHookStateWithoutCli()
@@ -147,6 +151,20 @@ namespace TerminalAppUnitTests
         openCode.pluginInstalled = true;
 
         VERIFY_IS_TRUE(HasHookState(&openCode));
+        VERIFY_IS_TRUE(ShouldShowHookRow(&openCode));
+    }
+
+    // A marketplace registered without the plugin (or vice-versa) is the
+    // partially-installed state the subtitle describes. The row must stay
+    // visible for it — that's the state the user most needs to act on.
+    void AgentHooksStatusTests::ShowsPartiallyInstalledCli()
+    {
+        CliStatus codex{};
+        codex.name = "codex";
+        codex.binaryOnPath = true;
+        codex.marketplaceRegistered = true;
+
+        VERIFY_IS_TRUE(ShouldShowHookRow(&codex));
     }
 
     void AgentHooksStatusTests::HidesAbsentCliWithoutHooks()
@@ -156,6 +174,8 @@ namespace TerminalAppUnitTests
 
         VERIFY_IS_FALSE(HasHookState(&openCode));
         VERIFY_IS_FALSE(HasHookState(nullptr));
+        VERIFY_IS_FALSE(ShouldShowHookRow(&openCode));
+        VERIFY_IS_FALSE(ShouldShowHookRow(nullptr));
     }
 
     void AgentHooksStatusTests::RejectsUnsupportedSchemaVersion()
@@ -550,11 +570,11 @@ namespace TerminalAppUnitTests
     {
         constexpr std::string_view js = R"({
             "schema_version": 1,
-            "clis": [ { "name": "newcli", "outcome": "failed" } ]
+            "clis": [ { "name": "unknown-cli", "outcome": "failed" } ]
         })";
         const auto r = ParseInstallReportJson(js);
         VERIFY_IS_TRUE(r.has_value());
-        VERIFY_ARE_EQUAL(std::wstring{ L"newcli" }, FormatFailedCliList(*r));
+        VERIFY_ARE_EQUAL(std::wstring{ L"unknown-cli" }, FormatFailedCliList(*r));
     }
 
     void AgentHooksStatusTests::RejectsUnsupportedInstallSchemaVersion()

--- a/src/cascadia/ut_app/AgentHooksStatusTests.cpp
+++ b/src/cascadia/ut_app/AgentHooksStatusTests.cpp
@@ -52,7 +52,7 @@ namespace TerminalAppUnitTests
         TEST_METHOD(AnyBinaryOnPathTrueWhenAny);
         TEST_METHOD(AnyBinaryOnPathFalseWhenNone);
         TEST_METHOD(FindCliReturnsNullptrForMissing);
-        TEST_METHOD(ShowsDetectedCliWithoutHooks);
+        TEST_METHOD(HidesDetectedCliWithoutHooks);
         TEST_METHOD(ShowsHookStateWithoutCli);
         TEST_METHOD(HidesAbsentCliWithoutHooks);
     };
@@ -119,14 +119,17 @@ namespace TerminalAppUnitTests
         VERIFY_IS_TRUE(report->bundlePath.has_value());
     }
 
-    void AgentHooksStatusTests::ShowsDetectedCliWithoutHooks()
+    // A CLI that's merely installed on the machine gets no row: the row only
+    // exists to carry the per-CLI Remove action, and there's nothing to
+    // remove. Regression guard for the OpenCode row that used to linger with
+    // a permanently-disabled Remove button after its hooks were uninstalled.
+    void AgentHooksStatusTests::HidesDetectedCliWithoutHooks()
     {
         CliStatus openCode{};
         openCode.name = "opencode";
         openCode.binaryOnPath = true;
 
         VERIFY_IS_FALSE(HasHookState(&openCode));
-        VERIFY_IS_TRUE(ShouldShowDetectedOrConfiguredHookRow(&openCode));
     }
 
     void AgentHooksStatusTests::ShowsHookStateWithoutCli()
@@ -136,7 +139,6 @@ namespace TerminalAppUnitTests
         openCode.pluginInstalled = true;
 
         VERIFY_IS_TRUE(HasHookState(&openCode));
-        VERIFY_IS_TRUE(ShouldShowDetectedOrConfiguredHookRow(&openCode));
     }
 
     void AgentHooksStatusTests::HidesAbsentCliWithoutHooks()
@@ -145,8 +147,7 @@ namespace TerminalAppUnitTests
         openCode.name = "opencode";
 
         VERIFY_IS_FALSE(HasHookState(&openCode));
-        VERIFY_IS_FALSE(ShouldShowDetectedOrConfiguredHookRow(&openCode));
-        VERIFY_IS_FALSE(ShouldShowDetectedOrConfiguredHookRow(nullptr));
+        VERIFY_IS_FALSE(HasHookState(nullptr));
     }
 
     void AgentHooksStatusTests::RejectsUnsupportedSchemaVersion()

--- a/src/cascadia/ut_app/AgentHooksStatusTests.cpp
+++ b/src/cascadia/ut_app/AgentHooksStatusTests.cpp
@@ -55,6 +55,14 @@ namespace TerminalAppUnitTests
         TEST_METHOD(HidesDetectedCliWithoutHooks);
         TEST_METHOD(ShowsHookStateWithoutCli);
         TEST_METHOD(HidesAbsentCliWithoutHooks);
+
+        TEST_METHOD(ParsesInstallReport);
+        TEST_METHOD(NamesEveryFailedInstallCli);
+        TEST_METHOD(FormatsNoFailuresAsEmpty);
+        TEST_METHOD(TreatsUnknownInstallOutcomeAsNonFailure);
+        TEST_METHOD(FallsBackToRawNameForUnknownCli);
+        TEST_METHOD(RejectsUnsupportedInstallSchemaVersion);
+        TEST_METHOD(RejectsMalformedInstallReport);
     };
 
     static constexpr std::string_view kHappyPathJson = R"({
@@ -447,5 +455,125 @@ namespace TerminalAppUnitTests
         const auto r = ParseStatusJson(kHappyPathJson);
         VERIFY_IS_TRUE(r.has_value());
         VERIFY_IS_NULL(FindCli(*r, "nonexistent"));
+    }
+
+    // ---- wta hooks install --json --------------------------------------
+
+    // Shape of a real failing run: Codex's marketplace still points at a
+    // moved bundle, so its `marketplace add` fails while every other CLI
+    // installs. This is the case the Settings UI used to report as a bare
+    // "Hooks installation failed" with no way to tell which CLI broke.
+    static constexpr std::string_view kInstallReportJson = R"({
+        "schema_version": 1,
+        "clis": [
+            { "name": "copilot", "outcome": "installed" },
+            { "name": "claude", "outcome": "installed" },
+            { "name": "gemini", "outcome": "skipped" },
+            { "name": "codex", "outcome": "failed",
+              "reason": "codex plugin marketplace add failed: already added from a different source" },
+            { "name": "opencode", "outcome": "skipped" }
+        ]
+    })";
+
+    void AgentHooksStatusTests::ParsesInstallReport()
+    {
+        const auto r = ParseInstallReportJson(kInstallReportJson);
+        VERIFY_IS_TRUE(r.has_value());
+        VERIFY_ARE_EQUAL(1u, r->schemaVersion);
+        VERIFY_ARE_EQUAL(size_t{ 5 }, r->clis.size());
+
+        VERIFY_ARE_EQUAL(std::string{ "codex" }, r->clis[3].name);
+        VERIFY_ARE_EQUAL(std::string{ "failed" }, r->clis[3].outcome);
+        VERIFY_IS_TRUE(r->clis[3].reason.has_value());
+
+        // A non-failure carries no reason, and absence must not be an error.
+        VERIFY_IS_FALSE(r->clis[0].reason.has_value());
+
+        VERIFY_ARE_EQUAL(std::wstring{ L"Codex CLI" }, FormatFailedCliList(*r));
+    }
+
+    void AgentHooksStatusTests::NamesEveryFailedInstallCli()
+    {
+        constexpr std::string_view js = R"({
+            "schema_version": 1,
+            "clis": [
+                { "name": "copilot", "outcome": "failed" },
+                { "name": "claude", "outcome": "installed" },
+                { "name": "opencode", "outcome": "failed" }
+            ]
+        })";
+        const auto r = ParseInstallReportJson(js);
+        VERIFY_IS_TRUE(r.has_value());
+        // Display names must match the row titles in AIAgents.xaml so the
+        // summary names each CLI the same way the list above it does.
+        VERIFY_ARE_EQUAL(std::wstring{ L"GitHub Copilot, OpenCode" }, FormatFailedCliList(*r));
+    }
+
+    // An all-clear report must produce no list — the caller uses "empty" to
+    // decide it has nothing to attribute and falls back to the generic
+    // message rather than rendering "failed for ." at the user.
+    void AgentHooksStatusTests::FormatsNoFailuresAsEmpty()
+    {
+        constexpr std::string_view js = R"({
+            "schema_version": 1,
+            "clis": [
+                { "name": "copilot", "outcome": "installed" },
+                { "name": "gemini", "outcome": "skipped" }
+            ]
+        })";
+        const auto r = ParseInstallReportJson(js);
+        VERIFY_IS_TRUE(r.has_value());
+        VERIFY_IS_TRUE(FormatFailedCliList(*r).empty());
+    }
+
+    // Forward compatibility: an outcome this build doesn't know must not be
+    // reported as a failure, or a future wta that adds a state would make
+    // every successful install look broken.
+    void AgentHooksStatusTests::TreatsUnknownInstallOutcomeAsNonFailure()
+    {
+        constexpr std::string_view js = R"({
+            "schema_version": 1,
+            "clis": [
+                { "name": "copilot", "outcome": "deferred" },
+                { "name": "claude" }
+            ]
+        })";
+        const auto r = ParseInstallReportJson(js);
+        VERIFY_IS_TRUE(r.has_value());
+        VERIFY_IS_TRUE(FormatFailedCliList(*r).empty());
+    }
+
+    // A CLI wta supports but this build has no display name for is still
+    // worth naming — dropping it would report a failure attributed to
+    // nothing at all.
+    void AgentHooksStatusTests::FallsBackToRawNameForUnknownCli()
+    {
+        constexpr std::string_view js = R"({
+            "schema_version": 1,
+            "clis": [ { "name": "newcli", "outcome": "failed" } ]
+        })";
+        const auto r = ParseInstallReportJson(js);
+        VERIFY_IS_TRUE(r.has_value());
+        VERIFY_ARE_EQUAL(std::wstring{ L"newcli" }, FormatFailedCliList(*r));
+    }
+
+    void AgentHooksStatusTests::RejectsUnsupportedInstallSchemaVersion()
+    {
+        constexpr std::string_view js = R"({
+            "schema_version": 99,
+            "clis": []
+        })";
+        VERIFY_IS_FALSE(ParseInstallReportJson(js).has_value());
+    }
+
+    void AgentHooksStatusTests::RejectsMalformedInstallReport()
+    {
+        VERIFY_IS_FALSE(ParseInstallReportJson("").has_value());
+        VERIFY_IS_FALSE(ParseInstallReportJson("not json").has_value());
+        // Missing `clis` entirely.
+        VERIFY_IS_FALSE(ParseInstallReportJson(R"({ "schema_version": 1 })").has_value());
+        // An entry without a name can't be attributed to a CLI.
+        VERIFY_IS_FALSE(
+            ParseInstallReportJson(R"({ "schema_version": 1, "clis": [ { "outcome": "failed" } ] })").has_value());
     }
 }

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -172,6 +172,14 @@ const STATUS_SCHEMA_VERSION: u32 = 4;
 /// upgrading from older wta builds don't end up with orphan files.
 const UNINSTALL_SCHEMA_VERSION: u32 = 2;
 
+/// Schema version of the JSON returned by `wta hooks install --json`.
+///
+/// v1: initial shape — `clis[]` of `{ name, outcome, reason? }` where
+/// `outcome` is `installed` / `skipped` / `failed`. Exists so the Settings
+/// UI can name the CLI that failed instead of showing a single generic
+/// "installation failed" line whose only remedy is reading the trace log.
+const INSTALL_SCHEMA_VERSION: u32 = 1;
+
 // ---------------------------------------------------------------------------
 // Public CLI enum (consumed by `wta hooks --cli=<name>`)
 // ---------------------------------------------------------------------------
@@ -434,6 +442,43 @@ pub struct UninstallReport {
 impl UninstallReport {
     pub fn succeeded(&self) -> bool {
         self.clis.iter().all(CliUninstallResult::succeeded)
+    }
+}
+
+/// Per-CLI outcome of an install run, as reported by
+/// `wta hooks install --json`.
+///
+/// `outcome` is a stable string rather than a serialized enum so the C++
+/// consumer can treat an unrecognized value as "not a failure" instead of
+/// failing the whole parse when this list grows.
+#[derive(Debug, Clone, Serialize)]
+pub struct CliInstallResult {
+    pub name: &'static str,
+    /// `"installed"` | `"skipped"` | `"failed"`.
+    pub outcome: &'static str,
+    /// Present only for `failed`, and only when we have a specific reason
+    /// beyond "hooks aren't registered afterwards".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+pub const INSTALL_OUTCOME_INSTALLED: &str = "installed";
+pub const INSTALL_OUTCOME_SKIPPED: &str = "skipped";
+pub const INSTALL_OUTCOME_FAILED: &str = "failed";
+
+/// Top-level shape of `wta hooks install --json`.
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallReport {
+    pub schema_version: u32,
+    pub clis: Vec<CliInstallResult>,
+}
+
+impl InstallReport {
+    pub fn new(clis: Vec<CliInstallResult>) -> Self {
+        Self {
+            schema_version: INSTALL_SCHEMA_VERSION,
+            clis,
+        }
     }
 }
 

--- a/tools/wta/src/cli/args.rs
+++ b/tools/wta/src/cli/args.rs
@@ -513,7 +513,8 @@ impl SessionsOriginArg {
 #[derive(Subcommand, Debug)]
 pub(crate) enum HooksAction {
     /// (Re-)install the wt-agent-hooks bridge. Installs for all supported
-    /// CLIs by default, or a single CLI with `--cli`.
+    /// CLIs by default, or a single CLI with `--cli`. With `--json` returns
+    /// a structured per-CLI outcome report.
     Install {
         /// Which CLI to install for. Default: `all`.
         #[arg(long, value_enum, default_value_t = HooksCliFilter::All)]

--- a/tools/wta/src/cli/hooks.rs
+++ b/tools/wta/src/cli/hooks.rs
@@ -673,7 +673,8 @@ mod tests {
     }
 
     /// The C++ parser rejects an unexpected `schema_version` outright, so the
-    /// version this code emits is part of the contract, not an detail.
+    /// version this code emits is part of the contract, not an implementation
+    /// detail.
     #[test]
     fn install_report_pins_its_schema_version() {
         let report =

--- a/tools/wta/src/cli/hooks.rs
+++ b/tools/wta/src/cli/hooks.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use super::args::HooksCliFilter;
 
-pub(crate) fn run_install(cli: HooksCliFilter) -> Result<()> {
+pub(crate) fn run_install(cli: HooksCliFilter, json_mode: bool) -> Result<()> {
     // Logging is initialized in `main()`; the install attempt is observable in
     // %LOCALAPPDATA%\IntelligentTerminal\logs\wta-install-hooks.log.
     let scope = cli.into_scope();
@@ -37,7 +37,22 @@ pub(crate) fn run_install(cli: HooksCliFilter) -> Result<()> {
         .map(|c| c.name)
         .collect();
 
+    if json_mode {
+        // Emitted for both outcomes: the Settings UI needs the per-CLI
+        // breakdown precisely when the run failed, and the exit code below
+        // still carries pass/fail for scripts.
+        let install_report = build_install_report(scope, &report, &spawn_failures, &missing);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&install_report)
+                .unwrap_or_else(|_| serde_json::to_string(&install_report).unwrap_or_default())
+        );
+    }
+
     if spawn_failures.is_empty() && missing.is_empty() {
+        if json_mode {
+            return Ok(());
+        }
         // The version rides inside the interpolated CLI list rather than in its
         // own placeholder, so adding it costs no re-translation across the
         // locale set — "name (vX.Y.Z)" reads the same in every language.
@@ -67,6 +82,61 @@ pub(crate) fn run_install(cli: HooksCliFilter) -> Result<()> {
     let message = format_install_failure(&spawn_failures, &missing);
     tracing::error!(target: "agent_hooks", "{}", message);
     anyhow::bail!(message)
+}
+
+/// Fold the two independent failure signals and the post-install status
+/// check into one per-CLI verdict.
+///
+/// Failure wins over the status check: a CLI whose install command failed
+/// while a PREVIOUS plugin is still on disk reads as `plugin_installed` in
+/// the status report, and reporting that as `installed` is exactly the
+/// silent-stale-build case [`run_install`] exists to catch.
+fn build_install_report(
+    scope: crate::agent_hooks_installer::CliScope,
+    status: &crate::agent_hooks_installer::StatusReport,
+    spawn_failures: &[crate::agent_hooks_installer::InstallFailure],
+    missing: &[&str],
+) -> crate::agent_hooks_installer::InstallReport {
+    use crate::agent_hooks_installer::{
+        CliInstallResult, CliScope, InstallReport, INSTALL_OUTCOME_FAILED,
+        INSTALL_OUTCOME_INSTALLED, INSTALL_OUTCOME_SKIPPED,
+    };
+
+    let clis = status
+        .clis
+        .iter()
+        .filter(|c| match scope {
+            CliScope::All => true,
+            CliScope::One(kind) => c.name == kind.name(),
+        })
+        .map(|c| {
+            if let Some(f) = spawn_failures.iter().find(|f| f.cli == c.name) {
+                return CliInstallResult {
+                    name: c.name,
+                    outcome: INSTALL_OUTCOME_FAILED,
+                    reason: Some(f.reason.clone()),
+                };
+            }
+            if missing.contains(&c.name) {
+                return CliInstallResult {
+                    name: c.name,
+                    outcome: INSTALL_OUTCOME_FAILED,
+                    reason: None,
+                };
+            }
+            CliInstallResult {
+                name: c.name,
+                outcome: if c.binary_on_path && c.plugin_installed {
+                    INSTALL_OUTCOME_INSTALLED
+                } else {
+                    INSTALL_OUTCOME_SKIPPED
+                },
+                reason: None,
+            }
+        })
+        .collect();
+
+    InstallReport::new(clis)
 }
 
 /// Render the user-facing failure text for an install that did not fully land.
@@ -283,8 +353,12 @@ fn yn(b: bool) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_bundle_source, format_install_failure, format_version_column};
-    use crate::agent_hooks_installer::{CliStatus, InstallFailure};
+    use super::{
+        build_install_report, format_bundle_source, format_install_failure, format_version_column,
+    };
+    use crate::agent_hooks_installer::{
+        BundleSourceInfo, CliScope, CliStatus, InstallFailure, StatusReport,
+    };
 
     fn failure(cli: &'static str, reason: &str) -> InstallFailure {
         InstallFailure {
@@ -454,5 +528,156 @@ mod tests {
             "exe-sibling v0.1.5"
         );
         assert_eq!(format_bundle_source("none", None), "none");
+    }
+
+    // ---- install report (`wta hooks install --json`) --------------------
+
+    fn status_of(clis: Vec<CliStatus>) -> StatusReport {
+        StatusReport {
+            schema_version: 4,
+            clis,
+            bundle_source: BundleSourceInfo {
+                kind: "exe-sibling",
+                path: None,
+            },
+        }
+    }
+
+    fn absent_cli(name: &'static str) -> CliStatus {
+        CliStatus {
+            name,
+            binary_on_path: false,
+            binary_path: None,
+            marketplace_registered: false,
+            marketplace_path: None,
+            marketplace_path_valid: false,
+            plugin_installed: false,
+            plugin_enabled: false,
+            installed_version: None,
+            bundle_version: None,
+            detection_fallback: None,
+        }
+    }
+
+    fn no_failures() -> [InstallFailure; 0] {
+        []
+    }
+
+    fn outcome_of<'a>(
+        report: &'a crate::agent_hooks_installer::InstallReport,
+        name: &str,
+    ) -> &'a str {
+        report
+            .clis
+            .iter()
+            .find(|c| c.name == name)
+            .unwrap_or_else(|| panic!("{name} missing from report"))
+            .outcome
+    }
+
+    /// The reason the JSON exists: the Settings UI needs to name the CLI that
+    /// failed. A spawn failure must be reported per-CLI, with its reason, and
+    /// must not contaminate the CLIs that installed fine.
+    #[test]
+    fn install_report_names_the_failing_cli_and_carries_its_reason() {
+        let status = status_of(vec![
+            cli_with_bundle("copilot", Some("0.1.6")),
+            cli_with_bundle("codex", Some("0.1.6")),
+        ]);
+        let failures = [failure(
+            "codex",
+            "codex plugin marketplace add failed: already added from a different source",
+        )];
+
+        let report = build_install_report(CliScope::All, &status, &failures, &[]);
+
+        assert_eq!(outcome_of(&report, "copilot"), "installed");
+        assert_eq!(outcome_of(&report, "codex"), "failed");
+        let codex = report.clis.iter().find(|c| c.name == "codex").unwrap();
+        assert!(
+            codex
+                .reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("already added from a different source"),
+            "the actionable reason must survive into the report: {:?}",
+            codex.reason
+        );
+    }
+
+    /// Mirrors `spawn_failure_is_reported_even_when_a_stale_plugin_is_still_installed`:
+    /// the status check sees the PREVIOUS plugin on disk, so only the spawn
+    /// failure distinguishes "installed" from "still running the old build".
+    #[test]
+    fn install_report_prefers_the_spawn_failure_over_a_stale_on_disk_plugin() {
+        let status = status_of(vec![cli_with_bundle("copilot", Some("0.1.5"))]);
+        let failures = [failure(
+            "copilot",
+            "install failed: Access is denied. (os error 5)",
+        )];
+
+        let report = build_install_report(CliScope::All, &status, &failures, &[]);
+
+        assert_eq!(
+            outcome_of(&report, "copilot"),
+            "failed",
+            "a stale plugin left on disk must not read as a successful install"
+        );
+    }
+
+    /// A CLI that simply isn't on the machine is not a failure — reporting it
+    /// as one would name every uninstalled CLI in the Settings error line.
+    #[test]
+    fn install_report_marks_an_absent_cli_as_skipped() {
+        let status = status_of(vec![
+            cli_with_bundle("copilot", Some("0.1.6")),
+            absent_cli("gemini"),
+        ]);
+
+        let report = build_install_report(CliScope::All, &status, &no_failures(), &[]);
+
+        assert_eq!(outcome_of(&report, "gemini"), "skipped");
+        assert_eq!(outcome_of(&report, "copilot"), "installed");
+    }
+
+    /// The silent no-op: the install command reported success but left nothing
+    /// registered. It has no spawn reason, so `reason` stays absent while the
+    /// outcome is still `failed`.
+    #[test]
+    fn install_report_reports_a_silent_no_op_as_failed_without_a_reason() {
+        let status = status_of(vec![absent_cli("claude")]);
+
+        let report = build_install_report(CliScope::All, &status, &no_failures(), &["claude"]);
+
+        let claude = report.clis.iter().find(|c| c.name == "claude").unwrap();
+        assert_eq!(claude.outcome, "failed");
+        assert!(claude.reason.is_none());
+    }
+
+    /// `--cli <x>` must narrow the report too, or the UI would name CLIs the
+    /// user never asked to install.
+    #[test]
+    fn install_report_honors_a_single_cli_scope() {
+        use crate::agent_hooks_installer::CliKind;
+
+        let status = status_of(vec![
+            cli_with_bundle("copilot", Some("0.1.6")),
+            cli_with_bundle("codex", Some("0.1.6")),
+        ]);
+
+        let report =
+            build_install_report(CliScope::One(CliKind::Codex), &status, &no_failures(), &[]);
+
+        assert_eq!(report.clis.len(), 1);
+        assert_eq!(report.clis[0].name, "codex");
+    }
+
+    /// The C++ parser rejects an unexpected `schema_version` outright, so the
+    /// version this code emits is part of the contract, not an detail.
+    #[test]
+    fn install_report_pins_its_schema_version() {
+        let report =
+            build_install_report(CliScope::All, &status_of(vec![]), &no_failures(), &[]);
+        assert_eq!(report.schema_version, 1);
     }
 }

--- a/tools/wta/src/cli/mod.rs
+++ b/tools/wta/src/cli/mod.rs
@@ -60,7 +60,7 @@ pub(crate) async fn run(command: Command, json_mode: bool) -> Result<()> {
             }
         },
         Command::Hooks { action } => match action {
-            HooksAction::Install { cli } => hooks::run_install(cli),
+            HooksAction::Install { cli } => hooks::run_install(cli, json_mode),
             HooksAction::Status => hooks::run_status(json_mode),
             HooksAction::Uninstall { cli } => hooks::run_uninstall(cli, json_mode),
         },


### PR DESCRIPTION
Two fixes to the **Settings → AI agents → Agent session tracking** section.

---

## 1. Hide the OpenCode hook row once its hooks are removed

### Problem

Removing OpenCode's hooks left its row behind with a permanently greyed-out Remove button. The other four agents (Copilot / Claude / Gemini / Codex) disappear from the list once their hooks are removed.

`wta hooks status` correctly reports the hooks as gone at that point:

```
opencode   ✗ not installed   (marketplace=no, path_valid=no, plugin=no, enabled=no)
```

The result is a dead row the user can neither act on nor dismiss.

### Root cause

`AgentHooksStatus.h` gave OpenCode a different row-visibility rule than every other CLI:

| CLI | Row visibility |
| --- | --- |
| Copilot / Claude / Gemini / Codex | `HasHookState` |
| OpenCode | `ShouldShowDetectedOrConfiguredHookRow` = `binaryOnPath \|\| HasHookState` |

With the `opencode` binary on PATH but its hooks uninstalled, `binaryOnPath` kept the row visible, while `CanRemoveOpenCodeHooks` (which requires `_openCodeHooksPresent`) evaluated to false — so the Remove button stayed disabled forever.

That special case existed so new users could discover that OpenCode supports hook integration. But installation is driven by the single **Install hooks** button at the top, which already covers every detected CLI. Remove is the only per-row action, so a detected-but-uninstalled row carries nothing the user can do.

### Change

All five rows are now driven by `HasHookState`, so a row disappears once its hooks are removed. Drops the now-dead `ShouldShowDetectedOrConfiguredHookRow()` helper, the `_openCodeHooksPresent` field, and the `CanRemoveOpenCodeHooks` IDL projection — OpenCode's Remove button binds to `CanRemoveAgentHooks` like every other row.

---

## 2. Name the CLIs that failed to install hooks

### Problem

Clicking **Install hooks** and having, say, Codex fail produced a single line:

> Hooks installation failed. Check `<log>` for details.

Every other CLI could have installed fine and the user had no way to tell which one broke — or that the rest succeeded — short of opening `wta-install-hooks.log`.

This is easy to hit in practice. A moved bundle path (worktree switch, redeployment, rebuilt AppX layout) makes Codex refuse to repoint its `wt-local` marketplace:

```
Error: marketplace 'wt-local' is already added from a different source;
       remove it before adding this source
```

That aborts the run, and the UI says only "installation failed".

### Root cause

wta already computes the answer. `run_install` folds two independent failure signals — the spawn errors the install commands reported, and the post-install status check that catches a command which claimed success but registered nothing — into a message naming each failing CLI with its reason. That message only ever reached stderr and the trace log, because the Settings UI shells out through `RunWtaAndWait` and sees a bare `bool`.

### Change

Give `wta hooks install` the `--json` treatment `status` and `uninstall` already have, and consume it.

**wta side** — `InstallReport` / `CliInstallResult` (schema v1) report per-CLI `installed` / `skipped` / `failed` plus the failure reason:

```jsonc
{
  "schema_version": 1,
  "clis": [
    { "name": "copilot", "outcome": "installed" },
    { "name": "codex", "outcome": "failed",
      "reason": "codex plugin marketplace add failed: ..." }
  ]
}
```

- Failure wins over the status check, so a spawn error with a **previous** plugin still on disk stays `failed` instead of reading as `installed`.
- A CLI that simply isn't on the machine is `skipped`, not `failed` — otherwise every uninstalled CLI would be named in the error line.
- `outcome` is a plain string, so an outcome added later lands as "not a failure" rather than failing the whole parse.
- The human output and the non-zero exit code are unchanged.

**Terminal side** — the install path now captures output independently of the exit code. wta prints the report and *then* exits non-zero, so the existing exit-0-only helper would have discarded exactly the payload we need. `RunWtaCapture` returns the combined output plus the exit code; `RunWtaCaptureStdout` becomes a thin wrapper preserving its old contract.

The summary falls back to the unattributed message whenever the report is unreadable or blames no particular CLI — a timeout, a crash before the report was written, or a failure that isn't per-CLI.

Adds `AIAgents_HooksInstallationFailedForSummary` across all 16 locales. The CLI names are brand names rendered with the same display names as the rows above the summary, and stay untranslated.

---

## Testing

- `cargo test` for wta — **1587 passing**, including 6 new cases covering the report construction (failing CLI carries its reason, stale-plugin spawn failure still reported, absent CLI is `skipped`, silent no-op is `failed` with no reason, `--cli` narrows the report, schema version pinned)
- `AgentHooksStatusTests` — **33 passing**, including 7 new cases for the install-report parser and failed-CLI formatting, plus `HidesDetectedCliWithoutHooks` as the regression guard for part 1
- Debug x64 builds of `Microsoft.Terminal.Settings.Editor.vcxproj` and `TerminalApp.UnitTests.vcxproj`
- All 16 `.resw` files verified for UTF-8 BOM, XML well-formedness, and `{0}`/`{1}` placeholder integrity; each diff is a single added `<data>` block
- Live check of both paths: `hooks install --json --cli codex` reports the real marketplace-repoint failure with its reason and exits 1; `--cli copilot` reports `installed` and exits 0

