### PR TITLE
Recover hook install when a running agent CLI holds the plugin directory

### DIFF
--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -861,11 +861,13 @@ fn install_for_claude(home: &Path) -> InstallOutcome {
     }
 
     let plugin_ref = format!("{}@{}", PLUGIN_NAME, MARKETPLACE_NAME);
-    if let Err(e) = run_plugin_cli(
+    if let Err(e) = run_plugin_cli_unlocking(
         "claude",
         &["plugin", "install", &plugin_ref],
-        "agent_hooks",
         &[],
+        &[],
+        CliKind::Claude,
+        installed_plugin_dir(CliKind::Claude, home).as_deref(),
     ) {
         tracing::warn!(
             target: "agent_hooks",
@@ -890,7 +892,7 @@ fn install_for_claude(home: &Path) -> InstallOutcome {
 /// Trust step: after install, the user must run `/hooks` inside Codex
 /// to trust the plugin before any events fire. That's documented in
 /// the slice-C README; this function returns success on registration.
-fn install_for_codex(_home: &Path) -> InstallOutcome {
+fn install_for_codex(home: &Path) -> InstallOutcome {
     if !cli_binary_on_path(CliKind::Codex) {
         tracing::debug!(
             target: "agent_hooks",
@@ -936,11 +938,13 @@ fn install_for_codex(_home: &Path) -> InstallOutcome {
     }
 
     let plugin_ref = format!("{}@{}", PLUGIN_NAME, MARKETPLACE_NAME);
-    match run_plugin_cli(
+    match run_plugin_cli_unlocking(
         "codex",
         &["plugin", "add", &plugin_ref],
-        "agent_hooks",
         &[],
+        &[],
+        CliKind::Codex,
+        installed_plugin_dir(CliKind::Codex, home).as_deref(),
     ) {
         Ok(()) => InstallOutcome::Installed,
         Err(e) => {
@@ -1054,11 +1058,13 @@ fn install_for_copilot(home: &Path) -> InstallOutcome {
     }
 
     let plugin_ref = format!("{}@{}", PLUGIN_NAME, MARKETPLACE_NAME);
-    if let Err(e) = run_plugin_cli(
+    if let Err(e) = run_plugin_cli_unlocking(
         "copilot",
         &["plugin", "install", &plugin_ref],
-        "copilot_hooks",
         &[],
+        &[],
+        CliKind::Copilot,
+        installed_plugin_dir(CliKind::Copilot, home).as_deref(),
     ) {
         tracing::warn!(
             target: "copilot_hooks",
@@ -1093,7 +1099,7 @@ fn install_for_copilot(home: &Path) -> InstallOutcome {
 }
 
 /// Install hooks for Gemini CLI by spawning `gemini extensions install`.
-fn install_for_gemini(_home: &Path) -> InstallOutcome {
+fn install_for_gemini(home: &Path) -> InstallOutcome {
     if !cli_binary_on_path(CliKind::Gemini) {
         tracing::debug!(
             target: "gemini_hooks",
@@ -1148,7 +1154,7 @@ fn install_for_gemini(_home: &Path) -> InstallOutcome {
     // exit code `0xC0000409`. The extension files are already on disk
     // at that point, so match the success line to avoid a misleading
     // `gemini extensions install failed` warning in the trace log.
-    match run_plugin_cli_with_env(
+    match run_plugin_cli_unlocking(
         "gemini",
         &[
             "extensions",
@@ -1158,8 +1164,9 @@ fn install_for_gemini(_home: &Path) -> InstallOutcome {
             "--skip-settings",
         ],
         &[("GEMINI_CLI_TRUST_WORKSPACE", "true")],
-        "gemini_hooks",
         &["already installed", "installed successfully and enabled"],
+        CliKind::Gemini,
+        installed_plugin_dir(CliKind::Gemini, home).as_deref(),
     ) {
         Ok(()) => InstallOutcome::Installed,
         Err(e) => {
@@ -2228,11 +2235,14 @@ fn copilot_uninstall(home: Option<&Path>) -> CliUninstallResult {
 
     if which::which("copilot").is_ok() {
         out.attempted = true;
-        let cli_removed = spawn_step(
+        let cli_removed = spawn_step_unlocking(
             &mut out.messages,
             "copilot",
             &["plugin", "uninstall", &plugin_ref],
             &["is not installed"],
+            CliKind::Copilot,
+            home.and_then(|h| installed_plugin_dir(CliKind::Copilot, h))
+                .as_deref(),
         );
         let config_clean = cleanup_copilot_plugin_config(home, &mut out.messages);
         out.plugin_uninstalled = Some(cli_removed && config_clean);
@@ -2328,11 +2338,14 @@ fn claude_uninstall(home: Option<&Path>) -> CliUninstallResult {
 
     if which::which("claude").is_ok() {
         out.attempted = true;
-        out.plugin_uninstalled = Some(spawn_step(
+        out.plugin_uninstalled = Some(spawn_step_unlocking(
             &mut out.messages,
             "claude",
             &["plugin", "uninstall", &plugin_ref],
             &[],
+            CliKind::Claude,
+            home.and_then(|h| installed_plugin_dir(CliKind::Claude, h))
+                .as_deref(),
         ));
         out.marketplace_removed = Some(spawn_step(
             &mut out.messages,
@@ -2399,11 +2412,14 @@ fn gemini_uninstall(home: Option<&Path>) -> CliUninstallResult {
         // Either substring matching converts the failure to a clean
         // `ok` line so `wta hooks uninstall` and the Settings UI's
         // status report don't mislead users.
-        out.plugin_uninstalled = Some(spawn_step(
+        out.plugin_uninstalled = Some(spawn_step_unlocking(
             &mut out.messages,
             "gemini",
             &["extensions", "uninstall", GEMINI_EXTENSION_DIR_NAME],
             &["successfully uninstalled", "extension not found"],
+            CliKind::Gemini,
+            home.and_then(|h| installed_plugin_dir(CliKind::Gemini, h))
+                .as_deref(),
         ));
     } else {
         out.messages
@@ -2908,30 +2924,61 @@ fn run_plugin_cli_with_env(
     idempotency_substrings: &[&str],
 ) -> std::io::Result<()> {
     let outcome = run_plugin_cli_capture_with_env(exe, args, env)?;
-    if !outcome.success {
-        if matches_idempotency_substring(&outcome.stdout, &outcome.stderr, idempotency_substrings) {
-            tracing::info!(
-                target: "agent_hooks",
-                exe = exe,
-                args = ?args,
-                "plugin CLI exited non-zero but matched idempotency substring; treating as success",
-            );
-            return Ok(());
-        }
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!(
-                "{} {} exited {}",
-                exe,
-                args.join(" "),
-                outcome
-                    .status_code
-                    .map(|c| c.to_string())
-                    .unwrap_or_else(|| "?".into()),
-            ),
-        ));
+    if plugin_cli_reached_goal(&outcome, exe, args, idempotency_substrings) {
+        return Ok(());
     }
-    Ok(())
+    Err(plugin_cli_exit_error(exe, args, &outcome))
+}
+
+/// Whether a finished plugin CLI run reached its goal state: either a
+/// clean exit, or a non-zero exit whose output matches one of the
+/// caller's `idempotency_substrings` (see [`run_plugin_cli`] for what
+/// those mean per call site).
+fn plugin_cli_reached_goal(
+    outcome: &CliRunOutcome,
+    exe: &str,
+    args: &[&str],
+    idempotency_substrings: &[&str],
+) -> bool {
+    if outcome.success {
+        return true;
+    }
+    if matches_idempotency_substring(&outcome.stdout, &outcome.stderr, idempotency_substrings) {
+        tracing::info!(
+            target: "agent_hooks",
+            exe = exe,
+            args = ?args,
+            "plugin CLI exited non-zero but matched idempotency substring; treating as success",
+        );
+        return true;
+    }
+    false
+}
+
+/// Error returned for a plugin CLI that ran to completion but did not
+/// reach its goal state. Carries the CLI's own message so the reason is
+/// visible wherever the error is logged or surfaced to the user.
+fn plugin_cli_exit_error(exe: &str, args: &[&str], outcome: &CliRunOutcome) -> std::io::Error {
+    let detail = if outcome.stderr.trim().is_empty() {
+        outcome.stdout.trim()
+    } else {
+        outcome.stderr.trim()
+    };
+    let code = outcome
+        .status_code
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "?".into());
+    if detail.is_empty() {
+        std::io::Error::other(format!("{} {} exited {}", exe, args.join(" "), code))
+    } else {
+        std::io::Error::other(format!(
+            "{} {} exited {}: {}",
+            exe,
+            args.join(" "),
+            code,
+            detail,
+        ))
+    }
 }
 
 /// Lower-cased substring search across the captured stdout+stderr for
@@ -2946,6 +2993,248 @@ fn matches_idempotency_substring(stdout: &str, stderr: &str, needles: &[&str]) -
     needles
         .iter()
         .any(|n| combined.contains(&n.to_ascii_lowercase()))
+}
+
+// ---------------------------------------------------------------------------
+// Locked plugin-directory recovery
+// ---------------------------------------------------------------------------
+//
+// Symptom: with an agent CLI already running elsewhere — most commonly
+// VS Code, which keeps several `copilot` processes alive for the whole
+// editor session — every hook install / update / uninstall fails:
+//
+//     > copilot plugin install wt-agent-hooks@wt-local
+//     Failed to install plugin: Error: Failed to install plugin: Access is denied. (os error 5)
+//
+// A live CLI process holds an open handle on the plugin directory it
+// loaded at startup, so the CLI's "replace the installed plugin folder"
+// step can neither rename nor remove that directory. The handle only
+// blocks operations on the *directory itself*: creating, overwriting,
+// and deleting entries *inside* it all still succeed.
+//
+// Recovery is therefore to empty the directory ourselves — file-level
+// deletes, which the handle does not block — and re-run the same CLI
+// command against the now-empty (but still present) directory. Verified
+// against Copilot CLI 1.0.81 with twelve live `copilot` processes:
+// installing into the populated directory fails every time, and
+// installing into the same directory after clearing succeeds.
+//
+// The contents are copied aside before clearing and put back when the
+// retry still fails, so a failure we cannot recover from leaves the
+// user's existing hooks exactly as they were.
+
+/// Subdirectory (under the IntelligentTerminal local cache root) holding
+/// the copy taken before a locked plugin directory is cleared.
+const PLUGIN_DIR_RECOVERY_SUBDIR: &str = "hook-plugin-recovery";
+
+/// Output snippets that identify the locked-directory failure. The exact
+/// spelling depends on which operation the CLI attempted and on its
+/// runtime: Copilot CLI 1.0.81 reports `Access is denied. (os error 5)`
+/// against a plugin directory a sibling `copilot` process loaded, while
+/// a plain sharing violation on the same directory surfaces as `The
+/// process cannot access the file because it is being used by another
+/// process. (os error 32)`. Node-based CLIs (Claude, Gemini) surface
+/// libuv's `EPERM` / `EBUSY` spellings for the same conditions.
+///
+/// Matching is case-insensitive, so these are written lower-cased.
+const LOCKED_PLUGIN_DIR_NEEDLES: &[&str] = &[
+    "access is denied",
+    "os error 5",
+    "os error 32",
+    "being used by another process",
+    "eperm",
+    "ebusy",
+    "operation not permitted",
+    "resource busy",
+];
+
+/// Directory the CLI copies our plugin into, and therefore the one it
+/// must replace on install / update / uninstall.
+///
+/// `None` for OpenCode, whose hooks are a plain file copy performed by
+/// wta itself: there is no CLI-owned directory-replace step to recover.
+fn installed_plugin_dir(cli: CliKind, home: &Path) -> Option<PathBuf> {
+    let dir = match cli {
+        CliKind::Copilot => home
+            .join(".copilot")
+            .join("installed-plugins")
+            .join(MARKETPLACE_NAME)
+            .join(PLUGIN_NAME),
+        CliKind::Claude => home
+            .join(".claude")
+            .join("plugins")
+            .join("cache")
+            .join(MARKETPLACE_NAME)
+            .join(PLUGIN_NAME),
+        CliKind::Codex => home
+            .join(".codex")
+            .join("plugins")
+            .join("cache")
+            .join(MARKETPLACE_NAME)
+            .join(PLUGIN_NAME),
+        CliKind::Gemini => gemini_extension_dir(home),
+        CliKind::OpenCode => return None,
+    };
+    Some(dir)
+}
+
+/// True when the CLI output looks like the locked-directory failure
+/// described above.
+fn is_locked_plugin_dir_failure(stdout: &str, stderr: &str) -> bool {
+    matches_idempotency_substring(stdout, stderr, LOCKED_PLUGIN_DIR_NEEDLES)
+}
+
+/// Delete every entry inside `dir` while leaving `dir` itself in place.
+/// This is precisely the set of operations a live CLI's directory handle
+/// does *not* block, and the reason the recovery below works at all.
+fn clear_dir_contents(dir: &Path) -> std::io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if entry.file_type()?.is_dir() {
+            fs::remove_dir_all(&path)?;
+        } else {
+            fs::remove_file(&path)?;
+        }
+    }
+    Ok(())
+}
+
+/// Copy `dir`'s contents to a scratch location, then empty `dir`.
+/// Returns the scratch path so the caller can restore it on failure or
+/// discard it on success.
+fn stash_plugin_dir_contents(cli: CliKind, dir: &Path) -> std::io::Result<PathBuf> {
+    let root = crate::runtime_paths::intelligent_terminal_local_root()
+        .ok_or_else(|| std::io::Error::other("IntelligentTerminal local root unavailable"))?;
+    let stash = root.join(PLUGIN_DIR_RECOVERY_SUBDIR).join(cli.dir_name());
+    restage_bundle_dir(dir, &stash)?;
+    clear_dir_contents(dir)?;
+    Ok(stash)
+}
+
+/// Put a stash taken by [`stash_plugin_dir_contents`] back and discard
+/// it. Best-effort: a failure is logged at error because it leaves the
+/// plugin directory empty, with the only surviving copy in the stash.
+fn restore_plugin_dir_contents(stash: &Path, dir: &Path) {
+    match copy_dir_recursive(stash, dir) {
+        Ok(()) => discard_plugin_dir_stash(stash),
+        Err(e) => tracing::error!(
+            target: "agent_hooks",
+            err = %e,
+            stash = %stash.display(),
+            dir = %dir.display(),
+            "failed to restore plugin directory contents; the previous contents remain in `stash`",
+        ),
+    }
+}
+
+/// Remove a stash we no longer need. Leftovers are harmless (the next
+/// recovery overwrites the directory), so failures only trace.
+fn discard_plugin_dir_stash(stash: &Path) {
+    if let Err(e) = fs::remove_dir_all(stash) {
+        tracing::debug!(
+            target: "agent_hooks",
+            err = %e,
+            stash = %stash.display(),
+            "failed to discard plugin directory stash; non-fatal",
+        );
+    }
+}
+
+/// [`run_plugin_cli`] plus recovery from the locked-plugin-directory
+/// failure documented above.
+///
+/// `plugin_dir` is the directory the CLI replaces; pass `None` to opt
+/// out. Behavior is identical to [`run_plugin_cli`] unless *all* of the
+/// following hold, in which case the directory is cleared and the
+/// command runs a second time:
+///
+///   * the CLI ran but did not reach its goal state,
+///   * its output matches [`is_locked_plugin_dir_failure`], and
+///   * `plugin_dir` exists and is non-empty.
+fn run_plugin_cli_unlocking(
+    exe: &str,
+    args: &[&str],
+    env: &[(&str, &str)],
+    idempotency_substrings: &[&str],
+    cli: CliKind,
+    plugin_dir: Option<&Path>,
+) -> std::io::Result<()> {
+    let outcome = run_plugin_cli_capture_with_env(exe, args, env)?;
+    if plugin_cli_reached_goal(&outcome, exe, args, idempotency_substrings) {
+        return Ok(());
+    }
+
+    let Some(dir) = plugin_dir.filter(|d| dir_has_entries(d)) else {
+        return Err(plugin_cli_exit_error(exe, args, &outcome));
+    };
+    if !is_locked_plugin_dir_failure(&outcome.stdout, &outcome.stderr) {
+        return Err(plugin_cli_exit_error(exe, args, &outcome));
+    }
+
+    tracing::warn!(
+        target: "agent_hooks",
+        exe = exe,
+        args = ?args,
+        dir = %dir.display(),
+        "plugin directory is held open by a running agent CLI; clearing its contents and retrying",
+    );
+
+    let stash = match stash_plugin_dir_contents(cli, dir) {
+        Ok(stash) => stash,
+        Err(e) => {
+            tracing::warn!(
+                target: "agent_hooks",
+                err = %e,
+                dir = %dir.display(),
+                "could not clear the locked plugin directory; reporting the original failure",
+            );
+            return Err(plugin_cli_exit_error(exe, args, &outcome));
+        }
+    };
+
+    let retry = run_plugin_cli_capture_with_env(exe, args, env);
+    if let Ok(retry) = &retry {
+        if plugin_cli_reached_goal(retry, exe, args, idempotency_substrings) {
+            discard_plugin_dir_stash(&stash);
+            tracing::info!(
+                target: "agent_hooks",
+                exe = exe,
+                args = ?args,
+                "retry succeeded after clearing the locked plugin directory",
+            );
+            return Ok(());
+        }
+    }
+
+    restore_plugin_dir_contents(&stash, dir);
+    match retry {
+        Ok(retry) => Err(plugin_cli_exit_error(exe, args, &retry)),
+        Err(e) => Err(e),
+    }
+}
+
+/// [`spawn_step`] with the locked-plugin-directory recovery from
+/// [`run_plugin_cli_unlocking`]. Used by the uninstall flows, which
+/// collect human-readable messages instead of returning errors.
+fn spawn_step_unlocking(
+    messages: &mut Vec<String>,
+    exe: &str,
+    args: &[&str],
+    success_substrings: &[&str],
+    cli: CliKind,
+    plugin_dir: Option<&Path>,
+) -> bool {
+    match run_plugin_cli_unlocking(exe, args, &[], success_substrings, cli, plugin_dir) {
+        Ok(()) => {
+            messages.push(format!("ok: {} {}", exe, args.join(" ")));
+            true
+        }
+        Err(e) => {
+            messages.push(format!("fail: {} {} :: {}", exe, args.join(" "), e));
+            false
+        }
+    }
 }
 
 /// Return the discovered home directory from `USERPROFILE`/`HOME`.
@@ -3459,11 +3748,13 @@ fn uninstall_for_codex(home: Option<&Path>) -> CliUninstallResult {
     result.attempted = true;
 
     let plugin_ref = format!("{}@{}", PLUGIN_NAME, MARKETPLACE_NAME);
-    match run_plugin_cli(
+    match run_plugin_cli_unlocking(
         "codex",
         &["plugin", "remove", &plugin_ref],
-        "agent_hooks",
+        &[],
         &["not installed"],
+        CliKind::Codex,
+        installed_plugin_dir(CliKind::Codex, home).as_deref(),
     ) {
         Ok(()) => {
             result.plugin_uninstalled = Some(true);
@@ -4371,7 +4662,7 @@ fn upgrade_one_cli(cli: CliKind, home: &Path, bundle_version: Option<Version>) -
             }
         },
         UpgradeAction::CodexReinstall => upgrade_codex(home),
-        UpgradeAction::GeminiUpdateInPlace => upgrade_gemini_in_place(),
+        UpgradeAction::GeminiUpdateInPlace => upgrade_gemini_in_place(home),
         UpgradeAction::GeminiReinstall => upgrade_gemini_reinstall(home),
         UpgradeAction::OpenCodeCopy => install_for_opencode(home).installed(),
     }
@@ -4391,11 +4682,13 @@ fn upgrade_copilot(home: &Path) -> bool {
         );
     }
     let plugin_ref = format!("{}@{}", PLUGIN_NAME, MARKETPLACE_NAME);
-    match run_plugin_cli(
+    match run_plugin_cli_unlocking(
         "copilot",
         &["plugin", "update", &plugin_ref],
-        "copilot_hooks",
         &[],
+        &[],
+        CliKind::Copilot,
+        installed_plugin_dir(CliKind::Copilot, home).as_deref(),
     ) {
         Ok(()) => true,
         Err(e) => {
@@ -4433,11 +4726,13 @@ fn upgrade_claude(home: &Path) -> bool {
     }
 
     let plugin_ref = format!("{}@{}", PLUGIN_NAME, MARKETPLACE_NAME);
-    match run_plugin_cli(
+    match run_plugin_cli_unlocking(
         "claude",
         &["plugin", "update", &plugin_ref],
-        "agent_hooks",
         &[],
+        &[],
+        CliKind::Claude,
+        installed_plugin_dir(CliKind::Claude, home).as_deref(),
     ) {
         Ok(()) => true,
         Err(e) => {
@@ -4484,17 +4779,18 @@ fn upgrade_codex(home: &Path) -> bool {
     install_for_codex(home).installed()
 }
 
-fn upgrade_gemini_in_place() -> bool {
+fn upgrade_gemini_in_place(home: &Path) -> bool {
     // `extensions update` upstream yargs does NOT accept `--consent` /
     // `--skip-settings` (those are install-only flags). Keep
     // GEMINI_CLI_TRUST_WORKSPACE which is honored as a generic
     // headless-mode signal.
-    match run_plugin_cli_with_env(
+    match run_plugin_cli_unlocking(
         "gemini",
         &["extensions", "update", GEMINI_EXTENSION_DIR_NAME],
         &[("GEMINI_CLI_TRUST_WORKSPACE", "true")],
-        "gemini_hooks",
         &[],
+        CliKind::Gemini,
+        installed_plugin_dir(CliKind::Gemini, home).as_deref(),
     ) {
         Ok(()) => true,
         Err(e) => {
@@ -4533,11 +4829,13 @@ fn upgrade_gemini_reinstall(home: &Path) -> bool {
     };
 
     // 2. Uninstall — tolerate "extension not found" idempotency.
-    let uninstall_succeeded = match run_plugin_cli(
+    let uninstall_succeeded = match run_plugin_cli_unlocking(
         "gemini",
         &["extensions", "uninstall", GEMINI_EXTENSION_DIR_NAME],
-        "gemini_hooks",
+        &[],
         &["extension not found", "successfully uninstalled"],
+        CliKind::Gemini,
+        installed_plugin_dir(CliKind::Gemini, home).as_deref(),
     ) {
         Ok(()) => true,
         Err(e) => {

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -2955,6 +2955,17 @@ fn plugin_cli_reached_goal(
     false
 }
 
+/// Error returned when the plugin CLI could not be started at all — the
+/// binary is missing from `PATH`, or the OS refused the spawn. Named the
+/// same way as [`plugin_cli_exit_error`] so callers can surface either
+/// without adding a command prefix of their own.
+fn plugin_cli_spawn_error(exe: &str, args: &[&str], error: std::io::Error) -> std::io::Error {
+    std::io::Error::new(
+        error.kind(),
+        format!("{} {} failed to start: {}", exe, args.join(" "), error),
+    )
+}
+
 /// Error returned for a plugin CLI that ran to completion but did not
 /// reach its goal state. Carries the CLI's own message so the reason is
 /// visible wherever the error is logged or surfaced to the user.
@@ -3027,16 +3038,12 @@ fn matches_idempotency_substring(stdout: &str, stderr: &str, needles: &[&str]) -
 /// the copy taken before a locked plugin directory is cleared.
 const PLUGIN_DIR_RECOVERY_SUBDIR: &str = "hook-plugin-recovery";
 
-/// Output snippets that identify the locked-directory failure. The exact
-/// spelling depends on which operation the CLI attempted and on its
-/// runtime: Copilot CLI 1.0.81 reports `Access is denied. (os error 5)`
-/// against a plugin directory a sibling `copilot` process loaded, while
-/// a plain sharing violation on the same directory surfaces as `The
-/// process cannot access the file because it is being used by another
-/// process. (os error 32)`. Node-based CLIs (Claude, Gemini) report the
-/// same conditions through libuv, which always spells the error code
-/// out in prose — `operation not permitted` and `resource busy` — so
-/// matching the prose also covers the bare error codes that precede it.
+/// Win32 spellings of the locked-directory failure. Copilot CLI 1.0.81
+/// reports `Access is denied. (os error 5)` against a plugin directory a
+/// sibling `copilot` process loaded, while a plain sharing violation on
+/// the same directory surfaces as `The process cannot access the file
+/// because it is being used by another process. (os error 32)`. These
+/// only arise for this condition, so a match is conclusive on its own.
 ///
 /// Matching is case-insensitive, so these are written lower-cased.
 const LOCKED_PLUGIN_DIR_NEEDLES: &[&str] = &[
@@ -3044,9 +3051,21 @@ const LOCKED_PLUGIN_DIR_NEEDLES: &[&str] = &[
     "os error 5",
     "os error 32",
     "being used by another process",
-    "operation not permitted",
-    "resource busy",
 ];
+
+/// libuv's prose for the same conditions, used by the Node-based CLIs
+/// (Claude, Gemini). Ambiguous on its own: `install_for_claude` documents
+/// a completely unrelated `EPERM: operation not permitted, scandir '...'`
+/// raised while *reading* a WindowsApps bundle source. Treating that as a
+/// lock would clear a perfectly good plugin directory, so these only
+/// count when paired with [`LOCKED_PLUGIN_DIR_OPERATIONS`].
+const LOCKED_PLUGIN_DIR_PROSE: &[&str] = &["operation not permitted", "resource busy"];
+
+/// Operations that mutate the directory itself — the ones a live CLI's
+/// handle actually blocks. libuv names the syscall right after the prose
+/// (`EPERM: operation not permitted, rename '...'`), which is what lets
+/// us separate a directory lock from an unrelated `scandir` denial.
+const LOCKED_PLUGIN_DIR_OPERATIONS: &[&str] = &["rename", "rmdir", "unlink"];
 
 /// Directory the CLI copies our plugin into, and therefore the one it
 /// must replace on install / update / uninstall.
@@ -3080,8 +3099,17 @@ fn installed_plugin_dir(cli: CliKind, home: &Path) -> Option<PathBuf> {
 
 /// True when the CLI output looks like the locked-directory failure
 /// described above.
+///
+/// A Win32 spelling is conclusive. libuv prose has to additionally name
+/// an operation that mutates the directory, so an unrelated denial such
+/// as the WindowsApps `scandir` case never reaches the destructive
+/// recovery path.
 fn is_locked_plugin_dir_failure(stdout: &str, stderr: &str) -> bool {
-    matches_idempotency_substring(stdout, stderr, LOCKED_PLUGIN_DIR_NEEDLES)
+    if matches_idempotency_substring(stdout, stderr, LOCKED_PLUGIN_DIR_NEEDLES) {
+        return true;
+    }
+    matches_idempotency_substring(stdout, stderr, LOCKED_PLUGIN_DIR_PROSE)
+        && matches_idempotency_substring(stdout, stderr, LOCKED_PLUGIN_DIR_OPERATIONS)
 }
 
 /// Delete every entry inside `dir` while leaving `dir` itself in place.
@@ -3198,7 +3226,8 @@ fn run_plugin_cli_unlocking(
     cli: CliKind,
     plugin_dir: Option<&Path>,
 ) -> std::io::Result<()> {
-    let outcome = run_plugin_cli_capture_with_env(exe, args, env)?;
+    let outcome = run_plugin_cli_capture_with_env(exe, args, env)
+        .map_err(|e| plugin_cli_spawn_error(exe, args, e))?;
     if plugin_cli_reached_goal(&outcome, exe, args, idempotency_substrings) {
         return Ok(());
     }
@@ -3248,7 +3277,7 @@ fn run_plugin_cli_unlocking(
     restore_plugin_dir_contents(&stash, dir);
     match retry {
         Ok(retry) => Err(plugin_cli_exit_error(exe, args, &retry)),
-        Err(e) => Err(e),
+        Err(e) => Err(plugin_cli_spawn_error(exe, args, e)),
     }
 }
 
@@ -3268,8 +3297,10 @@ fn spawn_step_unlocking(
             messages.push(format!("ok: {} {}", exe, args.join(" ")));
             true
         }
+        // Both error shapes from `run_plugin_cli_unlocking` already name
+        // the command, so repeating it here would only double it up.
         Err(e) => {
-            messages.push(format!("fail: {} {} :: {}", exe, args.join(" "), e));
+            messages.push(format!("fail: {}", e));
             false
         }
     }

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -3033,8 +3033,10 @@ const PLUGIN_DIR_RECOVERY_SUBDIR: &str = "hook-plugin-recovery";
 /// against a plugin directory a sibling `copilot` process loaded, while
 /// a plain sharing violation on the same directory surfaces as `The
 /// process cannot access the file because it is being used by another
-/// process. (os error 32)`. Node-based CLIs (Claude, Gemini) surface
-/// libuv's `EPERM` / `EBUSY` spellings for the same conditions.
+/// process. (os error 32)`. Node-based CLIs (Claude, Gemini) report the
+/// same conditions through libuv, which always spells the error code
+/// out in prose — `operation not permitted` and `resource busy` — so
+/// matching the prose also covers the bare error codes that precede it.
 ///
 /// Matching is case-insensitive, so these are written lower-cased.
 const LOCKED_PLUGIN_DIR_NEEDLES: &[&str] = &[
@@ -3042,8 +3044,6 @@ const LOCKED_PLUGIN_DIR_NEEDLES: &[&str] = &[
     "os error 5",
     "os error 32",
     "being used by another process",
-    "eperm",
-    "ebusy",
     "operation not permitted",
     "resource busy",
 ];
@@ -3103,18 +3103,35 @@ fn clear_dir_contents(dir: &Path) -> std::io::Result<()> {
 /// Copy `dir`'s contents to a scratch location, then empty `dir`.
 /// Returns the scratch path so the caller can restore it on failure or
 /// discard it on success.
+///
+/// A partial clear would leave the user with half their hooks, so a
+/// mid-way failure is undone here rather than surfaced to the caller as
+/// an ambiguous directory state: on error `dir` is refilled from the
+/// stash before the error propagates.
 fn stash_plugin_dir_contents(cli: CliKind, dir: &Path) -> std::io::Result<PathBuf> {
     let root = crate::runtime_paths::intelligent_terminal_local_root()
         .ok_or_else(|| std::io::Error::other("IntelligentTerminal local root unavailable"))?;
     let stash = root.join(PLUGIN_DIR_RECOVERY_SUBDIR).join(cli.dir_name());
     restage_bundle_dir(dir, &stash)?;
-    clear_dir_contents(dir)?;
+    if let Err(e) = clear_dir_contents(dir) {
+        tracing::warn!(
+            target: "agent_hooks",
+            err = %e,
+            dir = %dir.display(),
+            "failed to clear the plugin directory; restoring what was already removed",
+        );
+        restore_plugin_dir_contents(&stash, dir);
+        return Err(e);
+    }
     Ok(stash)
 }
 
 /// Put a stash taken by [`stash_plugin_dir_contents`] back and discard
-/// it. Best-effort: a failure is logged at error because it leaves the
-/// plugin directory empty, with the only surviving copy in the stash.
+/// it. Copies over whatever is still in `dir`, so it works for both a
+/// fully emptied directory and one a failed clear left half-populated.
+/// Best-effort: a failure is logged at error because it leaves the
+/// plugin directory incomplete, with the only surviving copy in the
+/// stash.
 fn restore_plugin_dir_contents(stash: &Path, dir: &Path) {
     match copy_dir_recursive(stash, dir) {
         Ok(()) => discard_plugin_dir_stash(stash),

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -3127,14 +3127,35 @@ fn stash_plugin_dir_contents(cli: CliKind, dir: &Path) -> std::io::Result<PathBu
 }
 
 /// Put a stash taken by [`stash_plugin_dir_contents`] back and discard
-/// it. Copies over whatever is still in `dir`, so it works for both a
-/// fully emptied directory and one a failed clear left half-populated.
-/// Best-effort: a failure is logged at error because it leaves the
-/// plugin directory incomplete, with the only surviving copy in the
-/// stash.
+/// it.
+///
+/// The failed attempt this rolls back may have written part of the new
+/// plugin before giving up, so `dir` is emptied before the stash is
+/// copied over it. Without that, `copy_dir_recursive` would overwrite
+/// the paths the two versions share and leave the rest of the partial
+/// write in place, handing the user a mix of old and new hooks instead
+/// of the pre-recovery state.
+///
+/// Best-effort: failures are logged rather than propagated, and the
+/// stash is kept unless the restore was provably complete, since it is
+/// then the only pristine copy left.
 fn restore_plugin_dir_contents(stash: &Path, dir: &Path) {
+    let emptied = match clear_dir_contents(dir) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::warn!(
+                target: "agent_hooks",
+                err = %e,
+                dir = %dir.display(),
+                "could not empty the plugin directory before restoring it; \
+                 the result may be mixed with a partially written retry",
+            );
+            false
+        }
+    };
     match copy_dir_recursive(stash, dir) {
-        Ok(()) => discard_plugin_dir_stash(stash),
+        Ok(()) if emptied => discard_plugin_dir_stash(stash),
+        Ok(()) => {}
         Err(e) => tracing::error!(
             target: "agent_hooks",
             err = %e,

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -3614,6 +3614,42 @@ fn restore_plugin_dir_contents_refills_a_partially_cleared_dir() {
     assert!(!stash.exists(), "stash is discarded once restored");
 }
 
+/// A retry that fails after writing part of the new plugin leaves files
+/// the stash has no counterpart for. Restoring has to drop them instead
+/// of merging the two versions.
+#[test]
+fn restore_plugin_dir_contents_removes_what_a_failed_retry_left_behind() {
+    let dir = unique_dir("restore-leftovers");
+    fs::create_dir_all(dir.join("hooks")).unwrap();
+    fs::write(dir.join("plugin.json"), "old manifest").unwrap();
+    fs::write(dir.join("hooks").join("hooks.json"), "old hooks").unwrap();
+
+    let stash = unique_dir("restore-leftovers-stash").join("stash");
+    restage_bundle_dir(&dir, &stash).unwrap();
+    clear_dir_contents(&dir).unwrap();
+
+    // The CLI got partway through writing the new version before failing.
+    fs::create_dir_all(dir.join("scripts")).unwrap();
+    fs::write(dir.join("plugin.json"), "new manifest").unwrap();
+    fs::write(dir.join("scripts").join("leftover.ps1"), "new").unwrap();
+
+    restore_plugin_dir_contents(&stash, &dir);
+
+    assert_eq!(
+        fs::read_to_string(dir.join("plugin.json")).unwrap(),
+        "old manifest",
+        "a shared path must be rolled back, not left at the retry's version",
+    );
+    assert_eq!(
+        fs::read_to_string(dir.join("hooks").join("hooks.json")).unwrap(),
+        "old hooks",
+    );
+    assert!(
+        !dir.join("scripts").exists(),
+        "the retry's partial output must not survive the restore",
+    );
+}
+
 fn outcome(success: bool, status_code: Option<i32>, stdout: &str, stderr: &str) -> CliRunOutcome {
     CliRunOutcome {
         success,

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -3484,6 +3484,27 @@ fn locked_plugin_dir_failure_matches_sharing_violation() {
     ));
 }
 
+/// The WindowsApps bundle-source denial that `install_for_claude`
+/// documents is an `EPERM` too, but it names `scandir` — it is a failure
+/// to *read the source*, not a lock on the installed plugin directory.
+/// Matching it would clear a perfectly good install, so the predicate has
+/// to keep the two apart.
+#[test]
+fn locked_plugin_dir_failure_ignores_the_windowsapps_scandir_denial() {
+    assert!(!is_locked_plugin_dir_failure(
+        "",
+        "EPERM: operation not permitted, scandir \
+         'C:\\Program Files\\WindowsApps\\IntelligentTerminal_0.7.0.11_x64__rd9vj3e6a2mbr'",
+    ));
+}
+
+/// Bare libuv prose with no operation named is not enough on its own.
+#[test]
+fn locked_plugin_dir_failure_ignores_unpaired_libuv_prose() {
+    assert!(!is_locked_plugin_dir_failure("", "operation not permitted"));
+    assert!(!is_locked_plugin_dir_failure("", "resource busy"));
+}
+
 /// Failures we cannot fix by clearing the directory must not trigger
 /// the destructive recovery path.
 #[test]
@@ -3705,4 +3726,25 @@ fn plugin_cli_exit_error_carries_the_cli_message() {
 fn plugin_cli_exit_error_omits_the_detail_when_the_cli_said_nothing() {
     let err = plugin_cli_exit_error("codex", &["plugin", "add"], &outcome(false, None, "", ""));
     assert_eq!(err.to_string(), "codex plugin add exited ?");
+}
+
+/// A spawn failure has to name the command too: `spawn_step_unlocking`
+/// prints the error verbatim, so anything missing here is lost from the
+/// uninstall report.
+#[test]
+fn plugin_cli_spawn_error_names_the_command() {
+    let err = plugin_cli_spawn_error(
+        "copilot",
+        &["plugin", "uninstall", "wt-agent-hooks@wt-local"],
+        std::io::Error::new(std::io::ErrorKind::NotFound, "program not found"),
+    );
+    assert_eq!(
+        err.to_string(),
+        "copilot plugin uninstall wt-agent-hooks@wt-local failed to start: program not found",
+    );
+    assert_eq!(
+        err.kind(),
+        std::io::ErrorKind::NotFound,
+        "kind is preserved"
+    );
 }

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -3582,6 +3582,38 @@ fn restore_plugin_dir_contents_round_trips_and_discards_the_stash() {
     assert!(!stash.exists(), "stash is discarded once restored");
 }
 
+/// A clear that fails partway leaves `dir` half-populated, so restore
+/// has to cope with entries that were never removed rather than assume
+/// an empty target.
+#[test]
+fn restore_plugin_dir_contents_refills_a_partially_cleared_dir() {
+    let dir = unique_dir("restore-partial");
+    fs::create_dir_all(dir.join("hooks")).unwrap();
+    fs::write(dir.join("plugin.json"), "manifest").unwrap();
+    fs::write(dir.join("hooks").join("hooks.json"), "hooks").unwrap();
+
+    let stash = unique_dir("restore-partial-stash").join("stash");
+    restage_bundle_dir(&dir, &stash).unwrap();
+
+    // Simulate `clear_dir_contents` dying after the first entry: the
+    // manifest is gone, the hooks subtree is still there.
+    fs::remove_file(dir.join("plugin.json")).unwrap();
+
+    restore_plugin_dir_contents(&stash, &dir);
+
+    assert_eq!(
+        fs::read_to_string(dir.join("plugin.json")).unwrap(),
+        "manifest",
+        "the removed entry must come back",
+    );
+    assert_eq!(
+        fs::read_to_string(dir.join("hooks").join("hooks.json")).unwrap(),
+        "hooks",
+        "the surviving entry must be left intact",
+    );
+    assert!(!stash.exists(), "stash is discarded once restored");
+}
+
 fn outcome(success: bool, status_code: Option<i32>, stdout: &str, stderr: &str) -> CliRunOutcome {
     CliRunOutcome {
         success,

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -3450,3 +3450,191 @@ fn gemini_source_under_bundle_walks_ancestors() {
     let outside = unique_dir("gemini-outside");
     assert!(!gemini_source_under_bundle(&outside, &bundle));
 }
+
+// ---- locked plugin-directory recovery -----------------------------
+
+/// The verbatim message Copilot CLI 1.0.81 prints when a live
+/// `copilot` process (typically one VS Code keeps alive) holds the
+/// installed plugin directory open.
+#[test]
+fn locked_plugin_dir_failure_matches_copilot_access_denied() {
+    assert!(is_locked_plugin_dir_failure(
+        "",
+        "Failed to install plugin: Error: Failed to install plugin: Access is denied. (os error 5)",
+    ));
+}
+
+/// Node-based CLIs surface the same condition as libuv's `EPERM`.
+#[test]
+fn locked_plugin_dir_failure_matches_node_eperm() {
+    assert!(is_locked_plugin_dir_failure(
+        "",
+        "EPERM: operation not permitted, rename 'C:\\Users\\u\\.claude\\plugins\\cache\\wt-local'",
+    ));
+}
+
+/// The same held directory handle surfaces as a plain sharing violation
+/// when the CLI's replace step trips on it before the rename.
+#[test]
+fn locked_plugin_dir_failure_matches_sharing_violation() {
+    assert!(is_locked_plugin_dir_failure(
+        "",
+        "Failed to install plugin: Error: Failed to install plugin: The process cannot access \
+         the file because it is being used by another process. (os error 32)",
+    ));
+}
+
+/// Failures we cannot fix by clearing the directory must not trigger
+/// the destructive recovery path.
+#[test]
+fn locked_plugin_dir_failure_ignores_unrelated_errors() {
+    assert!(!is_locked_plugin_dir_failure(
+        "",
+        "Failed to install plugin: Error: Marketplace \"wt-local\" not found",
+    ));
+    assert!(!is_locked_plugin_dir_failure(
+        "",
+        "Failed to add marketplace: Error: source path does not exist",
+    ));
+}
+
+#[test]
+fn installed_plugin_dir_matches_each_cli_layout() {
+    let home = Path::new(r"C:\Users\u");
+    assert_eq!(
+        installed_plugin_dir(CliKind::Copilot, home).unwrap(),
+        home.join(".copilot")
+            .join("installed-plugins")
+            .join(MARKETPLACE_NAME)
+            .join(PLUGIN_NAME),
+    );
+    assert_eq!(
+        installed_plugin_dir(CliKind::Claude, home).unwrap(),
+        home.join(".claude")
+            .join("plugins")
+            .join("cache")
+            .join(MARKETPLACE_NAME)
+            .join(PLUGIN_NAME),
+    );
+    assert_eq!(
+        installed_plugin_dir(CliKind::Codex, home).unwrap(),
+        home.join(".codex")
+            .join("plugins")
+            .join("cache")
+            .join(MARKETPLACE_NAME)
+            .join(PLUGIN_NAME),
+    );
+    assert_eq!(
+        installed_plugin_dir(CliKind::Gemini, home).unwrap(),
+        gemini_extension_dir(home),
+    );
+    // OpenCode hooks are a wta-owned file copy: no CLI-owned
+    // directory-replace step, so nothing to recover.
+    assert!(installed_plugin_dir(CliKind::OpenCode, home).is_none());
+}
+
+/// The recovery hinges on emptying the directory *without* removing it,
+/// since removing it is exactly what the live CLI's handle blocks.
+#[test]
+fn clear_dir_contents_empties_dir_but_keeps_it() {
+    let dir = unique_dir("clear-contents");
+    fs::create_dir_all(dir.join("hooks")).unwrap();
+    fs::write(dir.join("plugin.json"), "{}").unwrap();
+    fs::write(dir.join("hooks").join("hooks.json"), "{}").unwrap();
+
+    clear_dir_contents(&dir).unwrap();
+
+    assert!(dir.is_dir(), "the directory itself must survive");
+    assert!(!dir_has_entries(&dir), "the directory must be empty");
+}
+
+#[test]
+fn clear_dir_contents_is_a_noop_on_an_empty_dir() {
+    let dir = unique_dir("clear-contents-empty");
+    clear_dir_contents(&dir).unwrap();
+    assert!(dir.is_dir());
+}
+
+/// Restoring must put every file back where it was, so a retry that
+/// still fails leaves the user's existing hooks untouched.
+#[test]
+fn restore_plugin_dir_contents_round_trips_and_discards_the_stash() {
+    let dir = unique_dir("restore-plugin-dir");
+    fs::create_dir_all(dir.join("hooks")).unwrap();
+    fs::write(dir.join("plugin.json"), "manifest").unwrap();
+    fs::write(dir.join("hooks").join("hooks.json"), "hooks").unwrap();
+
+    let stash = unique_dir("restore-plugin-stash").join("stash");
+    restage_bundle_dir(&dir, &stash).unwrap();
+    clear_dir_contents(&dir).unwrap();
+    assert!(!dir_has_entries(&dir));
+
+    restore_plugin_dir_contents(&stash, &dir);
+
+    assert_eq!(
+        fs::read_to_string(dir.join("plugin.json")).unwrap(),
+        "manifest"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.join("hooks").join("hooks.json")).unwrap(),
+        "hooks",
+    );
+    assert!(!stash.exists(), "stash is discarded once restored");
+}
+
+fn outcome(success: bool, status_code: Option<i32>, stdout: &str, stderr: &str) -> CliRunOutcome {
+    CliRunOutcome {
+        success,
+        status_code,
+        stdout: stdout.to_string(),
+        stderr: stderr.to_string(),
+    }
+}
+
+#[test]
+fn plugin_cli_reached_goal_accepts_clean_exit_and_idempotent_failure() {
+    assert!(plugin_cli_reached_goal(
+        &outcome(true, Some(0), "", ""),
+        "copilot",
+        &["plugin", "install"],
+        &[],
+    ));
+    assert!(plugin_cli_reached_goal(
+        &outcome(
+            false,
+            Some(1),
+            "",
+            "Marketplace \"wt-local\" already registered"
+        ),
+        "copilot",
+        &["plugin", "marketplace", "add"],
+        &["already registered"],
+    ));
+    assert!(!plugin_cli_reached_goal(
+        &outcome(false, Some(1), "", "Access is denied. (os error 5)"),
+        "copilot",
+        &["plugin", "install"],
+        &["already registered"],
+    ));
+}
+
+/// The CLI's own message has to survive into the error so
+/// `wta-install-hooks.log` says *why* a step failed.
+#[test]
+fn plugin_cli_exit_error_carries_the_cli_message() {
+    let err = plugin_cli_exit_error(
+        "copilot",
+        &["plugin", "install", "wt-agent-hooks@wt-local"],
+        &outcome(false, Some(1), "", "Access is denied. (os error 5)"),
+    );
+    let text = err.to_string();
+    assert!(text.contains("copilot plugin install wt-agent-hooks@wt-local"));
+    assert!(text.contains("exited 1"));
+    assert!(text.contains("Access is denied. (os error 5)"));
+}
+
+#[test]
+fn plugin_cli_exit_error_omits_the_detail_when_the_cli_said_nothing() {
+    let err = plugin_cli_exit_error("codex", &["plugin", "add"], &outcome(false, None, "", ""));
+    assert_eq!(err.to_string(), "codex plugin add exited ?");
+}


### PR DESCRIPTION
## Summary

With an agent CLI already running elsewhere — most commonly VS Code, which keeps several `copilot` processes alive for the whole editor session — **every** hook install, update, and uninstall fails:

```console
> copilot plugin install wt-agent-hooks@wt-local
Failed to install plugin: Error: Failed to install plugin: Access is denied. (os error 5)
```

This hits both entry points: the auto-upgrade at `wta-master` startup and the Settings UI / FRE "Install hooks" button.

## Root cause

A live CLI process holds an open handle on the plugin directory it loaded at startup, so the CLI's "replace the installed plugin folder" step can neither rename nor remove that directory.

The handle only blocks operations on the **directory itself**. Probing `~/.copilot/installed-plugins/wt-local/wt-agent-hooks/` while 12 `copilot` processes were live:

| Operation | Result |
| --- | --- |
| Rename / remove the directory | ❌ `Access is denied` |
| Create a file or subdirectory inside | ✅ |
| Overwrite an existing file | ✅ |
| Delete a file or subdirectory inside | ✅ |

## Fix

`run_plugin_cli_unlocking` uses that asymmetry. When a plugin CLI fails with the locked-directory signature, it copies the directory contents aside, empties the directory with file-level deletes, and runs the same command again.

- Retry succeeds → the stash is discarded.
- Retry fails again → the contents are **restored**, and the original CLI error is reported. A permission problem we cannot recover from leaves the user's existing hooks exactly as they were.

The directory itself is never removed. That also keeps the working directory valid for live CLI sessions, which spawn hooks with their `cwd` set to the plugin root — removing it out from under them makes their hook spawns fail with `os error 267`.

Wired into install / update / uninstall for **Copilot, Claude, Codex, and Gemini**. OpenCode opts out: its hooks are a wta-owned file copy with no CLI-owned directory-replace step.

Behavior is unchanged unless *all* of these hold: the CLI ran but did not reach its goal state, its output matches the locked-directory signature, and the plugin directory exists and is non-empty.

Drive-by: `plugin_cli_reached_goal` and `plugin_cli_exit_error` are extracted out of `run_plugin_cli_with_env` so both paths report failures identically. The error now carries the CLI's own message instead of just an exit code, so `wta-install-hooks.log` says *why* a step failed.

## Validation

Verified against Copilot CLI 1.0.81 with twelve live `copilot` processes.

Manual, before the fix — establishing that clearing is sufficient:

- Install into the populated directory → fails, 4/4 attempts.
- Install into a brand-new directory → succeeds.
- Empty the directory, then install into it → succeeds, 2/2 attempts.

End-to-end with the built binary, against a held directory handle:

- **Retry succeeds** → `retry succeeded after clearing the locked plugin directory`, plugin contents present, stash discarded.
- **Retry still fails** → contents restored byte-for-byte, original error surfaced, no data loss.
- **Uninstall** under the same lock → `plugin=ok marketplace=ok staging=ok`.

Automated:

```console
cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml
test result: ok. 1619 passed; 0 failed
```

11 new tests cover the failure-signature matching (including the `os error 32` sharing-violation spelling and the negative cases that must **not** trigger the destructive path), the per-CLI directory layouts, `clear_dir_contents` leaving the directory in place, the stash/restore round-trip, and the error-message plumbing.

## Notes for reviewers

- The recovery is deliberately narrow. `is_locked_plugin_dir_failure` gates it so an unrelated failure — a missing marketplace, a stale source path — never causes us to clear a working install.
- `cargo fmt` was **not** run crate-wide: the committed tree is not clean under the locally installed rustfmt and formatting everything would rewrite ~46k lines. `agent_hooks_installer.rs` was verified to be rustfmt-clean on its own.
