### PR TITLE
Name the agent's execution source in session management

### DIFF
--- a/doc/specs/wsl-session-management.md
+++ b/doc/specs/wsl-session-management.md
@@ -454,7 +454,8 @@ at all, a pooled agent for its source exists.
 
 ### Still in place
 
-- The `[WSL-<distro>]` row tag (`origin_prefix_for`).
+- Naming the distro on the row, now as a `· <distro>` suffix beside the CLI
+  provider (`cli_suffix_for`) rather than a leading `[WSL-<distro>]` tag.
 - Resume back into the distro, including the `wsl -d <distro> --cd ...` command
   shape and the suppression of Shift+Enter "resume in agent pane" for WSL rows.
 - `SessionLocation` on the wire, which is now load-bearing for filtering rather

--- a/src/cascadia/TerminalApp/AgentPaneContent.cpp
+++ b/src/cascadia/TerminalApp/AgentPaneContent.cpp
@@ -231,9 +231,11 @@ namespace winrt::TerminalApp::implementation
         StateChanged.raise(*this, nullptr);
     }
 
-    // Swap the bar between two modes:
-    //   * chat / connecting / etc. (active=false) — agent logo + agent/model label
-    //   * session management view (active=true)  — no logo, "Agent sessions"
+    // Swap the bar between two modes. Both keep the agent logo and the
+    // "<agent> · <backend>" identity so the pane reads the same either way:
+    //   * chat / connecting / etc. (active=false) — identity + version + model
+    //   * session management view (active=true)   — identity inside the
+    //     "Agent sessions: {0}" title
     // Idempotent so callers don't need to dedupe.
     void AgentPaneContent::SetSessionsView(bool active)
     {
@@ -338,55 +340,64 @@ namespace winrt::TerminalApp::implementation
 
     void AgentPaneContent::_refreshLabel()
     {
-        // Session-management view takes over the bar — the wta TUI below no
-        // longer renders its own "Agent sessions" header, so this is where
-        // that title lives.
-        if (_isSessionsView)
-        {
-            const auto text = _agentName.empty() ?
-                                  std::wstring{ RS_(L"AgentPane_SessionsTitle") } :
-                                  RS_fmt(L"AgentPane_SessionsTitleFormat", std::wstring{ _agentName });
-            AgentLabelText().Text(winrt::hstring{ text });
-            return;
-        }
-
         std::wstring text;
         if (_agentName.empty())
         {
-            text = _agentState == L"connecting" ?
-                       std::wstring{ RS_(L"AgentPane_ConnectingTitle") } :
-                       std::wstring{ RS_(L"AgentPane_DefaultTitle") };
+            // No agent name yet. The chat view names the assistant and its
+            // connection state; the sessions view falls through to its own
+            // no-agent title below.
+            if (!_isSessionsView)
+            {
+                text = _agentState == L"connecting" ?
+                           std::wstring{ RS_(L"AgentPane_ConnectingTitle") } :
+                           std::wstring{ RS_(L"AgentPane_DefaultTitle") };
+            }
         }
         else
         {
+            // Both views lead with the same agent identity ("Copilot · Debian")
+            // so the bar doesn't appear to change agents when the user opens
+            // session management. Only the chat view appends the version and
+            // model — those describe the live conversation, not the session
+            // list, and the sessions rows carry their own per-row detail.
             text = std::wstring{ _agentName };
             if (!_agentBackend.empty())
             {
                 text += L" \u00B7 ";
                 text += _agentBackend;
             }
-            if (!_agentVersion.empty())
+            if (!_isSessionsView)
             {
-                text += L" ";
-                text += _agentVersion;
+                if (!_agentVersion.empty())
+                {
+                    text += L" ";
+                    text += _agentVersion;
+                }
+                if (_agentState == L"connected" && !_agentModel.empty())
+                {
+                    text += L" \u00B7 ";
+                    text += _agentModel;
+                }
             }
-            if (_agentState == L"connected" && !_agentModel.empty())
-            {
-                text += L" \u00B7 ";
-                text += _agentModel;
-            }
+        }
+
+        // The session-management view takes over the bar — the wta TUI below
+        // no longer renders its own "Agent sessions" header, so that title
+        // lives here and keeps naming the view even once the agent is known.
+        if (_isSessionsView)
+        {
+            text = text.empty() ?
+                       std::wstring{ RS_(L"AgentPane_SessionsTitle") } :
+                       RS_fmt(L"AgentPane_SessionsTitleFormat", text);
         }
         AgentLabelText().Text(winrt::hstring{ text });
     }
 
     void AgentPaneContent::_refreshLogo()
     {
-        if (_isSessionsView)
-        {
-            AgentLogo().Visibility(Visibility::Collapsed);
-            return;
-        }
-
+        // The logo stays up in the session-management view: the bar keeps
+        // showing which agent (and backend) owns the pane, so hiding the
+        // mark there would make the two views look unrelated.
         if (_agentName.empty())
         {
             AgentLogo().Visibility(Visibility::Collapsed);

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1325,7 +1325,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="AgentPane_SessionsTitleFormat" xml:space="preserve">
     <value>Agent sessions: {0}</value>
-    <comment>Title shown in the agent pane title bar when the session-management view is active. {0} is replaced with the AI agent display name.</comment>
+    <comment>Title shown in the agent pane title bar when the session-management view is active. {0} is replaced with the AI agent display name and the environment it runs in, for example "Copilot · Debian".</comment>
   </data>
   <data name="AgentPane_SwitchAgentAutomationName" xml:space="preserve">
     <value>Switch agent</value>

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -3518,13 +3518,13 @@ fn agents_rows_snapshot_preserves_wsl_location() {
 }
 
 /// End-to-end render proof: a WSL `SessionInfo` in the `/sessions`
-/// snapshot must actually paint its bracketed distro tag (`[WSL-Ubuntu]`)
-/// on screen. `agents_rows_snapshot_preserves_wsl_location` proves the
-/// data path and `origin_prefix_shows_distro_for_wsl_rows` proves the
-/// prefix builder; this closes the loop through `crate::ui::render` so a
-/// regression in `agents_view::render`'s own `session_info_to_agent_session`
-/// conversion (a *second* call site, separate from `agents_rows_for_tab`)
-/// can't silently drop the tag.
+/// snapshot must actually paint its distro on screen.
+/// `agents_rows_snapshot_preserves_wsl_location` proves the data path and
+/// `cli_suffix_appends_the_wsl_distro` proves the suffix builder; this closes
+/// the loop through `crate::ui::render` so a regression in
+/// `agents_view::render`'s own `session_info_to_agent_session` conversion (a
+/// *second* call site, separate from `agents_rows_for_tab`) can't silently
+/// drop it.
 #[test]
 fn render_sessions_view_paints_wsl_distro_tag() {
     use crate::agent_sessions::{OriginFilter, SessionLocation};
@@ -3545,11 +3545,17 @@ fn render_sessions_view_paints_wsl_distro_tag() {
 
     app.current_tab_mut().current_view = View::Agents;
     app.current_tab_mut().agents_view.snapshot = Some(vec![info]);
+    // Opening the view for real selects row 0 (`toggle_agents_view`); this test
+    // installs the snapshot directly, so select it here — the distro rides the
+    // CLI suffix, which only surfaces on the selected or active row.
+    app.current_tab_mut().agents_list_state.select(Some(0));
 
     let text = render_to_text(&mut app, 80, 24);
     assert!(
-        text.contains("[WSL-Ubuntu]"),
-        "the /sessions view must paint the bracketed WSL distro tag; rendered:\n{text}"
+        // `session_info_for_test` reports Claude; the distro must ride the same
+        // suffix, right after the provider.
+        text.contains("· claude · Ubuntu"),
+        "the /sessions view must paint the WSL distro beside the CLI; rendered:\n{text}"
     );
 }
 

--- a/tools/wta/src/cli/sessions.rs
+++ b/tools/wta/src/cli/sessions.rs
@@ -109,8 +109,8 @@ pub(crate) async fn register_launched(
         title: String::new(),
     };
     // A WSL delegate carries its distro so the master stamps the row
-    // `Wsl { distro }` → the session view shows the `[WSL-<distro>]`
-    // prefix.
+    // `Wsl { distro }` → the session view names the distro in the row
+    // suffix.
     let req = match wsl_distro {
         Some(distro) => crate::session_registry::build_born_bound_request_wsl(&event, distro),
         None => crate::session_registry::build_born_bound_request(&event),

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -5881,8 +5881,8 @@ async fn handle_session_hook(
 /// Applies the event exactly like [`handle_session_hook`] (binding-only), then —
 /// for a WSL delegate — stamps the freshly-created row `SessionLocation::Wsl {
 /// distro }`. The `SessionStarted` reducer defaults every row to `Host`, so
-/// without this a born-bound WSL delegate row would render without the
-/// `[WSL-<distro>]` prefix the session view already shows for in-distro rows.
+/// without this a born-bound WSL delegate row would render without the distro
+/// suffix the session view already shows for in-distro rows.
 /// Re-broadcasts `sessions/changed` only when the location actually changed, so
 /// the host path (no distro) adds no extra push.
 async fn handle_session_born_bound(

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -9712,7 +9712,7 @@ async fn session_born_bound_marks_born_bound_not_hook_owned() {
 async fn born_bound_wsl_stamps_wsl_location() {
     // A WSL `?<prompt>` delegate registers with a distro; the master must
     // stamp the row `Wsl { distro }` (the reducer defaults to Host) so the
-    // session view renders the [WSL-<distro>] prefix.
+    // session view names the distro in the row suffix.
     let state = make_state();
     let event = crate::agent_sessions::SessionEvent::SessionStarted {
         key: "bb-wsl-loc".to_string(),

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -485,7 +485,7 @@ pub enum WtaExtRequest {
     /// (same body as `SessionHook` plus an optional `wsl_distro` → binding-only
     /// semantics). The second field is the WSL distro when the born-bound
     /// session runs inside a distro (delegate `?<prompt>` from a WSL pane), so
-    /// the master can stamp the row `Wsl { distro }` for the `[WSL-…]` prefix.
+    /// the master can stamp the row `Wsl { distro }` for the distro suffix.
     SessionBornBound(crate::agent_sessions::SessionEvent, Option<String>),
     /// `_intellterm.wta/session_resume_dispatched` — optimistic resume flip.
     SessionResumeDispatched(SessionResumeDispatchedParams),
@@ -900,7 +900,7 @@ pub fn build_born_bound_request(
 /// Like [`build_born_bound_request`] but tags the session as running inside a
 /// WSL distro. The master stamps the created row `SessionLocation::Wsl {
 /// distro }` (the reducer defaults `SessionStarted` to `Host`) so the session
-/// view renders the `[WSL-<distro>]` prefix — used by the `?<prompt>` delegate
+/// view names the distro in the row suffix — used by the `?<prompt>` delegate
 /// path when the active pane is a WSL pane.
 pub fn build_born_bound_request_wsl(
     event: &crate::agent_sessions::SessionEvent,
@@ -1156,7 +1156,7 @@ pub trait SessionRegistry: Send + Sync {
     /// `true` iff the value actually changed. Used to stamp a born-bound WSL
     /// delegate row as `Wsl { distro }` after the reducer creates it (the
     /// reducer defaults every `SessionStarted` to `Host`), so the session view
-    /// renders the `[WSL-<distro>]` prefix.
+    /// names the distro in the row suffix.
     async fn set_location(
         &self,
         sid: &acp::schema::v1::SessionId,

--- a/tools/wta/src/ui/agents_view.rs
+++ b/tools/wta/src/ui/agents_view.rs
@@ -615,24 +615,39 @@ fn badge_style(s: &AgentSession) -> Style {
     }
 }
 
-/// Show the CLI provider (`claude`, `codex`, `copilot`, `gemini`, `opencode`) only on the
-/// active row or the keyboard-selected row — matches the Figma where the
-/// agent icon appears only on the currently-engaged session and avoids
-/// cluttering the historical list.
+/// Show the CLI provider (`claude`, `codex`, `copilot`, `gemini`, `opencode`) and,
+/// for in-distro rows, the WSL distro that runs it — only on the active row or
+/// the keyboard-selected row, matching the Figma where the agent icon appears
+/// only on the currently-engaged session and avoids cluttering the historical
+/// list.
+///
+/// The distro rides this suffix ("· copilot · Ubuntu") rather than a leading
+/// `[WSL-Ubuntu]` tag: `matches_source` already narrows the list to the viewing
+/// pane's own execution source, so every visible row shares one location and the
+/// distro reads as identity, not as disambiguation.
 fn cli_suffix_for(s: &AgentSession, selected: bool) -> String {
     let surface = selected || matches!(s.status, AgentStatus::Working | AgentStatus::Attention);
     if !surface {
         return String::new();
     }
-    let label = match s.cli_source {
-        CliSource::Claude => "claude",
-        CliSource::Codex => "codex",
-        CliSource::Copilot => "copilot",
-        CliSource::Gemini => "gemini",
-        CliSource::OpenCode => "opencode",
-        CliSource::Unknown(_) => return String::new(),
+    let cli = match s.cli_source {
+        CliSource::Claude => Some("claude"),
+        CliSource::Codex => Some("codex"),
+        CliSource::Copilot => Some("copilot"),
+        CliSource::Gemini => Some("gemini"),
+        CliSource::OpenCode => Some("opencode"),
+        CliSource::Unknown(_) => None,
     };
-    format!("· {}", label)
+    let distro = match &s.location {
+        SessionLocation::Wsl { distro } => Some(distro.as_str()),
+        SessionLocation::Host => None,
+    };
+    [cli, distro]
+        .into_iter()
+        .flatten()
+        .map(|part| format!("· {part}"))
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Surface a tiny "originated from the Intelligent Terminal agent pane"
@@ -647,12 +662,6 @@ fn cli_suffix_for(s: &AgentSession, selected: bool) -> String {
 /// is live, and historical rows benefit because their badge area is
 /// empty.
 fn origin_prefix_for(s: &AgentSession) -> Option<String> {
-    // WSL rows get a bracketed `WSL-<distro>` tag (e.g. "[WSL-Ubuntu] ") so
-    // the user can tell in-distro sessions from host ones. WSL rows are never
-    // AgentPane, so this branch is exclusive with the one below.
-    if let crate::agent_sessions::SessionLocation::Wsl { distro } = &s.location {
-        return Some(format!("[WSL-{distro}] "));
-    }
     if s.origin == SessionOrigin::AgentPane {
         // Take the first 8 chars of the ACP/CLI session id. For real
         // sessions this is the leading group of the UUID
@@ -1141,7 +1150,7 @@ mod tests {
     }
 
     #[test]
-    fn origin_prefix_shows_distro_for_wsl_rows() {
+    fn cli_suffix_appends_the_wsl_distro() {
         let s = AgentSession {
             key:              "abc".to_string(),
             cli_source:       CliSource::Copilot,
@@ -1160,7 +1169,18 @@ mod tests {
             origin:           SessionOrigin::Unknown,
             location:         crate::agent_sessions::SessionLocation::Wsl { distro: "Ubuntu".to_string() },
         };
-        assert_eq!(origin_prefix_for(&s).as_deref(), Some("[WSL-Ubuntu] "));
+        assert_eq!(cli_suffix_for(&s, true), "· copilot · Ubuntu");
+        // The distro follows the provider's surfacing rule, so an unselected
+        // idle row stays clean.
+        assert_eq!(cli_suffix_for(&s, false), String::new());
+        // No provider to name still leaves the distro worth showing.
+        let unknown = AgentSession {
+            cli_source: CliSource::Unknown(String::new()),
+            ..s.clone()
+        };
+        assert_eq!(cli_suffix_for(&unknown, true), "· Ubuntu");
+        // WSL rows no longer carry a leading tag.
+        assert_eq!(origin_prefix_for(&s), None);
     }
 
     /// Release checklist §4 "Session states": the inline activity badge shown next to a session


### PR DESCRIPTION
## Summary of the Pull Request

Session management didn't say where the agent runs the way the agent pane does,
and said it in a place of its own for rows.

**Title bar.** Before: the agent pane bar named the agent and where it runs --
`Copilot · Debian` for a WSL agent, `Copilot · Windows` for a host one -- but
opening session management replaced that with `Agent sessions: Copilot`: no
logo, no backend. After: the sessions view keeps the agent logo and reads
`Agent sessions: Copilot · Debian`. The chat view is unchanged.

**Rows.** Before: an in-distro row led with a bracketed `[WSL-Ubuntu] ` tag, so
a WSL list read as a column of brackets and the distro sat far from the provider
it qualifies. After: the distro joins the existing provider suffix --
`· copilot · Ubuntu`.

## Detailed Description of the Pull Request / Additional comments

`_refreshLabel` now composes `<agent> · <backend>` once and reuses it. The
chat view still appends the version and connected model; the sessions view
wraps the identity in the existing `Agent sessions: {0}` title instead of just
the agent name, and version and model stay out of it. `_refreshLogo` no longer
collapses the agent mark in the sessions view.

Only the en-US `<comment>` for `AgentPane_SessionsTitleFormat` changed, to say
`{0}` is now the agent and its environment. The string value is untouched, so
no locale needs retranslation.

For rows, the bracketed tag also predates source filtering: rows are now
narrowed to the viewing pane's own execution source, so every visible row
shares one location and the tag disambiguates nothing -- it only repeats which
distro the pane already is. `origin_prefix_for` keeps only its agent-pane
marker, and the distro inherits the provider's surfacing rule (selected or
active row). A row whose provider is unknown still names its distro.

## Validation Steps Performed

* `cargo test`: 1616 passed, 0 failed. Updated
  `render_sessions_view_paints_wsl_distro_tag` to assert the new suffix and
  replaced the prefix unit test with `cli_suffix_appends_the_wsl_distro`.
* Full Debug solution build: 0 errors.
* Loose Debug package deployed and launched.
