### PR TITLE
Use detected CLIs for Claude and Codex ACP adapters

### DIFF
--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -7,6 +7,7 @@
 #include "FreOverlay.g.cpp"
 
 #include "../inc/AgentRegistry.h"
+#include "../inc/AgentAvailability.h"
 #include "../inc/WtaProcess.h"
 #include "../inc/ShellIntegration.h"
 #include "../inc/RtlHelper.h"
@@ -115,6 +116,7 @@ namespace winrt::TerminalApp::implementation
         }
 
         const auto allowedAgents = Reg::FilteredAcpAgents();
+        const auto availableAgents = ::Microsoft::Terminal::AgentAvailability::ProbeHostAgentIds();
         auto items = AgentComboBox().Items();
         items.Clear();
         int32_t selectedIndex = 0;
@@ -122,7 +124,7 @@ namespace winrt::TerminalApp::implementation
 
         for (const auto& a : allowedAgents)
         {
-            const bool installed = _IsAgentInstalled(std::wstring{ a.id }.c_str());
+            const bool installed = availableAgents.contains(std::wstring{ a.id });
             const bool isCopilot = (a.id == L"copilot");
 
             // Show Copilot always + detected agents only
@@ -1573,10 +1575,9 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        // After installing prerequisites, refresh the current process's
-        // PATH from the Windows registry so SearchPathW (used by
-        // _DetectAgentCli, Settings UI, etc.) can find freshly-installed
-        // CLIs without restarting Terminal.
+        // After installing prerequisites, refresh the current process's PATH
+        // from the Windows registry so generic executable checks and child
+        // processes can find freshly-installed CLIs without restarting.
         if (needsCopilot || needsNode)
         {
             _agentPaneLog("[FRE] Refreshing process PATH from registry");

--- a/src/cascadia/TerminalApp/FreOverlay.h
+++ b/src/cascadia/TerminalApp/FreOverlay.h
@@ -129,7 +129,8 @@ namespace winrt::TerminalApp::implementation
         // after a save) and preserves the current selection.
         void _PopulateAgentComboBox();
 
-        // Detect whether an executable is on PATH.
+        // Detect whether a generic executable is on PATH. ACP agent choices
+        // use WTA's authoritative Host availability probe instead.
         static bool _IsAgentInstalled(const wchar_t* name);
         static bool _IsNodeInstalled();
         static bool _IsWingetInstalled();

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -18,6 +18,7 @@
 #include "../../types/inc/utils.hpp"
 #include "../WinRTUtils/inc/WtExeUtils.h"
 #include "../inc/AcpModelUtils.h"
+#include "../inc/AgentAvailability.h"
 #include "../inc/AgentRegistry.h"
 #include "../inc/AgentPolicy.h"
 #include "../inc/AgentPaneBackend.h"
@@ -880,8 +881,8 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Method Description:
-    // - Auto-detects an installed agent CLI by iterating the GPO-filtered
-    //   built-in agent list and searching the system PATH for each.
+    // - Auto-detects a Host agent that WTA can launch by iterating the
+    //   GPO-filtered built-in list against WTA's authoritative probe.
     // Arguments:
     // - <none>
     // Return Value:
@@ -890,17 +891,15 @@ namespace winrt::TerminalApp::implementation
     //   through _BuildAgentCommandLine to get a launchable command.
     winrt::hstring TerminalPage::_DetectAgentCli() const
     {
-        wchar_t buffer[MAX_PATH];
-
         // Walk the policy-filtered agent list so we never auto-detect an
         // agent that is blocked by GPO.  FilteredAcpAgents() returns only
         // agents whose id passes AgentPolicy::IsAgentAllowed(); when no
         // AllowedAgents policy is configured it returns all built-in agents.
         namespace Reg = ::Microsoft::Terminal::Settings::Model::AgentRegistry;
+        const auto availableAgents = ::Microsoft::Terminal::AgentAvailability::ProbeHostAgentIds();
         for (const auto& agent : Reg::FilteredAcpAgents())
         {
-            if (SearchPathW(nullptr, agent.id.data(), L".exe", MAX_PATH, buffer, nullptr) > 0 ||
-                SearchPathW(nullptr, agent.id.data(), L".cmd", MAX_PATH, buffer, nullptr) > 0)
+            if (availableAgents.contains(std::wstring{ agent.id }))
             {
                 return winrt::hstring{ agent.id };
             }

--- a/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgentsViewModel.cpp
@@ -9,6 +9,7 @@
 #include "CustomModelProviderEntry.g.cpp"
 #include "EnumEntry.h"
 #include "../inc/AcpModelUtils.h"
+#include "../inc/AgentAvailability.h"
 #include "../inc/AgentRegistry.h"
 #include "../inc/AgentHooksStatus.h"
 #include "../inc/CustomAgentId.h"
@@ -171,10 +172,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // installed — the dropdown only offers choices the user can actually
         // launch.
         const auto filteredAcp = Reg::FilteredAcpAgents();
+        const auto availableAcpAgents = ::Microsoft::Terminal::AgentAvailability::ProbeHostAgentIds();
         std::vector<Editor::AgentEntry> acpEntries;
         for (const auto& a : filteredAcp)
         {
-            if (!_IsAgentInstalled(std::wstring{ a.id }.c_str()))
+            if (!availableAcpAgents.contains(std::wstring{ a.id }))
             {
                 continue;
             }

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -10,6 +10,7 @@
 
 #include "../WinRTUtils/inc/Utils.h"
 #include "../inc/AgentPaneBackend.h"
+#include "../inc/AgentAvailability.h"
 #include "../inc/AgentRegistry.h"
 #include "../inc/ShellIntegrationProfileGate.h"
 #include "../inc/WslShellIntegration.h"
@@ -55,18 +56,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return id.empty() ? winrt::hstring{ L"Agent" } : winrt::hstring{ id };
     }
 
-    static bool _HostAgentInstalled(const std::wstring_view id)
-    {
-        wchar_t path[MAX_PATH];
-        const std::wstring executable{ id };
-        if (SearchPathW(nullptr, executable.c_str(), L".exe", MAX_PATH, path, nullptr) > 0)
-        {
-            return true;
-        }
-        const auto commandShim = executable + L".cmd";
-        return SearchPathW(nullptr, commandShim.c_str(), nullptr, MAX_PATH, path, nullptr) > 0;
-    }
-
     static void _RebuildAgentBackendList(
         const Windows::Foundation::Collections::IObservableVector<Editor::AgentEntry>& list,
         const std::wstring_view globalId,
@@ -77,6 +66,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         namespace Backend = ::Microsoft::Terminal::Settings::Model;
 
+        const auto availableHostAgents = ::Microsoft::Terminal::AgentAvailability::ProbeHostAgentIds();
         std::vector<Editor::AgentEntry> entries;
         const auto globalEntry = winrt::make<implementation::AgentEntry>(
             L"",
@@ -89,7 +79,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         bool globalEntryAdded = false;
         for (const auto& agent : allowedAgents)
         {
-            if (_HostAgentInstalled(agent.id))
+            if (availableHostAgents.contains(std::wstring{ agent.id }))
             {
                 const bool isGlobalAgent = agent.id == globalId;
                 entries.emplace_back(winrt::make<implementation::AgentEntry>(

--- a/src/cascadia/inc/AgentAvailability.h
+++ b/src/cascadia/inc/AgentAvailability.h
@@ -34,7 +34,8 @@ namespace Microsoft::Terminal::AgentAvailability
             const auto& id = agent["id"];
             if (id.isString())
             {
-                ids.emplace(winrt::to_hstring(id.asString()));
+                const auto hstringId = winrt::to_hstring(id.asString());
+                ids.emplace(hstringId.c_str(), hstringId.size());
             }
         }
         return ids;

--- a/src/cascadia/inc/AgentAvailability.h
+++ b/src/cascadia/inc/AgentAvailability.h
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include "WtaProcess.h"
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+
+#include <json/json.h>
+#include <winrt/base.h>
+
+namespace Microsoft::Terminal::AgentAvailability
+{
+    inline std::unordered_set<std::wstring> ParseHostAgentIds(const std::string_view payload)
+    {
+        Json::Value root;
+        Json::CharReaderBuilder builder;
+        const std::unique_ptr<Json::CharReader> reader{ builder.newCharReader() };
+        std::string errors;
+        if (!reader->parse(payload.data(), payload.data() + payload.size(), &root, &errors) ||
+            !root.isObject() ||
+            !root["agents"].isArray())
+        {
+            return {};
+        }
+
+        std::unordered_set<std::wstring> ids;
+        for (const auto& agent : root["agents"])
+        {
+            const auto& id = agent["id"];
+            if (id.isString())
+            {
+                ids.emplace(winrt::to_hstring(id.asString()));
+            }
+        }
+        return ids;
+    }
+
+    inline std::unordered_set<std::wstring> ProbeHostAgentIds()
+    {
+        const auto wtaPath = WtaProcess::ResolveWtaExePath();
+        if (wtaPath.empty())
+        {
+            return {};
+        }
+
+        const auto output = WtaProcess::RunWtaCaptureStdout(
+            wtaPath,
+            L"probe-host-agents",
+            2'000);
+        return ParseHostAgentIds(output);
+    }
+}

--- a/tools/wta/src/agent_check.rs
+++ b/tools/wta/src/agent_check.rs
@@ -444,7 +444,11 @@ fn merge_paths(fresh: &str, current: &str) -> String {
 pub fn check_agent(agent_id: &str) -> AgentStatus {
     let profile = agent_registry::lookup_profile_by_id(agent_id);
     let cli_path = find_exe(agent_id);
-    let cli_found = cli_path.is_some();
+    let cli_found = host_requirements_available(
+        profile,
+        cli_path.is_some(),
+        || find_exe("npx").is_some(),
+    );
 
     AgentStatus {
         id: agent_id.to_string(),
@@ -455,6 +459,22 @@ pub fn check_agent(agent_id: &str) -> AgentStatus {
         auth_hint: profile.auth_hint.to_string(),
         auto_installable: agent_id == "copilot",
     }
+}
+
+fn host_requirements_available(
+    profile: &agent_registry::AgentProfile,
+    cli_found: bool,
+    find_npx: impl FnOnce() -> bool,
+) -> bool {
+    cli_found && (!profile.acp_launch_command.starts_with("npx ") || find_npx())
+}
+
+/// Whether a built-in agent has every Host-side executable required to start
+/// its configured ACP command. Adapter-backed agents need both their native
+/// CLI and npx; this is the same gate used by preflight and exposed to the
+/// Terminal settings surfaces through `probe-host-agents`.
+pub fn host_agent_available(agent_id: &str) -> bool {
+    check_agent(agent_id).cli_found
 }
 
 pub async fn check_agent_in_source(
@@ -740,6 +760,17 @@ mod tests {
             find_configured_executable(Some(OsStr::new(r"C:\Missing\codex.exe")), |_| false),
             None
         );
+    }
+
+    #[test]
+    fn host_adapter_requires_both_native_cli_and_npx() {
+        let claude = agent_registry::lookup_profile_by_id("claude");
+        assert!(host_requirements_available(claude, true, || true));
+        assert!(!host_requirements_available(claude, true, || false));
+        assert!(!host_requirements_available(claude, false, || true));
+
+        let copilot = agent_registry::lookup_profile_by_id("copilot");
+        assert!(host_requirements_available(copilot, true, || false));
     }
 
     #[test]

--- a/tools/wta/src/agent_check.rs
+++ b/tools/wta/src/agent_check.rs
@@ -57,6 +57,7 @@ pub fn find_exe(agent_id: &str) -> Option<String> {
         return find_claude_executable_in_path(
             &path_var,
             std::env::var_os(CLAUDE_CODE_EXECUTABLE).as_deref(),
+            claude_sdk_platform_package(std::env::consts::ARCH),
             Path::is_file,
         )
         .map(|path| path.to_string_lossy().into_owned());
@@ -101,28 +102,62 @@ pub fn find_exe(agent_id: &str) -> Option<String> {
 fn find_claude_executable_in_path(
     path_var: &OsStr,
     configured_executable: Option<&OsStr>,
+    sdk_platform_package: Option<&str>,
     is_file: impl Fn(&Path) -> bool,
 ) -> Option<PathBuf> {
-    if let Some(path) = find_configured_executable(configured_executable, &is_file) {
+    if let Some(path) = find_configured_native_executable(configured_executable, &is_file) {
         return Some(path);
     }
 
     for directory in std::env::split_paths(path_var) {
-        let candidates = [
+        let mut candidates = vec![
             directory.join("claude.exe"),
             directory.join(r"node_modules\@anthropic-ai\claude-code\bin\claude.exe"),
-            directory.join(
-                r"node_modules\@anthropic-ai\claude-agent-sdk-win32-x64\claude.exe",
-            ),
-            directory.join(
-                r"node_modules\@anthropic-ai\claude-code\node_modules\@anthropic-ai\claude-agent-sdk-win32-x64\claude.exe",
-            ),
         ];
+        if let Some(package) = sdk_platform_package {
+            candidates.push(
+                directory
+                    .join("node_modules")
+                    .join("@anthropic-ai")
+                    .join(package)
+                    .join("claude.exe"),
+            );
+            candidates.push(
+                directory
+                    .join("node_modules")
+                    .join("@anthropic-ai")
+                    .join("claude-code")
+                    .join("node_modules")
+                    .join("@anthropic-ai")
+                    .join(package)
+                    .join("claude.exe"),
+            );
+        }
         if let Some(path) = candidates.into_iter().find(|path| is_file(path)) {
             return Some(path);
         }
     }
     None
+}
+
+fn claude_sdk_platform_package(arch: &str) -> Option<&'static str> {
+    match arch {
+        "x86_64" => Some("claude-agent-sdk-win32-x64"),
+        "aarch64" => Some("claude-agent-sdk-win32-arm64"),
+        _ => None,
+    }
+}
+
+fn find_configured_native_executable(
+    configured_executable: Option<&OsStr>,
+    is_file: impl Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    let path = PathBuf::from(configured_executable?);
+    let is_exe = path
+        .extension()
+        .and_then(OsStr::to_str)
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("exe"));
+    (is_exe && is_file(&path)).then_some(path)
 }
 
 fn find_configured_executable(
@@ -636,6 +671,7 @@ mod tests {
         let resolved = find_claude_executable_in_path(
             OsStr::new(r"C:\npm"),
             Some(configured.as_os_str()),
+            Some("claude-agent-sdk-win32-x64"),
             |path| path == configured,
         );
         assert_eq!(resolved.as_deref(), Some(configured));
@@ -645,8 +681,12 @@ mod tests {
     fn claude_resolution_finds_native_binary_next_to_npm_shim_directory() {
         let expected =
             Path::new(r"C:\npm\node_modules\@anthropic-ai\claude-code\bin\claude.exe");
-        let resolved =
-            find_claude_executable_in_path(OsStr::new(r"C:\npm"), None, |path| path == expected);
+        let resolved = find_claude_executable_in_path(
+            OsStr::new(r"C:\npm"),
+            None,
+            Some("claude-agent-sdk-win32-x64"),
+            |path| path == expected,
+        );
         assert_eq!(resolved.as_deref(), Some(expected));
     }
 
@@ -655,17 +695,37 @@ mod tests {
         let expected = Path::new(
             r"C:\npm\node_modules\@anthropic-ai\claude-agent-sdk-win32-x64\claude.exe",
         );
-        let resolved =
-            find_claude_executable_in_path(OsStr::new(r"C:\npm"), None, |path| path == expected);
+        let resolved = find_claude_executable_in_path(
+            OsStr::new(r"C:\npm"),
+            None,
+            Some("claude-agent-sdk-win32-x64"),
+            |path| path == expected,
+        );
         assert_eq!(resolved.as_deref(), Some(expected));
     }
 
     #[test]
     fn claude_resolution_rejects_shim_only_installation() {
-        let resolved = find_claude_executable_in_path(OsStr::new(r"C:\npm"), None, |path| {
-            path == Path::new(r"C:\npm\claude.cmd")
-        });
+        let resolved = find_claude_executable_in_path(
+            OsStr::new(r"C:\npm"),
+            Some(OsStr::new(r"C:\npm\claude.cmd")),
+            Some("claude-agent-sdk-win32-x64"),
+            |path| path == Path::new(r"C:\npm\claude.cmd"),
+        );
         assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn claude_sdk_package_matches_windows_architecture() {
+        assert_eq!(
+            claude_sdk_platform_package("x86_64"),
+            Some("claude-agent-sdk-win32-x64")
+        );
+        assert_eq!(
+            claude_sdk_platform_package("aarch64"),
+            Some("claude-agent-sdk-win32-arm64")
+        );
+        assert_eq!(claude_sdk_platform_package("x86"), None);
     }
 
     #[test]

--- a/tools/wta/src/agent_check.rs
+++ b/tools/wta/src/agent_check.rs
@@ -11,9 +11,13 @@
 //!   - `ensure_installed`  — find_exe → install if missing → refresh_path → find_exe
 
 use crate::agent_registry;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
 
 const WSL_AGENT_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const WSL_AGENT_PROBE_ATTEMPTS: usize = 3;
+const CLAUDE_CODE_EXECUTABLE: &str = "CLAUDE_CODE_EXECUTABLE";
+const CODEX_PATH: &str = "CODEX_PATH";
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
@@ -40,11 +44,31 @@ impl AgentStatus {
 
 // ─── Basic functions ────────────────────────────────────────────────────────
 
-/// Find the agent executable using a fresh PATH read from the Windows registry.
-/// Returns the full path if found, None otherwise.
+/// Find the executable used by an agent. Claude's ACP adapter needs the native
+/// binary rather than the npm shim used to launch the interactive CLI.
 pub fn find_exe(agent_id: &str) -> Option<String> {
     let profile = agent_registry::lookup_profile_by_id(agent_id);
-    let path_var = fresh_path();
+    let path_var = spawn_path()
+        .map(std::ffi::OsString::from)
+        .or_else(|| std::env::var_os("PATH"))
+        .unwrap_or_default();
+
+    if profile.id == agent_registry::CLAUDE_AGENT_ID {
+        return find_claude_executable_in_path(
+            &path_var,
+            std::env::var_os(CLAUDE_CODE_EXECUTABLE).as_deref(),
+            Path::is_file,
+        )
+        .map(|path| path.to_string_lossy().into_owned());
+    }
+    if profile.id == agent_registry::CODEX_AGENT_ID {
+        if let Some(path) =
+            find_configured_executable(std::env::var_os(CODEX_PATH).as_deref(), Path::is_file)
+        {
+            return Some(path.to_string_lossy().into_owned());
+        }
+    }
+
     let resolved = agent_registry::resolve_bare_agent_name(agent_id);
 
     // Try resolved name first (e.g. "copilot.exe")
@@ -72,6 +96,41 @@ pub fn find_exe(agent_id: &str) -> Option<String> {
     }
 
     None
+}
+
+fn find_claude_executable_in_path(
+    path_var: &OsStr,
+    configured_executable: Option<&OsStr>,
+    is_file: impl Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    if let Some(path) = find_configured_executable(configured_executable, &is_file) {
+        return Some(path);
+    }
+
+    for directory in std::env::split_paths(path_var) {
+        let candidates = [
+            directory.join("claude.exe"),
+            directory.join(r"node_modules\@anthropic-ai\claude-code\bin\claude.exe"),
+            directory.join(
+                r"node_modules\@anthropic-ai\claude-agent-sdk-win32-x64\claude.exe",
+            ),
+            directory.join(
+                r"node_modules\@anthropic-ai\claude-code\node_modules\@anthropic-ai\claude-agent-sdk-win32-x64\claude.exe",
+            ),
+        ];
+        if let Some(path) = candidates.into_iter().find(|path| is_file(path)) {
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn find_configured_executable(
+    configured_executable: Option<&OsStr>,
+    is_file: impl Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    let path = PathBuf::from(configured_executable?);
+    is_file(&path).then_some(path)
 }
 
 /// Resolve a native Linux executable inside one WSL distro.
@@ -570,6 +629,58 @@ fn expand_env_vars(s: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn claude_resolution_prefers_configured_native_executable() {
+        let configured = Path::new(r"C:\Claude\claude.exe");
+        let resolved = find_claude_executable_in_path(
+            OsStr::new(r"C:\npm"),
+            Some(configured.as_os_str()),
+            |path| path == configured,
+        );
+        assert_eq!(resolved.as_deref(), Some(configured));
+    }
+
+    #[test]
+    fn claude_resolution_finds_native_binary_next_to_npm_shim_directory() {
+        let expected =
+            Path::new(r"C:\npm\node_modules\@anthropic-ai\claude-code\bin\claude.exe");
+        let resolved =
+            find_claude_executable_in_path(OsStr::new(r"C:\npm"), None, |path| path == expected);
+        assert_eq!(resolved.as_deref(), Some(expected));
+    }
+
+    #[test]
+    fn claude_resolution_finds_direct_global_sdk_binary() {
+        let expected = Path::new(
+            r"C:\npm\node_modules\@anthropic-ai\claude-agent-sdk-win32-x64\claude.exe",
+        );
+        let resolved =
+            find_claude_executable_in_path(OsStr::new(r"C:\npm"), None, |path| path == expected);
+        assert_eq!(resolved.as_deref(), Some(expected));
+    }
+
+    #[test]
+    fn claude_resolution_rejects_shim_only_installation() {
+        let resolved = find_claude_executable_in_path(OsStr::new(r"C:\npm"), None, |path| {
+            path == Path::new(r"C:\npm\claude.cmd")
+        });
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn configured_adapter_path_must_exist() {
+        let configured = Path::new(r"C:\Codex\codex.exe");
+        assert_eq!(
+            find_configured_executable(Some(configured.as_os_str()), |path| path == configured)
+                .as_deref(),
+            Some(configured)
+        );
+        assert_eq!(
+            find_configured_executable(Some(OsStr::new(r"C:\Missing\codex.exe")), |_| false),
+            None
+        );
+    }
 
     #[test]
     fn merge_paths_prefers_fresh_and_removes_duplicates_case_insensitively() {

--- a/tools/wta/src/cli/args.rs
+++ b/tools/wta/src/cli/args.rs
@@ -418,6 +418,11 @@ pub(crate) enum Command {
         #[arg(long)]
         wsl_distro: String,
     },
+    /// List built-in ACP agents that WTA can launch on the Windows host.
+    /// Used by FRE, Settings, and automatic agent selection so those surfaces
+    /// share WTA's executable resolution with the actual ACP spawn path.
+    #[command(hide = true)]
+    ProbeHostAgents,
     /// Diagnostic: spawn an agent CLI, ACP `initialize`, then call
     /// `session/list` (`list_sessions`) and print what it returns.
     /// Used to evaluate whether ACP session enumeration can replace

--- a/tools/wta/src/cli/mod.rs
+++ b/tools/wta/src/cli/mod.rs
@@ -66,6 +66,7 @@ pub(crate) async fn run(command: Command, json_mode: bool) -> Result<()> {
         },
         Command::ProbeModels { agent } => probes::run_models(&agent).await,
         Command::ProbeAgentSources { wsl_distro } => probes::run_agent_sources(&wsl_distro).await,
+        Command::ProbeHostAgents => probes::run_host_agents(),
         Command::ProbeSessions { agent } => probes::run_sessions(&agent).await,
         Command::ProbeHostSessions { agent } => probes::run_host_sessions(&agent).await,
         Command::ProbeWslSessions { cli } => probes::run_wsl_sessions(cli.as_deref()).await,

--- a/tools/wta/src/cli/probes.rs
+++ b/tools/wta/src/cli/probes.rs
@@ -58,6 +58,29 @@ struct AgentSourceProbeResult {
     agents: Vec<AgentSourceProbeEntry>,
 }
 
+#[derive(serde::Serialize)]
+struct HostAgentProbeResult {
+    agents: Vec<AgentSourceProbeEntry>,
+}
+
+pub(crate) fn run_host_agents() -> Result<()> {
+    let agents = crate::agent_registry::KNOWN_AGENTS
+        .iter()
+        .filter(|profile| crate::agent_check::host_agent_available(profile.id))
+        .map(|profile| AgentSourceProbeEntry {
+            id: profile.id,
+            display_name: profile.display_name,
+        })
+        .collect();
+
+    println!(
+        "{}",
+        serde_json::to_string(&HostAgentProbeResult { agents })
+            .context("serialize Host agent probe")?
+    );
+    Ok(())
+}
+
 pub(crate) async fn run_agent_sources(wsl_distro: &str) -> Result<()> {
     let distro = wsl_distro.trim();
     anyhow::ensure!(!distro.is_empty(), "--wsl-distro must not be empty");

--- a/tools/wta/src/protocol/acp/spawn.rs
+++ b/tools/wta/src/protocol/acp/spawn.rs
@@ -250,6 +250,9 @@ pub(crate) fn spawn_agent_process(
     // ACP host. Scrub unconditionally; other agents don't care.
     cmd.env_remove("CLAUDECODE");
     configure_child_environment(&mut cmd, agent_cmd, agent_id, environment_policy)?;
+    if is_npx && should_omit_optional_dependencies(agent_cmd, agent_id) {
+        cmd.arg("--omit=optional");
+    }
 
     // Give the agent CLI a fresh PATH and make this package's `wta.exe`
     // App Execution Alias the first match. The package-specific alias directory
@@ -399,16 +402,47 @@ fn configure_child_environment(
     agent_id: Option<&str>,
     environment_policy: ChildEnvironmentPolicy,
 ) -> Result<Option<crate::agent_registry::ByokMode>> {
-    match environment_policy {
+    let profile = resolve_spawn_profile(agent_cmd, agent_id);
+    let configured_provider = match environment_policy {
         ChildEnvironmentPolicy::ApplySharedProvider => {
-            let profile = resolve_spawn_profile(agent_cmd, agent_id);
             crate::custom_model_provider::configure_child(command, profile.byok_mode)
         }
         ChildEnvironmentPolicy::CleanCloudDiscovery => {
             crate::custom_model_provider::scrub_child_for_cloud_discovery(command);
             Ok(None)
         }
-    }
+    }?;
+    configure_adapter_executable_environment(command, profile, crate::agent_check::find_exe)?;
+    Ok(configured_provider)
+}
+
+fn configure_adapter_executable_environment(
+    command: &mut tokio::process::Command,
+    profile: &crate::agent_registry::AgentProfile,
+    find_executable: impl FnOnce(&str) -> Option<String>,
+) -> Result<()> {
+    let (variable, missing_message) = match profile.id {
+        crate::agent_registry::CLAUDE_AGENT_ID => (
+            "CLAUDE_CODE_EXECUTABLE",
+            "Claude native binary not found. Reinstall Claude Code or set \
+             CLAUDE_CODE_EXECUTABLE to the full path of claude.exe",
+        ),
+        crate::agent_registry::CODEX_AGENT_ID => (
+            "CODEX_PATH",
+            "Codex executable not found. Reinstall Codex or set CODEX_PATH to its full path",
+        ),
+        _ => return Ok(()),
+    };
+    let executable = find_executable(profile.id).ok_or_else(|| anyhow!(missing_message))?;
+    command.env(variable, executable);
+    Ok(())
+}
+
+fn should_omit_optional_dependencies(agent_cmd: &str, agent_id: Option<&str>) -> bool {
+    matches!(
+        resolve_spawn_profile(agent_cmd, agent_id).id,
+        crate::agent_registry::CLAUDE_AGENT_ID | crate::agent_registry::CODEX_AGENT_ID
+    )
 }
 
 /// Spawn an ACP agent in the selected per-tab execution source.
@@ -635,6 +669,59 @@ mod tests {
                 "cloud policy must scrub {key}"
             );
         }
+    }
+
+    #[test]
+    fn adapter_spawns_use_the_same_executables_as_preflight() {
+        for (agent_id, variable, executable) in [
+            ("claude", "CLAUDE_CODE_EXECUTABLE", r"C:\Claude\claude.exe"),
+            ("codex", "CODEX_PATH", r"C:\Codex\codex.exe"),
+        ] {
+            let mut command = tokio::process::Command::new("npx");
+            let profile = crate::agent_registry::lookup_profile_by_id(agent_id);
+            configure_adapter_executable_environment(&mut command, profile, |requested_id| {
+                assert_eq!(requested_id, agent_id);
+                Some(executable.to_string())
+            })
+            .unwrap();
+            let configured_env: std::collections::HashMap<_, _> =
+                command.as_std().get_envs().collect();
+            assert_eq!(
+                configured_env.get(std::ffi::OsStr::new(variable)),
+                Some(&Some(std::ffi::OsStr::new(executable)))
+            );
+        }
+    }
+
+    #[test]
+    fn adapter_spawns_fail_before_launch_when_preflight_executable_is_missing() {
+        for agent_id in ["claude", "codex"] {
+            let mut command = tokio::process::Command::new("npx");
+            let profile = crate::agent_registry::lookup_profile_by_id(agent_id);
+            let error = configure_adapter_executable_environment(&mut command, profile, |_| None)
+                .unwrap_err();
+            assert!(error.to_string().contains("not found"));
+        }
+    }
+
+    #[test]
+    fn only_builtin_host_adapters_omit_optional_npm_dependencies() {
+        assert!(should_omit_optional_dependencies(
+            "npx -y @agentclientprotocol/claude-agent-acp@0.65.0",
+            Some("claude")
+        ));
+        assert!(should_omit_optional_dependencies(
+            "npx -y @agentclientprotocol/codex-acp@1.1.13",
+            Some("codex")
+        ));
+        assert!(!should_omit_optional_dependencies(
+            "npx -y @example/custom-agent",
+            Some("custom:test")
+        ));
+        assert!(!should_omit_optional_dependencies(
+            "copilot --acp --stdio",
+            Some("copilot")
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- resolve Claude's native `claude.exe` during the same preflight used by onboarding, including explicit `CLAUDE_CODE_EXECUTABLE`, npm's global Claude Code layout, and the SDK platform layout
- pass the resolved Claude/Codex executable to the ACP wrappers through `CLAUDE_CODE_EXECUTABLE` and `CODEX_PATH`
- launch the built-in host adapters with `--omit=optional` so npx does not install duplicate platform-native packages
- fail before wrapper startup when the executable required by a built-in adapter is unavailable

## Validation
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml adapter_spawns -- --nocapture`
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml claude_resolution -- --nocapture`
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml configured_adapter_path -- --nocapture`
- WTA suite: 1614 passed with the unrelated local `bundled_hook_commands_run_in_every_shell` test excluded because the deployed `wtcli.exe` does not expose `agent-hook`
- explicit-target WTA build
- live Claude FRE: `session/new` succeeded, global Claude executable ran, npx tree contained no `claude.exe`
- live Codex FRE: `session/new` succeeded, global Codex executable ran, npx tree contained no Codex platform package or `codex.exe`

Fixes #640