### PR TITLE
Render agent responses as Markdown

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -617,6 +617,7 @@ if it were canonical for the whole group.
 - **deranged** v0.5.8 -- [https://github.com/jhpratt/deranged](https://github.com/jhpratt/deranged) -- `Apache-2.0 OR MIT`
 - **derive_more** v2.1.1 -- [https://github.com/JelteF/derive_more](https://github.com/JelteF/derive_more) -- `MIT`
 - **derive_more-impl** v2.1.1 -- [https://github.com/JelteF/derive_more](https://github.com/JelteF/derive_more) -- `MIT`
+- **diff** v0.1.13 -- [https://github.com/utkarshkukreti/diff.rs](https://github.com/utkarshkukreti/diff.rs) -- `Apache-2.0 OR MIT`
 - **digest** v0.10.7 -- [https://github.com/RustCrypto/traits](https://github.com/RustCrypto/traits) -- `Apache-2.0 OR MIT`
 - **document-features** v0.2.12 -- [https://github.com/slint-ui/document-features](https://github.com/slint-ui/document-features) -- `Apache-2.0 OR MIT`
 - **dyn-clone** v1.0.20 -- [https://github.com/dtolnay/dyn-clone](https://github.com/dtolnay/dyn-clone) -- `Apache-2.0 OR MIT`
@@ -648,8 +649,10 @@ if it were canonical for the whole group.
 - **futures-macro** v0.3.32 -- [https://github.com/rust-lang/futures-rs](https://github.com/rust-lang/futures-rs) -- `Apache-2.0 OR MIT`
 - **futures-sink** v0.3.32 -- [https://github.com/rust-lang/futures-rs](https://github.com/rust-lang/futures-rs) -- `Apache-2.0 OR MIT`
 - **futures-task** v0.3.32 -- [https://github.com/rust-lang/futures-rs](https://github.com/rust-lang/futures-rs) -- `Apache-2.0 OR MIT`
+- **futures-timer** v3.0.4 -- [https://github.com/async-rs/futures-timer](https://github.com/async-rs/futures-timer) -- `Apache-2.0 OR MIT`
 - **futures-util** v0.3.32 -- [https://github.com/rust-lang/futures-rs](https://github.com/rust-lang/futures-rs) -- `Apache-2.0 OR MIT`
 - **generic-array** v0.14.7 -- [https://github.com/fizyk20/generic-array.git](https://github.com/fizyk20/generic-array.git) -- `MIT`
+- **getopts** v0.2.24 -- [https://github.com/rust-lang/getopts](https://github.com/rust-lang/getopts) -- `Apache-2.0 OR MIT`
 - **getrandom** v0.3.4 -- [https://github.com/rust-random/getrandom](https://github.com/rust-random/getrandom) -- `Apache-2.0 OR MIT`
 - **getrandom** v0.4.2 -- [https://github.com/rust-random/getrandom](https://github.com/rust-random/getrandom) -- `Apache-2.0 OR MIT`
 - **glob** v0.3.3 -- [https://github.com/rust-lang/glob](https://github.com/rust-lang/glob) -- `Apache-2.0 OR MIT`
@@ -669,6 +672,7 @@ if it were canonical for the whole group.
 - **is_terminal_polyfill** v1.70.2 -- [https://github.com/polyfill-rs/is_terminal_polyfill](https://github.com/polyfill-rs/is_terminal_polyfill) -- `Apache-2.0 OR MIT`
 - **itertools** v0.11.0 -- [https://github.com/rust-itertools/itertools](https://github.com/rust-itertools/itertools) -- `Apache-2.0 OR MIT`
 - **itertools** v0.14.0 -- [https://github.com/rust-itertools/itertools](https://github.com/rust-itertools/itertools) -- `Apache-2.0 OR MIT`
+- **itertools** v0.15.0 -- [https://github.com/rust-itertools/itertools](https://github.com/rust-itertools/itertools) -- `Apache-2.0 OR MIT`
 - **itoa** v1.0.17 -- [https://github.com/dtolnay/itoa](https://github.com/dtolnay/itoa) -- `Apache-2.0 OR MIT`
 - **kasuari** v0.4.11 -- [https://github.com/ratatui/kasuari](https://github.com/ratatui/kasuari) -- `Apache-2.0 OR MIT`
 - **lab** v0.11.0 -- [https://github.com/TooManyBees/lab](https://github.com/TooManyBees/lab) -- `MIT`
@@ -716,7 +720,11 @@ if it were canonical for the whole group.
 - **polling** v3.11.0 -- [https://github.com/smol-rs/polling](https://github.com/smol-rs/polling) -- `Apache-2.0 OR MIT`
 - **portable-atomic** v1.13.1 -- [https://github.com/taiki-e/portable-atomic](https://github.com/taiki-e/portable-atomic) -- `Apache-2.0 OR MIT`
 - **powerfmt** v0.2.0 -- [https://github.com/jhpratt/powerfmt](https://github.com/jhpratt/powerfmt) -- `Apache-2.0 OR MIT`
+- **pretty_assertions** v1.4.1 -- [https://github.com/rust-pretty-assertions/rust-pretty-assertions](https://github.com/rust-pretty-assertions/rust-pretty-assertions) -- `Apache-2.0 OR MIT`
+- **proc-macro-crate** v3.5.0 -- [https://github.com/bkchr/proc-macro-crate](https://github.com/bkchr/proc-macro-crate) -- `Apache-2.0 OR MIT`
 - **proc-macro2** v1.0.106 -- [https://github.com/dtolnay/proc-macro2](https://github.com/dtolnay/proc-macro2) -- `Apache-2.0 OR MIT`
+- **pulldown-cmark** v0.13.4 -- [https://github.com/raphlinus/pulldown-cmark](https://github.com/raphlinus/pulldown-cmark) -- `MIT`
+- **pulldown-cmark-escape** v0.11.0 -- [https://github.com/raphlinus/pulldown-cmark](https://github.com/raphlinus/pulldown-cmark) -- `MIT`
 - **pxfm** v0.1.29 -- [https://github.com/awxkee/pxfm](https://github.com/awxkee/pxfm) -- `Apache-2.0 OR BSD-3-Clause`
 - **quote** v1.0.45 -- [https://github.com/dtolnay/quote](https://github.com/dtolnay/quote) -- `Apache-2.0 OR MIT`
 - **rand** v0.8.5 -- [https://github.com/rust-random/rand](https://github.com/rust-random/rand) -- `Apache-2.0 OR MIT`
@@ -732,6 +740,9 @@ if it were canonical for the whole group.
 - **regex** v1.12.3 -- [https://github.com/rust-lang/regex](https://github.com/rust-lang/regex) -- `Apache-2.0 OR MIT`
 - **regex-automata** v0.4.14 -- [https://github.com/rust-lang/regex](https://github.com/rust-lang/regex) -- `Apache-2.0 OR MIT`
 - **regex-syntax** v0.8.10 -- [https://github.com/rust-lang/regex](https://github.com/rust-lang/regex) -- `Apache-2.0 OR MIT`
+- **relative-path** v1.9.3 -- [https://github.com/udoprog/relative-path](https://github.com/udoprog/relative-path) -- `Apache-2.0 OR MIT`
+- **rstest** v0.26.1 -- [https://github.com/la10736/rstest](https://github.com/la10736/rstest) -- `Apache-2.0 OR MIT`
+- **rstest_macros** v0.26.1 -- [https://github.com/la10736/rstest](https://github.com/la10736/rstest) -- `Apache-2.0 OR MIT`
 - **rust-i18n** v3.1.5 -- [https://github.com/longbridge/rust-i18n](https://github.com/longbridge/rust-i18n) -- `MIT`
 - **rust-i18n-macro** v3.1.5 -- [https://github.com/longbridge/rust-i18n](https://github.com/longbridge/rust-i18n) -- `MIT`
 - **rust-i18n-support** v3.1.5 -- [https://github.com/longbridge/rust-i18n](https://github.com/longbridge/rust-i18n) -- `MIT`
@@ -791,7 +802,10 @@ if it were canonical for the whole group.
 - **tokio-util** v0.7.18 -- [https://github.com/tokio-rs/tokio](https://github.com/tokio-rs/tokio) -- `MIT`
 - **toml** v0.8.23 -- [https://github.com/toml-rs/toml](https://github.com/toml-rs/toml) -- `Apache-2.0 OR MIT`
 - **toml_datetime** v0.6.11 -- [https://github.com/toml-rs/toml](https://github.com/toml-rs/toml) -- `Apache-2.0 OR MIT`
+- **toml_datetime** v1.1.1+spec-1.1.0 -- [https://github.com/toml-rs/toml](https://github.com/toml-rs/toml) -- `Apache-2.0 OR MIT`
 - **toml_edit** v0.22.27 -- [https://github.com/toml-rs/toml](https://github.com/toml-rs/toml) -- `Apache-2.0 OR MIT`
+- **toml_edit** v0.25.13+spec-1.1.0 -- [https://github.com/toml-rs/toml](https://github.com/toml-rs/toml) -- `Apache-2.0 OR MIT`
+- **toml_parser** v1.1.3+spec-1.1.0 -- [https://github.com/toml-rs/toml](https://github.com/toml-rs/toml) -- `Apache-2.0 OR MIT`
 - **toml_write** v0.1.2 -- [https://github.com/toml-rs/toml](https://github.com/toml-rs/toml) -- `Apache-2.0 OR MIT`
 - **tracelogging** v1.2.4 -- [https://github.com/microsoft/tracelogging](https://github.com/microsoft/tracelogging) -- `MIT`
 - **tracelogging_macros** v1.2.3 -- [https://github.com/microsoft/tracelogging](https://github.com/microsoft/tracelogging) -- `MIT`
@@ -802,8 +816,10 @@ if it were canonical for the whole group.
 - **tracing-log** v0.2.0 -- [https://github.com/tokio-rs/tracing](https://github.com/tokio-rs/tracing) -- `MIT`
 - **tracing-subscriber** v0.3.23 -- [https://github.com/tokio-rs/tracing](https://github.com/tokio-rs/tracing) -- `MIT`
 - **triomphe** v0.1.15 -- [https://github.com/Manishearth/triomphe](https://github.com/Manishearth/triomphe) -- `Apache-2.0 OR MIT`
+- **tui-markdown** v0.3.9 -- [https://github.com/joshka/tui-markdown](https://github.com/joshka/tui-markdown) -- `Apache-2.0 OR MIT`
 - **typenum** v1.19.0 -- [https://github.com/paholg/typenum](https://github.com/paholg/typenum) -- `Apache-2.0 OR MIT`
 - **ucd-trie** v0.1.7 -- [https://github.com/BurntSushi/ucd-generate](https://github.com/BurntSushi/ucd-generate) -- `Apache-2.0 OR MIT`
+- **unicase** v2.9.0 -- [https://github.com/seanmonstar/unicase](https://github.com/seanmonstar/unicase) -- `Apache-2.0 OR MIT`
 - **unicode-ident** v1.0.24 -- [https://github.com/dtolnay/unicode-ident](https://github.com/dtolnay/unicode-ident) -- `(MIT OR Apache-2.0) AND Unicode-3.0`
 - **unicode-linebreak** v0.1.5 -- [https://github.com/axelf4/unicode-linebreak](https://github.com/axelf4/unicode-linebreak) -- `Apache-2.0`
 - **unicode-segmentation** v1.12.0 -- [https://github.com/unicode-rs/unicode-segmentation](https://github.com/unicode-rs/unicode-segmentation) -- `Apache-2.0 OR MIT`
@@ -830,7 +846,9 @@ if it were canonical for the whole group.
 - **windows-sys** v0.61.2 -- [https://github.com/microsoft/windows-rs](https://github.com/microsoft/windows-rs) -- `Apache-2.0 OR MIT`
 - **windows-targets** v0.48.5 -- [https://github.com/microsoft/windows-rs](https://github.com/microsoft/windows-rs) -- `Apache-2.0 OR MIT`
 - **winnow** v0.7.15 -- [https://github.com/winnow-rs/winnow](https://github.com/winnow-rs/winnow) -- `MIT`
+- **winnow** v1.0.4 -- [https://github.com/winnow-rs/winnow](https://github.com/winnow-rs/winnow) -- `MIT`
 - **winsafe** v0.0.19 -- [https://github.com/rodrigocfd/winsafe](https://github.com/rodrigocfd/winsafe) -- `MIT`
+- **yansi** v1.0.1 -- [https://github.com/SergioBenitez/yansi](https://github.com/SergioBenitez/yansi) -- `Apache-2.0 OR MIT`
 - **zmij** v1.0.21 -- [https://github.com/dtolnay/zmij](https://github.com/dtolnay/zmij) -- `MIT`
 
 ## License texts
@@ -856,7 +874,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 ### `Apache-2.0`
 
-Applies to 190 crate(s) (directly or via composite identifiers): adler2 v2.0.1, agent-client-protocol v1.3.0, agent-client-protocol-derive v1.3.0, agent-client-protocol-schema v1.4.0, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, ... (+182 more)
+Applies to 205 crate(s) (directly or via composite identifiers): adler2 v2.0.1, agent-client-protocol v1.3.0, agent-client-protocol-derive v1.3.0, agent-client-protocol-schema v1.4.0, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, ... (+197 more)
 
 _Canonical text reproduced from upstream `SPDX:Apache-2.0`:_
 
@@ -951,11 +969,13 @@ Copyright (c) 2014 Chris Wong
 Copyright (c) 2014 Paho Lurie-Gregg
 Copyright (c) 2014 The Rust Project Developers
 Copyright (c) 2014-2026 Alex Crichton
+Copyright (c) 2014-2026 Sean McArthur
 Copyright (c) 2014, Kang Seonghoon.
 Copyright (c) 2015 Alice Maz
 Copyright (c) 2015 Andrew Gallant
 Copyright (c) 2015 nwin
 Copyright (c) 2015 The Rust Project Developers
+Copyright (c) 2015 Utkarsh Kukreti
 Copyright (c) 2015-2018 The winapi-rs Developers
 Copyright (c) 2015-2020 The rust-hex Developers
 Copyright (c) 2016 Alex Crichton
@@ -963,6 +983,7 @@ Copyright (c) 2016 Amanieu d'Antras
 Copyright (c) 2016 Artyom Pavlov
 Copyright (c) 2016 Dylan Ede
 Copyright (c) 2016 Joe Wilm
+Copyright (c) 2016 rust-derive-builder contributors
 Copyright (c) 2016 The roaring-rs developers.
 Copyright (c) 2016 The Rust Project Developers
 Copyright (c) 2016 Tomasz Miąsko
@@ -973,6 +994,7 @@ Copyright (c) 2017 Contributors
 Copyright (c) 2017 Frommi
 Copyright (c) 2017 Nikolai Vazquez
 Copyright (c) 2017 Robert Grosse
+Copyright (c) 2017 Sergio Benitez
 Copyright (c) 2017 The Tokio Authors
 Copyright (c) 2017-2024 oyvindln
 Copyright (c) 2018 Ashley Mannix, Christopher Armstrong, Dylan DPC, Hunar Roop Kahlon
@@ -1004,7 +1026,9 @@ Copyright 2012-2016 The Rust Project Developers.
 Copyright 2013-2014 RAD Game Tools and Valve Software
 Copyright 2014 Paho Lurie-Gregg
 Copyright 2016-2026 Frank Denis.
+Copyright 2017 Sergio Benitez
 Copyright 2018 Developers of the Rand project
+Copyright 2018-19 Michele d'Amico
 Copyright 2020 Nor Khasyatillah
 Copyright 2020 Tomasz "Soveu" Marx
 Copyright 2020 Yoshua Wuyts
@@ -1214,7 +1238,7 @@ _Canonical text reproduced from upstream `SPDX:LLVM-exception`:_
 
 ### `MIT`
 
-Applies to 266 crate(s) (directly or via composite identifiers): adler2 v2.0.1, aho-corasick v1.1.4, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, anstyle-query v1.1.5, anstyle-wincon v3.0.11, ... (+258 more)
+Applies to 284 crate(s) (directly or via composite identifiers): adler2 v2.0.1, aho-corasick v1.1.4, allocator-api2 v0.2.21, anstream v0.6.21, anstyle v1.0.13, anstyle-parse v0.2.7, anstyle-query v1.1.5, anstyle-wincon v3.0.11, ... (+276 more)
 
 _Canonical text reproduced from upstream `SPDX:MIT`:_
 
@@ -1258,6 +1282,7 @@ Copyright (c) 2014 The Rust Project Developers
 Copyright (c) 2014-2019 Geoffroy Couprie
 Copyright (c) 2014-2022 Steven Fackler, Yuki Okushi
 Copyright (c) 2014-2026 Alex Crichton
+Copyright (c) 2014-2026 Sean McArthur
 Copyright (c) 2014, Kang Seonghoon.
 Copyright (c) 2015 Alice Maz
 Copyright (c) 2015 Andrew Gallant
@@ -1268,6 +1293,7 @@ Copyright (c) 2015 François Bernier
 Copyright (c) 2015 Jonathan Reem
 Copyright (c) 2015 nwin
 Copyright (c) 2015 The Rust Project Developers
+Copyright (c) 2015 Utkarsh Kukreti
 Copyright (c) 2015-2018 The winapi-rs Developers
 Copyright (c) 2015-2020 The rust-hex Developers
 Copyright (c) 2016 Alex Crichton
@@ -1278,6 +1304,7 @@ Copyright (c) 2016 Jelte Fennema
 Copyright (c) 2016 Jerome Froelich
 Copyright (c) 2016 Joe Wilm
 Copyright (c) 2016 Martin Geisler
+Copyright (c) 2016 rust-derive-builder contributors
 Copyright (c) 2016 The roaring-rs developers.
 Copyright (c) 2016 The Rust Project Developers
 Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com>
@@ -1293,6 +1320,7 @@ Copyright (c) 2017 Gilad Naaman
 Copyright (c) 2017 Martin Geisler
 Copyright (c) 2017 Nikolai Vazquez
 Copyright (c) 2017 Robert Grosse
+Copyright (c) 2017 Sergio Benitez
 Copyright (c) 2017 Ted Driggs
 Copyright (c) 2017 The Tokio Authors
 Copyright (c) 2017-2024 oyvindln
@@ -1344,9 +1372,12 @@ Copyright 2010-2014 Rich Geldreich and Tenacious Software LLC
 Copyright 2012-2016 The Rust Project Developers.
 Copyright 2013-2014 RAD Game Tools and Valve Software
 Copyright 2014 Paho Lurie-Gregg
+Copyright 2015 Google Inc. All rights reserved.
 Copyright 2015 The Fancy Regex Authors.
 Copyright 2016-2026 Frank Denis.
+Copyright 2017 Sergio Benitez
 Copyright 2018 Developers of the Rand project
+Copyright 2018-19 Michele d'Amico
 Copyright 2019 Ryan O'Beirne
 Copyright 2020 Nor Khasyatillah
 Copyright 2020 Tomasz "Soveu" Marx

--- a/tools/wta/Cargo.lock
+++ b/tools/wta/Cargo.lock
@@ -667,6 +667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +960,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +990,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1229,6 +1250,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -1756,6 +1786,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +1806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.13+spec-1.1.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1822,25 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.11.0",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pxfm"
@@ -1958,6 +2026,41 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-ident",
+]
 
 [[package]]
 name = "rust-i18n"
@@ -2641,8 +2744,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -2655,6 +2758,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2663,9 +2775,30 @@ dependencies = [
  "indexmap 2.13.0",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -2775,6 +2908,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tui-markdown"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c95afc7b66008823dea2614a800d944e18990690db47517efc66cd01ff9cee"
+dependencies = [
+ "itertools 0.15.0",
+ "pretty_assertions",
+ "pulldown-cmark",
+ "ratatui-core",
+ "rstest",
+ "tracing",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2785,6 +2932,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -3244,6 +3397,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3363,11 +3525,18 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "tui-markdown",
  "unicode-width",
  "uuid",
  "which",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zmij"

--- a/tools/wta/Cargo.toml
+++ b/tools/wta/Cargo.toml
@@ -23,6 +23,7 @@ notify = "6"
 futures = "0.3"
 unicode-width = "0.2"
 textwrap = "0.16"
+tui-markdown = { version = "0.3.9", default-features = false }
 serde = { version = "1", features = ["derive"] }
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",

--- a/tools/wta/cgmanifest.json
+++ b/tools/wta/cgmanifest.json
@@ -554,6 +554,15 @@
       "component": {
         "type": "cargo",
         "cargo": {
+          "name": "diff",
+          "version": "0.1.13"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
           "name": "digest",
           "version": "0.10.7"
         }
@@ -833,6 +842,15 @@
       "component": {
         "type": "cargo",
         "cargo": {
+          "name": "futures-timer",
+          "version": "3.0.4"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
           "name": "futures-util",
           "version": "0.3.32"
         }
@@ -844,6 +862,15 @@
         "cargo": {
           "name": "generic-array",
           "version": "0.14.7"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "getopts",
+          "version": "0.2.24"
         }
       }
     },
@@ -1015,6 +1042,15 @@
         "cargo": {
           "name": "itertools",
           "version": "0.14.0"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "itertools",
+          "version": "0.15.0"
         }
       }
     },
@@ -1445,8 +1481,44 @@
       "component": {
         "type": "cargo",
         "cargo": {
+          "name": "pretty_assertions",
+          "version": "1.4.1"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "proc-macro-crate",
+          "version": "3.5.0"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
           "name": "proc-macro2",
           "version": "1.0.106"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "pulldown-cmark",
+          "version": "0.13.4"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "pulldown-cmark-escape",
+          "version": "0.11.0"
         }
       }
     },
@@ -1582,6 +1654,33 @@
         "cargo": {
           "name": "regex-syntax",
           "version": "0.8.10"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "relative-path",
+          "version": "1.9.3"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "rstest",
+          "version": "0.26.1"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "rstest_macros",
+          "version": "0.26.1"
         }
       }
     },
@@ -2120,8 +2219,35 @@
       "component": {
         "type": "cargo",
         "cargo": {
+          "name": "toml_datetime",
+          "version": "1.1.1+spec-1.1.0"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
           "name": "toml_edit",
           "version": "0.22.27"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "toml_edit",
+          "version": "0.25.13+spec-1.1.0"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "toml_parser",
+          "version": "1.1.3+spec-1.1.0"
         }
       }
     },
@@ -2219,6 +2345,15 @@
       "component": {
         "type": "cargo",
         "cargo": {
+          "name": "tui-markdown",
+          "version": "0.3.9"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
           "name": "typenum",
           "version": "1.19.0"
         }
@@ -2230,6 +2365,15 @@
         "cargo": {
           "name": "ucd-trie",
           "version": "0.1.7"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "unicase",
+          "version": "2.9.0"
         }
       }
     },
@@ -2471,8 +2615,26 @@
       "component": {
         "type": "cargo",
         "cargo": {
+          "name": "winnow",
+          "version": "1.0.4"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
           "name": "winsafe",
           "version": "0.0.19"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "yansi",
+          "version": "1.0.1"
         }
       }
     },

--- a/tools/wta/src/theme.rs
+++ b/tools/wta/src/theme.rs
@@ -20,7 +20,9 @@ pub const TOOL_CALL_PENDING: Style = Style::new().fg(Color::Yellow).add_modifier
 pub const TOOL_CALL_RUNNING: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
 pub const TOOL_CALL_SUCCESS: Style = Style::new().fg(Color::Green).add_modifier(Modifier::BOLD);
 pub const TOOL_CALL_FAILURE: Style = Style::new().fg(Color::Red).add_modifier(Modifier::BOLD);
-pub const TOOL_CALL_CANCELED: Style = Style::new().fg(Color::DarkGray).add_modifier(Modifier::ITALIC);
+pub const TOOL_CALL_CANCELED: Style = Style::new()
+    .fg(Color::DarkGray)
+    .add_modifier(Modifier::ITALIC);
 pub const PLAN_STYLE: Style = Style::new().fg(Color::Cyan);
 pub const ERROR_STYLE: Style = Style::new().fg(Color::Red);
 pub const IN_PROGRESS: Style = Style::new()
@@ -32,17 +34,13 @@ pub const DIM: Style = Style::new().fg(Color::DarkGray);
 pub const SELECTED: Style = Style::new().fg(Color::Cyan);
 // Preserve the selection when the pane loses focus without presenting it as
 // the active keyboard target.
-pub const SELECTED_INACTIVE: Style = Style::new()
-    .fg(Color::Cyan)
-    .add_modifier(Modifier::DIM);
+pub const SELECTED_INACTIVE: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::DIM);
 pub const DEBUG_SENT: Style = Style::new().fg(Color::Green);
 pub const DEBUG_RECEIVED: Style = Style::new().fg(Color::Cyan);
 pub const RECOMMENDATION_TITLE: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
 // Dimmed default fg rather than Color::Gray (ANSI 7, near-white) so secondary
 // text stays readable on light schemes while still reading as "muted" (#234).
-pub const RECOMMENDATION_DETAIL: Style = Style::new()
-    .fg(Color::Reset)
-    .add_modifier(Modifier::DIM);
+pub const RECOMMENDATION_DETAIL: Style = Style::new().fg(Color::Reset).add_modifier(Modifier::DIM);
 // Card-style recommendation UI.
 // Border color = `#FFF @ 10%` over `#000`: 0×0.9 + 255×0.1 ≈ 26 → #1A1A1A.
 pub const CARD_FRAME_COLOR: Color = Color::Rgb(26, 26, 26);
@@ -65,6 +63,17 @@ pub const BUTTON_PLAIN: Style = Style::new().fg(Color::Reset);
 // Chat message dot indicators
 pub const DOT_ERROR: Style = Style::new().fg(Color::Red).add_modifier(Modifier::BOLD);
 pub const DOT_AGENT: Style = Style::new().fg(Color::DarkGray);
+pub const MARKDOWN_HEADING: Style = AGENT_TEXT.add_modifier(Modifier::BOLD);
+pub const MARKDOWN_CODE: Style = AGENT_TEXT.add_modifier(Modifier::REVERSED);
+pub const MARKDOWN_LINK: Style = Style::new()
+    .fg(Color::Cyan)
+    .add_modifier(Modifier::UNDERLINED);
+pub const MARKDOWN_QUOTE: Style = AGENT_TEXT
+    .add_modifier(Modifier::DIM)
+    .add_modifier(Modifier::ITALIC);
+pub const MARKDOWN_META: Style = AGENT_TEXT.add_modifier(Modifier::DIM);
+pub const MARKDOWN_TABLE_HEADER: Style = AGENT_TEXT.add_modifier(Modifier::BOLD);
+pub const MARKDOWN_TABLE_BORDER: Style = AGENT_TEXT.add_modifier(Modifier::DIM);
 // Notification badge/banner styles
 pub const BADGE_CRITICAL: Style = Style::new().fg(Color::Red).add_modifier(Modifier::BOLD);
 pub const BADGE_ACTIONABLE: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use tui_markdown::{Options as MarkdownOptions, StyleSheet};
+use unicode_width::UnicodeWidthChar;
 
 use crate::app::{
     App, ChatMessage, CompletedTurn, NoticeKind, PlanEntryStatus, ToolCallKind, ToolCallOutput,
@@ -10,7 +12,9 @@ use crate::theme;
 use crate::ui::shimmer;
 use crate::ui_trace;
 
-fn activity_label() -> String { t!("chat.activity_thinking").into_owned() }
+fn activity_label() -> String {
+    t!("chat.activity_thinking").into_owned()
+}
 
 const MAX_RENDER_LINE_CHARS: usize = 4096;
 const MAX_TOOL_OUTPUT_LINES: usize = 4;
@@ -50,32 +54,32 @@ fn tool_output_lines(output: &ToolCallOutput) -> Vec<String> {
 pub fn estimated_block_height(app: &App, area_width: u16) -> u16 {
     let tab = app.current_tab();
     let wrap_width = (area_width as usize).max(1);
-    // Fetch once for the pending-height calculation.
-    let pending_text = pending_render_text(tab);
 
-    let messages: usize = tab.messages.iter().map(|m| message_height(m, wrap_width)).sum();
-    let turns: usize = tab.completed_turns.iter().map(|t| turn_height(t, wrap_width)).sum();
-    let pending = pending_text
-        .as_deref()
-        .map(|text| {
-            let body_width = wrap_width.saturating_sub(2).max(1);
-            dot_wrap_count(text, body_width)
-        })
-        .unwrap_or(0);
+    let messages: usize = tab
+        .messages
+        .iter()
+        .map(|m| message_height(m, wrap_width))
+        .sum();
+    let turns: usize = tab
+        .completed_turns
+        .iter()
+        .map(|t| turn_height(t, wrap_width))
+        .sum();
+    let pending = pending_height(tab, wrap_width);
     // Welcome overlay sits above all chat content when `show_welcome_hint`
     // is on; must be counted here or else any pushed message will scroll
     // it off the top of the visible chat block. Always a single row —
     // terminal min-width guarantees the localized title fits without
     // wrapping.
-    let welcome = if app.show_welcome_hint
-        && app.state == crate::app::ConnectionState::Connected
-    {
+    let welcome = if app.show_welcome_hint && app.state == crate::app::ConnectionState::Connected {
         1
     } else {
         0
     };
 
-    (messages + turns + pending + welcome).max(1).min(u16::MAX as usize) as u16
+    (messages + turns + pending + welcome)
+        .max(1)
+        .min(u16::MAX as usize) as u16
 }
 
 fn wrap_count(text: &str, width: usize) -> usize {
@@ -83,7 +87,11 @@ fn wrap_count(text: &str, width: usize) -> usize {
     text.split('\n')
         .map(|line| {
             let chars = line.chars().count();
-            if chars == 0 { 1 } else { chars.div_ceil(w) }
+            if chars == 0 {
+                1
+            } else {
+                chars.div_ceil(w)
+            }
         })
         .sum::<usize>()
         .max(1)
@@ -96,6 +104,160 @@ fn dot_wrap_count(text: &str, width: usize) -> usize {
     wrap_count(text.trim_start_matches('\n'), width)
 }
 
+#[derive(Clone)]
+struct AgentMarkdownStyleSheet;
+
+impl StyleSheet for AgentMarkdownStyleSheet {
+    fn heading(&self, _level: u8) -> Style {
+        theme::MARKDOWN_HEADING
+    }
+
+    fn code(&self) -> Style {
+        theme::MARKDOWN_CODE
+    }
+
+    fn link(&self) -> Style {
+        theme::MARKDOWN_LINK
+    }
+
+    fn blockquote(&self) -> Style {
+        theme::MARKDOWN_QUOTE
+    }
+
+    fn heading_meta(&self) -> Style {
+        theme::MARKDOWN_META
+    }
+
+    fn metadata_block(&self) -> Style {
+        theme::MARKDOWN_META
+    }
+
+    fn table_header(&self) -> Style {
+        theme::MARKDOWN_TABLE_HEADER
+    }
+
+    fn table_cell(&self) -> Style {
+        theme::AGENT_TEXT
+    }
+
+    fn table_border(&self) -> Style {
+        theme::MARKDOWN_TABLE_BORDER
+    }
+
+    fn heading_marker(&self, _level: u8) -> &str {
+        ""
+    }
+
+    fn code_block_fence(&self) -> &str {
+        ""
+    }
+}
+
+#[derive(Clone, Copy)]
+struct StyledChar {
+    value: char,
+    style: Style,
+}
+
+fn styled_chars_to_line(chars: &[StyledChar]) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    for styled in chars {
+        if let Some(span) = spans.last_mut().filter(|span| span.style == styled.style) {
+            span.content.to_mut().push(styled.value);
+        } else {
+            spans.push(Span::styled(styled.value.to_string(), styled.style));
+        }
+    }
+    Line::from(spans)
+}
+
+fn wrap_markdown_line(line: Line<'_>, width: usize) -> Vec<Line<'static>> {
+    let base_style = theme::AGENT_TEXT.patch(line.style);
+    let chars: Vec<StyledChar> = line
+        .spans
+        .into_iter()
+        .flat_map(|span| {
+            let style = base_style.patch(span.style);
+            span.content
+                .into_owned()
+                .chars()
+                .map(move |value| StyledChar { value, style })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    if chars.is_empty() {
+        return vec![Line::default()];
+    }
+
+    let width = width.max(1);
+    let mut wrapped = Vec::new();
+    let mut start = 0;
+    while start < chars.len() {
+        let mut end = start;
+        let mut cells = 0;
+        let mut last_whitespace = None;
+        while end < chars.len() {
+            let char_width = UnicodeWidthChar::width(chars[end].value).unwrap_or(0);
+            if end > start && cells + char_width > width {
+                break;
+            }
+            cells += char_width;
+            if chars[end].value.is_whitespace() {
+                last_whitespace = Some(end);
+            }
+            end += 1;
+            if cells >= width {
+                break;
+            }
+        }
+
+        let next = if end < chars.len() {
+            last_whitespace
+                .filter(|index| *index > start)
+                .unwrap_or(end)
+        } else {
+            end
+        };
+        wrapped.push(styled_chars_to_line(&chars[start..next]));
+        start = next;
+        while start < chars.len() && chars[start].value.is_whitespace() {
+            start += 1;
+        }
+    }
+    wrapped
+}
+
+fn agent_markdown_lines(text: &str, wrap_width: usize, dot_style: Style) -> Vec<Line<'static>> {
+    let options = MarkdownOptions::new(AgentMarkdownStyleSheet);
+    let markdown = tui_markdown::from_str_with_options(text.trim_start_matches('\n'), &options);
+    let body_width = wrap_width.saturating_sub(2).max(1);
+    let mut lines = Vec::new();
+    let mut first_row = true;
+
+    for logical_line in markdown.lines {
+        for mut line in wrap_markdown_line(logical_line, body_width) {
+            if line.width() == 0 {
+                if !first_row {
+                    lines.push(Line::default());
+                }
+                continue;
+            }
+
+            let mut spans = Vec::with_capacity(line.spans.len() + 1);
+            if first_row {
+                spans.push(Span::styled("● ", dot_style));
+                first_row = false;
+            } else {
+                spans.push(Span::raw("  "));
+            }
+            spans.append(&mut line.spans);
+            lines.push(Line::from(spans));
+        }
+    }
+    lines
+}
+
 struct MessageLayout {
     height: usize,
     has_trailing_blank: bool,
@@ -106,7 +268,11 @@ fn message_layout(msg: &ChatMessage, wrap_width: usize) -> MessageLayout {
     // "> " for user) and a trailing blank line.
     let body_width = wrap_width.saturating_sub(2).max(1);
     match msg {
-        ChatMessage::Agent(t) | ChatMessage::Error(t) => MessageLayout {
+        ChatMessage::Agent(t) => MessageLayout {
+            height: agent_markdown_lines(t, wrap_width, theme::DOT_AGENT).len() + 1,
+            has_trailing_blank: true,
+        },
+        ChatMessage::Error(t) => MessageLayout {
             height: dot_wrap_count(t, body_width) + 1,
             has_trailing_blank: true,
         },
@@ -157,10 +323,7 @@ fn message_layout(msg: &ChatMessage, wrap_width: usize) -> MessageLayout {
             };
             let has_trailing_blank = command_lines + output_rows > 0;
             MessageLayout {
-                height: 1
-                    + command_lines
-                    + output_rows
-                    + usize::from(has_trailing_blank),
+                height: 1 + command_lines + output_rows + usize::from(has_trailing_blank),
                 has_trailing_blank,
             }
         }
@@ -215,7 +378,8 @@ fn tool_call_presentation(status: &str) -> (&'static str, Style, Option<&str>) {
         ("○", theme::TOOL_CALL_PENDING, None)
     } else if status.eq_ignore_ascii_case("inprogress") || status.eq_ignore_ascii_case("running") {
         ("●", theme::TOOL_CALL_RUNNING, None)
-    } else if status.eq_ignore_ascii_case("completed") || status.eq_ignore_ascii_case("exited (0)") {
+    } else if status.eq_ignore_ascii_case("completed") || status.eq_ignore_ascii_case("exited (0)")
+    {
         ("✓", theme::TOOL_CALL_SUCCESS, None)
     } else if status.eq_ignore_ascii_case("failed") {
         ("✗", theme::TOOL_CALL_FAILURE, None)
@@ -306,7 +470,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         let pane_focused = app.pane_focused;
         for (idx, turn) in app.current_tab().completed_turns.iter().enumerate().rev() {
             let is_selected = selected_idx == Some(idx);
-            let mut turn_lines = build_completed_turn_lines(turn, is_selected, pane_focused, wrap_width);
+            let mut turn_lines =
+                build_completed_turn_lines(turn, is_selected, pane_focused, wrap_width);
             reversed_lines.extend(turn_lines.drain(..).rev());
             if reversed_lines.len() >= requested_lines {
                 truncated = true;
@@ -316,25 +481,25 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     }
 
     // First-run welcome: shown once until user sends first message
-    if app.show_welcome_hint
-        && app.state == crate::app::ConnectionState::Connected
-    {
-        let mut welcome_lines = vec![
-            Line::from(vec![
-                Span::styled("● ", Style::new().fg(Color::Reset).add_modifier(Modifier::BOLD)),
-                Span::styled(
-                    t!("chat.welcome_title").into_owned(),
-                    Style::new().fg(Color::Reset).add_modifier(Modifier::BOLD),
-                ),
-            ]),
-        ];
+    if app.show_welcome_hint && app.state == crate::app::ConnectionState::Connected {
+        let mut welcome_lines = vec![Line::from(vec![
+            Span::styled(
+                "● ",
+                Style::new().fg(Color::Reset).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                t!("chat.welcome_title").into_owned(),
+                Style::new().fg(Color::Reset).add_modifier(Modifier::BOLD),
+            ),
+        ])];
         reversed_lines.extend(welcome_lines.drain(..).rev());
     }
 
     let lines: Vec<Line> = reversed_lines.into_iter().rev().collect();
 
     let total_lines = lines.len();
-    let scroll = total_lines.saturating_sub(visible_height.saturating_add(app.current_tab().chat_scroll.offset));
+    let scroll = total_lines
+        .saturating_sub(visible_height.saturating_add(app.current_tab().chat_scroll.offset));
 
     let paragraph = Paragraph::new(lines)
         .block(inner)
@@ -358,7 +523,11 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         format!(
             "messages={} pending_chars={} requested_lines={} visible_height={} area={}x{}",
             app.current_tab().messages.len(),
-            app.current_tab().turn.buffer().map(|b| b.chars().count()).unwrap_or(0),
+            app.current_tab()
+                .turn
+                .buffer()
+                .map(|b| b.chars().count())
+                .unwrap_or(0),
             requested_lines,
             visible_height,
             area.width,
@@ -480,10 +649,7 @@ pub fn render_activity(frame: &mut Frame, app: &App, area: Rect) {
         return;
     }
     let label = activity_label();
-    let line = Line::from(shimmer::shimmer_spans(
-        &label,
-        tab.activity_frame,
-    ));
+    let line = Line::from(shimmer::shimmer_spans(&label, tab.activity_frame));
     frame.render_widget(Paragraph::new(line), area);
 }
 
@@ -499,9 +665,33 @@ fn pending_render_text(tab: &crate::app::TabSession) -> Option<Cow<'_, str>> {
     user_visible_stream_text(tab.turn.buffer()?)
 }
 
+fn pending_revealed_text(tab: &crate::app::TabSession) -> Option<Cow<'_, str>> {
+    let text = pending_render_text(tab)?;
+    let total = text.chars().count();
+    let shown = tab.reveal_chars.min(total);
+    if shown >= total {
+        Some(text)
+    } else {
+        Some(Cow::Owned(text.chars().take(shown).collect()))
+    }
+}
+
+fn pending_height(tab: &crate::app::TabSession, wrap_width: usize) -> usize {
+    pending_revealed_text(tab)
+        .as_deref()
+        .map(|text| agent_markdown_lines(text, wrap_width, theme::DOT_AGENT).len())
+        .unwrap_or(0)
+}
+
 fn build_pending_stream_lines<'a>(app: &App, wrap_width: usize) -> Vec<Line<'a>> {
-    let tab = app.current_tab();
-    let Some(text) = pending_render_text(tab) else {
+    build_pending_stream_lines_for_tab(app.current_tab(), wrap_width)
+}
+
+fn build_pending_stream_lines_for_tab<'a>(
+    tab: &crate::app::TabSession,
+    wrap_width: usize,
+) -> Vec<Line<'a>> {
+    let Some(revealed) = pending_revealed_text(tab) else {
         return Vec::new();
     };
     // Typewriter smoothing: only reveal the first `reveal_chars` characters of
@@ -510,24 +700,7 @@ fn build_pending_stream_lines<'a>(app: &App, wrap_width: usize) -> Vec<Line<'a>>
     // upstream ~90-char-every-~100ms bursts into a smooth character flow. The
     // full text is always in `turn.buffer()`, and finalize commits it in full,
     // so this never drops or delays the final content.
-    let revealed: Cow<'_, str> = {
-        let total = text.chars().count();
-        let shown = tab.reveal_chars.min(total);
-        if shown >= total {
-            text
-        } else {
-            Cow::Owned(text.chars().take(shown).collect())
-        }
-    };
-    let mut lines = Vec::new();
-    push_dot_prefixed_lines(
-        &mut lines,
-        &revealed,
-        wrap_width,
-        theme::DOT_AGENT,
-        theme::AGENT_TEXT,
-    );
-    lines
+    agent_markdown_lines(&revealed, wrap_width, theme::DOT_AGENT)
 }
 
 fn build_message_lines<'a>(
@@ -545,13 +718,7 @@ fn build_message_lines<'a>(
             lines.push(Line::default());
         }
         ChatMessage::Agent(text) => {
-            push_dot_prefixed_lines(
-                &mut lines,
-                text,
-                wrap_width,
-                theme::DOT_AGENT,
-                theme::AGENT_TEXT,
-            );
+            lines.extend(agent_markdown_lines(text, wrap_width, theme::DOT_AGENT));
             if !agent_streaming || !is_last_message {
                 lines.push(Line::default());
             }
@@ -680,7 +847,10 @@ fn build_message_lines<'a>(
             }
         }
         ChatMessage::Plan(entries) => {
-            lines.push(Line::from(Span::styled(t!("chat.plan_header").into_owned(), theme::PLAN_STYLE)));
+            lines.push(Line::from(Span::styled(
+                t!("chat.plan_header").into_owned(),
+                theme::PLAN_STYLE,
+            )));
             for entry in entries {
                 let marker = match entry.status {
                     PlanEntryStatus::Completed => t!("chat.plan_marker_completed").into_owned(),
@@ -1032,7 +1202,10 @@ mod tests {
         assert_eq!(line_text(line), expected_text);
         assert_eq!(line.spans[0].style, expected_marker_style);
         assert_eq!(line.spans[2].style, theme::TOOL_CALL_TITLE);
-        assert_eq!(line.spans.get(3).map(|span| span.style), expected_detail_style);
+        assert_eq!(
+            line.spans.get(3).map(|span| span.style),
+            expected_detail_style
+        );
     }
 
     /// A `location` hint renders as a dim `(path)` suffix right after the
@@ -1314,6 +1487,59 @@ mod tests {
     }
 
     #[test]
+    fn pending_stream_renders_markdown_and_preserves_partial_syntax() {
+        let complete = "# Heading\n\nStreaming **bold** text";
+        let complete_tab = streaming_tab(complete, complete.chars().count());
+
+        let lines = build_pending_stream_lines_for_tab(&complete_tab, 80);
+        assert_eq!(line_text(&lines[0]), "● Heading");
+        assert!(lines.iter().flat_map(|line| &line.spans).any(|span| {
+            span.content == "bold" && span.style == theme::AGENT_TEXT.add_modifier(Modifier::BOLD)
+        }));
+
+        let partial = "# Heading\n\nStreaming **bo";
+        let partial_tab = streaming_tab(partial, partial.chars().count());
+        let partial_text = build_pending_stream_lines_for_tab(&partial_tab, 80)
+            .iter()
+            .map(line_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(partial_text.contains("bo"));
+    }
+
+    #[test]
+    fn narrow_table_preserves_rows_and_matches_finalized_and_pending_heights() {
+        let table = concat!(
+            "| Key | One | Two |\n",
+            "|:----|----:|----:|\n",
+            "| A | A1 | A2 |\n",
+            "| B | B1 | B2 |\n",
+            "| C | C1 | C2 |",
+        );
+        let width = 24_u16;
+        let message = ChatMessage::Agent(table.into());
+        let finalized = build_message_lines(&message, false, false, None, 0, width as usize);
+        let finalized_text = finalized
+            .iter()
+            .map(line_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        for row in ["│ A", "│ B", "│ C"] {
+            assert!(finalized_text.contains(row), "missing table row {row}");
+        }
+        assert_eq!(finalized.len(), message_height(&message, width as usize));
+
+        let mut pending_tab = streaming_tab(table, table.chars().count());
+        let pending = build_pending_stream_lines_for_tab(&pending_tab, width as usize);
+        assert_eq!(pending.len(), pending_height(&pending_tab, width as usize));
+
+        pending_tab.reveal_chars = table.find("| C").expect("final table row");
+        let partial = build_pending_stream_lines_for_tab(&pending_tab, width as usize);
+        assert_eq!(partial.len(), pending_height(&pending_tab, width as usize));
+    }
+
+    #[test]
     fn thinking_activity_follows_turn_lifecycle() {
         let mut tab = streaming_tab("", 0);
         assert!(should_show_turn_activity(&tab));
@@ -1328,10 +1554,7 @@ mod tests {
         assert_eq!(breathing_dot(5), "•");
         assert_eq!(breathing_dot(9), "·");
         assert_eq!(breathing_dot(14), "•");
-        assert_eq!(
-            breathing_dot(crate::ui::ACTIVITY_CYCLE_FRAMES),
-            "●"
-        );
+        assert_eq!(breathing_dot(crate::ui::ACTIVITY_CYCLE_FRAMES), "●");
     }
 
     #[test]
@@ -1359,8 +1582,7 @@ mod tests {
             exit_code: None,
         };
 
-        let matching_lines =
-            build_message_lines(&matching, false, false, Some("tool-2"), 9, 80);
+        let matching_lines = build_message_lines(&matching, false, false, Some("tool-2"), 9, 80);
         let other_lines = build_message_lines(&other, false, false, Some("tool-2"), 9, 80);
 
         assert_eq!(matching_lines[0].spans[0].content, "·");
@@ -1443,8 +1665,9 @@ mod tests {
         // must round-trip below the threshold.
         let under: String = std::iter::repeat('é').take(MAX_RENDER_LINE_CHARS).collect();
         assert!(matches!(truncate_render_text(&under), Cow::Borrowed(_)));
-        let over: String =
-            std::iter::repeat('é').take(MAX_RENDER_LINE_CHARS + 10).collect();
+        let over: String = std::iter::repeat('é')
+            .take(MAX_RENDER_LINE_CHARS + 10)
+            .collect();
         let _ = truncate_render_text(&over).into_owned(); // must not panic
     }
 
@@ -1455,7 +1678,13 @@ mod tests {
         // Models often prefix prose with \n / \n\n; the dot must land on the
         // first content row, not burn on an empty line.
         let mut lines = Vec::new();
-        push_dot_prefixed_lines(&mut lines, "\n\nHello", 40, theme::DOT_AGENT, theme::AGENT_TEXT);
+        push_dot_prefixed_lines(
+            &mut lines,
+            "\n\nHello",
+            40,
+            theme::DOT_AGENT,
+            theme::AGENT_TEXT,
+        );
         assert_eq!(lines.len(), 1, "leading blanks must be dropped");
         assert_eq!(line_text(&lines[0]), "● Hello");
     }
@@ -1463,9 +1692,18 @@ mod tests {
     #[test]
     fn dot_prefix_preserves_paragraph_break_and_indents_continuation() {
         let mut lines = Vec::new();
-        push_dot_prefixed_lines(&mut lines, "A\n\nB", 40, theme::DOT_AGENT, theme::AGENT_TEXT);
+        push_dot_prefixed_lines(
+            &mut lines,
+            "A\n\nB",
+            40,
+            theme::DOT_AGENT,
+            theme::AGENT_TEXT,
+        );
         let texts: Vec<String> = lines.iter().map(line_text).collect();
-        assert_eq!(texts, vec!["● A".to_string(), String::new(), "  B".to_string()]);
+        assert_eq!(
+            texts,
+            vec!["● A".to_string(), String::new(), "  B".to_string()]
+        );
     }
 
     #[test]
@@ -1480,11 +1718,70 @@ mod tests {
             theme::AGENT_TEXT,
         );
         assert!(lines.len() >= 2, "long paragraph must wrap");
-        assert!(line_text(&lines[0]).starts_with("● "), "first row gets the dot");
+        assert!(
+            line_text(&lines[0]).starts_with("● "),
+            "first row gets the dot"
+        );
         assert!(
             line_text(&lines[1]).starts_with("  "),
             "continuation rows get a 2-cell hanging indent"
         );
+    }
+
+    #[test]
+    fn agent_message_renders_multiline_markdown_with_theme_relative_styles() {
+        let message =
+            ChatMessage::Agent("# Heading\n\nFirst **bold** line\n\nSecond paragraph".into());
+
+        let lines = build_message_lines(&message, false, false, None, 0, 80);
+        let texts: Vec<String> = lines.iter().map(line_text).collect();
+
+        assert_eq!(texts[0], "● Heading");
+        assert!(texts.iter().any(|line| line == "  Second paragraph"));
+        assert!(lines.iter().flat_map(|line| &line.spans).any(|span| {
+            span.content == "bold" && span.style == theme::AGENT_TEXT.add_modifier(Modifier::BOLD)
+        }));
+        assert_eq!(lines.len(), message_height(&message, 80));
+    }
+
+    #[test]
+    fn agent_markdown_styles_follow_the_agent_pane_palette() {
+        let pane_relative = [
+            theme::AGENT_TEXT,
+            theme::MARKDOWN_HEADING,
+            theme::MARKDOWN_CODE,
+            theme::MARKDOWN_QUOTE,
+            theme::MARKDOWN_META,
+            theme::MARKDOWN_TABLE_HEADER,
+            theme::MARKDOWN_TABLE_BORDER,
+        ];
+
+        for style in pane_relative {
+            assert_eq!(style.fg, Some(Color::Reset));
+            assert_eq!(style.bg, None);
+        }
+        assert_eq!(theme::MARKDOWN_LINK.fg, Some(Color::Cyan));
+        assert_eq!(theme::MARKDOWN_LINK.bg, None);
+        assert!(
+            theme::MARKDOWN_CODE
+                .add_modifier
+                .contains(Modifier::REVERSED)
+        );
+
+        let lines = agent_markdown_lines(
+            concat!(
+                "# Heading\n\n",
+                "[link](https://example.test) and `code`\n\n",
+                "> quote\n\n",
+                "| H | V |\n|---|---|\n| A | B |",
+            ),
+            80,
+            theme::DOT_AGENT,
+        );
+        assert!(lines
+            .iter()
+            .flat_map(|line| &line.spans)
+            .all(|span| span.style.bg.is_none()));
     }
 
     // ── push_prompt_prefixed_lines (regression: issue #492) ─────────────────
@@ -1499,7 +1796,10 @@ mod tests {
         let mut lines = Vec::new();
         push_prompt_prefixed_lines(&mut lines, concat!("line one\n", "line two"), 40);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
-        assert_eq!(texts, vec!["> line one".to_string(), "  line two".to_string()]);
+        assert_eq!(
+            texts,
+            vec!["> line one".to_string(), "  line two".to_string()]
+        );
     }
 
     #[test]
@@ -1515,7 +1815,10 @@ mod tests {
         let mut lines = Vec::new();
         push_prompt_prefixed_lines(&mut lines, "A\n\nB", 40);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
-        assert_eq!(texts, vec!["> A".to_string(), String::new(), "  B".to_string()]);
+        assert_eq!(
+            texts,
+            vec!["> A".to_string(), String::new(), "  B".to_string()]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Render finalized and streaming agent responses with theme-relative CommonMark/GFM styles, preserve multiline and table layout height consistency, cover partial streaming syntax and independent agent-pane themes, and update third-party dependency notices.

## Summary of the Pull Request
incremental markdown rendering.

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
