### PR TITLE
Stop resuming a session into a POSIX starting directory

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -6127,10 +6127,33 @@ namespace winrt::TerminalApp::implementation
         }
 
         // Step 1: create a new tab.
+        //
+        // The session's cwd can be POSIX (`/home/<user>`) even for a row the
+        // registry stamped as a host session: an agent CLI that syncs its
+        // sessions from a backend reports the cwd of the machine that created
+        // them, so a Linux-created session surfaces in the Windows CLI's
+        // listing. Handing such a path to `startingDirectory` fails the whole
+        // tab launch with ERROR_DIRECTORY (0x8007010b) because WT passes
+        // "linux-y" paths through verbatim (Utils::EvaluateStartingDirectory,
+        // GH#592) and only a WSL profile can mangle them. Skip it and let the
+        // profile default win — `_pendingLoadSessions` still carries the raw
+        // cwd, which is what the in-distro `session/load` needs.
         Settings::Model::NewTerminalArgs newTerminalArgs{};
-        if (!cwdStr.empty())
+        // POSIX absolute (`/home/me`, but not the `//server/share` UNC form)
+        // and home-relative (`~`, `~/proj`) — exactly what WT treats as
+        // "linux-y".
+        const bool cwdIsPosixStyle =
+            !cwdStr.empty() &&
+            ((cwdStr.front() == '/' && !(cwdStr.size() > 1 && cwdStr[1] == '/')) ||
+             (cwdStr.front() == '~' && (cwdStr.size() == 1 || cwdStr[1] == '/' || cwdStr[1] == '\\')));
+        if (!cwdStr.empty() && !cwdIsPosixStyle)
         {
             newTerminalArgs.StartingDirectory(winrt::to_hstring(cwdStr));
+        }
+        else if (cwdIsPosixStyle)
+        {
+            _agentPaneLog("OnResumeInNewAgentTabRequested: session cwd '" + cwdStr +
+                          "' is not a Windows path; using the profile default for the new tab");
         }
         const auto hr = _OpenNewTab(newTerminalArgs, /*openInBackground*/ false);
         if (FAILED(hr))

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -2881,20 +2881,25 @@ impl App {
         // reset guarantees any post-failure output isn't tinted /
         // blinking.
         let raw_cwd_string = s.cwd.to_string_lossy().to_string();
-        // Drop stale cwd so wtcli falls back to the profile default
-        // rather than failing CreateProcessW with ERROR_DIRECTORY.
+        // Drop unusable cwd so wtcli falls back to the profile default
+        // rather than failing the launch with ERROR_DIRECTORY (0x8007010b).
         // WSL rows use `wsl --cd` inside the distro command; passing
         // the Linux path as a Windows `-d` flag to wtcli would fail.
+        // Host rows need the *Windows-strict* check: a cloud-synced agent
+        // session created inside a distro is listed by the Windows CLI with
+        // its POSIX cwd (`/home/<user>`), so a `Host` row can still carry a
+        // path only WSL can resolve.
         let valid_cwd = if s.location.is_wsl() {
             None
         } else {
-            crate::cwd_util::validate_starting_directory(&s.cwd)
+            crate::cwd_util::validate_windows_starting_directory(&s.cwd)
         };
         if valid_cwd.is_none() && !raw_cwd_string.is_empty() {
             tracing::warn!(
                 target: "agents_view",
                 key = %key,
-                "dispatch_resume: stored cwd is no longer a valid directory; falling back to profile default",
+                wsl = s.location.is_wsl(),
+                "dispatch_resume: stored cwd is not usable as a Windows starting directory; falling back to profile default",
             );
         }
         let short_key: String = key.chars().take(8).collect();

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -11238,6 +11238,100 @@ fn enter_on_wsl_history_row_resumes_inside_distro() {
     );
 }
 
+/// A `Host` row can still carry a POSIX cwd: an agent CLI that syncs its
+/// sessions from a backend lists sessions created on another machine, so a
+/// Linux-created session shows up in the Windows CLI's `session/list` with
+/// `/home/<user>` as its cwd. Passing that to `wtcli new-tab -d` fails the
+/// whole launch with `ERROR_DIRECTORY (0x8007010b)` — WT never resolves a
+/// "linux-y" path for a non-WSL profile — so it must be dropped and the
+/// profile default used instead.
+#[test]
+fn enter_on_host_row_with_posix_cwd_drops_the_starting_directory() {
+    use crate::agent_sessions::{AgentStatus, CliSource, SessionLocation, SessionOrigin};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    let row = crate::agent_sessions::AgentSession {
+        key: "bae9051a-b7e5".to_string(),
+        cli_source: CliSource::Copilot,
+        pane_session_id: None,
+        window_id: None,
+        tab_id: None,
+        title: "t".to_string(),
+        cwd: std::path::PathBuf::from("/home/yuazha"),
+        started_at: std::time::SystemTime::UNIX_EPOCH,
+        last_activity_at: std::time::SystemTime::UNIX_EPOCH,
+        status: AgentStatus::Historical,
+        last_error: None,
+        current_tool: None,
+        attention_reason: None,
+        log_path: None,
+        origin: SessionOrigin::Unknown,
+        location: SessionLocation::Host,
+    };
+    let mut app = test_app();
+    app.agent_sessions.merge_historical(vec![row]);
+    app.current_tab_mut().current_view = View::Agents;
+    app.current_tab_mut().agents_list_state.select(Some(0));
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    let cmd = app
+        .last_dispatched_command_for_test()
+        .expect("a command was dispatched");
+    assert_eq!(cmd.kind, DispatchedCommandKind::NewTabResume);
+    assert!(
+        !cmd.argv.iter().any(|a| a == "-d"),
+        "a POSIX cwd must not become a Windows starting directory; argv: {:?}",
+        cmd.argv
+    );
+    // The resume itself still happens — the CLI resolves the session by id.
+    let argv = cmd.argv.join(" ");
+    assert!(
+        argv.contains("copilot --resume bae9051a-b7e5"),
+        "expected the host resume command; argv: {argv}"
+    );
+}
+
+/// An existing Windows cwd is still forwarded — the POSIX guard must not
+/// regress the common case.
+#[test]
+fn enter_on_host_row_keeps_a_real_windows_cwd() {
+    use crate::agent_sessions::{AgentStatus, CliSource, SessionLocation, SessionOrigin};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    let cwd = std::env::temp_dir();
+    let row = crate::agent_sessions::AgentSession {
+        key: "win-1".to_string(),
+        cli_source: CliSource::Copilot,
+        pane_session_id: None,
+        window_id: None,
+        tab_id: None,
+        title: "t".to_string(),
+        cwd: cwd.clone(),
+        started_at: std::time::SystemTime::UNIX_EPOCH,
+        last_activity_at: std::time::SystemTime::UNIX_EPOCH,
+        status: AgentStatus::Historical,
+        last_error: None,
+        current_tool: None,
+        attention_reason: None,
+        log_path: None,
+        origin: SessionOrigin::Unknown,
+        location: SessionLocation::Host,
+    };
+    let mut app = test_app();
+    app.agent_sessions.merge_historical(vec![row]);
+    app.current_tab_mut().current_view = View::Agents;
+    app.current_tab_mut().agents_list_state.select(Some(0));
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    let cmd = app
+        .last_dispatched_command_for_test()
+        .expect("a command was dispatched");
+    let argv = cmd.argv.join(" ");
+    assert!(
+        cmd.argv.iter().any(|a| a == "-d"),
+        "an existing Windows cwd must be forwarded; argv: {argv}"
+    );
+    assert!(argv.contains(&cwd.to_string_lossy().to_string()));
+}
+
 fn usage_snapshot() -> crate::usage::UsageSnapshot {
     crate::usage::UsageSnapshot {
         context: Some(crate::usage::UsageContext {

--- a/tools/wta/src/cwd_util.rs
+++ b/tools/wta/src/cwd_util.rs
@@ -8,6 +8,11 @@
 //! and network UNC paths pass through unchanged: they can't be checked
 //! against the Windows fs without false-rejecting valid WSL paths, and
 //! WSL/network UNC can stall `fs::metadata` for seconds (see GH#9541).
+//!
+//! Launchers that hand the value to a **Windows** process (`wtcli new-tab
+//! -d`, a WT tab's `startingDirectory`) must use
+//! [`validate_windows_starting_directory`] instead: a POSIX path is a valid
+//! cwd for an in-distro agent but not for `CreateProcessW`.
 
 use std::path::{Component, Path, Prefix};
 
@@ -26,6 +31,42 @@ pub fn validate_starting_directory<P: AsRef<Path>>(path: P) -> Option<String> {
     match std::fs::metadata(p) {
         Ok(meta) if meta.is_dir() => Some(s.into_owned()),
         _ => None,
+    }
+}
+
+/// [`validate_starting_directory`] plus a POSIX-path rejection, for
+/// launchers whose target is a **Windows** process.
+///
+/// A session's recorded cwd can be POSIX (`/home/me`) even when the row is
+/// stamped `SessionLocation::Host` — an agent CLI that syncs its sessions
+/// from a backend reports the cwd of the machine that created them, so a
+/// Linux-created session shows up in a Windows CLI's `session/list`.
+/// Handing that path to `wtcli new-tab -d` (or to a tab's
+/// `startingDirectory`) fails the launch outright with
+/// `ERROR_DIRECTORY (0x8007010b)` — WT deliberately passes "linux-y" paths
+/// through verbatim (`Utils::EvaluateStartingDirectory`, GH#592) so only a
+/// WSL profile can mangle them. Dropping the cwd lets the launcher fall
+/// back to the profile default and the CLI report its own resume result.
+pub fn validate_windows_starting_directory<P: AsRef<Path>>(path: P) -> Option<String> {
+    let p = path.as_ref();
+    if is_posix_style_path(p) {
+        return None;
+    }
+    validate_starting_directory(p)
+}
+
+/// `true` for paths that only resolve on a Unix host (a WSL distro): POSIX
+/// absolute (`/`, `/home/me`) and home-relative (`~`, `~/proj`) forms.
+/// These are exactly the shapes WT treats as "linux-y" and refuses to
+/// resolve against the Windows filesystem. Forward-slash UNC
+/// (`//server/share`) is NOT POSIX-style — Windows opens it fine.
+fn is_posix_style_path(path: &Path) -> bool {
+    let s = path.to_string_lossy();
+    let bytes = s.as_bytes();
+    match bytes.first() {
+        Some(b'/') => bytes.get(1) != Some(&b'/'),
+        Some(b'~') => matches!(bytes.get(1), None | Some(b'/') | Some(b'\\')),
+        _ => false,
     }
 }
 
@@ -168,6 +209,84 @@ mod tests {
         // Missing extended-length path → None.
         let _ = fs::remove_dir_all(&dir);
         assert_eq!(validate_starting_directory(&ext), None);
+    }
+
+    /// The Windows-strict variant must drop POSIX cwds. A cloud-synced
+    /// agent session created inside WSL is listed by the *Windows* CLI with
+    /// its Linux cwd, so the row is `SessionLocation::Host` but its cwd
+    /// only exists in the distro. Passing it to `wtcli new-tab -d` fails
+    /// the whole launch with `ERROR_DIRECTORY (0x8007010b)`.
+    #[test]
+    fn windows_variant_rejects_posix_style_paths() {
+        for s in ["/home/user/proj", "/", "/tmp", "~", "~/work", r"~\work"] {
+            assert_eq!(
+                validate_windows_starting_directory(s),
+                None,
+                "POSIX-style path `{}` must not be used as a Windows starting directory",
+                s
+            );
+            assert_eq!(
+                validate_starting_directory(s),
+                Some(s.to_string()),
+                "the lenient variant must still pass `{}` through for in-distro use",
+                s
+            );
+        }
+    }
+
+    /// Everything the lenient variant accepts and that Windows can actually
+    /// open must survive the strict variant unchanged.
+    #[test]
+    fn windows_variant_keeps_windows_resolvable_paths() {
+        let dir = unique_temp_dir("win_ok");
+        fs::create_dir_all(&dir).unwrap();
+        assert_eq!(
+            validate_windows_starting_directory(&dir),
+            Some(dir.to_string_lossy().into_owned())
+        );
+        let _ = fs::remove_dir_all(&dir);
+
+        for s in [
+            r"\\wsl$\Ubuntu\home\user\proj",
+            r"\\wsl.localhost\Ubuntu\home\user\proj",
+            r"\\server\share\proj",
+            "//server/share/proj",
+            r"foo\bar",
+            "~tilde-prefixed-name",
+        ] {
+            assert_eq!(
+                validate_windows_starting_directory(s),
+                Some(s.to_string()),
+                "`{}` is Windows-resolvable and must be kept",
+                s
+            );
+        }
+
+        assert_eq!(validate_windows_starting_directory(""), None);
+    }
+
+    #[test]
+    fn posix_style_path_classification() {
+        for s in ["/", "/home/user", "/mnt/c/src", "~", "~/proj", r"~\proj"] {
+            assert!(is_posix_style_path(Path::new(s)), "should be POSIX: {}", s);
+        }
+        for s in [
+            "",
+            r"C:\foo",
+            "C:/foo",
+            r"\\wsl$\Ubuntu\home",
+            r"\\server\share",
+            "//server/share",
+            r"\foo",
+            "foo/bar",
+            "~tilde-prefixed-name",
+        ] {
+            assert!(
+                !is_posix_style_path(Path::new(s)),
+                "should NOT be POSIX: {}",
+                s
+            );
+        }
     }
 
     #[test]

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -262,6 +262,14 @@ struct MasterStateInner {
     /// Used to source HOST session history via `session/list` instead of
     /// reading the CLI's on-disk files.
     agent_conn: OnceLock<conn::ClientLink>,
+    /// Execution source of the agent behind `agent_conn`, captured in the
+    /// same step. The "host" history bridge is really "whatever the first
+    /// lazily spawned agent is", and that agent can be WSL-hosted
+    /// (`wsl.exe -d <distro> -- … --acp`). Its `session/list` then returns
+    /// in-distro sessions with POSIX cwds, so stamping them
+    /// `SessionLocation::Host` would make the picker resume them as a plain
+    /// Windows command line instead of `wsl -d <distro> -- …`.
+    host_agent_source: OnceLock<crate::agent_source::AgentSource>,
     /// The CLI provider master is multiplexing. Resolved once at
     /// startup from `config.agent` via `agent_registry::resolve_agent_id_from_cmd`.
     /// Used to stamp `cli_source` on every SessionInfo upserted from
@@ -3719,6 +3727,7 @@ async fn run_master_loop(config: MasterConfig, pipe_name: String) -> Result<()> 
         allowed_agent_ids,
         cached_init_resp: OnceLock::new(),
         agent_conn: OnceLock::new(),
+        host_agent_source: OnceLock::new(),
         cli_source: crate::agent_sessions::CliSource::from_agent_id(
             config
                 .agent_id
@@ -4333,6 +4342,10 @@ async fn spawn_one_agent(
     // from the bound AgentCli below.
     let _ = state.cached_init_resp.set(init_resp.clone());
     if state.agent_conn.set(conn.clone()).is_ok() {
+        // Same slot, same agent: the history scan must stamp its rows with the
+        // source this CLI actually runs in, or a WSL-hosted default agent
+        // reports its in-distro sessions as host sessions.
+        let _ = state.host_agent_source.set(source.clone());
         let state_for_history = Arc::clone(state);
         tokio::task::spawn_local(async move {
             let count = seed_host_and_broadcast(&state_for_history).await;
@@ -4970,6 +4983,17 @@ async fn host_session_list_raw(
     outcome
 }
 
+/// Where the rows returned by [`host_session_list_raw`] actually live. The
+/// history bridge's agent is the first lazily spawned CLI, which may itself be
+/// WSL-hosted; `Host` only when that agent runs on Windows.
+fn host_scan_location(state: &MasterStateInner) -> crate::agent_sessions::SessionLocation {
+    state
+        .host_agent_source
+        .get()
+        .map(crate::agent_source::AgentSource::session_location)
+        .unwrap_or_default()
+}
+
 /// Host history from the already-running agent's `session/list`, gated on the
 /// `sessionCapabilities.list` capability. `None` when unsupported (Gemini,
 /// non-ACP custom) / not connected / failed — distinct from `Some(vec![])`
@@ -4995,7 +5019,7 @@ async fn host_history_via_acp(
     Some(crate::session_history::classify_and_map(
         &sessions,
         &idx,
-        crate::agent_sessions::SessionLocation::Host,
+        host_scan_location(state),
         &cli,
     ))
 }
@@ -5043,6 +5067,7 @@ async fn host_titles_via_acp(
 /// agent couldn't be listed.
 async fn sync_host_history(state: &MasterStateInner) -> Option<(bool, usize)> {
     let rows = host_history_via_acp(state).await?;
+    let scan_location = host_scan_location(state);
     let listed_ids: std::collections::HashSet<String> =
         rows.iter().map(|r| r.key.clone()).collect();
 
@@ -5070,13 +5095,13 @@ async fn sync_host_history(state: &MasterStateInner) -> Option<(bool, usize)> {
     // lock, so a row a hook/watcher flips live between the snapshot above and
     // the remove below is never deleted out from under that update.
     for row in &snapshot {
-        if !is_stale_host_history_row(row, &listed_ids) {
+        if !is_stale_host_history_row(row, &listed_ids, &scan_location) {
             continue;
         }
         let removed = state
             .registry
             .remove_if(&row.session_id, &|cur| {
-                is_stale_host_history_row(cur, &listed_ids)
+                is_stale_host_history_row(cur, &listed_ids, &scan_location)
             })
             .await;
         if removed.is_some() {
@@ -5092,16 +5117,19 @@ async fn sync_host_history(state: &MasterStateInner) -> Option<(bool, usize)> {
     Some((changed, rows.len()))
 }
 
-/// Whether a registry row is a stale host-history row to drop during reconcile:
-/// a terminal (Historical / Ended) Class-B **host** row whose id is NOT in the
-/// authoritative `session/list` set. Live rows (Working / Idle), agent panes
-/// (ACP-driven), and WSL rows are never reconciled away. Pure for unit testing.
+/// Whether a registry row is a stale history row to drop during reconcile:
+/// a terminal (Historical / Ended) Class-B row **from the scanned location**
+/// whose id is NOT in the authoritative `session/list` set. Live rows
+/// (Working / Idle), agent panes (ACP-driven), and rows located anywhere other
+/// than the scan's own source (another distro, or any WSL row when the history
+/// agent runs on Windows) are never reconciled away. Pure for unit testing.
 fn is_stale_host_history_row(
     row: &crate::session_registry::SessionInfo,
     listed_ids: &std::collections::HashSet<String>,
+    scan_location: &crate::agent_sessions::SessionLocation,
 ) -> bool {
-    use crate::agent_sessions::{AgentStatus, SessionLocation, SessionOrigin};
-    if !matches!(row.location, SessionLocation::Host) {
+    use crate::agent_sessions::{AgentStatus, SessionOrigin};
+    if row.location != *scan_location {
         return false;
     }
     if row.origin == Some(SessionOrigin::AgentPane) {

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -719,6 +719,7 @@ fn make_state() -> Arc<MasterStateInner> {
         allowed_agent_ids: None,
         cached_init_resp: OnceLock::new(),
         agent_conn: OnceLock::new(),
+        host_agent_source: OnceLock::new(),
         cli_source: Some(crate::agent_sessions::CliSource::Copilot),
         helper_meta: Mutex::new(HashMap::new()),
         tab_ownership_gate: Mutex::new(()),
@@ -5445,6 +5446,7 @@ fn make_state_with_wt(wt: Arc<dyn crate::shell::wt_channel::WtChannel>) -> Arc<M
         allowed_agent_ids: None,
         cached_init_resp: OnceLock::new(),
         agent_conn: OnceLock::new(),
+        host_agent_source: OnceLock::new(),
         cli_source: Some(crate::agent_sessions::CliSource::Copilot),
         helper_meta: Mutex::new(HashMap::new()),
         tab_ownership_gate: Mutex::new(()),
@@ -5930,6 +5932,10 @@ fn is_stale_host_history_row_reconcile_rules() {
     use crate::agent_sessions::{AgentStatus, SessionLocation, SessionOrigin};
     use std::collections::HashSet;
     let listed: HashSet<String> = ["kept".to_string()].into_iter().collect();
+    let host = SessionLocation::Host;
+    let ubuntu = SessionLocation::Wsl {
+        distro: "Ubuntu".to_string(),
+    };
     let mk = |id: &str| {
         let mut r = crate::session_registry::SessionInfo::new(
             acp::schema::v1::SessionId::new(id.to_string()),
@@ -5940,23 +5946,31 @@ fn is_stale_host_history_row_reconcile_rules() {
         r
     };
     // Terminal Class-B host row NOT in session/list → stale (drop).
-    assert!(is_stale_host_history_row(&mk("gone"), &listed));
+    assert!(is_stale_host_history_row(&mk("gone"), &listed, &host));
     // Still listed → keep.
-    assert!(!is_stale_host_history_row(&mk("kept"), &listed));
+    assert!(!is_stale_host_history_row(&mk("kept"), &listed, &host));
     // Live (Idle/Working) → keep even if not listed.
     let mut live = mk("gone");
     live.status = Some(AgentStatus::Idle);
-    assert!(!is_stale_host_history_row(&live, &listed));
+    assert!(!is_stale_host_history_row(&live, &listed, &host));
     // Agent pane → never reconciled.
     let mut pane = mk("gone");
     pane.origin = Some(SessionOrigin::AgentPane);
-    assert!(!is_stale_host_history_row(&pane, &listed));
-    // WSL row → host can't authoritatively list distro sessions.
+    assert!(!is_stale_host_history_row(&pane, &listed, &host));
+    // WSL row → a Windows-hosted agent can't authoritatively list distro
+    // sessions.
     let mut wsl = mk("gone");
-    wsl.location = SessionLocation::Wsl {
-        distro: "Ubuntu".to_string(),
+    wsl.location = ubuntu.clone();
+    assert!(!is_stale_host_history_row(&wsl, &listed, &host));
+    // A WSL-hosted history agent reconciles ITS distro's rows...
+    assert!(is_stale_host_history_row(&wsl, &listed, &ubuntu));
+    // ...but never the host's, nor another distro's.
+    assert!(!is_stale_host_history_row(&mk("gone"), &listed, &ubuntu));
+    let mut debian = mk("gone");
+    debian.location = SessionLocation::Wsl {
+        distro: "Debian".to_string(),
     };
-    assert!(!is_stale_host_history_row(&wsl, &listed));
+    assert!(!is_stale_host_history_row(&debian, &listed, &ubuntu));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Resuming a Copilot session that had been created inside WSL failed the whole tab launch:

```
error 2147942667 (0x8007010b) when launching
`cmd /c echo Resuming copilot session bae9051a... && copilot --resume bae9051a-…`
Could not access starting directory "/home/yuazha"
```

The new tab never opened, so the session was unreachable from the `/sessions` picker.

## Root cause

The failing row was a genuine **host** row that carried a **POSIX cwd**. Two independent paths produce that shape:

1. **Cloud-synced sessions.** Copilot syncs sessions from its backend, so the *Windows* CLI's `session/list` returns sessions that were created inside a distro — cwd (`/home/<user>`) included. From master's point of view the row is correctly `SessionLocation::Host`; only its cwd is Linux.
2. **A WSL-hosted history agent.** Master's history bridge (`agent_conn` / `cached_init_resp`) binds to the *first lazily spawned* agent, and that agent can itself be WSL-hosted. The user's log shows both shapes in one session:

   ```
   master: agent CLI spawned program=copilot.exe agent_cmd=copilot --acp --stdio agent_source=host
   master: agent CLI spawned program=wsl.exe -d Ubuntu agent_cmd=copilot --acp --stdio agent_source=wsl:Ubuntu
   ```

   `host_history_via_acp` stamped every listed session `SessionLocation::Host` unconditionally, so a WSL-hosted default agent reported its in-distro sessions as host sessions.

`cwd_util::validate_starting_directory` deliberately passes POSIX paths through — an in-distro `session/load` needs them — so `/home/yuazha` reached `wtcli new-tab -d` and a new tab's `startingDirectory`. WT passes "linux-y" paths through verbatim (`Utils::EvaluateStartingDirectory`, GH#592) and only a WSL profile can mangle them, so `CreateProcessW` failed with `ERROR_DIRECTORY` instead of falling back to the profile default.

Confirmed from `wta-main_helper-82112.log` — no `wsl -d`, and the Windows `-d` flag carrying a Linux path:

```
dispatch_resume: new-tab scheduled key=bae9051a-… cli=copilot
  commandline=copilot --resume bae9051a-…
  launch_commandline=cmd /c echo Resuming copilot session bae9051a... && copilot --resume bae9051a-…
```

## Changes

- **`cwd_util.rs`** — add `validate_windows_starting_directory`, the Windows-strict variant. It rejects POSIX absolute (`/`, `/home/me`) and home-relative (`~`, `~/proj`) paths on top of the existing missing-directory check, while keeping `//server/share`, `\\wsl$\…` UNC, and relative paths. The lenient variant is unchanged, so `--initial-load-cwd` still forwards POSIX paths to the in-distro agent.
- **`app.rs`** — the Enter-resume path (`dispatch_resume`) uses the strict variant for host rows. WSL rows keep using `wsl --cd` inside the distro command as before.
- **`TerminalPage.cpp`** — `OnResumeInNewAgentTabRequested` (Shift+Enter) skips `StartingDirectory` for POSIX paths. `_pendingLoadSessions` still carries the raw cwd, which is what the in-distro `session/load` consumes.
- **`master/mod.rs`** — record the history agent's real `AgentSource` next to `agent_conn`, stamp scanned rows with it, and reconcile against that same location. A WSL-hosted default agent's sessions are now stamped `Wsl { distro }` and resume through `wsl -d <distro> -- bash -lc "…"`; the reconcile no longer treats another location's rows as stale.

## Behavior after the fix

Resuming a session whose cwd cannot be resolved on Windows opens the tab in the profile default directory and lets the CLI resolve the session by id, instead of failing the launch outright. A warning is logged with the row key so the dropped cwd is diagnosable.

## Test plan

- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml` — **1613 passed, 0 failed**.
  - New: `cwd_util::tests::windows_variant_rejects_posix_style_paths`, `windows_variant_keeps_windows_resolvable_paths`, `posix_style_path_classification`
  - New: `app::tests::enter_on_host_row_with_posix_cwd_drops_the_starting_directory`, `enter_on_host_row_keeps_a_real_windows_cwd`
  - Extended: `master::tests::is_stale_host_history_row_reconcile_rules` now covers a WSL-hosted scan location (reconciles its own distro, never the host's or another distro's)
  - Unchanged and still passing: `app::tests::enter_on_wsl_history_row_resumes_inside_distro`
- `cmd.exe /c "tools\razzle.cmd && cd src\cascadia\TerminalApp && bx"` — 0 errors.
- `cargo clippy --all-targets` — no findings in the changed code.
