### PR TITLE
Fix agent helper process cleanup

### DIFF
--- a/src/cascadia/TerminalApp/AgentPaneContent.cpp
+++ b/src/cascadia/TerminalApp/AgentPaneContent.cpp
@@ -41,6 +41,7 @@ namespace winrt::TerminalApp::implementation
                                                                            std::chrono::duration_cast<std::chrono::milliseconds>(
                                                                                AgentHelperExitTimeout)
                                                                                .count()));
+            const auto waitError = waitResult == WAIT_FAILED ? GetLastError() : ERROR_SUCCESS;
             if (waitResult == WAIT_OBJECT_0)
             {
                 _agentPaneLog("wta-helper exited after pane close pid=" + std::to_string(pid));
@@ -49,13 +50,75 @@ namespace winrt::TerminalApp::implementation
 
             if (waitResult == WAIT_TIMEOUT)
             {
-                _agentPaneLog("wta-helper did not exit after pane close; terminating pid=" + std::to_string(pid));
-                LOG_IF_WIN32_BOOL_FALSE(TerminateProcess(process.get(), 1));
-                WaitForSingleObject(process.get(), 5000);
-                co_return;
+                _agentPaneLog("wta-helper did not exit after pane close; checking before termination pid=" + std::to_string(pid));
+            }
+            else if (waitResult == WAIT_FAILED)
+            {
+                LOG_WIN32_MSG(waitError, "Waiting for wta-helper after pane close failed (pid=%lu)", pid);
+                _agentPaneLog("waiting for wta-helper after pane close failed error=" + std::to_string(waitError) + "; checking before termination pid=" + std::to_string(pid));
+            }
+            else
+            {
+                _agentPaneLog("waiting for wta-helper after pane close returned unexpected result=" + std::to_string(waitResult) + "; checking before termination pid=" + std::to_string(pid));
             }
 
-            LOG_LAST_ERROR();
+            // The helper may have exited between the initial wait and forced cleanup.
+            const auto preTerminateWaitResult = WaitForSingleObject(process.get(), 0);
+            const auto preTerminateWaitError = preTerminateWaitResult == WAIT_FAILED ? GetLastError() : ERROR_SUCCESS;
+            if (preTerminateWaitResult == WAIT_OBJECT_0)
+            {
+                _agentPaneLog("wta-helper exited before forced termination pid=" + std::to_string(pid));
+                co_return;
+            }
+            if (preTerminateWaitResult == WAIT_FAILED)
+            {
+                LOG_WIN32_MSG(preTerminateWaitError, "Rechecking wta-helper before forced termination failed (pid=%lu)", pid);
+                _agentPaneLog("rechecking wta-helper before forced termination failed error=" + std::to_string(preTerminateWaitError) + " pid=" + std::to_string(pid));
+
+                DWORD exitCode = STILL_ACTIVE;
+                if (GetExitCodeProcess(process.get(), &exitCode))
+                {
+                    if (exitCode != STILL_ACTIVE)
+                    {
+                        _agentPaneLog("wta-helper had already exited before forced termination pid=" + std::to_string(pid));
+                        co_return;
+                    }
+                }
+                else
+                {
+                    const auto exitCodeError = GetLastError();
+                    LOG_WIN32_MSG(exitCodeError, "Querying wta-helper exit code before forced termination failed (pid=%lu)", pid);
+                    _agentPaneLog("querying wta-helper exit code before forced termination failed error=" + std::to_string(exitCodeError) + " pid=" + std::to_string(pid));
+                }
+            }
+
+            _agentPaneLog("terminating wta-helper after pane close pid=" + std::to_string(pid));
+            if (!TerminateProcess(process.get(), 1))
+            {
+                const auto terminateError = GetLastError();
+                LOG_WIN32_MSG(terminateError, "Terminating wta-helper after pane close failed (pid=%lu)", pid);
+                _agentPaneLog("terminating wta-helper after pane close failed error=" + std::to_string(terminateError) + " pid=" + std::to_string(pid));
+            }
+
+            const auto reapResult = WaitForSingleObject(process.get(), 5000);
+            if (reapResult == WAIT_OBJECT_0)
+            {
+                _agentPaneLog("wta-helper reaped after forced termination pid=" + std::to_string(pid));
+            }
+            else if (reapResult == WAIT_TIMEOUT)
+            {
+                _agentPaneLog("timed out waiting to reap wta-helper after forced termination pid=" + std::to_string(pid));
+            }
+            else if (reapResult == WAIT_FAILED)
+            {
+                const auto reapError = GetLastError();
+                LOG_WIN32_MSG(reapError, "Waiting to reap wta-helper after forced termination failed (pid=%lu)", pid);
+                _agentPaneLog("waiting to reap wta-helper after forced termination failed error=" + std::to_string(reapError) + " pid=" + std::to_string(pid));
+            }
+            else
+            {
+                _agentPaneLog("waiting to reap wta-helper after forced termination returned unexpected result=" + std::to_string(reapResult) + " pid=" + std::to_string(pid));
+            }
         }
 
         wil::unique_handle _DuplicateAgentHelperProcess(const winrt::TerminalApp::TerminalPaneContent& inner)

--- a/src/cascadia/TerminalApp/AgentPaneContent.cpp
+++ b/src/cascadia/TerminalApp/AgentPaneContent.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "AgentPaneContent.h"
 #include "AgentPaneContent.g.cpp"
+#include "AgentPaneLog.h"
 
 #include <algorithm>
 #include <cwctype>
@@ -15,6 +16,7 @@ using namespace winrt::Windows::UI::Xaml::Controls;
 using namespace winrt::Windows::UI::Xaml::Media;
 using namespace winrt::Microsoft::Terminal::Control;
 using namespace winrt::Microsoft::Terminal::Settings::Model;
+using namespace winrt::Microsoft::Terminal::TerminalConnection;
 
 namespace winrt::TerminalApp::implementation
 {
@@ -28,6 +30,61 @@ namespace winrt::TerminalApp::implementation
             Codex,
             OpenCode,
         };
+
+        constexpr auto AgentHelperExitTimeout{ std::chrono::seconds{ 3 } };
+
+        safe_void_coroutine _EnsureAgentHelperExited(wil::unique_handle process, const DWORD pid)
+        {
+            co_await winrt::resume_background();
+
+            const auto waitResult = WaitForSingleObject(process.get(), static_cast<DWORD>(
+                                                                           std::chrono::duration_cast<std::chrono::milliseconds>(
+                                                                               AgentHelperExitTimeout)
+                                                                               .count()));
+            if (waitResult == WAIT_OBJECT_0)
+            {
+                _agentPaneLog("wta-helper exited after pane close pid=" + std::to_string(pid));
+                co_return;
+            }
+
+            if (waitResult == WAIT_TIMEOUT)
+            {
+                _agentPaneLog("wta-helper did not exit after pane close; terminating pid=" + std::to_string(pid));
+                LOG_IF_WIN32_BOOL_FALSE(TerminateProcess(process.get(), 1));
+                WaitForSingleObject(process.get(), 5000);
+                co_return;
+            }
+
+            LOG_LAST_ERROR();
+        }
+
+        wil::unique_handle _DuplicateAgentHelperProcess(const winrt::TerminalApp::TerminalPaneContent& inner)
+        {
+            const auto impl = winrt::get_self<implementation::TerminalPaneContent>(inner);
+            if (!impl)
+            {
+                return {};
+            }
+            const auto control = impl->GetTermControl();
+            const auto connection = control ? control.Connection() : nullptr;
+            const auto conpty = connection.try_as<ConptyConnection>();
+            const auto processValue = conpty ? conpty.RootProcessHandle() : 0;
+            if (!processValue)
+            {
+                return {};
+            }
+
+            wil::unique_handle duplicate;
+            LOG_IF_WIN32_BOOL_FALSE(DuplicateHandle(
+                GetCurrentProcess(),
+                reinterpret_cast<HANDLE>(processValue),
+                GetCurrentProcess(),
+                duplicate.addressof(),
+                SYNCHRONIZE | PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION,
+                FALSE,
+                0));
+            return duplicate;
+        }
 
         // Map the agent's display name (case-insensitive substring) to its
         // XAML path. Unknown agents fall back to Copilot.
@@ -333,9 +390,15 @@ namespace winrt::TerminalApp::implementation
     void AgentPaneContent::Close()
     {
         _unwireInnerEvents();
+        auto helperProcess = _DuplicateAgentHelperProcess(_inner);
+        const auto helperPid = helperProcess ? GetProcessId(helperProcess.get()) : 0;
         if (const auto& impl = winrt::get_self<implementation::TerminalPaneContent>(_inner))
         {
             impl->Close();
+        }
+        if (helperProcess)
+        {
+            _EnsureAgentHelperExited(std::move(helperProcess), helperPid);
         }
     }
 

--- a/src/cascadia/TerminalApp/AgentPaneContent.cpp
+++ b/src/cascadia/TerminalApp/AgentPaneContent.cpp
@@ -390,11 +390,15 @@ namespace winrt::TerminalApp::implementation
     void AgentPaneContent::Close()
     {
         _unwireInnerEvents();
-        auto helperProcess = _DuplicateAgentHelperProcess(_inner);
+        auto helperProcess = _helperTransferredForDrag ? wil::unique_handle{} : _DuplicateAgentHelperProcess(_inner);
         const auto helperPid = helperProcess ? GetProcessId(helperProcess.get()) : 0;
         if (const auto& impl = winrt::get_self<implementation::TerminalPaneContent>(_inner))
         {
             impl->Close();
+        }
+        if (_helperTransferredForDrag)
+        {
+            _agentPaneLog("skipping wta-helper exit enforcement for cross-window transfer");
         }
         if (helperProcess)
         {

--- a/src/cascadia/TerminalApp/AgentPaneContent.h
+++ b/src/cascadia/TerminalApp/AgentPaneContent.h
@@ -89,6 +89,7 @@ namespace winrt::TerminalApp::implementation
             _pendingAgentSourceProfileGuid.reset();
             return value;
         }
+        void PrepareForCrossWindowTransfer() noexcept { _helperTransferredForDrag = true; }
 
         // Apply the provided background and foreground brushes to the
         // agent-pane top bar (#348). Internal-only (not on IDL).
@@ -176,6 +177,7 @@ namespace winrt::TerminalApp::implementation
         // is pending. See SetPendingRenameFromTabId / TakePendingRenameFromTabId.
         winrt::hstring _pendingRenameFromTabId{};
         std::optional<winrt::guid> _pendingAgentSourceProfileGuid;
+        bool _helperTransferredForDrag{ false };
 
         // Inner content event tokens — forwarded to our own BasicPaneEvents.
         winrt::event_token _innerCloseRequested{};

--- a/src/cascadia/TerminalApp/SharedWta.cpp
+++ b/src/cascadia/TerminalApp/SharedWta.cpp
@@ -16,6 +16,8 @@ namespace
     // Must remain strictly greater than WTA's 15-second
     // SESSION_CLOSE_TIMEOUT in tools/wta/src/master/mod.rs.
     constexpr auto WtaSessionCloseGracePeriod{ std::chrono::seconds{ 16 } };
+    constexpr auto WtaMasterExitTimeout{ std::chrono::seconds{ 3 } };
+    constexpr auto WtaMasterForcedExitTimeout{ std::chrono::seconds{ 5 } };
 }
 
 namespace winrt::TerminalApp::implementation::details
@@ -367,6 +369,56 @@ namespace winrt::TerminalApp::implementation::details
         operations.terminateProcess(process, 1);
         return false;
     }
+
+    bool EnsureProcessExitedBeforeRestart(
+        const HANDLE process,
+        const DWORD pid,
+        const DWORD exitTimeoutMs,
+        const DWORD forcedExitTimeoutMs,
+        const ProcessRetirementOperations& operations)
+    {
+        const auto waitResult = operations.waitForSingleObject(process, exitTimeoutMs);
+        if (waitResult == WAIT_OBJECT_0)
+        {
+            return true;
+        }
+
+        if (waitResult == WAIT_TIMEOUT)
+        {
+            _agentPaneLog(
+                "wta-master did not exit before restart pid=" + std::to_string(pid) +
+                " timeout_ms=" + std::to_string(exitTimeoutMs) + "; forcing termination");
+        }
+        else
+        {
+            const auto error = GetLastError();
+            _agentPaneLog(
+                "waiting for wta-master before restart failed pid=" + std::to_string(pid) +
+                " result=" + std::to_string(waitResult) +
+                " error=" + std::to_string(error) + "; forcing termination");
+        }
+
+        if (!operations.terminateProcess(process, 1))
+        {
+            const auto error = GetLastError();
+            _agentPaneLog(
+                "failed to terminate wta-master before restart pid=" + std::to_string(pid) +
+                " error=" + std::to_string(error) + "; verifying process exit");
+        }
+
+        const auto reapResult = operations.waitForSingleObject(process, forcedExitTimeoutMs);
+        if (reapResult != WAIT_OBJECT_0)
+        {
+            const auto error = reapResult == WAIT_FAILED ? GetLastError() : ERROR_SUCCESS;
+            _agentPaneLog(
+                "failed to reap wta-master before restart pid=" + std::to_string(pid) +
+                " result=" + std::to_string(reapResult) +
+                " error=" + std::to_string(error) + "; replacement suppressed");
+            return false;
+        }
+
+        return true;
+    }
 }
 
 namespace winrt::TerminalApp::implementation
@@ -487,6 +539,10 @@ namespace winrt::TerminalApp::implementation
         }
 
         std::lock_guard lock{ _mtx };
+        if (_spawnSuppressed)
+        {
+            return false;
+        }
 
         // Degraded latch: the master died unexpectedly and hasn't been
         // recovered via /restart yet. Open the pane WITHOUT respawning master,
@@ -536,6 +592,10 @@ namespace winrt::TerminalApp::implementation
     bool SharedWta::Restart()
     {
         std::lock_guard lock{ _mtx };
+        if (_spawnSuppressed)
+        {
+            return false;
+        }
 
         // `/restart` is the explicit recovery: clear the degraded latch up
         // front so the teardown+reopen this call drives (and any racing
@@ -561,17 +621,7 @@ namespace winrt::TerminalApp::implementation
             return false;
         }
 
-        // Drop the Job first so KILL_ON_JOB_CLOSE reaps the old master +
-        // every agent CLI descendant, then respawn under the same
-        // _masterPipeName. Any helper that's about to be torn down (the
-        // /restart caller closes every agent pane) sees its pipe go EOF
-        // and exits naturally; any helper that races a reconnect against
-        // the respawn finds the new master listening on the same name.
-        // Refcount is left untouched on purpose — the caller is still
-        // holding refs for the panes it's about to close-and-reopen, and
-        // the matching ReleasePane / AcquirePane pair will balance out.
-        _CleanupLocked();
-        return _SpawnLocked(std::wstring_view{ _cachedWtaPath }, _cachedExtraArgs, _cachedEnvironment);
+        return _RestartLocked(std::wstring_view{ _cachedWtaPath }, _cachedExtraArgs, _cachedEnvironment);
     }
 
     bool SharedWta::Restart(const std::wstring_view wtaPath,
@@ -584,6 +634,10 @@ namespace winrt::TerminalApp::implementation
         }
 
         std::lock_guard lock{ _mtx };
+        if (_spawnSuppressed)
+        {
+            return false;
+        }
 
         // Settings-change respawn is also an explicit recovery point —
         // clear the degraded latch so the rebuilt stack spawns normally.
@@ -612,14 +666,45 @@ namespace winrt::TerminalApp::implementation
             return true;
         }
 
-        // Respawn the master with the *new* args so the running agent
-        // CLI is replaced with whatever the new settings demand. The
-        // surrounding `_RebuildAgentStack` flow has already torn down
-        // every agent pane in this window and is about to reopen one;
-        // refcount is left alone for the same reason as the cached-args
-        // overload — outgoing ReleasePane / incoming AcquirePane balance.
-        _CleanupLocked();
-        return _SpawnLocked(wtaPath, extraArgs, environment);
+        return _RestartLocked(wtaPath, extraArgs, environment);
+    }
+
+    bool SharedWta::_RestartLocked(
+        const std::wstring_view wtaPath,
+        std::span<const std::wstring> extraArgs,
+        std::span<const std::pair<std::wstring, std::wstring>> environment)
+    {
+        // Own the next inputs independently of the cache. The cached-args
+        // overload passes spans into member vectors that _SpawnLocked updates
+        // after success.
+        const std::wstring nextWtaPath{ wtaPath };
+        const std::vector<std::wstring> nextExtraArgs{ extraArgs.begin(), extraArgs.end() };
+        const std::vector<std::pair<std::wstring, std::wstring>> nextEnvironment{
+            environment.begin(), environment.end()
+        };
+
+        // Closing the KILL_ON_JOB_CLOSE job requests termination, but process
+        // teardown and named-pipe release are asynchronous. Keep the old
+        // process handle until it is signaled so the replacement cannot race
+        // the old master for the stable, process-wide pipe name. Holding _mtx
+        // throughout also preserves cross-window restart deduplication.
+        const auto retiredPid = _pid;
+        auto retiredProcess = _CleanupLocked();
+        if (retiredProcess &&
+            !details::EnsureProcessExitedBeforeRestart(
+                retiredProcess.get(),
+                retiredPid,
+                static_cast<DWORD>(std::chrono::duration_cast<std::chrono::milliseconds>(WtaMasterExitTimeout).count()),
+                static_cast<DWORD>(std::chrono::duration_cast<std::chrono::milliseconds>(WtaMasterForcedExitTimeout).count())))
+        {
+            _spawnSuppressed = true;
+            return false;
+        }
+
+        // Refcount is deliberately untouched. The surrounding pane teardown
+        // and reopen balances its outgoing ReleasePane and incoming
+        // AcquirePane after the replacement has claimed the shared pipe.
+        return _SpawnLocked(nextWtaPath, nextExtraArgs, nextEnvironment);
     }
 
     bool SharedWta::_SpawnLocked(const std::wstring_view wtaPath,
@@ -825,16 +910,16 @@ namespace winrt::TerminalApp::implementation
         return true;
     }
 
-    void SharedWta::_CleanupLocked()
+    wil::unique_handle SharedWta::_CleanupLocked()
     {
         // Order matters: drop the job FIRST so KILL_ON_JOB_CLOSE
         // terminates wta + descendants while we still hold a process
-        // handle that lets us observe the termination if needed.
+        // handle that lets restart observe termination and pipe release.
         // Deliberate teardown: the master is reaped silently (job close, no
         // console event), so it can't log its own death — record it here.
         _agentPaneLog("releasing wta-master pid=" + std::to_string(_pid) + " (deliberate teardown via KILL_ON_JOB_CLOSE)");
+        auto process = std::move(_process);
         _job.reset();
-        _process.reset();
         if (_waitHandle)
         {
             // Non-blocking unregister. If the callback is in flight
@@ -844,6 +929,7 @@ namespace winrt::TerminalApp::implementation
             _waitHandle = nullptr;
         }
         _pid = 0;
+        return process;
     }
 
     void CALLBACK SharedWta::_OnProcessExitedThunk(PVOID context, BOOLEAN /*timedOut*/)

--- a/src/cascadia/TerminalApp/SharedWta.cpp
+++ b/src/cascadia/TerminalApp/SharedWta.cpp
@@ -20,6 +20,266 @@ namespace
 
 namespace winrt::TerminalApp::implementation::details
 {
+    uint64_t LiveObjectGenerationTracker::Get(const winrt::Windows::Foundation::IInspectable& object)
+    {
+        std::lock_guard lock{ _mutex };
+        for (auto entry = _entries.begin(); entry != _entries.end();)
+        {
+            if (const auto live = entry->object.get())
+            {
+                if (live == object)
+                {
+                    return entry->generation;
+                }
+                ++entry;
+            }
+            else
+            {
+                entry = _entries.erase(entry);
+            }
+        }
+
+        const auto generation = ++_nextGeneration;
+        _entries.emplace_back(winrt::make_weak(object), generation);
+        return generation;
+    }
+
+    std::string RetirementCoordinator::_CreateIdLocked(const std::string_view kind)
+    {
+        auto id = std::to_string(GetCurrentProcessId());
+        id.push_back('-');
+        id.append(kind);
+        id.push_back('-');
+        id.append(std::to_string(++_nextOperationId));
+        return id;
+    }
+
+    std::string RetirementCoordinator::CreateRequestId()
+    {
+        std::lock_guard lock{ _mutex };
+        return _CreateIdLocked("request");
+    }
+
+    RetirementRegistration RetirementCoordinator::Register(
+        const bool scopeAll,
+        const std::string_view /*reason*/,
+        const std::string_view requestId)
+    {
+        std::lock_guard lock{ _mutex };
+
+        if (scopeAll && !requestId.empty())
+        {
+            if (const auto existing = _allOperationsByRequest.find(std::string{ requestId });
+                existing != _allOperationsByRequest.end())
+            {
+                if (const auto operation = _operations.find(existing->second);
+                    operation != _operations.end())
+                {
+                    if (operation->second.recordedInHistory)
+                    {
+                        const auto completed = std::find(
+                            _completedOperations.begin(),
+                            _completedOperations.end(),
+                            operation->first);
+                        if (completed != _completedOperations.end())
+                        {
+                            _completedOperations.erase(completed);
+                        }
+                        operation->second.recordedInHistory = false;
+                    }
+                    ++operation->second.continuationCount;
+                    return {
+                        operation->first,
+                        false,
+                        operation->second.completed,
+                    };
+                }
+            }
+        }
+
+        auto operationId = _CreateIdLocked("operation");
+        Operation operation;
+        if (scopeAll && !requestId.empty())
+        {
+            operation.requestId = requestId;
+            _allOperationsByRequest[*operation.requestId] = operationId;
+        }
+        operation.continuationCount = 1;
+        _operations.emplace(operationId, std::move(operation));
+        return { std::move(operationId), true, false };
+    }
+
+    void RetirementCoordinator::_EraseLocked(const std::string& operationId)
+    {
+        if (const auto operation = _operations.find(operationId);
+            operation != _operations.end())
+        {
+            if (operation->second.requestId)
+            {
+                if (const auto request = _allOperationsByRequest.find(*operation->second.requestId);
+                    request != _allOperationsByRequest.end() && request->second == operationId)
+                {
+                    _allOperationsByRequest.erase(request);
+                }
+            }
+            _operations.erase(operation);
+        }
+    }
+
+    void RetirementCoordinator::_FinalizeCompletedLocked(
+        const std::unordered_map<std::string, Operation>::iterator operation)
+    {
+        if (!operation->second.completed || operation->second.continuationCount != 0)
+        {
+            return;
+        }
+
+        if (operation->second.expireAfterContinuations)
+        {
+            const auto operationId = operation->first;
+            _EraseLocked(operationId);
+        }
+        else if (!operation->second.recordedInHistory)
+        {
+            operation->second.recordedInHistory = true;
+            _completedOperations.emplace_back(operation->first);
+            _PruneCompletedLocked();
+        }
+    }
+
+    void RetirementCoordinator::_PruneCompletedLocked()
+    {
+        while (_completedOperations.size() > CompletedHistoryLimit)
+        {
+            auto operationId = std::move(_completedOperations.front());
+            _completedOperations.pop_front();
+            _EraseLocked(operationId);
+        }
+    }
+
+    bool RetirementCoordinator::Complete(
+        const std::string_view operationId,
+        const bool expireAfterContinuations)
+    {
+        std::lock_guard lock{ _mutex };
+        if (const auto operation = _operations.find(std::string{ operationId });
+            operation != _operations.end())
+        {
+            operation->second.completed = true;
+            operation->second.expireAfterContinuations =
+                operation->second.expireAfterContinuations || expireAfterContinuations;
+            _FinalizeCompletedLocked(operation);
+            return true;
+        }
+        return false;
+    }
+
+    void RetirementCoordinator::ReleaseContinuation(const std::string_view operationId)
+    {
+        std::lock_guard lock{ _mutex };
+        if (const auto operation = _operations.find(std::string{ operationId });
+            operation != _operations.end())
+        {
+            if (operation->second.continuationCount != 0)
+            {
+                --operation->second.continuationCount;
+            }
+            if (operation->second.continuationCount == 0 && !operation->second.completed)
+            {
+                const auto id = operation->first;
+                _EraseLocked(id);
+            }
+            else
+            {
+                _FinalizeCompletedLocked(operation);
+            }
+        }
+    }
+
+    void RetirementCoordinator::Expire(const std::string_view operationId)
+    {
+        std::lock_guard lock{ _mutex };
+        const std::string id{ operationId };
+        _EraseLocked(id);
+    }
+
+    bool RetirementCoordinator::ClaimAction(const std::string_view operationId, const std::string_view action)
+    {
+        std::lock_guard lock{ _mutex };
+        if (const auto operation = _operations.find(std::string{ operationId });
+            operation != _operations.end())
+        {
+            return operation->second.claimedActions.emplace(action).second;
+        }
+        return false;
+    }
+
+    bool TabRetirementTracker::BeginRebuild(const std::string_view tabId)
+    {
+        return _closeRequested.emplace(tabId, false).second;
+    }
+
+    bool TabRetirementTracker::RequestClose(const std::string_view tabId)
+    {
+        const auto [entry, inserted] = _closeRequested.emplace(tabId, true);
+        entry->second = true;
+        return inserted;
+    }
+
+    bool TabRetirementTracker::Complete(const std::string_view tabId)
+    {
+        const auto entry = _closeRequested.find(std::string{ tabId });
+        if (entry == _closeRequested.end())
+        {
+            return false;
+        }
+        const bool shouldReopen = !entry->second;
+        _closeRequested.erase(entry);
+        return shouldReopen;
+    }
+
+    void RestartSuppressionTracker::Mark(const std::string_view tabId)
+    {
+        _marks[std::string{ tabId }] = std::chrono::steady_clock::now();
+    }
+
+    void RestartSuppressionTracker::Clear(const std::string_view tabId)
+    {
+        _marks.erase(std::string{ tabId });
+    }
+
+    bool RestartSuppressionTracker::Consume(const std::string_view tabId)
+    {
+        const auto mark = _marks.find(std::string{ tabId });
+        if (mark == _marks.end())
+        {
+            return false;
+        }
+        const auto age = std::chrono::steady_clock::now() - mark->second;
+        _marks.erase(mark);
+        return age < std::chrono::seconds{ 5 };
+    }
+
+    void CoalescedRequest::Queue(std::string requestId)
+    {
+        _requestId = std::move(requestId);
+    }
+
+    std::optional<std::string> CoalescedRequest::Take()
+    {
+        return std::exchange(_requestId, std::nullopt);
+    }
+
+    void CoalescedRequest::Clear()
+    {
+        _requestId.reset();
+    }
+
+    bool CoalescedRequest::Pending() const noexcept
+    {
+        return _requestId.has_value();
+    }
+
     std::optional<std::wstring> BuildEnvironmentBlock(
         const std::span<const std::pair<std::wstring, std::wstring>> overrides) noexcept
     {
@@ -98,6 +358,46 @@ namespace winrt::TerminalApp::implementation
         // cleanup for the master and its descendants.
         static auto* const s_instance = new SharedWta;
         return *s_instance;
+    }
+
+    std::string SharedWta::CreateRetirementRequestId()
+    {
+        return _retirementCoordinator.CreateRequestId();
+    }
+
+    details::RetirementRegistration SharedWta::RegisterRetirement(
+        const bool scopeAll,
+        const std::string_view reason,
+        const std::string_view requestId)
+    {
+        return _retirementCoordinator.Register(scopeAll, reason, requestId);
+    }
+
+    bool SharedWta::CompleteRetirement(
+        const std::string_view operationId,
+        const bool expireAfterContinuations)
+    {
+        return _retirementCoordinator.Complete(operationId, expireAfterContinuations);
+    }
+
+    void SharedWta::ReleaseRetirementContinuation(const std::string_view operationId)
+    {
+        _retirementCoordinator.ReleaseContinuation(operationId);
+    }
+
+    void SharedWta::ExpireRetirement(const std::string_view operationId)
+    {
+        _retirementCoordinator.Expire(operationId);
+    }
+
+    bool SharedWta::ClaimRetirementAction(const std::string_view operationId, const std::string_view action)
+    {
+        return _retirementCoordinator.ClaimAction(operationId, action);
+    }
+
+    uint64_t SharedWta::GetSettingsGeneration(const winrt::Windows::Foundation::IInspectable& settings)
+    {
+        return _settingsGenerations.Get(settings);
     }
 
     SharedWta::~SharedWta()
@@ -232,25 +532,6 @@ namespace winrt::TerminalApp::implementation
             return true;
         }
 
-        // Dedup the multi-window fan-out. `/restart` (and auth-recovery)
-        // arrives via `_dispatchRestartAgentStackToPage`, which calls
-        // `OnRestartAgentStackRequested` (and thus `Restart()`) on EVERY
-        // window's UI thread. Without this guard, window B's Restart kills
-        // window A's just-spawned master, breaking the freshly-reopened
-        // helper in window A. Key off the last *restart request*, NOT
-        // `_lastRespawn`: the initial master spawn also stamps `_lastRespawn`,
-        // so keying on it would wrongly suppress a legitimate restart that
-        // fires shortly after the master first comes up (e.g. an auth-recovery
-        // restart against a freshly poisoned master). 500 ms is comfortably
-        // larger than the typical UI-thread RunAsync hop (the 07:32 log showed
-        // a 240 ms gap between windows) and tiny compared to any human- or
-        // recovery-driven legitimate "two restarts in a row".
-        if (_lastRestartRequest &&
-            std::chrono::steady_clock::now() - *_lastRestartRequest < std::chrono::milliseconds(500))
-        {
-            return true;
-        }
-
         // No cached args means we've never successfully spawned in this
         // process, which contradicts `_process.is_valid()` — defensive
         // bail rather than spawning with empty wtaPath.
@@ -269,14 +550,7 @@ namespace winrt::TerminalApp::implementation
         // holding refs for the panes it's about to close-and-reopen, and
         // the matching ReleasePane / AcquirePane pair will balance out.
         _CleanupLocked();
-        const bool spawned = _SpawnLocked(std::wstring_view{ _cachedWtaPath }, _cachedExtraArgs, _cachedEnvironment);
-        if (spawned)
-        {
-            // Stamp the restart (not just the spawn) so the fan-out dedup above
-            // suppresses only follow-up duplicate restarts, never the first.
-            _lastRestartRequest = std::chrono::steady_clock::now();
-        }
-        return spawned;
+        return _SpawnLocked(std::wstring_view{ _cachedWtaPath }, _cachedExtraArgs, _cachedEnvironment);
     }
 
     bool SharedWta::Restart(const std::wstring_view wtaPath,
@@ -324,12 +598,7 @@ namespace winrt::TerminalApp::implementation
         // refcount is left alone for the same reason as the cached-args
         // overload — outgoing ReleasePane / incoming AcquirePane balance.
         _CleanupLocked();
-        const bool spawned = _SpawnLocked(wtaPath, extraArgs, environment);
-        if (spawned)
-        {
-            _lastRestartRequest = std::chrono::steady_clock::now();
-        }
-        return spawned;
+        return _SpawnLocked(wtaPath, extraArgs, environment);
     }
 
     bool SharedWta::_SpawnLocked(const std::wstring_view wtaPath,
@@ -528,7 +797,6 @@ namespace winrt::TerminalApp::implementation
         _cachedWtaPath.assign(wtaPath);
         _cachedExtraArgs.assign(extraArgs.begin(), extraArgs.end());
         _cachedEnvironment.assign(environment.begin(), environment.end());
-        _lastRespawn = std::chrono::steady_clock::now();
         return true;
     }
 

--- a/src/cascadia/TerminalApp/SharedWta.cpp
+++ b/src/cascadia/TerminalApp/SharedWta.cpp
@@ -346,6 +346,27 @@ namespace winrt::TerminalApp::implementation::details
             return std::nullopt;
         }
     }
+
+    bool ResumeSuspendedProcess(
+        const HANDLE thread,
+        const HANDLE process,
+        HANDLE& waitHandle,
+        const SuspendedProcessOperations& operations) noexcept
+    {
+        const auto resumeResult = operations.resumeThread(thread);
+        if (resumeResult != static_cast<DWORD>(-1))
+        {
+            return true;
+        }
+
+        if (waitHandle)
+        {
+            operations.unregisterWait(waitHandle, nullptr);
+            waitHandle = nullptr;
+        }
+        operations.terminateProcess(process, 1);
+        return false;
+    }
 }
 
 namespace winrt::TerminalApp::implementation
@@ -780,9 +801,13 @@ namespace winrt::TerminalApp::implementation
             waitHandle = nullptr;
         }
 
-        // Hand wta the go-ahead. After this point, any failure has to
-        // route through the normal Release path / external crash path.
-        ResumeThread(thread.get());
+        // Hand wta the go-ahead. A resume failure leaves the child suspended,
+        // so cancel its wait registration and terminate it before any process
+        // state or spawn inputs are published.
+        if (!details::ResumeSuspendedProcess(thread.get(), process.get(), waitHandle))
+        {
+            return false;
+        }
 
         _process = std::move(process);
         _job = std::move(job);

--- a/src/cascadia/TerminalApp/SharedWta.cpp
+++ b/src/cascadia/TerminalApp/SharedWta.cpp
@@ -419,6 +419,41 @@ namespace winrt::TerminalApp::implementation::details
 
         return true;
     }
+
+    ProcessWaitGenerationTracker::Generation ProcessWaitGenerationTracker::Register(const DWORD pid) noexcept
+    {
+        do
+        {
+            ++_nextGeneration;
+        } while (_nextGeneration == 0);
+
+        _currentGeneration = _nextGeneration;
+        _pid = pid;
+        return _currentGeneration;
+    }
+
+    void ProcessWaitGenerationTracker::Retire() noexcept
+    {
+        _currentGeneration = 0;
+        _pid = 0;
+    }
+
+    std::optional<DWORD> ProcessWaitGenerationTracker::Claim(const Generation generation) noexcept
+    {
+        if (generation == 0 || generation != _currentGeneration)
+        {
+            return std::nullopt;
+        }
+
+        const auto pid = _pid;
+        Retire();
+        return pid;
+    }
+
+    ProcessWaitGenerationTracker::Generation ProcessWaitGenerationTracker::Current() const noexcept
+    {
+        return _currentGeneration;
+    }
 }
 
 namespace winrt::TerminalApp::implementation
@@ -486,6 +521,7 @@ namespace winrt::TerminalApp::implementation
         HANDLE waitToCancel = nullptr;
         {
             std::lock_guard lock{ _mtx };
+            _waitGeneration.Retire();
             waitToCancel = _waitHandle;
             _waitHandle = nullptr;
         }
@@ -866,17 +902,17 @@ namespace winrt::TerminalApp::implementation
         // BEFORE ResumeThread so the wait is in place by the time
         // the child actually starts running.
         //
-        // Context is the PID, not a `this` pointer. The callback
-        // dispatches via `Instance()` and uses the captured PID to
-        // detect a stale registration (see `_OnProcessExited`'s
-        // mismatch bail). Casting via `uintptr_t` is the canonical
-        // PVOID-as-integer round trip.
+        // Context is a registration generation, not a PID or `this`
+        // pointer. PID reuse cannot make a delayed callback match a
+        // replacement wait, and the integer context has no lifetime to
+        // manage while non-blocking unregister drains queued callbacks.
         HANDLE waitHandle = nullptr;
+        const auto waitGeneration = _waitGeneration.Register(pid);
         if (!RegisterWaitForSingleObject(
                 &waitHandle,
                 process.get(),
                 &SharedWta::_OnProcessExitedThunk,
-                reinterpret_cast<PVOID>(static_cast<uintptr_t>(pid)),
+                reinterpret_cast<PVOID>(waitGeneration),
                 INFINITE,
                 WT_EXECUTEONLYONCE))
         {
@@ -884,6 +920,7 @@ namespace winrt::TerminalApp::implementation
             // rather than fail the spawn. wta still runs; the user just
             // won't get a transparent respawn if it crashes.
             waitHandle = nullptr;
+            _waitGeneration.Retire();
         }
 
         // Hand wta the go-ahead. A resume failure leaves the child suspended,
@@ -891,6 +928,7 @@ namespace winrt::TerminalApp::implementation
         // state or spawn inputs are published.
         if (!details::ResumeSuspendedProcess(thread.get(), process.get(), waitHandle))
         {
+            _waitGeneration.Retire();
             return false;
         }
 
@@ -922,11 +960,16 @@ namespace winrt::TerminalApp::implementation
         _job.reset();
         if (_waitHandle)
         {
-            // Non-blocking unregister. If the callback is in flight
-            // it will take _mtx after we release it, observe an
-            // invalid _process, and bail.
+            // Invalidate before the non-blocking unregister. A queued
+            // callback can run after a replacement is spawned, but its
+            // retired generation cannot claim the replacement state.
+            _waitGeneration.Retire();
             UnregisterWaitEx(_waitHandle, nullptr);
             _waitHandle = nullptr;
+        }
+        else
+        {
+            _waitGeneration.Retire();
         }
         _pid = 0;
         return process;
@@ -934,15 +977,11 @@ namespace winrt::TerminalApp::implementation
 
     void CALLBACK SharedWta::_OnProcessExitedThunk(PVOID context, BOOLEAN /*timedOut*/)
     {
-        // `context` is the PID at registration time, packed via
-        // `reinterpret_cast<PVOID>(static_cast<uintptr_t>(pid))`. Round
-        // trip back and let `_OnProcessExited` compare against the
-        // currently-registered PID to detect a stale callback.
-        const auto observedPid = static_cast<DWORD>(reinterpret_cast<uintptr_t>(context));
-        SharedWta::Instance()._OnProcessExited(observedPid);
+        const auto generation = reinterpret_cast<details::ProcessWaitGenerationTracker::Generation>(context);
+        SharedWta::Instance()._OnProcessExited(generation);
     }
 
-    void SharedWta::_OnProcessExited(DWORD observedPid)
+    void SharedWta::_OnProcessExited(const details::ProcessWaitGenerationTracker::Generation generation)
     {
         // Runs on a Win32 thread-pool thread. wta has exited (crash,
         // OOM, manual kill). Clear our process record so the next
@@ -952,14 +991,11 @@ namespace winrt::TerminalApp::implementation
         // _process is already invalid).
         std::lock_guard lock{ _mtx };
 
-        // Stale-callback bail. `_CleanupLocked` only does a non-blocking
-        // `UnregisterWaitEx(nullptr)`, so a callback that was already
-        // queued for the OLD master can still fire after `_SpawnLocked`
-        // has installed a NEW master. The captured PID lets us tell:
-        // when it doesn't match the live `_pid`, the callback is for
-        // a previously-killed master and must not touch `_process` /
-        // `_waitHandle` (which now belong to the new master).
-        if (_pid != observedPid)
+        // Claiming also retires the current generation. A callback queued
+        // before cleanup/restart cannot claim a later registration, even
+        // when Windows assigns both process lifetimes the same PID.
+        const auto observedPid = _waitGeneration.Claim(generation);
+        if (!observedPid)
         {
             return;
         }
@@ -976,7 +1012,7 @@ namespace winrt::TerminalApp::implementation
         // is the external observer that makes otherwise-silent master deaths
         // diagnosable; deliberate teardowns never reach here (they reset
         // _process first, so the validity check above bails).
-        _agentPaneLog("wta-master exited unexpectedly pid=" + std::to_string(observedPid) + " (crash/OOM/external kill — observed by wait callback)");
+        _agentPaneLog("wta-master exited unexpectedly pid=" + std::to_string(*observedPid) + " (crash/OOM/external kill — observed by wait callback)");
         _job.reset();
         _process.reset();
         if (_waitHandle)

--- a/src/cascadia/TerminalApp/SharedWta.h
+++ b/src/cascadia/TerminalApp/SharedWta.h
@@ -26,19 +26,116 @@
 
 #include <atomic>
 #include <chrono>
+#include <deque>
 #include <mutex>
 #include <optional>
 #include <span>
 #include <string>
 #include <string_view>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <wil/resource.h>
+#include <winrt/Windows.Foundation.h>
 
 namespace winrt::TerminalApp::implementation
 {
     namespace details
     {
+        class LiveObjectGenerationTracker
+        {
+        public:
+            uint64_t Get(const winrt::Windows::Foundation::IInspectable& object);
+
+        private:
+            struct Entry
+            {
+                winrt::weak_ref<winrt::Windows::Foundation::IInspectable> object;
+                uint64_t generation;
+            };
+
+            std::mutex _mutex;
+            uint64_t _nextGeneration{ 0 };
+            std::vector<Entry> _entries;
+        };
+
+        struct RetirementRegistration
+        {
+            std::string operationId;
+            bool shouldPublish{ false };
+            bool alreadyCompleted{ false };
+        };
+
+        class RetirementCoordinator
+        {
+        public:
+            static constexpr size_t CompletedHistoryLimit{ 64 };
+
+            std::string CreateRequestId();
+            RetirementRegistration Register(bool scopeAll, std::string_view reason, std::string_view requestId = {});
+            bool Complete(std::string_view operationId, bool expireAfterContinuations = false);
+            void ReleaseContinuation(std::string_view operationId);
+            void Expire(std::string_view operationId);
+            bool ClaimAction(std::string_view operationId, std::string_view action);
+
+        private:
+            struct Operation
+            {
+                bool completed{ false };
+                bool expireAfterContinuations{ false };
+                bool recordedInHistory{ false };
+                size_t continuationCount{ 0 };
+                std::optional<std::string> requestId;
+                std::unordered_set<std::string> claimedActions;
+            };
+
+            std::string _CreateIdLocked(std::string_view kind);
+            void _EraseLocked(const std::string& operationId);
+            void _FinalizeCompletedLocked(std::unordered_map<std::string, Operation>::iterator operation);
+            void _PruneCompletedLocked();
+
+            std::mutex _mutex;
+            uint64_t _nextOperationId{ 0 };
+            std::unordered_map<std::string, Operation> _operations;
+            std::unordered_map<std::string, std::string> _allOperationsByRequest;
+            std::deque<std::string> _completedOperations;
+        };
+
+        class TabRetirementTracker
+        {
+        public:
+            bool BeginRebuild(std::string_view tabId);
+            bool RequestClose(std::string_view tabId);
+            bool Complete(std::string_view tabId);
+
+        private:
+            std::unordered_map<std::string, bool> _closeRequested;
+        };
+
+        class RestartSuppressionTracker
+        {
+        public:
+            void Mark(std::string_view tabId);
+            void Clear(std::string_view tabId);
+            bool Consume(std::string_view tabId);
+
+        private:
+            std::unordered_map<std::string, std::chrono::steady_clock::time_point> _marks;
+        };
+
+        class CoalescedRequest
+        {
+        public:
+            void Queue(std::string requestId);
+            std::optional<std::string> Take();
+            void Clear();
+            bool Pending() const noexcept;
+
+        private:
+            std::optional<std::string> _requestId;
+        };
+
         constexpr bool IsValidEnvironmentOverride(const std::wstring_view name, const std::wstring_view value) noexcept
         {
             return !name.empty() &&
@@ -138,6 +235,17 @@ namespace winrt::TerminalApp::implementation
                      std::span<const std::wstring> extraArgs,
                      std::span<const std::pair<std::wstring, std::wstring>> environment = {});
 
+        std::string CreateRetirementRequestId();
+        details::RetirementRegistration RegisterRetirement(
+            bool scopeAll,
+            std::string_view reason,
+            std::string_view requestId = {});
+        bool CompleteRetirement(std::string_view operationId, bool expireAfterContinuations = false);
+        void ReleaseRetirementContinuation(std::string_view operationId);
+        void ExpireRetirement(std::string_view operationId);
+        bool ClaimRetirementAction(std::string_view operationId, std::string_view action);
+        uint64_t GetSettingsGeneration(const winrt::Windows::Foundation::IInspectable& settings);
+
         /// Whether wta is currently spawned. Becomes false after a
         /// crash is observed by the wait callback, or after the last
         /// pane releases.
@@ -219,24 +327,6 @@ namespace winrt::TerminalApp::implementation
         std::wstring _cachedWtaPath;
         std::vector<std::wstring> _cachedExtraArgs;
         std::vector<std::pair<std::wstring, std::wstring>> _cachedEnvironment;
-        // Wall-clock-ish stamp of the most recent successful spawn.
-        // Used by the no-arg `Restart()` to dedup the fan-out from
-        // `_dispatchRestartAgentStackToPage`: every open window's
-        // `OnRestartAgentStackRequested` calls `Restart()` on its own
-        // UI thread, and without dedup they sequentially kill each
-        // other's freshly-spawned masters. A short time window is
-        // enough because the fan-out runs in tight succession on
-        // adjacent UI-thread ticks.
-        std::optional<std::chrono::steady_clock::time_point> _lastRespawn;
-        // Stamp of the most recent *restart request* that actually respawned
-        // the master (set in the no-arg `Restart()` after a successful spawn).
-        // The fan-out dedup keys off THIS, not `_lastRespawn`: `_lastRespawn`
-        // is also stamped by the initial spawn, so keying on it would wrongly
-        // suppress a legitimate restart that fires shortly after the master
-        // first comes up (e.g. an auth-recovery restart against a freshly
-        // poisoned master). Keyed on the last restart, only restart-after-
-        // restart (the true fan-out duplicate) is suppressed.
-        std::optional<std::chrono::steady_clock::time_point> _lastRestartRequest;
         // "Degraded" latch: set when the master dies UNEXPECTEDLY
         // (crash/OOM/external kill, observed by the wait callback) while
         // panes still hold refs. While set, `AcquirePane` refuses to
@@ -249,5 +339,7 @@ namespace winrt::TerminalApp::implementation
         // `!_process.is_valid()`, which is also true on a clean cold start
         // or after the last release — those MUST still spawn.
         bool _degraded{ false };
+        details::RetirementCoordinator _retirementCoordinator;
+        details::LiveObjectGenerationTracker _settingsGenerations;
     };
 }

--- a/src/cascadia/TerminalApp/SharedWta.h
+++ b/src/cascadia/TerminalApp/SharedWta.h
@@ -174,6 +174,22 @@ namespace winrt::TerminalApp::implementation
             DWORD exitTimeoutMs,
             DWORD forcedExitTimeoutMs,
             const ProcessRetirementOperations& operations = {});
+
+        class ProcessWaitGenerationTracker
+        {
+        public:
+            using Generation = uintptr_t;
+
+            Generation Register(DWORD pid) noexcept;
+            void Retire() noexcept;
+            std::optional<DWORD> Claim(Generation generation) noexcept;
+            Generation Current() const noexcept;
+
+        private:
+            Generation _nextGeneration{ 0 };
+            Generation _currentGeneration{ 0 };
+            DWORD _pid{ 0 };
+        };
     }
 
     class SharedWta
@@ -326,21 +342,18 @@ namespace winrt::TerminalApp::implementation
         wil::unique_handle _CleanupLocked();
 
         // Wait-callback bridge — `RegisterWaitForSingleObject` requires
-        // a free function. The `context` PVOID carries the PID this
-        // wait was registered for (not a `this` pointer — the singleton
-        // is reached via `Instance()`), so the callback can detect a
-        // stale registration after `_CleanupLocked` + `_SpawnLocked`
-        // replaced the master out from under it. Without that check,
-        // a delayed callback for the OLD master would null out the
-        // *new* master's `_process` / `_waitHandle` and silently break
-        // crash detection.
+        // a free function. The `context` PVOID carries a monotonically
+        // increasing registration generation (not a `this` pointer), so
+        // delayed callbacks cannot match a replacement process even if
+        // Windows reused the old PID.
         static void CALLBACK _OnProcessExitedThunk(PVOID context, BOOLEAN timedOut);
-        void _OnProcessExited(DWORD observedPid);
+        void _OnProcessExited(details::ProcessWaitGenerationTracker::Generation generation);
 
         mutable std::mutex _mtx;
         wil::unique_handle _process;
         wil::unique_handle _job;
         HANDLE _waitHandle{ nullptr };
+        details::ProcessWaitGenerationTracker _waitGeneration;
         DWORD _pid{ 0 };
         size_t _refCount{ 0 };
         // Generated lazily on first AcquirePane; reused across

--- a/src/cascadia/TerminalApp/SharedWta.h
+++ b/src/cascadia/TerminalApp/SharedWta.h
@@ -161,6 +161,19 @@ namespace winrt::TerminalApp::implementation
             HANDLE process,
             HANDLE& waitHandle,
             const SuspendedProcessOperations& operations = {}) noexcept;
+
+        struct ProcessRetirementOperations
+        {
+            DWORD(WINAPI* waitForSingleObject)(HANDLE, DWORD){ ::WaitForSingleObject };
+            BOOL(WINAPI* terminateProcess)(HANDLE, UINT){ ::TerminateProcess };
+        };
+
+        bool EnsureProcessExitedBeforeRestart(
+            HANDLE process,
+            DWORD pid,
+            DWORD exitTimeoutMs,
+            DWORD forcedExitTimeoutMs,
+            const ProcessRetirementOperations& operations = {});
     }
 
     class SharedWta
@@ -307,7 +320,10 @@ namespace winrt::TerminalApp::implementation
         bool _SpawnLocked(const std::wstring_view wtaPath,
                           std::span<const std::wstring> extraArgs,
                           std::span<const std::pair<std::wstring, std::wstring>> environment);
-        void _CleanupLocked();
+        bool _RestartLocked(const std::wstring_view wtaPath,
+                            std::span<const std::wstring> extraArgs,
+                            std::span<const std::pair<std::wstring, std::wstring>> environment);
+        wil::unique_handle _CleanupLocked();
 
         // Wait-callback bridge — `RegisterWaitForSingleObject` requires
         // a free function. The `context` PVOID carries the PID this
@@ -352,6 +368,10 @@ namespace winrt::TerminalApp::implementation
         // `!_process.is_valid()`, which is also true on a clean cold start
         // or after the last release — those MUST still spawn.
         bool _degraded{ false };
+        // A restart could not confirm that the retired master exited. Never
+        // risk another process claiming the stable pipe in this Terminal
+        // process; recovery requires restarting Terminal.
+        bool _spawnSuppressed{ false };
         details::RetirementCoordinator _retirementCoordinator;
         details::LiveObjectGenerationTracker _settingsGenerations;
     };

--- a/src/cascadia/TerminalApp/SharedWta.h
+++ b/src/cascadia/TerminalApp/SharedWta.h
@@ -148,6 +148,19 @@ namespace winrt::TerminalApp::implementation
         // environment; nullopt means the requested block could not be built.
         std::optional<std::wstring> BuildEnvironmentBlock(
             std::span<const std::pair<std::wstring, std::wstring>> overrides) noexcept;
+
+        struct SuspendedProcessOperations
+        {
+            DWORD(WINAPI* resumeThread)(HANDLE){ ::ResumeThread };
+            BOOL(WINAPI* unregisterWait)(HANDLE, HANDLE){ ::UnregisterWaitEx };
+            BOOL(WINAPI* terminateProcess)(HANDLE, UINT){ ::TerminateProcess };
+        };
+
+        bool ResumeSuspendedProcess(
+            HANDLE thread,
+            HANDLE process,
+            HANDLE& waitHandle,
+            const SuspendedProcessOperations& operations = {}) noexcept;
     }
 
     class SharedWta

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -602,7 +602,8 @@ namespace winrt::TerminalApp::implementation
                 {
                     return false;
                 }
-                if (!content.try_as<winrt::TerminalApp::AgentPaneContent>())
+                const auto agentContent = content.try_as<winrt::TerminalApp::AgentPaneContent>();
+                if (!agentContent)
                 {
                     return false;
                 }
@@ -624,6 +625,10 @@ namespace winrt::TerminalApp::implementation
                     cid,
                     myStableId,
                     sourceProfileGuid);
+                if (const auto impl = winrt::get_self<implementation::AgentPaneContent>(agentContent))
+                {
+                    impl->PrepareForCrossWindowTransfer();
+                }
                 return false;
             });
         }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -249,6 +249,12 @@ namespace winrt::TerminalApp::implementation
 
     TerminalPage::~TerminalPage()
     {
+        auto& sharedWta = winrt::TerminalApp::implementation::SharedWta::Instance();
+        for (const auto& retirement : _pendingAgentRetirements)
+        {
+            sharedWta.ReleaseRetirementContinuation(retirement.first);
+        }
+
         // wta-helper processes are conpty children of TermControl and so
         // are torn down by the standard pane teardown path. No per-page
         // wta-process watch state to disarm here (removed in Phase 5).
@@ -319,6 +325,15 @@ namespace winrt::TerminalApp::implementation
             }
         }
         _settings = settings;
+        if (!firstLoad && needRefreshUI)
+        {
+            const auto generation =
+                winrt::TerminalApp::implementation::SharedWta::Instance().GetSettingsGeneration(settings);
+            _settingsReloadRequestId =
+                "settings-" +
+                std::to_string(generation) +
+                "-";
+        }
 
         // Seed the agent-settings baseline on first load so that later
         // in-memory mutations (e.g. the bottom-bar agent selector click,
@@ -1672,6 +1687,37 @@ namespace winrt::TerminalApp::implementation
         return snapshot;
     }
 
+    std::string TerminalPage::_AgentSettingsRequestIdentity(const AgentSettingsSnapshot& snapshot)
+    {
+        Json::Value identity{ Json::objectValue };
+        identity["acp_agent"] = winrt::to_string(winrt::hstring{ snapshot.acpAgent });
+        identity["acp_custom_command"] = winrt::to_string(winrt::hstring{ snapshot.acpCustomCommand });
+        identity["acp_model"] = winrt::to_string(winrt::hstring{ snapshot.acpModel });
+        if (snapshot.customModelLaunch)
+        {
+            const auto& custom = *snapshot.customModelLaunch;
+            auto& value = identity["custom_model"];
+            value["selection_id"] = winrt::to_string(winrt::hstring{ custom.selectionId });
+            value["endpoint"] = winrt::to_string(winrt::hstring{ custom.endpoint });
+            value["model_id"] = winrt::to_string(winrt::hstring{ custom.modelId });
+            value["credential_id"] = winrt::to_string(winrt::hstring{ custom.credentialId });
+            value["api_key_required"] = custom.apiKeyRequired;
+        }
+        auto& profiles = identity["profile_backends"];
+        profiles = Json::arrayValue;
+        for (const auto& [profileGuid, backend] : snapshot.profileBackends)
+        {
+            Json::Value value{ Json::objectValue };
+            value["profile"] = winrt::to_string(winrt::to_hstring(profileGuid));
+            value["backend"] = winrt::to_string(winrt::hstring{ backend });
+            profiles.append(std::move(value));
+        }
+
+        Json::StreamWriterBuilder writer;
+        writer["indentation"] = "";
+        return Json::writeString(writer, identity);
+    }
+
     bool TerminalPage::_AgentSettingsChanged(const AgentSettingsSnapshot& a, const AgentSettingsSnapshot& b)
     {
         // Agent identity and effective model changes rebuild helpers. A profile
@@ -1799,7 +1845,7 @@ namespace winrt::TerminalApp::implementation
                 // event is recognized as a deliberate teardown and skipped
                 // by `OnAgentPaneRestartRequested` rather than respawning a
                 // pane we just intentionally closed.
-                _agentPaneRestartSuppression[tab->StableId()] = std::chrono::steady_clock::now();
+                _agentPaneRestartSuppression.Mark(winrt::to_string(tab->StableId()));
             }
             _agentPaneLog("_TeardownAgentPane: closing agent pane on tab");
             pane->Close();
@@ -1830,22 +1876,50 @@ namespace winrt::TerminalApp::implementation
         {
             return;
         }
+        const auto tabId = tab->StableId();
+        const auto tabKey = winrt::to_string(tabId);
+        if (!_agentTabRetirements.BeginRebuild(tabKey))
+        {
+            _agentPaneLog("_RebuildAgentPaneForTab: retirement already pending for tab");
+            return;
+        }
         const bool hadPane = tab->FindAgentPane() != nullptr;
-        _TeardownAgentPane(tab);
+        _BeginAgentSessionRetirement(
+            false,
+            { tabId },
+            "agent_switch",
+            {},
+            [weakThis = get_weak(), tabId, tabKey, hadPane](const std::string_view) {
+                if (const auto strongThis = weakThis.get())
+                {
+                    const bool shouldReopen = strongThis->_agentTabRetirements.Complete(tabKey);
+                    const auto currentTab = strongThis->_FindTabByStableId(tabId);
+                    if (!currentTab)
+                    {
+                        return;
+                    }
 
-        const auto focusedTab = _GetFocusedTabImpl();
-        if (focusedTab && focusedTab == tab)
-        {
-            // `/agent` was entered in this tab's visible agent pane, so reopen
-            // a visible pane immediately.
-            _OpenOrReuseAgentPane(false, L"AgentSwitch");
-        }
-        else if (hadPane)
-        {
-            // Background tab: respawn a stashed (pre-warmed) helper so the
-            // new agent takes effect without stealing focus.
-            _AutoCreateHiddenAgentPaneShared(tab, /*intoSessionsView*/ false, /*autoStash*/ true);
-        }
+                    strongThis->_TeardownAgentPane(currentTab);
+                    if (!shouldReopen)
+                    {
+                        currentTab->SetAgentChipOverride(std::nullopt);
+                        return;
+                    }
+                    strongThis->_agentPaneRestartSuppression.Clear(tabKey);
+                    const auto focusedTab = strongThis->_GetFocusedTabImpl();
+                    if (focusedTab && focusedTab == currentTab)
+                    {
+                        strongThis->_OpenOrReuseAgentPane(false, L"AgentSwitch");
+                    }
+                    else if (hadPane)
+                    {
+                        strongThis->_AutoCreateHiddenAgentPaneShared(
+                            currentTab,
+                            /*intoSessionsView*/ false,
+                            /*autoStash*/ true);
+                    }
+                }
+            });
     }
 
     std::shared_ptr<Pane> TerminalPage::_WrapInAgentPaneContent(std::shared_ptr<Pane> rawPane)
@@ -1906,6 +1980,130 @@ namespace winrt::TerminalApp::implementation
         Json::Value tabParams;
         tabParams["tab_id"] = winrt::to_string(tabId);
         _RaiseProtocolEvent("reset_tab_session", tabParams);
+    }
+
+    void TerminalPage::_BeginAgentSessionRetirement(
+        const bool scopeAll,
+        std::vector<winrt::hstring> tabIds,
+        std::string reason,
+        std::string requestId,
+        std::function<void(std::string_view)> continuation)
+    {
+        auto& sharedWta = winrt::TerminalApp::implementation::SharedWta::Instance();
+        const auto registration = sharedWta.RegisterRetirement(scopeAll, reason, requestId);
+        if (registration.operationId.empty())
+        {
+            _agentPaneLog("_BeginAgentSessionRetirement: failed to allocate operation id; continuing teardown");
+            continuation({});
+            return;
+        }
+
+        const auto [pending, inserted] = _pendingAgentRetirements.emplace(
+            registration.operationId,
+            _PendingAgentRetirement{ std::move(continuation), reason });
+        if (!inserted)
+        {
+            sharedWta.ReleaseRetirementContinuation(registration.operationId);
+            _agentPaneLog("_BeginAgentSessionRetirement: page already joined operation");
+            return;
+        }
+
+        if (registration.alreadyCompleted)
+        {
+            _CompleteAgentSessionRetirement(registration.operationId, false);
+            return;
+        }
+
+        if (registration.shouldPublish)
+        {
+            Json::Value params;
+            params["operation_id"] = registration.operationId;
+            params["scope"] = scopeAll ? "all" : "tabs";
+            params["reason"] = reason;
+            params["tab_ids"] = Json::arrayValue;
+            for (const auto& tabId : tabIds)
+            {
+                if (!tabId.empty())
+                {
+                    params["tab_ids"].append(winrt::to_string(tabId));
+                }
+            }
+            _RaiseProtocolEvent("retire_agent_sessions", params);
+        }
+
+        _WaitForAgentSessionRetirement(registration.operationId);
+    }
+
+    safe_void_coroutine TerminalPage::_WaitForAgentSessionRetirement(std::string operationId)
+    {
+        const auto weakThis = get_weak();
+        const auto dispatcher = Dispatcher();
+        co_await winrt::resume_after(std::chrono::seconds{ 17 });
+        co_await winrt::resume_foreground(dispatcher);
+        if (const auto strongThis = weakThis.get())
+        {
+            strongThis->_CompleteAgentSessionRetirement(operationId, true);
+        }
+    }
+
+    void TerminalPage::_CompleteAgentSessionRetirement(const std::string_view operationId, const bool timedOut)
+    {
+        auto pending = _pendingAgentRetirements.find(std::string{ operationId });
+        if (pending == _pendingAgentRetirements.end())
+        {
+            return;
+        }
+
+        auto continuation = std::move(pending->second.continuation);
+        const auto reason = std::move(pending->second.reason);
+        _pendingAgentRetirements.erase(pending);
+
+        auto& sharedWta = winrt::TerminalApp::implementation::SharedWta::Instance();
+        sharedWta.CompleteRetirement(operationId, timedOut);
+        if (timedOut)
+        {
+            _agentPaneLog(
+                "_CompleteAgentSessionRetirement: timed out after 17 seconds; continuing local teardown reason=" + reason);
+        }
+        const auto releaseContinuation = wil::scope_exit([&sharedWta, operationId] {
+            sharedWta.ReleaseRetirementContinuation(operationId);
+        });
+        continuation(operationId);
+    }
+
+    void TerminalPage::OnAgentSessionsRetired(hstring eventJson)
+    {
+        Json::Value event;
+        Json::CharReaderBuilder reader;
+        std::istringstream stream{ winrt::to_string(eventJson) };
+        std::string errors;
+        if (!Json::parseFromStream(reader, stream, &event, &errors) ||
+            !event.isMember("params") || !event["params"].isObject())
+        {
+            _agentPaneLog("OnAgentSessionsRetired: malformed event");
+            return;
+        }
+
+        const auto& params = event["params"];
+        if (!params.isMember("operation_id") || !params["operation_id"].isString() ||
+            params["operation_id"].asString().empty() ||
+            !params.isMember("success") || !params["success"].isBool() ||
+            !params.isMember("reason") || !params["reason"].isString() ||
+            !params.isMember("failed_tabs") || !params["failed_tabs"].isArray())
+        {
+            _agentPaneLog("OnAgentSessionsRetired: invalid completion payload");
+            return;
+        }
+
+        const auto operationId = params["operation_id"].asString();
+        winrt::TerminalApp::implementation::SharedWta::Instance().CompleteRetirement(operationId);
+        if (!params["success"].asBool())
+        {
+            _agentPaneLog(
+                "OnAgentSessionsRetired: master used logical fallback for " +
+                std::to_string(params["failed_tabs"].size()) + " tab(s)");
+        }
+        _CompleteAgentSessionRetirement(operationId, false);
     }
 
     // Tells wta that a tab has been destroyed so it can drop the per-tab
@@ -2570,6 +2768,12 @@ namespace winrt::TerminalApp::implementation
         const auto splitDirection = _AgentPanePositionToSplitDirection(panePosition);
         tab->SplitPaneAtRoot(splitDirection, newPane);
 
+        // A rooted pane is now the authoritative helper generation for this
+        // tab. Deliberate teardown retires the outgoing session before close
+        // (drag replacement sends tab_reset first), so no old recovery event
+        // can legitimately target this replacement after the mark is cleared.
+        _agentPaneRestartSuppression.Clear(winrt::to_string(stableId));
+
         if (autoStash)
         {
             // Pre-warm path: spawn the helper conpty child NOW, then stash
@@ -3176,7 +3380,7 @@ namespace winrt::TerminalApp::implementation
     // Called whenever agent-identity settings may have changed. Diffs the
     // last known snapshot against the current one, tears down + rebuilds
     // the agent pane, and updates the snapshot.
-    void TerminalPage::_RebuildAgentStack()
+    void TerminalPage::_RebuildAgentStack(std::string requestId)
     {
         const auto current = _CaptureAgentSettingsSnapshot();
 
@@ -3261,7 +3465,12 @@ namespace winrt::TerminalApp::implementation
         // Reentrancy guard.
         if (_agentRebuilding)
         {
-            _agentPaneLog("_RebuildAgentStack: already rebuilding, skipping nested trigger");
+            _pendingAgentRebuild = true;
+            if (!requestId.empty())
+            {
+                _pendingAgentRebuildRequestId = std::move(requestId);
+            }
+            _agentPaneLog("_RebuildAgentStack: already rebuilding, queued latest settings reconciliation");
             return;
         }
 
@@ -3275,14 +3484,17 @@ namespace winrt::TerminalApp::implementation
         const auto focusedTab = _GetFocusedTabImpl();
         // Only `==` auto-generates for projected WinRT types — `!=` doesn't.
         const bool canHostPane = focusedTab && !(*focusedTab == _settingsTab);
-        if (!canHostPane)
+        if (!canHostPane && !masterConfigurationChanged)
         {
             _pendingAgentRebuild = true;
+            if (!requestId.empty())
+            {
+                _pendingAgentRebuildRequestId = std::move(requestId);
+            }
             return;
         }
 
         _agentRebuilding = true;
-        auto guard = wil::scope_exit([this]() noexcept { _agentRebuilding = false; });
 
         _agentPaneLog("_RebuildAgentStack: agent settings changed, rebuilding");
 
@@ -3291,7 +3503,7 @@ namespace winrt::TerminalApp::implementation
         // so every local helper is collected even when its tab has a runtime
         // override. Unselected provider metadata changes stay on the hot path.
         bool hadAny = false;
-        std::vector<winrt::com_ptr<Tab>> tabsThatHadAgentPane;
+        std::vector<winrt::hstring> tabIdsThatHadAgentPane;
         for (const auto& t : _tabs)
         {
             if (auto tabImpl = _GetTabImpl(t))
@@ -3335,88 +3547,111 @@ namespace winrt::TerminalApp::implementation
                 if (tabImpl->FindAgentPane() && affected)
                 {
                     hadAny = true;
-                    tabsThatHadAgentPane.push_back(tabImpl);
+                    tabIdsThatHadAgentPane.push_back(tabImpl->StableId());
                 }
             }
         }
 
-        // Tear down every tab's agent pane first. The user must reopen
-        // each (per-tab toggle) — there's no longer a "shared pane" to
-        // reposition. Tear down is async: the pane's `Closed` handlers
-        // (which call `SharedWta::ReleasePane`) typically haven't fired
-        // yet when control returns to us.
-        for (const auto& tabImpl : tabsThatHadAgentPane)
-        {
-            _TeardownAgentPane(tabImpl);
-        }
-
-        // Built-in agent identity changes do not restart the master. It is now a
-        // multi-agent broker — it spawns/reuses one agent CLI per distinct
-        // agent command line, driven by each helper's `initialize`
-        // handshake (which carries the tab's agent). The master's own
-        // `--agent` is only a fallback default for helpers that don't
-        // declare one (ours always do), so a global-agent change no longer
-        // requires respawning the master. Tearing down + reopening the
-        // affected (non-override) tabs' helpers is enough: each fresh
-        // helper declares the new global agent and the master lazily
-        // spawns/reuses the matching CLI, leaving overridden tabs' CLIs
-        // (and other windows) untouched. Custom commands and model selections
-        // are exceptions: model/provider launch state is supplied on the
-        // master's trusted launch configuration, and a model change requires a
-        // fresh agent CLI rather than mutating the existing ACP session.
-        if (masterConfigurationChanged)
-        {
-            const auto wtaPath = _DetectWtaPath();
-            const auto extraArgs = _BuildSharedWtaExtraArgs();
-            const auto environment = _BuildSharedWtaEnvironment();
-            if (wtaPath.empty() ||
-                !winrt::TerminalApp::implementation::SharedWta::Instance().Restart(
-                    std::wstring_view{ wtaPath },
-                    extraArgs,
-                    environment))
-            {
-                _agentPaneLog("_RebuildAgentStack: master configuration SharedWta::Restart failed");
-            }
-        }
-
-        if (!hadAny)
+        if (!hadAny && !masterConfigurationChanged)
         {
             _lastAgentSettings = current;
+            _agentRebuilding = false;
             _agentPaneLog("_RebuildAgentStack: no affected agent pane, snapshot only");
             return;
         }
 
-        // A master-configuration restart invalidates every helper, so reconnect
-        // all tabs that had panes: active remains visible and background tabs
-        // are pre-warmed stashed. Built-in changes retain the existing
-        // active-tab behavior and leave overrides untouched.
-        if (const auto activeTab = _GetFocusedTabImpl();
-            masterConfigurationChanged && activeTab)
+        if (masterConfigurationChanged && requestId.empty())
         {
-            for (const auto& tabImpl : tabsThatHadAgentPane)
-            {
-                if (tabImpl == activeTab)
-                {
-                    _OpenOrReuseAgentPane(false, L"SettingsReload");
-                }
-                else
-                {
-                    _AutoCreateHiddenAgentPaneShared(tabImpl,
-                                                     /*intoSessionsView*/ false,
-                                                     /*autoStash*/ true);
-                }
-            }
-        }
-        else if (activeTab &&
-                 std::find(tabsThatHadAgentPane.begin(), tabsThatHadAgentPane.end(), activeTab) != tabsThatHadAgentPane.end())
-        {
-            _OpenOrReuseAgentPane(false, L"SettingsReload");
+            requestId = winrt::TerminalApp::implementation::SharedWta::Instance().CreateRetirementRequestId();
         }
 
-        // Snapshot update at the very end of the change-handling block
-        // so any early-failure path above leaves the snapshot stale and
-        // the next entry re-triggers a rebuild attempt.
-        _lastAgentSettings = current;
+        _BeginAgentSessionRetirement(
+            masterConfigurationChanged,
+            tabIdsThatHadAgentPane,
+            masterConfigurationChanged ? "settings_master_configuration_changed" : "settings_agent_changed",
+            masterConfigurationChanged ? std::move(requestId) : std::string{},
+            [weakThis = get_weak(),
+             current,
+             tabIdsThatHadAgentPane,
+             masterConfigurationChanged](const std::string_view operationId) {
+                if (const auto strongThis = weakThis.get())
+                {
+                    std::vector<winrt::com_ptr<Tab>> tabsToReopen;
+                    for (const auto& tabId : tabIdsThatHadAgentPane)
+                    {
+                        if (const auto tab = strongThis->_FindTabByStableId(tabId);
+                            tab && tab->FindAgentPane())
+                        {
+                            tabsToReopen.push_back(tab);
+                            strongThis->_TeardownAgentPane(tab);
+                        }
+                    }
+
+                    if (masterConfigurationChanged)
+                    {
+                        auto& sharedWta = winrt::TerminalApp::implementation::SharedWta::Instance();
+                        if (sharedWta.ClaimRetirementAction(operationId, "restart_master"))
+                        {
+                            const auto wtaPath = strongThis->_DetectWtaPath();
+                            const auto extraArgs = strongThis->_BuildSharedWtaExtraArgs();
+                            const auto environment = strongThis->_BuildSharedWtaEnvironment();
+                            if (wtaPath.empty() ||
+                                !sharedWta.Restart(std::wstring_view{ wtaPath }, extraArgs, environment))
+                            {
+                                _agentPaneLog(
+                                    "_RebuildAgentStack: master configuration SharedWta::Restart failed");
+                            }
+                        }
+                    }
+
+                    const auto activeTab = strongThis->_GetFocusedTabImpl();
+                    if (masterConfigurationChanged)
+                    {
+                        for (const auto& tab : tabsToReopen)
+                        {
+                            strongThis->_agentPaneRestartSuppression.Clear(winrt::to_string(tab->StableId()));
+                            if (activeTab && activeTab == tab)
+                            {
+                                strongThis->_OpenOrReuseAgentPane(false, L"SettingsReload");
+                            }
+                            else
+                            {
+                                strongThis->_AutoCreateHiddenAgentPaneShared(
+                                    tab,
+                                    /*intoSessionsView*/ false,
+                                    /*autoStash*/ true);
+                            }
+                        }
+                    }
+                    else if (activeTab)
+                    {
+                        if (const auto affected = std::find(tabsToReopen.begin(), tabsToReopen.end(), activeTab);
+                            affected != tabsToReopen.end())
+                        {
+                            strongThis->_OpenOrReuseAgentPane(false, L"SettingsReload");
+                        }
+                    }
+
+                    strongThis->_lastAgentSettings = current;
+                    strongThis->_agentRebuilding = false;
+                    const auto latest = strongThis->_CaptureAgentSettingsSnapshot();
+                    const bool settingsChangedAgain = TerminalPage::_AgentSettingsChanged(current, latest);
+                    if (settingsChangedAgain)
+                    {
+                        winrt::TerminalApp::implementation::SharedWta::Instance().ExpireRetirement(operationId);
+                    }
+                    if (const auto pendingRestart = strongThis->_pendingAgentStackRestart.Take())
+                    {
+                        strongThis->_RestartAgentStack(*pendingRestart);
+                    }
+                    else if (std::exchange(strongThis->_pendingAgentRebuild, false) ||
+                             settingsChangedAgain)
+                    {
+                        auto pendingRequest = std::exchange(strongThis->_pendingAgentRebuildRequestId, std::nullopt);
+                        strongThis->_RebuildAgentStack(pendingRequest ? std::move(*pendingRequest) : std::string{});
+                    }
+                }
+            });
     }
 
     void TerminalPage::_FlushPendingAgentRebuild()
@@ -3431,7 +3666,8 @@ namespace winrt::TerminalApp::implementation
             return;
         }
         _pendingAgentRebuild = false;
-        _RebuildAgentStack();
+        auto pendingRequest = std::exchange(_pendingAgentRebuildRequestId, std::nullopt);
+        _RebuildAgentStack(pendingRequest ? std::move(*pendingRequest) : std::string{});
     }
 
     void TerminalPage::_OpenOrReuseAgentPane(bool intoSessionsView, const wchar_t* triggerSource, std::wstring_view initialAuthAgent)
@@ -5532,13 +5768,28 @@ namespace winrt::TerminalApp::implementation
             // Tab is unknown in this window — belongs to another window.
             return;
         }
-        // Tell wta to drop this tab's ACP session.
-        _NotifyAgentTabReset(ownerTab->StableId());
-        // The agent pane (and its helper) is going away, so any chip
-        // override the helper had set is no longer authoritative. Drop it
-        // here so the chip can't get pinned by a dead helper.
-        ownerTab->SetAgentChipOverride(std::nullopt);
-        _TeardownAgentPane(ownerTab);
+        const auto tabKey = winrt::to_string(tabId);
+        if (!_agentTabRetirements.RequestClose(tabKey))
+        {
+            _agentPaneLog("OnCloseAgentPaneRequested: deferred behind pending retirement");
+            return;
+        }
+        _BeginAgentSessionRetirement(
+            false,
+            { tabId },
+            "close_agent_pane",
+            {},
+            [weakThis = get_weak(), tabId, tabKey](const std::string_view) {
+                if (const auto strongThis = weakThis.get())
+                {
+                    strongThis->_agentTabRetirements.Complete(tabKey);
+                    if (const auto currentTab = strongThis->_FindTabByStableId(tabId))
+                    {
+                        currentTab->SetAgentChipOverride(std::nullopt);
+                        strongThis->_TeardownAgentPane(currentTab);
+                    }
+                }
+            });
     }
 
     void TerminalPage::OnDefaultPasteRequested(hstring eventJson)
@@ -5740,7 +5991,8 @@ namespace winrt::TerminalApp::implementation
                 return;
             }
             _agentPaneLog("OnAgentSwitchRequested: persisted cloud model selection");
-            _RebuildAgentStack();
+            _RebuildAgentStack(
+                winrt::TerminalApp::implementation::SharedWta::Instance().CreateRetirementRequestId());
             return;
         }
 
@@ -5809,7 +6061,8 @@ namespace winrt::TerminalApp::implementation
                 return;
             }
             _agentPaneLog("OnAgentSwitchRequested: persisted BYOK model selection");
-            _RebuildAgentStack();
+            _RebuildAgentStack(
+                winrt::TerminalApp::implementation::SharedWta::Instance().CreateRetirementRequestId());
             return;
         }
 
@@ -5846,88 +6099,102 @@ namespace winrt::TerminalApp::implementation
     // already respawned the master) sees a valid `_process` and just
     // bumps the refcount — connecting the new helper to the freshly-spawned
     // master under the same stable pipe name.
-    void TerminalPage::OnRestartAgentStackRequested(hstring /*eventJson*/)
+    void TerminalPage::OnRestartAgentStackRequested(hstring eventJson)
+    {
+        std::string requestId;
+        Json::Value event;
+        Json::CharReaderBuilder reader;
+        std::istringstream stream{ winrt::to_string(eventJson) };
+        std::string errors;
+        if (Json::parseFromStream(reader, stream, &event, &errors) &&
+            event.isMember("params") && event["params"].isObject() &&
+            event["params"].isMember("request_id") && event["params"]["request_id"].isString())
+        {
+            requestId = event["params"]["request_id"].asString();
+        }
+        if (requestId.empty())
+        {
+            requestId = winrt::TerminalApp::implementation::SharedWta::Instance().CreateRetirementRequestId();
+        }
+        _RestartAgentStack(std::move(requestId));
+    }
+
+    void TerminalPage::_RestartAgentStack(std::string requestId)
     {
         _agentPaneLog("OnRestartAgentStackRequested: /restart received from wta");
 
-        // Reentrancy guard — share the flag with the settings-driven
-        // `_RebuildAgentStack` path. If a settings reload is racing this
-        // request, skip; the reload will pick up where we'd leave off.
         if (_agentRebuilding)
         {
-            _agentPaneLog("OnRestartAgentStackRequested: already rebuilding, skipping");
+            _pendingAgentStackRestart.Queue(std::move(requestId));
+            _agentPaneLog("OnRestartAgentStackRequested: rebuild pending; queued restart");
             return;
         }
         _agentRebuilding = true;
-        auto guard = wil::scope_exit([this]() noexcept { _agentRebuilding = false; });
 
-        // Mirror _RebuildAgentStack's "find every tab that has an agent
-        // pane right now" scan; teardown is per-tab so we have to enumerate
-        // before mutating.
-        std::vector<winrt::com_ptr<Tab>> tabsThatHadAgentPane;
+        std::vector<winrt::hstring> tabIds;
         for (const auto& t : _tabs)
         {
             if (auto tabImpl = _GetTabImpl(t))
             {
                 if (tabImpl->FindAgentPane())
                 {
-                    tabsThatHadAgentPane.push_back(tabImpl);
+                    tabIds.push_back(tabImpl->StableId());
                 }
             }
         }
 
-        if (tabsThatHadAgentPane.empty())
-        {
-            _agentPaneLog("OnRestartAgentStackRequested: no agent pane in this window, nothing to tear down");
-            // Still kick the master restart — another window may have
-            // panes that need master reset. SharedWta::Restart no-ops if
-            // master isn't running, so this is safe either way.
-            winrt::TerminalApp::implementation::SharedWta::Instance().Restart();
-            return;
-        }
+        _BeginAgentSessionRetirement(
+            true,
+            tabIds,
+            "restart_agent_stack",
+            std::move(requestId),
+            [weakThis = get_weak(), tabIds](const std::string_view operationId) {
+                if (const auto strongThis = weakThis.get())
+                {
+                    std::vector<winrt::com_ptr<Tab>> tabsToReopen;
+                    for (const auto& tabId : tabIds)
+                    {
+                        if (const auto tab = strongThis->_FindTabByStableId(tabId);
+                            tab && tab->FindAgentPane())
+                        {
+                            tabsToReopen.push_back(tab);
+                            strongThis->_TeardownAgentPane(tab);
+                        }
+                    }
 
-        for (const auto& tabImpl : tabsThatHadAgentPane)
-        {
-            _TeardownAgentPane(tabImpl);
-        }
+                    auto& sharedWta = winrt::TerminalApp::implementation::SharedWta::Instance();
+                    if (sharedWta.ClaimRetirementAction(operationId, "restart_master") &&
+                        !sharedWta.Restart())
+                    {
+                        _agentPaneLog("OnRestartAgentStackRequested: SharedWta::Restart returned false");
+                    }
 
-        // Force-respawn master with the cached spawn args (same agent CLI,
-        // same per-process settings). Bypasses AcquirePane's refcount so
-        // we don't have to wait for the just-issued teardowns' async
-        // Closed handlers to fire and drive refcount to zero.
-        if (!winrt::TerminalApp::implementation::SharedWta::Instance().Restart())
-        {
-            _agentPaneLog("OnRestartAgentStackRequested: SharedWta::Restart returned false");
-            // Fall through anyway — the reopen below will retry via
-            // AcquirePane, which lazily spawns when _process is invalid.
-        }
+                    const auto activeTab = strongThis->_GetFocusedTabImpl();
+                    for (const auto& tab : tabsToReopen)
+                    {
+                        strongThis->_agentPaneRestartSuppression.Clear(winrt::to_string(tab->StableId()));
+                        if (activeTab && activeTab == tab)
+                        {
+                            strongThis->_OpenOrReuseAgentPane(false, L"RestartAgent");
+                        }
+                        else
+                        {
+                            strongThis->_AutoCreateHiddenAgentPaneShared(
+                                tab,
+                                /*intoSessionsView*/ false,
+                                /*autoStash*/ true);
+                        }
+                    }
 
-        // Reconnect EVERY tab that had an agent pane, not just the active one
-        // — a /restart recovers the whole stack, so a user who restarts from
-        // one pane shouldn't have to re-toggle every other tab's pane by hand.
-        // The active tab is reopened visible (continuity); the rest are
-        // re-warmed stashed, so their helpers reconnect to the fresh master in
-        // the background and the panes restore as soon as the user switches to
-        // them. Recovery sessions aren't resumed (master is brand new with an
-        // empty registry), so chat history starts fresh — same as before.
-        const auto activeTab = _GetFocusedTabImpl();
-        for (const auto& tabImpl : tabsThatHadAgentPane)
-        {
-            const bool isActive = activeTab && activeTab == tabImpl;
-            if (isActive)
-            {
-                // Active tab: reopen visible via the normal path.
-                _OpenOrReuseAgentPane(false, L"RestartAgent");
-            }
-            else
-            {
-                // Background tab: re-warm a stashed helper so it reconnects
-                // now and the pane restores when the user switches over.
-                _AutoCreateHiddenAgentPaneShared(tabImpl,
-                                                 /*intoSessionsView*/ false,
-                                                 /*autoStash*/ true);
-            }
-        }
+                    strongThis->_agentRebuilding = false;
+                    strongThis->_pendingAgentStackRestart.Clear();
+                    if (std::exchange(strongThis->_pendingAgentRebuild, false))
+                    {
+                        auto pendingRequest = std::exchange(strongThis->_pendingAgentRebuildRequestId, std::nullopt);
+                        strongThis->_RebuildAgentStack(pendingRequest ? std::move(*pendingRequest) : std::string{});
+                    }
+                }
+            });
     }
 
     // Inbound event from WTA: {method:"restart_agent_pane",
@@ -5967,15 +6234,10 @@ namespace winrt::TerminalApp::implementation
         // Suppression check (consume on read). A mark within the last few
         // seconds means this tab's helper died because we deliberately tore
         // the pane down — don't respawn it.
-        if (const auto it = _agentPaneRestartSuppression.find(tabId); it != _agentPaneRestartSuppression.end())
+        if (_agentPaneRestartSuppression.Consume(winrt::to_string(tabId)))
         {
-            const auto age = std::chrono::steady_clock::now() - it->second;
-            _agentPaneRestartSuppression.erase(it);
-            if (age < std::chrono::seconds(5))
-            {
-                _agentPaneLog("OnAgentPaneRestartRequested: suppressed (deliberate teardown)");
-                return;
-            }
+            _agentPaneLog("OnAgentPaneRestartRequested: suppressed (deliberate teardown)");
+            return;
         }
 
         const auto ownerTab = _FindTabByStableId(tabId);
@@ -6000,7 +6262,8 @@ namespace winrt::TerminalApp::implementation
         // Tear down any leftover dead/wedged pane first. Suppress so that
         // killing a wedged helper here doesn't loop back into yet another
         // restart event.
-        _TeardownAgentPane(ownerTab, /*suppressMasterRestart*/ true);
+        _TeardownAgentPane(ownerTab, /*suppressMasterRestart*/ false);
+        _agentPaneRestartSuppression.Clear(winrt::to_string(tabId));
 
         _agentPaneLog("OnAgentPaneRestartRequested: re-warming helper after disconnect");
         _AutoCreateHiddenAgentPaneShared(ownerTab,
@@ -9067,7 +9330,12 @@ namespace winrt::TerminalApp::implementation
         // command for either ACP or delegate) changed, tear down and
         // recreate the affected layers so the new values take effect
         // without a terminal restart.
-        _RebuildAgentStack();
+        auto requestId = std::exchange(_settingsReloadRequestId, {});
+        if (!requestId.empty())
+        {
+            requestId.append(_AgentSettingsRequestIdentity(_CaptureAgentSettingsSnapshot()));
+        }
+        _RebuildAgentStack(std::move(requestId));
 
         // Re-project cached per-tab status after settings-only presentation
         // changes, including showTokenUsageAndCost.

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -4,6 +4,9 @@
 #pragma once
 
 #include <ThrottledFunc.h>
+#include <functional>
+#include <unordered_map>
+#include <unordered_set>
 
 #include "TerminalPage.g.h"
 #include "Tab.h"
@@ -17,6 +20,7 @@
 #include "WindowListEntry.g.h"
 #include "WindowListRequest.g.h"
 #include "Toast.h"
+#include "SharedWta.h"
 
 #include "WindowsPackageManagerFactory.h"
 #include "../inc/CustomModelProviderUtils.h"
@@ -261,6 +265,7 @@ namespace winrt::TerminalApp::implementation
         void OnAgentChipTargetChanged(hstring eventJson);
         void OnRestartAgentStackRequested(hstring eventJson);
         void OnAgentPaneRestartRequested(hstring eventJson);
+        void OnAgentSessionsRetired(hstring eventJson);
 
         til::property_changed_event PropertyChanged;
 
@@ -443,6 +448,9 @@ namespace winrt::TerminalApp::implementation
         };
         AgentSettingsSnapshot _lastAgentSettings{};
         bool _agentSettingsSnapshotInitialized{ false };
+        std::string _settingsReloadRequestId;
+        std::optional<std::string> _pendingAgentRebuildRequestId;
+        static std::string _AgentSettingsRequestIdentity(const AgentSettingsSnapshot& snapshot);
         // Hot-updatable runtime agent config. When any of these change we
         // push a single consolidated `agent_config_changed` event to the
         // running wta-helper(s) so they update in place — no agent-pane
@@ -482,6 +490,14 @@ namespace winrt::TerminalApp::implementation
         std::atomic<bool> _shellIntegrationDesiredEnabled{ false };
         std::mutex _shellIntegrationReconcileMutex;
         bool _agentRebuilding{ false };
+        details::CoalescedRequest _pendingAgentStackRestart;
+        struct _PendingAgentRetirement
+        {
+            std::function<void(std::string_view)> continuation;
+            std::string reason;
+        };
+        std::unordered_map<std::string, _PendingAgentRetirement> _pendingAgentRetirements;
+        details::TabRetirementTracker _agentTabRetirements;
         // Set when a settings change wants a rebuild but the active
         // tab can't host an agent pane (e.g. the Settings tab itself).
         // _FlushPendingAgentRebuild runs the deferred rebuild from
@@ -518,7 +534,7 @@ namespace winrt::TerminalApp::implementation
         // deliberate teardown and genuine crash, so this is how C++
         // distinguishes them. Entries are consumed on read and otherwise
         // expire after a few seconds.
-        std::unordered_map<winrt::hstring, std::chrono::steady_clock::time_point> _agentPaneRestartSuppression;
+        details::RestartSuppressionTracker _agentPaneRestartSuppression;
         AgentSettingsSnapshot _CaptureAgentSettingsSnapshot() const;
         // Compares only agent-CLI *identity* fields — the change that forces
         // a master respawn. Model/delegate changes are handled by
@@ -533,8 +549,16 @@ namespace winrt::TerminalApp::implementation
         // ProtocolVtSequenceReceived. Single source of the wta protocol-event
         // wire shape — callers just supply the method name and a params object.
         void _RaiseProtocolEvent(std::string_view method, const Json::Value& params);
+        void _BeginAgentSessionRetirement(bool scopeAll,
+                                          std::vector<winrt::hstring> tabIds,
+                                          std::string reason,
+                                          std::string requestId,
+                                          std::function<void(std::string_view)> continuation);
+        safe_void_coroutine _WaitForAgentSessionRetirement(std::string operationId);
+        void _CompleteAgentSessionRetirement(std::string_view operationId, bool timedOut);
         void _TeardownAgentPane(const winrt::com_ptr<Tab>& tab, bool suppressMasterRestart = true);
-        void _RebuildAgentStack();
+        void _RebuildAgentStack(std::string requestId = {});
+        void _RestartAgentStack(std::string requestId);
         // Scoped per-tab rebuild after a tab's agent override changes
         // (agent-bar chip flyout). Does not restart the shared master.
         void _RebuildAgentPaneForTab(const winrt::com_ptr<Tab>& tab);

--- a/src/cascadia/TerminalApp/TerminalPage.idl
+++ b/src/cascadia/TerminalApp/TerminalPage.idl
@@ -215,5 +215,9 @@ namespace TerminalApp
         // re-warms a fresh helper, resuming `session_id`. Suppressed when
         // the pane was torn down deliberately (Ctrl+C×2, tab close).
         void OnAgentPaneRestartRequested(String eventJson);
+
+        // Inbound completion for a destructive agent-session retirement:
+        // {method:"agent_sessions_retired",params:{operation_id,success,reason,failed_tabs}}.
+        void OnAgentSessionsRetired(String eventJson);
     }
 }

--- a/src/cascadia/TerminalProtocol/ProtocolParsing.h
+++ b/src/cascadia/TerminalProtocol/ProtocolParsing.h
@@ -41,6 +41,7 @@ namespace Microsoft::Terminal::Protocol::Parsing
         AgentChipTarget,      // Direct to TerminalPage, no broadcast — "draw the Agent chip on this pane (or hide override)"
         RestartAgentStack,    // Direct to TerminalPage, no broadcast — `/restart` from any agent pane TUI
         RestartAgentPane,     // Direct to TerminalPage, no broadcast — master detected helper death; re-warm a fresh helper for this tab
+        AgentSessionsRetired, // Direct to TerminalPage, no broadcast — destructive retirement transaction completed
         Broadcast,            // Normalize envelope + broadcast to all subscribers
         Invalid               // Failed validation
     };
@@ -110,6 +111,10 @@ namespace Microsoft::Terminal::Protocol::Parsing
             {
                 return SendEventRoute::RestartAgentPane;
             }
+            if (method == "agent_sessions_retired")
+            {
+                return SendEventRoute::AgentSessionsRetired;
+            }
         }
 
         // Broadcast path: params.event is required
@@ -124,6 +129,21 @@ namespace Microsoft::Terminal::Protocol::Parsing
         outEvt["method"] = "agent_event";
 
         return SendEventRoute::Broadcast;
+    }
+
+    inline void EnsureRequestId(Json::Value& event, const std::string_view requestId)
+    {
+        auto& params = event["params"];
+        if (!params.isObject())
+        {
+            params = Json::Value{ Json::objectValue };
+        }
+        if (!params.isMember("request_id") ||
+            !params["request_id"].isString() ||
+            params["request_id"].asString().empty())
+        {
+            params["request_id"] = std::string{ requestId };
+        }
     }
 
     // ── SplitPane direction mapping ──

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
@@ -1107,6 +1107,9 @@ try
         // the pane was torn down deliberately (Ctrl+C×2, tab close).
         _dispatchRestartAgentPaneToPage(eventH);
         return S_OK;
+    case ProtocolParsing::SendEventRoute::AgentSessionsRetired:
+        _dispatchAgentSessionsRetiredToPage(eventH);
+        return S_OK;
     case ProtocolParsing::SendEventRoute::Broadcast:
     {
         Json::StreamWriterBuilder wb;
@@ -1301,11 +1304,22 @@ void TerminalProtocolComServer::_dispatchRestartAgentStackToPage(const winrt::hs
     {
         return;
     }
-    // Fan out to every window so each page tears down its own agent panes.
-    // The actual `SharedWta::Restart()` call inside each page-side handler
-    // takes the shared lock and is safe to invoke multiple times — only the
-    // first one in flight does work; the others observe `_process` invalid
-    // (or already-respawned by the winning thread) and no-op.
+    Json::Value event;
+    if (!ProtocolParsing::ParseJson(winrt::to_string(eventJson), event))
+    {
+        return;
+    }
+    static std::atomic<uint64_t> nextRequestId{ 0 };
+    const auto requestId =
+        std::to_string(GetCurrentProcessId()) + "-restart-" +
+        std::to_string(++nextRequestId);
+    ProtocolParsing::EnsureRequestId(event, requestId);
+    Json::StreamWriterBuilder writer;
+    writer["indentation"] = "";
+    const auto stampedEvent = winrt::to_hstring(Json::writeString(writer, event));
+
+    // Stamp once before fan-out so every page joins the same retirement
+    // operation, even when one window handles the dispatch much later.
     for (const auto& host : s_emperor->GetWindows())
     {
         auto page = _getPage(host.get());
@@ -1320,10 +1334,10 @@ void TerminalProtocolComServer::_dispatchRestartAgentStackToPage(const winrt::hs
         }
         dispatcher.RunAsync(
             winrt::Windows::UI::Core::CoreDispatcherPriority::Normal,
-            [page, eventJson]() {
+            [page, stampedEvent]() {
                 try
                 {
-                    page.OnRestartAgentStackRequested(eventJson);
+                    page.OnRestartAgentStackRequested(stampedEvent);
                 }
                 catch (...)
                 {
@@ -1339,6 +1353,7 @@ void TerminalProtocolComServer::_dispatchRestartAgentPaneToPage(const winrt::hst
     {
         return;
     }
+
     // Fan out to every window; the wta-master is shared across all windows
     // and the page-side handler resolves the right tab via `tab_id`. Pages
     // without a matching tab no-op (see OnAgentPaneRestartRequested).
@@ -1364,6 +1379,38 @@ void TerminalProtocolComServer::_dispatchRestartAgentPaneToPage(const winrt::hst
                 catch (...)
                 {
                     // Swallow: page may have been torn down during dispatch.
+                }
+            });
+    }
+}
+
+void TerminalProtocolComServer::_dispatchAgentSessionsRetiredToPage(const winrt::hstring& eventJson)
+{
+    if (!s_emperor)
+    {
+        return;
+    }
+    for (const auto& host : s_emperor->GetWindows())
+    {
+        auto page = _getPage(host.get());
+        if (!page)
+        {
+            continue;
+        }
+        const auto dispatcher = page.Dispatcher();
+        if (!dispatcher)
+        {
+            continue;
+        }
+        dispatcher.RunAsync(
+            winrt::Windows::UI::Core::CoreDispatcherPriority::Normal,
+            [page, eventJson]() {
+                try
+                {
+                    page.OnAgentSessionsRetired(eventJson);
+                }
+                catch (...)
+                {
                 }
             });
     }

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.h
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.h
@@ -139,6 +139,7 @@ private:
     static void _dispatchAgentChipTargetToPage(const winrt::hstring& eventJson);
     static void _dispatchRestartAgentStackToPage(const winrt::hstring& eventJson);
     static void _dispatchRestartAgentPaneToPage(const winrt::hstring& eventJson);
+    static void _dispatchAgentSessionsRetiredToPage(const winrt::hstring& eventJson);
 
     static WindowEmperor* s_emperor;
 };

--- a/src/cascadia/ut_app/ProtocolParsingTests.cpp
+++ b/src/cascadia/ut_app/ProtocolParsingTests.cpp
@@ -15,6 +15,8 @@ namespace TerminalAppUnitTests
         TEST_CLASS(ProtocolParsingTests);
 
         TEST_METHOD(DefaultPasteRequestUsesDirectRoute);
+        TEST_METHOD(AgentSessionsRetiredUsesDirectRoute);
+        TEST_METHOD(RestartRequestIdentityIsStampedOnce);
     };
 
     void ProtocolParsingTests::DefaultPasteRequestUsesDirectRoute()
@@ -26,5 +28,29 @@ namespace TerminalAppUnitTests
 
         VERIFY_ARE_EQUAL(SendEventRoute::DefaultPaste, route);
         VERIFY_ARE_EQUAL("request_default_paste", event["method"].asString());
+    }
+
+    void ProtocolParsingTests::AgentSessionsRetiredUsesDirectRoute()
+    {
+        Json::Value event;
+        const auto route = ClassifySendEvent(
+            R"({"type":"event","method":"agent_sessions_retired","params":{"operation_id":"123-1","success":true,"reason":"restart_agent_stack","failed_tabs":[]}})",
+            event);
+
+        VERIFY_ARE_EQUAL(SendEventRoute::AgentSessionsRetired, route);
+        VERIFY_ARE_EQUAL("123-1", event["params"]["operation_id"].asString());
+    }
+
+    void ProtocolParsingTests::RestartRequestIdentityIsStampedOnce()
+    {
+        Json::Value event;
+        VERIFY_IS_TRUE(ParseJson(
+            R"({"type":"event","method":"restart_agent_stack","params":{}})",
+            event));
+
+        EnsureRequestId(event, "request-1");
+        EnsureRequestId(event, "request-2");
+
+        VERIFY_ARE_EQUAL("request-1", event["params"]["request_id"].asString());
     }
 }

--- a/src/cascadia/ut_app/SharedWtaTests.cpp
+++ b/src/cascadia/ut_app/SharedWtaTests.cpp
@@ -125,6 +125,8 @@ namespace TerminalAppUnitTests
         TEST_METHOD(RestartTimeoutTerminatesThenReapsRetiredProcess);
         TEST_METHOD(RestartWaitFailureTerminatesThenReapsRetiredProcess);
         TEST_METHOD(RestartFailsWhenForcedProcessReapTimesOut);
+        TEST_METHOD(StaleWaitCallbackCannotClaimReplacementWithReusedPid);
+        TEST_METHOD(RetiredWaitCallbackCannotClaimAfterCleanup);
         TEST_METHOD(AllScopeRetirementJoinsSameRequest);
         TEST_METHOD(LiveSettingsObjectSharesGeneration);
         TEST_METHOD(LaterSettingsObjectGetsNewGenerationAfterValueReuse);
@@ -340,6 +342,36 @@ namespace TerminalAppUnitTests
         VERIFY_ARE_EQUAL(std::string{ "wait" }, callState.calls[0]);
         VERIFY_ARE_EQUAL(std::string{ "terminate" }, callState.calls[1]);
         VERIFY_ARE_EQUAL(std::string{ "wait" }, callState.calls[2]);
+    }
+
+    void SharedWtaTests::StaleWaitCallbackCannotClaimReplacementWithReusedPid()
+    {
+        details::ProcessWaitGenerationTracker tracker;
+        constexpr DWORD reusedPid{ 46 };
+
+        const auto staleGeneration = tracker.Register(reusedPid);
+        tracker.Retire();
+        const auto replacementGeneration = tracker.Register(reusedPid);
+
+        VERIFY_ARE_NOT_EQUAL(staleGeneration, replacementGeneration);
+        VERIFY_IS_FALSE(tracker.Claim(staleGeneration).has_value());
+        VERIFY_ARE_EQUAL(replacementGeneration, tracker.Current());
+
+        const auto replacementPid = tracker.Claim(replacementGeneration);
+        VERIFY_IS_TRUE(replacementPid.has_value());
+        VERIFY_ARE_EQUAL(reusedPid, *replacementPid);
+        VERIFY_ARE_EQUAL(details::ProcessWaitGenerationTracker::Generation{ 0 }, tracker.Current());
+    }
+
+    void SharedWtaTests::RetiredWaitCallbackCannotClaimAfterCleanup()
+    {
+        details::ProcessWaitGenerationTracker tracker;
+        const auto retiredGeneration = tracker.Register(47);
+
+        tracker.Retire();
+
+        VERIFY_IS_FALSE(tracker.Claim(retiredGeneration).has_value());
+        VERIFY_ARE_EQUAL(details::ProcessWaitGenerationTracker::Generation{ 0 }, tracker.Current());
     }
 
     void SharedWtaTests::AllScopeRetirementJoinsSameRequest()

--- a/src/cascadia/ut_app/SharedWtaTests.cpp
+++ b/src/cascadia/ut_app/SharedWtaTests.cpp
@@ -25,6 +25,20 @@ namespace TerminalAppUnitTests
 
         thread_local SuspendedProcessCallState* suspendedProcessCallState{ nullptr };
 
+        struct ProcessRetirementCallState
+        {
+            HANDLE process{ nullptr };
+            std::array<DWORD, 2> waitResults{};
+            size_t waitResultCount{ 0 };
+            size_t waitResultIndex{ 0 };
+            std::vector<std::string> calls;
+            std::vector<DWORD> waitTimeouts;
+            BOOL terminateResult{ TRUE };
+            UINT exitCode{ 0 };
+        };
+
+        thread_local ProcessRetirementCallState* processRetirementCallState{ nullptr };
+
         DWORD WINAPI ResumeThreadFailure(const HANDLE thread)
         {
             suspendedProcessCallState->resumedThread = thread;
@@ -43,6 +57,37 @@ namespace TerminalAppUnitTests
             suspendedProcessCallState->terminatedProcess = process;
             suspendedProcessCallState->exitCode = exitCode;
             return TRUE;
+        }
+
+        DWORD WINAPI ScriptProcessWait(const HANDLE process, const DWORD timeout)
+        {
+            auto& state = *processRetirementCallState;
+            state.calls.emplace_back("wait");
+            state.process = process;
+            state.waitTimeouts.emplace_back(timeout);
+            if (state.waitResultIndex >= state.waitResultCount)
+            {
+                return WAIT_FAILED;
+            }
+            const auto result = state.waitResults[state.waitResultIndex++];
+            if (result == WAIT_FAILED)
+            {
+                SetLastError(ERROR_INVALID_HANDLE);
+            }
+            return result;
+        }
+
+        BOOL WINAPI ScriptProcessTerminate(const HANDLE process, const UINT exitCode)
+        {
+            auto& state = *processRetirementCallState;
+            state.calls.emplace_back("terminate");
+            state.process = process;
+            state.exitCode = exitCode;
+            if (!state.terminateResult)
+            {
+                SetLastError(ERROR_ACCESS_DENIED);
+            }
+            return state.terminateResult;
         }
     }
 
@@ -76,6 +121,10 @@ namespace TerminalAppUnitTests
         TEST_METHOD(RejectsEmbeddedNullInEnvironmentName);
         TEST_METHOD(RejectsEmbeddedNullInEnvironmentValue);
         TEST_METHOD(ResumeFailureCleansUpSuspendedProcess);
+        TEST_METHOD(RestartWaitsForRetiredProcessBeforeContinuing);
+        TEST_METHOD(RestartTimeoutTerminatesThenReapsRetiredProcess);
+        TEST_METHOD(RestartWaitFailureTerminatesThenReapsRetiredProcess);
+        TEST_METHOD(RestartFailsWhenForcedProcessReapTimesOut);
         TEST_METHOD(AllScopeRetirementJoinsSameRequest);
         TEST_METHOD(LiveSettingsObjectSharesGeneration);
         TEST_METHOD(LaterSettingsObjectGetsNewGenerationAfterValueReuse);
@@ -202,6 +251,95 @@ namespace TerminalAppUnitTests
         VERIFY_IS_NULL(callState.unregisterCompletionEvent);
         VERIFY_ARE_EQUAL(process, callState.terminatedProcess);
         VERIFY_ARE_EQUAL(UINT{ 1 }, callState.exitCode);
+    }
+
+    void SharedWtaTests::RestartWaitsForRetiredProcessBeforeContinuing()
+    {
+        const auto process = reinterpret_cast<HANDLE>(static_cast<uintptr_t>(4));
+        ProcessRetirementCallState callState{
+            .waitResults = { WAIT_OBJECT_0 },
+            .waitResultCount = 1,
+        };
+        processRetirementCallState = &callState;
+        const auto resetCallState = wil::scope_exit([]() noexcept { processRetirementCallState = nullptr; });
+        const details::ProcessRetirementOperations operations{
+            &ScriptProcessWait,
+            &ScriptProcessTerminate,
+        };
+
+        VERIFY_IS_TRUE(details::EnsureProcessExitedBeforeRestart(process, 42, 3000, 5000, operations));
+        VERIFY_ARE_EQUAL(process, callState.process);
+        VERIFY_ARE_EQUAL(size_t{ 1 }, callState.calls.size());
+        VERIFY_ARE_EQUAL(std::string{ "wait" }, callState.calls[0]);
+        VERIFY_ARE_EQUAL(size_t{ 1 }, callState.waitTimeouts.size());
+        VERIFY_ARE_EQUAL(DWORD{ 3000 }, callState.waitTimeouts[0]);
+    }
+
+    void SharedWtaTests::RestartTimeoutTerminatesThenReapsRetiredProcess()
+    {
+        const auto process = reinterpret_cast<HANDLE>(static_cast<uintptr_t>(5));
+        ProcessRetirementCallState callState{
+            .waitResults = { WAIT_TIMEOUT, WAIT_OBJECT_0 },
+            .waitResultCount = 2,
+        };
+        processRetirementCallState = &callState;
+        const auto resetCallState = wil::scope_exit([]() noexcept { processRetirementCallState = nullptr; });
+        const details::ProcessRetirementOperations operations{
+            &ScriptProcessWait,
+            &ScriptProcessTerminate,
+        };
+
+        VERIFY_IS_TRUE(details::EnsureProcessExitedBeforeRestart(process, 43, 3000, 5000, operations));
+        VERIFY_ARE_EQUAL(size_t{ 3 }, callState.calls.size());
+        VERIFY_ARE_EQUAL(std::string{ "wait" }, callState.calls[0]);
+        VERIFY_ARE_EQUAL(std::string{ "terminate" }, callState.calls[1]);
+        VERIFY_ARE_EQUAL(std::string{ "wait" }, callState.calls[2]);
+        VERIFY_ARE_EQUAL(size_t{ 2 }, callState.waitTimeouts.size());
+        VERIFY_ARE_EQUAL(DWORD{ 3000 }, callState.waitTimeouts[0]);
+        VERIFY_ARE_EQUAL(DWORD{ 5000 }, callState.waitTimeouts[1]);
+        VERIFY_ARE_EQUAL(UINT{ 1 }, callState.exitCode);
+    }
+
+    void SharedWtaTests::RestartWaitFailureTerminatesThenReapsRetiredProcess()
+    {
+        const auto process = reinterpret_cast<HANDLE>(static_cast<uintptr_t>(6));
+        ProcessRetirementCallState callState{
+            .waitResults = { WAIT_FAILED, WAIT_OBJECT_0 },
+            .waitResultCount = 2,
+        };
+        processRetirementCallState = &callState;
+        const auto resetCallState = wil::scope_exit([]() noexcept { processRetirementCallState = nullptr; });
+        const details::ProcessRetirementOperations operations{
+            &ScriptProcessWait,
+            &ScriptProcessTerminate,
+        };
+
+        VERIFY_IS_TRUE(details::EnsureProcessExitedBeforeRestart(process, 44, 3000, 5000, operations));
+        VERIFY_ARE_EQUAL(size_t{ 3 }, callState.calls.size());
+        VERIFY_ARE_EQUAL(std::string{ "wait" }, callState.calls[0]);
+        VERIFY_ARE_EQUAL(std::string{ "terminate" }, callState.calls[1]);
+        VERIFY_ARE_EQUAL(std::string{ "wait" }, callState.calls[2]);
+    }
+
+    void SharedWtaTests::RestartFailsWhenForcedProcessReapTimesOut()
+    {
+        const auto process = reinterpret_cast<HANDLE>(static_cast<uintptr_t>(7));
+        ProcessRetirementCallState callState{
+            .waitResults = { WAIT_TIMEOUT, WAIT_TIMEOUT },
+            .waitResultCount = 2,
+        };
+        processRetirementCallState = &callState;
+        const auto resetCallState = wil::scope_exit([]() noexcept { processRetirementCallState = nullptr; });
+        const details::ProcessRetirementOperations operations{
+            &ScriptProcessWait,
+            &ScriptProcessTerminate,
+        };
+
+        VERIFY_IS_FALSE(details::EnsureProcessExitedBeforeRestart(process, 45, 3000, 5000, operations));
+        VERIFY_ARE_EQUAL(size_t{ 3 }, callState.calls.size());
+        VERIFY_ARE_EQUAL(std::string{ "wait" }, callState.calls[0]);
+        VERIFY_ARE_EQUAL(std::string{ "terminate" }, callState.calls[1]);
+        VERIFY_ARE_EQUAL(std::string{ "wait" }, callState.calls[2]);
     }
 
     void SharedWtaTests::AllScopeRetirementJoinsSameRequest()

--- a/src/cascadia/ut_app/SharedWtaTests.cpp
+++ b/src/cascadia/ut_app/SharedWtaTests.cpp
@@ -12,6 +12,40 @@ using namespace winrt::TerminalApp::implementation;
 
 namespace TerminalAppUnitTests
 {
+    namespace
+    {
+        struct SuspendedProcessCallState
+        {
+            HANDLE resumedThread{ nullptr };
+            HANDLE unregisteredWait{ nullptr };
+            HANDLE unregisterCompletionEvent{ nullptr };
+            HANDLE terminatedProcess{ nullptr };
+            UINT exitCode{ 0 };
+        };
+
+        thread_local SuspendedProcessCallState* suspendedProcessCallState{ nullptr };
+
+        DWORD WINAPI ResumeThreadFailure(const HANDLE thread)
+        {
+            suspendedProcessCallState->resumedThread = thread;
+            return static_cast<DWORD>(-1);
+        }
+
+        BOOL WINAPI RecordUnregisterWait(const HANDLE wait, const HANDLE completionEvent)
+        {
+            suspendedProcessCallState->unregisteredWait = wait;
+            suspendedProcessCallState->unregisterCompletionEvent = completionEvent;
+            return TRUE;
+        }
+
+        BOOL WINAPI RecordTerminateProcess(const HANDLE process, const UINT exitCode)
+        {
+            suspendedProcessCallState->terminatedProcess = process;
+            suspendedProcessCallState->exitCode = exitCode;
+            return TRUE;
+        }
+    }
+
     struct GenerationTestObject :
         winrt::implements<GenerationTestObject, winrt::Windows::Foundation::IStringable>
     {
@@ -41,6 +75,7 @@ namespace TerminalAppUnitTests
         TEST_METHOD(RejectsEqualsInEnvironmentName);
         TEST_METHOD(RejectsEmbeddedNullInEnvironmentName);
         TEST_METHOD(RejectsEmbeddedNullInEnvironmentValue);
+        TEST_METHOD(ResumeFailureCleansUpSuspendedProcess);
         TEST_METHOD(AllScopeRetirementJoinsSameRequest);
         TEST_METHOD(LiveSettingsObjectSharesGeneration);
         TEST_METHOD(LaterSettingsObjectGetsNewGenerationAfterValueReuse);
@@ -143,6 +178,30 @@ namespace TerminalAppUnitTests
     {
         constexpr wchar_t value[]{ L'd', L'e', L'b', L'u', L'g', L'\0', L't', L'r', L'a', L'c', L'e' };
         VERIFY_IS_FALSE(details::IsValidEnvironmentOverride(L"WTA_LOG", std::wstring_view{ value, std::size(value) }));
+    }
+
+    void SharedWtaTests::ResumeFailureCleansUpSuspendedProcess()
+    {
+        const auto thread = reinterpret_cast<HANDLE>(static_cast<uintptr_t>(1));
+        const auto process = reinterpret_cast<HANDLE>(static_cast<uintptr_t>(2));
+        HANDLE wait = reinterpret_cast<HANDLE>(static_cast<uintptr_t>(3));
+        SuspendedProcessCallState callState;
+        suspendedProcessCallState = &callState;
+        const auto resetCallState = wil::scope_exit([]() noexcept { suspendedProcessCallState = nullptr; });
+
+        const details::SuspendedProcessOperations operations{
+            &ResumeThreadFailure,
+            &RecordUnregisterWait,
+            &RecordTerminateProcess,
+        };
+
+        VERIFY_IS_FALSE(details::ResumeSuspendedProcess(thread, process, wait, operations));
+        VERIFY_IS_NULL(wait);
+        VERIFY_ARE_EQUAL(thread, callState.resumedThread);
+        VERIFY_ARE_EQUAL(reinterpret_cast<HANDLE>(static_cast<uintptr_t>(3)), callState.unregisteredWait);
+        VERIFY_IS_NULL(callState.unregisterCompletionEvent);
+        VERIFY_ARE_EQUAL(process, callState.terminatedProcess);
+        VERIFY_ARE_EQUAL(UINT{ 1 }, callState.exitCode);
     }
 
     void SharedWtaTests::AllScopeRetirementJoinsSameRequest()

--- a/src/cascadia/ut_app/SharedWtaTests.cpp
+++ b/src/cascadia/ut_app/SharedWtaTests.cpp
@@ -12,6 +12,23 @@ using namespace winrt::TerminalApp::implementation;
 
 namespace TerminalAppUnitTests
 {
+    struct GenerationTestObject :
+        winrt::implements<GenerationTestObject, winrt::Windows::Foundation::IStringable>
+    {
+        explicit GenerationTestObject(winrt::hstring value) :
+            _value{ std::move(value) }
+        {
+        }
+
+        winrt::hstring ToString() const
+        {
+            return _value;
+        }
+
+    private:
+        winrt::hstring _value;
+    };
+
     class SharedWtaTests
     {
         TEST_CLASS(SharedWtaTests);
@@ -24,6 +41,19 @@ namespace TerminalAppUnitTests
         TEST_METHOD(RejectsEqualsInEnvironmentName);
         TEST_METHOD(RejectsEmbeddedNullInEnvironmentName);
         TEST_METHOD(RejectsEmbeddedNullInEnvironmentValue);
+        TEST_METHOD(AllScopeRetirementJoinsSameRequest);
+        TEST_METHOD(LiveSettingsObjectSharesGeneration);
+        TEST_METHOD(LaterSettingsObjectGetsNewGenerationAfterValueReuse);
+        TEST_METHOD(DistinctAllScopeRequestsRemainDistinct);
+        TEST_METHOD(TabScopeRetirementIsNeverDeduplicated);
+        TEST_METHOD(RetirementActionIsClaimedOnce);
+        TEST_METHOD(TimedOutSettingsRetirementKeepsRestartClaimableAcrossPages);
+        TEST_METHOD(TimedOutRestartRetirementKeepsRestartClaimableAcrossPages);
+        TEST_METHOD(CompletedRetirementHistoryIsBounded);
+        TEST_METHOD(ExpiredRetirementRequestCanRegisterAgain);
+        TEST_METHOD(CloseSupersedesPendingRebuild);
+        TEST_METHOD(RestartSuppressionClearsBeforeReopen);
+        TEST_METHOD(RepeatedRestartRequestsAreCoalescedOnCompletion);
     };
 
     void SharedWtaTests::EmptyEnvironmentOverridesInheritParent()
@@ -113,5 +143,212 @@ namespace TerminalAppUnitTests
     {
         constexpr wchar_t value[]{ L'd', L'e', L'b', L'u', L'g', L'\0', L't', L'r', L'a', L'c', L'e' };
         VERIFY_IS_FALSE(details::IsValidEnvironmentOverride(L"WTA_LOG", std::wstring_view{ value, std::size(value) }));
+    }
+
+    void SharedWtaTests::AllScopeRetirementJoinsSameRequest()
+    {
+        details::RetirementCoordinator coordinator;
+
+        const auto first = coordinator.Register(true, "restart_agent_stack", "request-1");
+        const auto second = coordinator.Register(true, "restart_agent_stack", "request-1");
+
+        VERIFY_IS_FALSE(first.operationId.empty());
+        VERIFY_IS_TRUE(first.shouldPublish);
+        VERIFY_IS_FALSE(second.shouldPublish);
+        VERIFY_ARE_EQUAL(first.operationId, second.operationId);
+
+        VERIFY_IS_TRUE(coordinator.Complete(first.operationId));
+        coordinator.ReleaseContinuation(first.operationId);
+        const auto lateJoin = coordinator.Register(true, "restart_agent_stack", "request-1");
+        VERIFY_ARE_EQUAL(first.operationId, lateJoin.operationId);
+        VERIFY_IS_TRUE(lateJoin.alreadyCompleted);
+        coordinator.ReleaseContinuation(lateJoin.operationId);
+    }
+
+    void SharedWtaTests::LiveSettingsObjectSharesGeneration()
+    {
+        details::LiveObjectGenerationTracker tracker;
+        const auto settings = winrt::make<GenerationTestObject>(L"A");
+        const auto sameSettings = settings;
+
+        VERIFY_ARE_EQUAL(tracker.Get(settings), tracker.Get(sameSettings));
+    }
+
+    void SharedWtaTests::LaterSettingsObjectGetsNewGenerationAfterValueReuse()
+    {
+        details::LiveObjectGenerationTracker tracker;
+
+        auto settings = winrt::make<GenerationTestObject>(L"A");
+        const auto firstGeneration = tracker.Get(settings);
+        settings = nullptr;
+
+        auto replacement = winrt::make<GenerationTestObject>(L"B");
+        const auto secondGeneration = tracker.Get(replacement);
+        replacement = nullptr;
+
+        const auto sameValueReplacement = winrt::make<GenerationTestObject>(L"A");
+        const auto thirdGeneration = tracker.Get(sameValueReplacement);
+
+        VERIFY_IS_LESS_THAN(firstGeneration, secondGeneration);
+        VERIFY_IS_LESS_THAN(secondGeneration, thirdGeneration);
+    }
+
+    void SharedWtaTests::DistinctAllScopeRequestsRemainDistinct()
+    {
+        details::RetirementCoordinator coordinator;
+
+        const auto first = coordinator.Register(true, "settings_master_configuration_changed", "settings-a");
+        const auto second = coordinator.Register(true, "settings_master_configuration_changed", "settings-b");
+
+        VERIFY_ARE_NOT_EQUAL(first.operationId, second.operationId);
+        VERIFY_IS_TRUE(coordinator.ClaimAction(first.operationId, "restart_master"));
+        VERIFY_IS_TRUE(coordinator.ClaimAction(second.operationId, "restart_master"));
+    }
+
+    void SharedWtaTests::TabScopeRetirementIsNeverDeduplicated()
+    {
+        details::RetirementCoordinator coordinator;
+
+        const auto first = coordinator.Register(false, "agent_switch");
+        const auto second = coordinator.Register(false, "agent_switch");
+
+        VERIFY_IS_TRUE(first.shouldPublish);
+        VERIFY_IS_TRUE(second.shouldPublish);
+        VERIFY_ARE_NOT_EQUAL(first.operationId, second.operationId);
+    }
+
+    void SharedWtaTests::RetirementActionIsClaimedOnce()
+    {
+        details::RetirementCoordinator coordinator;
+        const auto operation = coordinator.Register(true, "restart_agent_stack", "request-1");
+
+        VERIFY_IS_TRUE(coordinator.ClaimAction(operation.operationId, "restart_master"));
+        VERIFY_IS_FALSE(coordinator.ClaimAction(operation.operationId, "restart_master"));
+    }
+
+    void SharedWtaTests::TimedOutSettingsRetirementKeepsRestartClaimableAcrossPages()
+    {
+        details::RetirementCoordinator coordinator;
+        const auto firstPage = coordinator.Register(
+            true,
+            "settings_master_configuration_changed",
+            "settings-timeout");
+        const auto secondPage = coordinator.Register(
+            true,
+            "settings_master_configuration_changed",
+            "settings-timeout");
+
+        VERIFY_ARE_EQUAL(firstPage.operationId, secondPage.operationId);
+        VERIFY_IS_TRUE(coordinator.Complete(firstPage.operationId, true));
+        coordinator.ReleaseContinuation(firstPage.operationId);
+
+        VERIFY_IS_TRUE(coordinator.ClaimAction(secondPage.operationId, "restart_master"));
+        VERIFY_IS_FALSE(coordinator.ClaimAction(firstPage.operationId, "restart_master"));
+        coordinator.ReleaseContinuation(secondPage.operationId);
+
+        VERIFY_IS_FALSE(coordinator.ClaimAction(firstPage.operationId, "restart_master"));
+        VERIFY_IS_FALSE(coordinator.Complete(firstPage.operationId));
+    }
+
+    void SharedWtaTests::TimedOutRestartRetirementKeepsRestartClaimableAcrossPages()
+    {
+        details::RetirementCoordinator coordinator;
+        const auto firstPage = coordinator.Register(true, "restart_agent_stack", "restart-timeout");
+        const auto secondPage = coordinator.Register(true, "restart_agent_stack", "restart-timeout");
+
+        VERIFY_ARE_EQUAL(firstPage.operationId, secondPage.operationId);
+        VERIFY_IS_TRUE(coordinator.Complete(firstPage.operationId, true));
+        VERIFY_IS_TRUE(coordinator.ClaimAction(firstPage.operationId, "restart_master"));
+        coordinator.ReleaseContinuation(firstPage.operationId);
+
+        VERIFY_IS_FALSE(coordinator.ClaimAction(secondPage.operationId, "restart_master"));
+        coordinator.ReleaseContinuation(secondPage.operationId);
+
+        const auto replacement = coordinator.Register(true, "restart_agent_stack", "restart-timeout");
+        VERIFY_ARE_NOT_EQUAL(firstPage.operationId, replacement.operationId);
+        VERIFY_IS_TRUE(replacement.shouldPublish);
+    }
+
+    void SharedWtaTests::CompletedRetirementHistoryIsBounded()
+    {
+        details::RetirementCoordinator coordinator;
+        const auto inFlight = coordinator.Register(true, "restart_agent_stack", "in-flight");
+        std::string firstCompletedId;
+        std::string lastCompletedId;
+
+        for (size_t i = 0; i <= details::RetirementCoordinator::CompletedHistoryLimit; ++i)
+        {
+            const auto requestId = "completed-" + std::to_string(i);
+            const auto operation = coordinator.Register(true, "restart_agent_stack", requestId);
+            if (i == 0)
+            {
+                firstCompletedId = operation.operationId;
+            }
+            lastCompletedId = operation.operationId;
+            VERIFY_IS_TRUE(coordinator.Complete(operation.operationId));
+            coordinator.ReleaseContinuation(operation.operationId);
+        }
+
+        const auto evicted = coordinator.Register(true, "restart_agent_stack", "completed-0");
+        VERIFY_ARE_NOT_EQUAL(firstCompletedId, evicted.operationId);
+        VERIFY_IS_TRUE(evicted.shouldPublish);
+
+        const auto retained = coordinator.Register(
+            true,
+            "restart_agent_stack",
+            "completed-" + std::to_string(details::RetirementCoordinator::CompletedHistoryLimit));
+        VERIFY_ARE_EQUAL(lastCompletedId, retained.operationId);
+        VERIFY_IS_TRUE(retained.alreadyCompleted);
+        coordinator.ReleaseContinuation(retained.operationId);
+
+        VERIFY_IS_TRUE(coordinator.ClaimAction(inFlight.operationId, "restart_master"));
+        VERIFY_IS_TRUE(coordinator.Complete(inFlight.operationId));
+        coordinator.ReleaseContinuation(inFlight.operationId);
+    }
+
+    void SharedWtaTests::ExpiredRetirementRequestCanRegisterAgain()
+    {
+        details::RetirementCoordinator coordinator;
+        const auto first = coordinator.Register(true, "restart_agent_stack", "request-1");
+
+        coordinator.Expire(first.operationId);
+        const auto replacement = coordinator.Register(true, "restart_agent_stack", "request-1");
+
+        VERIFY_ARE_NOT_EQUAL(first.operationId, replacement.operationId);
+        VERIFY_IS_TRUE(replacement.shouldPublish);
+    }
+
+    void SharedWtaTests::CloseSupersedesPendingRebuild()
+    {
+        details::TabRetirementTracker tracker;
+
+        VERIFY_IS_TRUE(tracker.BeginRebuild("tab-1"));
+        VERIFY_IS_FALSE(tracker.RequestClose("tab-1"));
+        VERIFY_IS_FALSE(tracker.Complete("tab-1"));
+    }
+
+    void SharedWtaTests::RestartSuppressionClearsBeforeReopen()
+    {
+        details::RestartSuppressionTracker tracker;
+
+        tracker.Mark("tab-1");
+        tracker.Clear("tab-1");
+        VERIFY_IS_FALSE(tracker.Consume("tab-1"));
+
+        tracker.Mark("tab-1");
+        VERIFY_IS_TRUE(tracker.Consume("tab-1"));
+        VERIFY_IS_FALSE(tracker.Consume("tab-1"));
+    }
+
+    void SharedWtaTests::RepeatedRestartRequestsAreCoalescedOnCompletion()
+    {
+        details::CoalescedRequest pending;
+
+        pending.Queue("restart-1");
+        pending.Queue("restart-2");
+        VERIFY_IS_TRUE(pending.Pending());
+        pending.Clear();
+        VERIFY_IS_FALSE(pending.Pending());
+        VERIFY_IS_FALSE(pending.Take().has_value());
     }
 }

--- a/tools/wta/Cargo.toml
+++ b/tools/wta/Cargo.toml
@@ -34,6 +34,7 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Console",
     "Win32_System_DataExchange",
     "Win32_System_Environment",
+    "Win32_System_JobObjects",
     "Win32_System_Memory",
     "Win32_System_Registry",
     "Win32_System_Threading",

--- a/tools/wta/src/helper/runtime.rs
+++ b/tools/wta/src/helper/runtime.rs
@@ -20,6 +20,65 @@ use crate::{
 
 use super::config::{HelperConfig, InitialView};
 
+#[cfg(windows)]
+fn install_descendant_job() {
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError};
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+        SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+    unsafe {
+        let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+        if job.is_null() {
+            tracing::warn!(
+                target: "helper",
+                error = GetLastError(),
+                "failed to create helper descendant job"
+            );
+            return;
+        }
+
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        if SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            std::ptr::addr_of!(limits).cast(),
+            std::mem::size_of_val(&limits) as u32,
+        ) == 0
+        {
+            tracing::warn!(
+                target: "helper",
+                error = GetLastError(),
+                "failed to configure helper descendant job"
+            );
+            CloseHandle(job);
+            return;
+        }
+
+        if AssignProcessToJobObject(job, GetCurrentProcess()) == 0 {
+            tracing::warn!(
+                target: "helper",
+                error = GetLastError(),
+                "failed to assign helper to descendant job"
+            );
+            CloseHandle(job);
+            return;
+        }
+
+        // This process must retain the only job handle for its entire lifetime.
+        // Windows closes it on every exit path, including TerminateProcess, and
+        // KILL_ON_JOB_CLOSE then reclaims wtcli and other helper descendants.
+        tracing::info!(target: "helper", "helper descendant job installed");
+    }
+}
+
+#[cfg(not(windows))]
+fn install_descendant_job() {}
+
 /// Drive the standard ACP TUI but use `pipe_name` as the ACP transport
 /// (helper mode). The helper attaches to wta-master over the supplied
 /// named pipe and forwards ACP traffic over it.
@@ -27,6 +86,7 @@ pub(super) async fn run_default_tui_over_pipe(
     mut config: HelperConfig,
     pipe_name: String,
 ) -> Result<()> {
+    install_descendant_job();
     tracing::info!(target: "helper", pipe = %pipe_name, "=== wta-helper starting (TUI) ===");
     let agent_source = crate::agent_source::AgentSource::from_wire(
         config.agent_source.as_deref(),

--- a/tools/wta/src/helper/runtime.rs
+++ b/tools/wta/src/helper/runtime.rs
@@ -1,6 +1,6 @@
 //! Per-pane helper runtime bootstrap and orchestration.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use crossterm::{
     cursor::{SetCursorStyle, Show},
     event::{DisableMouseCapture, EnableMouseCapture},
@@ -21,8 +21,8 @@ use crate::{
 use super::config::{HelperConfig, InitialView};
 
 #[cfg(windows)]
-fn install_descendant_job() {
-    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError};
+fn install_descendant_job() -> Result<()> {
+    use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
     use windows_sys::Win32::System::JobObjects::{
         AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
         SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
@@ -33,55 +33,48 @@ fn install_descendant_job() {
     unsafe {
         let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
         if job.is_null() {
-            tracing::warn!(
-                target: "helper",
-                error = GetLastError(),
-                "failed to create helper descendant job"
-            );
-            return;
+            return Err(io::Error::last_os_error())
+                .context("failed to create helper descendant job");
         }
+        let job = OwnedHandle::from_raw_handle(job);
 
         let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
         limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
         if SetInformationJobObject(
-            job,
+            job.as_raw_handle(),
             JobObjectExtendedLimitInformation,
             std::ptr::addr_of!(limits).cast(),
             std::mem::size_of_val(&limits) as u32,
         ) == 0
         {
-            tracing::warn!(
-                target: "helper",
-                error = GetLastError(),
-                "failed to configure helper descendant job"
-            );
-            CloseHandle(job);
-            return;
+            let error = io::Error::last_os_error();
+            drop(job);
+            return Err(error).context("failed to configure helper descendant job");
         }
 
-        if AssignProcessToJobObject(job, GetCurrentProcess()) == 0 {
-            tracing::warn!(
-                target: "helper",
-                error = GetLastError(),
-                "failed to assign helper to descendant job"
-            );
-            CloseHandle(job);
-            return;
+        if AssignProcessToJobObject(job.as_raw_handle(), GetCurrentProcess()) == 0 {
+            let error = io::Error::last_os_error();
+            drop(job);
+            return Err(error).context("failed to assign helper to descendant job");
         }
 
         // This process must retain the only job handle for its entire lifetime.
         // Windows closes it on every exit path, including TerminateProcess, and
         // KILL_ON_JOB_CLOSE then reclaims wtcli and other helper descendants.
+        std::mem::forget(job);
         tracing::info!(
             target: "helper",
             helper_pid = std::process::id(),
             "helper descendant job installed"
         );
+        Ok(())
     }
 }
 
 #[cfg(not(windows))]
-fn install_descendant_job() {}
+fn install_descendant_job() -> Result<()> {
+    Ok(())
+}
 
 /// Drive the standard ACP TUI but use `pipe_name` as the ACP transport
 /// (helper mode). The helper attaches to wta-master over the supplied
@@ -90,7 +83,7 @@ pub(super) async fn run_default_tui_over_pipe(
     mut config: HelperConfig,
     pipe_name: String,
 ) -> Result<()> {
-    install_descendant_job();
+    install_descendant_job()?;
     tracing::info!(target: "helper", pipe = %pipe_name, "=== wta-helper starting (TUI) ===");
     let agent_source = crate::agent_source::AgentSource::from_wire(
         config.agent_source.as_deref(),

--- a/tools/wta/src/helper/runtime.rs
+++ b/tools/wta/src/helper/runtime.rs
@@ -72,7 +72,11 @@ fn install_descendant_job() {
         // This process must retain the only job handle for its entire lifetime.
         // Windows closes it on every exit path, including TerminateProcess, and
         // KILL_ON_JOB_CLOSE then reclaims wtcli and other helper descendants.
-        tracing::info!(target: "helper", "helper descendant job installed");
+        tracing::info!(
+            target: "helper",
+            helper_pid = std::process::id(),
+            "helper descendant job installed"
+        );
     }
 }
 

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -142,6 +142,14 @@ impl OwnerlessRetirementSafety {
             Self::DenyNextOwner => true,
         }
     }
+
+    fn rekey(&mut self, old_tab_id: &str, new_tab_id: &str) {
+        if let Self::Targets(targets) = self {
+            if targets.remove(old_tab_id) {
+                targets.insert(new_tab_id.to_string());
+            }
+        }
+    }
 }
 
 /// Per-session routing entry. Owned by `session_to_helper` and
@@ -366,6 +374,9 @@ struct MasterStateInner {
     /// the outgoing helper generation through completion and is consumed by
     /// its disconnect or by the first post-completion replacement helper.
     tab_retirement_fences: Mutex<HashMap<String, TabRetirementFence>>,
+    /// Stable-id moves for active tab retirement transactions. Entries exist
+    /// only while an operation still needs to follow a tab across a drag.
+    tab_retirement_rekeys: Mutex<HashMap<String, String>>,
     /// Retired tab ids that an ownerless connected helper could still claim.
     /// State is bounded per HelperId; overflow conservatively denies that
     /// connection's first owner publication instead of evicting safety.
@@ -403,6 +414,8 @@ struct MasterStateInner {
     retirement_pending_timeout: std::time::Duration,
     #[cfg(test)]
     disconnect_orphan_publication_pause: Mutex<Option<Arc<DisconnectOrphanPublicationPause>>>,
+    #[cfg(test)]
+    deferred_retirement_cleanup_complete: tokio::sync::Notify,
     /// Session ids claimed by an *authoritative* producer — a native agent hook
     /// (arrives via `intellterm.wta/session_hook`) or an ACP agent-pane
     /// session (driven by ACP `session/*`), both of which fully own binding and
@@ -915,7 +928,7 @@ fn agent_supports_session_close(agent: &AgentCli) -> bool {
 }
 
 async fn handle_close_tab_session(
-    state: &MasterStateInner,
+    state: &Arc<MasterStateInner>,
     params: &crate::session_registry::CloseTabSessionParams,
     reset_only: bool,
 ) -> acp::Result<acp::schema::v1::ExtResponse> {
@@ -927,25 +940,28 @@ async fn handle_close_tab_session(
 }
 
 async fn retire_tab_session(
-    state: &MasterStateInner,
+    state: &Arc<MasterStateInner>,
     params: &crate::session_registry::CloseTabSessionParams,
     reset_only: bool,
     destructive: bool,
     deadline: tokio::time::Instant,
 ) -> acp::Result<ReplacedSessionCleanup> {
-    let (target, newly_marked_close, deferred_pending) = {
+    let (tab_id, target, newly_marked_close, deferred_pending) = {
         let _ownership_guard = state.tab_ownership_gate.lock().await;
+        let rekeys = state.tab_retirement_rekeys.lock().await;
+        let tab_id = resolve_tab_retirement_id(&rekeys, &params.tab_id);
+        drop(rekeys);
         let mut target = {
             let meta = state.helper_meta.lock().await;
             meta.iter().find_map(|(helper_id, recovery)| {
-                (recovery.owner_tab_id.as_deref() == Some(params.tab_id.as_str()))
+                (recovery.owner_tab_id.as_deref() == Some(tab_id.as_str()))
                     .then(|| (*helper_id, recovery.last_session_id.clone()))
             })
         };
         if target.is_none() {
             target = state.pending_session_helpers.lock().await.iter().find_map(
                 |(helper_id, owner_tab_id)| {
-                    (owner_tab_id.as_deref() == Some(params.tab_id.as_str()))
+                    (owner_tab_id.as_deref() == Some(tab_id.as_str()))
                         .then_some((*helper_id, None))
                 },
             );
@@ -968,7 +984,7 @@ async fn retire_tab_session(
         } else {
             false
         };
-        (target, newly_marked_close, deferred_pending)
+        (tab_id, target, newly_marked_close, deferred_pending)
     };
     let matched_helper_id = target.as_ref().map(|(helper_id, _)| *helper_id);
 
@@ -1004,22 +1020,28 @@ async fn retire_tab_session(
                 .orphaned_tabs
                 .lock()
                 .await
-                .get(&params.tab_id)
+                .get(&tab_id)
                 .cloned()
         };
         if let Some((agent_key, orphan_helper_id, orphan_session_id)) = orphan {
             let gate = session_lifecycle_gate(state, &orphan_session_id).await;
             let _guard = match tokio::time::timeout_at(deadline, gate.lock()).await {
-                Ok(guard) => Some(guard),
+                Ok(guard) => guard,
                 Err(_) if destructive => {
                     tracing::error!(
                         target: "master_retirement",
-                        tab_id = %params.tab_id,
+                        tab_id,
                         helper_id = ?orphan_helper_id,
                         session_id = %orphan_session_id,
-                        "retirement deadline expired waiting for orphan lifecycle gate; retiring WTA state"
+                        "retirement deadline expired waiting for orphan lifecycle gate; deferring exact orphan cleanup"
                     );
-                    None
+                    schedule_deferred_tab_orphan_cleanup(
+                        state,
+                        agent_key,
+                        orphan_helper_id,
+                        orphan_session_id,
+                    );
+                    return Ok(ReplacedSessionCleanup::LogicalFallback);
                 }
                 Err(_) => {
                     return Err(retirement_deadline_error(
@@ -1028,46 +1050,11 @@ async fn retire_tab_session(
                     ));
                 }
             };
-            if _guard.is_none() {
-                {
-                    let mut orphaned_sessions = state.orphaned_sessions.lock().await;
-                    if let Some(sessions) = orphaned_sessions.get_mut(&agent_key) {
-                        sessions.remove(&orphan_session_id);
-                        if sessions.is_empty() {
-                            orphaned_sessions.remove(&agent_key);
-                        }
-                    }
-                }
-                state.orphaned_tabs.lock().await.remove(&params.tab_id);
-                state.pending_usage.lock().await.remove(&orphan_session_id);
-                state
-                    .session_mcp_capabilities
-                    .remove_session(&orphan_session_id)
-                    .await;
-                state.registry.remove(&orphan_session_id).await;
-                state.helper_meta.lock().await.remove(&orphan_helper_id);
-                state
-                    .pending_session_helpers
-                    .lock()
-                    .await
-                    .remove(&orphan_helper_id);
-                broadcast_ext_to_helpers(
-                    state,
-                    crate::session_registry::build_session_removed_notification(&orphan_session_id),
-                )
-                .await;
-                broadcast_ext_to_helpers(
-                    state,
-                    crate::session_registry::build_sessions_changed_notification(),
-                )
-                .await;
-                return Ok(ReplacedSessionCleanup::LogicalFallback);
-            }
             let orphan_is_current = state
                 .orphaned_tabs
                 .lock()
                 .await
-                .get(&params.tab_id)
+                .get(&tab_id)
                 .is_some_and(|current| {
                     current
                         == &(
@@ -1085,7 +1072,7 @@ async fn retire_tab_session(
                 .await
                 .contains_key(&orphan_session_id)
             {
-                state.orphaned_tabs.lock().await.remove(&params.tab_id);
+                state.orphaned_tabs.lock().await.remove(&tab_id);
                 return Ok(ReplacedSessionCleanup::NotOwned);
             }
             let agent = {
@@ -1106,7 +1093,7 @@ async fn retire_tab_session(
                     Ok(Err(error)) => {
                     tracing::warn!(
                         target: "master",
-                        tab_id = %params.tab_id,
+                        tab_id,
                         session_id = %orphan_session_id,
                         error = %error,
                             "failed to cancel orphaned turn before retirement"
@@ -1116,7 +1103,7 @@ async fn retire_tab_session(
                     Err(_) if destructive => {
                         tracing::error!(
                             target: "master_retirement",
-                            tab_id = %params.tab_id,
+                            tab_id,
                             session_id = %orphan_session_id,
                             "retirement deadline expired cancelling orphaned turn; retiring WTA state"
                         );
@@ -1143,7 +1130,7 @@ async fn retire_tab_session(
                     Ok(Err(error)) if error.code == acp::ErrorCode::MethodNotFound => {
                         tracing::warn!(
                             target: "master",
-                            tab_id = %params.tab_id,
+                            tab_id,
                             session_id = %orphan_session_id,
                             error = %error,
                             "agent advertised session/close but rejected it; retiring orphaned WTA state"
@@ -1153,7 +1140,7 @@ async fn retire_tab_session(
                         Ok(Err(error)) if destructive => {
                             tracing::error!(
                                 target: "master",
-                                tab_id = %params.tab_id,
+                                tab_id,
                                 session_id = %orphan_session_id,
                                 error = %error,
                                 "failed to physically close orphan; retiring WTA state"
@@ -1164,7 +1151,7 @@ async fn retire_tab_session(
                         Err(_) if destructive => {
                             tracing::error!(
                                 target: "master",
-                                tab_id = %params.tab_id,
+                                tab_id,
                                 session_id = %orphan_session_id,
                                 "session/close timed out for orphan; retiring WTA state"
                             );
@@ -1174,7 +1161,7 @@ async fn retire_tab_session(
                         return Err(acp::Error::internal_error().data(serde_json::json!({
                             "message": format!(
                                 "session/close timed out for orphaned tab {}",
-                                params.tab_id
+                                tab_id
                             )
                         })));
                     }
@@ -1185,7 +1172,7 @@ async fn retire_tab_session(
             } else if destructive {
                 tracing::warn!(
                     target: "master",
-                    tab_id = %params.tab_id,
+                    tab_id,
                     session_id = %orphan_session_id,
                     "orphan agent is unavailable; retiring WTA state"
                 );
@@ -1194,7 +1181,7 @@ async fn retire_tab_session(
                 return Err(acp::Error::internal_error().data(serde_json::json!({
                     "message": format!(
                         "agent for orphaned tab {} is no longer available",
-                        params.tab_id
+                        tab_id
                     )
                 })));
             };
@@ -1208,7 +1195,7 @@ async fn retire_tab_session(
                     }
                 }
             }
-            state.orphaned_tabs.lock().await.remove(&params.tab_id);
+            state.orphaned_tabs.lock().await.remove(&tab_id);
             state.pending_usage.lock().await.remove(&orphan_session_id);
             state
                 .session_mcp_capabilities
@@ -1235,7 +1222,7 @@ async fn retire_tab_session(
             .await;
             tracing::info!(
                 target: "master",
-                tab_id = %params.tab_id,
+                tab_id,
                 helper_id = ?orphan_helper_id,
                 session_id = %orphan_session_id,
                 cleanup = ?cleanup,
@@ -1256,7 +1243,7 @@ async fn retire_tab_session(
         }
         tracing::debug!(
             target: "master",
-            tab_id = %params.tab_id,
+            tab_id,
             deferred = deferred_pending,
             "close-by-tab found no live session; treating duplicate, late, or in-flight request as success"
         );
@@ -1285,7 +1272,7 @@ async fn retire_tab_session(
     } else if destructive {
         tracing::warn!(
             target: "master",
-            tab_id = %params.tab_id,
+            tab_id,
             helper_id = ?owner_helper_id,
             session_id = %session_id,
             agent_instance_id = %agent_instance_id,
@@ -1296,7 +1283,7 @@ async fn retire_tab_session(
         return Err(acp::Error::internal_error().data(serde_json::json!({
             "message": format!(
                 "agent instance {} for tab {} is no longer available",
-                agent_instance_id, params.tab_id
+                agent_instance_id, tab_id
             )
         })));
     };
@@ -1306,7 +1293,7 @@ async fn retire_tab_session(
         // marker or the helper disconnects. Keeping the marker here closes the
         // race where a committing transaction has just removed its pending
         // flag but has not yet checked whether tab close retired its session.
-        state.orphaned_tabs.lock().await.remove(&params.tab_id);
+        state.orphaned_tabs.lock().await.remove(&tab_id);
         if reset_only && !deferred_pending {
             state
                 .closing_session_helpers
@@ -1318,7 +1305,7 @@ async fn retire_tab_session(
             }
         }
         if destructive {
-            state.orphaned_tabs.lock().await.remove(&params.tab_id);
+            state.orphaned_tabs.lock().await.remove(&tab_id);
             {
                 let mut orphaned_sessions = state.orphaned_sessions.lock().await;
                 for sessions in orphaned_sessions.values_mut() {
@@ -1338,7 +1325,7 @@ async fn retire_tab_session(
     }
     tracing::info!(
         target: "master",
-        tab_id = %params.tab_id,
+        tab_id,
         helper_id = ?owner_helper_id,
         session_id = %session_id,
         cleanup = ?cleanup,
@@ -2251,13 +2238,13 @@ impl HelperHandler {
             .lock()
             .await
             .remove(&self.helper_id);
+        let _guard = self.state.tab_ownership_gate.lock().await;
         let destructive = self
             .state
             .destructive_session_helpers
             .lock()
             .await
             .contains(&self.helper_id);
-        let _guard = self.state.tab_ownership_gate.lock().await;
         self.state
             .pending_session_helpers
             .lock()
@@ -4195,6 +4182,7 @@ async fn run_master_loop(config: MasterConfig, pipe_name: String) -> Result<()> 
         connected_helpers: Mutex::new(HashSet::new()),
         all_retirement_fence: Mutex::new(AllRetirementFence::default()),
         tab_retirement_fences: Mutex::new(HashMap::new()),
+        tab_retirement_rekeys: Mutex::new(HashMap::new()),
         unresolved_owner_retirements: Mutex::new(HashMap::new()),
         pending_session_helpers: Mutex::new(HashMap::new()),
         pending_session_mcp: Mutex::new(HashMap::new()),
@@ -4210,6 +4198,8 @@ async fn run_master_loop(config: MasterConfig, pipe_name: String) -> Result<()> 
         retirement_pending_timeout: SESSION_CLOSE_TIMEOUT,
         #[cfg(test)]
         disconnect_orphan_publication_pause: Mutex::new(None),
+        #[cfg(test)]
+        deferred_retirement_cleanup_complete: tokio::sync::Notify::new(),
         hook_owned: Mutex::new(HashSet::new()),
         born_bound: Mutex::new(HashSet::new()),
         orphaned_sessions: Mutex::new(HashMap::new()),
@@ -6160,10 +6150,10 @@ fn build_agent_sessions_retired_event(
     event
 }
 
-fn publish_agent_sessions_retired(state: &MasterStateInner, event: serde_json::Value) {
+fn publish_agent_sessions_retired(_state: &MasterStateInner, event: serde_json::Value) {
     #[cfg(test)]
     {
-        if let Ok(mut completion_tx) = state.retirement_completion_tx.try_lock() {
+        if let Ok(mut completion_tx) = _state.retirement_completion_tx.try_lock() {
             if let Some(completion_tx) = completion_tx.as_mut() {
                 let _ = completion_tx.send(event);
                 return;
@@ -6171,6 +6161,23 @@ fn publish_agent_sessions_retired(state: &MasterStateInner, event: serde_json::V
         }
     }
     crate::wt_protocol_events::send(event.to_string());
+}
+
+fn resolve_tab_retirement_id(rekeys: &HashMap<String, String>, tab_id: &str) -> String {
+    let mut current = tab_id;
+    for _ in 0..=rekeys.len() {
+        let Some(next) = rekeys.get(current) else {
+            return current.to_string();
+        };
+        current = next;
+    }
+    current.to_string()
+}
+
+async fn current_tab_retirement_id(state: &MasterStateInner, tab_id: &str) -> String {
+    let _ownership_guard = state.tab_ownership_gate.lock().await;
+    let rekeys = state.tab_retirement_rekeys.lock().await;
+    resolve_tab_retirement_id(&rekeys, tab_id)
 }
 
 async fn begin_tab_retirement(
@@ -6292,18 +6299,37 @@ async fn begin_tab_retirement(
 
 async fn complete_tab_retirement(state: &MasterStateInner, tab_id: &str) {
     let _ownership_guard = state.tab_ownership_gate.lock().await;
+    let current_tab_id = {
+        let rekeys = state.tab_retirement_rekeys.lock().await;
+        resolve_tab_retirement_id(&rekeys, tab_id)
+    };
     let mut fences = state.tab_retirement_fences.lock().await;
-    let remove = if let Some(fence) = fences.get_mut(tab_id) {
+    let (remove, operation_complete) = if let Some(fence) = fences.get_mut(&current_tab_id) {
         fence.active_operations = fence.active_operations.saturating_sub(1);
         if fence.active_operations == 0 {
             fence.phase = TabRetirementPhase::CompletedAwaitingDisconnect;
         }
-        fence.active_operations == 0 && fence.outgoing_helpers.is_empty()
+        (
+            fence.active_operations == 0 && fence.outgoing_helpers.is_empty(),
+            fence.active_operations == 0,
+        )
     } else {
-        false
+        (false, true)
     };
     if remove {
-        fences.remove(tab_id);
+        fences.remove(&current_tab_id);
+    }
+    drop(fences);
+    if operation_complete {
+        let mut rekeys = state.tab_retirement_rekeys.lock().await;
+        let completed_aliases = rekeys
+            .keys()
+            .filter(|alias| resolve_tab_retirement_id(&rekeys, alias) == current_tab_id)
+            .cloned()
+            .collect::<Vec<_>>();
+        for alias in completed_aliases {
+            rekeys.remove(&alias);
+        }
     }
 }
 
@@ -6567,6 +6593,139 @@ fn retirement_remaining(deadline: tokio::time::Instant) -> std::time::Duration {
     deadline.saturating_duration_since(tokio::time::Instant::now())
 }
 
+fn schedule_deferred_tab_orphan_cleanup(
+    state: &Arc<MasterStateInner>,
+    agent_key: AgentCmdKey,
+    helper_id: HelperId,
+    session_id: acp::schema::v1::SessionId,
+) {
+    let state = Arc::clone(state);
+    tokio::task::spawn_local(async move {
+        let gate = session_lifecycle_gate(&state, &session_id).await;
+        let gate_result = tokio::time::timeout(SESSION_CLOSE_TIMEOUT, gate.lock()).await;
+        if let Ok(_guard) = gate_result {
+            let orphan_tab_id =
+                state
+                    .orphaned_tabs
+                    .lock()
+                    .await
+                    .iter()
+                    .find_map(|(tab_id, current)| {
+                        (current == &(agent_key.clone(), helper_id, session_id.clone()))
+                            .then_some(tab_id.clone())
+                    });
+            let orphan_session_is_current = state
+                .orphaned_sessions
+                .lock()
+                .await
+                .get(&agent_key)
+                .is_some_and(|sessions| sessions.contains(&session_id));
+            if let Some(orphan_tab_id) = orphan_tab_id.filter(|_| orphan_session_is_current) {
+                let rebound = state
+                    .session_to_helper
+                    .lock()
+                    .await
+                    .contains_key(&session_id);
+                state.orphaned_tabs.lock().await.remove(&orphan_tab_id);
+                let mut orphaned_sessions = state.orphaned_sessions.lock().await;
+                if let Some(sessions) = orphaned_sessions.get_mut(&agent_key) {
+                    sessions.remove(&session_id);
+                    if sessions.is_empty() {
+                        orphaned_sessions.remove(&agent_key);
+                    }
+                }
+                drop(orphaned_sessions);
+                if !rebound {
+                    retire_unbound_session_state_gate_held(&state, &session_id).await;
+                    let _ownership_guard = state.tab_ownership_gate.lock().await;
+                    let remove_meta =
+                        state
+                            .helper_meta
+                            .lock()
+                            .await
+                            .get(&helper_id)
+                            .is_some_and(|meta| {
+                                meta.last_session_id.as_ref() == Some(&session_id)
+                                    && meta.owner_tab_id.as_deref() == Some(orphan_tab_id.as_str())
+                            });
+                    if remove_meta {
+                        state.helper_meta.lock().await.remove(&helper_id);
+                    }
+                    let remove_pending = state
+                        .pending_session_helpers
+                        .lock()
+                        .await
+                        .get(&helper_id)
+                        .is_some_and(|owner| owner.as_deref() == Some(orphan_tab_id.as_str()));
+                    if remove_pending {
+                        state
+                            .pending_session_helpers
+                            .lock()
+                            .await
+                            .remove(&helper_id);
+                        state.session_transaction_changed.notify_waiters();
+                    }
+                }
+            }
+        } else {
+            tracing::warn!(
+                target: "master_retirement",
+                helper_id = ?helper_id,
+                session_id = %session_id,
+                "deferred tab orphan cleanup expired waiting for lifecycle gate"
+            );
+        };
+        #[cfg(test)]
+        state.deferred_retirement_cleanup_complete.notify_one();
+    });
+}
+
+fn schedule_deferred_ownerless_orphan_cleanup(
+    state: &Arc<MasterStateInner>,
+    agent_key: AgentCmdKey,
+    session_id: acp::schema::v1::SessionId,
+) {
+    let state = Arc::clone(state);
+    tokio::task::spawn_local(async move {
+        let gate = session_lifecycle_gate(&state, &session_id).await;
+        let gate_result = tokio::time::timeout(SESSION_CLOSE_TIMEOUT, gate.lock()).await;
+        if let Ok(_guard) = gate_result {
+            let orphan_is_current = state
+                .orphaned_sessions
+                .lock()
+                .await
+                .get(&agent_key)
+                .is_some_and(|sessions| sessions.contains(&session_id));
+            if orphan_is_current {
+                let rebound = state
+                    .session_to_helper
+                    .lock()
+                    .await
+                    .contains_key(&session_id);
+                let mut orphaned_sessions = state.orphaned_sessions.lock().await;
+                if let Some(sessions) = orphaned_sessions.get_mut(&agent_key) {
+                    sessions.remove(&session_id);
+                    if sessions.is_empty() {
+                        orphaned_sessions.remove(&agent_key);
+                    }
+                }
+                drop(orphaned_sessions);
+                if !rebound {
+                    retire_unbound_session_state_gate_held(&state, &session_id).await;
+                }
+            }
+        } else {
+            tracing::warn!(
+                target: "master_retirement",
+                session_id = %session_id,
+                "deferred ownerless orphan cleanup expired waiting for lifecycle gate"
+            );
+        };
+        #[cfg(test)]
+        state.deferred_retirement_cleanup_complete.notify_one();
+    });
+}
+
 fn prune_retirement_operations(
     operations: &mut HashMap<String, RetirementOperationState>,
     now: tokio::time::Instant,
@@ -6656,6 +6815,7 @@ async fn force_cleanup_retirement_helper(
         },
     ));
 
+    let mut session_cleanup_timed_out = false;
     for session_id in &session_ids {
         let forced = match tokio::time::timeout_at(
             deadline,
@@ -6674,6 +6834,7 @@ async fn force_cleanup_retirement_helper(
                 );
                 cleanup =
                     merge_retirement_cleanup(cleanup, ReplacedSessionCleanup::LogicalFallback);
+                session_cleanup_timed_out = true;
                 break;
             }
         };
@@ -6691,13 +6852,14 @@ async fn force_cleanup_retirement_helper(
                 );
                 cleanup =
                     merge_retirement_cleanup(cleanup, ReplacedSessionCleanup::LogicalFallback);
+                session_cleanup_timed_out = true;
                 break;
             }
         }
         cleanup = merge_retirement_cleanup(cleanup, forced);
     }
 
-    if !session_ids.is_empty() {
+    if !session_cleanup_timed_out && !session_ids.is_empty() {
         let mut orphaned_sessions = state.orphaned_sessions.lock().await;
         for sessions in orphaned_sessions.values_mut() {
             for session_id in &session_ids {
@@ -6706,29 +6868,36 @@ async fn force_cleanup_retirement_helper(
         }
         orphaned_sessions.retain(|_, sessions| !sessions.is_empty());
     }
-    state
-        .orphaned_tabs
-        .lock()
-        .await
-        .retain(|orphan_tab_id, (_, orphan_helper_id, _)| {
-            orphan_tab_id != tab_id && *orphan_helper_id != helper_id
-        });
+    if !session_cleanup_timed_out {
+        state
+            .orphaned_tabs
+            .lock()
+            .await
+            .retain(|orphan_tab_id, (_, orphan_helper_id, _)| {
+                orphan_tab_id != tab_id && *orphan_helper_id != helper_id
+            });
+    }
 
     let pending_removed = {
         let _ownership_guard = state.tab_ownership_gate.lock().await;
-        let pending_removed = state
-            .pending_session_helpers
-            .lock()
-            .await
-            .remove(&helper_id)
-            .is_some();
-        state.helper_meta.lock().await.remove(&helper_id);
-        state
-            .unresolved_owner_retirements
-            .lock()
-            .await
-            .remove(&helper_id);
-        if !requires_future_disconnect {
+        let pending_removed = if session_cleanup_timed_out {
+            false
+        } else {
+            let pending_removed = state
+                .pending_session_helpers
+                .lock()
+                .await
+                .remove(&helper_id)
+                .is_some();
+            state.helper_meta.lock().await.remove(&helper_id);
+            state
+                .unresolved_owner_retirements
+                .lock()
+                .await
+                .remove(&helper_id);
+            pending_removed
+        };
+        if !requires_future_disconnect && !session_cleanup_timed_out {
             state
                 .closing_session_helpers
                 .lock()
@@ -6746,8 +6915,10 @@ async fn force_cleanup_retirement_helper(
         }
         pending_removed
     };
-    if let Some(pending_mcp) = state.pending_session_mcp.lock().await.remove(&helper_id) {
-        state.session_mcp_capabilities.cancel(&pending_mcp).await;
+    if !session_cleanup_timed_out {
+        if let Some(pending_mcp) = state.pending_session_mcp.lock().await.remove(&helper_id) {
+            state.session_mcp_capabilities.cancel(&pending_mcp).await;
+        }
     }
     if pending_removed {
         state.session_transaction_changed.notify_waiters();
@@ -6875,7 +7046,7 @@ async fn retire_captured_orphan_session(
 }
 
 async fn retire_ownerless_orphan_session(
-    state: &MasterStateInner,
+    state: &Arc<MasterStateInner>,
     agent_key: &AgentCmdKey,
     session_id: &acp::schema::v1::SessionId,
     deadline: tokio::time::Instant,
@@ -6885,15 +7056,13 @@ async fn retire_ownerless_orphan_session(
         tracing::error!(
             target: "master_retirement",
             session_id = %session_id,
-            "retirement deadline expired waiting for ownerless orphan lifecycle gate; retiring orphan marker"
+            "retirement deadline expired waiting for ownerless orphan lifecycle gate; deferring exact orphan cleanup"
         );
-        let mut orphaned_sessions = state.orphaned_sessions.lock().await;
-        if let Some(sessions) = orphaned_sessions.get_mut(agent_key) {
-            sessions.remove(session_id);
-            if sessions.is_empty() {
-                orphaned_sessions.remove(agent_key);
-            }
-        }
+        schedule_deferred_ownerless_orphan_cleanup(
+            state,
+            agent_key.clone(),
+            session_id.clone(),
+        );
         return ReplacedSessionCleanup::LogicalFallback;
     };
 
@@ -7115,7 +7284,7 @@ async fn retire_helper_transaction(
 }
 
 async fn retire_tab_transaction(
-    state: &MasterStateInner,
+    state: &Arc<MasterStateInner>,
     tab_id: String,
     deadline: tokio::time::Instant,
 ) -> ReplacedSessionCleanup {
@@ -7123,11 +7292,12 @@ async fn retire_tab_transaction(
     // a concurrent owner publication serialize either wholly before the fence
     // (and become the bound outgoing helper) or wholly after it (and fail).
     let retirement_target = begin_tab_retirement(state, &tab_id).await;
+    let current_tab_id = current_tab_retirement_id(state, &tab_id).await;
 
     let mut cleanup = match retire_tab_session(
         state,
         &crate::session_registry::CloseTabSessionParams {
-            tab_id: tab_id.clone(),
+            tab_id: current_tab_id,
         },
         false,
         true,
@@ -7170,17 +7340,16 @@ async fn retire_tab_transaction(
                 break;
             }
         }
+        let current_tab_id = current_tab_retirement_id(state, &tab_id).await;
         cleanup = force_cleanup_retirement_helper(
             state,
             helper_id,
-            &tab_id,
+            &current_tab_id,
             cleanup,
             deadline,
             retirement_target.requires_future_disconnect,
         )
         .await;
-    } else {
-        state.orphaned_tabs.lock().await.remove(&tab_id);
     }
     complete_tab_retirement(state, &tab_id).await;
     cleanup
@@ -7440,6 +7609,9 @@ async fn handle_master_wt_event(state: &Arc<MasterStateInner>, event_json: serde
             );
             return;
         }
+        if old_tab_id == new_tab_id {
+            return;
+        }
         let mut renamed_helpers = 0usize;
         let _ownership_guard = state.tab_ownership_gate.lock().await;
         {
@@ -7465,11 +7637,52 @@ async fn handle_master_wt_event(state: &Arc<MasterStateInner>, event_json: serde
                 orphaned_tabs.insert(new_tab_id.to_string(), orphan);
             }
         }
+        for safety in state.unresolved_owner_retirements.lock().await.values_mut() {
+            safety.rekey(old_tab_id, new_tab_id);
+        }
+        let retirement_rekeyed = {
+            let mut fences = state.tab_retirement_fences.lock().await;
+            if let Some(old_fence) = fences.remove(old_tab_id) {
+                let active = old_fence.active_operations > 0;
+                if let Some(new_fence) = fences.get_mut(new_tab_id) {
+                    if old_fence.phase == TabRetirementPhase::Fencing {
+                        new_fence.phase = TabRetirementPhase::Fencing;
+                    }
+                    new_fence.active_operations += old_fence.active_operations;
+                    new_fence
+                        .outgoing_helpers
+                        .extend(old_fence.outgoing_helpers);
+                } else {
+                    fences.insert(new_tab_id.to_string(), old_fence);
+                }
+                active
+            } else {
+                false
+            }
+        };
+        if retirement_rekeyed {
+            let mut rekeys = state.tab_retirement_rekeys.lock().await;
+            let aliases = rekeys
+                .keys()
+                .filter(|alias| resolve_tab_retirement_id(&rekeys, alias) == old_tab_id)
+                .cloned()
+                .chain(std::iter::once(old_tab_id.to_string()))
+                .collect::<HashSet<_>>();
+            rekeys.remove(new_tab_id);
+            for alias in aliases {
+                if alias == new_tab_id {
+                    rekeys.remove(&alias);
+                } else {
+                    rekeys.insert(alias, new_tab_id.to_string());
+                }
+            }
+        }
         tracing::info!(
             target: "master_wt_event",
             old_tab_id,
             new_tab_id,
             renamed_helpers,
+            retirement_rekeyed,
             "rekeyed master tab ownership after drag"
         );
         return;

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -36,8 +36,7 @@
 //     then runs the same code path it ran pre-helper-split (TUI
 //     permission UI, `ShellManager`, etc.).
 
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::future::Future;
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock, Weak};
@@ -79,6 +78,71 @@ pub(crate) struct HelperId(u64);
 type AgentCmdKey = String;
 type AgentInstanceId = uuid::Uuid;
 type AgentCell = Arc<tokio::sync::OnceCell<Arc<AgentCli>>>;
+
+#[derive(Clone)]
+enum RetirementOperationState {
+    InFlight,
+    Completed {
+        event: serde_json::Value,
+        completed_at: tokio::time::Instant,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TabRetirementPhase {
+    Fencing,
+    CompletedAwaitingDisconnect,
+}
+
+struct TabRetirementFence {
+    phase: TabRetirementPhase,
+    active_operations: usize,
+    /// Helpers connected before the fence was established belong to the
+    /// outgoing generation. A helper connected after Terminal observes
+    /// completion is a replacement and may claim the tab.
+    outgoing_helpers: HashSet<HelperId>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TabRetirementTarget {
+    helper_id: HelperId,
+    requires_future_disconnect: bool,
+}
+
+#[derive(Default)]
+struct AllRetirementFence {
+    active_operations: usize,
+    outgoing_helpers: HashSet<HelperId>,
+}
+
+#[derive(Debug)]
+enum OwnerlessRetirementSafety {
+    Targets(HashSet<String>),
+    DenyNextOwner,
+}
+
+impl OwnerlessRetirementSafety {
+    fn record(&mut self, tab_id: &str) {
+        let Self::Targets(targets) = self else {
+            return;
+        };
+        if targets.contains(tab_id) {
+            return;
+        }
+        if targets.len() == OWNERLESS_RETIREMENT_TARGET_CAP {
+            *self = Self::DenyNextOwner;
+        } else {
+            targets.insert(tab_id.to_string());
+        }
+    }
+
+    fn rejects(&self, tab_id: &str) -> bool {
+        match self {
+            Self::Targets(targets) => targets.contains(tab_id),
+            Self::DenyNextOwner => true,
+        }
+    }
+}
 
 /// Per-session routing entry. Owned by `session_to_helper` and
 /// keyed by `acp::schema::v1::SessionId`.
@@ -288,15 +352,57 @@ struct MasterStateInner {
     /// routing hot path never contends on it.
     pub(crate) helper_meta: Mutex<HashMap<HelperId, HelperRecoveryMeta>>,
     /// Serializes publication and rename of helper/tab ownership across the
-    /// pending transaction map and recovery metadata.
+    /// pending transaction map, recovery metadata, and retirement fences.
     tab_ownership_gate: Mutex<()>,
+    /// Helpers whose pipe connected before a tab retirement fence. Membership
+    /// gives retirement an explicit helper generation boundary even when the
+    /// helper has not published its tab owner yet.
+    connected_helpers: Mutex<HashSet<HelperId>>,
+    /// Active process-wide retirement generation. Helpers admitted while this
+    /// fence is active join the outgoing generation before they can publish an
+    /// owner or start a session transaction.
+    all_retirement_fence: Mutex<AllRetirementFence>,
+    /// Destructive retirement fences keyed by stable tab id. A fence blocks
+    /// the outgoing helper generation through completion and is consumed by
+    /// its disconnect or by the first post-completion replacement helper.
+    tab_retirement_fences: Mutex<HashMap<String, TabRetirementFence>>,
+    /// Retired tab ids that an ownerless connected helper could still claim.
+    /// State is bounded per HelperId; overflow conservatively denies that
+    /// connection's first owner publication instead of evicting safety.
+    unresolved_owner_retirements: Mutex<HashMap<HelperId, OwnerlessRetirementSafety>>,
     /// Helpers with a session/new or session/load transaction in flight.
     /// Tab-close keeps their recovery metadata until the response arrives so
     /// the newly created/loaded session can be closed before it is exposed.
     pending_session_helpers: Mutex<HashMap<HelperId, Option<String>>>,
+    /// Unbound session MCP capability owned by each in-flight session
+    /// transaction. Retirement can revoke it before the provider responds.
+    pending_session_mcp: Mutex<HashMap<HelperId, session_mcp::PendingCapability>>,
     /// Helpers whose owning tab was destroyed while a session transaction was
     /// in flight. The transaction checks this before committing its response.
     closing_session_helpers: Mutex<HashSet<HelperId>>,
+    /// Closing helpers participating in a destructive retirement. For
+    /// `scope=all`, every helper connected at operation start is captured here
+    /// even if it has not published owner metadata yet. HelperIds are unique
+    /// for the master lifetime, so later replacement helpers are not blocked.
+    /// Late session results use logical fallback instead of preserving routes.
+    destructive_session_helpers: Mutex<HashSet<HelperId>>,
+    /// Destructive helpers whose retirement transaction is still collecting
+    /// late session cleanup outcomes. Unlike the destructive tombstone, this
+    /// entry is removed by the forced cleanup epilogue.
+    active_retirement_helpers: Mutex<HashSet<HelperId>>,
+    /// Physical/logical outcome produced by a late session transaction.
+    closing_session_results: Mutex<HashMap<HelperId, ReplacedSessionCleanup>>,
+    /// Wakes destructive retirement transactions waiting for an in-flight
+    /// session/new or session/load to consume its closing marker.
+    session_transaction_changed: tokio::sync::Notify,
+    /// Process-wide idempotency state for Terminal retirement transactions.
+    retirement_operations: Mutex<HashMap<String, RetirementOperationState>>,
+    #[cfg(test)]
+    retirement_completion_tx: Mutex<Option<mpsc::UnboundedSender<serde_json::Value>>>,
+    #[cfg(test)]
+    retirement_pending_timeout: std::time::Duration,
+    #[cfg(test)]
+    disconnect_orphan_publication_pause: Mutex<Option<Arc<DisconnectOrphanPublicationPause>>>,
     /// Session ids claimed by an *authoritative* producer — a native agent hook
     /// (arrives via `intellterm.wta/session_hook`) or an ACP agent-pane
     /// session (driven by ACP `session/*`), both of which fully own binding and
@@ -364,6 +470,13 @@ struct MasterStateInner {
     /// throttle (a cold snap distro pays a 40 s ACP init), so a time throttle
     /// alone can't prevent concurrent `wsl.exe` processes — this guard does.
     wsl_seed_in_flight: std::sync::atomic::AtomicBool,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct DisconnectOrphanPublicationPause {
+    routes_dropped: tokio::sync::Notify,
+    resume_publication: tokio::sync::Notify,
 }
 
 async fn session_lifecycle_gate(
@@ -481,6 +594,9 @@ fn rollback_swapped_session_route_locked(
 // on transient 5s stalls observed in live runs. SharedWta.cpp keeps pane-driven
 // master teardown alive for 16s; keep that grace strictly above this timeout.
 const SESSION_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+const RETIREMENT_COMPLETION_TTL: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+const RETIREMENT_COMPLETION_CAP: usize = 256;
+const OWNERLESS_RETIREMENT_TARGET_CAP: usize = 32;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ReplacedSessionCleanup {
@@ -503,14 +619,34 @@ async fn close_and_retire_replaced_session(
     session_id: &acp::schema::v1::SessionId,
     timeout: std::time::Duration,
 ) -> acp::Result<ReplacedSessionCleanup> {
+    close_and_retire_owned_session(
+        state,
+        helper_id,
+        agent,
+        session_id,
+        tokio::time::Instant::now() + timeout,
+        false,
+    )
+    .await
+}
+
+async fn close_and_retire_owned_session(
+    state: &MasterStateInner,
+    helper_id: HelperId,
+    agent: &AgentCli,
+    session_id: &acp::schema::v1::SessionId,
+    deadline: tokio::time::Instant,
+    retire_on_close_failure: bool,
+) -> acp::Result<ReplacedSessionCleanup> {
     let gate = session_lifecycle_gate(state, session_id).await;
-    let _guard = gate.lock().await;
+    let _guard = tokio::time::timeout_at(deadline, gate.lock())
+        .await
+        .map_err(|_| retirement_deadline_error(session_id, "lifecycle_gate"))?;
     {
         let routes = state.session_to_helper.lock().await;
-        if !routes
-            .get(session_id)
-            .is_some_and(|route| route.helper_id == helper_id)
-        {
+        if !routes.get(session_id).is_some_and(|route| {
+            route.helper_id == helper_id && route.agent_instance_id == agent.instance_id
+        }) {
             return Ok(ReplacedSessionCleanup::NotOwned);
         }
     }
@@ -525,11 +661,20 @@ async fn close_and_retire_replaced_session(
             outcome = "unsupported_logical_fallback",
             "agent does not advertise session/close; cancelling best-effort and retiring only WTA state"
         );
-        if let Err(error) = agent
+        let remaining = retirement_remaining(deadline);
+        if remaining.is_zero() {
+            return Err(retirement_deadline_error(session_id, "cancel"));
+        }
+        match tokio::time::timeout(
+            remaining,
+            agent
             .conn
-            .cancel(acp::schema::v1::CancelNotification::new(session_id.clone()))
+                .cancel(acp::schema::v1::CancelNotification::new(session_id.clone())),
+        )
             .await
         {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
             tracing::warn!(
                 target: "master",
                 step = "helper→agent",
@@ -540,13 +685,24 @@ async fn close_and_retire_replaced_session(
                 "legacy session/cancel fallback failed"
             );
         }
+            Err(_) => return Err(retirement_deadline_error(session_id, "cancel")),
+        }
         ReplacedSessionCleanup::LogicalFallback
     } else {
-        if let Err(error) = agent
+        let remaining = retirement_remaining(deadline);
+        if remaining.is_zero() {
+            return Err(retirement_deadline_error(session_id, "cancel"));
+        }
+        match tokio::time::timeout(
+            remaining,
+            agent
             .conn
-            .cancel(acp::schema::v1::CancelNotification::new(session_id.clone()))
+                .cancel(acp::schema::v1::CancelNotification::new(session_id.clone())),
+        )
             .await
         {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
             tracing::warn!(
                 target: "master",
                 step = "helper→agent",
@@ -557,9 +713,15 @@ async fn close_and_retire_replaced_session(
                 "failed to cancel active turn before session/close"
             );
         }
+            Err(_) => return Err(retirement_deadline_error(session_id, "cancel")),
+        }
         let started = std::time::Instant::now();
+        let remaining = retirement_remaining(deadline);
+        if remaining.is_zero() {
+            return Err(retirement_deadline_error(session_id, "session_close"));
+        }
         match tokio::time::timeout(
-            timeout,
+            remaining,
             agent
                 .conn
                 .close_session(acp::schema::v1::CloseSessionRequest::new(
@@ -606,8 +768,12 @@ async fn close_and_retire_replaced_session(
                         elapsed_ms = started.elapsed().as_millis() as u64,
                         "failed to physically close replaced ACP session"
                     );
+                    if retire_on_close_failure {
+                        ReplacedSessionCleanup::LogicalFallback
+                    } else {
                     return Err(error);
                 }
+            }
             }
             Err(_) => {
                 let message =
@@ -619,9 +785,12 @@ async fn close_and_retire_replaced_session(
                     helper_id = ?helper_id,
                     old_session_id = %session_id,
                     outcome = "timeout",
-                    timeout_ms = timeout.as_millis() as u64,
+                    timeout_ms = remaining.as_millis() as u64,
                     "timed out physically closing replaced ACP session"
                 );
+                if retire_on_close_failure {
+                    ReplacedSessionCleanup::LogicalFallback
+                } else {
                 return Err(
                     acp::Error::new(-32603, message.clone()).data(serde_json::json!({
                         "message": message
@@ -629,14 +798,14 @@ async fn close_and_retire_replaced_session(
                 );
             }
         }
+        }
     };
 
     {
         let mut routes = state.session_to_helper.lock().await;
-        if !routes
-            .get(session_id)
-            .is_some_and(|route| route.helper_id == helper_id)
-        {
+        if !routes.get(session_id).is_some_and(|route| {
+            route.helper_id == helper_id && route.agent_instance_id == agent.instance_id
+        }) {
             unreachable!("session route cannot change while its lifecycle gate is held");
         }
         routes.remove(session_id);
@@ -661,10 +830,19 @@ async fn close_and_retire_replaced_session(
     Ok(cleanup)
 }
 
+fn retirement_deadline_error(session_id: &acp::schema::v1::SessionId, phase: &str) -> acp::Error {
+    let message = format!("retirement deadline expired during {phase} for session {session_id}");
+    acp::Error::new(-32603, message.clone()).data(serde_json::json!({
+        "message": message
+    }))
+}
+
 async fn retire_unbound_session_state(
     state: &MasterStateInner,
     session_id: &acp::schema::v1::SessionId,
 ) {
+    let gate = session_lifecycle_gate(state, session_id).await;
+    let _guard = gate.lock().await;
     if state
         .session_to_helper
         .lock()
@@ -673,6 +851,13 @@ async fn retire_unbound_session_state(
     {
         return;
     }
+    retire_unbound_session_state_gate_held(state, session_id).await;
+}
+
+async fn retire_unbound_session_state_gate_held(
+    state: &MasterStateInner,
+    session_id: &acp::schema::v1::SessionId,
+) {
     state.pending_usage.lock().await.remove(session_id);
     state
         .session_mcp_capabilities
@@ -691,6 +876,35 @@ async fn retire_unbound_session_state(
     .await;
 }
 
+async fn force_retire_owned_session_state(
+    state: &MasterStateInner,
+    helper_id: HelperId,
+    session_id: &acp::schema::v1::SessionId,
+) -> ReplacedSessionCleanup {
+    let gate = session_lifecycle_gate(state, session_id).await;
+    let _guard = gate.lock().await;
+    let removed = {
+        let mut routes = state.session_to_helper.lock().await;
+        if routes
+            .get(session_id)
+            .is_some_and(|route| route.helper_id == helper_id)
+        {
+            routes.remove(session_id);
+            true
+        } else {
+            false
+        }
+    };
+    if !removed {
+        return ReplacedSessionCleanup::NotOwned;
+    }
+    // Keep the SessionId gate across ownership validation, route removal,
+    // registry/MCP cleanup, and broadcasts. A rebound route cannot appear
+    // between the absence check and destructive cleanup.
+    retire_unbound_session_state_gate_held(state, session_id).await;
+    ReplacedSessionCleanup::LogicalFallback
+}
+
 fn agent_supports_session_close(agent: &AgentCli) -> bool {
     agent
         .cached_init_resp
@@ -705,6 +919,20 @@ async fn handle_close_tab_session(
     params: &crate::session_registry::CloseTabSessionParams,
     reset_only: bool,
 ) -> acp::Result<acp::schema::v1::ExtResponse> {
+    let deadline = tokio::time::Instant::now() + SESSION_CLOSE_TIMEOUT;
+    retire_tab_session(state, params, reset_only, false, deadline).await?;
+    let raw = serde_json::value::RawValue::from_string("{}".to_string())
+        .expect("empty object is valid JSON");
+    Ok(acp::schema::v1::ExtResponse::new(raw.into()))
+}
+
+async fn retire_tab_session(
+    state: &MasterStateInner,
+    params: &crate::session_registry::CloseTabSessionParams,
+    reset_only: bool,
+    destructive: bool,
+    deadline: tokio::time::Instant,
+) -> acp::Result<ReplacedSessionCleanup> {
     let (target, newly_marked_close, deferred_pending) = {
         let _ownership_guard = state.tab_ownership_gate.lock().await;
         let mut target = {
@@ -781,7 +1009,60 @@ async fn handle_close_tab_session(
         };
         if let Some((agent_key, orphan_helper_id, orphan_session_id)) = orphan {
             let gate = session_lifecycle_gate(state, &orphan_session_id).await;
-            let _guard = gate.lock().await;
+            let _guard = match tokio::time::timeout_at(deadline, gate.lock()).await {
+                Ok(guard) => Some(guard),
+                Err(_) if destructive => {
+                    tracing::error!(
+                        target: "master_retirement",
+                        tab_id = %params.tab_id,
+                        helper_id = ?orphan_helper_id,
+                        session_id = %orphan_session_id,
+                        "retirement deadline expired waiting for orphan lifecycle gate; retiring WTA state"
+                    );
+                    None
+                }
+                Err(_) => {
+                    return Err(retirement_deadline_error(
+                        &orphan_session_id,
+                        "lifecycle_gate",
+                    ));
+                }
+            };
+            if _guard.is_none() {
+                {
+                    let mut orphaned_sessions = state.orphaned_sessions.lock().await;
+                    if let Some(sessions) = orphaned_sessions.get_mut(&agent_key) {
+                        sessions.remove(&orphan_session_id);
+                        if sessions.is_empty() {
+                            orphaned_sessions.remove(&agent_key);
+                        }
+                    }
+                }
+                state.orphaned_tabs.lock().await.remove(&params.tab_id);
+                state.pending_usage.lock().await.remove(&orphan_session_id);
+                state
+                    .session_mcp_capabilities
+                    .remove_session(&orphan_session_id)
+                    .await;
+                state.registry.remove(&orphan_session_id).await;
+                state.helper_meta.lock().await.remove(&orphan_helper_id);
+                state
+                    .pending_session_helpers
+                    .lock()
+                    .await
+                    .remove(&orphan_helper_id);
+                broadcast_ext_to_helpers(
+                    state,
+                    crate::session_registry::build_session_removed_notification(&orphan_session_id),
+                )
+                .await;
+                broadcast_ext_to_helpers(
+                    state,
+                    crate::session_registry::build_sessions_changed_notification(),
+                )
+                .await;
+                return Ok(ReplacedSessionCleanup::LogicalFallback);
+            }
             let orphan_is_current = state
                 .orphaned_tabs
                 .lock()
@@ -796,9 +1077,7 @@ async fn handle_close_tab_session(
                         )
                 });
             if !orphan_is_current {
-                let raw = serde_json::value::RawValue::from_string("{}".to_string())
-                    .expect("empty object is valid JSON");
-                return Ok(acp::schema::v1::ExtResponse::new(raw.into()));
+                return Ok(ReplacedSessionCleanup::NotOwned);
             }
             if state
                 .session_to_helper
@@ -807,45 +1086,51 @@ async fn handle_close_tab_session(
                 .contains_key(&orphan_session_id)
             {
                 state.orphaned_tabs.lock().await.remove(&params.tab_id);
-                let raw = serde_json::value::RawValue::from_string("{}".to_string())
-                    .expect("empty object is valid JSON");
-                return Ok(acp::schema::v1::ExtResponse::new(raw.into()));
+                return Ok(ReplacedSessionCleanup::NotOwned);
             }
             let agent = {
                 let agents = state.agents.lock().await;
                 agents.get(&agent_key).and_then(|cell| cell.get()).cloned()
-            }
-            .ok_or_else(|| {
-                acp::Error::internal_error().data(serde_json::json!({
-                    "message": format!(
-                        "agent for orphaned tab {} is no longer available",
-                        params.tab_id
-                    )
-                }))
-            })?;
+            };
 
-            let cleanup = if agent_supports_session_close(&agent) {
-                // A disconnected helper cannot fire its local prompt-cancel
-                // signal anymore. Stop the orphaned turn first so agents that
-                // serialize session operations can process session/close
-                // promptly instead of wedging behind the in-flight prompt.
-                if let Err(error) = agent
-                    .conn
-                    .cancel(acp::schema::v1::CancelNotification::new(
+            let cleanup = if let Some(agent) = agent {
+                let cancel = tokio::time::timeout_at(
+                    deadline,
+                    agent.conn.cancel(acp::schema::v1::CancelNotification::new(
                         orphan_session_id.clone(),
-                    ))
-                    .await
-                {
+                    )),
+                )
+                .await;
+                let cancel_timed_out = match cancel {
+                    Ok(Ok(())) => false,
+                    Ok(Err(error)) => {
                     tracing::warn!(
                         target: "master",
                         tab_id = %params.tab_id,
                         session_id = %orphan_session_id,
                         error = %error,
-                        "failed to cancel orphaned turn before session/close"
+                            "failed to cancel orphaned turn before retirement"
                     );
+                        false
                 }
-                match tokio::time::timeout(
-                    SESSION_CLOSE_TIMEOUT,
+                    Err(_) if destructive => {
+                        tracing::error!(
+                            target: "master_retirement",
+                            tab_id = %params.tab_id,
+                            session_id = %orphan_session_id,
+                            "retirement deadline expired cancelling orphaned turn; retiring WTA state"
+                        );
+                        true
+                    }
+                    Err(_) => {
+                        return Err(retirement_deadline_error(&orphan_session_id, "cancel"));
+                    }
+                };
+                if cancel_timed_out {
+                    ReplacedSessionCleanup::LogicalFallback
+                } else if agent_supports_session_close(&agent) {
+                    match tokio::time::timeout_at(
+                        deadline,
                     agent
                         .conn
                         .close_session(acp::schema::v1::CloseSessionRequest::new(
@@ -865,7 +1150,26 @@ async fn handle_close_tab_session(
                         );
                         ReplacedSessionCleanup::LogicalFallback
                     }
+                        Ok(Err(error)) if destructive => {
+                            tracing::error!(
+                                target: "master",
+                                tab_id = %params.tab_id,
+                                session_id = %orphan_session_id,
+                                error = %error,
+                                "failed to physically close orphan; retiring WTA state"
+                            );
+                            ReplacedSessionCleanup::LogicalFallback
+                        }
                     Ok(Err(error)) => return Err(error),
+                        Err(_) if destructive => {
+                            tracing::error!(
+                                target: "master",
+                                tab_id = %params.tab_id,
+                                session_id = %orphan_session_id,
+                                "session/close timed out for orphan; retiring WTA state"
+                            );
+                            ReplacedSessionCleanup::LogicalFallback
+                        }
                     Err(_) => {
                         return Err(acp::Error::internal_error().data(serde_json::json!({
                             "message": format!(
@@ -876,22 +1180,34 @@ async fn handle_close_tab_session(
                     }
                 }
             } else {
-                let _ = agent
-                    .conn
-                    .cancel(acp::schema::v1::CancelNotification::new(
-                        orphan_session_id.clone(),
-                    ))
-                    .await;
                 ReplacedSessionCleanup::LogicalFallback
+                }
+            } else if destructive {
+                tracing::warn!(
+                    target: "master",
+                    tab_id = %params.tab_id,
+                    session_id = %orphan_session_id,
+                    "orphan agent is unavailable; retiring WTA state"
+                );
+                ReplacedSessionCleanup::LogicalFallback
+            } else {
+                return Err(acp::Error::internal_error().data(serde_json::json!({
+                    "message": format!(
+                        "agent for orphaned tab {} is no longer available",
+                        params.tab_id
+                    )
+                })));
             };
 
-            state
-                .orphaned_sessions
-                .lock()
-                .await
-                .entry(agent_key)
-                .or_default()
-                .remove(&orphan_session_id);
+            {
+                let mut orphaned_sessions = state.orphaned_sessions.lock().await;
+                if let Some(sessions) = orphaned_sessions.get_mut(&agent_key) {
+                    sessions.remove(&orphan_session_id);
+                    if sessions.is_empty() {
+                        orphaned_sessions.remove(&agent_key);
+                    }
+                }
+            }
             state.orphaned_tabs.lock().await.remove(&params.tab_id);
             state.pending_usage.lock().await.remove(&orphan_session_id);
             state
@@ -905,11 +1221,8 @@ async fn handle_close_tab_session(
                 .lock()
                 .await
                 .remove(&orphan_helper_id);
-            state
-                .closing_session_helpers
-                .lock()
-                .await
-                .remove(&orphan_helper_id);
+            // Disconnect consumes the closing tombstone after its orphan
+            // publication phase has observed this physical retirement.
             broadcast_ext_to_helpers(
                 state,
                 crate::session_registry::build_session_removed_notification(&orphan_session_id),
@@ -928,12 +1241,10 @@ async fn handle_close_tab_session(
                 cleanup = ?cleanup,
                 "closed ACP session resolved from destroyed tab"
             );
-            let raw = serde_json::value::RawValue::from_string("{}".to_string())
-                .expect("empty object is valid JSON");
-            return Ok(acp::schema::v1::ExtResponse::new(raw.into()));
+            return Ok(cleanup);
         }
 
-        if !deferred_pending && newly_marked_close {
+        if !destructive && !deferred_pending && newly_marked_close {
             if let Some(helper_id) = matched_helper_id {
                 state.helper_meta.lock().await.remove(&helper_id);
                 state
@@ -949,9 +1260,7 @@ async fn handle_close_tab_session(
             deferred = deferred_pending,
             "close-by-tab found no live session; treating duplicate, late, or in-flight request as success"
         );
-        let raw = serde_json::value::RawValue::from_string("{}".to_string())
-            .expect("empty object is valid JSON");
-        return Ok(acp::schema::v1::ExtResponse::new(raw.into()));
+        return Ok(ReplacedSessionCleanup::NotOwned);
     };
 
     let agent = {
@@ -961,24 +1270,36 @@ async fn handle_close_tab_session(
             .filter_map(|cell| cell.get())
             .find(|agent| agent.instance_id == agent_instance_id)
             .cloned()
-    }
-    .ok_or_else(|| {
-        acp::Error::internal_error().data(serde_json::json!({
-            "message": format!(
-                "agent instance {} for tab {} is no longer available",
-                agent_instance_id, params.tab_id
-            )
-        }))
-    })?;
+    };
 
-    let cleanup = close_and_retire_replaced_session(
+    let cleanup = if let Some(agent) = agent {
+        close_and_retire_owned_session(
         state,
         owner_helper_id,
         &agent,
         &session_id,
-        SESSION_CLOSE_TIMEOUT,
+            deadline,
+            destructive,
     )
-    .await?;
+        .await?
+    } else if destructive {
+        tracing::warn!(
+            target: "master",
+            tab_id = %params.tab_id,
+            helper_id = ?owner_helper_id,
+            session_id = %session_id,
+            agent_instance_id = %agent_instance_id,
+            "owning agent is unavailable; retiring WTA state"
+        );
+        force_retire_owned_session_state(state, owner_helper_id, &session_id).await
+    } else {
+        return Err(acp::Error::internal_error().data(serde_json::json!({
+            "message": format!(
+                "agent instance {} for tab {} is no longer available",
+                agent_instance_id, params.tab_id
+            )
+        })));
+    };
     if cleanup != ReplacedSessionCleanup::NotOwned {
         // This is intentional tab destruction, not a helper crash. Remove the
         // recovery record only when the transaction consumes the closing
@@ -996,6 +1317,24 @@ async fn handle_close_tab_session(
                 meta.last_session_id = None;
             }
         }
+        if destructive {
+            state.orphaned_tabs.lock().await.remove(&params.tab_id);
+            {
+                let mut orphaned_sessions = state.orphaned_sessions.lock().await;
+                for sessions in orphaned_sessions.values_mut() {
+                    sessions.remove(&session_id);
+                }
+            }
+            if !deferred_pending {
+                state.helper_meta.lock().await.remove(&owner_helper_id);
+                state
+                    .pending_session_helpers
+                    .lock()
+                    .await
+                    .remove(&owner_helper_id);
+                state.session_transaction_changed.notify_waiters();
+            }
+        }
     }
     tracing::info!(
         target: "master",
@@ -1006,9 +1345,7 @@ async fn handle_close_tab_session(
         "closed ACP session resolved from destroyed tab"
     );
 
-    let raw = serde_json::value::RawValue::from_string("{}".to_string())
-        .expect("empty object is valid JSON");
-    Ok(acp::schema::v1::ExtResponse::new(raw.into()))
+    Ok(cleanup)
 }
 
 /// Canonical key for the agent-CLI pool: authoritative agent identity,
@@ -1780,8 +2117,68 @@ struct HelperHandler {
 }
 
 impl HelperHandler {
-    async fn publish_pending_owner(&self, owner_tab_id: Option<String>) {
+    async fn publish_pending_owner(&self, owner_tab_id: Option<String>) -> acp::Result<()> {
         let _guard = self.state.tab_ownership_gate.lock().await;
+        let helper_is_retired = self
+            .state
+            .destructive_session_helpers
+            .lock()
+            .await
+            .contains(&self.helper_id);
+        let blocked_by_fence = if let Some(owner_tab_id) = owner_tab_id.as_deref() {
+            let blocked_by_unresolved = self
+                .state
+                .unresolved_owner_retirements
+                .lock()
+                .await
+                .remove(&self.helper_id)
+                .is_some_and(|safety| safety.rejects(owner_tab_id));
+            let mut fences = self.state.tab_retirement_fences.lock().await;
+            fences.retain(|fence_tab_id, fence| {
+                if fence_tab_id != owner_tab_id
+                    && fence.phase == TabRetirementPhase::CompletedAwaitingDisconnect
+                {
+                    fence.outgoing_helpers.remove(&self.helper_id);
+                }
+                fence.phase == TabRetirementPhase::Fencing || !fence.outgoing_helpers.is_empty()
+            });
+            let blocked_by_tab = match fences.get_mut(owner_tab_id) {
+                Some(fence)
+                    if fence.phase == TabRetirementPhase::Fencing
+                        || fence.outgoing_helpers.contains(&self.helper_id) =>
+                {
+                    fence.outgoing_helpers.insert(self.helper_id);
+                    true
+                }
+                Some(_) => {
+                    // Terminal only creates a replacement helper after it has
+                    // received completion. This helper is outside the captured
+                    // outgoing generation, so consuming the completed fence is
+                    // safe and prevents it from blocking the replacement.
+                    fences.remove(owner_tab_id);
+                    false
+                }
+                None => false,
+            };
+            blocked_by_tab || blocked_by_unresolved
+        } else {
+            false
+        };
+        if helper_is_retired || blocked_by_fence {
+            self.state
+                .closing_session_helpers
+                .lock()
+                .await
+                .insert(self.helper_id);
+            self.state
+                .destructive_session_helpers
+                .lock()
+                .await
+                .insert(self.helper_id);
+            return Err(acp::Error::invalid_params().data(serde_json::json!({
+                "message": "the owning tab's outgoing helper generation has been retired"
+            })));
+        }
         self.state
             .pending_session_helpers
             .lock()
@@ -1796,10 +2193,26 @@ impl HelperHandler {
                 .or_default()
                 .owner_tab_id = Some(owner_tab_id);
         }
+        Ok(())
     }
 
-    async fn commit_pending_owner(&self) {
+    async fn commit_pending_session(&self, session_id: &acp::schema::v1::SessionId) -> bool {
         let _guard = self.state.tab_ownership_gate.lock().await;
+        if self
+            .state
+            .closing_session_helpers
+            .lock()
+            .await
+            .contains(&self.helper_id)
+            || self
+                .state
+                .destructive_session_helpers
+                .lock()
+                .await
+                .contains(&self.helper_id)
+        {
+            return false;
+        }
         let owner_tab_id = self
             .state
             .pending_session_helpers
@@ -1808,33 +2221,119 @@ impl HelperHandler {
             .get(&self.helper_id)
             .cloned()
             .flatten();
+        if let Some(owner_tab_id) = owner_tab_id.as_deref() {
+            let fences = self.state.tab_retirement_fences.lock().await;
+            if fences.get(owner_tab_id).is_some_and(|fence| {
+                fence.phase == TabRetirementPhase::Fencing
+                    || fence.outgoing_helpers.contains(&self.helper_id)
+            }) {
+                return false;
+            }
+        }
+        let mut meta = self.state.helper_meta.lock().await;
+        let entry = meta.entry(self.helper_id).or_default();
         if let Some(owner_tab_id) = owner_tab_id {
+            entry.owner_tab_id = Some(owner_tab_id);
+        }
+        entry.last_session_id = Some(session_id.clone());
             self.state
-                .helper_meta
+            .pending_session_helpers
                 .lock()
                 .await
-                .entry(self.helper_id)
-                .or_default()
-                .owner_tab_id = Some(owner_tab_id);
-        }
+            .remove(&self.helper_id);
+        true
     }
 
     async fn finish_failed_pending_session(&self) {
+        let pending_mcp = self
+            .state
+            .pending_session_mcp
+            .lock()
+            .await
+            .remove(&self.helper_id);
+        let destructive = self
+            .state
+            .destructive_session_helpers
+            .lock()
+            .await
+            .contains(&self.helper_id);
         let _guard = self.state.tab_ownership_gate.lock().await;
         self.state
             .pending_session_helpers
             .lock()
             .await
             .remove(&self.helper_id);
-        if self
-            .state
+        let closing = if destructive {
+            self.state
+                .closing_session_helpers
+                .lock()
+                .await
+                .contains(&self.helper_id)
+        } else {
+            self.state
             .closing_session_helpers
             .lock()
             .await
             .remove(&self.helper_id)
-        {
+        };
+        if closing {
             self.state.helper_meta.lock().await.remove(&self.helper_id);
         }
+        self.state.session_transaction_changed.notify_waiters();
+        drop(_guard);
+        if let Some(pending_mcp) = pending_mcp {
+            self.state
+                .session_mcp_capabilities
+                .cancel(&pending_mcp)
+                .await;
+        }
+    }
+
+    async fn close_session_for_destroyed_tab(
+        &self,
+        agent: &AgentCli,
+        session_id: &acp::schema::v1::SessionId,
+    ) -> acp::Result<ReplacedSessionCleanup> {
+        let destructive = self
+            .state
+            .destructive_session_helpers
+            .lock()
+            .await
+            .contains(&self.helper_id);
+        let result = close_and_retire_owned_session(
+            &self.state,
+            self.helper_id,
+            agent,
+            session_id,
+            tokio::time::Instant::now() + SESSION_CLOSE_TIMEOUT,
+            destructive,
+        )
+        .await;
+        if destructive
+            && self
+                .state
+                .active_retirement_helpers
+                .lock()
+                .await
+                .contains(&self.helper_id)
+        {
+            let outcome = result
+                .as_ref()
+                .copied()
+                .unwrap_or(ReplacedSessionCleanup::LogicalFallback);
+            let mut outcomes = self.state.closing_session_results.lock().await;
+            outcomes
+                .entry(self.helper_id)
+                .and_modify(|current| {
+                    if outcome == ReplacedSessionCleanup::LogicalFallback
+                        || *current == ReplacedSessionCleanup::NotOwned
+                    {
+                        *current = outcome;
+                    }
+                })
+                .or_insert(outcome);
+        }
+        result
     }
 
     /// Snapshot the populated `AgentSideConnection` for this helper.
@@ -2291,7 +2790,7 @@ impl HelperHandler {
         let mut args = args;
         let wta_meta = crate::session_registry::extract_wta_meta(&mut args.meta);
         self.publish_pending_owner(wta_meta.owner_tab_id.clone())
-            .await;
+            .await?;
         let previous_session_id = self
             .state
             .helper_meta
@@ -2357,6 +2856,11 @@ impl HelperHandler {
                 .session_mcp_capabilities
                 .prepare(agent.instance_id, None)
                 .await;
+            self.state
+                .pending_session_mcp
+                .lock()
+                .await
+                .insert(self.helper_id, pending.clone());
             args.mcp_servers
                 .push(session_mcp::server_config(&endpoint, &pending));
             Some(pending)
@@ -2389,12 +2893,17 @@ impl HelperHandler {
             }
         };
         if let Some(pending) = session_mcp.as_ref() {
-            if !self
+            let bound = self
                 .state
                 .session_mcp_capabilities
                 .bind(pending, resp.session_id.clone())
+                .await;
+            self.state
+                .pending_session_mcp
+                .lock()
                 .await
-            {
+                .remove(&self.helper_id);
+            if !bound {
                 tracing::warn!(
                     target: "session_mcp",
                     session_id = %resp.session_id,
@@ -2468,13 +2977,8 @@ impl HelperHandler {
             .await
             .contains(&self.helper_id)
         {
-            let cleanup = close_and_retire_replaced_session(
-                &self.state,
-                self.helper_id,
-                &agent,
-                &resp.session_id,
-                SESSION_CLOSE_TIMEOUT,
-            )
+            let cleanup = self
+                .close_session_for_destroyed_tab(&agent, &resp.session_id)
             .await;
             self.finish_failed_pending_session().await;
             let cleanup = cleanup?;
@@ -2525,31 +3029,9 @@ impl HelperHandler {
         // WT tab StableId (so master can address a `restart_agent_pane`
         // event on disconnect) and the just-created session as the
         // resume target. See `MasterStateInner::helper_meta`.
-        {
-            self.commit_pending_owner().await;
-            let mut meta = self.state.helper_meta.lock().await;
-            let entry = meta.entry(self.helper_id).or_default();
-            entry.last_session_id = Some(resp.session_id.clone());
-        }
-        self.state
-            .pending_session_helpers
-            .lock()
-            .await
-            .remove(&self.helper_id);
-        if self
-            .state
-            .closing_session_helpers
-            .lock()
-            .await
-            .contains(&self.helper_id)
-        {
-            let cleanup = close_and_retire_replaced_session(
-                &self.state,
-                self.helper_id,
-                &agent,
-                &resp.session_id,
-                SESSION_CLOSE_TIMEOUT,
-            )
+        if !self.commit_pending_session(&resp.session_id).await {
+            let cleanup = self
+                .close_session_for_destroyed_tab(&agent, &resp.session_id)
             .await;
             self.finish_failed_pending_session().await;
             let cleanup = cleanup?;
@@ -2632,7 +3114,7 @@ impl HelperHandler {
         let mut args = args;
         let wta_meta = crate::session_registry::extract_wta_meta(&mut args.meta);
         self.publish_pending_owner(wta_meta.owner_tab_id.clone())
-            .await;
+            .await?;
         let session_id = args.session_id.clone();
         let previous_session_id = self
             .state
@@ -2758,6 +3240,11 @@ impl HelperHandler {
                     .session_mcp_capabilities
                     .prepare(agent.instance_id, Some(session_id.clone()))
                     .await;
+                self.state
+                    .pending_session_mcp
+                    .lock()
+                    .await
+                    .insert(self.helper_id, pending.clone());
                 args.mcp_servers
                     .push(session_mcp::server_config(&endpoint, &pending));
                 Some(pending)
@@ -2784,6 +3271,11 @@ impl HelperHandler {
                     rebound_existing_session = true;
                     if let Some(pending) = session_mcp.take() {
                         self.state.session_mcp_capabilities.cancel(&pending).await;
+                        self.state
+                            .pending_session_mcp
+                            .lock()
+                            .await
+                            .remove(&self.helper_id);
                     }
                     tracing::info!(
                         target: "master",
@@ -2838,13 +3330,8 @@ impl HelperHandler {
             if let Some(pending) = session_mcp.as_ref() {
                 self.state.session_mcp_capabilities.cancel(pending).await;
             }
-            let cleanup_result = close_and_retire_replaced_session(
-                &self.state,
-                self.helper_id,
-                &agent,
-                &session_id,
-                SESSION_CLOSE_TIMEOUT,
-            )
+            let cleanup_result = self
+                .close_session_for_destroyed_tab(&agent, &session_id)
             .await;
             let cleanup_result = match cleanup_result {
                 Ok(mut cleanup) => {
@@ -2853,13 +3340,8 @@ impl HelperHandler {
                         .as_ref()
                         .filter(|sid| *sid != &session_id)
                     {
-                        match close_and_retire_replaced_session(
-                            &self.state,
-                            self.helper_id,
-                            &agent,
-                            previous_session_id,
-                            SESSION_CLOSE_TIMEOUT,
-                        )
+                        match self
+                            .close_session_for_destroyed_tab(&agent, previous_session_id)
                         .await
                         {
                             Ok(predecessor_cleanup) => {
@@ -2981,12 +3463,17 @@ impl HelperHandler {
         }
 
         if let Some(pending) = session_mcp.as_ref() {
-            if !self
+            let bound = self
                 .state
                 .session_mcp_capabilities
                 .bind(pending, session_id.clone())
+                .await;
+            self.state
+                .pending_session_mcp
+                .lock()
                 .await
-            {
+                .remove(&self.helper_id);
+            if !bound {
                 tracing::warn!(
                     target: "session_mcp",
                     session_id = %session_id,
@@ -3038,34 +3525,12 @@ impl HelperHandler {
         }
         self.state.registry.upsert(info.clone()).await;
         // Refresh crash-recovery metadata so a later resume targets this session.
-        {
-            self.commit_pending_owner().await;
-            let mut meta = self.state.helper_meta.lock().await;
-            let entry = meta.entry(self.helper_id).or_default();
-            entry.last_session_id = Some(session_id.clone());
-        }
-        self.state
-            .pending_session_helpers
-            .lock()
-            .await
-            .remove(&self.helper_id);
-        if self
-            .state
-            .closing_session_helpers
-            .lock()
-            .await
-            .contains(&self.helper_id)
-        {
+        if !self.commit_pending_session(&session_id).await {
             if let Some(pending) = session_mcp.as_ref() {
                 self.state.session_mcp_capabilities.cancel(pending).await;
             }
-            let cleanup = close_and_retire_replaced_session(
-                &self.state,
-                self.helper_id,
-                &agent,
-                &session_id,
-                SESSION_CLOSE_TIMEOUT,
-            )
+            let cleanup = self
+                .close_session_for_destroyed_tab(&agent, &session_id)
             .await;
             self.finish_failed_pending_session().await;
             let cleanup = cleanup?;
@@ -3727,8 +4192,24 @@ async fn run_master_loop(config: MasterConfig, pipe_name: String) -> Result<()> 
         ),
         helper_meta: Mutex::new(HashMap::new()),
         tab_ownership_gate: Mutex::new(()),
+        connected_helpers: Mutex::new(HashSet::new()),
+        all_retirement_fence: Mutex::new(AllRetirementFence::default()),
+        tab_retirement_fences: Mutex::new(HashMap::new()),
+        unresolved_owner_retirements: Mutex::new(HashMap::new()),
         pending_session_helpers: Mutex::new(HashMap::new()),
+        pending_session_mcp: Mutex::new(HashMap::new()),
         closing_session_helpers: Mutex::new(HashSet::new()),
+        destructive_session_helpers: Mutex::new(HashSet::new()),
+        active_retirement_helpers: Mutex::new(HashSet::new()),
+        closing_session_results: Mutex::new(HashMap::new()),
+        session_transaction_changed: tokio::sync::Notify::new(),
+        retirement_operations: Mutex::new(HashMap::new()),
+        #[cfg(test)]
+        retirement_completion_tx: Mutex::new(None),
+        #[cfg(test)]
+        retirement_pending_timeout: SESSION_CLOSE_TIMEOUT,
+        #[cfg(test)]
+        disconnect_orphan_publication_pause: Mutex::new(None),
         hook_owned: Mutex::new(HashSet::new()),
         born_bound: Mutex::new(HashSet::new()),
         orphaned_sessions: Mutex::new(HashMap::new()),
@@ -4427,6 +4908,7 @@ async fn serve_helper(
     state: Arc<MasterStateInner>,
 ) -> Result<()> {
     tracing::info!(target: "master", helper_id = ?helper_id, "helper connected");
+    register_connected_helper(&state, helper_id).await;
 
     let (notif_tx, mut notif_rx) =
         mpsc::channel::<acp::schema::v1::SessionNotification>(NOTIF_CHANNEL_CAPACITY);
@@ -4707,46 +5189,13 @@ async fn serve_helper(
     // lighting up "unknown SessionId" warnings. Master intentionally
     // sends nothing to the shared CLI here: a closed tab's orphan turn
     // routes nowhere and the CLI keeps serving every surviving tab.
-    let victims = drop_sessions_for_helper(&state, helper_id).await;
-    if let Some((_tab_id, session_id)) = &orphan_tab_candidate {
-        if !victims.contains(session_id) {
-            let _ownership_guard = state.tab_ownership_gate.lock().await;
-            state.orphaned_tabs.lock().await.retain(
-                |_, (_, orphan_helper_id, orphan_session_id)| {
-                    orphan_helper_id != &helper_id || orphan_session_id != session_id
-                },
-            );
-        }
-    }
-
-    // The dropped sessions are still loaded on the shared CLI — they're now
-    // orphans. Record them under the owning agent's key so a later resume
-    // re-binds directly instead of forwarding a `session/load` that the CLI
-    // rejects "already loaded" (or, mid-turn, wedges behind the running
-    // turn). Guard on `Arc::ptr_eq`: only record if the helper's bound CLI
-    // is STILL the live pool instance for its key. If that CLI already died
-    // (reaped, possibly respawned under the same command line), these
-    // sessions are gone — recording them would make a later resume skip the
-    // `session/load` the new CLI needs, binding to a session it never had.
-    if !victims.is_empty() {
-        if let Some(agent) = handler.agent.get() {
-            let key = agent.cmd_key.clone();
-            let still_live = {
-                let agents = state.agents.lock().await;
-                agents
-                    .get(&key)
-                    .and_then(|cell| cell.get())
-                    .is_some_and(|current| Arc::ptr_eq(current, agent))
-            };
-            if still_live {
-                let mut orphans = state.orphaned_sessions.lock().await;
-                let set = orphans.entry(key).or_default();
-                for sid in &victims {
-                    set.insert(sid.clone());
-                }
-            }
-        }
-    }
+    let victims = drop_and_publish_disconnected_helper_sessions(
+        &state,
+        helper_id,
+        handler.agent.get(),
+        orphan_tab_candidate.as_ref(),
+    )
+    .await;
 
     tracing::info!(
         target: "master",
@@ -4763,29 +5212,154 @@ async fn serve_helper(
     // `OnAgentPaneRestartRequested`. The pipe-disconnect that brings us
     // here is the same signal for both crash and clean exit, which is
     // exactly what we want: respawn unless C++ knows it was intentional.
-    {
-        let _ownership_guard = state.tab_ownership_gate.lock().await;
-        state
-            .pending_session_helpers
-            .lock()
-            .await
-            .remove(&helper_id);
-        let intentional_close = state
-            .closing_session_helpers
-            .lock()
-            .await
-            .remove(&helper_id);
-        let recovery = state.helper_meta.lock().await.remove(&helper_id);
-        if !intentional_close {
-            if let Some(recovery) = recovery {
-                if let Some(tab_id) = recovery.owner_tab_id {
-                    emit_restart_agent_pane(&tab_id, recovery.last_session_id.as_ref());
-                }
+    let pending_mcp = state.pending_session_mcp.lock().await.remove(&helper_id);
+    if let Some(pending_mcp) = pending_mcp {
+        state.session_mcp_capabilities.cancel(&pending_mcp).await;
+    }
+    let (intentional_close, recovery) =
+        consume_disconnected_helper_retirement_state(&state, helper_id).await;
+    if !intentional_close {
+        if let Some(recovery) = recovery {
+            if let Some(tab_id) = recovery.owner_tab_id {
+                emit_restart_agent_pane(&tab_id, recovery.last_session_id.as_ref());
             }
         }
     }
 
     result
+}
+
+async fn drop_and_publish_disconnected_helper_sessions(
+    state: &MasterStateInner,
+    helper_id: HelperId,
+    agent: Option<&Arc<AgentCli>>,
+    orphan_tab_candidate: Option<&(String, acp::schema::v1::SessionId)>,
+) -> Vec<acp::schema::v1::SessionId> {
+    let victims = drop_sessions_for_helper(state, helper_id).await;
+
+    #[cfg(test)]
+    if let Some(pause) = state
+        .disconnect_orphan_publication_pause
+        .lock()
+        .await
+        .clone()
+    {
+        pause.routes_dropped.notify_one();
+        pause.resume_publication.notified().await;
+    }
+
+    if let Some((_tab_id, session_id)) = orphan_tab_candidate {
+        if !victims.contains(session_id) {
+            let _ownership_guard = state.tab_ownership_gate.lock().await;
+            state.orphaned_tabs.lock().await.retain(
+                |_, (_, orphan_helper_id, orphan_session_id)| {
+                    orphan_helper_id != &helper_id || orphan_session_id != session_id
+                },
+            );
+        }
+    }
+
+    // Closing and destructive helpers keep their tombstones until disconnect
+    // consumes them. Check each victim under its lifecycle gate so a physical
+    // retirement or replacement bind that wins after route removal cannot be
+    // reintroduced as resumable.
+    if !victims.is_empty() {
+        if let Some(agent) = agent {
+            let key = agent.cmd_key.clone();
+            for session_id in &victims {
+                let gate = session_lifecycle_gate(state, session_id).await;
+                let _session_guard = gate.lock().await;
+                if state
+                    .session_to_helper
+                    .lock()
+                    .await
+                    .contains_key(session_id)
+    {
+                    continue;
+                }
+
+        let _ownership_guard = state.tab_ownership_gate.lock().await;
+                let closing = state
+                    .closing_session_helpers
+                    .lock()
+                    .await
+                    .contains(&helper_id);
+                let destructive = state
+                    .destructive_session_helpers
+                    .lock()
+                    .await
+                    .contains(&helper_id);
+                if closing || destructive {
+                    continue;
+                }
+
+                let agents = state.agents.lock().await;
+                let still_live = agents
+                    .get(&key)
+                    .and_then(|cell| cell.get())
+                    .is_some_and(|current| Arc::ptr_eq(current, agent));
+                if still_live {
+        state
+                        .orphaned_sessions
+                        .lock()
+                        .await
+                        .entry(key.clone())
+                        .or_default()
+                        .insert(session_id.clone());
+                }
+            }
+        }
+    }
+
+    victims
+}
+
+async fn consume_disconnected_helper_retirement_state(
+    state: &MasterStateInner,
+    helper_id: HelperId,
+) -> (bool, Option<HelperRecoveryMeta>) {
+    let _ownership_guard = state.tab_ownership_gate.lock().await;
+    let pending_removed = state
+            .pending_session_helpers
+            .lock()
+            .await
+        .remove(&helper_id)
+        .is_some();
+        let intentional_close = state
+            .closing_session_helpers
+            .lock()
+            .await
+            .remove(&helper_id);
+    state
+        .destructive_session_helpers
+        .lock()
+        .await
+        .remove(&helper_id);
+    state
+        .active_retirement_helpers
+        .lock()
+        .await
+        .remove(&helper_id);
+    state
+        .closing_session_results
+        .lock()
+        .await
+        .remove(&helper_id);
+    state.connected_helpers.lock().await.remove(&helper_id);
+    state
+        .unresolved_owner_retirements
+        .lock()
+        .await
+        .remove(&helper_id);
+    state.tab_retirement_fences.lock().await.retain(|_, fence| {
+        fence.outgoing_helpers.remove(&helper_id);
+        fence.phase == TabRetirementPhase::Fencing || !fence.outgoing_helpers.is_empty()
+    });
+        let recovery = state.helper_meta.lock().await.remove(&helper_id);
+    if pending_removed {
+        state.session_transaction_changed.notify_waiters();
+                }
+    (intentional_close, recovery)
 }
 
 /// Emit a `restart_agent_pane` WT-protocol event so C++ re-warms a fresh
@@ -5561,6 +6135,1262 @@ async fn apply_watcher_event(state: &MasterStateInner, emitted: crate::session_w
     // is nothing left to do — drop it.
 }
 
+fn build_agent_sessions_retired_event(
+    operation_id: &str,
+    reason: &str,
+    failed_tabs: &[String],
+    unattributed_failures: &[String],
+) -> serde_json::Value {
+    let mut event = serde_json::json!({
+        "type": "event",
+        "method": "agent_sessions_retired",
+        "params": {
+            "operation_id": operation_id,
+            "success": failed_tabs.is_empty() && unattributed_failures.is_empty(),
+            "reason": reason,
+            "failed_tabs": failed_tabs,
+        }
+    });
+    if !unattributed_failures.is_empty() {
+        event["params"]["unattributed_failures"] = serde_json::json!({
+            "count": unattributed_failures.len(),
+            "helpers": unattributed_failures,
+        });
+    }
+    event
+}
+
+fn publish_agent_sessions_retired(state: &MasterStateInner, event: serde_json::Value) {
+    #[cfg(test)]
+    {
+        if let Ok(mut completion_tx) = state.retirement_completion_tx.try_lock() {
+            if let Some(completion_tx) = completion_tx.as_mut() {
+                let _ = completion_tx.send(event);
+                return;
+            }
+        }
+    }
+    crate::wt_protocol_events::send(event.to_string());
+}
+
+async fn begin_tab_retirement(
+    state: &MasterStateInner,
+    tab_id: &str,
+) -> Option<TabRetirementTarget> {
+    let _ownership_guard = state.tab_ownership_gate.lock().await;
+    let connected_helpers = state.connected_helpers.lock().await.clone();
+    let helper_meta = state.helper_meta.lock().await;
+    let pending_helpers = state.pending_session_helpers.lock().await;
+    let mut outgoing_helpers = HashSet::new();
+    let mut ownerless_helpers = Vec::new();
+    for helper_id in &connected_helpers {
+        let published_owner = pending_helpers
+            .get(helper_id)
+            .and_then(Option::as_deref)
+            .or_else(|| {
+                helper_meta
+                    .get(helper_id)
+                    .and_then(|recovery| recovery.owner_tab_id.as_deref())
+            });
+        match published_owner {
+            Some(owner_tab_id) if owner_tab_id == tab_id => {
+                outgoing_helpers.insert(*helper_id);
+            }
+            Some(_) => {}
+            None => ownerless_helpers.push(*helper_id),
+        }
+    }
+    drop(pending_helpers);
+    drop(helper_meta);
+    {
+        let mut unresolved = state.unresolved_owner_retirements.lock().await;
+        for helper_id in ownerless_helpers {
+            unresolved
+                .entry(helper_id)
+                .or_insert_with(|| OwnerlessRetirementSafety::Targets(HashSet::new()))
+                .record(tab_id);
+        }
+    }
+    {
+        let mut fences = state.tab_retirement_fences.lock().await;
+        let fence = fences
+            .entry(tab_id.to_string())
+            .or_insert_with(|| TabRetirementFence {
+                phase: TabRetirementPhase::Fencing,
+                active_operations: 0,
+                outgoing_helpers: HashSet::new(),
+            });
+        fence.phase = TabRetirementPhase::Fencing;
+        fence.active_operations += 1;
+        fence.outgoing_helpers.extend(outgoing_helpers);
+    }
+
+    let helper_id = state
+        .helper_meta
+        .lock()
+        .await
+        .iter()
+        .find_map(|(helper_id, recovery)| {
+            (recovery.owner_tab_id.as_deref() == Some(tab_id)).then_some(*helper_id)
+        });
+    let helper_id =
+        if helper_id.is_some() {
+            helper_id
+        } else {
+            state.pending_session_helpers.lock().await.iter().find_map(
+                |(helper_id, owner_tab_id)| {
+                    (owner_tab_id.as_deref() == Some(tab_id)).then_some(*helper_id)
+                },
+            )
+        };
+    let (helper_id, resolved_from_orphan) = if helper_id.is_some() {
+        (helper_id, false)
+    } else {
+        (
+            state
+                .orphaned_tabs
+                .lock()
+                .await
+                .get(tab_id)
+                .map(|(_, helper_id, _)| *helper_id),
+            true,
+        )
+    };
+    if let Some(helper_id) = helper_id {
+        let requires_future_disconnect =
+            !resolved_from_orphan || connected_helpers.contains(&helper_id);
+        let mut fences = state.tab_retirement_fences.lock().await;
+        let fence = fences
+            .get_mut(tab_id)
+            .expect("retirement fence was inserted under the ownership gate");
+        // Ownership is now authoritative; unrelated helpers that happened to
+        // be connected at the generation boundary must not keep this tab's
+        // completed fence alive after its actual helper disconnects.
+        fence.outgoing_helpers.clear();
+        if requires_future_disconnect {
+            fence.outgoing_helpers.insert(helper_id);
+            state.closing_session_helpers.lock().await.insert(helper_id);
+            state
+                .destructive_session_helpers
+                .lock()
+                .await
+                .insert(helper_id);
+        }
+        state
+            .active_retirement_helpers
+            .lock()
+            .await
+            .insert(helper_id);
+        Some(TabRetirementTarget {
+            helper_id,
+            requires_future_disconnect,
+        })
+    } else {
+        None
+    }
+}
+
+async fn complete_tab_retirement(state: &MasterStateInner, tab_id: &str) {
+    let _ownership_guard = state.tab_ownership_gate.lock().await;
+    let mut fences = state.tab_retirement_fences.lock().await;
+    let remove = if let Some(fence) = fences.get_mut(tab_id) {
+        fence.active_operations = fence.active_operations.saturating_sub(1);
+        if fence.active_operations == 0 {
+            fence.phase = TabRetirementPhase::CompletedAwaitingDisconnect;
+        }
+        fence.active_operations == 0 && fence.outgoing_helpers.is_empty()
+    } else {
+        false
+    };
+    if remove {
+        fences.remove(tab_id);
+    }
+}
+
+struct CapturedRetirementSession {
+    session_id: acp::schema::v1::SessionId,
+    agent: Arc<AgentCli>,
+    source: CapturedRetirementSessionSource,
+}
+
+enum CapturedRetirementSessionSource {
+    Route(HelperRoute),
+    Orphan {
+        tab_id: String,
+        agent_key: AgentCmdKey,
+    },
+}
+
+struct CapturedHelperRetirement {
+    helper_id: HelperId,
+    owner_tab_id: Option<String>,
+    sessions: Vec<CapturedRetirementSession>,
+    logical_fallback_required: bool,
+}
+
+struct AllRetirementTargets {
+    helpers: Vec<CapturedHelperRetirement>,
+    orphaned_tabs: Vec<String>,
+    ownerless_orphans: Vec<(AgentCmdKey, acp::schema::v1::SessionId)>,
+}
+
+async fn capture_helper_retirements(
+    state: &MasterStateInner,
+    helper_ids: &HashSet<HelperId>,
+) -> (Vec<CapturedHelperRetirement>, HashSet<String>) {
+    let agents_by_instance = state
+        .agents
+        .lock()
+        .await
+        .values()
+        .filter_map(|cell| cell.get().cloned())
+        .map(|agent| (agent.instance_id, agent))
+        .collect::<HashMap<_, _>>();
+    let agents_by_key = agents_by_instance
+        .values()
+        .map(|agent| (agent.cmd_key.clone(), Arc::clone(agent)))
+        .collect::<HashMap<_, _>>();
+    let mut sessions_by_helper: HashMap<HelperId, Vec<CapturedRetirementSession>> = HashMap::new();
+    for (session_id, route) in state.session_to_helper.lock().await.iter() {
+        if helper_ids.contains(&route.helper_id) {
+            if let Some(agent) = agents_by_instance.get(&route.agent_instance_id) {
+                sessions_by_helper.entry(route.helper_id).or_default().push(
+                    CapturedRetirementSession {
+                        session_id: session_id.clone(),
+                        agent: Arc::clone(agent),
+                        source: CapturedRetirementSessionSource::Route(route.clone()),
+                    },
+                );
+            }
+        }
+    }
+    let helper_meta = state.helper_meta.lock().await;
+    let pending_helpers = state.pending_session_helpers.lock().await;
+    let orphaned_tabs = state.orphaned_tabs.lock().await;
+    let mut captured_orphaned_tabs = HashSet::new();
+    let mut unclosable_helpers = HashSet::new();
+    for (tab_id, (agent_key, helper_id, session_id)) in orphaned_tabs.iter() {
+        if !helper_ids.contains(helper_id) {
+            continue;
+        }
+        let Some(agent) = agents_by_key.get(agent_key) else {
+            unclosable_helpers.insert(*helper_id);
+            continue;
+        };
+        let sessions = sessions_by_helper.entry(*helper_id).or_default();
+        let already_captured = sessions.iter().any(|session| {
+            session.session_id == *session_id && session.agent.instance_id == agent.instance_id
+        });
+        if !already_captured {
+            sessions.push(CapturedRetirementSession {
+                session_id: session_id.clone(),
+                agent: Arc::clone(agent),
+                source: CapturedRetirementSessionSource::Orphan {
+                    tab_id: tab_id.clone(),
+                    agent_key: agent_key.clone(),
+                },
+            });
+        }
+        captured_orphaned_tabs.insert(tab_id.clone());
+    }
+    let helpers = helper_ids
+        .iter()
+        .copied()
+        .map(|helper_id| {
+            let owner_tab_id = pending_helpers
+                .get(&helper_id)
+                .and_then(Clone::clone)
+                .or_else(|| {
+                    helper_meta
+                        .get(&helper_id)
+                        .and_then(|meta| meta.owner_tab_id.clone())
+                })
+                .or_else(|| {
+                    orphaned_tabs.iter().find_map(|(tab_id, (_, owner, _))| {
+                        (*owner == helper_id).then_some(tab_id.clone())
+                    })
+                });
+            CapturedHelperRetirement {
+                helper_id,
+                owner_tab_id,
+                sessions: sessions_by_helper.remove(&helper_id).unwrap_or_default(),
+                logical_fallback_required: unclosable_helpers.contains(&helper_id),
+            }
+        })
+        .collect();
+    (helpers, captured_orphaned_tabs)
+}
+
+async fn begin_all_retirement(state: &MasterStateInner) -> AllRetirementTargets {
+    let _ownership_guard = state.tab_ownership_gate.lock().await;
+    let outgoing_helpers = state.connected_helpers.lock().await.clone();
+    {
+        let mut fence = state.all_retirement_fence.lock().await;
+        fence.active_operations += 1;
+        fence
+            .outgoing_helpers
+            .extend(outgoing_helpers.iter().copied());
+    }
+    state
+        .closing_session_helpers
+        .lock()
+        .await
+        .extend(outgoing_helpers.iter().copied());
+    state
+        .destructive_session_helpers
+        .lock()
+        .await
+        .extend(outgoing_helpers.iter().copied());
+    state
+        .active_retirement_helpers
+        .lock()
+        .await
+        .extend(outgoing_helpers.iter().copied());
+    let (helpers, captured_orphaned_tabs) =
+        capture_helper_retirements(state, &outgoing_helpers).await;
+
+    let orphaned_tabs_guard = state.orphaned_tabs.lock().await;
+    let owned_orphans = orphaned_tabs_guard
+        .values()
+        .map(|(agent_key, _, session_id)| (agent_key.clone(), session_id.clone()))
+        .collect::<HashSet<_>>();
+    let orphaned_tabs = orphaned_tabs_guard
+        .keys()
+        .filter(|tab_id| !captured_orphaned_tabs.contains(*tab_id))
+        .cloned()
+        .collect();
+    let routed_sessions = state
+        .session_to_helper
+        .lock()
+        .await
+        .keys()
+        .cloned()
+        .collect::<HashSet<_>>();
+    let ownerless_orphans = state
+        .orphaned_sessions
+        .lock()
+        .await
+        .iter()
+        .flat_map(|(agent_key, sessions)| {
+            sessions.iter().filter_map(|session_id| {
+                (!owned_orphans.contains(&(agent_key.clone(), session_id.clone()))
+                    && !routed_sessions.contains(session_id))
+                .then_some((agent_key.clone(), session_id.clone()))
+            })
+        })
+        .collect();
+    AllRetirementTargets {
+        helpers,
+        orphaned_tabs,
+        ownerless_orphans,
+    }
+}
+
+async fn finish_all_retirement_batch(
+    state: &MasterStateInner,
+    processed: &HashSet<HelperId>,
+) -> Option<HashSet<HelperId>> {
+    let _ownership_guard = state.tab_ownership_gate.lock().await;
+    let mut fence = state.all_retirement_fence.lock().await;
+    let remaining = fence
+        .outgoing_helpers
+        .difference(processed)
+        .copied()
+        .collect::<HashSet<_>>();
+    if !remaining.is_empty() {
+        return Some(remaining);
+    }
+    fence.active_operations = fence.active_operations.saturating_sub(1);
+    if fence.active_operations == 0 {
+        fence.outgoing_helpers.clear();
+    }
+    None
+}
+
+async fn register_connected_helper(state: &MasterStateInner, helper_id: HelperId) {
+    let _ownership_guard = state.tab_ownership_gate.lock().await;
+    state.connected_helpers.lock().await.insert(helper_id);
+    let outgoing = {
+        let mut fence = state.all_retirement_fence.lock().await;
+        if fence.active_operations == 0 {
+            false
+        } else {
+            fence.outgoing_helpers.insert(helper_id);
+            true
+        }
+    };
+    if outgoing {
+        state.closing_session_helpers.lock().await.insert(helper_id);
+        state
+            .destructive_session_helpers
+            .lock()
+            .await
+            .insert(helper_id);
+        state
+            .active_retirement_helpers
+            .lock()
+            .await
+            .insert(helper_id);
+    }
+}
+
+fn merge_retirement_cleanup(
+    current: ReplacedSessionCleanup,
+    next: ReplacedSessionCleanup,
+) -> ReplacedSessionCleanup {
+    if current == ReplacedSessionCleanup::LogicalFallback
+        || next == ReplacedSessionCleanup::LogicalFallback
+    {
+        ReplacedSessionCleanup::LogicalFallback
+    } else if current == ReplacedSessionCleanup::PhysicallyClosed
+        || next == ReplacedSessionCleanup::PhysicallyClosed
+    {
+        ReplacedSessionCleanup::PhysicallyClosed
+    } else {
+        ReplacedSessionCleanup::NotOwned
+    }
+}
+
+fn retirement_pending_timeout(state: &MasterStateInner) -> std::time::Duration {
+    #[cfg(test)]
+    {
+        state.retirement_pending_timeout
+    }
+    #[cfg(not(test))]
+    {
+        let _ = state;
+        SESSION_CLOSE_TIMEOUT
+    }
+}
+
+fn retirement_remaining(deadline: tokio::time::Instant) -> std::time::Duration {
+    deadline.saturating_duration_since(tokio::time::Instant::now())
+}
+
+fn prune_retirement_operations(
+    operations: &mut HashMap<String, RetirementOperationState>,
+    now: tokio::time::Instant,
+) {
+    operations.retain(|_, state| match state {
+        RetirementOperationState::InFlight => true,
+        RetirementOperationState::Completed { completed_at, .. } => {
+            now.saturating_duration_since(*completed_at) < RETIREMENT_COMPLETION_TTL
+        }
+    });
+
+    let mut completed = operations
+        .iter()
+        .filter_map(|(operation_id, state)| match state {
+            RetirementOperationState::InFlight => None,
+            RetirementOperationState::Completed { completed_at, .. } => {
+                Some((operation_id.clone(), *completed_at))
+            }
+        })
+        .collect::<Vec<_>>();
+    if completed.len() <= RETIREMENT_COMPLETION_CAP {
+        return;
+    }
+    let excess = completed.len() - RETIREMENT_COMPLETION_CAP;
+    completed.sort_unstable_by_key(|(_, completed_at)| *completed_at);
+    for (operation_id, _) in completed.into_iter().take(excess) {
+        operations.remove(&operation_id);
+    }
+}
+
+async fn record_retirement_completion(
+    state: &MasterStateInner,
+    operation_id: String,
+    event: serde_json::Value,
+) {
+    let now = tokio::time::Instant::now();
+    let mut operations = state.retirement_operations.lock().await;
+    operations.insert(
+        operation_id,
+        RetirementOperationState::Completed {
+            event,
+            completed_at: now,
+        },
+    );
+    prune_retirement_operations(&mut operations, now);
+}
+
+async fn force_cleanup_retirement_helper(
+    state: &MasterStateInner,
+    helper_id: HelperId,
+    tab_id: &str,
+    mut cleanup: ReplacedSessionCleanup,
+    deadline: tokio::time::Instant,
+    requires_future_disconnect: bool,
+) -> ReplacedSessionCleanup {
+    if let Some(late_cleanup) = state
+        .closing_session_results
+        .lock()
+        .await
+        .remove(&helper_id)
+    {
+        cleanup = merge_retirement_cleanup(cleanup, late_cleanup);
+    }
+
+    let mut session_ids = {
+        let routes = state.session_to_helper.lock().await;
+        routes
+            .iter()
+            .filter_map(|(session_id, route)| {
+                (route.helper_id == helper_id).then_some(session_id.clone())
+            })
+            .collect::<HashSet<_>>()
+    };
+    if let Some(session_id) = state
+        .helper_meta
+        .lock()
+        .await
+        .get(&helper_id)
+        .and_then(|meta| meta.last_session_id.clone())
+    {
+        session_ids.insert(session_id);
+    }
+    session_ids.extend(state.orphaned_tabs.lock().await.iter().filter_map(
+        |(orphan_tab_id, (_, orphan_helper_id, session_id))| {
+            (orphan_tab_id == tab_id || *orphan_helper_id == helper_id)
+                .then_some(session_id.clone())
+        },
+    ));
+
+    for session_id in &session_ids {
+        let forced = match tokio::time::timeout_at(
+            deadline,
+            force_retire_owned_session_state(state, helper_id, session_id),
+        )
+        .await
+        {
+            Ok(forced) => forced,
+            Err(_) => {
+                tracing::error!(
+                    target: "master_retirement",
+                    tab_id,
+                    helper_id = ?helper_id,
+                    session_id = %session_id,
+                    "retirement deadline expired during forced session cleanup"
+                );
+                cleanup =
+                    merge_retirement_cleanup(cleanup, ReplacedSessionCleanup::LogicalFallback);
+                break;
+            }
+        };
+        if forced == ReplacedSessionCleanup::NotOwned {
+            if tokio::time::timeout_at(deadline, retire_unbound_session_state(state, session_id))
+                .await
+                .is_err()
+            {
+                tracing::error!(
+                    target: "master_retirement",
+                    tab_id,
+                    helper_id = ?helper_id,
+                    session_id = %session_id,
+                    "retirement deadline expired during forced unbound-session cleanup"
+                );
+                cleanup =
+                    merge_retirement_cleanup(cleanup, ReplacedSessionCleanup::LogicalFallback);
+                break;
+            }
+        }
+        cleanup = merge_retirement_cleanup(cleanup, forced);
+    }
+
+    if !session_ids.is_empty() {
+        let mut orphaned_sessions = state.orphaned_sessions.lock().await;
+        for sessions in orphaned_sessions.values_mut() {
+            for session_id in &session_ids {
+                sessions.remove(session_id);
+            }
+        }
+        orphaned_sessions.retain(|_, sessions| !sessions.is_empty());
+    }
+    state
+        .orphaned_tabs
+        .lock()
+        .await
+        .retain(|orphan_tab_id, (_, orphan_helper_id, _)| {
+            orphan_tab_id != tab_id && *orphan_helper_id != helper_id
+        });
+
+    let pending_removed = {
+        let _ownership_guard = state.tab_ownership_gate.lock().await;
+        let pending_removed = state
+            .pending_session_helpers
+            .lock()
+            .await
+            .remove(&helper_id)
+            .is_some();
+        state.helper_meta.lock().await.remove(&helper_id);
+        state
+            .unresolved_owner_retirements
+            .lock()
+            .await
+            .remove(&helper_id);
+        if !requires_future_disconnect {
+            state
+                .closing_session_helpers
+                .lock()
+                .await
+                .remove(&helper_id);
+            state
+                .destructive_session_helpers
+                .lock()
+                .await
+                .remove(&helper_id);
+            state.tab_retirement_fences.lock().await.retain(|_, fence| {
+                fence.outgoing_helpers.remove(&helper_id);
+                fence.phase == TabRetirementPhase::Fencing || !fence.outgoing_helpers.is_empty()
+            });
+        }
+        pending_removed
+    };
+    if let Some(pending_mcp) = state.pending_session_mcp.lock().await.remove(&helper_id) {
+        state.session_mcp_capabilities.cancel(&pending_mcp).await;
+    }
+    if pending_removed {
+        state.session_transaction_changed.notify_waiters();
+    }
+    state
+        .active_retirement_helpers
+        .lock()
+        .await
+        .remove(&helper_id);
+    cleanup
+}
+
+async fn retire_captured_orphan_session(
+    state: &MasterStateInner,
+    helper_id: HelperId,
+    tab_id: &str,
+    agent_key: &AgentCmdKey,
+    agent: &AgentCli,
+    session_id: &acp::schema::v1::SessionId,
+    deadline: tokio::time::Instant,
+) -> ReplacedSessionCleanup {
+    let gate = session_lifecycle_gate(state, session_id).await;
+    let Ok(_guard) = tokio::time::timeout_at(deadline, gate.lock()).await else {
+        return ReplacedSessionCleanup::LogicalFallback;
+    };
+    let orphan_is_current = state
+        .orphaned_tabs
+        .lock()
+        .await
+        .get(tab_id)
+        .is_some_and(|current| current == &(agent_key.clone(), helper_id, session_id.clone()));
+    if !orphan_is_current
+        || state
+            .session_to_helper
+            .lock()
+            .await
+            .contains_key(session_id)
+    {
+        return ReplacedSessionCleanup::LogicalFallback;
+    }
+
+    let cancel = tokio::time::timeout_at(
+        deadline,
+        agent
+            .conn
+            .cancel(acp::schema::v1::CancelNotification::new(session_id.clone())),
+    )
+    .await;
+    match cancel {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            tracing::warn!(
+                target: "master_retirement",
+                tab_id,
+                helper_id = ?helper_id,
+                session_id = %session_id,
+                agent_instance_id = %agent.instance_id,
+                error = %error,
+                "failed to cancel captured orphan before retirement"
+            );
+        }
+        Err(_) => return ReplacedSessionCleanup::LogicalFallback,
+    }
+
+    let cleanup = if agent_supports_session_close(agent) {
+        match tokio::time::timeout_at(
+            deadline,
+            agent
+                .conn
+                .close_session(acp::schema::v1::CloseSessionRequest::new(
+                    session_id.clone(),
+                )),
+        )
+        .await
+        {
+            Ok(Ok(_)) => ReplacedSessionCleanup::PhysicallyClosed,
+            Ok(Err(error)) => {
+                tracing::error!(
+                    target: "master_retirement",
+                    tab_id,
+                    helper_id = ?helper_id,
+                    session_id = %session_id,
+                    agent_instance_id = %agent.instance_id,
+                    error = %error,
+                    "failed to physically close captured orphan; retiring WTA state"
+                );
+                ReplacedSessionCleanup::LogicalFallback
+            }
+            Err(_) => {
+                tracing::error!(
+                    target: "master_retirement",
+                    tab_id,
+                    helper_id = ?helper_id,
+                    session_id = %session_id,
+                    agent_instance_id = %agent.instance_id,
+                    "timed out physically closing captured orphan; retiring WTA state"
+                );
+                ReplacedSessionCleanup::LogicalFallback
+            }
+        }
+    } else {
+        ReplacedSessionCleanup::LogicalFallback
+    };
+
+    {
+        let mut orphaned_tabs = state.orphaned_tabs.lock().await;
+        if orphaned_tabs
+            .get(tab_id)
+            .is_some_and(|current| current == &(agent_key.clone(), helper_id, session_id.clone()))
+        {
+            orphaned_tabs.remove(tab_id);
+        }
+    }
+    {
+        let mut orphaned_sessions = state.orphaned_sessions.lock().await;
+        if let Some(sessions) = orphaned_sessions.get_mut(agent_key) {
+            sessions.remove(session_id);
+            if sessions.is_empty() {
+                orphaned_sessions.remove(agent_key);
+            }
+        }
+    }
+    retire_unbound_session_state_gate_held(state, session_id).await;
+    cleanup
+}
+
+async fn retire_ownerless_orphan_session(
+    state: &MasterStateInner,
+    agent_key: &AgentCmdKey,
+    session_id: &acp::schema::v1::SessionId,
+    deadline: tokio::time::Instant,
+) -> ReplacedSessionCleanup {
+    let gate = session_lifecycle_gate(state, session_id).await;
+    let Ok(_guard) = tokio::time::timeout_at(deadline, gate.lock()).await else {
+        tracing::error!(
+            target: "master_retirement",
+            session_id = %session_id,
+            "retirement deadline expired waiting for ownerless orphan lifecycle gate; retiring orphan marker"
+        );
+        let mut orphaned_sessions = state.orphaned_sessions.lock().await;
+        if let Some(sessions) = orphaned_sessions.get_mut(agent_key) {
+            sessions.remove(session_id);
+            if sessions.is_empty() {
+                orphaned_sessions.remove(agent_key);
+            }
+        }
+        return ReplacedSessionCleanup::LogicalFallback;
+    };
+
+    let orphan_is_current = state
+        .orphaned_sessions
+        .lock()
+        .await
+        .get(agent_key)
+        .is_some_and(|sessions| sessions.contains(session_id));
+    if !orphan_is_current {
+        return ReplacedSessionCleanup::NotOwned;
+    }
+    if state
+        .session_to_helper
+        .lock()
+        .await
+        .contains_key(session_id)
+    {
+        let mut orphaned_sessions = state.orphaned_sessions.lock().await;
+        if let Some(sessions) = orphaned_sessions.get_mut(agent_key) {
+            sessions.remove(session_id);
+            if sessions.is_empty() {
+                orphaned_sessions.remove(agent_key);
+            }
+        }
+        return ReplacedSessionCleanup::NotOwned;
+    }
+
+    let agent = {
+        let agents = state.agents.lock().await;
+        agents.get(agent_key).and_then(|cell| cell.get()).cloned()
+    };
+    let cleanup = if let Some(agent) = agent {
+        let cancel_timed_out = match tokio::time::timeout_at(
+            deadline,
+            agent
+                .conn
+                .cancel(acp::schema::v1::CancelNotification::new(session_id.clone())),
+        )
+        .await
+        {
+            Ok(Ok(())) => false,
+            Ok(Err(error)) => {
+                tracing::warn!(
+                    target: "master_retirement",
+                    session_id = %session_id,
+                    agent_instance_id = %agent.instance_id,
+                    error = %error,
+                    "failed to cancel ownerless orphan before retirement"
+                );
+                false
+            }
+            Err(_) => {
+                tracing::error!(
+                    target: "master_retirement",
+                    session_id = %session_id,
+                    agent_instance_id = %agent.instance_id,
+                    "timed out cancelling ownerless orphan; retiring WTA state"
+                );
+                true
+            }
+        };
+        if cancel_timed_out || !agent_supports_session_close(&agent) {
+            ReplacedSessionCleanup::LogicalFallback
+        } else {
+            match tokio::time::timeout_at(
+                deadline,
+                agent
+                    .conn
+                    .close_session(acp::schema::v1::CloseSessionRequest::new(
+                        session_id.clone(),
+                    )),
+            )
+            .await
+            {
+                Ok(Ok(_)) => ReplacedSessionCleanup::PhysicallyClosed,
+                Ok(Err(error)) => {
+                    tracing::error!(
+                        target: "master_retirement",
+                        session_id = %session_id,
+                        agent_instance_id = %agent.instance_id,
+                        error = %error,
+                        "failed to physically close ownerless orphan; retiring WTA state"
+                    );
+                    ReplacedSessionCleanup::LogicalFallback
+                }
+                Err(_) => {
+                    tracing::error!(
+                        target: "master_retirement",
+                        session_id = %session_id,
+                        agent_instance_id = %agent.instance_id,
+                        "timed out physically closing ownerless orphan; retiring WTA state"
+                    );
+                    ReplacedSessionCleanup::LogicalFallback
+                }
+            }
+        }
+    } else {
+        tracing::warn!(
+            target: "master_retirement",
+            session_id = %session_id,
+            "ownerless orphan agent is unavailable; retiring WTA state"
+        );
+        ReplacedSessionCleanup::LogicalFallback
+    };
+
+    {
+        let mut orphaned_sessions = state.orphaned_sessions.lock().await;
+        if let Some(sessions) = orphaned_sessions.get_mut(agent_key) {
+            sessions.remove(session_id);
+            if sessions.is_empty() {
+                orphaned_sessions.remove(agent_key);
+            }
+        }
+    }
+    retire_unbound_session_state_gate_held(state, session_id).await;
+    cleanup
+}
+
+async fn retire_helper_transaction(
+    state: &MasterStateInner,
+    captured: CapturedHelperRetirement,
+    deadline: tokio::time::Instant,
+) -> (HelperId, Option<String>, ReplacedSessionCleanup) {
+    let CapturedHelperRetirement {
+        helper_id,
+        owner_tab_id,
+        sessions,
+        logical_fallback_required,
+    } = captured;
+    let results = futures::future::join_all(sessions.into_iter().map(|session| async move {
+        let CapturedRetirementSession {
+            session_id,
+            agent,
+            source,
+        } = session;
+        let route = match source {
+            CapturedRetirementSessionSource::Route(route) => route,
+            CapturedRetirementSessionSource::Orphan { tab_id, agent_key } => {
+                return retire_captured_orphan_session(
+                    state,
+                    helper_id,
+                    &tab_id,
+                    &agent_key,
+                    &agent,
+                    &session_id,
+                    deadline,
+                )
+                .await;
+            }
+        };
+        let gate = session_lifecycle_gate(state, &session_id).await;
+        let restored = match tokio::time::timeout_at(deadline, gate.lock()).await {
+            Ok(_guard) => {
+                let mut routes = state.session_to_helper.lock().await;
+                match routes.get(&session_id) {
+                    Some(route)
+                        if route.helper_id == helper_id
+                            && route.agent_instance_id == agent.instance_id =>
+                    {
+                        true
+                    }
+                    Some(_) => false,
+                    None => {
+                        routes.insert(session_id.clone(), route);
+                        true
+                    }
+                }
+            }
+            Err(_) => false,
+        };
+        if !restored {
+            return ReplacedSessionCleanup::LogicalFallback;
+        }
+        close_and_retire_owned_session(state, helper_id, &agent, &session_id, deadline, true)
+            .await
+            .map(|cleanup| {
+                if cleanup == ReplacedSessionCleanup::NotOwned {
+                    ReplacedSessionCleanup::LogicalFallback
+                } else {
+                    cleanup
+                }
+            })
+            .unwrap_or(ReplacedSessionCleanup::LogicalFallback)
+    }))
+    .await;
+    let initial_cleanup = if logical_fallback_required {
+        ReplacedSessionCleanup::LogicalFallback
+    } else {
+        ReplacedSessionCleanup::NotOwned
+    };
+    let mut cleanup = results
+        .into_iter()
+        .fold(initial_cleanup, merge_retirement_cleanup);
+
+    loop {
+        let notified = state.session_transaction_changed.notified();
+        if !state
+            .pending_session_helpers
+            .lock()
+            .await
+            .contains_key(&helper_id)
+        {
+            break;
+        }
+        if tokio::time::timeout_at(deadline, notified).await.is_err() {
+            tracing::error!(
+                target: "master_retirement",
+                helper_id = ?helper_id,
+                "timed out waiting for captured helper session transaction retirement"
+            );
+            cleanup = merge_retirement_cleanup(cleanup, ReplacedSessionCleanup::LogicalFallback);
+            break;
+        }
+    }
+
+    cleanup = force_cleanup_retirement_helper(state, helper_id, "", cleanup, deadline, true).await;
+    (helper_id, owner_tab_id, cleanup)
+}
+
+async fn retire_tab_transaction(
+    state: &MasterStateInner,
+    tab_id: String,
+    deadline: tokio::time::Instant,
+) -> ReplacedSessionCleanup {
+    // Establish the destructive fence before resolving ownership. This makes
+    // a concurrent owner publication serialize either wholly before the fence
+    // (and become the bound outgoing helper) or wholly after it (and fail).
+    let retirement_target = begin_tab_retirement(state, &tab_id).await;
+
+    let mut cleanup = match retire_tab_session(
+        state,
+        &crate::session_registry::CloseTabSessionParams {
+            tab_id: tab_id.clone(),
+        },
+        false,
+        true,
+        deadline,
+    )
+    .await
+    {
+        Ok(cleanup) => cleanup,
+        Err(error) => {
+            tracing::error!(
+                target: "master_retirement",
+                tab_id,
+                error = %error,
+                "destructive tab retirement failed; forcing logical cleanup"
+            );
+            ReplacedSessionCleanup::LogicalFallback
+        }
+    };
+    if let Some(retirement_target) = retirement_target {
+        let helper_id = retirement_target.helper_id;
+        loop {
+            let notified = state.session_transaction_changed.notified();
+            if !state
+                .pending_session_helpers
+                .lock()
+                .await
+                .contains_key(&helper_id)
+            {
+                break;
+            }
+            if tokio::time::timeout_at(deadline, notified).await.is_err() {
+                tracing::error!(
+                    target: "master_retirement",
+                    tab_id,
+                    helper_id = ?helper_id,
+                    "timed out waiting for pending session transaction retirement"
+                );
+                cleanup =
+                    merge_retirement_cleanup(cleanup, ReplacedSessionCleanup::LogicalFallback);
+                break;
+            }
+        }
+        cleanup = force_cleanup_retirement_helper(
+            state,
+            helper_id,
+            &tab_id,
+            cleanup,
+            deadline,
+            retirement_target.requires_future_disconnect,
+        )
+        .await;
+    } else {
+        state.orphaned_tabs.lock().await.remove(&tab_id);
+    }
+    complete_tab_retirement(state, &tab_id).await;
+    cleanup
+}
+
+async fn run_retirement_operation(
+    state: Arc<MasterStateInner>,
+    operation_id: String,
+    scope: String,
+    requested_tabs: Vec<String>,
+    reason: String,
+) {
+    if scope == "all" {
+        let targets = begin_all_retirement(&state).await;
+        let deadline = tokio::time::Instant::now() + retirement_pending_timeout(&state);
+        let mut processed_helpers = HashSet::new();
+        let orphaned_tabs = targets.orphaned_tabs;
+        let ownerless_orphans = targets.ownerless_orphans;
+        let helper_results = futures::future::join_all(
+            targets
+                .helpers
+                .into_iter()
+                .map(|captured| retire_helper_transaction(&state, captured, deadline)),
+        );
+        let orphan_results = futures::future::join_all(
+            orphaned_tabs
+                .iter()
+                .cloned()
+                .map(|tab_id| retire_tab_transaction(&state, tab_id, deadline)),
+        );
+        let ownerless_results =
+            futures::future::join_all(ownerless_orphans.iter().map(|(agent_key, session_id)| {
+                retire_ownerless_orphan_session(&state, agent_key, session_id, deadline)
+            }));
+        let (helper_results, orphan_results, ownerless_results) =
+            tokio::join!(helper_results, orphan_results, ownerless_results);
+        let mut failed_tabs = Vec::new();
+        let mut unattributed_failures = Vec::new();
+        for (helper_id, owner_tab_id, cleanup) in helper_results {
+            processed_helpers.insert(helper_id);
+            if cleanup == ReplacedSessionCleanup::LogicalFallback {
+                if let Some(tab_id) = owner_tab_id {
+                    failed_tabs.push(tab_id);
+                } else {
+                    unattributed_failures.push(format!("{helper_id:?}"));
+                }
+            }
+        }
+        unattributed_failures.extend(ownerless_orphans.iter().zip(ownerless_results).filter_map(
+            |((_, session_id), cleanup)| {
+                (cleanup == ReplacedSessionCleanup::LogicalFallback)
+                    .then(|| format!("orphan:{session_id}"))
+            },
+        ));
+        while let Some(next_batch) = finish_all_retirement_batch(&state, &processed_helpers).await {
+            let (captured, captured_orphaned_tabs) =
+                capture_helper_retirements(&state, &next_batch).await;
+            let orphaned_tabs = state
+                .orphaned_tabs
+                .lock()
+                .await
+                .iter()
+                .filter_map(|(tab_id, (_, helper_id, _))| {
+                    (next_batch.contains(helper_id) && !captured_orphaned_tabs.contains(tab_id))
+                        .then_some(tab_id.clone())
+                })
+                .collect::<Vec<_>>();
+            let helper_results = futures::future::join_all(
+                captured
+                    .into_iter()
+                    .map(|captured| retire_helper_transaction(&state, captured, deadline)),
+            );
+            let orphan_results = futures::future::join_all(
+                orphaned_tabs
+                    .iter()
+                    .cloned()
+                    .map(|tab_id| retire_tab_transaction(&state, tab_id, deadline)),
+            );
+            let (helper_results, orphan_results) = tokio::join!(helper_results, orphan_results);
+            for (helper_id, owner_tab_id, cleanup) in helper_results {
+                processed_helpers.insert(helper_id);
+                if cleanup == ReplacedSessionCleanup::LogicalFallback {
+                    if let Some(tab_id) = owner_tab_id {
+                        failed_tabs.push(tab_id);
+                    } else {
+                        unattributed_failures.push(format!("{helper_id:?}"));
+                    }
+                }
+            }
+            failed_tabs.extend(orphaned_tabs.into_iter().zip(orphan_results).filter_map(
+                |(tab_id, cleanup)| {
+                    (cleanup == ReplacedSessionCleanup::LogicalFallback).then_some(tab_id)
+                },
+            ));
+        }
+        failed_tabs.extend(orphaned_tabs.into_iter().zip(orphan_results).filter_map(
+            |(tab_id, cleanup)| {
+                (cleanup == ReplacedSessionCleanup::LogicalFallback).then_some(tab_id)
+            },
+        ));
+        failed_tabs.sort();
+        failed_tabs.dedup();
+        unattributed_failures.sort();
+        unattributed_failures.dedup();
+        let event = build_agent_sessions_retired_event(
+            &operation_id,
+            &reason,
+            &failed_tabs,
+            &unattributed_failures,
+        );
+        record_retirement_completion(&state, operation_id, event.clone()).await;
+        publish_agent_sessions_retired(&state, event);
+        return;
+    }
+
+    let targets: Vec<String> = if scope == "tabs" {
+        requested_tabs
+            .into_iter()
+            .filter(|tab_id| !tab_id.is_empty())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    } else {
+        let event =
+            build_agent_sessions_retired_event(&operation_id, &reason, &requested_tabs, &[]);
+        record_retirement_completion(&state, operation_id, event.clone()).await;
+        publish_agent_sessions_retired(&state, event);
+        return;
+    };
+
+    let deadline = tokio::time::Instant::now() + retirement_pending_timeout(&state);
+    let results = futures::future::join_all(
+        targets
+            .iter()
+            .cloned()
+            .map(|tab_id| retire_tab_transaction(&state, tab_id, deadline)),
+    )
+    .await;
+    let failed_tabs = targets
+        .into_iter()
+        .zip(results)
+        .filter_map(|(tab_id, cleanup)| {
+            (cleanup == ReplacedSessionCleanup::LogicalFallback).then_some(tab_id)
+        })
+        .collect::<Vec<_>>();
+    let event = build_agent_sessions_retired_event(&operation_id, &reason, &failed_tabs, &[]);
+    record_retirement_completion(&state, operation_id, event.clone()).await;
+    publish_agent_sessions_retired(&state, event);
+}
+
+async fn handle_retire_agent_sessions_event(
+    state: &Arc<MasterStateInner>,
+    params: serde_json::Value,
+) {
+    let operation_id = params
+        .get("operation_id")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string();
+    if operation_id.is_empty() {
+        tracing::warn!(
+            target: "master_retirement",
+            "retire_agent_sessions missing nonempty operation_id"
+        );
+        return;
+    }
+    let scope = params
+        .get("scope")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string();
+    let reason = params
+        .get("reason")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string();
+    let tab_ids = params
+        .get("tab_ids")
+        .and_then(|value| value.as_array())
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let replay = {
+        let mut operations = state.retirement_operations.lock().await;
+        prune_retirement_operations(&mut operations, tokio::time::Instant::now());
+        match operations.get(&operation_id) {
+            Some(RetirementOperationState::InFlight) => return,
+            Some(RetirementOperationState::Completed { event, .. }) => Some(event.clone()),
+            None => {
+                operations.insert(operation_id.clone(), RetirementOperationState::InFlight);
+                None
+            }
+        }
+    };
+    if let Some(event) = replay {
+        publish_agent_sessions_retired(state, event);
+        return;
+    }
+
+    let operation_state = Arc::clone(state);
+    tokio::task::spawn_local(async move {
+        run_retirement_operation(operation_state, operation_id, scope, tab_ids, reason).await;
+    });
+}
+
 /// Master-side WT event subscriber. Bridges `connection_state`
 /// notifications from the COM channel into the master's session
 /// registry so that closing a pane (Ctrl+Shift+W, close-tab, hard kill)
@@ -5579,7 +7409,7 @@ async fn apply_watcher_event(state: &MasterStateInner, emitted: crate::session_w
 /// the publish-from-helper path works for them today; this subscriber
 /// makes the behavior uniform across CLIs and resilient to helper
 /// teardown order.
-async fn handle_master_wt_event(state: &MasterStateInner, event_json: serde_json::Value) {
+async fn handle_master_wt_event(state: &Arc<MasterStateInner>, event_json: serde_json::Value) {
     let method = event_json
         .get("method")
         .and_then(|v| v.as_str())
@@ -5588,6 +7418,11 @@ async fn handle_master_wt_event(state: &MasterStateInner, event_json: serde_json
         .get("params")
         .cloned()
         .unwrap_or_else(|| serde_json::json!({}));
+
+    if method == "retire_agent_sessions" {
+        handle_retire_agent_sessions_event(state, params).await;
+        return;
+    }
 
     if method == "tab_renamed" {
         let old_tab_id = params

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -33,6 +33,11 @@ struct BlockingCloseAgent {
 }
 
 #[derive(Clone)]
+struct BlockingCancelAgent {
+    events: mpsc::UnboundedSender<ReplacementEvent>,
+}
+
+#[derive(Clone)]
 struct RebindDuringCloseAgent {
     predecessor: SessionId,
     events: mpsc::UnboundedSender<ReplacementEvent>,
@@ -42,6 +47,7 @@ enum ReplacementEvent {
     Cancel(SessionId),
     Close(SessionId),
     BlockingClose(SessionId, tokio::sync::oneshot::Sender<()>),
+    BlockingCancel(SessionId, tokio::sync::oneshot::Sender<()>),
     FailingClose(SessionId, tokio::sync::oneshot::Sender<()>),
     Load(SessionId),
     New(usize, tokio::sync::oneshot::Sender<()>),
@@ -139,6 +145,22 @@ impl BlockingCloseAgent {
             .await
             .map_err(|_| acp::Error::internal_error().data("test release sender dropped"))?;
         Ok(acp::schema::v1::CloseSessionResponse::new())
+    }
+}
+
+impl BlockingCancelAgent {
+    async fn cancel(&self, args: acp::schema::v1::CancelNotification) -> acp::Result<()> {
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        self.events
+            .send(ReplacementEvent::BlockingCancel(
+                args.session_id,
+                release_tx,
+            ))
+            .map_err(|_| acp::Error::internal_error().data("test event receiver dropped"))?;
+        release_rx
+            .await
+            .map_err(|_| acp::Error::internal_error().data("test release sender dropped"))?;
+        Ok(())
     }
 }
 
@@ -703,6 +725,12 @@ fn pool_key_dedupes_same_selection_and_separates_distinct_agents() {
 }
 
 fn make_state() -> Arc<MasterStateInner> {
+    make_state_with_retirement_pending_timeout(SESSION_CLOSE_TIMEOUT)
+}
+
+fn make_state_with_retirement_pending_timeout(
+    retirement_pending_timeout: std::time::Duration,
+) -> Arc<MasterStateInner> {
     Arc::new(MasterStateInner {
         session_lifecycle_gates: Mutex::new(HashMap::new()),
         session_to_helper: Mutex::new(HashMap::new()),
@@ -722,8 +750,21 @@ fn make_state() -> Arc<MasterStateInner> {
         cli_source: Some(crate::agent_sessions::CliSource::Copilot),
         helper_meta: Mutex::new(HashMap::new()),
         tab_ownership_gate: Mutex::new(()),
+        connected_helpers: Mutex::new(HashSet::new()),
+        all_retirement_fence: Mutex::new(AllRetirementFence::default()),
+        tab_retirement_fences: Mutex::new(HashMap::new()),
+        unresolved_owner_retirements: Mutex::new(HashMap::new()),
         pending_session_helpers: Mutex::new(HashMap::new()),
+        pending_session_mcp: Mutex::new(HashMap::new()),
         closing_session_helpers: Mutex::new(HashSet::new()),
+        destructive_session_helpers: Mutex::new(HashSet::new()),
+        active_retirement_helpers: Mutex::new(HashSet::new()),
+        closing_session_results: Mutex::new(HashMap::new()),
+        session_transaction_changed: tokio::sync::Notify::new(),
+        retirement_operations: Mutex::new(HashMap::new()),
+        retirement_completion_tx: Mutex::new(None),
+        retirement_pending_timeout,
+        disconnect_orphan_publication_pause: Mutex::new(None),
         hook_owned: Mutex::new(HashSet::new()),
         born_bound: Mutex::new(HashSet::new()),
         orphaned_sessions: Mutex::new(HashMap::new()),
@@ -732,6 +773,51 @@ fn make_state() -> Arc<MasterStateInner> {
         wsl_titles_seed_at: Mutex::new(None),
         wsl_seed_in_flight: std::sync::atomic::AtomicBool::new(false),
     })
+}
+
+async fn capture_retirement_completions(
+    state: &MasterStateInner,
+) -> mpsc::UnboundedReceiver<serde_json::Value> {
+    let (tx, rx) = mpsc::unbounded_channel();
+    *state.retirement_completion_tx.lock().await = Some(tx);
+    rx
+}
+
+async fn register_retirement_tab(
+    state: &MasterStateInner,
+    agent: &Arc<AgentCli>,
+    helper_id: HelperId,
+    tab_id: &str,
+    session_id: &SessionId,
+) {
+    state.connected_helpers.lock().await.insert(helper_id);
+    let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+    bind_session_route(
+        state,
+        session_id.clone(),
+        HelperRoute {
+            helper_id,
+            agent_instance_id: agent.instance_id,
+            notif_tx,
+            forwarder: None,
+            consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        },
+    )
+    .await;
+    state
+        .registry
+        .upsert(crate::session_registry::SessionInfo::new(
+            session_id.clone(),
+            PathBuf::from("C:\\repo"),
+        ))
+        .await;
+    state.helper_meta.lock().await.insert(
+        helper_id,
+        HelperRecoveryMeta {
+            owner_tab_id: Some(tab_id.to_string()),
+            last_session_id: Some(session_id.clone()),
+        },
+    );
 }
 
 fn client_connection_to_controlled_new_session_agent(
@@ -952,6 +1038,45 @@ fn client_connection_to_blocking_close_agent(
     });
     let (client_conn, client_io) = conn::spawn_client(
         acp::Client.builder().name("blocking-close-client"),
+        conn::byte_streams(client_write.compat_write(), client_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = client_io.await;
+    });
+    client_conn
+}
+
+fn client_connection_to_blocking_cancel_agent(
+    events: mpsc::UnboundedSender<ReplacementEvent>,
+) -> conn::ClientLink {
+    let (client_pipe, agent_pipe) = tokio::io::duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_pipe);
+    let (agent_read, agent_write) = tokio::io::split(agent_pipe);
+    let mock = BlockingCancelAgent { events };
+    let agent_builder = acp::Agent
+        .builder()
+        .name("blocking-cancel-agent")
+        .on_receive_notification(
+            move |notif: acp::schema::v1::ClientNotification, _cx| {
+                let mock = mock.clone();
+                async move {
+                    if let acp::schema::v1::ClientNotification::CancelNotification(args) = notif {
+                        mock.cancel(args).await?;
+                    }
+                    Ok(())
+                }
+            },
+            acp::on_receive_notification!(),
+        );
+    let (_agent_conn, agent_io) = conn::spawn_agent(
+        agent_builder,
+        conn::byte_streams(agent_write.compat_write(), agent_read.compat()),
+    );
+    tokio::task::spawn_local(async move {
+        let _ = agent_io.await;
+    });
+    let (client_conn, client_io) = conn::spawn_client(
+        acp::Client.builder().name("blocking-cancel-client"),
         conn::byte_streams(client_write.compat_write(), client_read.compat()),
     );
     tokio::task::spawn_local(async move {
@@ -2043,6 +2168,2547 @@ async fn master_reset_tab_session_resolves_owner_and_physically_retires_session(
         .await;
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn retirement_event_physically_closes_once_and_replays_completion() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let mut completions = capture_retirement_completions(&state).await;
+            let helper_id = HelperId(201);
+            let session_id = SessionId::new("retirement-live");
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let live_sessions = Arc::new(Mutex::new(HashSet::from([session_id.clone()])));
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_controlled_new_session_agent_with_close_result(
+                    events_tx,
+                    Arc::clone(&live_sessions),
+                    None,
+                    false,
+                    true,
+                ),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "retirement-live-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            register_retirement_tab(&state, &agent, helper_id, "tab-live", &session_id).await;
+
+            let event = serde_json::json!({
+                "method": "retire_agent_sessions",
+                "params": {
+                    "operation_id": "retire-live-op",
+                    "scope": "tabs",
+                    "tab_ids": ["tab-live"],
+                    "reason": "window_close"
+                }
+            });
+            handle_master_wt_event(&state, event.clone()).await;
+            handle_master_wt_event(&state, event.clone()).await;
+
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Cancel(ref sid)) if sid == &session_id
+            ));
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Close(ref sid)) if sid == &session_id
+            ));
+            let completion = completions
+                .recv()
+                .await
+                .expect("completion must be emitted");
+            assert_eq!(
+                completion,
+                serde_json::json!({
+                    "type": "event",
+                    "method": "agent_sessions_retired",
+                    "params": {
+                        "operation_id": "retire-live-op",
+                        "success": true,
+                        "reason": "window_close",
+                        "failed_tabs": []
+                    }
+                })
+            );
+            assert!(state.session_to_helper.lock().await.is_empty());
+            assert!(state.registry.lookup(&session_id).await.is_none());
+            assert!(!state.helper_meta.lock().await.contains_key(&helper_id));
+            assert!(live_sessions.lock().await.is_empty());
+            assert!(events_rx.try_recv().is_err());
+
+            handle_master_wt_event(&state, event).await;
+            assert_eq!(
+                completions.recv().await,
+                Some(completion),
+                "completed duplicate must replay the same process-wide completion"
+            );
+            assert!(
+                events_rx.try_recv().is_err(),
+                "duplicate operation id must not close the rebound session twice"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn retirement_event_with_no_sessions_still_emits_completion() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let mut completions = capture_retirement_completions(&state).await;
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-empty-op",
+                        "scope": "all",
+                        "tab_ids": [],
+                        "reason": "empty_shutdown"
+                    }
+                }),
+            )
+            .await;
+
+            assert_eq!(
+                completions.recv().await,
+                Some(serde_json::json!({
+                    "type": "event",
+                    "method": "agent_sessions_retired",
+                    "params": {
+                        "operation_id": "retire-empty-op",
+                        "success": true,
+                        "reason": "empty_shutdown",
+                        "failed_tabs": []
+                    }
+                }))
+            );
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn no_owner_retirement_fences_outgoing_publication_and_allows_replacement() {
+    let state = make_state();
+    let outgoing = HelperId(210);
+    let replacement = HelperId(211);
+    state.connected_helpers.lock().await.insert(outgoing);
+
+    assert_eq!(
+        begin_tab_retirement(&state, "tab-owner-race")
+            .await
+            .map(|target| target.helper_id),
+        None,
+        "the fence must exist even before ownership is published"
+    );
+
+    let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+    let outgoing_handler = HelperHandler {
+        helper_id: outgoing,
+        agent: Arc::new(OnceLock::new()),
+        state: Arc::clone(&state),
+        replacement_gate: Arc::new(Mutex::new(())),
+        notif_tx: notif_tx.clone(),
+        agent_side_slot: Arc::new(OnceLock::new()),
+    };
+    let mut outgoing_request =
+        acp::schema::v1::NewSessionRequest::new(PathBuf::from("C:\\owner-race"));
+    crate::session_registry::inject_wta_meta(
+        &mut outgoing_request.meta,
+        &crate::session_registry::WtaMeta {
+            owner_tab_id: Some("tab-owner-race".to_string()),
+            ..Default::default()
+        },
+    );
+    let error = outgoing_handler
+        .new_session(outgoing_request)
+        .await
+        .expect_err("the outgoing helper must not start session/new after fencing");
+    assert!(format!("{error}").contains("outgoing helper generation"));
+    assert!(!state
+        .pending_session_helpers
+        .lock()
+        .await
+        .contains_key(&outgoing));
+
+    complete_tab_retirement(&state, "tab-owner-race").await;
+    state.connected_helpers.lock().await.insert(replacement);
+    let replacement_handler = HelperHandler {
+        helper_id: replacement,
+        agent: Arc::new(OnceLock::new()),
+        state: Arc::clone(&state),
+        replacement_gate: Arc::new(Mutex::new(())),
+        notif_tx,
+        agent_side_slot: Arc::new(OnceLock::new()),
+    };
+    replacement_handler
+        .publish_pending_owner(Some("tab-owner-race".to_string()))
+        .await
+        .expect("a post-completion replacement helper must consume the fence");
+    assert_eq!(
+        state
+            .pending_session_helpers
+            .lock()
+            .await
+            .get(&replacement)
+            .and_then(Option::as_deref),
+        Some("tab-owner-race")
+    );
+    assert!(state.tab_retirement_fences.lock().await.is_empty());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn scope_all_fences_connected_helper_without_owner_after_completion() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let mut completions = capture_retirement_completions(&state).await;
+            let outgoing = HelperId(212);
+            let replacement = HelperId(213);
+            state.connected_helpers.lock().await.insert(outgoing);
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-all-ownerless-op",
+                        "scope": "all",
+                        "tab_ids": [],
+                        "reason": "window_close"
+                    }
+                }),
+            )
+            .await;
+            assert_eq!(completions.recv().await.unwrap()["params"]["success"], true);
+            assert!(state
+                .destructive_session_helpers
+                .lock()
+                .await
+                .contains(&outgoing));
+
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let outgoing_handler = HelperHandler {
+                helper_id: outgoing,
+                agent: Arc::new(OnceLock::new()),
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx: notif_tx.clone(),
+                agent_side_slot: Arc::new(OnceLock::new()),
+            };
+            let mut request =
+                acp::schema::v1::NewSessionRequest::new(PathBuf::from("C:\\late-owner"));
+            crate::session_registry::inject_wta_meta(
+                &mut request.meta,
+                &crate::session_registry::WtaMeta {
+                    owner_tab_id: Some("tab-late-owner".to_string()),
+                    ..Default::default()
+                },
+            );
+            let error = outgoing_handler
+                .new_session(request)
+                .await
+                .expect_err("captured outgoing helper must remain fenced after completion");
+            assert!(format!("{error}").contains("outgoing helper generation"));
+            assert!(state.pending_session_helpers.lock().await.is_empty());
+            assert!(state.session_to_helper.lock().await.is_empty());
+
+            state.connected_helpers.lock().await.insert(replacement);
+            let replacement_handler = HelperHandler {
+                helper_id: replacement,
+                agent: Arc::new(OnceLock::new()),
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx,
+                agent_side_slot: Arc::new(OnceLock::new()),
+            };
+            replacement_handler
+                .publish_pending_owner(Some("tab-late-owner".to_string()))
+                .await
+                .expect("a helper admitted after completion must not inherit the outgoing fence");
+            assert_eq!(
+                state
+                    .pending_session_helpers
+                    .lock()
+                    .await
+                    .get(&replacement)
+                    .and_then(Option::as_deref),
+                Some("tab-late-owner")
+            );
+
+            let (intentional, _) =
+                consume_disconnected_helper_retirement_state(&state, outgoing).await;
+            assert!(intentional);
+            assert!(!state
+                .destructive_session_helpers
+                .lock()
+                .await
+                .contains(&outgoing));
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn helper_connecting_during_scope_all_is_outgoing_but_replacement_is_admitted() {
+    let state = make_state();
+    assert!(begin_all_retirement(&state).await.helpers.is_empty());
+
+    let outgoing = HelperId(215);
+    register_connected_helper(&state, outgoing).await;
+    assert!(state
+        .all_retirement_fence
+        .lock()
+        .await
+        .outgoing_helpers
+        .contains(&outgoing));
+    assert!(state
+        .destructive_session_helpers
+        .lock()
+        .await
+        .contains(&outgoing));
+
+    let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+    let outgoing_handler = HelperHandler {
+        helper_id: outgoing,
+        agent: Arc::new(OnceLock::new()),
+        state: Arc::clone(&state),
+        replacement_gate: Arc::new(Mutex::new(())),
+        notif_tx: notif_tx.clone(),
+        agent_side_slot: Arc::new(OnceLock::new()),
+    };
+    let error = outgoing_handler
+        .publish_pending_owner(Some("tab-connect-during-all".to_string()))
+        .await
+        .expect_err("a helper admitted during scope=all must join its outgoing generation");
+    assert!(format!("{error}").contains("outgoing helper generation"));
+
+    assert!(
+        finish_all_retirement_batch(&state, &HashSet::from([outgoing]))
+            .await
+            .is_none()
+    );
+    let replacement = HelperId(216);
+    register_connected_helper(&state, replacement).await;
+    let replacement_handler = HelperHandler {
+        helper_id: replacement,
+        agent: Arc::new(OnceLock::new()),
+        state: Arc::clone(&state),
+        replacement_gate: Arc::new(Mutex::new(())),
+        notif_tx,
+        agent_side_slot: Arc::new(OnceLock::new()),
+    };
+    replacement_handler
+        .publish_pending_owner(Some("tab-connect-during-all".to_string()))
+        .await
+        .expect("a helper admitted after scope=all completion is a replacement");
+    assert!(!state
+        .destructive_session_helpers
+        .lock()
+        .await
+        .contains(&replacement));
+}
+
+#[tokio::test]
+async fn repeated_retire_disconnect_consumes_helper_tombstones_and_fences() {
+    let state = make_state();
+    let surviving_sibling = HelperId(299);
+    state
+        .connected_helpers
+        .lock()
+        .await
+        .insert(surviving_sibling);
+
+    for generation in 300..332 {
+        let helper_id = HelperId(generation);
+        let tab_id = format!("bounded-retirement-{generation}");
+        state.connected_helpers.lock().await.insert(helper_id);
+        state.helper_meta.lock().await.insert(
+            helper_id,
+            HelperRecoveryMeta {
+                owner_tab_id: Some(tab_id.clone()),
+                last_session_id: None,
+            },
+        );
+
+        assert_eq!(
+            begin_tab_retirement(&state, &tab_id)
+                .await
+                .map(|target| target.helper_id),
+            Some(helper_id)
+        );
+        complete_tab_retirement(&state, &tab_id).await;
+        let (intentional, _) =
+            consume_disconnected_helper_retirement_state(&state, helper_id).await;
+        assert!(intentional);
+        assert!(
+            state.tab_retirement_fences.lock().await.is_empty(),
+            "an unrelated connected sibling must not retain the retired tab fence"
+        );
+    }
+
+    assert_eq!(
+        *state.connected_helpers.lock().await,
+        HashSet::from([surviving_sibling])
+    );
+    assert!(state.closing_session_helpers.lock().await.is_empty());
+    assert!(state.destructive_session_helpers.lock().await.is_empty());
+    assert!(state.active_retirement_helpers.lock().await.is_empty());
+    assert!(state.closing_session_results.lock().await.is_empty());
+    assert!(state.tab_retirement_fences.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn repeated_disconnected_orphan_retirement_keeps_tombstones_and_fences_empty() {
+    let state = make_state();
+
+    for generation in 0..64 {
+        let helper_id = HelperId(500 + generation);
+        let tab_id = format!("disconnected-orphan-tab-{generation}");
+        let session_id = SessionId::new(format!("disconnected-orphan-session-{generation}"));
+        let agent_key = format!("disconnected-orphan-agent-{generation}");
+        state.orphaned_tabs.lock().await.insert(
+            tab_id.clone(),
+            (agent_key.clone(), helper_id, session_id.clone()),
+        );
+        state
+            .orphaned_sessions
+            .lock()
+            .await
+            .entry(agent_key)
+            .or_default()
+            .insert(session_id.clone());
+        state
+            .registry
+            .upsert(crate::session_registry::SessionInfo::new(
+                session_id.clone(),
+                PathBuf::from(format!("C:\\disconnected-orphan-{generation}")),
+            ))
+            .await;
+
+        assert_eq!(
+            retire_tab_transaction(
+                &state,
+                tab_id,
+                tokio::time::Instant::now() + std::time::Duration::from_secs(1),
+            )
+            .await,
+            ReplacedSessionCleanup::LogicalFallback
+        );
+        assert!(state.registry.lookup(&session_id).await.is_none());
+        assert!(state.orphaned_tabs.lock().await.is_empty());
+        assert!(state.orphaned_sessions.lock().await.is_empty());
+        assert!(state.tab_retirement_fences.lock().await.is_empty());
+        assert!(state.closing_session_helpers.lock().await.is_empty());
+        assert!(state.destructive_session_helpers.lock().await.is_empty());
+    }
+
+    assert!(state.connected_helpers.lock().await.is_empty());
+    assert!(state.active_retirement_helpers.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn repeated_ownerless_stale_tab_retirement_keeps_fences_bounded() {
+    let state = make_state();
+    let unresolved = HelperId(333);
+    let owned_elsewhere = HelperId(334);
+    state
+        .connected_helpers
+        .lock()
+        .await
+        .extend([unresolved, owned_elsewhere]);
+    state.helper_meta.lock().await.insert(
+        owned_elsewhere,
+        HelperRecoveryMeta {
+            owner_tab_id: Some("authoritative-other-tab".to_string()),
+            last_session_id: None,
+        },
+    );
+
+    for generation in 0..(OWNERLESS_RETIREMENT_TARGET_CAP + 32) {
+        let tab_id = format!("stale-ownerless-tab-{generation}");
+        assert_eq!(
+            begin_tab_retirement(&state, &tab_id)
+                .await
+                .map(|target| target.helper_id),
+            None
+        );
+        complete_tab_retirement(&state, &tab_id).await;
+    }
+
+    {
+        assert!(state.tab_retirement_fences.lock().await.is_empty());
+        let unresolved_state = state.unresolved_owner_retirements.lock().await;
+        assert_eq!(unresolved_state.len(), 1);
+        assert!(matches!(
+            unresolved_state.get(&unresolved),
+            Some(OwnerlessRetirementSafety::DenyNextOwner)
+        ));
+    }
+
+    let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+    let handler = HelperHandler {
+        helper_id: unresolved,
+        agent: Arc::new(OnceLock::new()),
+        state: Arc::clone(&state),
+        replacement_gate: Arc::new(Mutex::new(())),
+        notif_tx,
+        agent_side_slot: Arc::new(OnceLock::new()),
+    };
+    handler
+        .publish_pending_owner(Some("actual-unrelated-tab".to_string()))
+        .await
+        .expect_err("overflow must conservatively deny the next owner publication");
+    assert!(
+        state.unresolved_owner_retirements.lock().await.is_empty(),
+        "the bounded deny-next-owner state must be consumed"
+    );
+}
+
+#[tokio::test]
+async fn ownerless_helper_cannot_claim_old_retired_tab_after_prior_fence_limits() {
+    let state = make_state();
+    let helper_id = HelperId(335);
+    state.connected_helpers.lock().await.insert(helper_id);
+
+    for generation in 0..300 {
+        let tab_id = format!("retired-ownerless-tab-{generation}");
+        assert_eq!(
+            begin_tab_retirement(&state, &tab_id)
+                .await
+                .map(|target| target.helper_id),
+            None
+        );
+        complete_tab_retirement(&state, &tab_id).await;
+    }
+
+    let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+    let handler = HelperHandler {
+        helper_id,
+        agent: Arc::new(OnceLock::new()),
+        state: Arc::clone(&state),
+        replacement_gate: Arc::new(Mutex::new(())),
+        notif_tx,
+        agent_side_slot: Arc::new(OnceLock::new()),
+    };
+    handler
+        .publish_pending_owner(Some("retired-ownerless-tab-0".to_string()))
+        .await
+        .expect_err("collapsed ownerless safety must preserve the oldest retired target");
+    assert!(state
+        .destructive_session_helpers
+        .lock()
+        .await
+        .contains(&helper_id));
+}
+
+#[tokio::test]
+async fn ownerless_helper_publishing_different_owner_clears_unrelated_safety() {
+    let state = make_state();
+    let helper_id = HelperId(336);
+    state.connected_helpers.lock().await.insert(helper_id);
+    assert_eq!(
+        begin_tab_retirement(&state, "retired-unrelated-tab")
+            .await
+            .map(|target| target.helper_id),
+        None
+    );
+    complete_tab_retirement(&state, "retired-unrelated-tab").await;
+
+    let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+    let handler = HelperHandler {
+        helper_id,
+        agent: Arc::new(OnceLock::new()),
+        state: Arc::clone(&state),
+        replacement_gate: Arc::new(Mutex::new(())),
+        notif_tx,
+        agent_side_slot: Arc::new(OnceLock::new()),
+    };
+    handler
+        .publish_pending_owner(Some("authoritative-live-tab".to_string()))
+        .await
+        .expect("a different authoritative owner safely resolves the helper");
+    assert!(state.unresolved_owner_retirements.lock().await.is_empty());
+    assert_eq!(
+        state
+            .pending_session_helpers
+            .lock()
+            .await
+            .get(&helper_id)
+            .and_then(Option::as_deref),
+        Some("authoritative-live-tab")
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn scope_all_retires_ownerless_helper_live_route_directly() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let mut completions = capture_retirement_completions(&state).await;
+            let helper_id = HelperId(337);
+            let session_id = SessionId::new("ownerless-live-route");
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let live_sessions = Arc::new(Mutex::new(HashSet::from([session_id.clone()])));
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_controlled_new_session_agent_with_close_result(
+                    events_tx,
+                    Arc::clone(&live_sessions),
+                    None,
+                    true,
+                    true,
+                ),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "ownerless-live-route-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            state.connected_helpers.lock().await.insert(helper_id);
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            bind_session_route(
+                &state,
+                session_id.clone(),
+                HelperRoute {
+                    helper_id,
+                    agent_instance_id: agent.instance_id,
+                    notif_tx,
+                    forwarder: None,
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+            state
+                .registry
+                .upsert(crate::session_registry::SessionInfo::new(
+                    session_id.clone(),
+                    PathBuf::from("C:\\ownerless-live"),
+                ))
+                .await;
+            state.helper_meta.lock().await.insert(
+                helper_id,
+                HelperRecoveryMeta {
+                    owner_tab_id: None,
+                    last_session_id: Some(session_id.clone()),
+                },
+            );
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry(agent.cmd_key.clone())
+                .or_default()
+                .insert(session_id.clone());
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-all-ownerless-live",
+                        "scope": "all",
+                        "tab_ids": [],
+                        "reason": "window_close"
+                    }
+                }),
+            )
+            .await;
+
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Cancel(ref sid)) if sid == &session_id
+            ));
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Close(ref sid)) if sid == &session_id
+            ));
+            let completion = completions.recv().await.unwrap();
+            assert_eq!(completion["params"]["success"], false);
+            assert_eq!(completion["params"]["failed_tabs"], serde_json::json!([]));
+            assert_eq!(
+                completion["params"]["unattributed_failures"]["count"],
+                serde_json::json!(1)
+            );
+            assert!(state.session_to_helper.lock().await.is_empty());
+            assert!(state.registry.lookup(&session_id).await.is_none());
+            assert!(!state.helper_meta.lock().await.contains_key(&helper_id));
+            assert!(state.orphaned_tabs.lock().await.is_empty());
+            assert!(state.orphaned_sessions.lock().await.is_empty());
+            assert_eq!(
+                *live_sessions.lock().await,
+                HashSet::from([session_id]),
+                "ownerless logical fallback must report failure while retiring WTA state"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn scope_all_captured_helper_disconnect_still_closes_once() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(339);
+            let session_id = SessionId::new("captured-disconnect-close");
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let live_sessions = Arc::new(Mutex::new(HashSet::from([session_id.clone()])));
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_controlled_new_session_agent_with_close_result(
+                    events_tx,
+                    Arc::clone(&live_sessions),
+                    None,
+                    false,
+                    true,
+                ),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "captured-disconnect-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            register_retirement_tab(
+                &state,
+                &agent,
+                helper_id,
+                "tab-captured-disconnect",
+                &session_id,
+            )
+            .await;
+
+            let mut targets = begin_all_retirement(&state).await;
+            assert_eq!(targets.helpers.len(), 1);
+            assert_eq!(
+                drop_sessions_for_helper(&state, helper_id).await,
+                vec![session_id.clone()]
+            );
+            let (intentional, _) =
+                consume_disconnected_helper_retirement_state(&state, helper_id).await;
+            assert!(intentional);
+
+            let (retired_helper, owner_tab, cleanup) = retire_helper_transaction(
+                &state,
+                targets.helpers.pop().unwrap(),
+                tokio::time::Instant::now() + std::time::Duration::from_secs(1),
+            )
+            .await;
+            assert_eq!(retired_helper, helper_id);
+            assert_eq!(owner_tab.as_deref(), Some("tab-captured-disconnect"));
+            assert_eq!(cleanup, ReplacedSessionCleanup::PhysicallyClosed);
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Cancel(ref sid)) if sid == &session_id
+            ));
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Close(ref sid)) if sid == &session_id
+            ));
+            assert!(
+                events_rx.try_recv().is_err(),
+                "captured retirement must close the disconnected session exactly once"
+            );
+            assert!(state.session_to_helper.lock().await.is_empty());
+            assert!(live_sessions.lock().await.is_empty());
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn scope_all_retirement_captures_orphan_after_route_drop_before_connected_helper_removal() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let mut completions = capture_retirement_completions(&state).await;
+            let helper_id = HelperId(340);
+            let tab_id = "tab-disconnect-ordering";
+            let session_id = SessionId::new("disconnect-ordering-close");
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let live_sessions = Arc::new(Mutex::new(HashSet::from([session_id.clone()])));
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_controlled_new_session_agent_with_close_result(
+                    events_tx,
+                    Arc::clone(&live_sessions),
+                    None,
+                    false,
+                    true,
+                ),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "disconnect-ordering-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            register_retirement_tab(&state, &agent, helper_id, tab_id, &session_id).await;
+
+            state.orphaned_tabs.lock().await.insert(
+                tab_id.to_string(),
+                (agent.cmd_key.clone(), helper_id, session_id.clone()),
+            );
+            assert_eq!(
+                drop_sessions_for_helper(&state, helper_id).await,
+                vec![session_id.clone()]
+            );
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry(agent.cmd_key.clone())
+                .or_default()
+                .insert(session_id.clone());
+            assert!(
+                state.connected_helpers.lock().await.contains(&helper_id),
+                "disconnect has not removed the helper from the connected set yet"
+            );
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-disconnect-ordering",
+                        "scope": "all",
+                        "tab_ids": [],
+                        "reason": "window_close"
+                    }
+                }),
+            )
+            .await;
+
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Cancel(ref sid)) if sid == &session_id
+            ));
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Close(ref sid)) if sid == &session_id
+            ));
+            assert_eq!(completions.recv().await.unwrap()["params"]["success"], true);
+            assert!(
+                events_rx.try_recv().is_err(),
+                "captured orphan must be cancelled and closed exactly once"
+            );
+            assert!(state.orphaned_tabs.lock().await.is_empty());
+            assert!(state.orphaned_sessions.lock().await.is_empty());
+            assert!(live_sessions.lock().await.is_empty());
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn retirement_completed_after_route_drop_cannot_republish_orphan() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let mut completions = capture_retirement_completions(&state).await;
+            let helper_id = HelperId(342);
+            let replacement_helper_id = HelperId(343);
+            let tab_id = "tab-disconnect-retirement-race";
+            let session_id = SessionId::new("disconnect-retirement-race");
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let live_sessions = Arc::new(Mutex::new(HashSet::from([session_id.clone()])));
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_controlled_new_session_agent_with_close_result(
+                    events_tx,
+                    Arc::clone(&live_sessions),
+                    None,
+                    false,
+                    true,
+                ),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "disconnect-retirement-race-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            register_retirement_tab(&state, &agent, helper_id, tab_id, &session_id).await;
+            state.orphaned_tabs.lock().await.insert(
+                tab_id.to_string(),
+                (agent.cmd_key.clone(), helper_id, session_id.clone()),
+            );
+
+            let pause = Arc::new(DisconnectOrphanPublicationPause::default());
+            *state.disconnect_orphan_publication_pause.lock().await = Some(Arc::clone(&pause));
+            let disconnect = tokio::task::spawn_local({
+                let state = Arc::clone(&state);
+                let agent = Arc::clone(&agent);
+                let orphan_tab_candidate = (tab_id.to_string(), session_id.clone());
+                async move {
+                    drop_and_publish_disconnected_helper_sessions(
+                        &state,
+                        helper_id,
+                        Some(&agent),
+                        Some(&orphan_tab_candidate),
+                    )
+                    .await
+                }
+            });
+
+            pause.routes_dropped.notified().await;
+            assert!(state.session_to_helper.lock().await.is_empty());
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-disconnect-publication-race",
+                        "scope": "all",
+                        "tab_ids": [],
+                        "reason": "window_close"
+                    }
+                }),
+            )
+            .await;
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Cancel(ref sid)) if sid == &session_id
+            ));
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Close(ref sid)) if sid == &session_id
+            ));
+            assert_eq!(completions.recv().await.unwrap()["params"]["success"], true);
+            assert!(live_sessions.lock().await.is_empty());
+
+            pause.resume_publication.notify_one();
+            assert_eq!(
+                disconnect.await.expect("disconnect cleanup should finish"),
+                vec![session_id.clone()]
+            );
+            assert!(
+                state.orphaned_sessions.lock().await.is_empty(),
+                "retired session must not be republished as an orphan"
+            );
+            let (intentional, _) =
+                consume_disconnected_helper_retirement_state(&state, helper_id).await;
+            assert!(intentional);
+
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let agent_slot = Arc::new(OnceLock::new());
+            assert!(agent_slot.set(Arc::clone(&agent)).is_ok());
+            let agent_side_slot = Arc::new(OnceLock::new());
+            agent_side_slot
+                .set(agent_link_to_noop_client())
+                .expect("agent-side forwarder should be set once");
+            let replacement = HelperHandler {
+                helper_id: replacement_helper_id,
+                agent: agent_slot,
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx,
+                agent_side_slot,
+            };
+            replacement
+                .load_session_with_timeout(
+                    acp::schema::v1::LoadSessionRequest::new(
+                        session_id.clone(),
+                        PathBuf::from("C:\\retired"),
+                    ),
+                    std::time::Duration::from_secs(1),
+                )
+                .await
+                .expect("later resume should perform a real session/load");
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Load(ref sid)) if sid == &session_id
+            ));
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn disconnect_orphan_publication_skips_tab_closed_session() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(345);
+            let tab_id = "tab-disconnect-ordinary-close-race";
+            let session_id = SessionId::new("disconnect-ordinary-close-race");
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let live_sessions = Arc::new(Mutex::new(HashSet::from([session_id.clone()])));
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_controlled_new_session_agent_with_close_result(
+                    events_tx,
+                    Arc::clone(&live_sessions),
+                    None,
+                    false,
+                    true,
+                ),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "disconnect-ordinary-close-race-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            register_retirement_tab(&state, &agent, helper_id, tab_id, &session_id).await;
+            state.orphaned_tabs.lock().await.insert(
+                tab_id.to_string(),
+                (agent.cmd_key.clone(), helper_id, session_id.clone()),
+            );
+
+            let pause = Arc::new(DisconnectOrphanPublicationPause::default());
+            *state.disconnect_orphan_publication_pause.lock().await = Some(Arc::clone(&pause));
+            let disconnect = tokio::task::spawn_local({
+                let state = Arc::clone(&state);
+                let agent = Arc::clone(&agent);
+                let orphan_tab_candidate = (tab_id.to_string(), session_id.clone());
+                async move {
+                    drop_and_publish_disconnected_helper_sessions(
+                        &state,
+                        helper_id,
+                        Some(&agent),
+                        Some(&orphan_tab_candidate),
+                    )
+                    .await
+                }
+            });
+
+            pause.routes_dropped.notified().await;
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "tab_closed",
+                    "params": {
+                        "tab_id": tab_id
+                    }
+                }),
+            )
+            .await;
+
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Cancel(ref sid)) if sid == &session_id
+            ));
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Close(ref sid)) if sid == &session_id
+            ));
+            assert!(live_sessions.lock().await.is_empty());
+            assert!(state
+                .closing_session_helpers
+                .lock()
+                .await
+                .contains(&helper_id));
+
+            pause.resume_publication.notify_one();
+            assert_eq!(
+                disconnect.await.expect("disconnect cleanup should finish"),
+                vec![session_id.clone()]
+            );
+            assert!(
+                state.orphaned_sessions.lock().await.is_empty(),
+                "physically closed tab session must not be published as an orphan"
+            );
+
+            let (intentional, _) =
+                consume_disconnected_helper_retirement_state(&state, helper_id).await;
+            assert!(intentional);
+            assert!(state.closing_session_helpers.lock().await.is_empty());
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn disconnect_orphan_publication_skips_rebound_session() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(346);
+            let replacement_helper_id = HelperId(347);
+            let session_id = SessionId::new("disconnect-rebind-race");
+            let (events_tx, _events_rx) = mpsc::unbounded_channel();
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_controlled_new_session_agent(
+                    events_tx,
+                    Arc::new(Mutex::new(HashSet::from([session_id.clone()]))),
+                    None,
+                ),
+                cached_init_resp: acp::schema::v1::InitializeResponse::new(
+                    acp::schema::ProtocolVersion::V1,
+                ),
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "disconnect-rebind-race-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            let (original_tx, _original_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            bind_session_route(
+                &state,
+                session_id.clone(),
+                HelperRoute {
+                    helper_id,
+                    agent_instance_id: agent.instance_id,
+                    notif_tx: original_tx,
+                    forwarder: None,
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+
+            let pause = Arc::new(DisconnectOrphanPublicationPause::default());
+            *state.disconnect_orphan_publication_pause.lock().await = Some(Arc::clone(&pause));
+            let disconnect = tokio::task::spawn_local({
+                let state = Arc::clone(&state);
+                let agent = Arc::clone(&agent);
+                async move {
+                    drop_and_publish_disconnected_helper_sessions(
+                        &state,
+                        helper_id,
+                        Some(&agent),
+                        None,
+                    )
+                    .await
+                }
+            });
+
+            pause.routes_dropped.notified().await;
+            let (replacement_tx, _replacement_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            bind_session_route(
+                &state,
+                session_id.clone(),
+                HelperRoute {
+                    helper_id: replacement_helper_id,
+                    agent_instance_id: agent.instance_id,
+                    notif_tx: replacement_tx,
+                    forwarder: None,
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+
+            pause.resume_publication.notify_one();
+            assert_eq!(
+                disconnect.await.expect("disconnect cleanup should finish"),
+                vec![session_id.clone()]
+            );
+            assert!(
+                state.orphaned_sessions.lock().await.is_empty(),
+                "a session rebound before publication must not retain an orphan marker"
+            );
+            assert_eq!(
+                state
+                    .session_to_helper
+                    .lock()
+                    .await
+                    .get(&session_id)
+                    .map(|route| route.helper_id),
+                Some(replacement_helper_id)
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn unexpected_disconnect_still_publishes_orphan() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(344);
+            let session_id = SessionId::new("unexpected-disconnect-orphan");
+            let (events_tx, _events_rx) = mpsc::unbounded_channel();
+            let live_sessions = Arc::new(Mutex::new(HashSet::from([session_id.clone()])));
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_controlled_new_session_agent(
+                    events_tx,
+                    live_sessions,
+                    None,
+                ),
+                cached_init_resp: acp::schema::v1::InitializeResponse::new(
+                    acp::schema::ProtocolVersion::V1,
+                ),
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "unexpected-disconnect-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            bind_session_route(
+                &state,
+                session_id.clone(),
+                HelperRoute {
+                    helper_id,
+                    agent_instance_id: agent.instance_id,
+                    notif_tx,
+                    forwarder: None,
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+
+            drop_and_publish_disconnected_helper_sessions(&state, helper_id, Some(&agent), None)
+                .await;
+
+            assert!(state
+                .orphaned_sessions
+                .lock()
+                .await
+                .get(&agent.cmd_key)
+                .is_some_and(|sessions| sessions.contains(&session_id)));
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn orphan_retirement_blocked_lifecycle_gate_uses_total_budget() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let retirement_budget = std::time::Duration::from_millis(40);
+            let state = make_state_with_retirement_pending_timeout(retirement_budget);
+            let mut completions = capture_retirement_completions(&state).await;
+            let helper_id = HelperId(348);
+            let tab_id = "tab-blocked-orphan-gate";
+            let session_id = SessionId::new("blocked-orphan-gate");
+            let agent_key = "blocked-orphan-gate-agent".to_string();
+            state.orphaned_tabs.lock().await.insert(
+                tab_id.to_string(),
+                (agent_key.clone(), helper_id, session_id.clone()),
+            );
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry(agent_key)
+                .or_default()
+                .insert(session_id.clone());
+            state
+                .registry
+                .upsert(crate::session_registry::SessionInfo::new(
+                    session_id.clone(),
+                    PathBuf::from("C:\\blocked-orphan-gate"),
+                ))
+                .await;
+
+            let gate = session_lifecycle_gate(&state, &session_id).await;
+            let gate_guard = gate.lock().await;
+            let started = tokio::time::Instant::now();
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-blocked-orphan-gate",
+                        "scope": "tabs",
+                        "tab_ids": [tab_id],
+                        "reason": "window_close"
+                    }
+                }),
+            )
+            .await;
+
+            let completion =
+                tokio::time::timeout(std::time::Duration::from_millis(500), completions.recv())
+                    .await
+                    .expect("blocked orphan gate must not start another timeout budget")
+                    .expect("blocked orphan gate must publish completion");
+            assert_eq!(completion["params"]["success"], false);
+            assert_eq!(
+                completion["params"]["failed_tabs"],
+                serde_json::json!([tab_id])
+            );
+            assert!(
+                started.elapsed() < std::time::Duration::from_millis(500),
+                "blocked orphan gate must remain bounded by the retirement deadline"
+            );
+            assert!(state.orphaned_tabs.lock().await.is_empty());
+            assert!(state.orphaned_sessions.lock().await.is_empty());
+            assert!(state.registry.lookup(&session_id).await.is_none());
+            drop(gate_guard);
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn orphan_retirement_blocked_cancel_uses_total_budget() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let retirement_budget = std::time::Duration::from_millis(40);
+            let state = make_state_with_retirement_pending_timeout(retirement_budget);
+            let mut completions = capture_retirement_completions(&state).await;
+            let helper_id = HelperId(349);
+            let tab_id = "tab-blocked-orphan-cancel";
+            let session_id = SessionId::new("blocked-orphan-cancel");
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_blocking_cancel_agent(events_tx),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "blocked-orphan-cancel-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            state.orphaned_tabs.lock().await.insert(
+                tab_id.to_string(),
+                (agent.cmd_key.clone(), helper_id, session_id.clone()),
+            );
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry(agent.cmd_key.clone())
+                .or_default()
+                .insert(session_id.clone());
+            state
+                .registry
+                .upsert(crate::session_registry::SessionInfo::new(
+                    session_id.clone(),
+                    PathBuf::from("C:\\blocked-orphan-cancel"),
+                ))
+                .await;
+
+            let started = tokio::time::Instant::now();
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-blocked-orphan-cancel",
+                        "scope": "tabs",
+                        "tab_ids": [tab_id],
+                        "reason": "window_close"
+                    }
+                }),
+            )
+            .await;
+            let ReplacementEvent::BlockingCancel(cancelled_session, _release) = events_rx
+                .recv()
+                .await
+                .expect("orphan retirement must attempt cancellation")
+            else {
+                panic!("expected blocking orphan cancellation");
+            };
+            assert_eq!(cancelled_session, session_id);
+
+            let completion =
+                tokio::time::timeout(std::time::Duration::from_millis(500), completions.recv())
+                    .await
+                    .expect("blocked orphan cancel must not start another timeout budget")
+                    .expect("blocked orphan cancel must publish completion");
+            assert_eq!(completion["params"]["success"], false);
+            assert_eq!(
+                completion["params"]["failed_tabs"],
+                serde_json::json!([tab_id])
+            );
+            assert!(
+                started.elapsed() < std::time::Duration::from_millis(500),
+                "blocked orphan cancel must remain bounded by the retirement deadline"
+            );
+            assert!(state.orphaned_tabs.lock().await.is_empty());
+            assert!(state.orphaned_sessions.lock().await.is_empty());
+            assert!(state.registry.lookup(&session_id).await.is_none());
+            assert!(
+                events_rx.try_recv().is_err(),
+                "session/close must not start after cancellation consumes the deadline"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn scope_all_physically_closes_ownerless_orphaned_session() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let mut completions = capture_retirement_completions(&state).await;
+            let session_id = SessionId::new("ownerless-orphan-physical-close");
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let live_sessions = Arc::new(Mutex::new(HashSet::from([session_id.clone()])));
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_controlled_new_session_agent_with_close_result(
+                    events_tx,
+                    Arc::clone(&live_sessions),
+                    None,
+                    false,
+                    true,
+                ),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "ownerless-orphan-physical-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry(agent.cmd_key.clone())
+                .or_default()
+                .insert(session_id.clone());
+            state
+                .registry
+                .upsert(crate::session_registry::SessionInfo::new(
+                    session_id.clone(),
+                    PathBuf::from("C:\\ownerless-orphan-physical"),
+                ))
+                .await;
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-ownerless-orphan-physical",
+                        "scope": "all",
+                        "tab_ids": [],
+                        "reason": "window_close"
+                    }
+                }),
+            )
+            .await;
+
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Cancel(ref sid)) if sid == &session_id
+            ));
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Close(ref sid)) if sid == &session_id
+            ));
+            assert_eq!(completions.recv().await.unwrap()["params"]["success"], true);
+            assert!(live_sessions.lock().await.is_empty());
+            assert!(state.orphaned_sessions.lock().await.is_empty());
+            assert!(state.registry.lookup(&session_id).await.is_none());
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn scope_all_preserves_ownerless_orphan_claimed_by_replacement_route() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let mut completions = capture_retirement_completions(&state).await;
+            let replacement_helper_id = HelperId(350);
+            let session_id = SessionId::new("ownerless-orphan-rebound");
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let live_sessions = Arc::new(Mutex::new(HashSet::from([session_id.clone()])));
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_controlled_new_session_agent_with_close_result(
+                    events_tx,
+                    Arc::clone(&live_sessions),
+                    None,
+                    false,
+                    true,
+                ),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "ownerless-orphan-rebound-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry(agent.cmd_key.clone())
+                .or_default()
+                .insert(session_id.clone());
+            state
+                .registry
+                .upsert(crate::session_registry::SessionInfo::new(
+                    session_id.clone(),
+                    PathBuf::from("C:\\ownerless-orphan-rebound"),
+                ))
+                .await;
+
+            let gate = session_lifecycle_gate(&state, &session_id).await;
+            let gate_guard = gate.lock().await;
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-ownerless-orphan-rebound",
+                        "scope": "all",
+                        "tab_ids": [],
+                        "reason": "window_close"
+                    }
+                }),
+            )
+            .await;
+            tokio::task::yield_now().await;
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            state.session_to_helper.lock().await.insert(
+                session_id.clone(),
+                HelperRoute {
+                    helper_id: replacement_helper_id,
+                    agent_instance_id: agent.instance_id,
+                    notif_tx,
+                    forwarder: None,
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            );
+            drop(gate_guard);
+
+            assert_eq!(completions.recv().await.unwrap()["params"]["success"], true);
+            assert_eq!(
+                state
+                    .session_to_helper
+                    .lock()
+                    .await
+                    .get(&session_id)
+                    .map(|route| route.helper_id),
+                Some(replacement_helper_id)
+            );
+            assert!(state.registry.lookup(&session_id).await.is_some());
+            assert_eq!(
+                *live_sessions.lock().await,
+                HashSet::from([session_id.clone()])
+            );
+            assert!(state.orphaned_sessions.lock().await.is_empty());
+            assert!(
+                events_rx.try_recv().is_err(),
+                "a replacement route must suppress orphan cancel and close"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn scope_all_ownerless_orphan_unavailable_agent_uses_logical_fallback() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let mut completions = capture_retirement_completions(&state).await;
+            let session_id = SessionId::new("ownerless-orphan-unavailable");
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry("ownerless-orphan-unavailable-agent".to_string())
+                .or_default()
+                .insert(session_id.clone());
+            state
+                .registry
+                .upsert(crate::session_registry::SessionInfo::new(
+                    session_id.clone(),
+                    PathBuf::from("C:\\ownerless-orphan-unavailable"),
+                ))
+                .await;
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-ownerless-orphan-unavailable",
+                        "scope": "all",
+                        "tab_ids": [],
+                        "reason": "window_close"
+                    }
+                }),
+            )
+            .await;
+
+            let completion = completions.recv().await.unwrap();
+            assert_eq!(completion["params"]["success"], false);
+            assert_eq!(completion["params"]["failed_tabs"], serde_json::json!([]));
+            assert_eq!(
+                completion["params"]["unattributed_failures"]["count"],
+                serde_json::json!(1)
+            );
+            assert!(state.orphaned_sessions.lock().await.is_empty());
+            assert!(state.registry.lookup(&session_id).await.is_none());
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn scope_all_retirement_reports_failure_when_outgoing_orphan_agent_is_unavailable() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let mut completions = capture_retirement_completions(&state).await;
+            let helper_id = HelperId(341);
+            let tab_id = "tab-unavailable-orphan";
+            let session_id = SessionId::new("unavailable-orphan");
+            state.connected_helpers.lock().await.insert(helper_id);
+            state.helper_meta.lock().await.insert(
+                helper_id,
+                HelperRecoveryMeta {
+                    owner_tab_id: Some(tab_id.to_string()),
+                    last_session_id: Some(session_id.clone()),
+                },
+            );
+            state.orphaned_tabs.lock().await.insert(
+                tab_id.to_string(),
+                (
+                    "unavailable-orphan-agent".to_string(),
+                    helper_id,
+                    session_id.clone(),
+                ),
+            );
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry("unavailable-orphan-agent".to_string())
+                .or_default()
+                .insert(session_id);
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-unavailable-orphan",
+                        "scope": "all",
+                        "tab_ids": [],
+                        "reason": "window_close"
+                    }
+                }),
+            )
+            .await;
+
+            let completion = completions.recv().await.unwrap();
+            assert_eq!(completion["params"]["success"], false);
+            assert_eq!(
+                completion["params"]["failed_tabs"],
+                serde_json::json!([tab_id])
+            );
+            assert!(state.orphaned_tabs.lock().await.is_empty());
+            assert!(state.orphaned_sessions.lock().await.is_empty());
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn scope_all_waits_for_ownerless_pending_transaction_cleanup() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let mut completions = capture_retirement_completions(&state).await;
+            let helper_id = HelperId(338);
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let live_sessions = Arc::new(Mutex::new(HashSet::new()));
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_controlled_new_session_agent(
+                    events_tx,
+                    Arc::clone(&live_sessions),
+                    None,
+                ),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "ownerless-pending-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            state.connected_helpers.lock().await.insert(helper_id);
+            let agent_slot = Arc::new(OnceLock::new());
+            assert!(agent_slot.set(Arc::clone(&agent)).is_ok());
+            let agent_side_slot = Arc::new(OnceLock::new());
+            agent_side_slot
+                .set(agent_link_to_noop_client())
+                .expect("agent-side forwarder should be initialized");
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let handler = HelperHandler {
+                helper_id,
+                agent: agent_slot,
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx,
+                agent_side_slot,
+            };
+            let new_task = tokio::task::spawn_local(async move {
+                handler
+                    .new_session(acp::schema::v1::NewSessionRequest::new(PathBuf::from(
+                        "C:\\ownerless-pending",
+                    )))
+                    .await
+            });
+            let ReplacementEvent::New(_, release_new) =
+                events_rx.recv().await.expect("session/new must block")
+            else {
+                panic!("expected controlled session/new");
+            };
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-all-ownerless-pending",
+                        "scope": "all",
+                        "tab_ids": [],
+                        "reason": "window_close"
+                    }
+                }),
+            )
+            .await;
+            tokio::task::yield_now().await;
+            assert!(
+                completions.try_recv().is_err(),
+                "scope=all must wait for the captured pending transaction"
+            );
+
+            release_new.send(()).unwrap();
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Close(_))
+            ));
+            let mut response = new_task.await.unwrap().unwrap();
+            assert_eq!(
+                crate::session_registry::extract_wta_meta(&mut response.meta)
+                    .session_result
+                    .as_deref(),
+                Some("retired")
+            );
+            assert_eq!(completions.recv().await.unwrap()["params"]["success"], true);
+            assert!(state.pending_session_helpers.lock().await.is_empty());
+            assert!(state.pending_session_mcp.lock().await.is_empty());
+            assert!(state.session_to_helper.lock().await.is_empty());
+            assert!(state.registry.lookup(&response.session_id).await.is_none());
+            assert!(!state.helper_meta.lock().await.contains_key(&helper_id));
+            assert!(live_sessions.lock().await.is_empty());
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn scope_all_unsupported_retirement_reports_failed_owner_tab() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let mut completions = capture_retirement_completions(&state).await;
+            let helper_id = HelperId(202);
+            let session_id = SessionId::new("retirement-unsupported");
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let live_sessions = Arc::new(Mutex::new(HashSet::from([session_id.clone()])));
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_controlled_new_session_agent_with_close_result(
+                    events_tx,
+                    Arc::clone(&live_sessions),
+                    None,
+                    false,
+                    true,
+                ),
+                cached_init_resp: acp::schema::v1::InitializeResponse::new(
+                    acp::schema::ProtocolVersion::V1,
+                ),
+                cli_source: Some(crate::agent_sessions::CliSource::Gemini),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "retirement-unsupported-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            register_retirement_tab(&state, &agent, helper_id, "tab-unsupported", &session_id)
+                .await;
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-unsupported-op",
+                        "scope": "all",
+                        "tab_ids": [],
+                        "reason": "profile_delete"
+                    }
+                }),
+            )
+            .await;
+
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Cancel(ref sid)) if sid == &session_id
+            ));
+            assert!(events_rx.try_recv().is_err());
+            let completion = completions
+                .recv()
+                .await
+                .expect("completion must be emitted");
+            assert_eq!(completion["params"]["success"], false);
+            assert_eq!(
+                completion["params"]["failed_tabs"],
+                serde_json::json!(["tab-unsupported"])
+            );
+            assert!(state.session_to_helper.lock().await.is_empty());
+            assert!(state.registry.lookup(&session_id).await.is_none());
+            assert!(!state.helper_meta.lock().await.contains_key(&helper_id));
+            assert_eq!(
+                *live_sessions.lock().await,
+                HashSet::from([session_id]),
+                "unsupported provider remains physically live but loses every WTA route"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn scope_all_starts_independent_session_closes_concurrently() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let mut completions = capture_retirement_completions(&state).await;
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent_a = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_blocking_close_agent(events_tx.clone()),
+                cached_init_resp: cached_init_resp.clone(),
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "retirement-all-agent-a".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let agent_b = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_blocking_close_agent(events_tx),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Gemini),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "retirement-all-agent-b".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell_a = Arc::new(tokio::sync::OnceCell::new());
+            let cell_b = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell_a.set(Arc::clone(&agent_a)).is_ok());
+            assert!(cell_b.set(Arc::clone(&agent_b)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent_a.cmd_key.clone(), cell_a);
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent_b.cmd_key.clone(), cell_b);
+            register_retirement_tab(
+                &state,
+                &agent_a,
+                HelperId(203),
+                "tab-all-a",
+                &SessionId::new("retirement-all-a"),
+            )
+            .await;
+            let orphan_session = SessionId::new("retirement-all-b");
+            state.orphaned_tabs.lock().await.insert(
+                "tab-all-b".to_string(),
+                (
+                    agent_b.cmd_key.clone(),
+                    HelperId(204),
+                    orphan_session.clone(),
+                ),
+            );
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry(agent_b.cmd_key.clone())
+                .or_default()
+                .insert(orphan_session.clone());
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-all-op",
+                        "scope": "all",
+                        "tab_ids": [],
+                        "reason": "shutdown"
+                    }
+                }),
+            )
+            .await;
+
+            let first = events_rx.recv().await.expect("first close must start");
+            let second =
+                tokio::time::timeout(std::time::Duration::from_millis(100), events_rx.recv())
+                    .await
+                    .expect("second close must start before the first 15s close completes")
+                    .expect("second close event must exist");
+            let mut helper_release = None;
+            let mut orphan_release = None;
+            let mut closed = HashSet::new();
+            for event in [first, second] {
+                let ReplacementEvent::BlockingClose(session_id, release) = event else {
+                    panic!("scope=all must issue session/close for each live tab");
+                };
+                if session_id == orphan_session {
+                    orphan_release = Some(release);
+                } else {
+                    helper_release = Some(release);
+                }
+                closed.insert(session_id);
+            }
+            assert_eq!(
+                closed,
+                HashSet::from([
+                    SessionId::new("retirement-all-a"),
+                    SessionId::new("retirement-all-b")
+                ])
+            );
+            orphan_release.unwrap().send(()).unwrap();
+            tokio::time::timeout(std::time::Duration::from_millis(100), async {
+                while state.orphaned_tabs.lock().await.contains_key("tab-all-b") {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("independent orphan retirement must finish while helper close is blocked");
+            assert!(
+                completions.try_recv().is_err(),
+                "the blocked helper still gates overall completion"
+            );
+            helper_release.unwrap().send(()).unwrap();
+            assert_eq!(completions.recv().await.unwrap()["params"]["success"], true);
+            assert!(state.session_to_helper.lock().await.is_empty());
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn retirement_uses_one_deadline_for_close_wait_and_forced_cleanup() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let retirement_budget = std::time::Duration::from_millis(40);
+            let state = make_state_with_retirement_pending_timeout(retirement_budget);
+            let mut completions = capture_retirement_completions(&state).await;
+            let helper_id = HelperId(214);
+            let session_id = SessionId::new("retirement-single-deadline");
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_blocking_close_agent(events_tx),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "retirement-single-deadline-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            register_retirement_tab(
+                &state,
+                &agent,
+                helper_id,
+                "tab-single-deadline",
+                &session_id,
+            )
+            .await;
+            state
+                .pending_session_helpers
+                .lock()
+                .await
+                .insert(helper_id, Some("tab-single-deadline".to_string()));
+
+            let started = tokio::time::Instant::now();
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-single-deadline-op",
+                        "scope": "tabs",
+                        "tab_ids": ["tab-single-deadline"],
+                        "reason": "window_close"
+                    }
+                }),
+            )
+            .await;
+
+            let ReplacementEvent::BlockingClose(closing_session, _release) =
+                events_rx.recv().await.expect("physical close must start")
+            else {
+                panic!("retirement must issue session/close");
+            };
+            assert_eq!(closing_session, session_id);
+            let completion =
+                tokio::time::timeout(std::time::Duration::from_millis(500), completions.recv())
+                    .await
+                    .expect("retirement must not start a second timeout budget")
+                    .expect("retirement completion must be emitted");
+            assert_eq!(completion["params"]["success"], false);
+            assert!(
+                started.elapsed() < std::time::Duration::from_millis(500),
+                "retirement must remain bounded by its single master deadline"
+            );
+            assert!(state.session_to_helper.lock().await.is_empty());
+            assert!(state.pending_session_helpers.lock().await.is_empty());
+            assert!(!state.helper_meta.lock().await.contains_key(&helper_id));
+            assert!(!state
+                .active_retirement_helpers
+                .lock()
+                .await
+                .contains(&helper_id));
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn retirement_lifecycle_gate_wait_does_not_renew_close_budget() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(217);
+            let session_id = SessionId::new("retirement-gate-deadline");
+            let agent_instance_id = AgentInstanceId::new_v4();
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            bind_session_route(
+                &state,
+                session_id.clone(),
+                HelperRoute {
+                    helper_id,
+                    agent_instance_id,
+                    notif_tx,
+                    forwarder: None,
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: agent_instance_id,
+                conn: client_connection_to_blocking_close_agent(events_tx),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "retirement-gate-deadline-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let gate = session_lifecycle_gate(&state, &session_id).await;
+            let gate_guard = gate.lock().await;
+            let budget = std::time::Duration::from_millis(200);
+            let started = tokio::time::Instant::now();
+            let close = tokio::task::spawn_local({
+                let state = Arc::clone(&state);
+                let agent = Arc::clone(&agent);
+                let session_id = session_id.clone();
+                async move {
+                    close_and_retire_owned_session(
+                        &state,
+                        helper_id,
+                        &agent,
+                        &session_id,
+                        started + budget,
+                        true,
+                    )
+                    .await
+                }
+            });
+
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+            drop(gate_guard);
+            let ReplacementEvent::BlockingClose(closing_session, _release) = events_rx
+                .recv()
+                .await
+                .expect("session/close must use the remaining budget")
+            else {
+                panic!("expected blocking session/close");
+            };
+            assert_eq!(closing_session, session_id);
+            assert!(close.await.unwrap().is_ok());
+            assert!(
+                started.elapsed() < std::time::Duration::from_millis(300),
+                "waiting for the lifecycle gate must not renew the retirement budget"
+            );
+            assert!(state.session_to_helper.lock().await.is_empty());
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn retirement_waits_for_and_retires_late_session_new() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let mut completions = capture_retirement_completions(&state).await;
+            let helper_id = HelperId(205);
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let live_sessions = Arc::new(Mutex::new(HashSet::new()));
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_controlled_new_session_agent_with_close_result(
+                    events_tx,
+                    Arc::clone(&live_sessions),
+                    None,
+                    false,
+                    true,
+                ),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "retirement-pending-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            let agent_slot = Arc::new(OnceLock::new());
+            assert!(agent_slot.set(Arc::clone(&agent)).is_ok());
+            let agent_side_slot = Arc::new(OnceLock::new());
+            agent_side_slot
+                .set(agent_link_to_noop_client())
+                .expect("agent-side forwarder should be initialized");
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let handler = HelperHandler {
+                helper_id,
+                agent: agent_slot,
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx,
+                agent_side_slot,
+            };
+            let mut request = acp::schema::v1::NewSessionRequest::new(PathBuf::from("C:\\pending"));
+            crate::session_registry::inject_wta_meta(
+                &mut request.meta,
+                &crate::session_registry::WtaMeta {
+                    owner_tab_id: Some("tab-pending-retirement".to_string()),
+                    ..Default::default()
+                },
+            );
+            let new_task =
+                tokio::task::spawn_local(async move { handler.new_session(request).await });
+            let ReplacementEvent::New(_, release_new) =
+                events_rx.recv().await.expect("session/new must block")
+            else {
+                panic!("expected controlled session/new");
+            };
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-pending-op",
+                        "scope": "tabs",
+                        "tab_ids": ["tab-pending-retirement"],
+                        "reason": "tab_group_delete"
+                    }
+                }),
+            )
+            .await;
+            tokio::task::yield_now().await;
+            assert!(
+                completions.try_recv().is_err(),
+                "completion must wait for the in-flight session result"
+            );
+
+            release_new.send(()).unwrap();
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Cancel(_))
+            ));
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Close(_))
+            ));
+            let mut response = new_task.await.unwrap().unwrap();
+            assert_eq!(
+                crate::session_registry::extract_wta_meta(&mut response.meta)
+                    .session_result
+                    .as_deref(),
+                Some("retired")
+            );
+            assert_eq!(completions.recv().await.unwrap()["params"]["success"], true);
+            assert!(live_sessions.lock().await.is_empty());
+            assert!(state.session_to_helper.lock().await.is_empty());
+            assert!(!state.helper_meta.lock().await.contains_key(&helper_id));
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn retirement_timeout_cleans_before_completion_and_fences_late_session_new() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state_with_retirement_pending_timeout(std::time::Duration::ZERO);
+            let mut completions = capture_retirement_completions(&state).await;
+            let helper_id = HelperId(206);
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let live_sessions = Arc::new(Mutex::new(HashSet::new()));
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_controlled_new_session_agent_with_close_result(
+                    events_tx,
+                    Arc::clone(&live_sessions),
+                    None,
+                    false,
+                    true,
+                ),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "retirement-timeout-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            let agent_slot = Arc::new(OnceLock::new());
+            assert!(agent_slot.set(Arc::clone(&agent)).is_ok());
+            let agent_side_slot = Arc::new(OnceLock::new());
+            agent_side_slot
+                .set(agent_link_to_noop_client())
+                .expect("agent-side forwarder should be initialized");
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let handler = HelperHandler {
+                helper_id,
+                agent: agent_slot,
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                    notif_tx,
+                agent_side_slot,
+            };
+            let mut request = acp::schema::v1::NewSessionRequest::new(PathBuf::from("C:\\pending"));
+            crate::session_registry::inject_wta_meta(
+                &mut request.meta,
+                &crate::session_registry::WtaMeta {
+                    owner_tab_id: Some("tab-retirement-timeout".to_string()),
+                    ..Default::default()
+                },
+            );
+            let new_task =
+                tokio::task::spawn_local(async move { handler.new_session(request).await });
+            let ReplacementEvent::New(_, release_new) =
+                events_rx.recv().await.expect("session/new must block")
+            else {
+                panic!("expected controlled session/new");
+            };
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-timeout-op",
+                        "scope": "tabs",
+                        "tab_ids": ["tab-retirement-timeout"],
+                        "reason": "window_close"
+                    }
+                }),
+            )
+            .await;
+
+            let completion = completions.recv().await.expect("timeout must complete");
+            assert_eq!(completion["params"]["success"], false);
+            assert!(state.pending_session_helpers.lock().await.is_empty());
+            assert!(state.pending_session_mcp.lock().await.is_empty());
+            assert!(state.session_to_helper.lock().await.is_empty());
+            assert!(!state.helper_meta.lock().await.contains_key(&helper_id));
+            assert!(state.orphaned_tabs.lock().await.is_empty());
+            assert!(state.orphaned_sessions.lock().await.is_empty());
+            assert!(state.closing_session_results.lock().await.is_empty());
+            assert_eq!(
+                state
+                    .session_mcp_capabilities
+                    .remove_owner(agent.instance_id)
+                    .await,
+                0,
+                "completion must follow revocation of the pending MCP capability"
+            );
+            assert!(state
+                .closing_session_helpers
+                .lock()
+                .await
+                .contains(&helper_id));
+            assert!(state
+                .destructive_session_helpers
+                .lock()
+                .await
+                .contains(&helper_id));
+            assert!(!state
+                .active_retirement_helpers
+                .lock()
+                .await
+                .contains(&helper_id));
+
+            release_new.send(()).unwrap();
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Cancel(_))
+            ));
+            assert!(matches!(
+                events_rx.recv().await,
+                Some(ReplacementEvent::Close(_))
+            ));
+            let mut response = new_task.await.unwrap().unwrap();
+            assert_eq!(
+                crate::session_registry::extract_wta_meta(&mut response.meta)
+                    .session_result
+                    .as_deref(),
+                Some("retired")
+            );
+            assert!(live_sessions.lock().await.is_empty());
+            assert!(state.session_to_helper.lock().await.is_empty());
+            assert!(state.registry.lookup(&response.session_id).await.is_none());
+            assert!(state.pending_session_mcp.lock().await.is_empty());
+            assert!(state.closing_session_results.lock().await.is_empty());
+            assert!(!state.helper_meta.lock().await.contains_key(&helper_id));
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn retirement_completion_cache_is_bounded_without_evicting_in_flight_entries() {
+    let state = make_state();
+    state.retirement_operations.lock().await.insert(
+        "still-running".to_string(),
+        RetirementOperationState::InFlight,
+            );
+
+    for index in 0..(RETIREMENT_COMPLETION_CAP + 32) {
+        record_retirement_completion(
+            &state,
+            format!("completed-{index}"),
+            serde_json::json!({ "operation": index }),
+        )
+        .await;
+    }
+
+    let now = tokio::time::Instant::now();
+    {
+        let mut operations = state.retirement_operations.lock().await;
+        operations.insert(
+            "expired".to_string(),
+            RetirementOperationState::Completed {
+                event: serde_json::json!({ "operation": "expired" }),
+                completed_at: now
+                    .checked_sub(RETIREMENT_COMPLETION_TTL)
+                    .expect("test instant must support TTL subtraction"),
+            },
+            );
+        prune_retirement_operations(&mut operations, now);
+        assert!(matches!(
+            operations.get("still-running"),
+            Some(RetirementOperationState::InFlight)
+        ));
+        assert!(!operations.contains_key("expired"));
+        assert_eq!(
+            operations
+                .values()
+                .filter(|state| matches!(state, RetirementOperationState::Completed { .. }))
+                .count(),
+            RETIREMENT_COMPLETION_CAP
+            );
+    }
+}
+
 #[tokio::test]
 async fn master_tab_rename_rekeys_live_and_orphan_ownership() {
     let state = make_state();
@@ -2501,6 +5167,7 @@ async fn overlapping_new_sessions_retire_the_intermediate_replacement() {
                 .set(agent_link_to_noop_client())
                 .expect("agent-side forwarder should be set once");
             let agent = Arc::new(OnceLock::new());
+            let agent_instance_id = AgentInstanceId::new_v4();
             let mut cached_init_resp =
                 acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
             cached_init_resp
@@ -2509,7 +5176,7 @@ async fn overlapping_new_sessions_retire_the_intermediate_replacement() {
                 .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
             assert!(agent
                 .set(Arc::new(AgentCli {
-                    instance_id: AgentInstanceId::new_v4(),
+                    instance_id: agent_instance_id,
                     conn: client_connection_to_controlled_new_session_agent(
                         events_tx,
                         Arc::clone(&live_sessions),
@@ -2537,7 +5204,7 @@ async fn overlapping_new_sessions_retire_the_intermediate_replacement() {
                 initial_session.clone(),
                 HelperRoute {
                     helper_id,
-                    agent_instance_id: AgentInstanceId::nil(),
+                    agent_instance_id,
                     notif_tx,
                     forwarder: Some(agent_link_to_noop_client()),
                     consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -3014,9 +5681,10 @@ async fn close_failure_keeps_predecessor_and_does_not_create_replacement() {
                 .session_capabilities
                 .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
             let agent = Arc::new(OnceLock::new());
+            let agent_instance_id = AgentInstanceId::new_v4();
             assert!(agent
                 .set(Arc::new(AgentCli {
-                    instance_id: AgentInstanceId::new_v4(),
+                    instance_id: agent_instance_id,
                     conn: client_connection_to_controlled_new_session_agent(
                         events_tx,
                         Arc::clone(&live_sessions),
@@ -3043,7 +5711,7 @@ async fn close_failure_keeps_predecessor_and_does_not_create_replacement() {
                 old_session.clone(),
                 HelperRoute {
                     helper_id,
-                    agent_instance_id: AgentInstanceId::nil(),
+                    agent_instance_id,
                     notif_tx,
                     forwarder: Some(agent_link_to_noop_client()),
                     consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -3240,7 +5908,7 @@ async fn load_close_failure_restores_target_route_and_capability() {
                 old_session.clone(),
                 HelperRoute {
                     helper_id,
-                    agent_instance_id: AgentInstanceId::nil(),
+                    agent_instance_id: agent_instance,
                     notif_tx,
                     forwarder: Some(agent_link_to_noop_client()),
                     consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -5001,6 +7669,47 @@ async fn physical_close_allows_agent_callback_route_lookup_before_response() {
         .await;
 }
 
+#[tokio::test]
+async fn force_retire_never_purges_a_rebound_session() {
+    let state = make_state();
+    let sid = SessionId::new("force-retire-rebound");
+    let old_owner = HelperId(1);
+    let new_owner = HelperId(2);
+    let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+    bind_session_route(
+        &state,
+        sid.clone(),
+        HelperRoute {
+            helper_id: new_owner,
+            agent_instance_id: AgentInstanceId::new_v4(),
+            notif_tx,
+            forwarder: None,
+            consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        },
+    )
+    .await;
+    state
+        .registry
+        .upsert(crate::session_registry::SessionInfo::new(
+            sid.clone(),
+            PathBuf::from("C:\\rebound"),
+        ))
+        .await;
+
+    assert_eq!(
+        force_retire_owned_session_state(&state, old_owner, &sid).await,
+        ReplacedSessionCleanup::NotOwned
+    );
+    assert_eq!(
+        state.session_to_helper.lock().await[&sid].helper_id,
+        new_owner
+    );
+    assert!(
+        state.registry.lookup(&sid).await.is_some(),
+        "force-retire must not purge registry/MCP state after ownership rebounds"
+    );
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn physical_close_blocks_rebind_until_retirement_completes() {
     tokio::task::LocalSet::new()
@@ -5012,12 +7721,13 @@ async fn physical_close_blocks_rebind_until_retirement_completes() {
             let (old_tx, _old_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
             let (new_tx, _new_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
             let (other_tx, _other_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let agent_instance_id = AgentInstanceId::new_v4();
             bind_session_route(
                 &state,
                 sid.clone(),
                 HelperRoute {
                     helper_id: old_owner,
-                    agent_instance_id: AgentInstanceId::nil(),
+                    agent_instance_id,
                     notif_tx: old_tx,
                     forwarder: None,
                     consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -5039,7 +7749,7 @@ async fn physical_close_blocks_rebind_until_retirement_completes() {
                 .session_capabilities
                 .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
             let agent = Arc::new(AgentCli {
-                instance_id: AgentInstanceId::new_v4(),
+                instance_id: agent_instance_id,
                 conn: client_connection_to_blocking_close_agent(events_tx),
                 cached_init_resp,
                 cli_source: Some(crate::agent_sessions::CliSource::Copilot),
@@ -5062,9 +7772,10 @@ async fn physical_close_blocks_rebind_until_retirement_completes() {
                 )
                 .await
             });
-            let ReplacementEvent::BlockingClose(closed_sid, release_close) = events_rx
-                .recv()
+            let ReplacementEvent::BlockingClose(closed_sid, release_close) =
+                tokio::time::timeout(std::time::Duration::from_secs(1), events_rx.recv())
                 .await
+                    .expect("physical close event must arrive before the test timeout")
                 .expect("physical close must reach the agent")
             else {
                 panic!("expected blocking session/close event");
@@ -5448,8 +8159,21 @@ fn make_state_with_wt(wt: Arc<dyn crate::shell::wt_channel::WtChannel>) -> Arc<M
         cli_source: Some(crate::agent_sessions::CliSource::Copilot),
         helper_meta: Mutex::new(HashMap::new()),
         tab_ownership_gate: Mutex::new(()),
+        connected_helpers: Mutex::new(HashSet::new()),
+        all_retirement_fence: Mutex::new(AllRetirementFence::default()),
+        tab_retirement_fences: Mutex::new(HashMap::new()),
+        unresolved_owner_retirements: Mutex::new(HashMap::new()),
         pending_session_helpers: Mutex::new(HashMap::new()),
+        pending_session_mcp: Mutex::new(HashMap::new()),
         closing_session_helpers: Mutex::new(HashSet::new()),
+        destructive_session_helpers: Mutex::new(HashSet::new()),
+        active_retirement_helpers: Mutex::new(HashSet::new()),
+        closing_session_results: Mutex::new(HashMap::new()),
+        session_transaction_changed: tokio::sync::Notify::new(),
+        retirement_operations: Mutex::new(HashMap::new()),
+        retirement_completion_tx: Mutex::new(None),
+        retirement_pending_timeout: SESSION_CLOSE_TIMEOUT,
+        disconnect_orphan_publication_pause: Mutex::new(None),
         hook_owned: Mutex::new(HashSet::new()),
         born_bound: Mutex::new(HashSet::new()),
         orphaned_sessions: Mutex::new(HashMap::new()),

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -753,6 +753,7 @@ fn make_state_with_retirement_pending_timeout(
         connected_helpers: Mutex::new(HashSet::new()),
         all_retirement_fence: Mutex::new(AllRetirementFence::default()),
         tab_retirement_fences: Mutex::new(HashMap::new()),
+        tab_retirement_rekeys: Mutex::new(HashMap::new()),
         unresolved_owner_retirements: Mutex::new(HashMap::new()),
         pending_session_helpers: Mutex::new(HashMap::new()),
         pending_session_mcp: Mutex::new(HashMap::new()),
@@ -765,6 +766,7 @@ fn make_state_with_retirement_pending_timeout(
         retirement_completion_tx: Mutex::new(None),
         retirement_pending_timeout,
         disconnect_orphan_publication_pause: Mutex::new(None),
+        deferred_retirement_cleanup_complete: tokio::sync::Notify::new(),
         hook_owned: Mutex::new(HashSet::new()),
         born_bound: Mutex::new(HashSet::new()),
         orphaned_sessions: Mutex::new(HashMap::new()),
@@ -1663,6 +1665,57 @@ async fn failed_pending_session_cleanup_retires_close_marked_recovery_state() {
         .await
         .contains(&helper_id));
     assert!(!state.helper_meta.lock().await.contains_key(&helper_id));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn failed_pending_cleanup_reads_destructive_marker_under_ownership_gate() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(121);
+            state
+                .pending_session_helpers
+                .lock()
+                .await
+                .insert(helper_id, Some("destructive-pending-tab".to_string()));
+            state.closing_session_helpers.lock().await.insert(helper_id);
+            state.helper_meta.lock().await.insert(
+                helper_id,
+                HelperRecoveryMeta {
+                    owner_tab_id: Some("destructive-pending-tab".to_string()),
+                    last_session_id: None,
+                },
+            );
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let handler = HelperHandler {
+                helper_id,
+                agent: Arc::new(OnceLock::new()),
+                state: Arc::clone(&state),
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx,
+                agent_side_slot: Arc::new(OnceLock::new()),
+            };
+
+            let ownership_guard = state.tab_ownership_gate.lock().await;
+            let cleanup =
+                tokio::task::spawn_local(async move { handler.finish_failed_pending_session().await });
+            tokio::task::yield_now().await;
+            state
+                .destructive_session_helpers
+                .lock()
+                .await
+                .insert(helper_id);
+            drop(ownership_guard);
+            cleanup.await.unwrap();
+
+            assert!(state
+                .closing_session_helpers
+                .lock()
+                .await
+                .contains(&helper_id));
+            assert!(!state.helper_meta.lock().await.contains_key(&helper_id));
+        })
+        .await;
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -3488,6 +3541,32 @@ async fn orphan_retirement_blocked_lifecycle_gate_uses_total_budget() {
 
             let gate = session_lifecycle_gate(&state, &session_id).await;
             let gate_guard = gate.lock().await;
+            let replacement_helper_id = HelperId(349);
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let (rebind_queued_tx, mut rebind_queued_rx) = mpsc::unbounded_channel();
+            let rebind = tokio::task::spawn_local({
+                let state = Arc::clone(&state);
+                let session_id = session_id.clone();
+                async move {
+                    rebind_queued_tx.send(()).unwrap();
+                    bind_session_route(
+                        &state,
+                        session_id,
+                        HelperRoute {
+                            helper_id: replacement_helper_id,
+                            agent_instance_id: AgentInstanceId::new_v4(),
+                            notif_tx,
+                            forwarder: None,
+                            consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                        },
+                    )
+                    .await;
+                }
+            });
+            rebind_queued_rx
+                .recv()
+                .await
+                .expect("replacement bind must queue behind the lifecycle gate");
             let started = tokio::time::Instant::now();
             handle_master_wt_event(
                 &state,
@@ -3517,10 +3596,33 @@ async fn orphan_retirement_blocked_lifecycle_gate_uses_total_budget() {
                 started.elapsed() < std::time::Duration::from_millis(500),
                 "blocked orphan gate must remain bounded by the retirement deadline"
             );
+            assert!(state.orphaned_tabs.lock().await.contains_key(tab_id));
+            assert!(state
+                .orphaned_sessions
+                .lock()
+                .await
+                .get("blocked-orphan-gate-agent")
+                .is_some_and(|sessions| sessions.contains(&session_id)));
+            assert!(state.registry.lookup(&session_id).await.is_some());
+            let deferred_cleanup =
+                state.deferred_retirement_cleanup_complete.notified();
+            drop(gate_guard);
+            rebind.await.expect("replacement bind must finish");
+            tokio::time::timeout(std::time::Duration::from_secs(1), deferred_cleanup)
+                .await
+                .expect("deferred orphan cleanup must revalidate after the queued bind");
+            assert_eq!(
+                state
+                    .session_to_helper
+                    .lock()
+                    .await
+                    .get(&session_id)
+                    .map(|route| route.helper_id),
+                Some(replacement_helper_id)
+            );
+            assert!(state.registry.lookup(&session_id).await.is_some());
             assert!(state.orphaned_tabs.lock().await.is_empty());
             assert!(state.orphaned_sessions.lock().await.is_empty());
-            assert!(state.registry.lookup(&session_id).await.is_none());
-            drop(gate_guard);
         })
         .await;
 }
@@ -3812,6 +3914,113 @@ async fn scope_all_preserves_ownerless_orphan_claimed_by_replacement_route() {
                 events_rx.try_recv().is_err(),
                 "a replacement route must suppress orphan cancel and close"
             );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn scope_all_ownerless_orphan_gate_timeout_preserves_queued_rebind() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state_with_retirement_pending_timeout(
+                std::time::Duration::from_millis(40),
+            );
+            let mut completions = capture_retirement_completions(&state).await;
+            let replacement_helper_id = HelperId(351);
+            let session_id = SessionId::new("ownerless-orphan-timeout-rebind");
+            let agent_key = "ownerless-orphan-timeout-agent".to_string();
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry(agent_key.clone())
+                .or_default()
+                .insert(session_id.clone());
+            state
+                .registry
+                .upsert(crate::session_registry::SessionInfo::new(
+                    session_id.clone(),
+                    PathBuf::from("C:\\ownerless-orphan-timeout"),
+                ))
+                .await;
+
+            let gate = session_lifecycle_gate(&state, &session_id).await;
+            let gate_guard = gate.lock().await;
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let (rebind_queued_tx, mut rebind_queued_rx) = mpsc::unbounded_channel();
+            let rebind = tokio::task::spawn_local({
+                let state = Arc::clone(&state);
+                let session_id = session_id.clone();
+                async move {
+                    rebind_queued_tx.send(()).unwrap();
+                    bind_session_route(
+                        &state,
+                        session_id,
+                        HelperRoute {
+                            helper_id: replacement_helper_id,
+                            agent_instance_id: AgentInstanceId::new_v4(),
+                            notif_tx,
+                            forwarder: None,
+                            consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                        },
+                    )
+                    .await;
+                }
+            });
+            rebind_queued_rx
+                .recv()
+                .await
+                .expect("replacement bind must queue behind the lifecycle gate");
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retire-ownerless-timeout-rebind",
+                        "scope": "all",
+                        "tab_ids": [],
+                        "reason": "window_close"
+                    }
+                }),
+            )
+            .await;
+            let completion =
+                tokio::time::timeout(std::time::Duration::from_millis(500), completions.recv())
+                    .await
+                    .expect("ownerless retirement must remain bounded")
+                    .expect("ownerless retirement must report completion");
+            assert_eq!(completion["params"]["success"], false);
+            assert_eq!(
+                completion["params"]["unattributed_failures"]["count"],
+                serde_json::json!(1)
+            );
+            assert!(state
+                .orphaned_sessions
+                .lock()
+                .await
+                .get(&agent_key)
+                .is_some_and(|sessions| sessions.contains(&session_id)));
+            assert!(state.registry.lookup(&session_id).await.is_some());
+
+            let deferred_cleanup =
+                state.deferred_retirement_cleanup_complete.notified();
+            drop(gate_guard);
+            rebind.await.expect("replacement bind must finish");
+            tokio::time::timeout(std::time::Duration::from_secs(1), deferred_cleanup)
+                .await
+                .expect("deferred ownerless cleanup must revalidate after the queued bind");
+            assert_eq!(
+                state
+                    .session_to_helper
+                    .lock()
+                    .await
+                    .get(&session_id)
+                    .map(|route| route.helper_id),
+                Some(replacement_helper_id)
+            );
+            assert!(state.registry.lookup(&session_id).await.is_some());
+            assert!(state.orphaned_sessions.lock().await.is_empty());
         })
         .await;
 }
@@ -4714,6 +4923,7 @@ async fn master_tab_rename_rekeys_live_and_orphan_ownership() {
     let state = make_state();
     let helper_id = HelperId(118);
     let session_id = SessionId::new("dragged-session");
+    state.connected_helpers.lock().await.insert(helper_id);
     state.helper_meta.lock().await.insert(
         helper_id,
         HelperRecoveryMeta {
@@ -4764,6 +4974,139 @@ async fn master_tab_rename_rekeys_live_and_orphan_ownership() {
     let orphaned_tabs = state.orphaned_tabs.lock().await;
     assert!(!orphaned_tabs.contains_key("old-stable-id"));
     assert!(orphaned_tabs.contains_key("new-stable-id"));
+    drop(orphaned_tabs);
+    assert!(state.tab_retirement_fences.lock().await.is_empty());
+    assert!(state.tab_retirement_rekeys.lock().await.is_empty());
+    assert!(state.closing_session_helpers.lock().await.is_empty());
+    assert!(state.destructive_session_helpers.lock().await.is_empty());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn active_retirement_follows_tab_rename_and_clears_moved_fence_on_disconnect() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let mut completions = capture_retirement_completions(&state).await;
+            let helper_id = HelperId(119);
+            let session_id = SessionId::new("retirement-drag-race");
+            let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+            let mut cached_init_resp =
+                acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+            cached_init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_blocking_close_agent(events_tx),
+                cached_init_resp,
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: "retirement-drag-race-agent".to_string(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(agent.cmd_key.clone(), cell);
+            register_retirement_tab(
+                &state,
+                &agent,
+                helper_id,
+                "retirement-drag-old",
+                &session_id,
+            )
+            .await;
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "retire_agent_sessions",
+                    "params": {
+                        "operation_id": "retirement-drag-race-op",
+                        "scope": "tabs",
+                        "tab_ids": ["retirement-drag-old"],
+                        "reason": "window_close"
+                    }
+                }),
+            )
+            .await;
+            let ReplacementEvent::BlockingClose(closing_session, release_close) = events_rx
+                .recv()
+                .await
+                .expect("retirement must reach session/close before the drag")
+            else {
+                panic!("expected blocking session/close");
+            };
+            assert_eq!(closing_session, session_id);
+
+            handle_master_wt_event(
+                &state,
+                serde_json::json!({
+                    "method": "tab_renamed",
+                    "params": {
+                        "old_tab_id": "retirement-drag-old",
+                        "new_tab_id": "retirement-drag-new"
+                    }
+                }),
+            )
+            .await;
+            assert_eq!(
+                state
+                    .helper_meta
+                    .lock()
+                    .await
+                    .get(&helper_id)
+                    .and_then(|meta| meta.owner_tab_id.as_deref()),
+                Some("retirement-drag-new")
+            );
+            assert!(!state
+                .tab_retirement_fences
+                .lock()
+                .await
+                .contains_key("retirement-drag-old"));
+            assert!(state
+                .tab_retirement_fences
+                .lock()
+                .await
+                .contains_key("retirement-drag-new"));
+            assert_eq!(
+                state
+                    .tab_retirement_rekeys
+                    .lock()
+                    .await
+                    .get("retirement-drag-old")
+                    .map(String::as_str),
+                Some("retirement-drag-new")
+            );
+
+            release_close.send(()).unwrap();
+            assert_eq!(completions.recv().await.unwrap()["params"]["success"], true);
+            assert!(state.session_to_helper.lock().await.is_empty());
+            assert!(state.registry.lookup(&session_id).await.is_none());
+            assert!(state.tab_retirement_rekeys.lock().await.is_empty());
+            assert!(state
+                .destructive_session_helpers
+                .lock()
+                .await
+                .contains(&helper_id));
+
+            let (intentional, recovery) =
+                consume_disconnected_helper_retirement_state(&state, helper_id).await;
+            assert!(intentional);
+            assert_eq!(
+                recovery.and_then(|meta| meta.owner_tab_id),
+                None,
+                "completed retirement must not retain recovery metadata"
+            );
+            assert!(state.tab_retirement_fences.lock().await.is_empty());
+            assert!(state.destructive_session_helpers.lock().await.is_empty());
+        })
+        .await;
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -8162,6 +8505,7 @@ fn make_state_with_wt(wt: Arc<dyn crate::shell::wt_channel::WtChannel>) -> Arc<M
         connected_helpers: Mutex::new(HashSet::new()),
         all_retirement_fence: Mutex::new(AllRetirementFence::default()),
         tab_retirement_fences: Mutex::new(HashMap::new()),
+        tab_retirement_rekeys: Mutex::new(HashMap::new()),
         unresolved_owner_retirements: Mutex::new(HashMap::new()),
         pending_session_helpers: Mutex::new(HashMap::new()),
         pending_session_mcp: Mutex::new(HashMap::new()),
@@ -8174,6 +8518,7 @@ fn make_state_with_wt(wt: Arc<dyn crate::shell::wt_channel::WtChannel>) -> Arc<M
         retirement_completion_tx: Mutex::new(None),
         retirement_pending_timeout: SESSION_CLOSE_TIMEOUT,
         disconnect_orphan_publication_pause: Mutex::new(None),
+        deferred_retirement_cleanup_complete: tokio::sync::Notify::new(),
         hook_owned: Mutex::new(HashSet::new()),
         born_bound: Mutex::new(HashSet::new()),
         orphaned_sessions: Mutex::new(HashMap::new()),

--- a/tools/wta/src/shell/wt_channel/cli_channel.rs
+++ b/tools/wta/src/shell/wt_channel/cli_channel.rs
@@ -400,34 +400,77 @@ impl CliChannel {
             let _ = previous.send(());
         }
         tokio::spawn(async move {
-            let Ok(mut child) = tokio::process::Command::new(&wtcli)
+            let mut child = match tokio::process::Command::new(&wtcli)
                 .args(["--json", "listen"])
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::null())
                 .kill_on_drop(true)
                 .spawn()
-            else {
-                return;
+            {
+                Ok(child) => child,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "wtcli",
+                        path = %wtcli,
+                        %error,
+                        "failed to start wtcli event listener"
+                    );
+                    return;
+                }
             };
+            let listener_pid = child.id();
+            tracing::info!(
+                target: "wtcli",
+                path = %wtcli,
+                pid = listener_pid,
+                "wtcli event listener started"
+            );
 
             let Some(stdout) = child.stdout.take() else {
-                let _ = child.start_kill();
-                let _ = child.wait().await;
+                tracing::warn!(
+                    target: "wtcli",
+                    pid = listener_pid,
+                    "wtcli event listener stdout unavailable"
+                );
+                if let Err(error) = child.start_kill() {
+                    tracing::debug!(
+                        target: "wtcli",
+                        pid = listener_pid,
+                        %error,
+                        "wtcli event listener kill request was unnecessary or failed"
+                    );
+                }
+                match child.wait().await {
+                    Ok(status) => tracing::info!(
+                        target: "wtcli",
+                        pid = listener_pid,
+                        %status,
+                        "wtcli event listener reaped"
+                    ),
+                    Err(error) => tracing::warn!(
+                        target: "wtcli",
+                        pid = listener_pid,
+                        %error,
+                        "failed to reap wtcli event listener"
+                    ),
+                }
                 return;
             };
             let mut reader = tokio::io::BufReader::new(stdout);
             let mut line = String::new();
 
-            loop {
+            let exit_reason = loop {
                 line.clear();
                 use tokio::io::AsyncBufReadExt;
                 tokio::select! {
-                    _ = &mut shutdown_rx => break,
+                    _ = &mut shutdown_rx => break "shutdown_requested",
                     result = reader.read_line(&mut line) => {
                         match result {
-                            Ok(0) => break,
+                            Ok(0) => break "stdout_closed",
                             Ok(_) => {
-                                let Some(this) = weak.upgrade() else { break };
+                                let Some(this) = weak.upgrade() else {
+                                    break "channel_dropped";
+                                };
                                 if let Ok(val) = serde_json::from_str::<serde_json::Value>(line.trim()) {
                                     let tx = this.event_tx.lock().unwrap();
                                     if let Some(tx) = tx.as_ref() {
@@ -435,20 +478,51 @@ impl CliChannel {
                                     }
                                 }
                             }
-                            Err(_) => break,
+                            Err(error) => {
+                                tracing::warn!(
+                                    target: "wtcli",
+                                    pid = listener_pid,
+                                    %error,
+                                    "wtcli event listener stdout read failed"
+                                );
+                                break "stdout_error";
+                            }
                         }
                     }
                 }
-            }
+            };
 
             drop(reader);
-            let _ = child.start_kill();
-            if let Err(error) = child.wait().await {
-                tracing::warn!(
+            tracing::info!(
+                target: "wtcli",
+                pid = listener_pid,
+                reason = exit_reason,
+                "stopping wtcli event listener"
+            );
+            if let Err(error) = child.start_kill() {
+                tracing::debug!(
                     target: "wtcli",
+                    pid = listener_pid,
+                    reason = exit_reason,
+                    %error,
+                    "wtcli event listener kill request was unnecessary or failed"
+                );
+            }
+            match child.wait().await {
+                Ok(status) => tracing::info!(
+                    target: "wtcli",
+                    pid = listener_pid,
+                    reason = exit_reason,
+                    %status,
+                    "wtcli event listener reaped"
+                ),
+                Err(error) => tracing::warn!(
+                    target: "wtcli",
+                    pid = listener_pid,
+                    reason = exit_reason,
                     %error,
                     "failed to reap wtcli event listener"
-                );
+                ),
             }
         });
     }

--- a/tools/wta/src/shell/wt_channel/cli_channel.rs
+++ b/tools/wta/src/shell/wt_channel/cli_channel.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -6,6 +7,158 @@ use tokio::sync::{mpsc, oneshot};
 
 use super::WtChannel;
 use crate::app_contracts::DebugMessage;
+
+const WTCLI_ONE_SHOT_TIMEOUT: Duration = Duration::from_secs(30);
+const WTCLI_ONE_SHOT_REAP_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug)]
+enum WtcliOneShotError {
+    Spawn(std::io::Error),
+    Wait(std::io::Error),
+    ReadStdout(std::io::Error),
+    ReadStderr(std::io::Error),
+    TimedOut {
+        timeout: Duration,
+        kill_error: Option<std::io::Error>,
+        reap_error: Option<std::io::Error>,
+        reap_timeout: Option<Duration>,
+    },
+}
+
+impl std::fmt::Display for WtcliOneShotError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Spawn(error) => write!(f, "failed to spawn wtcli: {error}"),
+            Self::Wait(error) => write!(f, "failed to wait for wtcli: {error}"),
+            Self::ReadStdout(error) => write!(f, "failed to read wtcli stdout: {error}"),
+            Self::ReadStderr(error) => write!(f, "failed to read wtcli stderr: {error}"),
+            Self::TimedOut {
+                timeout,
+                kill_error,
+                reap_error,
+                reap_timeout,
+            } => {
+                write!(f, "wtcli timed out after {timeout:?}")?;
+                if let Some(error) = kill_error {
+                    write!(f, "; kill failed: {error}")?;
+                }
+                if let Some(error) = reap_error {
+                    write!(f, "; reap failed: {error}")?;
+                }
+                if let Some(timeout) = reap_timeout {
+                    write!(f, "; reap timed out after {timeout:?}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for WtcliOneShotError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Spawn(error)
+            | Self::Wait(error)
+            | Self::ReadStdout(error)
+            | Self::ReadStderr(error) => Some(error),
+            Self::TimedOut { .. } => None,
+        }
+    }
+}
+
+async fn read_pipe<R>(pipe: Option<R>) -> std::io::Result<Vec<u8>>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    use tokio::io::AsyncReadExt;
+
+    let mut bytes = Vec::new();
+    if let Some(mut pipe) = pipe {
+        pipe.read_to_end(&mut bytes).await?;
+    }
+    Ok(bytes)
+}
+
+async fn run_wtcli_one_shot(
+    path: &str,
+    args: &[String],
+    capture_stdout: bool,
+    capture_stderr: bool,
+    timeout: Duration,
+) -> Result<std::process::Output, WtcliOneShotError> {
+    let mut command = tokio::process::Command::new(path);
+    command
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stdout(if capture_stdout {
+            std::process::Stdio::piped()
+        } else {
+            std::process::Stdio::null()
+        })
+        .stderr(if capture_stderr {
+            std::process::Stdio::piped()
+        } else {
+            std::process::Stdio::null()
+        })
+        .kill_on_drop(true);
+
+    let mut child = command.spawn().map_err(WtcliOneShotError::Spawn)?;
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    // Keep process completion and both pipe readers under one deadline. If it
+    // expires, dropping this future closes the readers before cleanup starts.
+    let completed = tokio::time::timeout(timeout, {
+        let child = &mut child;
+        async move { tokio::join!(child.wait(), read_pipe(stdout), read_pipe(stderr),) }
+    })
+    .await;
+
+    match completed {
+        Ok((status, stdout, stderr)) => Ok(std::process::Output {
+            status: status.map_err(WtcliOneShotError::Wait)?,
+            stdout: stdout.map_err(WtcliOneShotError::ReadStdout)?,
+            stderr: stderr.map_err(WtcliOneShotError::ReadStderr)?,
+        }),
+        Err(_) => {
+            let kill_error = child.start_kill().err();
+            let (reap_error, reap_timeout) =
+                match tokio::time::timeout(WTCLI_ONE_SHOT_REAP_TIMEOUT, child.wait()).await {
+                    Ok(Ok(_)) => (None, None),
+                    Ok(Err(error)) => (Some(error), None),
+                    Err(_) => (None, Some(WTCLI_ONE_SHOT_REAP_TIMEOUT)),
+                };
+            Err(WtcliOneShotError::TimedOut {
+                timeout,
+                kill_error,
+                reap_error,
+                reap_timeout,
+            })
+        }
+    }
+}
+
+fn spawn_wtcli_task<F>(task: F)
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+        drop(runtime.spawn(task));
+    } else {
+        std::thread::spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    tracing::warn!(target: "wtcli", %error, "failed to create wtcli task runtime");
+                    return;
+                }
+            };
+            runtime.block_on(task);
+        });
+    }
+}
 
 /// Extract a JSON value as a string, handling both String and Number types.
 /// Protocol IDs may arrive as either strings or numbers depending on the caller.
@@ -80,7 +233,7 @@ pub enum FocusPaneFailureReason {
     },
 }
 
-/// Run `wtcli focus-pane -t <id>` on a background thread and log stdout/stderr
+/// Run `wtcli focus-pane -t <id>` on a background task and log stdout/stderr
 /// on failure. Replaces `spawn_wtcli_async` for the focus-pane case so that
 /// silent failures (wrong GUID, dead pane, COM error) leave a trace in
 /// wta-main.log.
@@ -91,8 +244,8 @@ pub fn spawn_wtcli_focus_pane(pane_session_id: &str) {
     spawn_wtcli_focus_pane_with_callback(pane_session_id, None);
 }
 
-/// Same as `spawn_wtcli_focus_pane` but invokes `on_failure` (on the worker
-/// thread) when the spawned wtcli process exits non-zero. Used by
+/// Same as `spawn_wtcli_focus_pane` but invokes `on_failure` from the background
+/// task when the spawned wtcli process exits non-zero. Used by
 /// `dispatch_focus_pane` to demote stale-IDLE rows back to `Ended` when the
 /// underlying pane is gone (`FocusPaneFailureReason::NotFound`).
 #[allow(dead_code)]
@@ -102,15 +255,9 @@ pub fn spawn_wtcli_focus_pane_with_callback(
 ) {
     let path = resolve_wtcli_path();
     let pane = pane_session_id.to_string();
-    std::thread::spawn(move || {
+    spawn_wtcli_task(async move {
         let args = ["focus-pane".to_string(), "-t".to_string(), pane.clone()];
-        let res = std::process::Command::new(&path)
-            .args(&args)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .output();
-        match res {
+        match run_wtcli_one_shot(&path, &args, true, true, WTCLI_ONE_SHOT_TIMEOUT).await {
             Ok(out) => {
                 let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
                 if out.status.success() {
@@ -147,7 +294,7 @@ pub fn spawn_wtcli_focus_pane_with_callback(
                     }
                 }
             }
-            Err(err) => {
+            Err(WtcliOneShotError::Spawn(err)) => {
                 tracing::warn!(
                     target: "wtcli",
                     target_pane = %pane,
@@ -157,6 +304,14 @@ pub fn spawn_wtcli_focus_pane_with_callback(
                 // Don't fire on_failure for spawn errors (wtcli not on PATH,
                 // permission issues, etc.) — these are infrastructure
                 // problems, not "pane gone".
+            }
+            Err(err) => {
+                tracing::warn!(
+                    target: "wtcli",
+                    target_pane = %pane,
+                    %err,
+                    "focus-pane invocation failed",
+                );
             }
         }
     });
@@ -170,25 +325,24 @@ pub fn spawn_wtcli_focus_pane_with_callback(
 /// buffer underneath ratatui.
 pub fn spawn_wtcli_async(args: &[String]) {
     let path = resolve_wtcli_path();
-    match std::process::Command::new(&path)
-        .args(args)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-    {
-        Ok(_child) => {
-            tracing::debug!(target: "wtcli", path = %path, ?args, "spawned");
+    let args = args.to_vec();
+    spawn_wtcli_task(async move {
+        tracing::debug!(target: "wtcli", path = %path, ?args, "spawning");
+        match run_wtcli_one_shot(&path, &args, false, false, WTCLI_ONE_SHOT_TIMEOUT).await {
+            Ok(_) => {}
+            Err(WtcliOneShotError::Spawn(err)) => {
+                tracing::warn!(target: "wtcli", path = %path, ?args, %err, "spawn failed");
+            }
+            Err(err) => {
+                tracing::warn!(target: "wtcli", path = %path, ?args, %err, "invocation failed");
+            }
         }
-        Err(err) => {
-            tracing::warn!(target: "wtcli", path = %path, ?args, %err, "spawn failed");
-        }
-    }
+    });
 }
 
 /// Run `wtcli --json <args>`, parse the resulting `sessionId` (or `SessionId`)
 /// from stdout, then run `wtcli focus-pane -t <id>`. All performed on a
-/// background thread so the UI stays responsive.
+/// background task so the UI stays responsive.
 ///
 /// Why this exists: wtcli's split-pane subcommand passes `background=true` to
 /// the COM `SplitPane` call (see `src/tools/wtcli/main.cpp:446`), which leaves
@@ -211,7 +365,7 @@ pub fn spawn_wtcli_split_then_focus(args: &[String]) {
 /// `connection_state: closed` → `PaneClosed` path can't transition the row
 /// to Ended when the user later closes the pane.
 ///
-/// The callback runs on the same background thread that issued the split,
+/// The callback runs on the same background task that issued the split,
 /// after a successful JSON parse. It is NOT invoked when the split fails
 /// (process spawn error, non-zero exit, malformed JSON, missing
 /// `session_id`).
@@ -224,27 +378,32 @@ pub fn spawn_wtcli_split_then_focus_with_callback(
         .chain(args.iter().cloned())
         .collect();
 
-    std::thread::spawn(move || {
-        let output = std::process::Command::new(&path)
-            .args(&owned_args)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
-            .output();
-
-        let output = match output {
-            Ok(o) => o,
-            Err(err) => {
-                tracing::warn!(
-                    target: "wtcli",
-                    path = %path,
-                    ?owned_args,
-                    %err,
-                    "split-pane spawn failed",
-                );
-                return;
-            }
-        };
+    spawn_wtcli_task(async move {
+        let output =
+            match run_wtcli_one_shot(&path, &owned_args, true, false, WTCLI_ONE_SHOT_TIMEOUT).await
+            {
+                Ok(o) => o,
+                Err(WtcliOneShotError::Spawn(err)) => {
+                    tracing::warn!(
+                        target: "wtcli",
+                        path = %path,
+                        ?owned_args,
+                        %err,
+                        "split-pane spawn failed",
+                    );
+                    return;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        target: "wtcli",
+                        path = %path,
+                        ?owned_args,
+                        %err,
+                        "split-pane invocation failed",
+                    );
+                    return;
+                }
+            };
 
         if !output.status.success() {
             tracing::warn!(
@@ -307,13 +466,7 @@ pub fn spawn_wtcli_split_then_focus_with_callback(
             "-t".to_string(),
             session_id.clone(),
         ];
-        match std::process::Command::new(&path)
-            .args(&focus_args)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .output()
-        {
+        match run_wtcli_one_shot(&path, &focus_args, true, true, WTCLI_ONE_SHOT_TIMEOUT).await {
             Ok(out) => {
                 let stderr = String::from_utf8_lossy(&out.stderr);
                 if out.status.success() {
@@ -332,12 +485,20 @@ pub fn spawn_wtcli_split_then_focus_with_callback(
                     );
                 }
             }
-            Err(err) => {
+            Err(WtcliOneShotError::Spawn(err)) => {
                 tracing::warn!(
                     target: "wtcli",
                     %session_id,
                     %err,
                     "focus-pane spawn failed after split",
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    target: "wtcli",
+                    %session_id,
+                    %err,
+                    "focus-pane invocation failed after split",
                 );
             }
         }
@@ -530,13 +691,13 @@ impl CliChannel {
     /// Run a wtcli subcommand and return the parsed JSON output.
     /// wtcli inherits WT_COM_CLSID from this process's env.
     async fn run_wtcli(&self, args: &[&str]) -> anyhow::Result<serde_json::Value> {
-        let mut cmd = tokio::process::Command::new(&self.wtcli_path);
-        cmd.arg("--json").args(args).kill_on_drop(true);
-
-        let output = tokio::time::timeout(Duration::from_secs(30), cmd.output())
-            .await
-            .context("wtcli timed out after 30 seconds")?
-            .context("Failed to run wtcli")?;
+        let args: Vec<String> = std::iter::once("--json".to_string())
+            .chain(args.iter().map(|arg| (*arg).to_string()))
+            .collect();
+        let output =
+            run_wtcli_one_shot(&self.wtcli_path, &args, true, true, WTCLI_ONE_SHOT_TIMEOUT)
+                .await
+                .context("Failed to run wtcli")?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -767,5 +928,80 @@ impl WtChannel for CliChannel {
 
     fn is_available(&self) -> bool {
         self.available.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn one_shot_captures_output() {
+        let args = vec![
+            "/D".to_string(),
+            "/S".to_string(),
+            "/C".to_string(),
+            "echo bounded-output".to_string(),
+        ];
+
+        let output = run_wtcli_one_shot("cmd.exe", &args, true, true, Duration::from_secs(5))
+            .await
+            .expect("command should complete");
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "bounded-output"
+        );
+    }
+
+    #[tokio::test]
+    async fn one_shot_timeout_kills_and_reaps_child() {
+        let timeout = Duration::from_millis(100);
+        let args = vec![
+            "-NoLogo".to_string(),
+            "-NoProfile".to_string(),
+            "-NonInteractive".to_string(),
+            "-Command".to_string(),
+            "[Threading.Thread]::Sleep(60000)".to_string(),
+        ];
+
+        let error = run_wtcli_one_shot("powershell.exe", &args, false, false, timeout)
+            .await
+            .expect_err("command should time out");
+
+        match error {
+            WtcliOneShotError::TimedOut {
+                timeout: actual,
+                kill_error,
+                reap_error,
+                reap_timeout,
+            } => {
+                assert_eq!(actual, timeout);
+                assert!(kill_error.is_none(), "kill failed: {kill_error:?}");
+                assert!(reap_error.is_none(), "reap failed: {reap_error:?}");
+                assert!(
+                    reap_timeout.is_none(),
+                    "reap timed out after {reap_timeout:?}"
+                );
+            }
+            other => panic!("expected timeout, got {other}"),
+        }
+    }
+
+    #[test]
+    fn timeout_error_preserves_reap_timeout_diagnostics() {
+        let timeout = Duration::from_secs(30);
+        let error = WtcliOneShotError::TimedOut {
+            timeout,
+            kill_error: Some(std::io::Error::other("kill denied")),
+            reap_error: None,
+            reap_timeout: Some(WTCLI_ONE_SHOT_REAP_TIMEOUT),
+        };
+
+        let diagnostic = error.to_string();
+        assert!(diagnostic.contains("wtcli timed out after 30s"));
+        assert!(diagnostic.contains("kill failed: kill denied"));
+        assert!(diagnostic.contains("reap timed out after 2s"));
     }
 }

--- a/tools/wta/src/shell/wt_channel/cli_channel.rs
+++ b/tools/wta/src/shell/wt_channel/cli_channel.rs
@@ -1,7 +1,8 @@
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use super::WtChannel;
 use crate::app_contracts::DebugMessage;
@@ -348,7 +349,18 @@ pub struct CliChannel {
     available: AtomicBool,
     debug_tx: Option<mpsc::UnboundedSender<DebugMessage>>,
     event_tx: std::sync::Mutex<Option<mpsc::UnboundedSender<serde_json::Value>>>,
+    listener_shutdown: std::sync::Mutex<Option<oneshot::Sender<()>>>,
     wtcli_path: String,
+}
+
+impl Drop for CliChannel {
+    fn drop(&mut self) {
+        if let Ok(slot) = self.listener_shutdown.get_mut() {
+            if let Some(shutdown) = slot.take() {
+                let _ = shutdown.send(());
+            }
+        }
+    }
 }
 
 impl CliChannel {
@@ -362,6 +374,7 @@ impl CliChannel {
             available: AtomicBool::new(true),
             debug_tx: None,
             event_tx: std::sync::Mutex::new(None),
+            listener_shutdown: std::sync::Mutex::new(None),
             wtcli_path: resolve_wtcli_path(),
         })
     }
@@ -382,36 +395,60 @@ impl CliChannel {
     pub async fn start_reader(self: &std::sync::Arc<Self>) {
         let wtcli = self.wtcli_path.clone();
         let weak = std::sync::Arc::downgrade(self);
+        let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+        if let Some(previous) = self.listener_shutdown.lock().unwrap().replace(shutdown_tx) {
+            let _ = previous.send(());
+        }
         tokio::spawn(async move {
             let Ok(mut child) = tokio::process::Command::new(&wtcli)
                 .args(["--json", "listen"])
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::null())
+                .kill_on_drop(true)
                 .spawn()
             else {
                 return;
             };
 
-            let stdout = child.stdout.take().unwrap();
+            let Some(stdout) = child.stdout.take() else {
+                let _ = child.start_kill();
+                let _ = child.wait().await;
+                return;
+            };
             let mut reader = tokio::io::BufReader::new(stdout);
             let mut line = String::new();
 
             loop {
                 line.clear();
                 use tokio::io::AsyncBufReadExt;
-                match reader.read_line(&mut line).await {
-                    Ok(0) => break,
-                    Ok(_) => {
-                        let Some(this) = weak.upgrade() else { break };
-                        if let Ok(val) = serde_json::from_str::<serde_json::Value>(line.trim()) {
-                            let tx = this.event_tx.lock().unwrap();
-                            if let Some(tx) = tx.as_ref() {
-                                let _ = tx.send(val);
+                tokio::select! {
+                    _ = &mut shutdown_rx => break,
+                    result = reader.read_line(&mut line) => {
+                        match result {
+                            Ok(0) => break,
+                            Ok(_) => {
+                                let Some(this) = weak.upgrade() else { break };
+                                if let Ok(val) = serde_json::from_str::<serde_json::Value>(line.trim()) {
+                                    let tx = this.event_tx.lock().unwrap();
+                                    if let Some(tx) = tx.as_ref() {
+                                        let _ = tx.send(val);
+                                    }
+                                }
                             }
+                            Err(_) => break,
                         }
                     }
-                    Err(_) => break,
                 }
+            }
+
+            drop(reader);
+            let _ = child.start_kill();
+            if let Err(error) = child.wait().await {
+                tracing::warn!(
+                    target: "wtcli",
+                    %error,
+                    "failed to reap wtcli event listener"
+                );
             }
         });
     }
@@ -420,9 +457,12 @@ impl CliChannel {
     /// wtcli inherits WT_COM_CLSID from this process's env.
     async fn run_wtcli(&self, args: &[&str]) -> anyhow::Result<serde_json::Value> {
         let mut cmd = tokio::process::Command::new(&self.wtcli_path);
-        cmd.arg("--json").args(args);
+        cmd.arg("--json").args(args).kill_on_drop(true);
 
-        let output = cmd.output().await.context("Failed to run wtcli")?;
+        let output = tokio::time::timeout(Duration::from_secs(30), cmd.output())
+            .await
+            .context("wtcli timed out after 30 seconds")?
+            .context("Failed to run wtcli")?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -557,10 +597,7 @@ impl WtChannel for CliChannel {
                     .get("direction")
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
-                let profile = params
-                    .get("profile")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
+                let profile = params.get("profile").and_then(|v| v.as_str()).unwrap_or("");
                 let cmd_owned;
                 let dir_owned;
                 let profile_owned;


### PR DESCRIPTION
## Summary
- contain each `wta-helper` and its descendants in a `KILL_ON_JOB_CLOSE` Job Object
- give helpers three seconds to exit after their agent pane closes, then terminate and reap them by process handle
- explicitly stop and reap persistent `wtcli listen` children and bound one-shot `wtcli` calls with timeout + kill-on-drop

## Validation
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml shell::wt_channel --no-fail-fast`
- `msbuild src\cascadia\TerminalApp\TerminalAppLib.vcxproj /m /p:Configuration=Debug /p:Platform=x64 /p:SolutionDir=<repo>\ /p:BuildProjectReferences=false`
- full WTA suite: 1607 passed; the existing `bundled_hook_commands_run_in_every_shell` test failed because the locally resolved `wtcli.exe` predates the existing `agent-hook` command
- full TerminalApp `bx`: dependency build reached an unrelated Settings Editor XAML compiler internal error (`WMC9999`); direct TerminalAppLib build passed