### PR TITLE
Hot-switch ACP models without rebuilding agent panes

### DIFF
--- a/src/cascadia/TerminalApp/SharedWta.cpp
+++ b/src/cascadia/TerminalApp/SharedWta.cpp
@@ -705,6 +705,27 @@ namespace winrt::TerminalApp::implementation
         return _RestartLocked(wtaPath, extraArgs, environment);
     }
 
+    void SharedWta::UpdateCachedConfiguration(
+        const std::wstring_view wtaPath,
+        std::span<const std::wstring> extraArgs,
+        std::span<const std::pair<std::wstring, std::wstring>> environment)
+    {
+        if (wtaPath.empty())
+        {
+            return;
+        }
+
+        std::lock_guard lock{ _mtx };
+        if (_cachedWtaPath.empty())
+        {
+            return;
+        }
+
+        _cachedWtaPath.assign(wtaPath);
+        _cachedExtraArgs.assign(extraArgs.begin(), extraArgs.end());
+        _cachedEnvironment.assign(environment.begin(), environment.end());
+    }
+
     bool SharedWta::_RestartLocked(
         const std::wstring_view wtaPath,
         std::span<const std::wstring> extraArgs,

--- a/src/cascadia/TerminalApp/SharedWta.h
+++ b/src/cascadia/TerminalApp/SharedWta.h
@@ -261,12 +261,11 @@ namespace winrt::TerminalApp::implementation
         /// `/restart` semantically "give me the same agent CLI but
         /// fresh".
         ///
-        /// Settings changes (acpAgent / acpModel / etc.) need to spawn
-        /// the master with a *different* cmdline. For that case, call
-        /// the overload that takes a fresh `wtaPath` + `extraArgs` —
-        /// it replaces the cached spawn args before respawning, so
-        /// the new master inherits the new per-process settings and
-        /// any subsequent crash-recovery respawn uses the same.
+        /// Settings changes that alter trusted process launch state
+        /// (custom agent commands or provider environment) need to spawn the
+        /// master with a *different* cmdline. For that case, call the overload
+        /// that takes fresh inputs. Runtime changes such as `acpModel` use
+        /// `UpdateCachedConfiguration` after being applied in place.
         ///
         /// No-op if the master isn't running, or if there were no
         /// cached spawn args (no AcquirePane has succeeded this
@@ -276,6 +275,16 @@ namespace winrt::TerminalApp::implementation
         bool Restart(const std::wstring_view wtaPath,
                      std::span<const std::wstring> extraArgs,
                      std::span<const std::pair<std::wstring, std::wstring>> environment = {});
+
+        /// Refresh the configuration replayed by a later `Restart()` without
+        /// disturbing the running master. Runtime settings such as the ACP
+        /// model are applied over the live protocol connection, but the
+        /// cached launch inputs must still follow them so explicit recovery
+        /// cannot restore stale settings.
+        void UpdateCachedConfiguration(
+            const std::wstring_view wtaPath,
+            std::span<const std::wstring> extraArgs,
+            std::span<const std::pair<std::wstring, std::wstring>> environment = {});
 
         std::string CreateRetirementRequestId();
         details::RetirementRegistration RegisterRetirement(

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -399,15 +399,16 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        // Hot-reload of runtime agent config (autofix gate and delegate
-        // agent/model). When any of these change between settings
+        // Hot-reload of runtime agent config (ACP model, autofix gate, and
+        // delegate agent/model). When any of these change between settings
         // reloads we push a single consolidated `agent_config_changed`
         // event to the running wta-helper(s) so they update in place,
         // WITHOUT tearing down and restarting the agent pane. This is the
         // unified dispatch for every hot-updatable agent setting — adding a
         // new one means adding a field to AgentRuntimeConfigSnapshot, not a
-        // bespoke diff/emit block here. Agent identity and model changes go
-        // through _RebuildAgentStack in _RefreshUIForSettingsReload.
+        // bespoke diff/emit block here. Agent identity and provider launch
+        // changes go through _RebuildAgentStack in
+        // _RefreshUIForSettingsReload.
         _EmitAgentRuntimeConfigIfChanged();
 
         // Make sure to call SetCommands before _RefreshUIForSettingsReload.
@@ -1658,8 +1659,8 @@ namespace winrt::TerminalApp::implementation
 
     // --- Hot-reload of agent/model settings -------------------------------
     //
-    // When any agent-identity setting changes, the single shared wta pane must
-    // be torn down and recreated with the updated flags baked into argv.
+    // When an agent-identity or provider-launch setting changes, affected
+    // panes must be torn down and recreated with the updated trusted inputs.
     // `_RebuildAgentStack` is the single entry point; it is called from
     // SetSettings (settings.json reload + Settings UI writes) and from the
     // bottom-bar selector Click handler.
@@ -1719,14 +1720,15 @@ namespace winrt::TerminalApp::implementation
 
     bool TerminalPage::_AgentSettingsChanged(const AgentSettingsSnapshot& a, const AgentSettingsSnapshot& b)
     {
-        // Agent identity and effective model changes rebuild helpers. A profile
-        // backend is part of identity because it changes both the agent id and
-        // the execution source for that profile. Only selected-provider fields
-        // consumed by the master launch environment participate in identity.
-        // The helper-safe full catalog is hot-updated separately.
+        // A profile backend is part of identity because it changes both the
+        // agent id and execution source for that profile. Concrete ACP model
+        // changes are runtime updates. Clearing an existing override remains
+        // destructive because ACP has no portable reset-to-agent-default
+        // operation. Only selected-provider fields consumed by the master
+        // launch environment otherwise participate in identity.
         return a.acpAgent != b.acpAgent ||
                a.acpCustomCommand != b.acpCustomCommand ||
-               a.acpModel != b.acpModel ||
+               (!a.acpModel.empty() && b.acpModel.empty()) ||
                a.customModelLaunch != b.customModelLaunch ||
                a.profileBackends != b.profileBackends;
     }
@@ -1735,7 +1737,14 @@ namespace winrt::TerminalApp::implementation
     {
         const auto& globals = _settings.GlobalSettings();
         const auto customModelLaunch = _CaptureCustomModelLaunchConfiguration(globals);
+        auto effectiveAcpAgent = std::wstring{ globals.EffectiveAcpAgent() };
+        if (effectiveAcpAgent.empty())
+        {
+            effectiveAcpAgent = std::wstring{ _DetectAgentCli() };
+        }
         return AgentRuntimeConfigSnapshot{
+            std::move(effectiveAcpAgent),
+            customModelLaunch ? std::wstring{} : std::wstring{ globals.AcpModel() },
             std::wstring{ _ResolveEffectiveDelegateAgent(globals) },
             std::wstring{ globals.DelegateModel() },
             customModelLaunch ? customModelLaunch->selectionId : std::wstring{},
@@ -1745,10 +1754,10 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Hot-propagate runtime agent config to the running wta-helper(s) over the
-    // protocol event channel. Unlike agent identity/model changes (which
-    // require a master respawn via _RebuildAgentStack), these take effect
-    // without tearing down the agent pane. A single consolidated
+    // protocol event channel. Unlike agent identity/provider launch changes,
+    // these take effect without tearing down the agent pane. A single consolidated
     // `agent_config_changed` event carries only the fields that changed:
+    //   - acp_model + target_agent_id : live session model selection
     //   - autofix_enabled : the auto-suggest gate (was its own event)
     //   - delegate_agent + delegate_model : the delegate-tab agent identity
     //   - cloud_models + custom_models + custom_model_selection :
@@ -1769,6 +1778,32 @@ namespace winrt::TerminalApp::implementation
         }
 
         const auto& last = _lastAgentRuntimeConfig;
+        const auto currentLaunch = _CaptureAgentSettingsSnapshot();
+        const bool globalAgentChanged =
+            _lastAgentSettings.acpAgent != currentLaunch.acpAgent ||
+            _lastAgentSettings.acpCustomCommand != currentLaunch.acpCustomCommand;
+        const bool customMasterArgsChanged =
+            (til::starts_with(_lastAgentSettings.acpAgent, L"custom:") ||
+             til::starts_with(currentLaunch.acpAgent, L"custom:")) &&
+            globalAgentChanged;
+        const bool customModelLaunchChanged =
+            _lastAgentSettings.customModelLaunch != currentLaunch.customModelLaunch;
+        const bool globalModelReset =
+            !_lastAgentSettings.acpModel.empty() &&
+            currentLaunch.acpModel.empty();
+        const bool masterRestartRequired =
+            customMasterArgsChanged || customModelLaunchChanged;
+        // If the agent changes in the same settings transaction, the old
+        // helper must not receive the new agent's model. The same applies to
+        // provider launch changes and reset-to-default, which replace the
+        // affected helper. A profile-local backend change does not suppress
+        // updates for unrelated global followers.
+        const bool acpModelChanged =
+            !globalAgentChanged &&
+            !customModelLaunchChanged &&
+            !globalModelReset &&
+            last.acpAgent == current.acpAgent &&
+            last.acpModel != current.acpModel;
         const bool autofixChanged = last.autofixEnabled != current.autofixEnabled;
         const bool delegateChanged = last.delegateAgent != current.delegateAgent ||
                                      last.delegateModel != current.delegateModel;
@@ -1776,12 +1811,20 @@ namespace winrt::TerminalApp::implementation
             last.customModelSelection != current.customModelSelection ||
             last.customModels != current.customModels;
 
-        if (!autofixChanged && !delegateChanged && !customModelsChanged)
+        if (!acpModelChanged && !autofixChanged && !delegateChanged && !customModelsChanged)
         {
+            // Agent replacement consumes the new runtime values from startup
+            // metadata rather than sending them to the old helper.
+            _lastAgentRuntimeConfig = current;
             return;
         }
 
         Json::Value params{ Json::objectValue };
+        if (acpModelChanged)
+        {
+            params["acp_model"] = winrt::to_string(winrt::hstring{ current.acpModel });
+            params["target_agent_id"] = winrt::to_string(winrt::hstring{ current.acpAgent });
+        }
         if (autofixChanged)
         {
             params["autofix_enabled"] = current.autofixEnabled;
@@ -1800,6 +1843,24 @@ namespace winrt::TerminalApp::implementation
 
         _agentPaneLog("emitting agent_config_changed (hot settings update)");
         _RaiseProtocolEvent("agent_config_changed", params);
+
+        // Keep `/restart` and crash-recovery inputs aligned with settings that
+        // were applied in place. Do not update this cache while an identity or
+        // provider-launch rebuild is pending: Restart(new args) owns that path.
+        if (!masterRestartRequired)
+        {
+            const auto wtaPath = _DetectWtaPath();
+            if (!wtaPath.empty())
+            {
+                auto& sharedWta = winrt::TerminalApp::implementation::SharedWta::Instance();
+                const auto extraArgs = _BuildSharedWtaExtraArgs();
+                const auto environment = _BuildSharedWtaEnvironment();
+                sharedWta.UpdateCachedConfiguration(
+                    std::wstring_view{ wtaPath },
+                    extraArgs,
+                    environment);
+            }
+        }
 
         _lastAgentRuntimeConfig = current;
     }
@@ -3406,6 +3467,7 @@ namespace winrt::TerminalApp::implementation
 
         if (!_AgentSettingsChanged(_lastAgentSettings, current))
         {
+            _lastAgentSettings = current;
             _agentPaneLog("_RebuildAgentStack: no change, skip rebuild");
             return;
         }
@@ -3420,11 +3482,11 @@ namespace winrt::TerminalApp::implementation
              _lastAgentSettings.acpCustomCommand != current.acpCustomCommand);
         const bool customModelLaunchChanged =
             _lastAgentSettings.customModelLaunch != current.customModelLaunch;
-        const bool cloudModelChanged =
-            _lastAgentSettings.acpModel != current.acpModel;
+        const bool globalModelReset =
+            !_lastAgentSettings.acpModel.empty() &&
+            current.acpModel.empty();
         const bool masterConfigurationChanged =
             customMasterArgsChanged ||
-            cloudModelChanged ||
             customModelLaunchChanged;
         const bool globalAgentChanged =
             _lastAgentSettings.acpAgent != current.acpAgent ||
@@ -3535,11 +3597,11 @@ namespace winrt::TerminalApp::implementation
                             currentProfile == current.profileBackends.end() ||
                             currentProfile->second.empty();
                         affected = profileBackendChanged ||
-                                   (globalAgentChanged && followsGlobalAgent);
+                                   ((globalAgentChanged || globalModelReset) && followsGlobalAgent);
                     }
                     else
                     {
-                        affected = globalAgentChanged;
+                        affected = globalAgentChanged || globalModelReset;
                     }
                 }
 
@@ -5990,8 +6052,8 @@ namespace winrt::TerminalApp::implementation
                 return;
             }
             _agentPaneLog("OnAgentSwitchRequested: persisted cloud model selection");
-            _RebuildAgentStack(
-                winrt::TerminalApp::implementation::SharedWta::Instance().CreateRetirementRequestId());
+            _EmitAgentRuntimeConfigIfChanged();
+            _RebuildAgentStack();
             return;
         }
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -433,11 +433,13 @@ namespace winrt::TerminalApp::implementation
         // SetSettings and after every rebuild; a diff drives teardown/rebuild
         // of the agent pane.
         //
-        // Agent identity changes (global acpAgent/acpCustomCommand, the
-        // effective model selection, or an effective per-profile backend)
-        // rebuild affected helpers. Model changes force a master respawn so
-        // the agent CLI starts with a clean model-provider environment;
-        // unselected provider catalog changes are hot-updated.
+        // Agent identity changes (global acpAgent/acpCustomCommand or an
+        // effective per-profile backend) rebuild affected helpers. Ordinary
+        // ACP model changes are hot-applied to live sessions, except clearing
+        // an override: ACP has no portable reset-to-default request, so that
+        // case rebuilds affected helpers. Selected custom provider launch
+        // changes still restart the master because they alter its trusted
+        // environment.
         struct AgentSettingsSnapshot
         {
             std::wstring acpAgent;
@@ -461,6 +463,8 @@ namespace winrt::TerminalApp::implementation
         // ids already expanded).
         struct AgentRuntimeConfigSnapshot
         {
+            std::wstring acpAgent;
+            std::wstring acpModel;
             std::wstring delegateAgent;
             std::wstring delegateModel;
             std::wstring customModelSelection;
@@ -536,9 +540,10 @@ namespace winrt::TerminalApp::implementation
         // expire after a few seconds.
         details::RestartSuppressionTracker _agentPaneRestartSuppression;
         AgentSettingsSnapshot _CaptureAgentSettingsSnapshot() const;
-        // Compares only agent-CLI *identity* fields — the change that forces
-        // a master respawn. Model/delegate changes are handled by
-        // _EmitAgentRuntimeConfigIfChanged instead.
+        // Compares changes that require helper replacement. Concrete model
+        // selections and delegate changes are handled by
+        // _EmitAgentRuntimeConfigIfChanged instead; clearing a model remains
+        // here because ACP cannot portably reset a live session to its default.
         static bool _AgentSettingsChanged(const AgentSettingsSnapshot& a, const AgentSettingsSnapshot& b);
         AgentRuntimeConfigSnapshot _CaptureAgentRuntimeConfig() const;
         // Diffs the hot-updatable runtime config against the last snapshot

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1952,7 +1952,11 @@ impl App {
             return false;
         }
 
-        self.acp_model = new_model.filter(|s| !s.trim().is_empty());
+        let new_model = new_model.filter(|s| !s.trim().is_empty());
+        if self.acp_model == new_model {
+            return true;
+        }
+        self.acp_model = new_model;
         self.send_acp_model_update();
         self.publish_agent_status();
         true

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -2952,6 +2952,28 @@ fn global_model_hot_update_is_scoped_to_matching_global_followers() {
 }
 
 #[test]
+fn repeated_global_model_hot_update_is_idempotent() {
+    use crate::protocol::acp::client::MasterExtRequest;
+
+    let (mut app, mut master_rx) = test_app_with_master_rx();
+    app.current_agent_id = "claude".into();
+    app.follows_global_acp_model = true;
+    app.current_tab_mut().session_id = Some("claude-session".into());
+
+    assert!(app.apply_global_acp_model("claude", Some("claude-opus".into())));
+    assert!(matches!(
+        master_rx.try_recv(),
+        Ok(MasterExtRequest::SetSessionModel { model, .. }) if model == "claude-opus"
+    ));
+
+    assert!(app.apply_global_acp_model("claude", Some("claude-opus".into())));
+    assert!(
+        master_rx.try_recv().is_err(),
+        "the same multi-window settings update must not be sent twice"
+    );
+}
+
+#[test]
 fn custom_model_catalog_hot_update_rebuilds_picker_without_stale_rows() {
     let mut app = test_app();
     app.current_agent_id = "copilot".into();

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -2080,6 +2080,8 @@ async fn master_reset_tab_session_resolves_owner_and_physically_retires_session(
                 cmd_key: "sibling-close-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -2264,6 +2266,8 @@ async fn retirement_event_physically_closes_once_and_replays_completion() {
                 cmd_key: "retirement-live-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -2852,6 +2856,8 @@ async fn scope_all_retires_ownerless_helper_live_route_directly() {
                 cmd_key: "ownerless-live-route-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -2969,6 +2975,8 @@ async fn scope_all_captured_helper_disconnect_still_closes_once() {
                 cmd_key: "captured-disconnect-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -3055,6 +3063,8 @@ async fn scope_all_retirement_captures_orphan_after_route_drop_before_connected_
                 cmd_key: "disconnect-ordering-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -3152,6 +3162,8 @@ async fn retirement_completed_after_route_drop_cannot_republish_orphan() {
                 cmd_key: "disconnect-retirement-race-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -3287,6 +3299,8 @@ async fn disconnect_orphan_publication_skips_tab_closed_session() {
                 cmd_key: "disconnect-ordinary-close-race-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -3387,6 +3401,8 @@ async fn disconnect_orphan_publication_skips_rebound_session() {
                 cmd_key: "disconnect-rebind-race-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -3486,6 +3502,8 @@ async fn unexpected_disconnect_still_publishes_orphan() {
                 cmd_key: "unexpected-disconnect-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -3665,6 +3683,8 @@ async fn orphan_retirement_blocked_cancel_uses_total_budget() {
                 cmd_key: "blocked-orphan-cancel-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -3770,6 +3790,8 @@ async fn scope_all_physically_closes_ownerless_orphaned_session() {
                 cmd_key: "ownerless-orphan-physical-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -3854,6 +3876,8 @@ async fn scope_all_preserves_ownerless_orphan_claimed_by_replacement_route() {
                 cmd_key: "ownerless-orphan-rebound-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -4173,6 +4197,8 @@ async fn scope_all_waits_for_ownerless_pending_transaction_cleanup() {
                 cmd_key: "ownerless-pending-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -4279,6 +4305,8 @@ async fn scope_all_unsupported_retirement_reports_failed_owner_tab() {
                 cmd_key: "retirement-unsupported-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -4352,6 +4380,8 @@ async fn scope_all_starts_independent_session_closes_concurrently() {
                 cmd_key: "retirement-all-agent-a".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let agent_b = Arc::new(AgentCli {
                 instance_id: AgentInstanceId::new_v4(),
@@ -4362,6 +4392,8 @@ async fn scope_all_starts_independent_session_closes_concurrently() {
                 cmd_key: "retirement-all-agent-b".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell_a = Arc::new(tokio::sync::OnceCell::new());
             let cell_b = Arc::new(tokio::sync::OnceCell::new());
@@ -4487,6 +4519,8 @@ async fn retirement_uses_one_deadline_for_close_wait_and_forced_cleanup() {
                 cmd_key: "retirement-single-deadline-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -4589,6 +4623,8 @@ async fn retirement_lifecycle_gate_wait_does_not_renew_close_budget() {
                 cmd_key: "retirement-gate-deadline-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let gate = session_lifecycle_gate(&state, &session_id).await;
             let gate_guard = gate.lock().await;
@@ -4661,6 +4697,8 @@ async fn retirement_waits_for_and_retires_late_session_new() {
                 cmd_key: "retirement-pending-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());
@@ -5019,6 +5057,8 @@ async fn active_retirement_follows_tab_rename_and_clears_moved_fence_on_disconne
                 cmd_key: "retirement-drag-race-agent".to_string(),
                 cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
                 bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
             });
             let cell = Arc::new(tokio::sync::OnceCell::new());
             assert!(cell.set(Arc::clone(&agent)).is_ok());


### PR DESCRIPTION
## Summary
- hot-apply concrete global ACP model changes to matching live sessions without retiring sessions, rebuilding panes/helpers, or restarting wta-master
- keep pane-local model overrides isolated and deduplicate repeated multi-window settings delivery
- refresh SharedWta recovery launch inputs without disturbing the running master
- retain scoped helper replacement when clearing a model override because ACP has no portable reset-to-default operation, and retain master restart for BYOK/custom launch changes
- repair merged-main AgentCli test fixtures so the WTA test target compiles

## Validation
- WTA full suite: 1655 passed
- focused global model hot-update tests: 2 passed
- explicit-target WTA build
- TerminalApp and ut_app incremental builds