### PR TITLE
Switch agent and model settings without rebuilding panes

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -9,6 +9,7 @@ acidev
 ACIOSS
 ACL'd
 acp
+Acq
 actctx
 ACTCTXW
 activedir

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -72,6 +72,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(TestIterableColorSchemeCommands);
 
         TEST_METHOD(TestElevateArg);
+        TEST_METHOD(TestAgentSettingsFocusGate);
 
         TEST_CLASS_SETUP(ClassSetup)
         {
@@ -1619,4 +1620,15 @@ namespace TerminalAppLocalTests
         }
     }
 
+    void SettingsTests::TestAgentSettingsFocusGate()
+    {
+        using Page = winrt::TerminalApp::implementation::TerminalPage;
+        using ChangeKind = Page::AgentSettingsChangeKind;
+
+        VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::None, false, false));
+        VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::AgentRebind, false, false));
+        VERIFY_IS_TRUE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::Rebuild, false, false));
+        VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::Rebuild, true, false));
+        VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::Rebuild, false, true));
+    }
 }

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -76,6 +76,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(TestAgentSettingsFocusGate);
         TEST_METHOD(TestAgentPaneSettingsRebindClassification);
         TEST_METHOD(TestAgentPaneSettingsRebindRouting);
+        TEST_METHOD(TestAgentPaneModelHotUpdateRouting);
 
         TEST_CLASS_SETUP(ClassSetup)
         {
@@ -1731,22 +1732,31 @@ namespace TerminalAppLocalTests
 
         VERIFY_ARE_EQUAL(
             Disposition::Recreate,
-            Page::_ClassifyAgentPaneSettingsRebind(State::NotConnected));
+            Page::_ClassifyAgentPaneSettingsRebind(State::NotConnected, false));
+        VERIFY_ARE_EQUAL(
+            Disposition::Recreate,
+            Page::_ClassifyAgentPaneSettingsRebind(State::NotConnected, true));
+        VERIFY_ARE_EQUAL(
+            Disposition::Recreate,
+            Page::_ClassifyAgentPaneSettingsRebind(State::Connecting, false));
         VERIFY_ARE_EQUAL(
             Disposition::Rebind,
-            Page::_ClassifyAgentPaneSettingsRebind(State::Connecting));
+            Page::_ClassifyAgentPaneSettingsRebind(State::Connecting, true));
+        VERIFY_ARE_EQUAL(
+            Disposition::Recreate,
+            Page::_ClassifyAgentPaneSettingsRebind(State::Connected, false));
         VERIFY_ARE_EQUAL(
             Disposition::Rebind,
-            Page::_ClassifyAgentPaneSettingsRebind(State::Connected));
+            Page::_ClassifyAgentPaneSettingsRebind(State::Connected, true));
         VERIFY_ARE_EQUAL(
             Disposition::Recreate,
-            Page::_ClassifyAgentPaneSettingsRebind(State::Closing));
+            Page::_ClassifyAgentPaneSettingsRebind(State::Closing, true));
         VERIFY_ARE_EQUAL(
             Disposition::Recreate,
-            Page::_ClassifyAgentPaneSettingsRebind(State::Closed));
+            Page::_ClassifyAgentPaneSettingsRebind(State::Closed, true));
         VERIFY_ARE_EQUAL(
             Disposition::Recreate,
-            Page::_ClassifyAgentPaneSettingsRebind(State::Failed));
+            Page::_ClassifyAgentPaneSettingsRebind(State::Failed, true));
 
         const auto visibleActive = Page::_GetAgentPaneRecreationOptions(false, true);
         VERIFY_IS_FALSE(visibleActive.autoStash);
@@ -1914,11 +1924,11 @@ namespace TerminalAppLocalTests
             L"",
         });
 
-        auto unlaunchableCustomOverride = customOverride;
-        unlaunchableCustomOverride.agentCustomCommandOverride.clear();
+        auto nonLaunchableCustomOverride = customOverride;
+        nonLaunchableCustomOverride.agentCustomCommandOverride.clear();
         cases.push_back({
-            L"unlaunchable custom binding is excluded",
-            unlaunchableCustomOverride,
+            L"non-launchable custom binding is excluded",
+            nonLaunchableCustomOverride,
             false,
             false,
             true,
@@ -2029,5 +2039,48 @@ namespace TerminalAppLocalTests
                     payload["custom_model_selection"].asString());
             }
         }
+    }
+
+    void SettingsTests::TestAgentPaneModelHotUpdateRouting()
+    {
+        using Page = winrt::TerminalApp::implementation::TerminalPage;
+        using Request = Page::AgentPaneSettingsBindingRequest;
+
+        const auto globalFollower = Page::_ResolveAgentPaneSettingsBinding(Request{
+            .globalAgentId = L"copilot",
+            .globalModel = L"gpt-5.6",
+            .globalAgentCliPath = L"copilot --acp --stdio --model gpt-5.6",
+        });
+        const auto perTabModelOverride = Page::_ResolveAgentPaneSettingsBinding(Request{
+            .hasAgentOverride = true,
+            .agentIdOverride = L"copilot",
+            .agentModelOverride = L"gpt-5.5",
+            .agentSourceOverride = L"host",
+        });
+        const auto nonLaunchableGlobalFollower = Page::_ResolveAgentPaneSettingsBinding(Request{
+            .globalAgentId = L"copilot",
+            .globalModel = L"gpt-5.6",
+        });
+        using State = winrt::Microsoft::Terminal::TerminalConnection::ConnectionState;
+
+        VERIFY_IS_TRUE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, State::Connected, true));
+        VERIFY_IS_FALSE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, State::Connected, true));
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, State::Connected, false));
+        VERIFY_IS_TRUE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, State::Connected, false));
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, State::Failed, true));
+        VERIFY_IS_TRUE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, State::Failed, true));
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, State::NotConnected, true));
+        VERIFY_IS_TRUE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, State::NotConnected, true));
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, std::nullopt, true));
+        VERIFY_IS_TRUE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, std::nullopt, true));
+
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(std::nullopt, State::Connected, true));
+        VERIFY_IS_FALSE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(std::nullopt, State::Connected, false));
+
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(perTabModelOverride, State::Connected, true));
+        VERIFY_IS_FALSE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(perTabModelOverride, State::Connected, false));
+
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(nonLaunchableGlobalFollower, State::Connected, true));
+        VERIFY_IS_FALSE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(nonLaunchableGlobalFollower, State::Connected, false));
     }
 }

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -72,6 +72,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(TestIterableColorSchemeCommands);
 
         TEST_METHOD(TestElevateArg);
+        TEST_METHOD(TestAgentSettingsChangeClassification);
         TEST_METHOD(TestAgentSettingsFocusGate);
 
         TEST_CLASS_SETUP(ClassSetup)
@@ -1620,12 +1621,91 @@ namespace TerminalAppLocalTests
         }
     }
 
+    void SettingsTests::TestAgentSettingsChangeClassification()
+    {
+        using Page = winrt::TerminalApp::implementation::TerminalPage;
+        using ChangeKind = Page::AgentSettingsChangeKind;
+
+        const Page::AgentSettingsSnapshot native{
+            L"copilot", L"", L"gpt-5.4", std::nullopt, {}
+        };
+        VERIFY_ARE_EQUAL(ChangeKind::None, Page::_ClassifyAgentSettingsChange(native, native));
+
+        auto nativeHotUpdate = native;
+        nativeHotUpdate.acpModel = L"gpt-5.5";
+        VERIFY_ARE_EQUAL(
+            ChangeKind::ModelHotUpdate,
+            Page::_ClassifyAgentSettingsChange(native, nativeHotUpdate));
+
+        auto nativeReset = native;
+        nativeReset.acpModel.clear();
+        VERIFY_ARE_EQUAL(
+            ChangeKind::AgentRebind,
+            Page::_ClassifyAgentSettingsChange(native, nativeReset));
+
+        auto builtInAgentChange = native;
+        builtInAgentChange.acpAgent = L"codex";
+        VERIFY_ARE_EQUAL(
+            ChangeKind::AgentRebind,
+            Page::_ClassifyAgentSettingsChange(native, builtInAgentChange));
+
+        auto gemini = native;
+        gemini.acpAgent = L"gemini";
+        auto geminiModelChange = gemini;
+        geminiModelChange.acpModel = L"gemini-2.5-pro";
+        VERIFY_ARE_EQUAL(
+            ChangeKind::AgentRebind,
+            Page::_ClassifyAgentSettingsChange(gemini, geminiModelChange));
+
+        auto byok = native;
+        byok.acpModel.clear();
+        byok.customModelLaunch =
+            ::Microsoft::Terminal::CustomModels::MakeLaunchConfiguration(
+                L"custom:provider:model-a",
+                L"https://example.invalid/v1",
+                L"model-a",
+                L"credential-a",
+                true);
+        auto changedByok = byok;
+        changedByok.customModelLaunch->modelId = L"model-b";
+        VERIFY_ARE_EQUAL(
+            ChangeKind::AgentRebind,
+            Page::_ClassifyAgentSettingsChange(byok, changedByok));
+
+        auto changedByokEndpoint = byok;
+        changedByokEndpoint.customModelLaunch->endpoint = L"https://new.example.invalid/v1";
+        VERIFY_ARE_EQUAL(
+            ChangeKind::AgentRebind,
+            Page::_ClassifyAgentSettingsChange(byok, changedByokEndpoint));
+
+        auto changedByokCredential = byok;
+        changedByokCredential.customModelLaunch->credentialId = L"credential-b";
+        VERIFY_ARE_EQUAL(
+            ChangeKind::AgentRebind,
+            Page::_ClassifyAgentSettingsChange(byok, changedByokCredential));
+
+        VERIFY_ARE_EQUAL(
+            ChangeKind::AgentRebind,
+            Page::_ClassifyAgentSettingsChange(native, byok));
+        VERIFY_ARE_EQUAL(
+            ChangeKind::AgentRebind,
+            Page::_ClassifyAgentSettingsChange(byok, native));
+
+        auto customCommand = native;
+        customCommand.acpAgent = L"custom:local";
+        customCommand.acpCustomCommand = L"agent.exe --acp";
+        VERIFY_ARE_EQUAL(
+            ChangeKind::Rebuild,
+            Page::_ClassifyAgentSettingsChange(native, customCommand));
+    }
+
     void SettingsTests::TestAgentSettingsFocusGate()
     {
         using Page = winrt::TerminalApp::implementation::TerminalPage;
         using ChangeKind = Page::AgentSettingsChangeKind;
 
         VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::None, false, false));
+        VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::ModelHotUpdate, false, false));
         VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::AgentRebind, false, false));
         VERIFY_IS_TRUE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::Rebuild, false, false));
         VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::Rebuild, true, false));

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -75,6 +75,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(TestAgentSettingsChangeClassification);
         TEST_METHOD(TestAgentSettingsFocusGate);
         TEST_METHOD(TestAgentPaneSettingsRebindClassification);
+        TEST_METHOD(TestAgentPaneAgentSwitchClassification);
         TEST_METHOD(TestAgentPaneSettingsRebindRouting);
         TEST_METHOD(TestAgentPaneModelHotUpdateRouting);
 
@@ -2039,6 +2040,75 @@ namespace TerminalAppLocalTests
                     payload["custom_model_selection"].asString());
             }
         }
+    }
+
+    void SettingsTests::TestAgentPaneAgentSwitchClassification()
+    {
+        using Page = winrt::TerminalApp::implementation::TerminalPage;
+        using Binding = Page::AgentPaneSettingsBinding;
+        using Disposition = Page::AgentPaneSettingsRebindDisposition;
+        using State = winrt::Microsoft::Terminal::TerminalConnection::ConnectionState;
+
+        Binding hostCopilot{
+            .agentId = L"copilot",
+            .agentSource = L"host",
+            .launchable = true,
+        };
+        auto hostCodex = hostCopilot;
+        hostCodex.agentId = L"codex";
+        VERIFY_ARE_EQUAL(
+            Disposition::Rebind,
+            Page::_ClassifyAgentPaneAgentSwitch(hostCopilot, hostCodex, State::Connecting, true));
+        VERIFY_ARE_EQUAL(
+            Disposition::Rebind,
+            Page::_ClassifyAgentPaneAgentSwitch(hostCopilot, hostCodex, State::Connected, true));
+        VERIFY_ARE_EQUAL(
+            Disposition::Recreate,
+            Page::_ClassifyAgentPaneAgentSwitch(hostCopilot, hostCodex, State::Connected, false));
+        VERIFY_ARE_EQUAL(
+            Disposition::Recreate,
+            Page::_ClassifyAgentPaneAgentSwitch(hostCopilot, hostCodex, State::Closed, true));
+
+        auto wslCopilot = hostCopilot;
+        wslCopilot.agentSource = L"wsl";
+        wslCopilot.agentWslDistro = L"Ubuntu";
+        auto wslCodex = wslCopilot;
+        wslCodex.agentId = L"codex";
+        VERIFY_ARE_EQUAL(
+            Disposition::Rebind,
+            Page::_ClassifyAgentPaneAgentSwitch(wslCopilot, wslCodex, State::Connected, true));
+        VERIFY_ARE_EQUAL(
+            Disposition::Recreate,
+            Page::_ClassifyAgentPaneAgentSwitch(hostCopilot, wslCodex, State::Connected, true));
+
+        auto otherDistro = wslCodex;
+        otherDistro.agentWslDistro = L"Debian";
+        VERIFY_ARE_EQUAL(
+            Disposition::Recreate,
+            Page::_ClassifyAgentPaneAgentSwitch(wslCopilot, otherDistro, State::Connected, true));
+
+        auto customAgent = hostCopilot;
+        customAgent.agentId = L"custom:local";
+        VERIFY_ARE_EQUAL(
+            Disposition::Recreate,
+            Page::_ClassifyAgentPaneAgentSwitch(customAgent, hostCodex, State::Connected, true));
+        VERIFY_ARE_EQUAL(
+            Disposition::Recreate,
+            Page::_ClassifyAgentPaneAgentSwitch(hostCopilot, customAgent, State::Connected, true));
+
+        auto unavailableTarget = hostCodex;
+        unavailableTarget.launchable = false;
+        VERIFY_ARE_EQUAL(
+            Disposition::Recreate,
+            Page::_ClassifyAgentPaneAgentSwitch(hostCopilot, unavailableTarget, State::Connected, true));
+
+        VERIFY_IS_TRUE(Page::_CanRetainAgentPaneForMasterRestart(State::Connecting));
+        VERIFY_IS_TRUE(Page::_CanRetainAgentPaneForMasterRestart(State::Connected));
+        VERIFY_IS_FALSE(Page::_CanRetainAgentPaneForMasterRestart(State::Closed));
+
+        const auto payload = Page::_BuildAgentPaneSettingsRebindPayload(wslCodex);
+        VERIFY_ARE_EQUAL(std::string{ "wsl" }, payload["agent_source"].asString());
+        VERIFY_ARE_EQUAL(std::string{ "Ubuntu" }, payload["wsl_distro"].asString());
     }
 
     void SettingsTests::TestAgentPaneModelHotUpdateRouting()

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -2063,24 +2063,28 @@ namespace TerminalAppLocalTests
         });
         using State = winrt::Microsoft::Terminal::TerminalConnection::ConnectionState;
 
-        VERIFY_IS_TRUE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, State::Connected, true));
-        VERIFY_IS_FALSE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, State::Connected, true));
-        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, State::Connected, false));
-        VERIFY_IS_TRUE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, State::Connected, false));
-        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, State::Failed, true));
-        VERIFY_IS_TRUE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, State::Failed, true));
-        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, State::NotConnected, true));
-        VERIFY_IS_TRUE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, State::NotConnected, true));
-        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, std::nullopt, true));
-        VERIFY_IS_TRUE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, std::nullopt, true));
+        VERIFY_IS_TRUE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, State::Connected, true, true));
+        VERIFY_IS_FALSE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, State::Connected, true, true));
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, State::Connecting, true, false));
+        VERIFY_IS_TRUE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, State::Connecting, true, false));
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, State::Connected, true, false));
+        VERIFY_IS_TRUE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, State::Connected, true, false));
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, State::Connected, false, true));
+        VERIFY_IS_TRUE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, State::Connected, false, true));
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, State::Failed, true, true));
+        VERIFY_IS_TRUE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, State::Failed, true, true));
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, State::NotConnected, true, true));
+        VERIFY_IS_TRUE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, State::NotConnected, true, true));
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(globalFollower, std::nullopt, true, true));
+        VERIFY_IS_TRUE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(globalFollower, std::nullopt, true, true));
 
-        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(std::nullopt, State::Connected, true));
-        VERIFY_IS_FALSE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(std::nullopt, State::Connected, false));
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(std::nullopt, State::Connected, true, true));
+        VERIFY_IS_FALSE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(std::nullopt, State::Connected, false, false));
 
-        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(perTabModelOverride, State::Connected, true));
-        VERIFY_IS_FALSE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(perTabModelOverride, State::Connected, false));
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(perTabModelOverride, State::Connected, true, true));
+        VERIFY_IS_FALSE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(perTabModelOverride, State::Connected, false, false));
 
-        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(nonLaunchableGlobalFollower, State::Connected, true));
-        VERIFY_IS_FALSE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(nonLaunchableGlobalFollower, State::Connected, false));
+        VERIFY_IS_FALSE(Page::_IsAgentPaneModelHotUpdateTarget(nonLaunchableGlobalFollower, State::Connected, true, true));
+        VERIFY_IS_FALSE(Page::_ShouldRecreateAgentPaneForModelHotUpdate(nonLaunchableGlobalFollower, State::Connected, false, false));
     }
 }

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -74,8 +74,8 @@ namespace TerminalAppLocalTests
         TEST_METHOD(TestElevateArg);
         TEST_METHOD(TestAgentSettingsChangeClassification);
         TEST_METHOD(TestAgentSettingsFocusGate);
-        TEST_METHOD(TestAgentPaneSettingsRebindClassification);
-        TEST_METHOD(TestAgentPaneAgentSwitchClassification);
+        TEST_METHOD(TestAgentPaneRebindCapability);
+        TEST_METHOD(TestAgentPaneSwitchCapability);
         TEST_METHOD(TestAgentPaneSettingsRebindRouting);
         TEST_METHOD(TestAgentPaneModelHotUpdateRouting);
 
@@ -1699,7 +1699,7 @@ namespace TerminalAppLocalTests
         customCommand.acpAgent = L"custom:local";
         customCommand.acpCustomCommand = L"agent.exe --acp";
         VERIFY_ARE_EQUAL(
-            ChangeKind::Rebuild,
+            ChangeKind::RecreatePane,
             Page::_ClassifyAgentSettingsChange(native, customCommand));
 
         auto customModelChange = customCommand;
@@ -1708,7 +1708,7 @@ namespace TerminalAppLocalTests
         auto changedCustomModel = customModelChange;
         changedCustomModel.acpModel = L"model-b";
         VERIFY_ARE_EQUAL(
-            ChangeKind::Rebuild,
+            ChangeKind::RecreatePane,
             Page::_ClassifyAgentSettingsChange(customModelChange, changedCustomModel));
     }
 
@@ -1720,44 +1720,25 @@ namespace TerminalAppLocalTests
         VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::None, false, false));
         VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::ModelHotUpdate, false, false));
         VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::AgentRebind, false, false));
-        VERIFY_IS_TRUE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::Rebuild, false, false));
-        VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::Rebuild, true, false));
-        VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::Rebuild, false, true));
+        VERIFY_IS_TRUE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::RecreatePane, false, false));
+        VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::RecreatePane, true, false));
+        VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::RecreatePane, false, true));
     }
 
-    void SettingsTests::TestAgentPaneSettingsRebindClassification()
+    void SettingsTests::TestAgentPaneRebindCapability()
     {
         using Page = winrt::TerminalApp::implementation::TerminalPage;
-        using Disposition = Page::AgentPaneSettingsRebindDisposition;
         using State = winrt::Microsoft::Terminal::TerminalConnection::ConnectionState;
 
-        VERIFY_ARE_EQUAL(
-            Disposition::Recreate,
-            Page::_ClassifyAgentPaneSettingsRebind(State::NotConnected, false));
-        VERIFY_ARE_EQUAL(
-            Disposition::Recreate,
-            Page::_ClassifyAgentPaneSettingsRebind(State::NotConnected, true));
-        VERIFY_ARE_EQUAL(
-            Disposition::Recreate,
-            Page::_ClassifyAgentPaneSettingsRebind(State::Connecting, false));
-        VERIFY_ARE_EQUAL(
-            Disposition::Rebind,
-            Page::_ClassifyAgentPaneSettingsRebind(State::Connecting, true));
-        VERIFY_ARE_EQUAL(
-            Disposition::Recreate,
-            Page::_ClassifyAgentPaneSettingsRebind(State::Connected, false));
-        VERIFY_ARE_EQUAL(
-            Disposition::Rebind,
-            Page::_ClassifyAgentPaneSettingsRebind(State::Connected, true));
-        VERIFY_ARE_EQUAL(
-            Disposition::Recreate,
-            Page::_ClassifyAgentPaneSettingsRebind(State::Closing, true));
-        VERIFY_ARE_EQUAL(
-            Disposition::Recreate,
-            Page::_ClassifyAgentPaneSettingsRebind(State::Closed, true));
-        VERIFY_ARE_EQUAL(
-            Disposition::Recreate,
-            Page::_ClassifyAgentPaneSettingsRebind(State::Failed, true));
+        VERIFY_IS_FALSE(Page::_CanRebindAgentPane(State::NotConnected, false));
+        VERIFY_IS_FALSE(Page::_CanRebindAgentPane(State::NotConnected, true));
+        VERIFY_IS_FALSE(Page::_CanRebindAgentPane(State::Connecting, false));
+        VERIFY_IS_TRUE(Page::_CanRebindAgentPane(State::Connecting, true));
+        VERIFY_IS_FALSE(Page::_CanRebindAgentPane(State::Connected, false));
+        VERIFY_IS_TRUE(Page::_CanRebindAgentPane(State::Connected, true));
+        VERIFY_IS_FALSE(Page::_CanRebindAgentPane(State::Closing, true));
+        VERIFY_IS_FALSE(Page::_CanRebindAgentPane(State::Closed, true));
+        VERIFY_IS_FALSE(Page::_CanRebindAgentPane(State::Failed, true));
 
         const auto visibleActive = Page::_GetAgentPaneRecreationOptions(false, true);
         VERIFY_IS_FALSE(visibleActive.autoStash);
@@ -2042,11 +2023,10 @@ namespace TerminalAppLocalTests
         }
     }
 
-    void SettingsTests::TestAgentPaneAgentSwitchClassification()
+    void SettingsTests::TestAgentPaneSwitchCapability()
     {
         using Page = winrt::TerminalApp::implementation::TerminalPage;
         using Binding = Page::AgentPaneSettingsBinding;
-        using Disposition = Page::AgentPaneSettingsRebindDisposition;
         using State = winrt::Microsoft::Terminal::TerminalConnection::ConnectionState;
 
         Binding hostCopilot{
@@ -2056,51 +2036,31 @@ namespace TerminalAppLocalTests
         };
         auto hostCodex = hostCopilot;
         hostCodex.agentId = L"codex";
-        VERIFY_ARE_EQUAL(
-            Disposition::Rebind,
-            Page::_ClassifyAgentPaneAgentSwitch(hostCopilot, hostCodex, State::Connecting, true));
-        VERIFY_ARE_EQUAL(
-            Disposition::Rebind,
-            Page::_ClassifyAgentPaneAgentSwitch(hostCopilot, hostCodex, State::Connected, true));
-        VERIFY_ARE_EQUAL(
-            Disposition::Recreate,
-            Page::_ClassifyAgentPaneAgentSwitch(hostCopilot, hostCodex, State::Connected, false));
-        VERIFY_ARE_EQUAL(
-            Disposition::Recreate,
-            Page::_ClassifyAgentPaneAgentSwitch(hostCopilot, hostCodex, State::Closed, true));
+        VERIFY_IS_TRUE(Page::_CanSwitchAgentInPlace(hostCopilot, hostCodex, State::Connecting, true));
+        VERIFY_IS_TRUE(Page::_CanSwitchAgentInPlace(hostCopilot, hostCodex, State::Connected, true));
+        VERIFY_IS_FALSE(Page::_CanSwitchAgentInPlace(hostCopilot, hostCodex, State::Connected, false));
+        VERIFY_IS_FALSE(Page::_CanSwitchAgentInPlace(hostCopilot, hostCodex, State::Closed, true));
 
         auto wslCopilot = hostCopilot;
         wslCopilot.agentSource = L"wsl";
         wslCopilot.agentWslDistro = L"Ubuntu";
         auto wslCodex = wslCopilot;
         wslCodex.agentId = L"codex";
-        VERIFY_ARE_EQUAL(
-            Disposition::Rebind,
-            Page::_ClassifyAgentPaneAgentSwitch(wslCopilot, wslCodex, State::Connected, true));
-        VERIFY_ARE_EQUAL(
-            Disposition::Recreate,
-            Page::_ClassifyAgentPaneAgentSwitch(hostCopilot, wslCodex, State::Connected, true));
+        VERIFY_IS_TRUE(Page::_CanSwitchAgentInPlace(wslCopilot, wslCodex, State::Connected, true));
+        VERIFY_IS_FALSE(Page::_CanSwitchAgentInPlace(hostCopilot, wslCodex, State::Connected, true));
 
         auto otherDistro = wslCodex;
         otherDistro.agentWslDistro = L"Debian";
-        VERIFY_ARE_EQUAL(
-            Disposition::Recreate,
-            Page::_ClassifyAgentPaneAgentSwitch(wslCopilot, otherDistro, State::Connected, true));
+        VERIFY_IS_FALSE(Page::_CanSwitchAgentInPlace(wslCopilot, otherDistro, State::Connected, true));
 
         auto customAgent = hostCopilot;
         customAgent.agentId = L"custom:local";
-        VERIFY_ARE_EQUAL(
-            Disposition::Recreate,
-            Page::_ClassifyAgentPaneAgentSwitch(customAgent, hostCodex, State::Connected, true));
-        VERIFY_ARE_EQUAL(
-            Disposition::Recreate,
-            Page::_ClassifyAgentPaneAgentSwitch(hostCopilot, customAgent, State::Connected, true));
+        VERIFY_IS_FALSE(Page::_CanSwitchAgentInPlace(customAgent, hostCodex, State::Connected, true));
+        VERIFY_IS_FALSE(Page::_CanSwitchAgentInPlace(hostCopilot, customAgent, State::Connected, true));
 
         auto unavailableTarget = hostCodex;
         unavailableTarget.launchable = false;
-        VERIFY_ARE_EQUAL(
-            Disposition::Recreate,
-            Page::_ClassifyAgentPaneAgentSwitch(hostCopilot, unavailableTarget, State::Connected, true));
+        VERIFY_IS_FALSE(Page::_CanSwitchAgentInPlace(hostCopilot, unavailableTarget, State::Connected, true));
 
         VERIFY_IS_TRUE(Page::_CanRetainAgentPaneForMasterRestart(State::Connecting));
         VERIFY_IS_TRUE(Page::_CanRetainAgentPaneForMasterRestart(State::Connected));

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -1720,19 +1720,38 @@ namespace TerminalAppLocalTests
         using State = winrt::Microsoft::Terminal::TerminalConnection::ConnectionState;
 
         VERIFY_ARE_EQUAL(
-            Disposition::RecreateStashed,
+            Disposition::Recreate,
             Page::_ClassifyAgentPaneSettingsRebind(State::NotConnected));
+        VERIFY_ARE_EQUAL(
+            Disposition::Rebind,
+            Page::_ClassifyAgentPaneSettingsRebind(State::Connecting));
+        VERIFY_ARE_EQUAL(
+            Disposition::Rebind,
+            Page::_ClassifyAgentPaneSettingsRebind(State::Connected));
+        VERIFY_ARE_EQUAL(
+            Disposition::Recreate,
+            Page::_ClassifyAgentPaneSettingsRebind(State::Closing));
+        VERIFY_ARE_EQUAL(
+            Disposition::Recreate,
+            Page::_ClassifyAgentPaneSettingsRebind(State::Closed));
+        VERIFY_ARE_EQUAL(
+            Disposition::Recreate,
+            Page::_ClassifyAgentPaneSettingsRebind(State::Failed));
 
-        for (const auto state : {
-                 State::Connecting,
-                 State::Connected,
-                 State::Closing,
-                 State::Closed,
-                 State::Failed })
-        {
-            VERIFY_ARE_EQUAL(
-                Disposition::Rebind,
-                Page::_ClassifyAgentPaneSettingsRebind(state));
-        }
+        const auto visibleActive = Page::_GetAgentPaneRecreationOptions(false, true);
+        VERIFY_IS_FALSE(visibleActive.autoStash);
+        VERIFY_IS_TRUE(visibleActive.focusPane);
+
+        const auto visibleBackground = Page::_GetAgentPaneRecreationOptions(false, false);
+        VERIFY_IS_FALSE(visibleBackground.autoStash);
+        VERIFY_IS_FALSE(visibleBackground.focusPane);
+
+        const auto stashedActive = Page::_GetAgentPaneRecreationOptions(true, true);
+        VERIFY_IS_TRUE(stashedActive.autoStash);
+        VERIFY_IS_FALSE(stashedActive.focusPane);
+
+        const auto stashedBackground = Page::_GetAgentPaneRecreationOptions(true, false);
+        VERIFY_IS_TRUE(stashedBackground.autoStash);
+        VERIFY_IS_FALSE(stashedBackground.focusPane);
     }
 }

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -74,6 +74,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(TestElevateArg);
         TEST_METHOD(TestAgentSettingsChangeClassification);
         TEST_METHOD(TestAgentSettingsFocusGate);
+        TEST_METHOD(TestAgentPaneSettingsRebindClassification);
 
         TEST_CLASS_SETUP(ClassSetup)
         {
@@ -1710,5 +1711,28 @@ namespace TerminalAppLocalTests
         VERIFY_IS_TRUE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::Rebuild, false, false));
         VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::Rebuild, true, false));
         VERIFY_IS_FALSE(Page::_ShouldDeferAgentSettingsChange(ChangeKind::Rebuild, false, true));
+    }
+
+    void SettingsTests::TestAgentPaneSettingsRebindClassification()
+    {
+        using Page = winrt::TerminalApp::implementation::TerminalPage;
+        using Disposition = Page::AgentPaneSettingsRebindDisposition;
+        using State = winrt::Microsoft::Terminal::TerminalConnection::ConnectionState;
+
+        VERIFY_ARE_EQUAL(
+            Disposition::RecreateStashed,
+            Page::_ClassifyAgentPaneSettingsRebind(State::NotConnected));
+
+        for (const auto state : {
+                 State::Connecting,
+                 State::Connected,
+                 State::Closing,
+                 State::Closed,
+                 State::Failed })
+        {
+            VERIFY_ARE_EQUAL(
+                Disposition::Rebind,
+                Page::_ClassifyAgentPaneSettingsRebind(state));
+        }
     }
 }

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -75,6 +75,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(TestAgentSettingsChangeClassification);
         TEST_METHOD(TestAgentSettingsFocusGate);
         TEST_METHOD(TestAgentPaneSettingsRebindClassification);
+        TEST_METHOD(TestAgentPaneSettingsRebindRouting);
 
         TEST_CLASS_SETUP(ClassSetup)
         {
@@ -1698,6 +1699,15 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(
             ChangeKind::Rebuild,
             Page::_ClassifyAgentSettingsChange(native, customCommand));
+
+        auto customModelChange = customCommand;
+        customModelChange.acpAgent = L"custom:test";
+        customModelChange.acpModel = L"model-a";
+        auto changedCustomModel = customModelChange;
+        changedCustomModel.acpModel = L"model-b";
+        VERIFY_ARE_EQUAL(
+            ChangeKind::Rebuild,
+            Page::_ClassifyAgentSettingsChange(customModelChange, changedCustomModel));
     }
 
     void SettingsTests::TestAgentSettingsFocusGate()
@@ -1753,5 +1763,271 @@ namespace TerminalAppLocalTests
         const auto stashedBackground = Page::_GetAgentPaneRecreationOptions(true, false);
         VERIFY_IS_TRUE(stashedBackground.autoStash);
         VERIFY_IS_FALSE(stashedBackground.focusPane);
+    }
+
+    void SettingsTests::TestAgentPaneSettingsRebindRouting()
+    {
+        using Page = winrt::TerminalApp::implementation::TerminalPage;
+        using Request = Page::AgentPaneSettingsBindingRequest;
+
+        struct TestCase
+        {
+            const wchar_t* name;
+            Request request;
+            bool globalAgentChanged;
+            bool cloudModelChanged;
+            bool customModelLaunchChanged;
+            bool expectedAffected;
+            bool expectedLaunchable;
+            const wchar_t* expectedAgent;
+            const wchar_t* expectedSource;
+            const wchar_t* expectedModel;
+            const wchar_t* expectedCustomSelection;
+        };
+
+        const Request byokGlobal{
+            .globalAgentId = L"copilot",
+            .globalModel = L"gpt-cloud",
+            .globalAgentCliPath = L"copilot --acp --stdio",
+            .customModelSelection = L"custom:provider:model-b",
+        };
+        const Request cloudGlobal{
+            .globalAgentId = L"copilot",
+            .globalModel = L"gpt-5.6",
+            .globalAgentCliPath = L"copilot --acp --stdio --model gpt-5.6",
+        };
+
+        std::vector<TestCase> cases;
+        cases.push_back({
+            L"global Host Copilot inherits BYOK",
+            byokGlobal,
+            false,
+            false,
+            true,
+            true,
+            true,
+            L"copilot",
+            L"host",
+            L"",
+            L"custom:provider:model-b",
+        });
+
+        auto hostOpenCodeOverride = byokGlobal;
+        hostOpenCodeOverride.hasAgentOverride = true;
+        hostOpenCodeOverride.agentIdOverride = L"opencode";
+        hostOpenCodeOverride.agentModelOverride = L"override-model";
+        hostOpenCodeOverride.agentSourceOverride = L"host";
+        cases.push_back({
+            L"Host OpenCode override inherits BYOK",
+            hostOpenCodeOverride,
+            false,
+            false,
+            true,
+            true,
+            true,
+            L"opencode",
+            L"host",
+            L"",
+            L"custom:provider:model-b",
+        });
+
+        auto hostCopilotProfile = byokGlobal;
+        hostCopilotProfile.profileBackend = L"host:copilot";
+        cases.push_back({
+            L"host Copilot profile inherits BYOK",
+            hostCopilotProfile,
+            false,
+            false,
+            true,
+            true,
+            true,
+            L"copilot",
+            L"host",
+            L"",
+            L"custom:provider:model-b",
+        });
+
+        auto wslOpenCodeOverride = hostOpenCodeOverride;
+        wslOpenCodeOverride.agentSourceOverride = L"wsl";
+        wslOpenCodeOverride.agentWslDistroOverride = L"Ubuntu";
+        cases.push_back({
+            L"WSL OpenCode override does not inherit Host BYOK",
+            wslOpenCodeOverride,
+            false,
+            false,
+            true,
+            false,
+            true,
+            L"opencode",
+            L"wsl",
+            L"override-model",
+            L"",
+        });
+
+        auto wslCopilotProfile = byokGlobal;
+        wslCopilotProfile.profileBackend = L"wsl:Ubuntu:copilot";
+        wslCopilotProfile.profileActiveShell = L"wsl:Ubuntu";
+        cases.push_back({
+            L"WSL Copilot profile does not inherit Host BYOK",
+            wslCopilotProfile,
+            false,
+            false,
+            true,
+            false,
+            true,
+            L"copilot",
+            L"wsl",
+            L"",
+            L"",
+        });
+
+        auto unsupportedOverride = hostOpenCodeOverride;
+        unsupportedOverride.agentIdOverride = L"claude";
+        cases.push_back({
+            L"unsupported Host agent is excluded",
+            unsupportedOverride,
+            false,
+            false,
+            true,
+            false,
+            true,
+            L"claude",
+            L"host",
+            L"override-model",
+            L"",
+        });
+
+        auto customOverride = hostOpenCodeOverride;
+        customOverride.agentIdOverride = L"custom:local";
+        customOverride.agentCustomCommandOverride = L"agent.exe --acp";
+        cases.push_back({
+            L"custom Host agent is excluded",
+            customOverride,
+            false,
+            false,
+            true,
+            false,
+            true,
+            L"custom:local",
+            L"host",
+            L"override-model",
+            L"",
+        });
+
+        auto unlaunchableCustomOverride = customOverride;
+        unlaunchableCustomOverride.agentCustomCommandOverride.clear();
+        cases.push_back({
+            L"unlaunchable custom binding is excluded",
+            unlaunchableCustomOverride,
+            false,
+            false,
+            true,
+            false,
+            false,
+            L"custom:local",
+            L"host",
+            L"override-model",
+            L"",
+        });
+
+        auto unknownProfile = byokGlobal;
+        unknownProfile.profileBackend = L"host:unknown";
+        cases.push_back({
+            L"unknown profile agent is excluded",
+            unknownProfile,
+            false,
+            false,
+            true,
+            false,
+            false,
+            L"unknown",
+            L"host",
+            L"",
+            L"",
+        });
+
+        auto invalidProfile = byokGlobal;
+        invalidProfile.profileBackend = L"host:";
+        cases.push_back({
+            L"invalid profile backend is excluded",
+            invalidProfile,
+            false,
+            false,
+            true,
+            false,
+            false,
+            L"",
+            L"host",
+            L"",
+            L"",
+        });
+
+        cases.push_back({
+            L"native cloud model updates global follower",
+            cloudGlobal,
+            false,
+            true,
+            false,
+            true,
+            true,
+            L"copilot",
+            L"host",
+            L"gpt-5.6",
+            L"",
+        });
+
+        auto cloudOverride = cloudGlobal;
+        cloudOverride.hasAgentOverride = true;
+        cloudOverride.agentIdOverride = L"opencode";
+        cloudOverride.agentModelOverride = L"override-model";
+        cloudOverride.agentSourceOverride = L"host";
+        cases.push_back({
+            L"native cloud model excludes override",
+            cloudOverride,
+            false,
+            true,
+            false,
+            false,
+            true,
+            L"opencode",
+            L"host",
+            L"override-model",
+            L"",
+        });
+
+        for (const auto& test : cases)
+        {
+            Log::Comment(test.name);
+            const auto binding = Page::_ResolveAgentPaneSettingsBinding(test.request);
+            VERIFY_ARE_EQUAL(test.expectedLaunchable, binding.launchable);
+            VERIFY_ARE_EQUAL(std::wstring{ test.expectedAgent }, binding.agentId);
+            VERIFY_ARE_EQUAL(std::wstring{ test.expectedSource }, binding.agentSource);
+            VERIFY_ARE_EQUAL(std::wstring{ test.expectedModel }, binding.acpModel);
+            VERIFY_ARE_EQUAL(std::wstring{ test.expectedCustomSelection }, binding.customModelSelection);
+            VERIFY_ARE_EQUAL(
+                test.expectedAffected,
+                Page::_IsAgentPaneSettingsRebindAffected(
+                    binding,
+                    test.globalAgentChanged,
+                    test.cloudModelChanged,
+                    test.customModelLaunchChanged));
+
+            if (test.expectedAffected)
+            {
+                const auto payload = Page::_BuildAgentPaneSettingsRebindPayload(binding);
+                VERIFY_ARE_EQUAL(
+                    winrt::to_string(winrt::hstring{ test.expectedAgent }),
+                    payload["agent_id"].asString());
+                VERIFY_ARE_EQUAL(
+                    winrt::to_string(winrt::hstring{ test.expectedSource }),
+                    payload["agent_source"].asString());
+                VERIFY_ARE_EQUAL(
+                    winrt::to_string(winrt::hstring{ test.expectedModel }),
+                    payload["acp_model"].asString());
+                VERIFY_ARE_EQUAL(
+                    winrt::to_string(winrt::hstring{ test.expectedCustomSelection }),
+                    payload["custom_model_selection"].asString());
+            }
+        }
     }
 }

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -90,6 +90,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(BuildStartupActionsContentStashesAgentLaterSplitAsExistingTab);
         TEST_METHOD(TransferredAgentContentFirstPaneDefersTabRekey);
         TEST_METHOD(TransferredAgentContentSplitPaneRetiresDestinationAgentPane);
+        TEST_METHOD(TransferredAgentStatusReplaysMissedTabRekey);
 
         TEST_METHOD(NextMRUTab);
         TEST_METHOD(VerifyCommandPaletteTabSwitcherOrder);
@@ -1097,6 +1098,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_NOT_NULL(agentContent);
             const auto impl = winrt::get_self<winrt::TerminalApp::implementation::AgentPaneContent>(agentContent);
             VERIFY_IS_TRUE(impl->TakePendingRenameFromTabId() == oldTabId);
+            VERIFY_IS_TRUE(impl->TransferSourceTabId() == oldTabId);
             const auto pendingSourceProfileGuid = impl->TakePendingAgentSourceProfileGuid();
             VERIFY_IS_TRUE(pendingSourceProfileGuid.has_value());
             VERIFY_IS_TRUE(pendingSourceProfileGuid.value() == sourceProfileGuid);
@@ -1226,7 +1228,79 @@ namespace TerminalAppLocalTests
             VERIFY_IS_NOT_NULL(agentContent);
             const auto impl = winrt::get_self<winrt::TerminalApp::implementation::AgentPaneContent>(agentContent);
             VERIFY_IS_TRUE(impl->TakePendingRenameFromTabId().empty());
+            VERIFY_IS_TRUE(impl->TransferSourceTabId() == oldTabId);
             VERIFY_IS_FALSE(impl->TakePendingAgentSourceProfileGuid().has_value());
+        });
+    }
+
+    void TabTests::TransferredAgentStatusReplaysMissedTabRekey()
+    {
+        auto page = _commonSetup();
+        const auto oldTabId = winrt::hstring{ L"source-tab-id" };
+
+        TestOnUIThread([&]() {
+            const auto focusedTab = page->_GetFocusedTabImpl();
+            VERIFY_IS_NOT_NULL(focusedTab);
+
+            auto agentPane = page->_WrapInAgentPaneContent(page->_MakePane(nullptr, nullptr, nullptr));
+            VERIFY_IS_NOT_NULL(agentPane);
+            agentPane->IsAgentPane(true);
+            page->_SplitPane(focusedTab, SplitDirection::Left, 0.5f, agentPane);
+
+            const auto agentContent = focusedTab->FindAgentPaneContent();
+            VERIFY_IS_NOT_NULL(agentContent);
+            const auto impl = winrt::get_self<winrt::TerminalApp::implementation::AgentPaneContent>(agentContent);
+            impl->SetTransferSourceTabId(oldTabId);
+
+            std::vector<Json::Value> protocolEvents;
+            const auto token = page->ProtocolVtSequenceReceived(
+                [&](auto&&, const winrt::hstring& payload) {
+                    Json::Value event;
+                    Json::CharReaderBuilder readerBuilder;
+                    std::istringstream stream{ winrt::to_string(payload) };
+                    std::string errors;
+                    if (Json::parseFromStream(readerBuilder, stream, &event, &errors))
+                    {
+                        protocolEvents.emplace_back(std::move(event));
+                    }
+                });
+
+            const auto sendStatus = [&](const winrt::hstring& tabId, const char* model) {
+                Json::Value event{ Json::objectValue };
+                event["type"] = "event";
+                event["method"] = "agent_status";
+                event["params"]["agent_id"] = "copilot";
+                event["params"]["name"] = "Copilot";
+                event["params"]["version"] = "v1";
+                event["params"]["model"] = model;
+                event["params"]["state"] = "connected";
+                event["params"]["backend"] = "Windows";
+                event["params"]["host_catalog_ready"] = true;
+                event["params"]["tab_id"] = winrt::to_string(tabId);
+
+                Json::StreamWriterBuilder writerBuilder;
+                writerBuilder["indentation"] = "";
+                page->OnAgentStatusChanged(winrt::to_hstring(Json::writeString(writerBuilder, event)));
+            };
+
+            sendStatus(oldTabId, "model-a");
+
+            VERIFY_IS_TRUE(impl->IsHelperEventReady());
+            VERIFY_IS_TRUE(impl->IsAgentConnected());
+            VERIFY_IS_TRUE(impl->GetAgentName() == L"Copilot");
+            VERIFY_IS_TRUE(impl->GetAgentModel() == L"model-a");
+            VERIFY_ARE_EQUAL(1u, protocolEvents.size());
+            VERIFY_IS_TRUE(protocolEvents[0]["method"].asString() == "tab_renamed");
+            VERIFY_IS_TRUE(protocolEvents[0]["params"]["old_tab_id"].asString() == winrt::to_string(oldTabId));
+            VERIFY_IS_TRUE(protocolEvents[0]["params"]["new_tab_id"].asString() == winrt::to_string(focusedTab->StableId()));
+            VERIFY_IS_TRUE(impl->TransferSourceTabId().empty());
+
+            sendStatus(focusedTab->StableId(), "model-b");
+
+            VERIFY_IS_TRUE(impl->GetAgentModel() == L"model-b");
+            VERIFY_ARE_EQUAL(1u, protocolEvents.size());
+
+            page->ProtocolVtSequenceReceived(token);
         });
     }
 

--- a/src/cascadia/TerminalApp/AgentPaneContent.cpp
+++ b/src/cascadia/TerminalApp/AgentPaneContent.cpp
@@ -206,6 +206,7 @@ namespace winrt::TerminalApp::implementation
                                              const winrt::hstring& state,
                                              const winrt::hstring& backend)
     {
+        _helperEventReady = true;
         const bool nameChanged = _agentName != name;
         _agentName = name;
         _agentVersion = version;

--- a/src/cascadia/TerminalApp/AgentPaneContent.h
+++ b/src/cascadia/TerminalApp/AgentPaneContent.h
@@ -95,6 +95,10 @@ namespace winrt::TerminalApp::implementation
         // capability exists before connect (cold start) or after a
         // failure/disconnect, so the button must not appear at all.
         bool IsAgentConnected() const noexcept { return _agentState == L"connected"; }
+        // True after the first agent_status routed to this pane. The helper
+        // subscribes to WT events before it can publish that status, so this
+        // also proves that settings events can reach the helper.
+        bool IsHelperEventReady() const noexcept { return _helperEventReady; }
         winrt::hstring GetLastErrorPaneId() const noexcept { return _lastErrorPaneId; }
         winrt::hstring GetFixPreview() const noexcept { return _fixPreview; }
         winrt::hstring GetHotkeyHint() const noexcept { return _hotkeyHint; }
@@ -143,6 +147,7 @@ namespace winrt::TerminalApp::implementation
         winrt::hstring _agentModel{};
         winrt::hstring _agentState{};
         winrt::hstring _agentBackend{};
+        bool _helperEventReady{ false };
 
         // When true, the bar replaces the agent/model label with "Agent sessions"
         // and hides the agent logo. Driven by TerminalPage::OnAgentStateChanged

--- a/src/cascadia/TerminalApp/AgentPaneContent.h
+++ b/src/cascadia/TerminalApp/AgentPaneContent.h
@@ -73,6 +73,9 @@ namespace winrt::TerminalApp::implementation
             _pendingRenameFromTabId = {};
             return value;
         }
+        void SetTransferSourceTabId(const winrt::hstring& value) noexcept { _transferSourceTabId = value; }
+        winrt::hstring TransferSourceTabId() const noexcept { return _transferSourceTabId; }
+        void ClearTransferSourceTabId() noexcept { _transferSourceTabId = {}; }
         void SetPendingAgentSourceProfileGuid(const std::optional<winrt::guid>& value) noexcept { _pendingAgentSourceProfileGuid = value; }
         std::optional<winrt::guid> TakePendingAgentSourceProfileGuid() noexcept
         {
@@ -99,6 +102,8 @@ namespace winrt::TerminalApp::implementation
         // subscribes to WT events before it can publish that status, so this
         // also proves that settings events can reach the helper.
         bool IsHelperEventReady() const noexcept { return _helperEventReady; }
+        winrt::hstring GetAgentName() const noexcept { return _agentName; }
+        winrt::hstring GetAgentModel() const noexcept { return _agentModel; }
         winrt::hstring GetLastErrorPaneId() const noexcept { return _lastErrorPaneId; }
         winrt::hstring GetFixPreview() const noexcept { return _fixPreview; }
         winrt::hstring GetHotkeyHint() const noexcept { return _hotkeyHint; }
@@ -167,6 +172,9 @@ namespace winrt::TerminalApp::implementation
         // fallback; generic settings propagation must not overwrite it.
         winrt::hstring _agentPanePosition{ L"bottom" };
         winrt::hstring _pendingRenameFromTabId{};
+        // The old StableId remains a temporary alias until this replacement
+        // wrapper recovers the helper's first post-transfer status.
+        winrt::hstring _transferSourceTabId{};
         std::optional<winrt::guid> _pendingAgentSourceProfileGuid;
         bool _helperTransferredForDrag{ false };
 

--- a/src/cascadia/TerminalApp/SharedWta.cpp
+++ b/src/cascadia/TerminalApp/SharedWta.cpp
@@ -454,6 +454,34 @@ namespace winrt::TerminalApp::implementation::details
     {
         return _currentGeneration;
     }
+
+    void UnexpectedExitRecoveryPolicy::Arm(const Generation generation) noexcept
+    {
+        _armedGeneration = generation;
+    }
+
+    void UnexpectedExitRecoveryPolicy::Retire() noexcept
+    {
+        _armedGeneration = 0;
+    }
+
+    bool UnexpectedExitRecoveryPolicy::ShouldRespawn(
+        const Generation generation,
+        const size_t refCount,
+        const bool spawnSuppressed,
+        const bool hasCachedArgs) noexcept
+    {
+        if (generation == 0 || generation != _armedGeneration)
+        {
+            return false;
+        }
+
+        // One automatic recovery attempt belongs to each explicit spawn.
+        // The replacement is intentionally not armed, so another unexpected
+        // exit cannot create an unbounded respawn loop.
+        Retire();
+        return refCount > 0 && !spawnSuppressed && hasCachedArgs;
+    }
 }
 
 namespace winrt::TerminalApp::implementation
@@ -522,6 +550,7 @@ namespace winrt::TerminalApp::implementation
         {
             std::lock_guard lock{ _mtx };
             _waitGeneration.Retire();
+            _unexpectedExitRecovery.Retire();
             waitToCancel = _waitHandle;
             _waitHandle = nullptr;
         }
@@ -717,9 +746,11 @@ namespace winrt::TerminalApp::implementation
         return _SpawnLocked(nextWtaPath, nextExtraArgs, nextEnvironment);
     }
 
-    bool SharedWta::_SpawnLocked(const std::wstring_view wtaPath,
-                                 std::span<const std::wstring> extraArgs,
-                                 std::span<const std::pair<std::wstring, std::wstring>> environment)
+    bool SharedWta::_SpawnLocked(
+        const std::wstring_view wtaPath,
+        std::span<const std::wstring> extraArgs,
+        std::span<const std::pair<std::wstring, std::wstring>> environment,
+        const bool armUnexpectedExitRecovery)
     {
         // Lazily allocate the master pipe name once per process. We
         // intentionally keep it across master respawns: helpers
@@ -910,6 +941,14 @@ namespace winrt::TerminalApp::implementation
         _job = std::move(job);
         _pid = pid;
         _waitHandle = waitHandle;
+        if (waitHandle && armUnexpectedExitRecovery)
+        {
+            _unexpectedExitRecovery.Arm(waitGeneration);
+        }
+        else
+        {
+            _unexpectedExitRecovery.Retire();
+        }
 
         // Cache the spawn inputs so `Restart()` can replay them. Overwrites
         // any prior cache: if a respawn after crash used different
@@ -938,12 +977,14 @@ namespace winrt::TerminalApp::implementation
             // callback can run after a replacement is spawned, but its
             // retired generation cannot claim the replacement state.
             _waitGeneration.Retire();
+            _unexpectedExitRecovery.Retire();
             UnregisterWaitEx(_waitHandle, nullptr);
             _waitHandle = nullptr;
         }
         else
         {
             _waitGeneration.Retire();
+            _unexpectedExitRecovery.Retire();
         }
         _pid = 0;
         return process;
@@ -958,11 +999,9 @@ namespace winrt::TerminalApp::implementation
     void SharedWta::_OnProcessExited(const details::ProcessWaitGenerationTracker::Generation generation)
     {
         // Runs on a Win32 thread-pool thread. wta has exited (crash,
-        // OOM, manual kill). Clear our process record so the next
-        // AcquirePane respawns. Existing panes that still hold refs
-        // become zombies until their Closed handlers call
-        // ReleasePane (which will then no-op the cleanup since
-        // _process is already invalid).
+        // OOM, manual kill). Retained helpers reconnect to the stable pipe,
+        // so give the current explicitly-spawned generation one automatic
+        // replacement while pane references remain.
         std::lock_guard lock{ _mtx };
 
         // Claiming also retires the current generation. A callback queued
@@ -978,6 +1017,7 @@ namespace winrt::TerminalApp::implementation
         {
             // Race: Release already cleaned up before our callback
             // ran. Nothing to do.
+            _unexpectedExitRecovery.Retire();
             return;
         }
         // The master exited on its own — crash, OOM, or an external kill
@@ -997,5 +1037,22 @@ namespace winrt::TerminalApp::implementation
             _waitHandle = nullptr;
         }
         _pid = 0;
+
+        if (_unexpectedExitRecovery.ShouldRespawn(
+                generation,
+                _refCount,
+                _spawnSuppressed,
+                !_cachedWtaPath.empty()))
+        {
+            const std::wstring wtaPath{ _cachedWtaPath };
+            const std::vector<std::wstring> extraArgs{ _cachedExtraArgs };
+            const std::vector<std::pair<std::wstring, std::wstring>> environment{ _cachedEnvironment };
+            if (!_SpawnLocked(wtaPath, extraArgs, environment, false))
+            {
+                _agentPaneLog(
+                    "failed to respawn wta-master after unexpected exit pid=" +
+                    std::to_string(*observedPid) + "; retained helpers may remain disconnected");
+            }
+        }
     }
 }

--- a/src/cascadia/TerminalApp/SharedWta.cpp
+++ b/src/cascadia/TerminalApp/SharedWta.cpp
@@ -216,7 +216,7 @@ namespace winrt::TerminalApp::implementation::details
         return false;
     }
 
-    bool TabRetirementTracker::BeginRebuild(const std::string_view tabId)
+    bool TabRetirementTracker::BeginRecreation(const std::string_view tabId)
     {
         return _closeRequested.emplace(tabId, false).second;
     }
@@ -664,7 +664,7 @@ namespace winrt::TerminalApp::implementation
         }
 
         // Settings reload is delivered to every window, and a page may defer
-        // its rebuild until a terminal tab regains focus. If the live master
+        // its reconciliation until a terminal tab regains focus. If the live master
         // already has these exact trusted arguments, restarting it again is
         // both unnecessary and disruptive to helpers in other windows.
         const bool sameArgs = _cachedWtaPath == wtaPath &&

--- a/src/cascadia/TerminalApp/SharedWta.cpp
+++ b/src/cascadia/TerminalApp/SharedWta.cpp
@@ -618,20 +618,22 @@ namespace winrt::TerminalApp::implementation
             return false;
         }
 
-        // Nothing running → nothing to restart. Caller's surrounding
-        // teardown+reopen path will trigger the usual lazy `AcquirePane`
-        // spawn anyway, so this is a benign no-op (not an error).
-        if (!_process.is_valid())
-        {
-            return true;
-        }
-
         // No cached args means we've never successfully spawned in this
-        // process, which contradicts `_process.is_valid()` — defensive
-        // bail rather than spawning with empty wtaPath.
+        // process, so there is no trusted command line to restart.
         if (_cachedWtaPath.empty())
         {
             return false;
+        }
+
+        // A crashed master leaves retained helpers waiting on the stable pipe.
+        // Respawn it directly; there is no pane recreation/AcquirePane cycle
+        // in the normal restart path anymore.
+        if (!_process.is_valid())
+        {
+            return _SpawnLocked(
+                std::wstring_view{ _cachedWtaPath },
+                _cachedExtraArgs,
+                _cachedEnvironment);
         }
 
         return _RestartLocked(std::wstring_view{ _cachedWtaPath }, _cachedExtraArgs, _cachedEnvironment);
@@ -710,9 +712,8 @@ namespace winrt::TerminalApp::implementation
             return false;
         }
 
-        // Refcount is deliberately untouched. The surrounding pane teardown
-        // and reopen balances its outgoing ReleasePane and incoming
-        // AcquirePane after the replacement has claimed the shared pipe.
+        // Refcount is deliberately untouched. Existing panes and helpers stay
+        // alive and reconnect after the replacement claims the stable pipe.
         return _SpawnLocked(nextWtaPath, nextExtraArgs, nextEnvironment);
     }
 

--- a/src/cascadia/TerminalApp/SharedWta.h
+++ b/src/cascadia/TerminalApp/SharedWta.h
@@ -105,7 +105,7 @@ namespace winrt::TerminalApp::implementation
         class TabRetirementTracker
         {
         public:
-            bool BeginRebuild(std::string_view tabId);
+            bool BeginRecreation(std::string_view tabId);
             bool RequestClose(std::string_view tabId);
             bool Complete(std::string_view tabId);
 
@@ -246,14 +246,10 @@ namespace winrt::TerminalApp::implementation
 
         /// Force-restart the wta-master process, bypassing the
         /// `AcquirePane`/`ReleasePane` reference count. Used by the
-        /// `/restart` slash command path: the caller (TerminalPage)
-        /// tears down every agent pane around this call, so the
-        /// refcount-based teardown isn't enough — there may be other
-        /// panes' Closed handlers that have yet to fire. After this
-        /// returns, the next `AcquirePane` finds a fresh master
-        /// listening on the same `_masterPipeName` (intentionally
-        /// stable across respawns so any helpers spawned with the old
-        /// cmdline can still find it).
+        /// `/restart` slash command and launch-configuration changes after
+        /// their sessions retire. Existing panes and helpers stay alive; the
+        /// replacement master listens on the same `_masterPipeName` so they
+        /// can reconnect without rebuilding their physical terminal stack.
         ///
         /// Replays the `wtaPath` + `extraArgs` cached from the first
         /// successful spawn so the new master inherits the same

--- a/src/cascadia/TerminalApp/SharedWta.h
+++ b/src/cascadia/TerminalApp/SharedWta.h
@@ -190,6 +190,23 @@ namespace winrt::TerminalApp::implementation
             Generation _currentGeneration{ 0 };
             DWORD _pid{ 0 };
         };
+
+        class UnexpectedExitRecoveryPolicy
+        {
+        public:
+            using Generation = ProcessWaitGenerationTracker::Generation;
+
+            void Arm(Generation generation) noexcept;
+            void Retire() noexcept;
+            bool ShouldRespawn(
+                Generation generation,
+                size_t refCount,
+                bool spawnSuppressed,
+                bool hasCachedArgs) noexcept;
+
+        private:
+            Generation _armedGeneration{ 0 };
+        };
     }
 
     class SharedWta
@@ -318,7 +335,8 @@ namespace winrt::TerminalApp::implementation
         // All `*Locked` helpers assume the caller already holds `_mtx`.
         bool _SpawnLocked(const std::wstring_view wtaPath,
                           std::span<const std::wstring> extraArgs,
-                          std::span<const std::pair<std::wstring, std::wstring>> environment);
+                          std::span<const std::pair<std::wstring, std::wstring>> environment,
+                          bool armUnexpectedExitRecovery = true);
         bool _RestartLocked(const std::wstring_view wtaPath,
                             std::span<const std::wstring> extraArgs,
                             std::span<const std::pair<std::wstring, std::wstring>> environment);
@@ -337,6 +355,7 @@ namespace winrt::TerminalApp::implementation
         wil::unique_handle _job;
         HANDLE _waitHandle{ nullptr };
         details::ProcessWaitGenerationTracker _waitGeneration;
+        details::UnexpectedExitRecoveryPolicy _unexpectedExitRecovery;
         DWORD _pid{ 0 };
         size_t _refCount{ 0 };
         // Generated lazily on first AcquirePane; reused across

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -759,7 +759,7 @@ namespace winrt::TerminalApp::implementation
             // Flush any deferred agent settings rebuild now that a
             // terminal tab is active. Per-tab model — no shared pane
             // reconciliation needed.
-            _FlushPendingAgentRebuild();
+            _FlushPendingAgentSettingsReconciliation();
         }
 
         // GH#5559 - If we were in the middle of a drag/drop, end it by clearing
@@ -1461,7 +1461,7 @@ namespace winrt::TerminalApp::implementation
             // Flush any deferred agent-stack rebuild now that a real
             // terminal tab is active. Per-tab model — no shared pane
             // reconciliation needed.
-            _FlushPendingAgentRebuild();
+            _FlushPendingAgentSettingsReconciliation();
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1658,11 +1658,10 @@ namespace winrt::TerminalApp::implementation
 
     // --- Hot-reload of agent/model settings -------------------------------
     //
-    // When any agent-identity setting changes, the single shared wta pane must
-    // be torn down and recreated with the updated flags baked into argv.
-    // `_RebuildAgentStack` is the single entry point; it is called from
-    // SetSettings (settings.json reload + Settings UI writes) and from the
-    // bottom-bar selector Click handler.
+    // `_RebuildAgentStack` reconciles agent-identity settings changed through
+    // settings.json, Settings UI, or the bottom-bar selector. Built-in agent
+    // changes rebind the existing helper; changes to trusted launch arguments
+    // retain the destructive pane/master path.
     TerminalPage::AgentSettingsSnapshot TerminalPage::_CaptureAgentSettingsSnapshot() const
     {
         const auto& globals = _settings.GlobalSettings();
@@ -1717,18 +1716,60 @@ namespace winrt::TerminalApp::implementation
         return Json::writeString(writer, identity);
     }
 
+    TerminalPage::AgentSettingsChangeKind TerminalPage::_ClassifyAgentSettingsChange(
+        const AgentSettingsSnapshot& previous,
+        const AgentSettingsSnapshot& current)
+    {
+        const bool changed =
+            previous.acpAgent != current.acpAgent ||
+            previous.acpCustomCommand != current.acpCustomCommand ||
+            previous.acpModel != current.acpModel ||
+            previous.customModelLaunch != current.customModelLaunch ||
+            previous.profileBackends != current.profileBackends;
+        if (!changed)
+        {
+            return AgentSettingsChangeKind::None;
+        }
+
+        const auto isBuiltinAgent = [](const std::wstring_view id) {
+            const auto agents = ::Microsoft::Terminal::Settings::Model::AgentRegistry::FilteredAcpAgents();
+            return std::ranges::any_of(agents, [&](const auto& agent) {
+                return agent.id == id;
+            });
+        };
+
+        // The Settings picker clears acpModel when acpAgent changes because
+        // native model IDs are agent-specific. Treat that reset as one binding
+        // replacement; a simultaneous change to another non-empty model keeps
+        // the existing destructive model path. Custom commands, provider launch
+        // environment, and profile backends also remain destructive.
+        if (previous.acpAgent != current.acpAgent &&
+            isBuiltinAgent(previous.acpAgent) &&
+            isBuiltinAgent(current.acpAgent) &&
+            previous.acpCustomCommand == current.acpCustomCommand &&
+            (previous.acpModel == current.acpModel || current.acpModel.empty()) &&
+            previous.customModelLaunch == current.customModelLaunch &&
+            previous.profileBackends == current.profileBackends)
+        {
+            return AgentSettingsChangeKind::AgentRebind;
+        }
+
+        return AgentSettingsChangeKind::Rebuild;
+    }
+
     bool TerminalPage::_AgentSettingsChanged(const AgentSettingsSnapshot& a, const AgentSettingsSnapshot& b)
     {
-        // Agent identity and effective model changes rebuild helpers. A profile
-        // backend is part of identity because it changes both the agent id and
-        // the execution source for that profile. Only selected-provider fields
-        // consumed by the master launch environment participate in identity.
-        // The helper-safe full catalog is hot-updated separately.
-        return a.acpAgent != b.acpAgent ||
-               a.acpCustomCommand != b.acpCustomCommand ||
-               a.acpModel != b.acpModel ||
-               a.customModelLaunch != b.customModelLaunch ||
-               a.profileBackends != b.profileBackends;
+        return _ClassifyAgentSettingsChange(a, b) != AgentSettingsChangeKind::None;
+    }
+
+    bool TerminalPage::_ShouldDeferAgentSettingsChange(
+        const AgentSettingsChangeKind changeKind,
+        const bool canHostPane,
+        const bool masterConfigurationChanged) noexcept
+    {
+        return changeKind == AgentSettingsChangeKind::Rebuild &&
+               !canHostPane &&
+               !masterConfigurationChanged;
     }
 
     TerminalPage::AgentRuntimeConfigSnapshot TerminalPage::_CaptureAgentRuntimeConfig() const
@@ -1745,9 +1786,8 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Hot-propagate runtime agent config to the running wta-helper(s) over the
-    // protocol event channel. Unlike agent identity/model changes (which
-    // require a master respawn via _RebuildAgentStack), these take effect
-    // without tearing down the agent pane. A single consolidated
+    // protocol event channel. Agent identity/model changes are reconciled
+    // separately by _RebuildAgentStack. A single consolidated
     // `agent_config_changed` event carries only the fields that changed:
     //   - autofix_enabled : the auto-suggest gate (was its own event)
     //   - delegate_agent + delegate_model : the delegate-tab agent identity
@@ -3349,9 +3389,10 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
-    // Called whenever agent-identity settings may have changed. Diffs the
-    // last known snapshot against the current one, tears down + rebuilds
-    // the agent pane, and updates the snapshot.
+    // Called whenever agent-identity settings may have changed. Built-in
+    // global agent changes preserve the Pane/TermControl/ConPTY/helper and
+    // replace only the helper's ACP connection after retiring its old
+    // session. Other launch-identity changes keep the destructive path.
     void TerminalPage::_RebuildAgentStack(std::string requestId)
     {
         const auto current = _CaptureAgentSettingsSnapshot();
@@ -3377,12 +3418,14 @@ namespace winrt::TerminalApp::implementation
             return;
         }
 
-        if (!_AgentSettingsChanged(_lastAgentSettings, current))
+        const auto changeKind = _ClassifyAgentSettingsChange(_lastAgentSettings, current);
+        if (changeKind == AgentSettingsChangeKind::None)
         {
             _agentPaneLog("_RebuildAgentStack: no change, skip rebuild");
             return;
         }
 
+        const bool rebindAgentInPlace = changeKind == AgentSettingsChangeKind::AgentRebind;
         // Custom commands are trusted only when supplied on the master's own
         // argv. Helpers intentionally cannot ask the master to execute an
         // arbitrary command from pipe metadata, so entering/leaving a custom
@@ -3397,8 +3440,8 @@ namespace winrt::TerminalApp::implementation
             _lastAgentSettings.acpModel != current.acpModel;
         const bool masterConfigurationChanged =
             customMasterArgsChanged ||
-            cloudModelChanged ||
-            customModelLaunchChanged;
+            (!rebindAgentInPlace &&
+             (cloudModelChanged || customModelLaunchChanged));
         const bool globalAgentChanged =
             _lastAgentSettings.acpAgent != current.acpAgent ||
             _lastAgentSettings.acpCustomCommand != current.acpCustomCommand;
@@ -3446,17 +3489,19 @@ namespace winrt::TerminalApp::implementation
             return;
         }
 
-        // Defer the rebuild when there's no terminal tab in focus:
-        // TermControls on non-active tabs never raise
-        // SwapChainPanel.LayoutUpdated, so `connection.Start()` never
-        // runs and wta.exe never launches. _FlushPendingAgentRebuild
-        // re-enters once a terminal tab becomes active.
+        // Defer destructive rebuilds when there's no terminal tab in focus:
+        // newly created TermControls on non-active tabs never raise
+        // SwapChainPanel.LayoutUpdated, so `connection.Start()` never runs and
+        // wta.exe never launches. In-place rebinds reuse existing helpers and
+        // must continue while Settings is focused.
+        // _FlushPendingAgentRebuild re-enters once a terminal tab becomes
+        // active.
         // `_lastAgentSettings` stays unchanged so the dirty diff fires
         // again on next entry.
         const auto focusedTab = _GetFocusedTabImpl();
         // Only `==` auto-generates for projected WinRT types — `!=` doesn't.
         const bool canHostPane = focusedTab && !(*focusedTab == _settingsTab);
-        if (!canHostPane && !masterConfigurationChanged)
+        if (_ShouldDeferAgentSettingsChange(changeKind, canHostPane, masterConfigurationChanged))
         {
             _pendingAgentRebuild = true;
             if (!requestId.empty())
@@ -3468,7 +3513,10 @@ namespace winrt::TerminalApp::implementation
 
         _agentRebuilding = true;
 
-        _agentPaneLog("_RebuildAgentStack: agent settings changed, rebuilding");
+        _agentPaneLog(
+            rebindAgentInPlace ?
+                "_RebuildAgentStack: built-in agent changed, rebinding existing helpers" :
+                "_RebuildAgentStack: agent settings changed, rebuilding");
 
         // Rebuild only tabs whose effective agent identity changed. A custom
         // command or selected provider launch change restarts the shared master,
@@ -3537,25 +3585,53 @@ namespace winrt::TerminalApp::implementation
             requestId = winrt::TerminalApp::implementation::SharedWta::Instance().CreateRetirementRequestId();
         }
 
+        const auto rebindGeneration =
+            rebindAgentInPlace ? ++_agentSettingsRebindGeneration : 0;
         _BeginAgentSessionRetirement(
             masterConfigurationChanged,
             tabIdsThatHadAgentPane,
-            masterConfigurationChanged ? "settings_master_configuration_changed" : "settings_agent_changed",
+            masterConfigurationChanged ?
+                "settings_master_configuration_changed" :
+                (rebindAgentInPlace ? "settings_agent_rebind" : "settings_agent_changed"),
             masterConfigurationChanged ? std::move(requestId) : std::string{},
             [weakThis = get_weak(),
              current,
              tabIdsThatHadAgentPane,
-             masterConfigurationChanged](const std::string_view operationId) {
+             masterConfigurationChanged,
+             rebindAgentInPlace,
+             rebindGeneration](const std::string_view operationId) {
                 if (const auto strongThis = weakThis.get())
                 {
                     std::vector<winrt::com_ptr<Tab>> tabsToReopen;
-                    for (const auto& tabId : tabIdsThatHadAgentPane)
+                    if (rebindAgentInPlace)
                     {
-                        if (const auto tab = strongThis->_FindTabByStableId(tabId);
-                            tab && tab->FindAgentPane())
+                        for (const auto& tabId : tabIdsThatHadAgentPane)
                         {
-                            tabsToReopen.push_back(tab);
-                            strongThis->_TeardownAgentPane(tab);
+                            if (const auto tab = strongThis->_FindTabByStableId(tabId);
+                                tab && tab->FindAgentPane())
+                            {
+                                Json::Value params{ Json::objectValue };
+                                params["operation_id"] = std::string{ operationId };
+                                params["generation"] = Json::UInt64{ rebindGeneration };
+                                params["window_id"] = std::to_string(strongThis->_WindowProperties.WindowId());
+                                params["tab_id"] = winrt::to_string(tabId);
+                                params["agent_id"] = winrt::to_string(current.acpAgent);
+                                params["agent_source"] = "host";
+                                params["acp_model"] = winrt::to_string(current.acpModel);
+                                strongThis->_RaiseProtocolEvent("rebind_agent", params);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        for (const auto& tabId : tabIdsThatHadAgentPane)
+                        {
+                            if (const auto tab = strongThis->_FindTabByStableId(tabId);
+                                tab && tab->FindAgentPane())
+                            {
+                                tabsToReopen.push_back(tab);
+                                strongThis->_TeardownAgentPane(tab);
+                            }
                         }
                     }
 
@@ -9122,7 +9198,6 @@ namespace winrt::TerminalApp::implementation
         ////////////////////////////////////////////////////////////////////////
         // Begin Theme handling
         _updateThemeColors();
-
         _updateAllTabCloseButtons();
 
         // The user may have changed the "show title in titlebar" setting.
@@ -9642,7 +9717,6 @@ namespace winrt::TerminalApp::implementation
         {
             _tabView.SelectedItem(_settingsTab.TabViewItem());
         }
-
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -399,15 +399,15 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        // Hot-reload of runtime agent config (autofix gate and delegate
-        // agent/model). When any of these change between settings
+        // Hot-reload of runtime agent config (autofix gate, delegate
+        // agent/model, and model catalogs). When any of these change between settings
         // reloads we push a single consolidated `agent_config_changed`
         // event to the running wta-helper(s) so they update in place,
         // WITHOUT tearing down and restarting the agent pane. This is the
-        // unified dispatch for every hot-updatable agent setting — adding a
-        // new one means adding a field to AgentRuntimeConfigSnapshot, not a
-        // bespoke diff/emit block here. Agent identity and model changes go
-        // through _RebuildAgentStack in _RefreshUIForSettingsReload.
+        // unified dispatch for non-binding runtime settings. Agent identity
+        // and ACP model changes go through _RebuildAgentStack in
+        // _RefreshUIForSettingsReload so unready helpers can be recreated
+        // before the settings snapshot advances.
         _EmitAgentRuntimeConfigIfChanged();
 
         // Make sure to call SetCommands before _RefreshUIForSettingsReload.
@@ -1800,12 +1800,16 @@ namespace winrt::TerminalApp::implementation
     }
 
     TerminalPage::AgentPaneSettingsRebindDisposition TerminalPage::_ClassifyAgentPaneSettingsRebind(
-        const ConnectionState connectionState) noexcept
+        const ConnectionState connectionState,
+        const bool helperEventReady) noexcept
     {
         // Only these states can still have a helper subscribed to rebind_agent.
-        // Terminal states leave the pane visible but no durable helper behind.
-        return connectionState == ConnectionState::Connecting ||
-                       connectionState == ConnectionState::Connected ?
+        // agent_status is published only after that event receiver is
+        // subscribed, so the cached readiness bit closes the startup window
+        // where ConPTY is live but settings events would still be lost.
+        return helperEventReady &&
+                       (connectionState == ConnectionState::Connecting ||
+                        connectionState == ConnectionState::Connected) ?
                    AgentPaneSettingsRebindDisposition::Rebind :
                    AgentPaneSettingsRebindDisposition::Recreate;
     }
@@ -1917,6 +1921,32 @@ namespace winrt::TerminalApp::implementation
                  binding.supportsGlobalHostByok));
     }
 
+    bool TerminalPage::_IsAgentPaneModelHotUpdateTarget(
+        const std::optional<AgentPaneSettingsBinding>& binding,
+        const std::optional<ConnectionState> connectionState,
+        const bool helperEventReady) noexcept
+    {
+        return binding &&
+               binding->launchable &&
+               binding->followsGlobalAcpModel &&
+               connectionState &&
+               _ClassifyAgentPaneSettingsRebind(*connectionState, helperEventReady) ==
+                   AgentPaneSettingsRebindDisposition::Rebind;
+    }
+
+    bool TerminalPage::_ShouldRecreateAgentPaneForModelHotUpdate(
+        const std::optional<AgentPaneSettingsBinding>& binding,
+        const std::optional<ConnectionState> connectionState,
+        const bool helperEventReady) noexcept
+    {
+        return binding &&
+               binding->launchable &&
+               binding->followsGlobalAcpModel &&
+               (!connectionState ||
+                _ClassifyAgentPaneSettingsRebind(*connectionState, helperEventReady) ==
+                    AgentPaneSettingsRebindDisposition::Recreate);
+    }
+
     Json::Value TerminalPage::_BuildAgentPaneSettingsRebindPayload(
         const AgentPaneSettingsBinding& binding)
     {
@@ -1934,8 +1964,6 @@ namespace winrt::TerminalApp::implementation
         const auto& globals = _settings.GlobalSettings();
         const auto customModelLaunch = _CaptureCustomModelLaunchConfiguration(globals);
         return AgentRuntimeConfigSnapshot{
-            std::wstring{ globals.AcpAgent() },
-            customModelLaunch ? std::wstring{} : std::wstring{ globals.AcpModel() },
             std::wstring{ _ResolveEffectiveDelegateAgent(globals) },
             std::wstring{ globals.DelegateModel() },
             customModelLaunch ? customModelLaunch->selectionId : std::wstring{},
@@ -1948,7 +1976,6 @@ namespace winrt::TerminalApp::implementation
     // protocol event channel. A single consolidated `agent_config_changed`
     // event carries only the fields that changed:
     //   - autofix_enabled : the auto-suggest gate (was its own event)
-    //   - acp_model + target_agent_id : a scoped live ACP model update
     //   - delegate_agent + delegate_model : the delegate-tab agent identity
     //   - cloud_models + custom_models + custom_model_selection :
     //     credential-free picker metadata and its selected entry.
@@ -1974,19 +2001,9 @@ namespace winrt::TerminalApp::implementation
         const bool customModelsChanged =
             last.customModelSelection != current.customModelSelection ||
             last.customModels != current.customModels;
-        const bool acpModelChanged =
-            last.acpAgent == current.acpAgent &&
-            last.customModelSelection.empty() &&
-            current.customModelSelection.empty() &&
-            last.acpModel != current.acpModel &&
-            !current.acpModel.empty() &&
-            ::Microsoft::Terminal::Settings::Model::AgentRegistry::SupportsLiveModelSwitch(current.acpAgent);
 
-        if (!autofixChanged && !delegateChanged && !customModelsChanged && !acpModelChanged)
+        if (!autofixChanged && !delegateChanged && !customModelsChanged)
         {
-            // Agent identity is not itself a hot-update field, but it scopes
-            // the next model update. Advance the baseline even when the
-            // identity change is handled by the rebind path below.
             _lastAgentRuntimeConfig = current;
             return;
         }
@@ -1996,11 +2013,6 @@ namespace winrt::TerminalApp::implementation
         if (autofixChanged)
         {
             params["autofix_enabled"] = current.autofixEnabled;
-        }
-        if (acpModelChanged)
-        {
-            params["acp_model"] = winrt::to_string(current.acpModel);
-            params["target_agent_id"] = winrt::to_string(current.acpAgent);
         }
         if (delegateChanged)
         {
@@ -3613,13 +3625,7 @@ namespace winrt::TerminalApp::implementation
             _agentPaneLog("_RebuildAgentStack: no change, skip rebuild");
             return;
         }
-        if (changeKind == AgentSettingsChangeKind::ModelHotUpdate)
-        {
-            _lastAgentSettings = current;
-            _agentPaneLog("_RebuildAgentStack: native model changed, preserving live ACP sessions");
-            return;
-        }
-
+        const bool modelHotUpdate = changeKind == AgentSettingsChangeKind::ModelHotUpdate;
         const bool rebindAgentInPlace = changeKind == AgentSettingsChangeKind::AgentRebind;
         // Custom commands are trusted only when supplied on the master's own
         // argv. Helpers intentionally cannot ask the master to execute an
@@ -3634,8 +3640,9 @@ namespace winrt::TerminalApp::implementation
         const bool cloudModelChanged =
             _lastAgentSettings.acpModel != current.acpModel;
         const bool masterConfigurationChanged =
-            customMasterArgsChanged ||
-            (!rebindAgentInPlace && (cloudModelChanged || customModelLaunchChanged));
+            !modelHotUpdate &&
+            (customMasterArgsChanged ||
+             (!rebindAgentInPlace && (cloudModelChanged || customModelLaunchChanged)));
         const bool globalModelBindingChanged =
             cloudModelChanged || customModelLaunchChanged;
         const bool globalAgentChanged =
@@ -3709,17 +3716,24 @@ namespace winrt::TerminalApp::implementation
 
         _agentRebuilding = true;
 
-        _agentPaneLog(
-            rebindAgentInPlace ?
-                "_RebuildAgentStack: agent/model binding changed, rebinding existing helpers" :
-                "_RebuildAgentStack: agent settings changed, rebuilding");
+        if (modelHotUpdate)
+        {
+            _agentPaneLog("_RebuildAgentStack: native model changed, reconciling helper readiness");
+        }
+        else
+        {
+            _agentPaneLog(
+                rebindAgentInPlace ?
+                    "_RebuildAgentStack: agent/model binding changed, rebinding existing helpers" :
+                    "_RebuildAgentStack: agent settings changed, rebuilding");
+        }
 
         // Rebuild only tabs whose effective agent identity changed. A custom
         // command change restarts the shared master, so every local helper is
         // collected even when its tab has a runtime override. BYOK changes
         // rebind every launchable Host pane that consumed that bootstrap.
         AgentPaneSettingsBindingRequest baseBindingRequest;
-        if (rebindAgentInPlace)
+        if (rebindAgentInPlace || modelHotUpdate)
         {
             const auto& globals = _settings.GlobalSettings();
             const auto globalAgentCliPath =
@@ -3740,15 +3754,18 @@ namespace winrt::TerminalApp::implementation
 
         bool hadAny = false;
         bool hasStartedPaneToRebind = false;
+        bool hasModelHotUpdateTarget = false;
         std::vector<winrt::hstring> tabIdsThatHadAgentPane;
+        std::vector<winrt::hstring> tabIdsToRetire;
         std::vector<std::pair<winrt::hstring, AgentPaneSettingsBinding>> rebindTargets;
+        std::vector<std::pair<winrt::com_ptr<Tab>, AgentPaneRecreationOptions>> panesToRecreate;
         for (const auto& t : _tabs)
         {
             if (auto tabImpl = _GetTabImpl(t))
             {
                 bool affected = masterConfigurationChanged;
                 std::optional<AgentPaneSettingsBinding> rebindBinding;
-                if (rebindAgentInPlace)
+                if (rebindAgentInPlace || modelHotUpdate)
                 {
                     auto bindingRequest = baseBindingRequest;
                     bindingRequest.hasAgentOverride = tabImpl->HasAgentOverride();
@@ -3774,13 +3791,14 @@ namespace winrt::TerminalApp::implementation
                     }
 
                     rebindBinding = _ResolveAgentPaneSettingsBinding(bindingRequest);
-                    affected =
-                        affected ||
-                        _IsAgentPaneSettingsRebindAffected(
-                            *rebindBinding,
-                            globalAgentChanged,
-                            cloudModelChanged,
-                            customModelLaunchChanged);
+                    affected = modelHotUpdate ?
+                                   rebindBinding->launchable && rebindBinding->followsGlobalAcpModel :
+                                   affected ||
+                                       _IsAgentPaneSettingsRebindAffected(
+                                           *rebindBinding,
+                                           globalAgentChanged,
+                                           cloudModelChanged,
+                                           customModelLaunchChanged);
                 }
                 else if (!affected && !tabImpl->HasAgentOverride())
                 {
@@ -3823,21 +3841,100 @@ namespace winrt::TerminalApp::implementation
                     hadAny = true;
                     const auto tabId = tabImpl->StableId();
                     tabIdsThatHadAgentPane.push_back(tabId);
-                    if (rebindAgentInPlace)
+                    if (rebindAgentInPlace || modelHotUpdate)
                     {
-                        rebindTargets.emplace_back(tabId, std::move(*rebindBinding));
                         const auto pane = tabImpl->FindAgentPane();
-                        auto disposition = AgentPaneSettingsRebindDisposition::Recreate;
+                        bool helperEventReady = false;
+                        if (const auto content = tabImpl->FindAgentPaneContent())
+                        {
+                            helperEventReady =
+                                winrt::get_self<implementation::AgentPaneContent>(content)->IsHelperEventReady();
+                        }
+                        std::optional<ConnectionState> connectionState;
                         if (const auto control = pane->GetTerminalControl())
                         {
-                            disposition = _ClassifyAgentPaneSettingsRebind(control.ConnectionState());
+                            connectionState = control.ConnectionState();
+                        }
+
+                        if (modelHotUpdate)
+                        {
+                            if (_ShouldRecreateAgentPaneForModelHotUpdate(
+                                    rebindBinding,
+                                    connectionState,
+                                    helperEventReady))
+                            {
+                                panesToRecreate.emplace_back(
+                                    tabImpl,
+                                    _GetAgentPaneRecreationOptions(
+                                        tabImpl->HasStashedAgentPane(),
+                                        focusedTab && focusedTab == tabImpl));
+                            }
+                            else if (_IsAgentPaneModelHotUpdateTarget(
+                                         rebindBinding,
+                                         connectionState,
+                                         helperEventReady))
+                            {
+                                hasModelHotUpdateTarget = true;
+                            }
+                            continue;
+                        }
+
+                        if (!helperEventReady)
+                        {
+                            panesToRecreate.emplace_back(
+                                tabImpl,
+                                _GetAgentPaneRecreationOptions(
+                                    tabImpl->HasStashedAgentPane(),
+                                    focusedTab && focusedTab == tabImpl));
+                            continue;
+                        }
+
+                        auto disposition = AgentPaneSettingsRebindDisposition::Recreate;
+                        if (connectionState)
+                        {
+                            disposition = _ClassifyAgentPaneSettingsRebind(
+                                *connectionState,
+                                helperEventReady);
                         }
                         hasStartedPaneToRebind =
                             hasStartedPaneToRebind ||
                             disposition == AgentPaneSettingsRebindDisposition::Rebind;
+                        tabIdsToRetire.push_back(tabId);
+                        rebindTargets.emplace_back(tabId, std::move(*rebindBinding));
                     }
                 }
             }
+        }
+
+        for (const auto& [tab, recreationOptions] : panesToRecreate)
+        {
+            _agentPaneLog("_RebuildAgentStack: recreating unready agent pane with current settings");
+            _TeardownAgentPane(tab);
+            _AutoCreateHiddenAgentPaneShared(
+                tab,
+                /*intoSessionsView*/ false,
+                recreationOptions.autoStash,
+                {},
+                {},
+                {},
+                recreationOptions.focusPane);
+        }
+
+        if (modelHotUpdate)
+        {
+            if (hasModelHotUpdateTarget)
+            {
+                Json::Value params{ Json::objectValue };
+                params["window_id"] = std::to_string(_WindowProperties.WindowId());
+                params["acp_model"] = winrt::to_string(winrt::hstring{ current.acpModel });
+                params["target_agent_id"] = winrt::to_string(winrt::hstring{ current.acpAgent });
+                _RaiseProtocolEvent("agent_config_changed", params);
+            }
+
+            _lastAgentSettings = current;
+            _agentRebuilding = false;
+            _agentPaneLog("_RebuildAgentStack: native model updated ready helpers and recreated unready panes");
+            return;
         }
 
         if (!hadAny && !masterConfigurationChanged)
@@ -3848,13 +3945,24 @@ namespace winrt::TerminalApp::implementation
             return;
         }
 
+        if (rebindAgentInPlace && rebindTargets.empty())
+        {
+            _lastAgentSettings = current;
+            _agentRebuilding = false;
+            _agentPaneLog("_RebuildAgentStack: recreated all affected unready panes, snapshot only");
+            return;
+        }
+
         if (masterConfigurationChanged && requestId.empty())
         {
             requestId = winrt::TerminalApp::implementation::SharedWta::Instance().CreateRetirementRequestId();
         }
 
-        auto tabIdsToRetire = tabIdsThatHadAgentPane;
-        if (rebindAgentInPlace && !hasStartedPaneToRebind)
+        if (!rebindAgentInPlace)
+        {
+            tabIdsToRetire = tabIdsThatHadAgentPane;
+        }
+        else if (!hasStartedPaneToRebind)
         {
             tabIdsToRetire.clear();
         }
@@ -3888,9 +3996,17 @@ namespace winrt::TerminalApp::implementation
                                 tab && tab->FindAgentPane())
                             {
                                 auto disposition = AgentPaneSettingsRebindDisposition::Recreate;
+                                bool helperEventReady = false;
+                                if (const auto content = tab->FindAgentPaneContent())
+                                {
+                                    helperEventReady =
+                                        winrt::get_self<implementation::AgentPaneContent>(content)->IsHelperEventReady();
+                                }
                                 if (const auto control = tab->FindAgentPane()->GetTerminalControl())
                                 {
-                                    disposition = _ClassifyAgentPaneSettingsRebind(control.ConnectionState());
+                                    disposition = _ClassifyAgentPaneSettingsRebind(
+                                        control.ConnectionState(),
+                                        helperEventReady);
                                 }
 
                                 if (disposition == AgentPaneSettingsRebindDisposition::Recreate)
@@ -5807,6 +5923,10 @@ namespace winrt::TerminalApp::implementation
         const auto update = [&](const winrt::com_ptr<Tab>& tabImpl) {
             if (const auto content = tabImpl->FindAgentPaneContent())
             {
+                // UpdateAgentStatus also caches helper-event readiness. In
+                // helper startup, subscribe_events precedes App construction
+                // and every publish_agent_status call, so the first routed
+                // status proves this pane can receive later settings events.
                 content.UpdateAgentStatus(name, version, model, state, backend);
             }
         };

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -5813,6 +5813,62 @@ namespace winrt::TerminalApp::implementation
 
         _agentPaneLog("OnAgentStatusChanged: payload=" + winrt::to_string(eventJson).substr(0, 600));
 
+        // A transferred helper can still be starting while WT moves its
+        // TermControl to another window. In that race, the one-shot
+        // tab_renamed event precedes the helper's WT event subscription, so
+        // its first status still carries the source StableId. Match that
+        // temporary alias to the destination wrapper, then replay the rename
+        // now that this status proves the helper listener is ready.
+        winrt::com_ptr<Tab> statusTab;
+        bool recoveredTransferredTab = false;
+        if (!statusTabId.empty())
+        {
+            statusTab = _FindTabByStableId(statusTabId);
+            if (!statusTab)
+            {
+                for (const auto& candidate : _tabs)
+                {
+                    const auto candidateImpl = _GetTabImpl(candidate);
+                    if (!candidateImpl)
+                    {
+                        continue;
+                    }
+                    const auto content = candidateImpl->FindAgentPaneContent();
+                    if (!content)
+                    {
+                        continue;
+                    }
+                    const auto contentImpl = winrt::get_self<winrt::TerminalApp::implementation::AgentPaneContent>(content);
+                    if (contentImpl->TransferSourceTabId() == statusTabId)
+                    {
+                        statusTab = candidateImpl;
+                        recoveredTransferredTab = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        const auto effectiveStatusTabId = statusTab ? statusTab->StableId() : statusTabId;
+        if (recoveredTransferredTab)
+        {
+            Json::Value renameParams;
+            renameParams["old_tab_id"] = winrt::to_string(statusTabId);
+            renameParams["new_tab_id"] = winrt::to_string(effectiveStatusTabId);
+            renameParams["window_id"] = std::to_string(_WindowProperties.WindowId());
+            _agentPaneLog(
+                std::string{ "OnAgentStatusChanged: replaying tab_renamed after helper readiness old=" } +
+                winrt::to_string(statusTabId) + " new=" + winrt::to_string(effectiveStatusTabId));
+            _RaiseProtocolEvent("tab_renamed", renameParams);
+            if (const auto content = statusTab->FindAgentPaneContent())
+            {
+                if (const auto contentImpl = winrt::get_self<winrt::TerminalApp::implementation::AgentPaneContent>(content))
+                {
+                    contentImpl->ClearTransferSourceTabId();
+                }
+            }
+        }
+
         // If WTA signals a new agent selection (e.g. from FRE or preflight),
         // persist it to settings so the next launch uses the same agent.
         // BUT: never let a tab that the user pinned to a per-tab agent
@@ -5822,12 +5878,9 @@ namespace winrt::TerminalApp::implementation
         // behavior); a missing tab_id (broadcast context) also persists.
         const auto selectedAgent = pickStr("selected_agent");
         bool emittingTabHasOverride = false;
-        if (!statusTabId.empty())
+        if (statusTab)
         {
-            if (const auto srcTab = _FindTabByStableId(statusTabId))
-            {
-                emittingTabHasOverride = srcTab->HasAgentOverride();
-            }
+            emittingTabHasOverride = statusTab->HasAgentOverride();
         }
         if (!selectedAgent.empty() && !emittingTabHasOverride)
         {
@@ -5905,15 +5958,15 @@ namespace winrt::TerminalApp::implementation
             state == L"connected" &&
             !hostCatalogReady &&
             !agentId.empty() &&
-            !statusTabId.empty() &&
-            _FindTabByStableId(statusTabId))
+            !effectiveStatusTabId.empty() &&
+            statusTab)
         {
             const auto& globals = _settings.GlobalSettings();
             const auto customModels =
                 ::Microsoft::Terminal::CustomModels::CaptureCatalog(
                     globals.CustomModelProviders());
             Json::Value config{ Json::objectValue };
-            config["tab_id"] = winrt::to_string(statusTabId);
+            config["tab_id"] = winrt::to_string(effectiveStatusTabId);
             config["target_agent_id"] = winrt::to_string(agentId);
             config["cloud_models"] = _CloudModelOptionsToJson(agentId);
             config["custom_models"] =
@@ -5941,9 +5994,9 @@ namespace winrt::TerminalApp::implementation
         };
         if (!tabId.empty())
         {
-            if (const auto tab = _FindTabByStableId(tabId))
+            if (statusTab)
             {
-                update(tab);
+                update(statusTab);
             }
             return;
         }
@@ -9228,6 +9281,8 @@ namespace winrt::TerminalApp::implementation
                     {
                         agentContent.SetAgentPanePosition(_settings.GlobalSettings().AgentPanePosition());
                         _WireAgentPaneEvents(agentContent, winrt::com_ptr<Tab>{ nullptr });
+                        const auto impl = winrt::get_self<winrt::TerminalApp::implementation::AgentPaneContent>(agentContent);
+                        impl->SetTransferSourceTabId(oldTabId);
                         if (focusedTab)
                         {
                             if (sourceProfileGuid)
@@ -9248,13 +9303,10 @@ namespace winrt::TerminalApp::implementation
                                 _RaiseProtocolEvent("tab_renamed", params);
                             }
                         }
-                        if (const auto impl = winrt::get_self<winrt::TerminalApp::implementation::AgentPaneContent>(agentContent))
+                        if (!focusedTab)
                         {
-                            if (!focusedTab)
-                            {
-                                impl->SetPendingRenameFromTabId(oldTabId);
-                                impl->SetPendingAgentSourceProfileGuid(sourceProfileGuid);
-                            }
+                            impl->SetPendingRenameFromTabId(oldTabId);
+                            impl->SetPendingAgentSourceProfileGuid(sourceProfileGuid);
                         }
                     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -6911,8 +6911,11 @@ namespace winrt::TerminalApp::implementation
                     }
 
                     strongThis->_agentLifecycleOperationInProgress = false;
-                    strongThis->_pendingAgentStackRestart.Clear();
-                    if (std::exchange(strongThis->_pendingAgentSettingsReconciliation, false))
+                    if (const auto pendingRestart = strongThis->_pendingAgentStackRestart.Take())
+                    {
+                        strongThis->_RestartAgentStack(*pendingRestart);
+                    }
+                    else if (std::exchange(strongThis->_pendingAgentSettingsReconciliation, false))
                     {
                         auto pendingRequest = std::exchange(strongThis->_pendingAgentSettingsRequestId, std::nullopt);
                         strongThis->_ReconcileAgentSettings(pendingRequest ? std::move(*pendingRequest) : std::string{});

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1802,11 +1802,22 @@ namespace winrt::TerminalApp::implementation
     TerminalPage::AgentPaneSettingsRebindDisposition TerminalPage::_ClassifyAgentPaneSettingsRebind(
         const ConnectionState connectionState) noexcept
     {
-        // ConptyConnection::Start transitions synchronously to Connecting
-        // before launching the helper, so NotConnected proves it never started.
-        return connectionState == ConnectionState::NotConnected ?
-                   AgentPaneSettingsRebindDisposition::RecreateStashed :
-                   AgentPaneSettingsRebindDisposition::Rebind;
+        // Only these states can still have a helper subscribed to rebind_agent.
+        // Terminal states leave the pane visible but no durable helper behind.
+        return connectionState == ConnectionState::Connecting ||
+                       connectionState == ConnectionState::Connected ?
+                   AgentPaneSettingsRebindDisposition::Rebind :
+                   AgentPaneSettingsRebindDisposition::Recreate;
+    }
+
+    TerminalPage::AgentPaneRecreationOptions TerminalPage::_GetAgentPaneRecreationOptions(
+        const bool wasStashed,
+        const bool isActiveTab) noexcept
+    {
+        return AgentPaneRecreationOptions{
+            .autoStash = wasStashed,
+            .focusPane = !wasStashed && isActiveTab,
+        };
     }
 
     TerminalPage::AgentRuntimeConfigSnapshot TerminalPage::_CaptureAgentRuntimeConfig() const
@@ -2441,7 +2452,8 @@ namespace winrt::TerminalApp::implementation
                                                         bool autoStash,
                                                         std::string_view initialLoadSessionId,
                                                         std::string_view initialLoadCwd,
-                                                        std::wstring_view initialAuthAgent)
+                                                        std::wstring_view initialAuthAgent,
+                                                        bool focusPane)
     {
         if (!tab || !tab->GetActiveTerminalControl())
         {
@@ -2884,6 +2896,12 @@ namespace winrt::TerminalApp::implementation
             tab->StashAgentPane();
             _UpdateBottomBarState();
             _agentPaneLog("_AutoCreateHiddenAgentPaneShared: done — helper pre-warmed + stashed");
+            return true;
+        }
+
+        if (!focusPane)
+        {
+            _agentPaneLog("_AutoCreateHiddenAgentPaneShared: done without changing pane focus");
             return true;
         }
 
@@ -3642,7 +3660,7 @@ namespace winrt::TerminalApp::implementation
                     if (rebindAgentInPlace)
                     {
                         const auto pane = tabImpl->FindAgentPane();
-                        auto disposition = AgentPaneSettingsRebindDisposition::Rebind;
+                        auto disposition = AgentPaneSettingsRebindDisposition::Recreate;
                         if (const auto control = pane->GetTerminalControl())
                         {
                             disposition = _ClassifyAgentPaneSettingsRebind(control.ConnectionState());
@@ -3693,6 +3711,7 @@ namespace winrt::TerminalApp::implementation
                 if (const auto strongThis = weakThis.get())
                 {
                     std::vector<winrt::com_ptr<Tab>> tabsToReopen;
+                    const auto activeTab = strongThis->_GetFocusedTabImpl();
                     if (rebindAgentInPlace)
                     {
                         for (const auto& tabId : tabIdsThatHadAgentPane)
@@ -3700,20 +3719,27 @@ namespace winrt::TerminalApp::implementation
                             if (const auto tab = strongThis->_FindTabByStableId(tabId);
                                 tab && tab->FindAgentPane())
                             {
-                                auto disposition = AgentPaneSettingsRebindDisposition::Rebind;
+                                auto disposition = AgentPaneSettingsRebindDisposition::Recreate;
                                 if (const auto control = tab->FindAgentPane()->GetTerminalControl())
                                 {
                                     disposition = _ClassifyAgentPaneSettingsRebind(control.ConnectionState());
                                 }
 
-                                if (disposition == AgentPaneSettingsRebindDisposition::RecreateStashed)
+                                if (disposition == AgentPaneSettingsRebindDisposition::Recreate)
                                 {
-                                    _agentPaneLog("_RebuildAgentStack: recreating unstarted agent pane with current settings");
+                                    const auto recreationOptions = _GetAgentPaneRecreationOptions(
+                                        tab->HasStashedAgentPane(),
+                                        activeTab && activeTab == tab);
+                                    _agentPaneLog("_RebuildAgentStack: recreating terminal-state agent pane with current settings");
                                     strongThis->_TeardownAgentPane(tab);
                                     strongThis->_AutoCreateHiddenAgentPaneShared(
                                         tab,
                                         /*intoSessionsView*/ false,
-                                        /*autoStash*/ true);
+                                        recreationOptions.autoStash,
+                                        {},
+                                        {},
+                                        {},
+                                        recreationOptions.focusPane);
                                     continue;
                                 }
 
@@ -3763,7 +3789,6 @@ namespace winrt::TerminalApp::implementation
                         }
                     }
 
-                    const auto activeTab = strongThis->_GetFocusedTabImpl();
                     if (masterConfigurationChanged)
                     {
                         for (const auto& tab : tabsToReopen)

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1738,22 +1738,49 @@ namespace winrt::TerminalApp::implementation
             });
         };
 
-        // The Settings picker clears acpModel when acpAgent changes because
-        // native model IDs are agent-specific. Treat that reset as one binding
-        // replacement; a simultaneous change to another non-empty model keeps
-        // the existing destructive model path. Custom commands, provider launch
-        // environment, and profile backends also remain destructive.
-        if (previous.acpAgent != current.acpAgent &&
-            isBuiltinAgent(previous.acpAgent) &&
-            isBuiltinAgent(current.acpAgent) &&
-            previous.acpCustomCommand == current.acpCustomCommand &&
-            (previous.acpModel == current.acpModel || current.acpModel.empty()) &&
-            previous.customModelLaunch == current.customModelLaunch &&
-            previous.profileBackends == current.profileBackends)
+        const bool profileBackendsChanged =
+            previous.profileBackends != current.profileBackends;
+        const bool agentChanged =
+            previous.acpAgent != current.acpAgent;
+        const bool modelBindingChanged =
+            previous.acpModel != current.acpModel ||
+            previous.customModelLaunch != current.customModelLaunch;
+
+        // A trusted custom command can only enter the master through its own
+        // argv, and a profile backend change can move execution between Host
+        // and WSL. Those boundaries still require pane reconstruction.
+        if (previous.acpCustomCommand != current.acpCustomCommand ||
+            profileBackendsChanged ||
+            !isBuiltinAgent(previous.acpAgent) ||
+            !isBuiltinAgent(current.acpAgent))
+        {
+            return AgentSettingsChangeKind::Rebuild;
+        }
+
+        // Built-in agent changes and model changes that require launch-time
+        // configuration replace only the helper's ACP binding. This preserves
+        // Pane/TermControl/ConPTY/helper and the shared master.
+        if (agentChanged)
         {
             return AgentSettingsChangeKind::AgentRebind;
         }
 
+        if (modelBindingChanged)
+        {
+            const bool nativeModelChange =
+                !previous.customModelLaunch &&
+                !current.customModelLaunch;
+            if (nativeModelChange &&
+                !current.acpModel.empty() &&
+                ::Microsoft::Terminal::Settings::Model::AgentRegistry::SupportsLiveModelSwitch(current.acpAgent))
+            {
+                return AgentSettingsChangeKind::ModelHotUpdate;
+            }
+            return AgentSettingsChangeKind::AgentRebind;
+        }
+
+        // Keep this fallback conservative if another launch-affecting field is
+        // added to the snapshot without an explicit policy above.
         return AgentSettingsChangeKind::Rebuild;
     }
 
@@ -1777,6 +1804,8 @@ namespace winrt::TerminalApp::implementation
         const auto& globals = _settings.GlobalSettings();
         const auto customModelLaunch = _CaptureCustomModelLaunchConfiguration(globals);
         return AgentRuntimeConfigSnapshot{
+            std::wstring{ globals.AcpAgent() },
+            customModelLaunch ? std::wstring{} : std::wstring{ globals.AcpModel() },
             std::wstring{ _ResolveEffectiveDelegateAgent(globals) },
             std::wstring{ globals.DelegateModel() },
             customModelLaunch ? customModelLaunch->selectionId : std::wstring{},
@@ -1786,13 +1815,13 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Hot-propagate runtime agent config to the running wta-helper(s) over the
-    // protocol event channel. Agent identity/model changes are reconciled
-    // separately by _RebuildAgentStack. A single consolidated
-    // `agent_config_changed` event carries only the fields that changed:
+    // protocol event channel. A single consolidated `agent_config_changed`
+    // event carries only the fields that changed:
     //   - autofix_enabled : the auto-suggest gate (was its own event)
+    //   - acp_model + target_agent_id : a scoped live ACP model update
     //   - delegate_agent + delegate_model : the delegate-tab agent identity
     //   - cloud_models + custom_models + custom_model_selection :
-    //     credential-free picker metadata and its restart-required selection.
+    //     credential-free picker metadata and its selected entry.
     void TerminalPage::_EmitAgentRuntimeConfigIfChanged()
     {
         const auto current = _CaptureAgentRuntimeConfig();
@@ -1815,16 +1844,33 @@ namespace winrt::TerminalApp::implementation
         const bool customModelsChanged =
             last.customModelSelection != current.customModelSelection ||
             last.customModels != current.customModels;
+        const bool acpModelChanged =
+            last.acpAgent == current.acpAgent &&
+            last.customModelSelection.empty() &&
+            current.customModelSelection.empty() &&
+            last.acpModel != current.acpModel &&
+            !current.acpModel.empty() &&
+            ::Microsoft::Terminal::Settings::Model::AgentRegistry::SupportsLiveModelSwitch(current.acpAgent);
 
-        if (!autofixChanged && !delegateChanged && !customModelsChanged)
+        if (!autofixChanged && !delegateChanged && !customModelsChanged && !acpModelChanged)
         {
+            // Agent identity is not itself a hot-update field, but it scopes
+            // the next model update. Advance the baseline even when the
+            // identity change is handled by the rebind path below.
+            _lastAgentRuntimeConfig = current;
             return;
         }
 
         Json::Value params{ Json::objectValue };
+        params["window_id"] = std::to_string(_WindowProperties.WindowId());
         if (autofixChanged)
         {
             params["autofix_enabled"] = current.autofixEnabled;
+        }
+        if (acpModelChanged)
+        {
+            params["acp_model"] = winrt::to_string(current.acpModel);
+            params["target_agent_id"] = winrt::to_string(current.acpAgent);
         }
         if (delegateChanged)
         {
@@ -3424,6 +3470,12 @@ namespace winrt::TerminalApp::implementation
             _agentPaneLog("_RebuildAgentStack: no change, skip rebuild");
             return;
         }
+        if (changeKind == AgentSettingsChangeKind::ModelHotUpdate)
+        {
+            _lastAgentSettings = current;
+            _agentPaneLog("_RebuildAgentStack: native model changed, preserving live ACP sessions");
+            return;
+        }
 
         const bool rebindAgentInPlace = changeKind == AgentSettingsChangeKind::AgentRebind;
         // Custom commands are trusted only when supplied on the master's own
@@ -3440,8 +3492,9 @@ namespace winrt::TerminalApp::implementation
             _lastAgentSettings.acpModel != current.acpModel;
         const bool masterConfigurationChanged =
             customMasterArgsChanged ||
-            (!rebindAgentInPlace &&
-             (cloudModelChanged || customModelLaunchChanged));
+            (!rebindAgentInPlace && (cloudModelChanged || customModelLaunchChanged));
+        const bool globalModelBindingChanged =
+            cloudModelChanged || customModelLaunchChanged;
         const bool globalAgentChanged =
             _lastAgentSettings.acpAgent != current.acpAgent ||
             _lastAgentSettings.acpCustomCommand != current.acpCustomCommand;
@@ -3515,7 +3568,7 @@ namespace winrt::TerminalApp::implementation
 
         _agentPaneLog(
             rebindAgentInPlace ?
-                "_RebuildAgentStack: built-in agent changed, rebinding existing helpers" :
+                "_RebuildAgentStack: agent/model binding changed, rebinding existing helpers" :
                 "_RebuildAgentStack: agent settings changed, rebuilding");
 
         // Rebuild only tabs whose effective agent identity changed. A custom
@@ -3556,11 +3609,12 @@ namespace winrt::TerminalApp::implementation
                             currentProfile == current.profileBackends.end() ||
                             currentProfile->second.empty();
                         affected = profileBackendChanged ||
-                                   (globalAgentChanged && followsGlobalAgent);
+                                   ((globalAgentChanged || globalModelBindingChanged) &&
+                                    followsGlobalAgent);
                     }
                     else
                     {
-                        affected = globalAgentChanged;
+                        affected = globalAgentChanged || globalModelBindingChanged;
                     }
                 }
 
@@ -3592,7 +3646,9 @@ namespace winrt::TerminalApp::implementation
             tabIdsThatHadAgentPane,
             masterConfigurationChanged ?
                 "settings_master_configuration_changed" :
-                (rebindAgentInPlace ? "settings_agent_rebind" : "settings_agent_changed"),
+                (rebindAgentInPlace ?
+                     (globalModelBindingChanged ? "settings_model_rebind" : "settings_agent_rebind") :
+                     "settings_agent_changed"),
             masterConfigurationChanged ? std::move(requestId) : std::string{},
             [weakThis = get_weak(),
              current,
@@ -3618,6 +3674,10 @@ namespace winrt::TerminalApp::implementation
                                 params["agent_id"] = winrt::to_string(current.acpAgent);
                                 params["agent_source"] = "host";
                                 params["acp_model"] = winrt::to_string(current.acpModel);
+                                params["custom_model_selection"] =
+                                    current.customModelLaunch ?
+                                        winrt::to_string(winrt::hstring{ current.customModelLaunch->selectionId }) :
+                                        std::string{};
                                 strongThis->_RaiseProtocolEvent("rebind_agent", params);
                             }
                         }
@@ -9206,10 +9266,9 @@ namespace winrt::TerminalApp::implementation
         // Reposition existing agent panes if the position setting changed.
         _RepositionAgentPanes();
 
-        // If any of the agent-identity settings (agent / model / custom
-        // command for either ACP or delegate) changed, tear down and
-        // recreate the affected layers so the new values take effect
-        // without a terminal restart.
+        // Reconcile agent/model identity changes. Supported model changes stay
+        // on the live ACP session, launch-time model changes rebind the same
+        // helper, and only trusted command/backend boundaries rebuild panes.
         auto requestId = std::exchange(_settingsReloadRequestId, {});
         if (!requestId.empty())
         {

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1820,6 +1820,115 @@ namespace winrt::TerminalApp::implementation
         };
     }
 
+    TerminalPage::AgentPaneSettingsBinding TerminalPage::_ResolveAgentPaneSettingsBinding(
+        const AgentPaneSettingsBindingRequest& request)
+    {
+        namespace Backend = ::Microsoft::Terminal::Settings::Model;
+        namespace Registry = ::Microsoft::Terminal::Settings::Model::AgentRegistry;
+
+        AgentPaneSettingsBinding binding{
+            .agentSource = L"host",
+        };
+        winrt::hstring agentCliPath;
+        bool validSource = true;
+
+        if (request.hasAgentOverride)
+        {
+            binding.agentId = request.agentIdOverride;
+            binding.agentSource = request.agentSourceOverride;
+            binding.agentWslDistro = request.agentWslDistroOverride;
+            binding.acpModel = request.agentModelOverride;
+            agentCliPath = _ResolveAgentCliPathForId(
+                winrt::hstring{ binding.agentId },
+                winrt::hstring{ binding.acpModel },
+                winrt::hstring{ request.agentCustomCommandOverride });
+            validSource =
+                binding.agentSource == L"host" ||
+                (binding.agentSource == L"wsl" && !binding.agentWslDistro.empty());
+        }
+        else if (!request.profileBackend.empty())
+        {
+            if (const auto backend = Backend::AgentPaneBackend::Parse(request.profileBackend))
+            {
+                binding.agentId = backend->agentId;
+                binding.agentSource =
+                    backend->source == Backend::AgentPaneBackendSource::Wsl ? L"wsl" : L"host";
+                binding.agentWslDistro = backend->wslDistro;
+
+                const auto allowedAgents = Registry::FilteredAcpAgents();
+                const auto knownAndAllowed = std::ranges::any_of(allowedAgents, [&](const auto& agent) {
+                    return agent.id == binding.agentId;
+                });
+                if (knownAndAllowed)
+                {
+                    agentCliPath = _ResolveAgentCliPathForId(
+                        winrt::hstring{ binding.agentId },
+                        {},
+                        {});
+                }
+
+                if (backend->source == Backend::AgentPaneBackendSource::Wsl)
+                {
+                    const auto expectedShell = L"wsl:" + backend->wslDistro;
+                    validSource =
+                        !backend->wslDistro.empty() &&
+                        (request.profileActiveShell.empty() ||
+                         request.profileActiveShell == expectedShell);
+                }
+            }
+            else
+            {
+                validSource = false;
+            }
+        }
+        else
+        {
+            binding.agentId =
+                request.globalAgentId.empty() && !request.globalAgentCliPath.empty() ?
+                    request.detectedGlobalAgentId :
+                    request.globalAgentId;
+            binding.acpModel = request.globalModel;
+            binding.followsGlobalAcpModel = true;
+            agentCliPath = winrt::hstring{ request.globalAgentCliPath };
+        }
+
+        binding.launchable = validSource && !agentCliPath.empty();
+        binding.supportsGlobalHostByok =
+            binding.agentSource == L"host" &&
+            Registry::SupportsByok(binding.agentId);
+        if (binding.supportsGlobalHostByok && !request.customModelSelection.empty())
+        {
+            binding.acpModel.clear();
+            binding.customModelSelection = request.customModelSelection;
+        }
+        return binding;
+    }
+
+    bool TerminalPage::_IsAgentPaneSettingsRebindAffected(
+        const AgentPaneSettingsBinding& binding,
+        const bool globalAgentChanged,
+        const bool cloudModelChanged,
+        const bool customModelLaunchChanged) noexcept
+    {
+        return binding.launchable &&
+               (((globalAgentChanged || cloudModelChanged) &&
+                 binding.followsGlobalAcpModel) ||
+                (customModelLaunchChanged &&
+                 binding.supportsGlobalHostByok));
+    }
+
+    Json::Value TerminalPage::_BuildAgentPaneSettingsRebindPayload(
+        const AgentPaneSettingsBinding& binding)
+    {
+        Json::Value params{ Json::objectValue };
+        params["agent_id"] = winrt::to_string(winrt::hstring{ binding.agentId });
+        params["agent_source"] = winrt::to_string(winrt::hstring{ binding.agentSource });
+        params["acp_model"] = winrt::to_string(winrt::hstring{ binding.acpModel });
+        params["custom_model_selection"] =
+            winrt::to_string(winrt::hstring{ binding.customModelSelection });
+        return params;
+    }
+
     TerminalPage::AgentRuntimeConfigSnapshot TerminalPage::_CaptureAgentRuntimeConfig() const
     {
         const auto& globals = _settings.GlobalSettings();
@@ -3606,18 +3715,74 @@ namespace winrt::TerminalApp::implementation
                 "_RebuildAgentStack: agent settings changed, rebuilding");
 
         // Rebuild only tabs whose effective agent identity changed. A custom
-        // command or selected provider launch change restarts the shared master,
-        // so every local helper is collected even when its tab has a runtime
-        // override. Unselected provider metadata changes stay on the hot path.
+        // command change restarts the shared master, so every local helper is
+        // collected even when its tab has a runtime override. BYOK changes
+        // rebind every launchable Host pane that consumed that bootstrap.
+        AgentPaneSettingsBindingRequest baseBindingRequest;
+        if (rebindAgentInPlace)
+        {
+            const auto& globals = _settings.GlobalSettings();
+            const auto globalAgentCliPath =
+                _ResolveEffectiveAgentCliPath(globals, [this]() { return _DetectAgentCli(); });
+            baseBindingRequest.globalAgentId = std::wstring{ globals.EffectiveAcpAgent() };
+            baseBindingRequest.globalModel = std::wstring{ globals.AcpModel() };
+            baseBindingRequest.globalAgentCliPath = std::wstring{ globalAgentCliPath };
+            baseBindingRequest.customModelSelection =
+                current.customModelLaunch ?
+                    current.customModelLaunch->selectionId :
+                    std::wstring{};
+            if (baseBindingRequest.globalAgentId.empty() &&
+                !baseBindingRequest.globalAgentCliPath.empty())
+            {
+                baseBindingRequest.detectedGlobalAgentId = std::wstring{ _DetectAgentCli() };
+            }
+        }
+
         bool hadAny = false;
         bool hasStartedPaneToRebind = false;
         std::vector<winrt::hstring> tabIdsThatHadAgentPane;
+        std::vector<std::pair<winrt::hstring, AgentPaneSettingsBinding>> rebindTargets;
         for (const auto& t : _tabs)
         {
             if (auto tabImpl = _GetTabImpl(t))
             {
                 bool affected = masterConfigurationChanged;
-                if (!affected && !tabImpl->HasAgentOverride())
+                std::optional<AgentPaneSettingsBinding> rebindBinding;
+                if (rebindAgentInPlace)
+                {
+                    auto bindingRequest = baseBindingRequest;
+                    bindingRequest.hasAgentOverride = tabImpl->HasAgentOverride();
+                    if (bindingRequest.hasAgentOverride)
+                    {
+                        bindingRequest.agentIdOverride = std::wstring{ tabImpl->AgentIdOverride() };
+                        bindingRequest.agentModelOverride = std::wstring{ tabImpl->AgentModelOverride() };
+                        bindingRequest.agentCustomCommandOverride = std::wstring{ tabImpl->AgentCustomCommandOverride() };
+                        bindingRequest.agentSourceOverride = std::wstring{ tabImpl->AgentSourceOverride() };
+                        bindingRequest.agentWslDistroOverride = std::wstring{ tabImpl->AgentWslDistroOverride() };
+                    }
+                    else
+                    {
+                        if (const auto sourceProfile = _ResolveAgentSourceProfile(tabImpl, _settings))
+                        {
+                            tabImpl->AgentSourceProfileGuid(_AgentSourceProfileGuid(sourceProfile, _settings));
+                            bindingRequest.profileBackend = std::wstring{ sourceProfile.AgentPaneBackend() };
+                        }
+                        if (const auto control = tabImpl->GetActiveTerminalControl())
+                        {
+                            bindingRequest.profileActiveShell = std::wstring{ control.ShellName() };
+                        }
+                    }
+
+                    rebindBinding = _ResolveAgentPaneSettingsBinding(bindingRequest);
+                    affected =
+                        affected ||
+                        _IsAgentPaneSettingsRebindAffected(
+                            *rebindBinding,
+                            globalAgentChanged,
+                            cloudModelChanged,
+                            customModelLaunchChanged);
+                }
+                else if (!affected && !tabImpl->HasAgentOverride())
                 {
                     auto sourceProfileGuid = tabImpl->AgentSourceProfileGuid();
                     if (!sourceProfileGuid)
@@ -3656,9 +3821,11 @@ namespace winrt::TerminalApp::implementation
                 if (tabImpl->FindAgentPane() && affected)
                 {
                     hadAny = true;
-                    tabIdsThatHadAgentPane.push_back(tabImpl->StableId());
+                    const auto tabId = tabImpl->StableId();
+                    tabIdsThatHadAgentPane.push_back(tabId);
                     if (rebindAgentInPlace)
                     {
+                        rebindTargets.emplace_back(tabId, std::move(*rebindBinding));
                         const auto pane = tabImpl->FindAgentPane();
                         auto disposition = AgentPaneSettingsRebindDisposition::Recreate;
                         if (const auto control = pane->GetTerminalControl())
@@ -3705,6 +3872,7 @@ namespace winrt::TerminalApp::implementation
             [weakThis = get_weak(),
              current,
              tabIdsThatHadAgentPane,
+             rebindTargets,
              masterConfigurationChanged,
              rebindAgentInPlace,
              rebindGeneration](const std::string_view operationId) {
@@ -3714,7 +3882,7 @@ namespace winrt::TerminalApp::implementation
                     const auto activeTab = strongThis->_GetFocusedTabImpl();
                     if (rebindAgentInPlace)
                     {
-                        for (const auto& tabId : tabIdsThatHadAgentPane)
+                        for (const auto& [tabId, binding] : rebindTargets)
                         {
                             if (const auto tab = strongThis->_FindTabByStableId(tabId);
                                 tab && tab->FindAgentPane())
@@ -3743,18 +3911,11 @@ namespace winrt::TerminalApp::implementation
                                     continue;
                                 }
 
-                                Json::Value params{ Json::objectValue };
+                                auto params = _BuildAgentPaneSettingsRebindPayload(binding);
                                 params["operation_id"] = std::string{ operationId };
                                 params["generation"] = Json::UInt64{ rebindGeneration };
                                 params["window_id"] = std::to_string(strongThis->_WindowProperties.WindowId());
                                 params["tab_id"] = winrt::to_string(tabId);
-                                params["agent_id"] = winrt::to_string(current.acpAgent);
-                                params["agent_source"] = "host";
-                                params["acp_model"] = winrt::to_string(current.acpModel);
-                                params["custom_model_selection"] =
-                                    current.customModelLaunch ?
-                                        winrt::to_string(winrt::hstring{ current.customModelLaunch->selectionId }) :
-                                        std::string{};
                                 strongThis->_RaiseProtocolEvent("rebind_agent", params);
                             }
                         }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1924,11 +1924,13 @@ namespace winrt::TerminalApp::implementation
     bool TerminalPage::_IsAgentPaneModelHotUpdateTarget(
         const std::optional<AgentPaneSettingsBinding>& binding,
         const std::optional<ConnectionState> connectionState,
-        const bool helperEventReady) noexcept
+        const bool helperEventReady,
+        const bool agentConnected) noexcept
     {
         return binding &&
                binding->launchable &&
                binding->followsGlobalAcpModel &&
+               agentConnected &&
                connectionState &&
                _ClassifyAgentPaneSettingsRebind(*connectionState, helperEventReady) ==
                    AgentPaneSettingsRebindDisposition::Rebind;
@@ -1937,12 +1939,14 @@ namespace winrt::TerminalApp::implementation
     bool TerminalPage::_ShouldRecreateAgentPaneForModelHotUpdate(
         const std::optional<AgentPaneSettingsBinding>& binding,
         const std::optional<ConnectionState> connectionState,
-        const bool helperEventReady) noexcept
+        const bool helperEventReady,
+        const bool agentConnected) noexcept
     {
         return binding &&
                binding->launchable &&
                binding->followsGlobalAcpModel &&
-               (!connectionState ||
+               (!agentConnected ||
+                !connectionState ||
                 _ClassifyAgentPaneSettingsRebind(*connectionState, helperEventReady) ==
                     AgentPaneSettingsRebindDisposition::Recreate);
     }
@@ -3845,10 +3849,13 @@ namespace winrt::TerminalApp::implementation
                     {
                         const auto pane = tabImpl->FindAgentPane();
                         bool helperEventReady = false;
+                        bool agentConnected = false;
                         if (const auto content = tabImpl->FindAgentPaneContent())
                         {
-                            helperEventReady =
-                                winrt::get_self<implementation::AgentPaneContent>(content)->IsHelperEventReady();
+                            const auto contentImpl =
+                                winrt::get_self<implementation::AgentPaneContent>(content);
+                            helperEventReady = contentImpl->IsHelperEventReady();
+                            agentConnected = contentImpl->IsAgentConnected();
                         }
                         std::optional<ConnectionState> connectionState;
                         if (const auto control = pane->GetTerminalControl())
@@ -3861,7 +3868,8 @@ namespace winrt::TerminalApp::implementation
                             if (_ShouldRecreateAgentPaneForModelHotUpdate(
                                     rebindBinding,
                                     connectionState,
-                                    helperEventReady))
+                                    helperEventReady,
+                                    agentConnected))
                             {
                                 panesToRecreate.emplace_back(
                                     tabImpl,
@@ -3872,7 +3880,8 @@ namespace winrt::TerminalApp::implementation
                             else if (_IsAgentPaneModelHotUpdateTarget(
                                          rebindBinding,
                                          connectionState,
-                                         helperEventReady))
+                                         helperEventReady,
+                                         agentConnected))
                             {
                                 hasModelHotUpdateTarget = true;
                             }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1799,6 +1799,16 @@ namespace winrt::TerminalApp::implementation
                !masterConfigurationChanged;
     }
 
+    TerminalPage::AgentPaneSettingsRebindDisposition TerminalPage::_ClassifyAgentPaneSettingsRebind(
+        const ConnectionState connectionState) noexcept
+    {
+        // ConptyConnection::Start transitions synchronously to Connecting
+        // before launching the helper, so NotConnected proves it never started.
+        return connectionState == ConnectionState::NotConnected ?
+                   AgentPaneSettingsRebindDisposition::RecreateStashed :
+                   AgentPaneSettingsRebindDisposition::Rebind;
+    }
+
     TerminalPage::AgentRuntimeConfigSnapshot TerminalPage::_CaptureAgentRuntimeConfig() const
     {
         const auto& globals = _settings.GlobalSettings();
@@ -2063,6 +2073,12 @@ namespace winrt::TerminalApp::implementation
         std::string requestId,
         std::function<void(std::string_view)> continuation)
     {
+        if (!scopeAll && tabIds.empty())
+        {
+            continuation({});
+            return;
+        }
+
         auto& sharedWta = winrt::TerminalApp::implementation::SharedWta::Instance();
         const auto registration = sharedWta.RegisterRetirement(scopeAll, reason, requestId);
         if (registration.operationId.empty())
@@ -3576,6 +3592,7 @@ namespace winrt::TerminalApp::implementation
         // so every local helper is collected even when its tab has a runtime
         // override. Unselected provider metadata changes stay on the hot path.
         bool hadAny = false;
+        bool hasStartedPaneToRebind = false;
         std::vector<winrt::hstring> tabIdsThatHadAgentPane;
         for (const auto& t : _tabs)
         {
@@ -3622,6 +3639,18 @@ namespace winrt::TerminalApp::implementation
                 {
                     hadAny = true;
                     tabIdsThatHadAgentPane.push_back(tabImpl->StableId());
+                    if (rebindAgentInPlace)
+                    {
+                        const auto pane = tabImpl->FindAgentPane();
+                        auto disposition = AgentPaneSettingsRebindDisposition::Rebind;
+                        if (const auto control = pane->GetTerminalControl())
+                        {
+                            disposition = _ClassifyAgentPaneSettingsRebind(control.ConnectionState());
+                        }
+                        hasStartedPaneToRebind =
+                            hasStartedPaneToRebind ||
+                            disposition == AgentPaneSettingsRebindDisposition::Rebind;
+                    }
                 }
             }
         }
@@ -3639,11 +3668,16 @@ namespace winrt::TerminalApp::implementation
             requestId = winrt::TerminalApp::implementation::SharedWta::Instance().CreateRetirementRequestId();
         }
 
+        auto tabIdsToRetire = tabIdsThatHadAgentPane;
+        if (rebindAgentInPlace && !hasStartedPaneToRebind)
+        {
+            tabIdsToRetire.clear();
+        }
         const auto rebindGeneration =
             rebindAgentInPlace ? ++_agentSettingsRebindGeneration : 0;
         _BeginAgentSessionRetirement(
             masterConfigurationChanged,
-            tabIdsThatHadAgentPane,
+            std::move(tabIdsToRetire),
             masterConfigurationChanged ?
                 "settings_master_configuration_changed" :
                 (rebindAgentInPlace ?
@@ -3666,6 +3700,23 @@ namespace winrt::TerminalApp::implementation
                             if (const auto tab = strongThis->_FindTabByStableId(tabId);
                                 tab && tab->FindAgentPane())
                             {
+                                auto disposition = AgentPaneSettingsRebindDisposition::Rebind;
+                                if (const auto control = tab->FindAgentPane()->GetTerminalControl())
+                                {
+                                    disposition = _ClassifyAgentPaneSettingsRebind(control.ConnectionState());
+                                }
+
+                                if (disposition == AgentPaneSettingsRebindDisposition::RecreateStashed)
+                                {
+                                    _agentPaneLog("_RebuildAgentStack: recreating unstarted agent pane with current settings");
+                                    strongThis->_TeardownAgentPane(tab);
+                                    strongThis->_AutoCreateHiddenAgentPaneShared(
+                                        tab,
+                                        /*intoSessionsView*/ false,
+                                        /*autoStash*/ true);
+                                    continue;
+                                }
+
                                 Json::Value params{ Json::objectValue };
                                 params["operation_id"] = std::string{ operationId };
                                 params["generation"] = Json::UInt64{ rebindGeneration };
@@ -3743,7 +3794,7 @@ namespace winrt::TerminalApp::implementation
                     strongThis->_agentRebuilding = false;
                     const auto latest = strongThis->_CaptureAgentSettingsSnapshot();
                     const bool settingsChangedAgain = TerminalPage::_AgentSettingsChanged(current, latest);
-                    if (settingsChangedAgain)
+                    if (settingsChangedAgain && !operationId.empty())
                     {
                         winrt::TerminalApp::implementation::SharedWta::Instance().ExpireRetirement(operationId);
                     }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -338,11 +338,11 @@ namespace winrt::TerminalApp::implementation
 
         // Seed the agent-settings baseline on first load so that later
         // in-memory mutations (e.g. the bottom-bar agent selector click,
-        // which mutates AcpAgent *before* calling _RebuildAgentStack) are
+        // which mutates AcpAgent *before* reconciling settings) are
         // correctly diffed against the startup state. Without this, the
-        // very first _RebuildAgentStack invocation would take the lazy
+        // very first reconciliation would take the lazy
         // "seed-and-skip" branch with the *already-mutated* value and the
-        // real rebuild would never run.
+        // real reconciliation would never run.
         if (firstLoad)
         {
             _lastAgentSettings = _CaptureAgentSettingsSnapshot();
@@ -405,7 +405,7 @@ namespace winrt::TerminalApp::implementation
         // event to the running wta-helper(s) so they update in place,
         // WITHOUT tearing down and restarting the agent pane. This is the
         // unified dispatch for non-binding runtime settings. Agent identity
-        // and ACP model changes go through _RebuildAgentStack in
+        // and ACP model changes go through _ReconcileAgentSettings in
         // _RefreshUIForSettingsReload so unready helpers can be recreated
         // before the settings snapshot advances.
         _EmitAgentRuntimeConfigIfChanged();
@@ -1658,7 +1658,7 @@ namespace winrt::TerminalApp::implementation
 
     // --- Hot-reload of agent/model settings -------------------------------
     //
-    // `_RebuildAgentStack` reconciles agent-identity settings changed through
+    // `_ReconcileAgentSettings` reconciles agent-identity settings changed through
     // settings.json, Settings UI, or the bottom-bar selector. Built-in agent
     // changes rebind the existing helper; changes to trusted launch arguments
     // retain the destructive pane/master path.
@@ -1754,7 +1754,7 @@ namespace winrt::TerminalApp::implementation
             !isBuiltinAgent(previous.acpAgent) ||
             !isBuiltinAgent(current.acpAgent))
         {
-            return AgentSettingsChangeKind::Rebuild;
+            return AgentSettingsChangeKind::RecreatePane;
         }
 
         // Built-in agent changes and model changes that require launch-time
@@ -1781,7 +1781,7 @@ namespace winrt::TerminalApp::implementation
 
         // Keep this fallback conservative if another launch-affecting field is
         // added to the snapshot without an explicit policy above.
-        return AgentSettingsChangeKind::Rebuild;
+        return AgentSettingsChangeKind::RecreatePane;
     }
 
     bool TerminalPage::_AgentSettingsChanged(const AgentSettingsSnapshot& a, const AgentSettingsSnapshot& b)
@@ -1794,12 +1794,12 @@ namespace winrt::TerminalApp::implementation
         const bool canHostPane,
         const bool masterConfigurationChanged) noexcept
     {
-        return changeKind == AgentSettingsChangeKind::Rebuild &&
+        return changeKind == AgentSettingsChangeKind::RecreatePane &&
                !canHostPane &&
                !masterConfigurationChanged;
     }
 
-    TerminalPage::AgentPaneSettingsRebindDisposition TerminalPage::_ClassifyAgentPaneSettingsRebind(
+    bool TerminalPage::_CanRebindAgentPane(
         const ConnectionState connectionState,
         const bool helperEventReady) noexcept
     {
@@ -1808,13 +1808,11 @@ namespace winrt::TerminalApp::implementation
         // subscribed, so the cached readiness bit closes the startup window
         // where ConPTY is live but settings events would still be lost.
         return helperEventReady &&
-                       (connectionState == ConnectionState::Connecting ||
-                        connectionState == ConnectionState::Connected) ?
-                   AgentPaneSettingsRebindDisposition::Rebind :
-                   AgentPaneSettingsRebindDisposition::Recreate;
+               (connectionState == ConnectionState::Connecting ||
+                connectionState == ConnectionState::Connected);
     }
 
-    TerminalPage::AgentPaneSettingsRebindDisposition TerminalPage::_ClassifyAgentPaneAgentSwitch(
+    bool TerminalPage::_CanSwitchAgentInPlace(
         const AgentPaneSettingsBinding& current,
         const AgentPaneSettingsBinding& target,
         const ConnectionState connectionState,
@@ -1835,10 +1833,10 @@ namespace winrt::TerminalApp::implementation
             !isBuiltIn(target.agentId) ||
             !sameSource)
         {
-            return AgentPaneSettingsRebindDisposition::Recreate;
+            return false;
         }
 
-        return _ClassifyAgentPaneSettingsRebind(connectionState, helperEventReady);
+        return _CanRebindAgentPane(connectionState, helperEventReady);
     }
 
     bool TerminalPage::_CanRetainAgentPaneForMasterRestart(
@@ -2013,8 +2011,7 @@ namespace winrt::TerminalApp::implementation
                binding->followsGlobalAcpModel &&
                agentConnected &&
                connectionState &&
-               _ClassifyAgentPaneSettingsRebind(*connectionState, helperEventReady) ==
-                   AgentPaneSettingsRebindDisposition::Rebind;
+               _CanRebindAgentPane(*connectionState, helperEventReady);
     }
 
     bool TerminalPage::_ShouldRecreateAgentPaneForModelHotUpdate(
@@ -2028,8 +2025,7 @@ namespace winrt::TerminalApp::implementation
                binding->followsGlobalAcpModel &&
                (!agentConnected ||
                 !connectionState ||
-                _ClassifyAgentPaneSettingsRebind(*connectionState, helperEventReady) ==
-                    AgentPaneSettingsRebindDisposition::Recreate);
+                !_CanRebindAgentPane(*connectionState, helperEventReady));
     }
 
     Json::Value TerminalPage::_BuildAgentPaneSettingsRebindPayload(
@@ -2180,9 +2176,29 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
-    // Rebuild a SINGLE tab's agent pane when its per-tab agent override cannot
-    // reuse the existing helper. Scoped, unlike
-    // `_RebuildAgentStack`: it touches only this tab and does NOT restart
+    void TerminalPage::_RecreateAgentPane(
+        const winrt::com_ptr<Tab>& tab,
+        const AgentPaneRecreationOptions& options)
+    {
+        if (!tab)
+        {
+            _agentPaneLog("_RecreateAgentPane: missing tab");
+            return;
+        }
+
+        _TeardownAgentPane(tab);
+        _AutoCreateHiddenAgentPaneShared(
+            tab,
+            /*intoSessionsView*/ false,
+            options.autoStash,
+            {},
+            {},
+            {},
+            options.focusPane);
+    }
+
+    // Recreate a SINGLE tab's agent pane when its per-tab agent override cannot
+    // reuse the existing helper. It touches only this tab and does NOT restart
     // the shared master. The multi-agent master stays up; the freshly
     // spawned helper declares this tab's new agent in its `initialize`
     // handshake, so the master lazily spawns/reuses the matching CLI while
@@ -2192,7 +2208,7 @@ namespace winrt::TerminalApp::implementation
     // `FindAgentPane()` is already null when we reopen — the conpty /
     // `SharedWta::ReleasePane` teardown that lags behind balances against
     // the reopen's `AcquirePane`.
-    void TerminalPage::_RebuildAgentPaneForTab(const winrt::com_ptr<Tab>& tab)
+    void TerminalPage::_RecreateAgentPaneForTab(const winrt::com_ptr<Tab>& tab)
     {
         if (!tab)
         {
@@ -2200,9 +2216,9 @@ namespace winrt::TerminalApp::implementation
         }
         const auto tabId = tab->StableId();
         const auto tabKey = winrt::to_string(tabId);
-        if (!_agentTabRetirements.BeginRebuild(tabKey))
+        if (!_agentTabRetirements.BeginRecreation(tabKey))
         {
-            _agentPaneLog("_RebuildAgentPaneForTab: retirement already pending for tab");
+            _agentPaneLog("_RecreateAgentPaneForTab: retirement already pending for tab");
             return;
         }
         const bool hadPane = tab->FindAgentPane() != nullptr;
@@ -2250,7 +2266,7 @@ namespace winrt::TerminalApp::implementation
             });
     }
 
-    void TerminalPage::_RebindAgentPaneForTab(
+    void TerminalPage::_ApplyAgentPaneBindingForTab(
         const winrt::com_ptr<Tab>& tab,
         const AgentPaneSettingsBinding& current,
         const AgentPaneSettingsBinding& target)
@@ -2267,19 +2283,19 @@ namespace winrt::TerminalApp::implementation
             content &&
             winrt::get_self<implementation::AgentPaneContent>(content)->IsHelperEventReady();
         if (!control ||
-            _ClassifyAgentPaneAgentSwitch(
+            !_CanSwitchAgentInPlace(
                 current,
                 target,
                 control.ConnectionState(),
-                helperEventReady) == AgentPaneSettingsRebindDisposition::Recreate)
+                helperEventReady))
         {
-            _agentPaneLog("OnAgentSwitchRequested: rebuilding helper across an unsupported or unready boundary");
-            _RebuildAgentPaneForTab(tab);
+            _agentPaneLog("OnAgentSwitchRequested: recreating pane across an unsupported or unready boundary");
+            _RecreateAgentPaneForTab(tab);
             return;
         }
 
         const auto tabId = tab->StableId();
-        const auto rebindGeneration = ++_agentSettingsRebindGeneration;
+        const auto rebindGeneration = ++_agentRebindGeneration;
         _BeginAgentSessionRetirement(
             false,
             { tabId },
@@ -2306,9 +2322,7 @@ namespace winrt::TerminalApp::implementation
                         winrt::get_self<implementation::AgentPaneContent>(content)->IsHelperEventReady();
                     if (operationId.empty() ||
                         !control ||
-                        _ClassifyAgentPaneSettingsRebind(
-                            control.ConnectionState(),
-                            helperEventReady) == AgentPaneSettingsRebindDisposition::Recreate)
+                        !_CanRebindAgentPane(control.ConnectionState(), helperEventReady))
                     {
                         const auto focusedTab = strongThis->_GetFocusedTabImpl();
                         const auto recreationOptions = _GetAgentPaneRecreationOptions(
@@ -2316,15 +2330,7 @@ namespace winrt::TerminalApp::implementation
                             focusedTab && focusedTab == currentTab);
                         _agentPaneLog(
                             "OnAgentSwitchRequested: helper became unavailable during retirement; recreating pane");
-                        strongThis->_TeardownAgentPane(currentTab);
-                        strongThis->_AutoCreateHiddenAgentPaneShared(
-                            currentTab,
-                            /*intoSessionsView*/ false,
-                            recreationOptions.autoStash,
-                            {},
-                            {},
-                            {},
-                            recreationOptions.focusPane);
+                        strongThis->_RecreateAgentPane(currentTab, recreationOptions);
                         return;
                     }
 
@@ -2657,7 +2663,7 @@ namespace winrt::TerminalApp::implementation
     // Builds the per-process flag/value pairs that wta-master inherits
     // at spawn time. Single source of truth so the first-acquire path
     // (`_AutoCreateHiddenAgentPaneShared`) and the settings-change-
-    // driven respawn path (`_RebuildAgentStack` → `SharedWta::Restart`)
+    // driven respawn path (`_ReconcileAgentSettings` → `SharedWta::Restart`)
     // stay in sync. Each pair is pushed as two separate vector elements
     // so SharedWta can apply its own Windows command-line quoting.
     std::vector<std::wstring> TerminalPage::_BuildSharedWtaExtraArgs()
@@ -2919,7 +2925,7 @@ namespace winrt::TerminalApp::implementation
         // Build the per-process settings the master will inherit.
         // These are baked at first-spawn time only; subsequent acquires
         // reuse the same master (settings changes route through
-        // `_RebuildAgentStack` → `SharedWta::Restart` instead). Runtime
+        // `_ReconcileAgentSettings` → `SharedWta::Restart` instead). Runtime
         // changes flow over event channels (`autofix_enabled_changed`
         // is the existing one). See `_BuildSharedWtaExtraArgs` for the
         // shared arg layout.
@@ -3795,35 +3801,35 @@ namespace winrt::TerminalApp::implementation
     // global agent changes preserve the Pane/TermControl/ConPTY/helper and
     // replace only the helper's ACP connection after retiring its old
     // session. Other launch-identity changes keep the destructive path.
-    void TerminalPage::_RebuildAgentStack(std::string requestId)
+    void TerminalPage::_ReconcileAgentSettings(std::string requestId)
     {
         const auto current = _CaptureAgentSettingsSnapshot();
 
         {
-            std::string diag = "_RebuildAgentStack: entered. current.acp=";
+            std::string diag = "_ReconcileAgentSettings: entered. current.acp=";
             diag += winrt::to_string(current.acpAgent);
             diag += " last.acp=";
             diag += winrt::to_string(_lastAgentSettings.acpAgent);
             diag += " initialized=";
             diag += (_agentSettingsSnapshotInitialized ? "true" : "false");
-            diag += " rebuilding=";
-            diag += (_agentRebuilding ? "true" : "false");
+            diag += " operation_in_progress=";
+            diag += (_agentLifecycleOperationInProgress ? "true" : "false");
             _agentPaneLog(diag);
         }
 
-        // First call just seeds the snapshot — there's nothing to rebuild.
+        // First call only establishes the baseline.
         if (!_agentSettingsSnapshotInitialized)
         {
             _lastAgentSettings = current;
             _agentSettingsSnapshotInitialized = true;
-            _agentPaneLog("_RebuildAgentStack: seeded snapshot, skip rebuild");
+            _agentPaneLog("_ReconcileAgentSettings: seeded snapshot");
             return;
         }
 
         const auto changeKind = _ClassifyAgentSettingsChange(_lastAgentSettings, current);
         if (changeKind == AgentSettingsChangeKind::None)
         {
-            _agentPaneLog("_RebuildAgentStack: no change, skip rebuild");
+            _agentPaneLog("_ReconcileAgentSettings: no change");
             return;
         }
         const bool modelHotUpdate = changeKind == AgentSettingsChangeKind::ModelHotUpdate;
@@ -3882,23 +3888,23 @@ namespace winrt::TerminalApp::implementation
         }
 
         // Reentrancy guard.
-        if (_agentRebuilding)
+        if (_agentLifecycleOperationInProgress)
         {
-            _pendingAgentRebuild = true;
+            _pendingAgentSettingsReconciliation = true;
             if (!requestId.empty())
             {
-                _pendingAgentRebuildRequestId = std::move(requestId);
+                _pendingAgentSettingsRequestId = std::move(requestId);
             }
-            _agentPaneLog("_RebuildAgentStack: already rebuilding, queued latest settings reconciliation");
+            _agentPaneLog("_ReconcileAgentSettings: lifecycle operation in progress; queued reconciliation");
             return;
         }
 
-        // Defer destructive rebuilds when there's no terminal tab in focus:
+        // Defer pane recreation when there's no terminal tab in focus:
         // newly created TermControls on non-active tabs never raise
         // SwapChainPanel.LayoutUpdated, so `connection.Start()` never runs and
         // wta.exe never launches. In-place rebinds reuse existing helpers and
         // must continue while Settings is focused.
-        // _FlushPendingAgentRebuild re-enters once a terminal tab becomes
+        // _FlushPendingAgentSettingsReconciliation re-enters once a terminal tab becomes
         // active.
         // `_lastAgentSettings` stays unchanged so the dirty diff fires
         // again on next entry.
@@ -3907,29 +3913,29 @@ namespace winrt::TerminalApp::implementation
         const bool canHostPane = focusedTab && !(*focusedTab == _settingsTab);
         if (_ShouldDeferAgentSettingsChange(changeKind, canHostPane, masterConfigurationChanged))
         {
-            _pendingAgentRebuild = true;
+            _pendingAgentSettingsReconciliation = true;
             if (!requestId.empty())
             {
-                _pendingAgentRebuildRequestId = std::move(requestId);
+                _pendingAgentSettingsRequestId = std::move(requestId);
             }
             return;
         }
 
-        _agentRebuilding = true;
+        _agentLifecycleOperationInProgress = true;
 
         if (modelHotUpdate)
         {
-            _agentPaneLog("_RebuildAgentStack: native model changed, reconciling helper readiness");
+            _agentPaneLog("_ReconcileAgentSettings: native model changed");
         }
         else
         {
             _agentPaneLog(
                 rebindAgentInPlace ?
-                    "_RebuildAgentStack: agent/model binding changed, rebinding existing helpers" :
-                    "_RebuildAgentStack: agent settings changed, rebuilding");
+                    "_ReconcileAgentSettings: rebinding existing helpers" :
+                    "_ReconcileAgentSettings: recreating affected helpers");
         }
 
-        // Rebuild only tabs whose effective agent identity changed. A custom
+        // Reconcile only tabs whose effective Agent binding changed. A custom
         // command change restarts the shared master, so every local helper is
         // collected even when its tab has a runtime override. BYOK changes
         // rebind every launchable Host pane that consumed that bootstrap.
@@ -3954,7 +3960,6 @@ namespace winrt::TerminalApp::implementation
         }
 
         bool hadAny = false;
-        bool hasStartedPaneToRebind = false;
         bool hasModelHotUpdateTarget = false;
         std::vector<winrt::hstring> tabIdsThatHadAgentPane;
         std::vector<winrt::hstring> tabIdsToRetire;
@@ -4095,16 +4100,10 @@ namespace winrt::TerminalApp::implementation
                             continue;
                         }
 
-                        auto disposition = AgentPaneSettingsRebindDisposition::Recreate;
-                        if (connectionState)
-                        {
-                            disposition = _ClassifyAgentPaneSettingsRebind(
-                                *connectionState,
-                                helperEventReady);
-                        }
-                        hasStartedPaneToRebind =
-                            hasStartedPaneToRebind ||
-                            disposition == AgentPaneSettingsRebindDisposition::Rebind;
+                        // A helper that reached ready may still have a
+                        // master-side session after its ConPTY closes. Retire
+                        // that session before revalidating the connection and
+                        // falling back to pane recreation below.
                         tabIdsToRetire.push_back(tabId);
                         rebindTargets.emplace_back(tabId, std::move(*rebindBinding));
                     }
@@ -4114,16 +4113,8 @@ namespace winrt::TerminalApp::implementation
 
         for (const auto& [tab, recreationOptions] : panesToRecreate)
         {
-            _agentPaneLog("_RebuildAgentStack: recreating unready agent pane with current settings");
-            _TeardownAgentPane(tab);
-            _AutoCreateHiddenAgentPaneShared(
-                tab,
-                /*intoSessionsView*/ false,
-                recreationOptions.autoStash,
-                {},
-                {},
-                {},
-                recreationOptions.focusPane);
+            _agentPaneLog("_ReconcileAgentSettings: recreating unready agent pane");
+            _RecreateAgentPane(tab, recreationOptions);
         }
 
         if (modelHotUpdate)
@@ -4138,24 +4129,24 @@ namespace winrt::TerminalApp::implementation
             }
 
             _lastAgentSettings = current;
-            _agentRebuilding = false;
-            _agentPaneLog("_RebuildAgentStack: native model updated ready helpers and recreated unready panes");
+            _agentLifecycleOperationInProgress = false;
+            _agentPaneLog("_ReconcileAgentSettings: native model reconciliation complete");
             return;
         }
 
         if (!hadAny && !masterConfigurationChanged)
         {
             _lastAgentSettings = current;
-            _agentRebuilding = false;
-            _agentPaneLog("_RebuildAgentStack: no affected agent pane, snapshot only");
+            _agentLifecycleOperationInProgress = false;
+            _agentPaneLog("_ReconcileAgentSettings: no affected agent pane");
             return;
         }
 
         if (rebindAgentInPlace && rebindTargets.empty())
         {
             _lastAgentSettings = current;
-            _agentRebuilding = false;
-            _agentPaneLog("_RebuildAgentStack: recreated all affected unready panes, snapshot only");
+            _agentLifecycleOperationInProgress = false;
+            _agentPaneLog("_ReconcileAgentSettings: recreated affected unready panes");
             return;
         }
 
@@ -4168,12 +4159,8 @@ namespace winrt::TerminalApp::implementation
         {
             tabIdsToRetire = tabIdsThatHadAgentPane;
         }
-        else if (!hasStartedPaneToRebind)
-        {
-            tabIdsToRetire.clear();
-        }
         const auto rebindGeneration =
-            rebindAgentInPlace ? ++_agentSettingsRebindGeneration : 0;
+            rebindAgentInPlace ? ++_agentRebindGeneration : 0;
         _BeginAgentSessionRetirement(
             masterConfigurationChanged,
             std::move(tabIdsToRetire),
@@ -4201,44 +4188,31 @@ namespace winrt::TerminalApp::implementation
                             if (const auto tab = strongThis->_FindTabByStableId(tabId);
                                 tab && tab->FindAgentPane())
                             {
-                                auto disposition = AgentPaneSettingsRebindDisposition::Recreate;
                                 bool helperEventReady = false;
                                 if (const auto content = tab->FindAgentPaneContent())
                                 {
                                     helperEventReady =
                                         winrt::get_self<implementation::AgentPaneContent>(content)->IsHelperEventReady();
                                 }
-                                if (const auto control = tab->FindAgentPane()->GetTerminalControl())
-                                {
-                                    disposition = _ClassifyAgentPaneSettingsRebind(
+                                const auto control = tab->FindAgentPane()->GetTerminalControl();
+                                if (!control ||
+                                    !_CanRebindAgentPane(
                                         control.ConnectionState(),
-                                        helperEventReady);
-                                }
-
-                                if (disposition == AgentPaneSettingsRebindDisposition::Recreate)
+                                        helperEventReady))
                                 {
                                     const auto recreationOptions = _GetAgentPaneRecreationOptions(
                                         tab->HasStashedAgentPane(),
                                         activeTab && activeTab == tab);
-                                    _agentPaneLog("_RebuildAgentStack: recreating terminal-state agent pane with current settings");
-                                    strongThis->_TeardownAgentPane(tab);
-                                    strongThis->_AutoCreateHiddenAgentPaneShared(
-                                        tab,
-                                        /*intoSessionsView*/ false,
-                                        recreationOptions.autoStash,
-                                        {},
-                                        {},
-                                        {},
-                                        recreationOptions.focusPane);
+                                    _agentPaneLog("_ReconcileAgentSettings: recreating unavailable agent pane");
+                                    strongThis->_RecreateAgentPane(tab, recreationOptions);
                                     continue;
                                 }
 
-                                auto params = _BuildAgentPaneSettingsRebindPayload(binding);
-                                params["operation_id"] = std::string{ operationId };
-                                params["generation"] = Json::UInt64{ rebindGeneration };
-                                params["window_id"] = std::to_string(strongThis->_WindowProperties.WindowId());
-                                params["tab_id"] = winrt::to_string(tabId);
-                                strongThis->_RaiseProtocolEvent("rebind_agent", params);
+                                strongThis->_RaiseAgentPaneRebindRequest(
+                                    tab,
+                                    binding,
+                                    operationId,
+                                    rebindGeneration);
                             }
                         }
                     }
@@ -4267,7 +4241,7 @@ namespace winrt::TerminalApp::implementation
                                 !sharedWta.Restart(std::wstring_view{ wtaPath }, extraArgs, environment))
                             {
                                 _agentPaneLog(
-                                    "_RebuildAgentStack: master configuration SharedWta::Restart failed");
+                                    "_ReconcileAgentSettings: SharedWta::Restart failed");
                             }
                         }
                     }
@@ -4299,7 +4273,7 @@ namespace winrt::TerminalApp::implementation
                     }
 
                     strongThis->_lastAgentSettings = current;
-                    strongThis->_agentRebuilding = false;
+                    strongThis->_agentLifecycleOperationInProgress = false;
                     const auto latest = strongThis->_CaptureAgentSettingsSnapshot();
                     const bool settingsChangedAgain = TerminalPage::_AgentSettingsChanged(current, latest);
                     if (settingsChangedAgain && !operationId.empty())
@@ -4310,19 +4284,19 @@ namespace winrt::TerminalApp::implementation
                     {
                         strongThis->_RestartAgentStack(*pendingRestart);
                     }
-                    else if (std::exchange(strongThis->_pendingAgentRebuild, false) ||
+                    else if (std::exchange(strongThis->_pendingAgentSettingsReconciliation, false) ||
                              settingsChangedAgain)
                     {
-                        auto pendingRequest = std::exchange(strongThis->_pendingAgentRebuildRequestId, std::nullopt);
-                        strongThis->_RebuildAgentStack(pendingRequest ? std::move(*pendingRequest) : std::string{});
+                        auto pendingRequest = std::exchange(strongThis->_pendingAgentSettingsRequestId, std::nullopt);
+                        strongThis->_ReconcileAgentSettings(pendingRequest ? std::move(*pendingRequest) : std::string{});
                     }
                 }
             });
     }
 
-    void TerminalPage::_FlushPendingAgentRebuild()
+    void TerminalPage::_FlushPendingAgentSettingsReconciliation()
     {
-        if (!_pendingAgentRebuild)
+        if (!_pendingAgentSettingsReconciliation)
         {
             return;
         }
@@ -4331,9 +4305,9 @@ namespace winrt::TerminalApp::implementation
         {
             return;
         }
-        _pendingAgentRebuild = false;
-        auto pendingRequest = std::exchange(_pendingAgentRebuildRequestId, std::nullopt);
-        _RebuildAgentStack(pendingRequest ? std::move(*pendingRequest) : std::string{});
+        _pendingAgentSettingsReconciliation = false;
+        auto pendingRequest = std::exchange(_pendingAgentSettingsRequestId, std::nullopt);
+        _ReconcileAgentSettings(pendingRequest ? std::move(*pendingRequest) : std::string{});
     }
 
     void TerminalPage::_OpenOrReuseAgentPane(bool intoSessionsView, const wchar_t* triggerSource, std::wstring_view initialAuthAgent)
@@ -6085,10 +6059,10 @@ namespace winrt::TerminalApp::implementation
             if (globals.AcpAgent() != selectedAgent)
             {
                 globals.AcpAgent(selectedAgent);
-                // Update the snapshot so _RebuildAgentStack (triggered by
+                // Update the snapshot so settings reconciliation (triggered by
                 // the file-watcher after WriteSettingsToDisk) sees no diff
-                // and skips the teardown. The current WTA pane is already
-                // connected to the right agent.
+                // and does not rebind a helper that already connected to the
+                // selected Agent.
                 _lastAgentSettings.acpAgent = std::wstring{ selectedAgent };
                 try
                 {
@@ -6584,6 +6558,136 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
+    bool TerminalPage::_HandleAgentModelSwitch(
+        const hstring& agentId,
+        const Json::Value& params)
+    {
+        namespace Reg = ::Microsoft::Terminal::Settings::Model::AgentRegistry;
+        if (params.isMember("model_id"))
+        {
+            if (!params["model_id"].isString())
+            {
+                _agentPaneLog("OnAgentSwitchRequested: malformed cloud model");
+                return true;
+            }
+
+            const auto modelId = winrt::to_hstring(params["model_id"].asString());
+            bool found = false;
+            for (const auto& model :
+                 winrt::Microsoft::Terminal::Settings::Model::AcpRuntimeState::Current().AvailableModels(agentId))
+            {
+                if (model.Id() == modelId)
+                {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found)
+            {
+                _agentPaneLog("OnAgentSwitchRequested: unknown cloud model");
+                return true;
+            }
+
+            auto globals = _settings.GlobalSettings();
+            if (globals.CustomModelSelection().empty() && globals.AcpModel() == modelId)
+            {
+                return true;
+            }
+            globals.CustomModelSelection(L"");
+            globals.AcpModel(modelId);
+            try
+            {
+                _settings.WriteSettingsToDisk();
+            }
+            catch (...)
+            {
+                LOG_CAUGHT_EXCEPTION();
+                return true;
+            }
+            _agentPaneLog("OnAgentSwitchRequested: persisted cloud model selection");
+            _ReconcileAgentSettings(
+                winrt::TerminalApp::implementation::SharedWta::Instance().CreateRetirementRequestId());
+            return true;
+        }
+
+        if (params.isMember("custom_model_selection"))
+        {
+            if (!params["custom_model_selection"].isString())
+            {
+                _agentPaneLog("OnAgentSwitchRequested: malformed BYOK selection");
+                return true;
+            }
+            if (!Reg::SupportsByok(std::wstring_view{ agentId }))
+            {
+                _agentPaneLog("OnAgentSwitchRequested: BYOK selection rejected for unsupported agent");
+                return true;
+            }
+
+            const auto selection = winrt::to_hstring(params["custom_model_selection"].asString());
+            std::wstring providerId;
+            std::wstring modelId;
+            if (!::Microsoft::Terminal::CustomModels::TryParseSelectionId(
+                    std::wstring_view{ selection },
+                    providerId,
+                    modelId))
+            {
+                _agentPaneLog("OnAgentSwitchRequested: malformed BYOK selection");
+                return true;
+            }
+
+            bool found = false;
+            for (const auto& provider : _settings.GlobalSettings().CustomModelProviders())
+            {
+                if (provider.Id() != providerId)
+                {
+                    continue;
+                }
+                if (!::Microsoft::Terminal::CustomModels::IsSupportedApiContract(
+                        std::wstring_view{ provider.ApiContract() }))
+                {
+                    break;
+                }
+                for (const auto& model : provider.Models())
+                {
+                    if (model.Id() == modelId)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+                break;
+            }
+            if (!found)
+            {
+                _agentPaneLog("OnAgentSwitchRequested: unknown BYOK selection");
+                return true;
+            }
+
+            auto globals = _settings.GlobalSettings();
+            if (globals.CustomModelSelection() == selection)
+            {
+                return true;
+            }
+            globals.CustomModelSelection(selection);
+            globals.AcpModel(L"");
+            try
+            {
+                _settings.WriteSettingsToDisk();
+            }
+            catch (...)
+            {
+                LOG_CAUGHT_EXCEPTION();
+                return true;
+            }
+            _agentPaneLog("OnAgentSwitchRequested: persisted BYOK model selection");
+            _ReconcileAgentSettings(
+                winrt::TerminalApp::implementation::SharedWta::Instance().CreateRetirementRequestId());
+            return true;
+        }
+
+        return false;
+    }
+
     // Inbound `/agent` selection from WTA. SendEvent fans out to every page;
     // window_id plus the stable tab id ensure only the owning page applies it.
     void TerminalPage::OnAgentSwitchRequested(hstring eventJson)
@@ -6618,10 +6722,17 @@ namespace winrt::TerminalApp::implementation
         const auto wslDistro = params.isMember("wsl_distro") && params["wsl_distro"].isString() ?
                                    winrt::to_hstring(params["wsl_distro"].asString()) :
                                    winrt::hstring{};
-        if (!tab || agentId.empty())
+        if (!tab)
         {
+            _agentPaneLog("OnAgentSwitchRequested: target tab not found");
             return;
         }
+        if (agentId.empty())
+        {
+            _agentPaneLog("OnAgentSwitchRequested: empty agent id");
+            return;
+        }
+
         if (source != L"host" && source != L"wsl")
         {
             _agentPaneLog("OnAgentSwitchRequested: unknown agent source");
@@ -6663,129 +6774,16 @@ namespace winrt::TerminalApp::implementation
         }
 
         namespace Reg = ::Microsoft::Terminal::Settings::Model::AgentRegistry;
-        bool allowed = false;
-        for (const auto& agent : Reg::FilteredAcpAgents())
-        {
-            if (agent.id == std::wstring_view{ agentId })
-            {
-                allowed = true;
-                break;
-            }
-        }
+        const auto allowed = std::ranges::any_of(Reg::FilteredAcpAgents(), [&](const auto& agent) {
+            return agent.id == std::wstring_view{ agentId };
+        });
         if (!allowed)
         {
             _agentPaneLog("OnAgentSwitchRequested: unknown or policy-blocked agent");
             return;
         }
-
-        if (params.isMember("model_id") && params["model_id"].isString())
+        if (_HandleAgentModelSwitch(agentId, params))
         {
-            const auto modelId = winrt::to_hstring(params["model_id"].asString());
-            bool found = false;
-            for (const auto& model :
-                 winrt::Microsoft::Terminal::Settings::Model::AcpRuntimeState::Current().AvailableModels(agentId))
-            {
-                if (model.Id() == modelId)
-                {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found)
-            {
-                _agentPaneLog("OnAgentSwitchRequested: unknown cloud model");
-                return;
-            }
-
-            auto globals = _settings.GlobalSettings();
-            if (globals.CustomModelSelection().empty() && globals.AcpModel() == modelId)
-            {
-                return;
-            }
-            globals.CustomModelSelection(L"");
-            globals.AcpModel(modelId);
-            try
-            {
-                _settings.WriteSettingsToDisk();
-            }
-            catch (...)
-            {
-                LOG_CAUGHT_EXCEPTION();
-                return;
-            }
-            _agentPaneLog("OnAgentSwitchRequested: persisted cloud model selection");
-            _RebuildAgentStack(
-                winrt::TerminalApp::implementation::SharedWta::Instance().CreateRetirementRequestId());
-            return;
-        }
-
-        if (params.isMember("custom_model_selection") && params["custom_model_selection"].isString())
-        {
-            if (!Reg::SupportsByok(std::wstring_view{ agentId }))
-            {
-                _agentPaneLog("OnAgentSwitchRequested: BYOK selection rejected for unsupported agent");
-                return;
-            }
-
-            const auto selection = winrt::to_hstring(params["custom_model_selection"].asString());
-            std::wstring providerId;
-            std::wstring modelId;
-            if (!::Microsoft::Terminal::CustomModels::TryParseSelectionId(
-                    std::wstring_view{ selection },
-                    providerId,
-                    modelId))
-            {
-                _agentPaneLog("OnAgentSwitchRequested: malformed BYOK selection");
-                return;
-            }
-
-            bool found = false;
-            for (const auto& provider : _settings.GlobalSettings().CustomModelProviders())
-            {
-                if (provider.Id() != providerId)
-                {
-                    continue;
-                }
-                if (!::Microsoft::Terminal::CustomModels::IsSupportedApiContract(
-                        std::wstring_view{ provider.ApiContract() }))
-                {
-                    break;
-                }
-                for (const auto& model : provider.Models())
-                {
-                    if (model.Id() == modelId)
-                    {
-                        found = true;
-                        break;
-                    }
-                }
-                break;
-            }
-            if (!found)
-            {
-                _agentPaneLog("OnAgentSwitchRequested: unknown BYOK selection");
-                return;
-            }
-
-            auto globals = _settings.GlobalSettings();
-            if (globals.CustomModelSelection() == selection)
-            {
-                return;
-            }
-            globals.CustomModelSelection(selection);
-            globals.AcpModel(L"");
-            try
-            {
-                _settings.WriteSettingsToDisk();
-            }
-            catch (...)
-            {
-                LOG_CAUGHT_EXCEPTION();
-                return;
-            }
-            _agentPaneLog("OnAgentSwitchRequested: persisted BYOK model selection");
-            _RebuildAgentStack(
-                winrt::TerminalApp::implementation::SharedWta::Instance().CreateRetirementRequestId());
             return;
         }
 
@@ -6799,7 +6797,7 @@ namespace winrt::TerminalApp::implementation
 
         tab->SetAgentOverride(agentId, winrt::hstring{}, winrt::hstring{}, source, wslDistro);
         const auto targetBinding = _ResolveAgentPaneSettingsBindingForTab(tab);
-        _RebindAgentPaneForTab(tab, currentBinding, targetBinding);
+        _ApplyAgentPaneBindingForTab(tab, currentBinding, targetBinding);
     }
 
     // `/restart` replaces the shared master and its agent CLI pool while
@@ -6810,35 +6808,32 @@ namespace winrt::TerminalApp::implementation
     // already unavailable retain the scoped recreation fallback.
     void TerminalPage::OnRestartAgentStackRequested(hstring eventJson)
     {
-        std::string requestId;
         Json::Value event;
         Json::CharReaderBuilder reader;
         std::istringstream stream{ winrt::to_string(eventJson) };
         std::string errors;
-        if (Json::parseFromStream(reader, stream, &event, &errors) &&
-            event.isMember("params") && event["params"].isObject() &&
-            event["params"].isMember("request_id") && event["params"]["request_id"].isString())
+        if (!Json::parseFromStream(reader, stream, &event, &errors) ||
+            !event.isMember("params") || !event["params"].isObject() ||
+            !event["params"].isMember("request_id") || !event["params"]["request_id"].isString() ||
+            event["params"]["request_id"].asString().empty())
         {
-            requestId = event["params"]["request_id"].asString();
+            _agentPaneLog("OnRestartAgentStackRequested: missing request_id, dropping");
+            return;
         }
-        if (requestId.empty())
-        {
-            requestId = winrt::TerminalApp::implementation::SharedWta::Instance().CreateRetirementRequestId();
-        }
-        _RestartAgentStack(std::move(requestId));
+        _RestartAgentStack(event["params"]["request_id"].asString());
     }
 
     void TerminalPage::_RestartAgentStack(std::string requestId)
     {
         _agentPaneLog("OnRestartAgentStackRequested: /restart received from wta");
 
-        if (_agentRebuilding)
+        if (_agentLifecycleOperationInProgress)
         {
             _pendingAgentStackRestart.Queue(std::move(requestId));
-            _agentPaneLog("OnRestartAgentStackRequested: rebuild pending; queued restart");
+            _agentPaneLog("OnRestartAgentStackRequested: lifecycle operation pending; queued restart");
             return;
         }
-        _agentRebuilding = true;
+        _agentLifecycleOperationInProgress = true;
 
         std::vector<winrt::hstring> tabIds;
         for (const auto& t : _tabs)
@@ -6861,10 +6856,18 @@ namespace winrt::TerminalApp::implementation
                 if (const auto strongThis = weakThis.get())
                 {
                     auto& sharedWta = winrt::TerminalApp::implementation::SharedWta::Instance();
-                    if (sharedWta.ClaimRetirementAction(operationId, "restart_master") &&
-                        !sharedWta.Restart())
+                    if (sharedWta.ClaimRetirementAction(operationId, "restart_master"))
                     {
-                        _agentPaneLog("OnRestartAgentStackRequested: SharedWta::Restart returned false");
+                        if (!sharedWta.Restart())
+                        {
+                            _agentPaneLog("OnRestartAgentStackRequested: SharedWta::Restart returned false");
+                        }
+                        else
+                        {
+                            Json::Value params{ Json::objectValue };
+                            params["operation_id"] = std::string{ operationId };
+                            strongThis->_RaiseProtocolEvent("agent_master_restarted", params);
+                        }
                     }
 
                     const auto activeTab = strongThis->_GetFocusedTabImpl();
@@ -6888,24 +6891,16 @@ namespace winrt::TerminalApp::implementation
                                 activeTab && activeTab == tab);
                             _agentPaneLog(
                                 "OnRestartAgentStackRequested: recreating pane with unavailable helper process");
-                            strongThis->_TeardownAgentPane(tab);
-                            strongThis->_AutoCreateHiddenAgentPaneShared(
-                                tab,
-                                /*intoSessionsView*/ false,
-                                recreationOptions.autoStash,
-                                {},
-                                {},
-                                {},
-                                recreationOptions.focusPane);
+                            strongThis->_RecreateAgentPane(tab, recreationOptions);
                         }
                     }
 
-                    strongThis->_agentRebuilding = false;
+                    strongThis->_agentLifecycleOperationInProgress = false;
                     strongThis->_pendingAgentStackRestart.Clear();
-                    if (std::exchange(strongThis->_pendingAgentRebuild, false))
+                    if (std::exchange(strongThis->_pendingAgentSettingsReconciliation, false))
                     {
-                        auto pendingRequest = std::exchange(strongThis->_pendingAgentRebuildRequestId, std::nullopt);
-                        strongThis->_RebuildAgentStack(pendingRequest ? std::move(*pendingRequest) : std::string{});
+                        auto pendingRequest = std::exchange(strongThis->_pendingAgentSettingsRequestId, std::nullopt);
+                        strongThis->_ReconcileAgentSettings(pendingRequest ? std::move(*pendingRequest) : std::string{});
                     }
                 }
             });
@@ -9875,13 +9870,13 @@ namespace winrt::TerminalApp::implementation
 
         // Reconcile agent/model identity changes. Supported model changes stay
         // on the live ACP session, launch-time model changes rebind the same
-        // helper, and only trusted command/backend boundaries rebuild panes.
+        // helper, and only trusted command/backend boundaries recreate panes.
         auto requestId = std::exchange(_settingsReloadRequestId, {});
         if (!requestId.empty())
         {
             requestId.append(_AgentSettingsRequestIdentity(_CaptureAgentSettingsSnapshot()));
         }
-        _RebuildAgentStack(std::move(requestId));
+        _ReconcileAgentSettings(std::move(requestId));
 
         // Re-project cached per-tab status after settings-only presentation
         // changes, including showTokenUsageAndCost.

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2262,6 +2262,21 @@ namespace winrt::TerminalApp::implementation
                     {
                         strongThis->_OpenOrReuseAgentPane(false, L"AgentSwitch");
                     }
+                    else
+                    {
+                        // The old helper may already have closed and removed
+                        // its pane before this switch reached the tab. Restore
+                        // the background tab's normal pre-warmed state without
+                        // making the replacement pane visible.
+                        strongThis->_AutoCreateHiddenAgentPaneShared(
+                            currentTab,
+                            /*intoSessionsView*/ false,
+                            /*autoStash*/ true,
+                            {},
+                            {},
+                            {},
+                            /*focusPane*/ false);
+                    }
                 }
             });
     }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1814,6 +1814,40 @@ namespace winrt::TerminalApp::implementation
                    AgentPaneSettingsRebindDisposition::Recreate;
     }
 
+    TerminalPage::AgentPaneSettingsRebindDisposition TerminalPage::_ClassifyAgentPaneAgentSwitch(
+        const AgentPaneSettingsBinding& current,
+        const AgentPaneSettingsBinding& target,
+        const ConnectionState connectionState,
+        const bool helperEventReady) noexcept
+    {
+        const auto isBuiltIn = [](const std::wstring& agentId) noexcept {
+            return !agentId.empty() && !til::starts_with(agentId, L"custom:");
+        };
+        const bool sameSource =
+            current.agentSource == target.agentSource &&
+            (current.agentSource != L"wsl" ||
+             (!current.agentWslDistro.empty() &&
+              current.agentWslDistro == target.agentWslDistro));
+
+        if (!current.launchable ||
+            !target.launchable ||
+            !isBuiltIn(current.agentId) ||
+            !isBuiltIn(target.agentId) ||
+            !sameSource)
+        {
+            return AgentPaneSettingsRebindDisposition::Recreate;
+        }
+
+        return _ClassifyAgentPaneSettingsRebind(connectionState, helperEventReady);
+    }
+
+    bool TerminalPage::_CanRetainAgentPaneForMasterRestart(
+        const ConnectionState connectionState) noexcept
+    {
+        return connectionState == ConnectionState::Connecting ||
+               connectionState == ConnectionState::Connected;
+    }
+
     TerminalPage::AgentPaneRecreationOptions TerminalPage::_GetAgentPaneRecreationOptions(
         const bool wasStashed,
         const bool isActiveTab) noexcept
@@ -1908,6 +1942,53 @@ namespace winrt::TerminalApp::implementation
         return binding;
     }
 
+    TerminalPage::AgentPaneSettingsBinding TerminalPage::_ResolveAgentPaneSettingsBindingForTab(
+        const winrt::com_ptr<Tab>& tab)
+    {
+        AgentPaneSettingsBindingRequest request;
+        const auto& globals = _settings.GlobalSettings();
+        const auto globalAgentCliPath =
+            _ResolveEffectiveAgentCliPath(globals, [this]() { return _DetectAgentCli(); });
+        request.globalAgentId = std::wstring{ globals.EffectiveAcpAgent() };
+        request.globalModel = std::wstring{ globals.AcpModel() };
+        request.globalAgentCliPath = std::wstring{ globalAgentCliPath };
+        if (const auto customModelLaunch = _CaptureCustomModelLaunchConfiguration(globals))
+        {
+            request.customModelSelection = customModelLaunch->selectionId;
+        }
+        if (request.globalAgentId.empty() && !request.globalAgentCliPath.empty())
+        {
+            request.detectedGlobalAgentId = std::wstring{ _DetectAgentCli() };
+        }
+
+        if (tab)
+        {
+            request.hasAgentOverride = tab->HasAgentOverride();
+            if (request.hasAgentOverride)
+            {
+                request.agentIdOverride = std::wstring{ tab->AgentIdOverride() };
+                request.agentModelOverride = std::wstring{ tab->AgentModelOverride() };
+                request.agentCustomCommandOverride = std::wstring{ tab->AgentCustomCommandOverride() };
+                request.agentSourceOverride = std::wstring{ tab->AgentSourceOverride() };
+                request.agentWslDistroOverride = std::wstring{ tab->AgentWslDistroOverride() };
+            }
+            else
+            {
+                if (const auto sourceProfile = _ResolveAgentSourceProfile(tab, _settings))
+                {
+                    tab->AgentSourceProfileGuid(_AgentSourceProfileGuid(sourceProfile, _settings));
+                    request.profileBackend = std::wstring{ sourceProfile.AgentPaneBackend() };
+                }
+                if (const auto control = tab->GetActiveTerminalControl())
+                {
+                    request.profileActiveShell = std::wstring{ control.ShellName() };
+                }
+            }
+        }
+
+        return _ResolveAgentPaneSettingsBinding(request);
+    }
+
     bool TerminalPage::_IsAgentPaneSettingsRebindAffected(
         const AgentPaneSettingsBinding& binding,
         const bool globalAgentChanged,
@@ -1957,10 +2038,30 @@ namespace winrt::TerminalApp::implementation
         Json::Value params{ Json::objectValue };
         params["agent_id"] = winrt::to_string(winrt::hstring{ binding.agentId });
         params["agent_source"] = winrt::to_string(winrt::hstring{ binding.agentSource });
+        params["wsl_distro"] = winrt::to_string(winrt::hstring{ binding.agentWslDistro });
         params["acp_model"] = winrt::to_string(winrt::hstring{ binding.acpModel });
         params["custom_model_selection"] =
             winrt::to_string(winrt::hstring{ binding.customModelSelection });
         return params;
+    }
+
+    void TerminalPage::_RaiseAgentPaneRebindRequest(
+        const winrt::com_ptr<Tab>& tab,
+        const AgentPaneSettingsBinding& binding,
+        const std::string_view operationId,
+        const uint64_t generation)
+    {
+        if (!tab || operationId.empty())
+        {
+            return;
+        }
+
+        auto params = _BuildAgentPaneSettingsRebindPayload(binding);
+        params["operation_id"] = std::string{ operationId };
+        params["generation"] = Json::UInt64{ generation };
+        params["window_id"] = std::to_string(_WindowProperties.WindowId());
+        params["tab_id"] = winrt::to_string(tab->StableId());
+        _RaiseProtocolEvent("rebind_agent", params);
     }
 
     TerminalPage::AgentRuntimeConfigSnapshot TerminalPage::_CaptureAgentRuntimeConfig() const
@@ -2079,8 +2180,8 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
-    // Rebuild a SINGLE tab's agent pane after its per-tab agent override
-    // changed (via `/agent`). Scoped, unlike
+    // Rebuild a SINGLE tab's agent pane when its per-tab agent override cannot
+    // reuse the existing helper. Scoped, unlike
     // `_RebuildAgentStack`: it touches only this tab and does NOT restart
     // the shared master. The multi-agent master stays up; the freshly
     // spawned helper declares this tab's new agent in its `initialize`
@@ -2120,24 +2221,120 @@ namespace winrt::TerminalApp::implementation
                         return;
                     }
 
+                    const auto focusedTab = strongThis->_GetFocusedTabImpl();
+                    const auto recreationOptions = _GetAgentPaneRecreationOptions(
+                        currentTab->HasStashedAgentPane(),
+                        focusedTab && focusedTab == currentTab);
                     strongThis->_TeardownAgentPane(currentTab);
                     if (!shouldReopen)
                     {
                         currentTab->SetAgentChipOverride(std::nullopt);
                         return;
                     }
-                    const auto focusedTab = strongThis->_GetFocusedTabImpl();
-                    if (focusedTab && focusedTab == currentTab)
-                    {
-                        strongThis->_OpenOrReuseAgentPane(false, L"AgentSwitch");
-                    }
-                    else if (hadPane)
+                    if (hadPane)
                     {
                         strongThis->_AutoCreateHiddenAgentPaneShared(
                             currentTab,
                             /*intoSessionsView*/ false,
-                            /*autoStash*/ true);
+                            recreationOptions.autoStash,
+                            {},
+                            {},
+                            {},
+                            recreationOptions.focusPane);
                     }
+                    else if (focusedTab && focusedTab == currentTab)
+                    {
+                        strongThis->_OpenOrReuseAgentPane(false, L"AgentSwitch");
+                    }
+                }
+            });
+    }
+
+    void TerminalPage::_RebindAgentPaneForTab(
+        const winrt::com_ptr<Tab>& tab,
+        const AgentPaneSettingsBinding& current,
+        const AgentPaneSettingsBinding& target)
+    {
+        if (!tab)
+        {
+            return;
+        }
+
+        const auto pane = tab->FindAgentPane();
+        const auto content = tab->FindAgentPaneContent();
+        const auto control = pane ? pane->GetTerminalControl() : nullptr;
+        const bool helperEventReady =
+            content &&
+            winrt::get_self<implementation::AgentPaneContent>(content)->IsHelperEventReady();
+        if (!control ||
+            _ClassifyAgentPaneAgentSwitch(
+                current,
+                target,
+                control.ConnectionState(),
+                helperEventReady) == AgentPaneSettingsRebindDisposition::Recreate)
+        {
+            _agentPaneLog("OnAgentSwitchRequested: rebuilding helper across an unsupported or unready boundary");
+            _RebuildAgentPaneForTab(tab);
+            return;
+        }
+
+        const auto tabId = tab->StableId();
+        const auto rebindGeneration = ++_agentSettingsRebindGeneration;
+        _BeginAgentSessionRetirement(
+            false,
+            { tabId },
+            "agent_picker_rebind",
+            {},
+            [weakThis = get_weak(), tabId, target, rebindGeneration](const std::string_view operationId) {
+                if (const auto strongThis = weakThis.get())
+                {
+                    const auto currentTab = strongThis->_FindTabByStableId(tabId);
+                    if (!currentTab)
+                    {
+                        return;
+                    }
+
+                    const auto pane = currentTab->FindAgentPane();
+                    if (!pane)
+                    {
+                        return;
+                    }
+                    const auto content = currentTab->FindAgentPaneContent();
+                    const auto control = pane->GetTerminalControl();
+                    const bool helperEventReady =
+                        content &&
+                        winrt::get_self<implementation::AgentPaneContent>(content)->IsHelperEventReady();
+                    if (operationId.empty() ||
+                        !control ||
+                        _ClassifyAgentPaneSettingsRebind(
+                            control.ConnectionState(),
+                            helperEventReady) == AgentPaneSettingsRebindDisposition::Recreate)
+                    {
+                        const auto focusedTab = strongThis->_GetFocusedTabImpl();
+                        const auto recreationOptions = _GetAgentPaneRecreationOptions(
+                            currentTab->HasStashedAgentPane(),
+                            focusedTab && focusedTab == currentTab);
+                        _agentPaneLog(
+                            "OnAgentSwitchRequested: helper became unavailable during retirement; recreating pane");
+                        strongThis->_TeardownAgentPane(currentTab);
+                        strongThis->_AutoCreateHiddenAgentPaneShared(
+                            currentTab,
+                            /*intoSessionsView*/ false,
+                            recreationOptions.autoStash,
+                            {},
+                            {},
+                            {},
+                            recreationOptions.focusPane);
+                        return;
+                    }
+
+                    _agentPaneLog(
+                        "OnAgentSwitchRequested: rebinding existing helper to selected agent");
+                    strongThis->_RaiseAgentPaneRebindRequest(
+                        currentTab,
+                        target,
+                        operationId,
+                        rebindGeneration);
                 }
             });
     }
@@ -6592,39 +6789,25 @@ namespace winrt::TerminalApp::implementation
             return;
         }
 
-        const auto currentId = tab->HasAgentOverride() ?
-                                   tab->AgentIdOverride() :
-                                   _settings.GlobalSettings().EffectiveAcpAgent();
-        const auto currentSource = tab->HasAgentOverride() ?
-                                       tab->AgentSourceOverride() :
-                                       winrt::hstring{ L"host" };
-        const auto currentWslDistro = tab->HasAgentOverride() ?
-                                          tab->AgentWslDistroOverride() :
-                                          winrt::hstring{};
-        if (currentId == agentId && currentSource == source && currentWslDistro == wslDistro)
+        const auto currentBinding = _ResolveAgentPaneSettingsBindingForTab(tab);
+        if (currentBinding.agentId == std::wstring_view{ agentId } &&
+            currentBinding.agentSource == std::wstring_view{ source } &&
+            currentBinding.agentWslDistro == std::wstring_view{ wslDistro })
         {
             return;
         }
 
         tab->SetAgentOverride(agentId, winrt::hstring{}, winrt::hstring{}, source, wslDistro);
-        _RebuildAgentPaneForTab(tab);
+        const auto targetBinding = _ResolveAgentPaneSettingsBindingForTab(tab);
+        _RebindAgentPaneForTab(tab, currentBinding, targetBinding);
     }
 
-    // `/restart` from any agent pane's TUI lands here via the
-    // `restart_agent_stack` SendEvent route. The single window receiving
-    // the dispatch owns the user-visible side of the restart for itself;
-    // other windows' panes (if any) are torn down implicitly when the
-    // shared master they were attached to dies under `SharedWta::Restart()`
-    // (helper pipes go EOF → helpers exit → ConPty death → those tabs
-    // show "process exited" panes until the user toggles them open again).
-    //
-    // Designed as a near-clone of the `_RebuildAgentStack` settings-change
-    // path: tear down every agent pane in this window, then re-toggle the
-    // active tab's pane. The new wta-helper that gets spawned by the
-    // re-toggle calls `SharedWta::AcquirePane`, which (because Restart
-    // already respawned the master) sees a valid `_process` and just
-    // bumps the refcount — connecting the new helper to the freshly-spawned
-    // master under the same stable pipe name.
+    // `/restart` replaces the shared master and its agent CLI pool while
+    // preserving each viable pane, TermControl, ConPTY, and helper. All pages
+    // receive the same request ID, join one all-window session-retirement
+    // barrier, and then ask their helpers to reconnect over the stable master
+    // pipe using their existing immutable binding. Only panes whose ConPTY is
+    // already unavailable retain the scoped recreation fallback.
     void TerminalPage::OnRestartAgentStackRequested(hstring eventJson)
     {
         std::string requestId;
@@ -6677,17 +6860,6 @@ namespace winrt::TerminalApp::implementation
             [weakThis = get_weak(), tabIds](const std::string_view operationId) {
                 if (const auto strongThis = weakThis.get())
                 {
-                    std::vector<winrt::com_ptr<Tab>> tabsToReopen;
-                    for (const auto& tabId : tabIds)
-                    {
-                        if (const auto tab = strongThis->_FindTabByStableId(tabId);
-                            tab && tab->FindAgentPane())
-                        {
-                            tabsToReopen.push_back(tab);
-                            strongThis->_TeardownAgentPane(tab);
-                        }
-                    }
-
                     auto& sharedWta = winrt::TerminalApp::implementation::SharedWta::Instance();
                     if (sharedWta.ClaimRetirementAction(operationId, "restart_master") &&
                         !sharedWta.Restart())
@@ -6696,18 +6868,35 @@ namespace winrt::TerminalApp::implementation
                     }
 
                     const auto activeTab = strongThis->_GetFocusedTabImpl();
-                    for (const auto& tab : tabsToReopen)
+                    for (const auto& tabId : tabIds)
                     {
-                        if (activeTab && activeTab == tab)
+                        const auto tab = strongThis->_FindTabByStableId(tabId);
+                        const auto pane = tab ? tab->FindAgentPane() : nullptr;
+                        const auto control = pane ? pane->GetTerminalControl() : nullptr;
+                        if (control &&
+                            _CanRetainAgentPaneForMasterRestart(control.ConnectionState()))
                         {
-                            strongThis->_OpenOrReuseAgentPane(false, L"RestartAgent");
+                            _agentPaneLog(
+                                "OnRestartAgentStackRequested: retained helper will reconnect to replacement master");
+                            continue;
                         }
-                        else
+
+                        if (tab && pane)
                         {
+                            const auto recreationOptions = _GetAgentPaneRecreationOptions(
+                                tab->HasStashedAgentPane(),
+                                activeTab && activeTab == tab);
+                            _agentPaneLog(
+                                "OnRestartAgentStackRequested: recreating pane with unavailable helper process");
+                            strongThis->_TeardownAgentPane(tab);
                             strongThis->_AutoCreateHiddenAgentPaneShared(
                                 tab,
                                 /*intoSessionsView*/ false,
-                                /*autoStash*/ true);
+                                recreationOptions.autoStash,
+                                {},
+                                {},
+                                {},
+                                recreationOptions.focusPane);
                         }
                     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -428,15 +428,9 @@ namespace winrt::TerminalApp::implementation
         void _WireAgentPaneEvents(const winrt::TerminalApp::AgentPaneContent& content,
                                   const winrt::com_ptr<Tab>& ownerTab);
 
-        // Hot-reload of agent/model settings. Snapshot is captured on first
-        // SetSettings and after every reconciliation. Built-in global agent
-        // changes rebind the existing helper in place; changes that alter
-        // trusted master launch state keep the destructive rebuild path.
-        //
-        // Built-in agent and model binding changes rebind affected helpers.
-        // Native models with a live ACP switch path update the current session
-        // directly. Trusted custom commands and profile backend changes retain
-        // the destructive path.
+        // Hot-reload of agent/model settings. Native models update live,
+        // built-in binding changes reconnect helpers, and trust/execution
+        // boundary changes recreate the affected pane.
         struct AgentSettingsSnapshot
         {
             std::wstring acpAgent;
@@ -452,12 +446,7 @@ namespace winrt::TerminalApp::implementation
             None,
             ModelHotUpdate,
             AgentRebind,
-            Rebuild,
-        };
-        enum class AgentPaneSettingsRebindDisposition
-        {
-            Rebind,
-            Recreate,
+            RecreatePane,
         };
         struct AgentPaneSettingsBindingRequest
         {
@@ -492,8 +481,8 @@ namespace winrt::TerminalApp::implementation
             bool focusPane;
         };
         std::string _settingsReloadRequestId;
-        std::optional<std::string> _pendingAgentRebuildRequestId;
-        uint64_t _agentSettingsRebindGeneration{ 0 };
+        std::optional<std::string> _pendingAgentSettingsRequestId;
+        uint64_t _agentRebindGeneration{ 0 };
         static std::string _AgentSettingsRequestIdentity(const AgentSettingsSnapshot& snapshot);
         // Hot-updatable non-binding agent config. When any of these change we
         // push a single consolidated `agent_config_changed` event to the
@@ -534,7 +523,7 @@ namespace winrt::TerminalApp::implementation
         // back-to-back (e.g. file-watcher reload storms).
         std::atomic<bool> _shellIntegrationDesiredEnabled{ false };
         std::mutex _shellIntegrationReconcileMutex;
-        bool _agentRebuilding{ false };
+        bool _agentLifecycleOperationInProgress{ false };
         details::CoalescedRequest _pendingAgentStackRestart;
         struct _PendingAgentRetirement
         {
@@ -543,11 +532,11 @@ namespace winrt::TerminalApp::implementation
         };
         std::unordered_map<std::string, _PendingAgentRetirement> _pendingAgentRetirements;
         details::TabRetirementTracker _agentTabRetirements;
-        // Set when a settings change wants a rebuild but the active
+        // Set when a settings change needs reconciliation but the active
         // tab can't host an agent pane (e.g. the Settings tab itself).
-        // _FlushPendingAgentRebuild runs the deferred rebuild from
+        // _FlushPendingAgentSettingsReconciliation runs it from
         // _OnTabSelectionChanged once a terminal tab is active.
-        bool _pendingAgentRebuild{ false };
+        bool _pendingAgentSettingsReconciliation{ false };
 
         // Plan-C resume-into-new-tab bookkeeping. When the session
         // manager's Enter handler on a Historical/Ended row creates a
@@ -579,10 +568,10 @@ namespace winrt::TerminalApp::implementation
             AgentSettingsChangeKind changeKind,
             bool canHostPane,
             bool masterConfigurationChanged) noexcept;
-        static AgentPaneSettingsRebindDisposition _ClassifyAgentPaneSettingsRebind(
+        static bool _CanRebindAgentPane(
             winrt::Microsoft::Terminal::TerminalConnection::ConnectionState connectionState,
             bool helperEventReady) noexcept;
-        static AgentPaneSettingsRebindDisposition _ClassifyAgentPaneAgentSwitch(
+        static bool _CanSwitchAgentInPlace(
             const AgentPaneSettingsBinding& current,
             const AgentPaneSettingsBinding& target,
             winrt::Microsoft::Terminal::TerminalConnection::ConnectionState connectionState,
@@ -636,21 +625,27 @@ namespace winrt::TerminalApp::implementation
         safe_void_coroutine _WaitForAgentSessionRetirement(std::string operationId);
         void _CompleteAgentSessionRetirement(std::string_view operationId, bool timedOut);
         void _TeardownAgentPane(const winrt::com_ptr<Tab>& tab);
-        void _RebuildAgentStack(std::string requestId = {});
+        void _RecreateAgentPane(
+            const winrt::com_ptr<Tab>& tab,
+            const AgentPaneRecreationOptions& options);
+        void _ReconcileAgentSettings(std::string requestId = {});
         void _RestartAgentStack(std::string requestId);
         // Scoped per-tab fallback when an agent override cannot be rebound
         // through the existing helper. Does not restart the shared master.
-        void _RebuildAgentPaneForTab(const winrt::com_ptr<Tab>& tab);
-        void _RebindAgentPaneForTab(
+        void _RecreateAgentPaneForTab(const winrt::com_ptr<Tab>& tab);
+        void _ApplyAgentPaneBindingForTab(
             const winrt::com_ptr<Tab>& tab,
             const AgentPaneSettingsBinding& current,
             const AgentPaneSettingsBinding& target);
-        void _FlushPendingAgentRebuild();
+        bool _HandleAgentModelSwitch(
+            const winrt::hstring& agentId,
+            const Json::Value& params);
+        void _FlushPendingAgentSettingsReconciliation();
         // Build the per-process flag/value pairs that the wta-master
         // inherits at spawn time (--agent, --agent-id, --no-autofix,
         // --language, --acp-model, --delegate-agent, --delegate-model).
         // Single source of truth shared by `_AutoCreateHiddenAgentPaneShared`
-        // (first acquire) and `_RebuildAgentStack` (settings-change-driven
+        // (first acquire) and `_ReconcileAgentSettings` (settings-change-driven
         // SharedWta::Restart). Reads from `_settings.GlobalSettings()`.
         std::vector<std::wstring> _BuildSharedWtaExtraArgs();
         std::vector<std::pair<std::wstring, std::wstring>> _BuildSharedWtaEnvironment();

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -429,8 +429,9 @@ namespace winrt::TerminalApp::implementation
                                   const winrt::com_ptr<Tab>& ownerTab);
 
         // Hot-reload of agent/model settings. Snapshot is captured on first
-        // SetSettings and after every rebuild; a diff drives teardown/rebuild
-        // of the agent pane.
+        // SetSettings and after every reconciliation. Built-in global agent
+        // changes rebind the existing helper in place; changes that alter
+        // trusted master launch state keep the destructive rebuild path.
         //
         // Agent identity changes (global acpAgent/acpCustomCommand, the
         // effective model selection, or an effective per-profile backend)
@@ -447,8 +448,15 @@ namespace winrt::TerminalApp::implementation
         };
         AgentSettingsSnapshot _lastAgentSettings{};
         bool _agentSettingsSnapshotInitialized{ false };
+        enum class AgentSettingsChangeKind
+        {
+            None,
+            AgentRebind,
+            Rebuild,
+        };
         std::string _settingsReloadRequestId;
         std::optional<std::string> _pendingAgentRebuildRequestId;
+        uint64_t _agentSettingsRebindGeneration{ 0 };
         static std::string _AgentSettingsRequestIdentity(const AgentSettingsSnapshot& snapshot);
         // Hot-updatable runtime agent config. When any of these change we
         // push a single consolidated `agent_config_changed` event to the
@@ -526,9 +534,13 @@ namespace winrt::TerminalApp::implementation
         };
         std::unordered_map<winrt::hstring, _PendingLoadSession> _pendingLoadSessions;
         AgentSettingsSnapshot _CaptureAgentSettingsSnapshot() const;
-        // Compares only agent-CLI *identity* fields — the change that forces
-        // a master respawn. Model/delegate changes are handled by
-        // _EmitAgentRuntimeConfigIfChanged instead.
+        static AgentSettingsChangeKind _ClassifyAgentSettingsChange(
+            const AgentSettingsSnapshot& previous,
+            const AgentSettingsSnapshot& current);
+        static bool _ShouldDeferAgentSettingsChange(
+            AgentSettingsChangeKind changeKind,
+            bool canHostPane,
+            bool masterConfigurationChanged) noexcept;
         static bool _AgentSettingsChanged(const AgentSettingsSnapshot& a, const AgentSettingsSnapshot& b);
         AgentRuntimeConfigSnapshot _CaptureAgentRuntimeConfig() const;
         // Diffs the hot-updatable runtime config against the last snapshot

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -459,6 +459,33 @@ namespace winrt::TerminalApp::implementation
             Rebind,
             Recreate,
         };
+        struct AgentPaneSettingsBindingRequest
+        {
+            bool hasAgentOverride{ false };
+            std::wstring agentIdOverride;
+            std::wstring agentModelOverride;
+            std::wstring agentCustomCommandOverride;
+            std::wstring agentSourceOverride;
+            std::wstring agentWslDistroOverride;
+            std::wstring profileBackend;
+            std::wstring profileActiveShell;
+            std::wstring globalAgentId;
+            std::wstring globalModel;
+            std::wstring globalAgentCliPath;
+            std::wstring detectedGlobalAgentId;
+            std::wstring customModelSelection;
+        };
+        struct AgentPaneSettingsBinding
+        {
+            std::wstring agentId;
+            std::wstring agentSource;
+            std::wstring agentWslDistro;
+            std::wstring acpModel;
+            std::wstring customModelSelection;
+            bool followsGlobalAcpModel{ false };
+            bool launchable{ false };
+            bool supportsGlobalHostByok{ false };
+        };
         struct AgentPaneRecreationOptions
         {
             bool autoStash;
@@ -558,6 +585,15 @@ namespace winrt::TerminalApp::implementation
         static AgentPaneRecreationOptions _GetAgentPaneRecreationOptions(
             bool wasStashed,
             bool isActiveTab) noexcept;
+        static AgentPaneSettingsBinding _ResolveAgentPaneSettingsBinding(
+            const AgentPaneSettingsBindingRequest& request);
+        static bool _IsAgentPaneSettingsRebindAffected(
+            const AgentPaneSettingsBinding& binding,
+            bool globalAgentChanged,
+            bool cloudModelChanged,
+            bool customModelLaunchChanged) noexcept;
+        static Json::Value _BuildAgentPaneSettingsRebindPayload(
+            const AgentPaneSettingsBinding& binding);
         static bool _AgentSettingsChanged(const AgentSettingsSnapshot& a, const AgentSettingsSnapshot& b);
         AgentRuntimeConfigSnapshot _CaptureAgentRuntimeConfig() const;
         // Diffs the hot-updatable runtime config against the last snapshot

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -582,11 +582,20 @@ namespace winrt::TerminalApp::implementation
         static AgentPaneSettingsRebindDisposition _ClassifyAgentPaneSettingsRebind(
             winrt::Microsoft::Terminal::TerminalConnection::ConnectionState connectionState,
             bool helperEventReady) noexcept;
+        static AgentPaneSettingsRebindDisposition _ClassifyAgentPaneAgentSwitch(
+            const AgentPaneSettingsBinding& current,
+            const AgentPaneSettingsBinding& target,
+            winrt::Microsoft::Terminal::TerminalConnection::ConnectionState connectionState,
+            bool helperEventReady) noexcept;
+        static bool _CanRetainAgentPaneForMasterRestart(
+            winrt::Microsoft::Terminal::TerminalConnection::ConnectionState connectionState) noexcept;
         static AgentPaneRecreationOptions _GetAgentPaneRecreationOptions(
             bool wasStashed,
             bool isActiveTab) noexcept;
         static AgentPaneSettingsBinding _ResolveAgentPaneSettingsBinding(
             const AgentPaneSettingsBindingRequest& request);
+        AgentPaneSettingsBinding _ResolveAgentPaneSettingsBindingForTab(
+            const winrt::com_ptr<Tab>& tab);
         static bool _IsAgentPaneSettingsRebindAffected(
             const AgentPaneSettingsBinding& binding,
             bool globalAgentChanged,
@@ -604,6 +613,11 @@ namespace winrt::TerminalApp::implementation
             bool agentConnected) noexcept;
         static Json::Value _BuildAgentPaneSettingsRebindPayload(
             const AgentPaneSettingsBinding& binding);
+        void _RaiseAgentPaneRebindRequest(
+            const winrt::com_ptr<Tab>& tab,
+            const AgentPaneSettingsBinding& binding,
+            std::string_view operationId,
+            uint64_t generation);
         static bool _AgentSettingsChanged(const AgentSettingsSnapshot& a, const AgentSettingsSnapshot& b);
         AgentRuntimeConfigSnapshot _CaptureAgentRuntimeConfig() const;
         // Diffs the hot-updatable runtime config against the last snapshot
@@ -624,9 +638,13 @@ namespace winrt::TerminalApp::implementation
         void _TeardownAgentPane(const winrt::com_ptr<Tab>& tab);
         void _RebuildAgentStack(std::string requestId = {});
         void _RestartAgentStack(std::string requestId);
-        // Scoped per-tab rebuild after a tab's agent override changes
-        // (agent-bar chip flyout). Does not restart the shared master.
+        // Scoped per-tab fallback when an agent override cannot be rebound
+        // through the existing helper. Does not restart the shared master.
         void _RebuildAgentPaneForTab(const winrt::com_ptr<Tab>& tab);
+        void _RebindAgentPaneForTab(
+            const winrt::com_ptr<Tab>& tab,
+            const AgentPaneSettingsBinding& current,
+            const AgentPaneSettingsBinding& target);
         void _FlushPendingAgentRebuild();
         // Build the per-process flag/value pairs that the wta-master
         // inherits at spawn time (--agent, --agent-id, --no-autofix,

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -457,7 +457,12 @@ namespace winrt::TerminalApp::implementation
         enum class AgentPaneSettingsRebindDisposition
         {
             Rebind,
-            RecreateStashed,
+            Recreate,
+        };
+        struct AgentPaneRecreationOptions
+        {
+            bool autoStash;
+            bool focusPane;
         };
         std::string _settingsReloadRequestId;
         std::optional<std::string> _pendingAgentRebuildRequestId;
@@ -550,6 +555,9 @@ namespace winrt::TerminalApp::implementation
             bool masterConfigurationChanged) noexcept;
         static AgentPaneSettingsRebindDisposition _ClassifyAgentPaneSettingsRebind(
             winrt::Microsoft::Terminal::TerminalConnection::ConnectionState connectionState) noexcept;
+        static AgentPaneRecreationOptions _GetAgentPaneRecreationOptions(
+            bool wasStashed,
+            bool isActiveTab) noexcept;
         static bool _AgentSettingsChanged(const AgentSettingsSnapshot& a, const AgentSettingsSnapshot& b);
         AgentRuntimeConfigSnapshot _CaptureAgentRuntimeConfig() const;
         // Diffs the hot-updatable runtime config against the last snapshot
@@ -612,7 +620,8 @@ namespace winrt::TerminalApp::implementation
                                               bool autoStash = false,
                                               std::string_view initialLoadSessionId = {},
                                               std::string_view initialLoadCwd = {},
-                                              std::wstring_view initialAuthAgent = {});
+                                              std::wstring_view initialAuthAgent = {},
+                                              bool focusPane = true);
         // Wraps the raw terminal pane's TerminalPaneContent in an
         // AgentPaneContent so the leaf renders the 36px XAML agent bar
         // above the wta TermControl + the bottom-bar below.

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -495,18 +495,17 @@ namespace winrt::TerminalApp::implementation
         std::optional<std::string> _pendingAgentRebuildRequestId;
         uint64_t _agentSettingsRebindGeneration{ 0 };
         static std::string _AgentSettingsRequestIdentity(const AgentSettingsSnapshot& snapshot);
-        // Hot-updatable runtime agent config. When any of these change we
+        // Hot-updatable non-binding agent config. When any of these change we
         // push a single consolidated `agent_config_changed` event to the
-        // running wta-helper(s) so they update in place — no agent-pane
-        // teardown/restart. This is the unified dispatch point for every
-        // agent setting that can be hot-reloaded (ACP model, autofix gate,
-        // delegate agent/model, credential-free model catalogs).
+        // running wta-helper(s) so they update in place. ACP model binding
+        // changes are reconciled separately so unready helpers can be
+        // recreated before the settings snapshot advances. This remains the
+        // unified dispatch point for the autofix gate, delegate agent/model,
+        // and credential-free model catalogs.
         // `delegateAgent` holds the resolved effective value (custom-command
         // ids already expanded).
         struct AgentRuntimeConfigSnapshot
         {
-            std::wstring acpAgent;
-            std::wstring acpModel;
             std::wstring delegateAgent;
             std::wstring delegateModel;
             std::wstring customModelSelection;
@@ -581,7 +580,8 @@ namespace winrt::TerminalApp::implementation
             bool canHostPane,
             bool masterConfigurationChanged) noexcept;
         static AgentPaneSettingsRebindDisposition _ClassifyAgentPaneSettingsRebind(
-            winrt::Microsoft::Terminal::TerminalConnection::ConnectionState connectionState) noexcept;
+            winrt::Microsoft::Terminal::TerminalConnection::ConnectionState connectionState,
+            bool helperEventReady) noexcept;
         static AgentPaneRecreationOptions _GetAgentPaneRecreationOptions(
             bool wasStashed,
             bool isActiveTab) noexcept;
@@ -592,6 +592,14 @@ namespace winrt::TerminalApp::implementation
             bool globalAgentChanged,
             bool cloudModelChanged,
             bool customModelLaunchChanged) noexcept;
+        static bool _IsAgentPaneModelHotUpdateTarget(
+            const std::optional<AgentPaneSettingsBinding>& binding,
+            std::optional<winrt::Microsoft::Terminal::TerminalConnection::ConnectionState> connectionState,
+            bool helperEventReady) noexcept;
+        static bool _ShouldRecreateAgentPaneForModelHotUpdate(
+            const std::optional<AgentPaneSettingsBinding>& binding,
+            std::optional<winrt::Microsoft::Terminal::TerminalConnection::ConnectionState> connectionState,
+            bool helperEventReady) noexcept;
         static Json::Value _BuildAgentPaneSettingsRebindPayload(
             const AgentPaneSettingsBinding& binding);
         static bool _AgentSettingsChanged(const AgentSettingsSnapshot& a, const AgentSettingsSnapshot& b);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -595,11 +595,13 @@ namespace winrt::TerminalApp::implementation
         static bool _IsAgentPaneModelHotUpdateTarget(
             const std::optional<AgentPaneSettingsBinding>& binding,
             std::optional<winrt::Microsoft::Terminal::TerminalConnection::ConnectionState> connectionState,
-            bool helperEventReady) noexcept;
+            bool helperEventReady,
+            bool agentConnected) noexcept;
         static bool _ShouldRecreateAgentPaneForModelHotUpdate(
             const std::optional<AgentPaneSettingsBinding>& binding,
             std::optional<winrt::Microsoft::Terminal::TerminalConnection::ConnectionState> connectionState,
-            bool helperEventReady) noexcept;
+            bool helperEventReady,
+            bool agentConnected) noexcept;
         static Json::Value _BuildAgentPaneSettingsRebindPayload(
             const AgentPaneSettingsBinding& binding);
         static bool _AgentSettingsChanged(const AgentSettingsSnapshot& a, const AgentSettingsSnapshot& b);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -454,6 +454,11 @@ namespace winrt::TerminalApp::implementation
             AgentRebind,
             Rebuild,
         };
+        enum class AgentPaneSettingsRebindDisposition
+        {
+            Rebind,
+            RecreateStashed,
+        };
         std::string _settingsReloadRequestId;
         std::optional<std::string> _pendingAgentRebuildRequestId;
         uint64_t _agentSettingsRebindGeneration{ 0 };
@@ -543,6 +548,8 @@ namespace winrt::TerminalApp::implementation
             AgentSettingsChangeKind changeKind,
             bool canHostPane,
             bool masterConfigurationChanged) noexcept;
+        static AgentPaneSettingsRebindDisposition _ClassifyAgentPaneSettingsRebind(
+            winrt::Microsoft::Terminal::TerminalConnection::ConnectionState connectionState) noexcept;
         static bool _AgentSettingsChanged(const AgentSettingsSnapshot& a, const AgentSettingsSnapshot& b);
         AgentRuntimeConfigSnapshot _CaptureAgentRuntimeConfig() const;
         // Diffs the hot-updatable runtime config against the last snapshot

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -433,11 +433,10 @@ namespace winrt::TerminalApp::implementation
         // changes rebind the existing helper in place; changes that alter
         // trusted master launch state keep the destructive rebuild path.
         //
-        // Agent identity changes (global acpAgent/acpCustomCommand, the
-        // effective model selection, or an effective per-profile backend)
-        // rebuild affected helpers. Model changes force a master respawn so
-        // the agent CLI starts with a clean model-provider environment;
-        // unselected provider catalog changes are hot-updated.
+        // Built-in agent and model binding changes rebind affected helpers.
+        // Native models with a live ACP switch path update the current session
+        // directly. Trusted custom commands and profile backend changes retain
+        // the destructive path.
         struct AgentSettingsSnapshot
         {
             std::wstring acpAgent;
@@ -451,6 +450,7 @@ namespace winrt::TerminalApp::implementation
         enum class AgentSettingsChangeKind
         {
             None,
+            ModelHotUpdate,
             AgentRebind,
             Rebuild,
         };
@@ -462,12 +462,14 @@ namespace winrt::TerminalApp::implementation
         // push a single consolidated `agent_config_changed` event to the
         // running wta-helper(s) so they update in place — no agent-pane
         // teardown/restart. This is the unified dispatch point for every
-        // agent setting that can be hot-reloaded (autofix gate, delegate
-        // agent/model, credential-free model catalogs).
+        // agent setting that can be hot-reloaded (ACP model, autofix gate,
+        // delegate agent/model, credential-free model catalogs).
         // `delegateAgent` holds the resolved effective value (custom-command
         // ids already expanded).
         struct AgentRuntimeConfigSnapshot
         {
+            std::wstring acpAgent;
+            std::wstring acpModel;
             std::wstring delegateAgent;
             std::wstring delegateModel;
             std::wstring customModelSelection;

--- a/src/cascadia/TerminalApp/TerminalPage.idl
+++ b/src/cascadia/TerminalApp/TerminalPage.idl
@@ -165,7 +165,8 @@ namespace TerminalApp
 
         // Inbound event from `/agent` carrying
         // {method:"switch_agent",params:{window_id,tab_id,agent_id}}.
-        // Applies a runtime override and rebuilds only the target tab.
+        // Applies a runtime override and rebinds the target tab's helper when
+        // the execution source is unchanged.
         void OnAgentSwitchRequested(String eventJson);
 
         // Inbound event from WTA carrying {method:"close_agent_pane",params:{...}}.

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -24,6 +24,7 @@
 #include "NewTabMenuViewModel.h"
 #include "NewTabMenu.h"
 #include "NavConstants.h"
+#include "..\inc\AgentAvailability.h"
 #include "..\types\inc\utils.hpp"
 #include <..\WinRTUtils\inc\Utils.h>
 
@@ -157,10 +158,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 contentFrame().Navigate(xaml_typename<Editor::Extensions>(), winrt::make<NavigateToPageArgs>(_extensionsVM, *this));
             }
         });
-
         // Make sure to initialize the profiles _after_ we have initialized the color schemes page VM, because we pass
         // that VM into the appearance VMs within the profiles
         _InitializeProfilesList();
+        _ProbeHostAgentAvailabilityAsync();
 
         // Apply icons and tooltips (GH#19688, long names may be truncated) to static nav items
         for (const auto& item : SettingsNav().MenuItems())
@@ -680,6 +681,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 if (!_profileDefaultsVM)
                 {
                     _profileDefaultsVM = _viewModelForProfile(_settingsClone.ProfileDefaults(), _settingsClone, Dispatcher());
+                    _ApplyHostAgentAvailability(_profileDefaultsVM);
                     _profileDefaultsVM.SetupAppearances(_colorSchemesPageVM.AllColorSchemes());
                     _profileDefaultsVM.IsBaseLayer(true);
                 }
@@ -958,6 +960,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             if (!profile.Deleted())
             {
                 auto profileVM = _viewModelForProfile(profile, _settingsClone, Dispatcher());
+                _ApplyHostAgentAvailability(profileVM);
                 profileVM.SetupAppearances(_colorSchemesPageVM.AllColorSchemes());
                 auto navItem = _CreateProfileNavViewItem(profileVM);
                 _menuItemSource.Append(navItem);
@@ -1016,6 +1019,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         const auto newProfile{ profile ? profile : _settingsClone.CreateNewProfile() };
         const auto profileViewModel{ _viewModelForProfile(newProfile, _settingsClone, Dispatcher()) };
+        _ApplyHostAgentAvailability(profileViewModel);
         profileViewModel.SetupAppearances(_colorSchemesPageVM.AllColorSchemes());
         const auto navItem{ _CreateProfileNavViewItem(profileViewModel) };
 
@@ -1085,6 +1089,34 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _profileVMs.Append(profile);
 
         return profileNavItem;
+    }
+
+    void MainPage::_ApplyHostAgentAvailability(const Editor::ProfileViewModel& profile)
+    {
+        winrt::get_self<implementation::ProfileViewModel>(profile)->SetAvailableHostAgents(_availableHostAgents);
+    }
+
+    safe_void_coroutine MainPage::_ProbeHostAgentAvailabilityAsync()
+    {
+        const auto dispatcher = Dispatcher();
+        auto weakThis = get_weak();
+        co_await winrt::resume_background();
+
+        auto availableHostAgents = ::Microsoft::Terminal::AgentAvailability::ProbeHostAgentIds();
+
+        co_await wil::resume_foreground(dispatcher);
+        if (auto strongThis = weakThis.get())
+        {
+            strongThis->_availableHostAgents = std::move(availableHostAgents);
+            for (const auto& profile : strongThis->_profileVMs)
+            {
+                strongThis->_ApplyHostAgentAvailability(profile);
+            }
+            if (strongThis->_profileDefaultsVM)
+            {
+                strongThis->_ApplyHostAgentAvailability(strongThis->_profileDefaultsVM);
+            }
+        }
     }
 
     void MainPage::_DeleteProfile(const IInspectable /*sender*/, const Editor::DeleteProfileEventArgs& args)

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -9,6 +9,8 @@
 #include "Utils.h"
 #include "SearchIndex.h"
 
+#include <unordered_set>
+
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
     struct Breadcrumb : BreadcrumbT<Breadcrumb>
@@ -108,6 +110,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void _UpdateBackgroundForMica();
         void _MoveXamlParsedNavItemsIntoItemSource();
+        void _ApplyHostAgentAvailability(const Editor::ProfileViewModel& profile);
+        safe_void_coroutine _ProbeHostAgentAvailabilityAsync();
 
         safe_void_coroutine _UpdateSearchIndex();
 
@@ -125,6 +129,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _actionsViewModelChangedRevoker;
         Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _ntmViewModelChangedRevoker;
         Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _extensionsViewModelChangedRevoker;
+
+        std::unordered_set<std::wstring> _availableHostAgents;
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -10,7 +10,6 @@
 
 #include "../WinRTUtils/inc/Utils.h"
 #include "../inc/AgentPaneBackend.h"
-#include "../inc/AgentAvailability.h"
 #include "../inc/AgentRegistry.h"
 #include "../inc/ShellIntegrationProfileGate.h"
 #include "../inc/WslShellIntegration.h"
@@ -60,13 +59,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const Windows::Foundation::Collections::IObservableVector<Editor::AgentEntry>& list,
         const std::wstring_view globalId,
         const std::wstring_view selected,
+        const std::unordered_set<std::wstring>& availableHostAgents,
         const std::wstring_view wslDistro,
         const std::vector<std::wstring>& availableWslAgents,
         const std::vector<::Microsoft::Terminal::Settings::Model::AgentRegistry::BuiltinAgent>& allowedAgents)
     {
         namespace Backend = ::Microsoft::Terminal::Settings::Model;
 
-        const auto availableHostAgents = ::Microsoft::Terminal::AgentAvailability::ProbeHostAgentIds();
         std::vector<Editor::AgentEntry> entries;
         const auto globalEntry = winrt::make<implementation::AgentEntry>(
             L"",
@@ -357,9 +356,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
     }
 
-    void ProfileViewModel::_RebuildAgentBackendLists(
-        const std::wstring_view wslDistro,
-        const std::vector<std::wstring>& availableWslAgents)
+    void ProfileViewModel::SetAvailableHostAgents(const std::unordered_set<std::wstring>& availableHostAgents)
+    {
+        _availableHostAgents = availableHostAgents;
+        _RebuildAgentBackendLists();
+    }
+
+    void ProfileViewModel::_RebuildAgentBackendLists()
     {
         namespace Registry = ::Microsoft::Terminal::Settings::Model::AgentRegistry;
         const auto& globals = _appSettings.GlobalSettings();
@@ -367,15 +370,17 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             _agentPaneBackendList,
             std::wstring_view{ globals.EffectiveAcpAgent() },
             std::wstring_view{ AgentPaneBackend() },
-            wslDistro,
-            availableWslAgents,
+            _availableHostAgents,
+            _availableWslDistro,
+            _availableWslAgents,
             Registry::FilteredAcpAgents());
         _RebuildAgentBackendList(
             _commandPaletteAgentList,
             std::wstring_view{ globals.EffectiveDelegateAgent() },
             std::wstring_view{ CommandPaletteAgent() },
-            wslDistro,
-            availableWslAgents,
+            _availableHostAgents,
+            _availableWslDistro,
+            _availableWslAgents,
             Registry::FilteredDelegateAgents());
         _NotifyChanges(
             L"AgentPaneBackendList",
@@ -390,12 +395,16 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const auto commandline = std::wstring{ Commandline() };
         if (::Microsoft::Terminal::ShellIntegration::IsWslProfile(commandline))
         {
-            _RebuildAgentBackendLists(L"WSL", {});
+            _availableWslDistro = L"WSL";
+            _availableWslAgents.clear();
+            _RebuildAgentBackendLists();
             _ProbeWslAgentPaneBackendsAsync(commandline, generation);
         }
         else
         {
-            _RebuildAgentBackendLists({}, {});
+            _availableWslDistro.clear();
+            _availableWslAgents.clear();
+            _RebuildAgentBackendLists();
         }
     }
 
@@ -452,7 +461,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         co_await wil::resume_foreground(dispatcher);
         if (generation == _agentPaneBackendProbeGeneration)
         {
-            _RebuildAgentBackendLists(distro, availableAgents);
+            _availableWslDistro = std::move(distro);
+            _availableWslAgents = std::move(availableAgents);
+            _RebuildAgentBackendLists();
         }
     }
 

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -10,6 +10,8 @@
 #include "Utils.h"
 #include "ViewModelHelpers.h"
 
+#include <unordered_set>
+
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
     struct BellSoundViewModel : BellSoundViewModelT<BellSoundViewModel>, ViewModelHelper<BellSoundViewModel>
@@ -91,6 +93,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Windows::Foundation::Collections::IObservableVector<Editor::AgentEntry> CommandPaletteAgentList() const noexcept { return _commandPaletteAgentList; }
         Editor::AgentEntry CurrentCommandPaletteAgent();
         void CurrentCommandPaletteAgent(const Editor::AgentEntry& value);
+        void SetAvailableHostAgents(const std::unordered_set<std::wstring>& availableHostAgents);
 
         // general profile knowledge
         winrt::guid OriginalProfileGuid() const noexcept;
@@ -174,6 +177,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Windows::UI::Core::CoreDispatcher _dispatcher;
         Windows::Foundation::Collections::IObservableVector<Editor::AgentEntry> _agentPaneBackendList;
         Windows::Foundation::Collections::IObservableVector<Editor::AgentEntry> _commandPaletteAgentList;
+        std::unordered_set<std::wstring> _availableHostAgents;
+        std::wstring _availableWslDistro;
+        std::vector<std::wstring> _availableWslAgents;
         uint64_t _agentPaneBackendProbeGeneration{ 0 };
 
         winrt::Windows::UI::Xaml::Thickness _parsedPadding;
@@ -181,8 +187,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void _InitializeCurrentBellSounds();
         void _PrepareModelForBellSoundModification();
         void _MarkDuplicateBellSoundDirectories();
-        void _RebuildAgentBackendLists(std::wstring_view wslDistro,
-                                       const std::vector<std::wstring>& availableWslAgents);
+        void _RebuildAgentBackendLists();
         void _RefreshAgentPaneBackendList();
         winrt::fire_and_forget _ProbeWslAgentPaneBackendsAsync(std::wstring commandline,
                                                                uint64_t generation);

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -334,15 +334,20 @@ void AppHost::Close()
 
     _window->Close();
 
-    if (_windowLogic)
+    winrt::TerminalApp::TerminalWindow logic{ nullptr };
     {
-        _windowLogic.DismissDialog();
-        _windowLogic = nullptr;
+        std::lock_guard lock{ _stateMutex };
+        logic = std::exchange(_windowLogic, nullptr);
+    }
+    if (logic)
+    {
+        logic.DismissDialog();
     }
 }
 
 int64_t AppHost::GetLastActivatedTime() const noexcept
 {
+    std::lock_guard lock{ _stateMutex };
     return _lastActivatedTime.QuadPart;
 }
 
@@ -876,7 +881,12 @@ void AppHost::_WindowActivated(bool activated)
 
     if (activated)
     {
-        QueryPerformanceCounter(&_lastActivatedTime);
+        LARGE_INTEGER activatedTime;
+        QueryPerformanceCounter(&activatedTime);
+        {
+            std::lock_guard lock{ _stateMutex };
+            _lastActivatedTime = activatedTime;
+        }
         _virtualDesktopId = {};
     }
 }
@@ -1325,6 +1335,7 @@ safe_void_coroutine AppHost::_WindowInitializedHandler(const winrt::Windows::Fou
 
 winrt::TerminalApp::TerminalWindow AppHost::Logic()
 {
+    std::lock_guard lock{ _stateMutex };
     return _windowLogic;
 }
 

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -6,6 +6,7 @@
 #include "pch.h"
 #include "NonClientIslandWindow.h"
 #include <ThrottledFunc.h>
+#include <mutex>
 
 class WindowEmperor;
 
@@ -38,6 +39,7 @@ private:
     WindowEmperor* _windowManager = nullptr;
     std::unique_ptr<IslandWindow> _window;
     winrt::TerminalApp::AppLogic _appLogic{ nullptr };
+    mutable std::mutex _stateMutex;
     winrt::TerminalApp::TerminalWindow _windowLogic{ nullptr };
     std::shared_ptr<ThrottledFunc<bool>> _showHideWindowThrottler;
     SafeDispatcherTimer _frameTimer;

--- a/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
+++ b/src/cascadia/WindowsTerminal/TerminalProtocolComServer.cpp
@@ -174,6 +174,21 @@ static winrt::TerminalApp::TerminalPage _getPage(AppHost* host)
     return root.try_as<winrt::TerminalApp::TerminalPage>();
 }
 
+static std::shared_ptr<AppHost> _getMostRecentHost(const std::vector<std::shared_ptr<AppHost>>& windows) noexcept
+{
+    int64_t latest = INT64_MIN;
+    std::shared_ptr<AppHost> result;
+    for (const auto& host : windows)
+    {
+        if (const auto activated = host->GetLastActivatedTime(); activated > latest)
+        {
+            latest = activated;
+            result = host;
+        }
+    }
+    return result;
+}
+
 // Parse a JSON string into Json::Value
 static bool _parseJson(const std::string& str, Json::Value& out)
 {
@@ -544,10 +559,11 @@ try
     *json = nullptr;
     RETURN_HR_IF(E_NOT_VALID_STATE, !s_emperor);
 
-    const auto host = s_emperor->GetMostRecentWindow();
+    const auto windows = s_emperor->GetWindows();
+    const auto host = _getMostRecentHost(windows);
     RETURN_HR_IF(E_FAIL, !host);
 
-    const auto page = _getPage(host);
+    const auto page = _getPage(host.get());
     RETURN_HR_IF(E_FAIL, !page);
 
     auto info = page.GetProtocolActivePane().get();
@@ -569,10 +585,11 @@ try
     *json = nullptr;
     RETURN_HR_IF(E_NOT_VALID_STATE, !s_emperor);
 
-    const auto mostRecent = s_emperor->GetMostRecentWindow();
+    const auto windows = s_emperor->GetWindows();
+    const auto mostRecent = _getMostRecentHost(windows);
     Json::Value arr(Json::arrayValue);
 
-    for (const auto& host : s_emperor->GetWindows())
+    for (const auto& host : windows)
     {
         const auto logic = host->Logic();
         if (!logic)
@@ -583,7 +600,7 @@ try
         Protocol::WindowInfo info{};
         info.WindowId = props.WindowId();
         info.Title = props.WindowNameForDisplay();
-        info.IsFocused = (host.get() == mostRecent);
+        info.IsFocused = (host == mostRecent);
         info.TabCount = logic.TabCount();
         arr.append(_toJson(info));
     }
@@ -779,19 +796,30 @@ try
     *json = nullptr;
     RETURN_HR_IF(E_NOT_VALID_STATE, !s_emperor);
 
-    // Find target window.
-    AppHost* targetHost = nullptr;
+    // Hold a strong snapshot while resolving and dispatching to the target.
+    // A drag can add or remove WindowEmperor entries concurrently with this
+    // COM MTA call.
+    const auto windows = s_emperor->GetWindows();
+    std::shared_ptr<AppHost> targetHost;
     if (windowId != 0)
     {
-        targetHost = s_emperor->GetWindowById(windowId);
+        for (const auto& host : windows)
+        {
+            const auto logic = host->Logic();
+            if (logic && logic.WindowProperties().WindowId() == windowId)
+            {
+                targetHost = host;
+                break;
+            }
+        }
     }
     else
     {
-        targetHost = s_emperor->GetMostRecentWindow();
+        targetHost = _getMostRecentHost(windows);
     }
     RETURN_HR_IF(E_FAIL, !targetHost);
 
-    const auto page = _getPage(targetHost);
+    const auto page = _getPage(targetHost.get());
     RETURN_HR_IF(E_FAIL, !page);
 
     // Build NewTerminalArgs.

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -230,6 +230,12 @@ HWND WindowEmperor::GetMainWindow() const noexcept
     return _window.get();
 }
 
+std::vector<std::shared_ptr<::AppHost>> WindowEmperor::GetWindows() const
+{
+    std::lock_guard lock{ _windowsMutex };
+    return _windows;
+}
+
 AppHost* WindowEmperor::GetWindowById(uint64_t id) const noexcept
 {
     _assertIsMainThread();
@@ -282,14 +288,18 @@ void WindowEmperor::CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs args
     host->Initialize();
 
     _windowCount += 1;
-    _windows.emplace_back(std::move(host));
+    auto* const addedHost = host.get();
+    {
+        std::lock_guard lock{ _windowsMutex };
+        _windows.emplace_back(std::move(host));
+    }
 
     // Wire the new window's TerminalPage::ProtocolVtSequenceReceived
     // into the COM fan-out so events emitted by panes in this window
     // (agent-pane attach_pane / detach_pane, autofix OSC 133;D, etc.)
     // actually reach connected wta clients. Without this, only the
     // first-opened window's events propagate.
-    TerminalProtocolComServer::s_OnWindowAdded(_windows.back().get());
+    TerminalProtocolComServer::s_OnWindowAdded(addedHost);
 
     if (_windowCount == 1)
     {
@@ -1187,7 +1197,10 @@ LRESULT WindowEmperor::_messageHandler(HWND window, UINT const message, WPARAM c
                         }
                         CATCH_LOG();
 
-                        _windows.erase(it);
+                        {
+                            std::lock_guard lock{ _windowsMutex };
+                            _windows.erase(it);
+                        }
                         try
                         {
                             strong->Close();

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -17,6 +17,8 @@ Abstract:
 
 #pragma once
 
+#include <mutex>
+
 class AppHost;
 struct TerminalProtocolComServer;
 
@@ -57,7 +59,7 @@ public:
 
     // Protocol server access
     const std::wstring& GetComClsid() const noexcept { return _comClsid; }
-    const std::vector<std::shared_ptr<::AppHost>>& GetWindows() const noexcept { return _windows; }
+    std::vector<std::shared_ptr<::AppHost>> GetWindows() const;
     AppHost* GetMostRecentWindow() const noexcept { return _mostRecentWindow(); }
 
 private:
@@ -97,6 +99,7 @@ private:
 
     wil::unique_hwnd _window;
     winrt::TerminalApp::App _app{ nullptr };
+    mutable std::mutex _windowsMutex;
     std::vector<std::shared_ptr<::AppHost>> _windows;
 
     // Protocol server for AI CLI integration

--- a/src/cascadia/inc/AgentRegistry.h
+++ b/src/cascadia/inc/AgentRegistry.h
@@ -84,6 +84,14 @@ namespace Microsoft::Terminal::Settings::Model::AgentRegistry
         return GetByokMode(agentId) != ByokMode::Unsupported;
     }
 
+    inline constexpr bool SupportsLiveModelSwitch(const std::wstring_view agentId) noexcept
+    {
+        // Gemini accepts --model at process launch but its ACP server does not
+        // implement either model-switch request. Rebind its helper connection
+        // so the master can select a CLI launched with the new model.
+        return agentId != L"gemini";
+    }
+
     // Return only agents whose IDs are permitted by GPO policy.
     // When AllowedAgents is not configured, returns all agents.
     // Consumers should always use these instead of iterating the raw arrays.

--- a/src/cascadia/inc/AgentRegistry.h
+++ b/src/cascadia/inc/AgentRegistry.h
@@ -84,12 +84,38 @@ namespace Microsoft::Terminal::Settings::Model::AgentRegistry
         return GetByokMode(agentId) != ByokMode::Unsupported;
     }
 
+    inline constexpr bool AgentIdEquals(const std::wstring_view lhs, const std::wstring_view rhs) noexcept
+    {
+        if (lhs.size() != rhs.size())
+        {
+            return false;
+        }
+
+        for (size_t i = 0; i < lhs.size(); ++i)
+        {
+            const auto lower = [](const wchar_t ch) {
+                return ch >= L'A' && ch <= L'Z' ? ch + (L'a' - L'A') : ch;
+            };
+            if (lower(lhs[i]) != lower(rhs[i]))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
     inline constexpr bool SupportsLiveModelSwitch(const std::wstring_view agentId) noexcept
     {
-        // Gemini accepts --model at process launch but its ACP server does not
-        // implement either model-switch request. Rebind its helper connection
-        // so the master can select a CLI launched with the new model.
-        return agentId != L"gemini";
+        for (const auto& agent : BuiltinAcpAgents)
+        {
+            if (AgentIdEquals(agent.id, agentId))
+            {
+                // Gemini accepts --model at process launch but its ACP server
+                // does not implement either model-switch request.
+                return agent.id != L"gemini";
+            }
+        }
+        return false;
     }
 
     // Return only agents whose IDs are permitted by GPO policy.

--- a/src/cascadia/ut_app/AcpModelUtilsTests.cpp
+++ b/src/cascadia/ut_app/AcpModelUtilsTests.cpp
@@ -20,6 +20,7 @@ namespace TerminalAppUnitTests
         TEST_METHOD(AppendsSupportedModelFlags);
         TEST_METHOD(SuppressesCustomSelectionModelFlags);
         TEST_METHOD(CustomProvidersSupportOnlyChatCompletionsAgents);
+        TEST_METHOD(LiveModelSwitchRequiresKnownSupportedAgent);
         TEST_METHOD(HostCatalogStatusRejectsSameAgentFromWsl);
         TEST_METHOD(RejectsInvalidCatalogShapes);
         TEST_METHOD(ParsesAndNormalizesCatalog);
@@ -66,6 +67,22 @@ namespace TerminalAppUnitTests
         VERIFY_IS_FALSE(Registry::SupportsByok(L"claude"));
         VERIFY_IS_FALSE(Registry::SupportsByok(L"codex"));
         VERIFY_IS_FALSE(Registry::SupportsByok(L"gemini"));
+    }
+
+    void AcpModelUtilsTests::LiveModelSwitchRequiresKnownSupportedAgent()
+    {
+        namespace Registry = Microsoft::Terminal::Settings::Model::AgentRegistry;
+        for (const auto agent : { L"copilot", L"claude", L"codex", L"opencode" })
+        {
+            VERIFY_IS_TRUE(Registry::SupportsLiveModelSwitch(agent));
+        }
+        for (const auto agent : { L"gemini", L"custom:test", L"unknown", L"" })
+        {
+            VERIFY_IS_FALSE(Registry::SupportsLiveModelSwitch(agent));
+        }
+
+        VERIFY_IS_TRUE(Registry::SupportsLiveModelSwitch(L"CoPiLoT"));
+        VERIFY_IS_FALSE(Registry::SupportsLiveModelSwitch(L"GeMiNi"));
     }
 
     void AcpModelUtilsTests::HostCatalogStatusRejectsSameAgentFromWsl()

--- a/src/cascadia/ut_app/SharedWtaTests.cpp
+++ b/src/cascadia/ut_app/SharedWtaTests.cpp
@@ -551,7 +551,7 @@ namespace TerminalAppUnitTests
     {
         details::TabRetirementTracker tracker;
 
-        VERIFY_IS_TRUE(tracker.BeginRebuild("tab-1"));
+        VERIFY_IS_TRUE(tracker.BeginRecreation("tab-1"));
         VERIFY_IS_FALSE(tracker.RequestClose("tab-1"));
         VERIFY_IS_FALSE(tracker.Complete("tab-1"));
     }

--- a/src/cascadia/ut_app/SharedWtaTests.cpp
+++ b/src/cascadia/ut_app/SharedWtaTests.cpp
@@ -127,6 +127,10 @@ namespace TerminalAppUnitTests
         TEST_METHOD(RestartFailsWhenForcedProcessReapTimesOut);
         TEST_METHOD(StaleWaitCallbackCannotClaimReplacementWithReusedPid);
         TEST_METHOD(RetiredWaitCallbackCannotClaimAfterCleanup);
+        TEST_METHOD(CurrentUnexpectedExitWithRetainedRefsRespawnsOnce);
+        TEST_METHOD(UnexpectedExitWithoutRecoveryConditionsDoesNotRespawn);
+        TEST_METHOD(DeliberateOrStaleExitDoesNotRespawn);
+        TEST_METHOD(RecoveryReplacementExitDoesNotLoop);
         TEST_METHOD(AllScopeRetirementJoinsSameRequest);
         TEST_METHOD(LiveSettingsObjectSharesGeneration);
         TEST_METHOD(LaterSettingsObjectGetsNewGenerationAfterValueReuse);
@@ -374,6 +378,53 @@ namespace TerminalAppUnitTests
         VERIFY_ARE_EQUAL(details::ProcessWaitGenerationTracker::Generation{ 0 }, tracker.Current());
     }
 
+    void SharedWtaTests::CurrentUnexpectedExitWithRetainedRefsRespawnsOnce()
+    {
+        details::UnexpectedExitRecoveryPolicy policy;
+        policy.Arm(7);
+
+        VERIFY_IS_TRUE(policy.ShouldRespawn(7, 2, false, true));
+        VERIFY_IS_FALSE(policy.ShouldRespawn(7, 2, false, true));
+    }
+
+    void SharedWtaTests::UnexpectedExitWithoutRecoveryConditionsDoesNotRespawn()
+    {
+        details::UnexpectedExitRecoveryPolicy policy;
+        policy.Arm(7);
+        VERIFY_IS_FALSE(policy.ShouldRespawn(7, 0, false, true));
+
+        policy.Arm(8);
+        VERIFY_IS_FALSE(policy.ShouldRespawn(8, 1, true, true));
+
+        policy.Arm(9);
+        VERIFY_IS_FALSE(policy.ShouldRespawn(9, 1, false, false));
+    }
+
+    void SharedWtaTests::DeliberateOrStaleExitDoesNotRespawn()
+    {
+        details::UnexpectedExitRecoveryPolicy policy;
+        policy.Arm(7);
+
+        VERIFY_IS_FALSE(policy.ShouldRespawn(6, 1, false, true));
+        VERIFY_IS_TRUE(policy.ShouldRespawn(7, 1, false, true));
+
+        policy.Arm(8);
+        policy.Retire();
+        VERIFY_IS_FALSE(policy.ShouldRespawn(8, 1, false, true));
+    }
+
+    void SharedWtaTests::RecoveryReplacementExitDoesNotLoop()
+    {
+        details::UnexpectedExitRecoveryPolicy policy;
+        policy.Arm(7);
+
+        VERIFY_IS_TRUE(policy.ShouldRespawn(7, 1, false, true));
+        VERIFY_IS_FALSE(policy.ShouldRespawn(8, 1, false, true));
+
+        policy.Arm(9);
+        VERIFY_IS_TRUE(policy.ShouldRespawn(9, 1, false, true));
+    }
+
     void SharedWtaTests::AllScopeRetirementJoinsSameRequest()
     {
         details::RetirementCoordinator coordinator;
@@ -576,7 +627,15 @@ namespace TerminalAppUnitTests
         pending.Queue("restart-1");
         pending.Queue("restart-2");
         VERIFY_IS_TRUE(pending.Pending());
-        pending.Clear();
+
+        std::vector<std::string> restarted;
+        if (const auto pendingRestart = pending.Take())
+        {
+            restarted.emplace_back(*pendingRestart);
+        }
+
+        VERIFY_ARE_EQUAL(static_cast<size_t>(1), restarted.size());
+        VERIFY_ARE_EQUAL(std::string{ "restart-2" }, restarted.front());
         VERIFY_IS_FALSE(pending.Pending());
         VERIFY_IS_FALSE(pending.Take().has_value());
     }

--- a/src/tools/wtcli/main.cpp
+++ b/src/tools/wtcli/main.cpp
@@ -471,6 +471,22 @@ int wmain(int argc, wchar_t** argv)
         }
     });
 
+    // ── get-settings ──
+    auto* getSettingsCmd = app.add_subcommand("get-settings", "Read the current Terminal settings");
+    getSettingsCmd->callback([&]() {
+        auto server = connect();
+        if (!server) return;
+        Json::Value settings;
+        const auto hr = CallJson([&](BSTR* j) { return server->GetSettings(j); }, settings);
+        if (FAILED(hr))
+        {
+            fprintf(stderr, "GetSettings failed: 0x%08X\n", static_cast<uint32_t>(hr));
+            exitCode = 1;
+            return;
+        }
+        PrintJson(settings);
+    });
+
     // ── active-pane ──
     auto* activePaneCmd = app.add_subcommand("active-pane", "Show the currently active pane");
     activePaneCmd->callback([&]() {

--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -302,6 +302,12 @@ pub fn is_known_id(id: &str) -> bool {
     KNOWN_AGENTS.iter().any(|p| p.id == id)
 }
 
+/// Whether a running ACP session can accept model changes without replacing
+/// its agent process. Gemini currently accepts `--model` only at launch.
+pub fn supports_live_model_switch(id: &str) -> bool {
+    !id.eq_ignore_ascii_case(GEMINI_AGENT_ID)
+}
+
 /// Resolve a full agent command line (e.g. the value of `--agent`) into the
 /// canonical agent id known to [`KNOWN_AGENTS`] — `"copilot"`, `"claude"`,
 /// `"codex"`, `"gemini"`, `"opencode"` — or `"unknown"` if nothing matches.
@@ -552,6 +558,17 @@ mod tests {
                 lookup_profile_by_id(agent).byok_mode,
                 ByokMode::Unsupported,
                 "{agent} must not receive shared BYOK configuration"
+            );
+        }
+    }
+
+    #[test]
+    fn live_model_switch_capability_matches_agent_transport() {
+        assert!(!supports_live_model_switch("gemini"));
+        for agent in ["copilot", "claude", "codex", "opencode"] {
+            assert!(
+                supports_live_model_switch(agent),
+                "{agent} should keep its live ACP session when the model changes"
             );
         }
     }

--- a/tools/wta/src/agent_registry.rs
+++ b/tools/wta/src/agent_registry.rs
@@ -305,7 +305,8 @@ pub fn is_known_id(id: &str) -> bool {
 /// Whether a running ACP session can accept model changes without replacing
 /// its agent process. Gemini currently accepts `--model` only at launch.
 pub fn supports_live_model_switch(id: &str) -> bool {
-    !id.eq_ignore_ascii_case(GEMINI_AGENT_ID)
+    let canonical_id = id.to_ascii_lowercase();
+    is_known_id(&canonical_id) && canonical_id != GEMINI_AGENT_ID
 }
 
 /// Resolve a full agent command line (e.g. the value of `--agent`) into the
@@ -564,13 +565,21 @@ mod tests {
 
     #[test]
     fn live_model_switch_capability_matches_agent_transport() {
-        assert!(!supports_live_model_switch("gemini"));
         for agent in ["copilot", "claude", "codex", "opencode"] {
             assert!(
                 supports_live_model_switch(agent),
                 "{agent} should keep its live ACP session when the model changes"
             );
         }
+        for agent in ["gemini", "custom:test", "unknown", ""] {
+            assert!(
+                !supports_live_model_switch(agent),
+                "{agent:?} must not receive live ACP model changes"
+            );
+        }
+
+        assert!(supports_live_model_switch("CoPiLoT"));
+        assert!(!supports_live_model_switch("GeMiNi"));
     }
 
     #[test]

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -25,7 +25,8 @@ struct DeferredAcpParams {
         Option<mpsc::UnboundedReceiver<crate::protocol::acp::client::DropSessionRequest>>,
     rename_session_rx:
         Option<mpsc::UnboundedReceiver<crate::protocol::acp::client::RenameSessionRequest>>,
-    restart_rx: Option<mpsc::UnboundedReceiver<crate::protocol::acp::client::RestartRequest>>,
+    restart_rx:
+        Option<mpsc::UnboundedReceiver<crate::protocol::acp::client::AgentLifecycleRequest>>,
     master_ext_rx: Option<mpsc::UnboundedReceiver<crate::protocol::acp::client::MasterExtRequest>>,
     shell_mgr: Arc<crate::shell::ShellManager>,
     wt_connected: bool,
@@ -39,6 +40,22 @@ struct DeferredAcpParams {
     /// Owner tab id for pipe-mode reconnect (mirrors the original
     /// `--owner-tab-id` CLI arg).
     owner_tab_id: Option<String>,
+}
+
+#[derive(Debug, Default)]
+enum AgentReconnectState {
+    #[default]
+    Idle,
+    Disconnecting(AgentReconnectRequest),
+    Preflighting(AgentReconnectRequest),
+}
+
+#[derive(Debug, Default)]
+enum AuthRecoveryState {
+    #[default]
+    Idle,
+    WaitingForMaster { request_id: String },
+    Connecting,
 }
 
 fn agent_command_on_enter(input: &str, selected: Option<&AvailableAgent>) -> Option<ParsedCommand> {
@@ -118,7 +135,7 @@ use crate::pane_context::PaneContext;
 
 use crate::protocol::acp::client::{
     AgentReconnectRequest, CancelRequest, DropSessionRequest, LoadSessionForTab, NewSessionForTab,
-    PromptSubmission, RenameSessionRequest, RestartRequest,
+    AgentLifecycleRequest, PromptSubmission, RenameSessionRequest,
 };
 use crate::protocol::acp::turn_metrics::prompt_timing_log;
 use crate::ui;
@@ -979,6 +996,9 @@ pub struct App {
     /// succeeded) cannot force the sign-in screen onto a later, unrelated
     /// `Connecting` state.
     auth_recovery_generation: u64,
+    /// Synchronizes a failed post-login ACP task with replacement-master
+    /// readiness without letting a late disconnect start a duplicate client.
+    auth_recovery_state: AuthRecoveryState,
     /// Agent ID selected by user (FRE/preflight) — sent to C++ once connected.
     pending_agent_selection: Option<String>,
     /// Show first-run welcome hint until user sends first message.
@@ -987,13 +1007,12 @@ pub struct App {
     pub state: ConnectionState,
     /// The agent ID we're trying to connect to (set at preflight/FRE time).
     pub current_agent_id: String,
-    /// Highest host-issued Settings rebind generation observed by this helper.
+    /// Highest host-issued rebind generation observed by this helper.
     last_agent_rebind_generation: u64,
     last_agent_rebind_window_id: Option<String>,
-    /// Latest accepted target while the current ACP transport is unwinding.
-    pending_agent_reconnect: Option<AgentReconnectRequest>,
-    agent_reconnect_disconnect_pending: bool,
-    agent_reconnect_preflight_pending: bool,
+    /// Controlled same-helper transition from the old ACP transport to the
+    /// latest accepted Agent binding.
+    agent_reconnect_state: AgentReconnectState,
     suppress_next_failed_client_error: bool,
     /// Execution source paired with `current_agent_id`.
     pub current_agent_source: crate::agent_source::AgentSource,
@@ -1043,7 +1062,7 @@ pub struct App {
     load_session_tx: mpsc::UnboundedSender<LoadSessionForTab>,
     drop_session_tx: mpsc::UnboundedSender<DropSessionRequest>,
     rename_session_tx: mpsc::UnboundedSender<RenameSessionRequest>,
-    restart_tx: mpsc::UnboundedSender<RestartRequest>,
+    restart_tx: mpsc::UnboundedSender<AgentLifecycleRequest>,
     master_request_tx: mpsc::UnboundedSender<crate::protocol::acp::client::MasterExtRequest>,
     debug_capture_enabled: Arc<AtomicBool>,
     /// Cached for creating DeferredAcpParams after auth-error recovery.
@@ -1302,7 +1321,7 @@ impl App {
         load_session_tx: mpsc::UnboundedSender<LoadSessionForTab>,
         drop_session_tx: mpsc::UnboundedSender<DropSessionRequest>,
         rename_session_tx: mpsc::UnboundedSender<RenameSessionRequest>,
-        restart_tx: mpsc::UnboundedSender<RestartRequest>,
+        restart_tx: mpsc::UnboundedSender<AgentLifecycleRequest>,
         master_request_tx: mpsc::UnboundedSender<crate::protocol::acp::client::MasterExtRequest>,
         debug_capture_enabled: Arc<AtomicBool>,
         wt_connected: bool,
@@ -1319,6 +1338,7 @@ impl App {
             pending_acp_start: false,
             needs_post_login_authenticate: false,
             auth_recovery_generation: 0,
+            auth_recovery_state: AuthRecoveryState::Idle,
             pending_agent_selection: None,
             show_welcome_hint: false,
             deferred_acp: None,
@@ -1326,9 +1346,7 @@ impl App {
             current_agent_id: String::new(),
             last_agent_rebind_generation: 0,
             last_agent_rebind_window_id: None,
-            pending_agent_reconnect: None,
-            agent_reconnect_disconnect_pending: false,
-            agent_reconnect_preflight_pending: false,
+            agent_reconnect_state: AgentReconnectState::Idle,
             suppress_next_failed_client_error: false,
             current_agent_source: crate::agent_source::AgentSource::Host,
             allowed_agent_ids: Vec::new(),
@@ -1485,8 +1503,8 @@ impl App {
     /// **Pipe-mode branch.** When `deferred_acp.master_pipe_name.is_some()`
     /// (set at boot by [`Self::set_master_pipe_acp_params`] in helper
     /// mode), we route the reconnect through
-    /// [`run_acp_client_over_pipe`] so the rebuilt helper talks to the
-    /// shared wta-master singleton — same as the cold-boot helper path.
+    /// [`run_acp_client_over_pipe`] so the retained helper reconnects to the
+    /// shared wta-master singleton, just like the cold-boot helper path.
     /// We also rebuild the `session_hook` channel and re-bind the `_tx`
     /// half on `self.session_hook_tx`, because the original receiver was
     /// consumed (and dropped) by the dead initial pipe-mode task.
@@ -3503,13 +3521,14 @@ impl App {
             params.agent_cmd = resolved;
             params.agent_id = Some(agent_id.to_string());
         }
-        // Remember the selected agent so we can notify C++ after connection succeeds.
-        // We don't notify now because mid-FRE WriteSettingsToDisk triggers
-        // _RebuildAgentStack which tears down the in-progress agent pane.
+        // Notify C++ only after the selected Agent connects, so first-run
+        // settings persistence cannot race the in-progress connection.
         self.pending_agent_selection = Some(agent_id.to_string());
     }
 
     fn prepare_agent_reconnect(&mut self, request: &AgentReconnectRequest) {
+        self.auth_recovery_generation = self.auth_recovery_generation.wrapping_add(1);
+        self.auth_recovery_state = AuthRecoveryState::Idle;
         let new_cmd = self.build_agent_cmd(&request.agent_id);
         if let Some(ref mut params) = self.deferred_acp {
             params.agent_cmd.clone_from(&new_cmd);
@@ -3537,10 +3556,8 @@ impl App {
         self.pending_acp_start = false;
         self.pending_agent_selection = None;
         self.suppress_next_failed_client_error = false;
-        self.auth_recovery_generation = self.auth_recovery_generation.wrapping_add(1);
         self.needs_post_login_authenticate = false;
         self.preflight_setup_active = false;
-        self.agent_reconnect_preflight_pending = false;
         self.mode = AppMode::Chat;
         self.auth = None;
         self.setup = None;
@@ -3595,14 +3612,13 @@ impl App {
     }
 
     fn begin_pending_agent_reconnect_preflight(&mut self) -> Option<AgentReconnectRequest> {
-        if !self.agent_reconnect_disconnect_pending {
+        let AgentReconnectState::Disconnecting(latest) =
+            std::mem::take(&mut self.agent_reconnect_state)
+        else {
             return None;
-        }
-
-        self.agent_reconnect_disconnect_pending = false;
-        let latest = self.pending_agent_reconnect.clone()?;
+        };
         self.reset_agent_scoped_state();
-        self.agent_reconnect_preflight_pending = true;
+        self.agent_reconnect_state = AgentReconnectState::Preflighting(latest.clone());
         if let Some(tx) = self.event_tx.clone() {
             let operation_id = latest.operation_id.clone();
             let generation = latest.generation;
@@ -4033,10 +4049,7 @@ impl App {
                             if self.deferred_acp.is_some() {
                                 self.pending_acp_start = true;
                             } else {
-                                let new_cmd = self.build_agent_cmd(&agent_id);
-                                let _ = self.restart_tx.send(RestartRequest::RestartStack {
-                                    agent_cmd: Some(new_cmd),
-                                });
+                                let _ = self.restart_tx.send(AgentLifecycleRequest::RestartMaster);
                             }
                             // Don't clear setup yet — AgentConnected will transition to Chat,
                             // AgentError will update the Setup screen.
@@ -5357,20 +5370,9 @@ impl App {
         self.project_active_tab_state();
     }
 
-    /// `/restart` — reset the agent CLI subprocess. Behavior depends on which
-    /// transport this App is running on:
-    ///
-    /// * Standalone mode: the ACP client owns the agent CLI child.
-    ///   `restart_tx` triggers an in-process tear-down + respawn;
-    ///   subsequent prompts get a fresh session on each tab. The
-    ///   `Connecting("Restarting agent...")` state lasts until the
-    ///   new `initialize` round-trip lands.
-    ///
-    /// * Helper mode: master owns the agent CLI lifetime, so a single helper
-    ///   cannot restart it in-process. The helper's `restart_rx` arm asks C++
-    ///   to replace the shared master. Viable panes, ConPTYs, and helpers stay
-    ///   alive, then reconnect over the stable master pipe with clean ACP
-    ///   sessions.
+    /// `/restart` asks Windows Terminal to replace the shared master and Agent
+    /// CLI pool. Viable panes, ConPTYs, and helpers stay alive and reconnect
+    /// over the stable master pipe with clean ACP sessions.
     fn cmd_restart(&mut self) {
         self.state = ConnectionState::Connecting("Restarting agent...".to_string());
         self.session_to_tab.clear();
@@ -5384,9 +5386,7 @@ impl App {
             tab.completed_turns.clear();
             tab.session_id = None;
         }
-        let _ = self
-            .restart_tx
-            .send(RestartRequest::RestartStack { agent_cmd: None });
+        let _ = self.restart_tx.send(AgentLifecycleRequest::RestartMaster);
         self.publish_agent_status();
     }
 

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -5366,17 +5366,11 @@ impl App {
     ///   `Connecting("Restarting agent...")` state lasts until the
     ///   new `initialize` round-trip lands.
     ///
-    /// * Helper mode: master owns the agent CLI lifetime, so a
-    ///   single helper cannot restart it in-process. The helper's
-    ///   `restart_rx` arm asks the C++ side to force-restart the
-    ///   whole agent stack (`restart_agent_stack` SendEvent →
-    ///   TerminalPage tears down every agent pane,
-    ///   `SharedWta::Restart` respawns master on the same stable
-    ///   pipe name, then the active tab's pane is re-opened). The
-    ///   user briefly sees the agent pane flash closed and reopen
-    ///   with a clean session. The `Connecting("Restarting...")`
-    ///   state set below is short-lived — this helper process is
-    ///   on its way out as part of the pane teardown.
+    /// * Helper mode: master owns the agent CLI lifetime, so a single helper
+    ///   cannot restart it in-process. The helper's `restart_rx` arm asks C++
+    ///   to replace the shared master. Viable panes, ConPTYs, and helpers stay
+    ///   alive, then reconnect over the stable master pipe with clean ACP
+    ///   sessions.
     fn cmd_restart(&mut self) {
         self.state = ConnectionState::Connecting("Restarting agent...".to_string());
         self.session_to_tab.clear();

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -11,6 +11,7 @@ use tokio::sync::mpsc;
 
 struct DeferredAcpParams {
     agent_cmd: String,
+    agent_id: Option<String>,
     acp_model: Option<String>,
     agent_source: crate::agent_source::AgentSource,
     source_cwd: Option<String>,
@@ -115,8 +116,8 @@ use crate::coordinator::{recommended_choice_index, RecommendationChoice, Recomme
 use crate::pane_context::PaneContext;
 
 use crate::protocol::acp::client::{
-    CancelRequest, DropSessionRequest, LoadSessionForTab, NewSessionForTab, PromptSubmission,
-    RenameSessionRequest, RestartRequest,
+    AgentReconnectRequest, CancelRequest, DropSessionRequest, LoadSessionForTab, NewSessionForTab,
+    PromptSubmission, RenameSessionRequest, RestartRequest,
 };
 use crate::protocol::acp::turn_metrics::prompt_timing_log;
 use crate::ui;
@@ -960,6 +961,13 @@ pub struct App {
     pub state: ConnectionState,
     /// The agent ID we're trying to connect to (set at preflight/FRE time).
     pub current_agent_id: String,
+    /// Highest host-issued Settings rebind generation observed by this helper.
+    last_agent_rebind_generation: u64,
+    last_agent_rebind_window_id: Option<String>,
+    /// Latest accepted target while the current ACP transport is unwinding.
+    pending_agent_reconnect: Option<AgentReconnectRequest>,
+    agent_reconnect_disconnect_pending: bool,
+    suppress_next_failed_client_error: bool,
     /// Execution source paired with `current_agent_id`.
     pub current_agent_source: crate::agent_source::AgentSource,
     /// Agent ids supplied by Windows Terminal after GPO filtering.
@@ -1289,6 +1297,11 @@ impl App {
             deferred_acp: None,
             state: ConnectionState::Connecting(t!("connection.starting").into_owned()),
             current_agent_id: String::new(),
+            last_agent_rebind_generation: 0,
+            last_agent_rebind_window_id: None,
+            pending_agent_reconnect: None,
+            agent_reconnect_disconnect_pending: false,
+            suppress_next_failed_client_error: false,
             current_agent_source: crate::agent_source::AgentSource::Host,
             allowed_agent_ids: Vec::new(),
             host_agent_allowlist_present: false,
@@ -1407,6 +1420,7 @@ impl App {
         &mut self,
         pipe_name: String,
         agent_cmd: String,
+        agent_id: Option<String>,
         acp_model: Option<String>,
         agent_source: crate::agent_source::AgentSource,
         source_cwd: Option<String>,
@@ -1416,6 +1430,7 @@ impl App {
     ) {
         self.deferred_acp = Some(DeferredAcpParams {
             agent_cmd,
+            agent_id,
             acp_model,
             agent_source,
             source_cwd,
@@ -1517,14 +1532,16 @@ impl App {
                 let wt_connected = params.wt_connected;
                 let pipe_name_opt = params.master_pipe_name.clone();
                 let owner_tab_opt = params.owner_tab_id.clone();
-                // Per-tab agent identity for the multi-agent master: declare
-                // which agent this reconnecting helper wants. Derived from the
-                // configured agent_cmd — the master reconstructs the command
-                // from the id and never executes a string off the pipe.
-                let agent_cmd_opt = Some(params.agent_cmd.clone()).filter(|s| !s.trim().is_empty());
-                let agent_id_opt = agent_cmd_opt
-                    .as_deref()
-                    .map(|c| crate::agent_registry::resolve_agent_id_from_cmd(c).to_string());
+                // Per-tab agent identity for the multi-agent master. Prefer
+                // the canonical host-supplied id; command parsing is retained
+                // for compatibility with older deferred state.
+                let agent_id_opt = params.agent_id.clone().or_else(|| {
+                    Some(params.agent_cmd.as_str())
+                        .filter(|command| !command.trim().is_empty())
+                        .map(|command| {
+                            crate::agent_registry::resolve_agent_id_from_cmd(command).to_string()
+                        })
+                });
 
                 if let Some(pipe_name) = pipe_name_opt {
                     // Pipe-mode reconnect (helper after FRE login).
@@ -1551,7 +1568,7 @@ impl App {
                     let event_tx_for_pipe = event_tx.clone();
                     let proposal_channels = Arc::clone(&self.proposal_channels);
                     tokio::task::spawn_local(async move {
-                        if let Err(e) = crate::protocol::acp::client::run_acp_client_over_pipe(
+                        match crate::protocol::acp::client::run_acp_client_over_pipe(
                             pipe_name,
                             acp_model,
                             cloud_models,
@@ -1577,56 +1594,67 @@ impl App {
                         )
                         .await
                         {
-                            tracing::error!(
-                                target: "helper",
-                                error = %e,
-                                "run_acp_client_over_pipe failed on reconnect"
-                            );
-                            let failure = crate::protocol::acp::failure::classify_anyhow(
-                                &e,
-                                crate::protocol::acp::failure::HandshakeStage::Initialize,
-                            );
-                            // A post-login reconnect may fail because the old
-                            // shared master is stale/dead after login:
-                            //   * External-auth agent still AuthRequired after
-                            //     authenticate/new_session → the long-lived CLI
-                            //     cached unauthenticated state.
-                            //   * PipeConnect failure → the master died before
-                            //     login (e.g. Copilot was missing during IT
-                            //     install flow), so the saved pipe no longer
-                            //     exists.
-                            // Both need a fresh master rather than another
-                            // sign-in screen.
-                            let is_external = matches!(
-                                crate::agent_registry::lookup_profile_by_id(&recovery_agent_id)
-                                    .acp_auth_flow,
-                                crate::agent_registry::AcpAuthFlow::External
-                            );
-                            if should_trigger_post_login_recovery(
-                                post_login_auth,
-                                is_external,
-                                &failure,
-                            ) {
-                                tracing::warn!(
-                                    target: "auth_recovery",
-                                    agent_id = %recovery_agent_id,
-                                    tab_id = ?recovery_tab_id,
-                                    failure_class = failure.class(),
-                                    "post-login reconnect needs fresh master; requesting auth recovery"
+                            Ok(crate::protocol::acp::client::AcpClientExit::RebindAgent(
+                                request,
+                            )) => {
+                                let _ =
+                                    event_tx_for_pipe.send(AppEvent::AgentReconnectReady(request));
+                            }
+                            Ok(crate::protocol::acp::client::AcpClientExit::ChannelsClosed) => {}
+                            Err(e) => {
+                                let _ = event_tx_for_pipe.send(AppEvent::AgentClientFailed);
+                                tracing::error!(
+                                    target: "helper",
+                                    error = %e,
+                                    "run_acp_client_over_pipe failed on reconnect"
                                 );
-                                let _ = event_tx_for_pipe.send(AppEvent::PostLoginAuthRecovery {
-                                    failure,
-                                    tab_id: recovery_tab_id.clone(),
-                                    agent_id: recovery_agent_id.clone(),
-                                });
-                            } else {
-                                let _ = event_tx_for_pipe.send(AppEvent::AgentError {
-                                    session_id: None,
-                                    failure,
-                                    message: format!(
-                                        "helper ACP transport failed on reconnect: {e:#}"
-                                    ),
-                                });
+                                let failure = crate::protocol::acp::failure::classify_anyhow(
+                                    &e,
+                                    crate::protocol::acp::failure::HandshakeStage::Initialize,
+                                );
+                                // A post-login reconnect may fail because the old
+                                // shared master is stale/dead after login:
+                                //   * External-auth agent still AuthRequired after
+                                //     authenticate/new_session → the long-lived CLI
+                                //     cached unauthenticated state.
+                                //   * PipeConnect failure → the master died before
+                                //     login (e.g. Copilot was missing during IT
+                                //     install flow), so the saved pipe no longer
+                                //     exists.
+                                // Both need a fresh master rather than another
+                                // sign-in screen.
+                                let is_external = matches!(
+                                    crate::agent_registry::lookup_profile_by_id(&recovery_agent_id)
+                                        .acp_auth_flow,
+                                    crate::agent_registry::AcpAuthFlow::External
+                                );
+                                if should_trigger_post_login_recovery(
+                                    post_login_auth,
+                                    is_external,
+                                    &failure,
+                                ) {
+                                    tracing::warn!(
+                                        target: "auth_recovery",
+                                        agent_id = %recovery_agent_id,
+                                        tab_id = ?recovery_tab_id,
+                                        failure_class = failure.class(),
+                                        "post-login reconnect needs fresh master; requesting auth recovery"
+                                    );
+                                    let _ =
+                                        event_tx_for_pipe.send(AppEvent::PostLoginAuthRecovery {
+                                            failure,
+                                            tab_id: recovery_tab_id.clone(),
+                                            agent_id: recovery_agent_id.clone(),
+                                        });
+                                } else {
+                                    let _ = event_tx_for_pipe.send(AppEvent::AgentError {
+                                        session_id: None,
+                                        failure,
+                                        message: format!(
+                                            "helper ACP transport failed on reconnect: {e:#}"
+                                        ),
+                                    });
+                                }
                             }
                         }
                     });
@@ -1883,12 +1911,7 @@ impl App {
     /// this helper owns. No-op on an empty/whitespace model — an empty
     /// override means "agent default", which `set_session_model` can't
     /// express.
-    fn send_session_model(
-        &self,
-        session_id: Option<String>,
-        model: String,
-        pane_override: bool,
-    ) {
+    fn send_session_model(&self, session_id: Option<String>, model: String, pane_override: bool) {
         if model.trim().is_empty() {
             return;
         }
@@ -3443,11 +3466,102 @@ impl App {
                 resolved
             );
             params.agent_cmd = resolved;
+            params.agent_id = Some(agent_id.to_string());
         }
         // Remember the selected agent so we can notify C++ after connection succeeds.
         // We don't notify now because mid-FRE WriteSettingsToDisk triggers
         // _RebuildAgentStack which tears down the in-progress agent pane.
         self.pending_agent_selection = Some(agent_id.to_string());
+    }
+
+    fn prepare_agent_reconnect(&mut self, request: &AgentReconnectRequest) {
+        let new_cmd = self.build_agent_cmd(&request.agent_id);
+        if let Some(ref mut params) = self.deferred_acp {
+            params.agent_cmd.clone_from(&new_cmd);
+            params.agent_id = Some(request.agent_id.clone());
+            params.acp_model.clone_from(&request.acp_model);
+            params.agent_source = request.agent_source.clone();
+            if matches!(request.agent_source, crate::agent_source::AgentSource::Host) {
+                params.source_cwd = None;
+            }
+        }
+
+        self.current_agent_id.clone_from(&request.agent_id);
+        self.current_agent_source = request.agent_source.clone();
+        self.delegate_base_agent_cmd = new_cmd;
+        self.acp_model.clone_from(&request.acp_model);
+        self.reset_agent_scoped_state();
+    }
+
+    fn reset_agent_scoped_state(&mut self) {
+        self.pending_agent_selection = None;
+        self.suppress_next_failed_client_error = false;
+        self.auth_recovery_generation = self.auth_recovery_generation.wrapping_add(1);
+        self.needs_post_login_authenticate = false;
+        self.preflight_setup_active = false;
+        self.mode = AppMode::Chat;
+        self.auth = None;
+        self.setup = None;
+        self.agent_name.clear();
+        self.agent_model = None;
+        self.agent_version = None;
+        self.available_models.clear();
+        self.model_picker_models.clear();
+        self.current_model_id = None;
+        self.agent_models.clear();
+        self.agent_current_model_id = None;
+        self.agent_supports_load_session = false;
+        self.agent_supports_image = false;
+        self.host_catalog_ready = false;
+        self.cloud_models.clear();
+        self.session_id.clear();
+        self.session_to_tab.clear();
+        self.session_model_configs.clear();
+        self.session_config_options.clear();
+        let active_tab_id = self.active_tab_key().to_string();
+        for tab in self.tab_sessions.values_mut() {
+            tab.clear_chat_history();
+            tab.usage = None;
+            tab.usage_staleness = crate::usage::UsageStaleness::default();
+            tab.completed_turns.clear();
+            tab.session_id = None;
+            tab.loading_session = false;
+            tab.loading_target_session_id = None;
+            tab.model_override = None;
+            tab.model_picker_open = false;
+            tab.model_picker_selected = 0;
+            tab.config_picker = ConfigPickerState::Closed;
+            tab.config_pending_id = None;
+            tab.agent_picker_open = false;
+            tab.agent_picker_selected = 0;
+            tab.pending_terminal_action_proposal = None;
+            tab.active_direct_proposal_id = None;
+            tab.last_emitted_chip_override = None;
+            tab.autofix.generation = tab.autofix.generation.wrapping_add(1);
+            tab.autofix.pane_id = None;
+            tab.autofix.armed_at = None;
+            tab.autofix.suggested_pane_id = None;
+            tab.autofix.trigger_echo_pane = None;
+            tab.autofix.bar_snapshot = Default::default();
+        }
+        if self.tab_sessions.contains_key(&active_tab_id) {
+            self.emit_autofix_state_cleared(&active_tab_id);
+        }
+        self.proposal_channels.set_agent_transport_available(false);
+        self.state = ConnectionState::Connecting(t!("connection.starting").into_owned());
+        self.publish_agent_status();
+    }
+
+    fn complete_pending_agent_reconnect(&mut self) -> Option<AgentReconnectRequest> {
+        if !self.agent_reconnect_disconnect_pending {
+            return None;
+        }
+
+        self.agent_reconnect_disconnect_pending = false;
+        let latest = self.pending_agent_reconnect.take()?;
+        self.reset_agent_scoped_state();
+        self.pending_acp_start = true;
+        Some(latest)
     }
 
     pub fn set_event_tx(&mut self, tx: mpsc::UnboundedSender<AppEvent>) {
@@ -3817,7 +3931,7 @@ impl App {
                                 self.pending_acp_start = true;
                             } else {
                                 let new_cmd = self.build_agent_cmd(&agent_id);
-                                let _ = self.restart_tx.send(RestartRequest {
+                                let _ = self.restart_tx.send(RestartRequest::RestartStack {
                                     agent_cmd: Some(new_cmd),
                                 });
                             }
@@ -4079,6 +4193,8 @@ impl App {
             AppEvent::ConnectionStage(_) => "connection_stage",
             AppEvent::CloudModelsAvailable(_) => "cloud_models_available",
             AppEvent::AgentConnected { .. } => "agent_connected",
+            AppEvent::AgentReconnectReady(_) => "agent_reconnect_ready",
+            AppEvent::AgentClientFailed => "agent_client_failed",
             AppEvent::SessionAttached { .. } => "session_attached",
             AppEvent::UsageReported { .. } => "usage_reported",
             AppEvent::UsageCleared { .. } => "usage_cleared",
@@ -5168,7 +5284,9 @@ impl App {
             tab.completed_turns.clear();
             tab.session_id = None;
         }
-        let _ = self.restart_tx.send(RestartRequest { agent_cmd: None });
+        let _ = self
+            .restart_tx
+            .send(RestartRequest::RestartStack { agent_cmd: None });
         self.publish_agent_status();
     }
 

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -3534,6 +3534,7 @@ impl App {
     }
 
     fn reset_agent_scoped_state(&mut self) {
+        self.pending_acp_start = false;
         self.pending_agent_selection = None;
         self.suppress_next_failed_client_error = false;
         self.auth_recovery_generation = self.auth_recovery_generation.wrapping_add(1);

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -296,6 +296,31 @@ pub fn build_setup_options(
     opts
 }
 
+pub async fn preflight_agent_in_source(
+    agent_id: &str,
+    source: &crate::agent_source::AgentSource,
+) -> PreflightResult {
+    if agent_id.starts_with("custom:") || !crate::agent_registry::is_known_id(agent_id) {
+        return PreflightResult::passed_for_custom_agent(agent_id);
+    }
+
+    let status = crate::agent_check::check_agent_in_source(agent_id, source).await;
+    PreflightResult {
+        agent_id: agent_id.to_string(),
+        display_name: status.display_name,
+        cli_status: if status.cli_found {
+            CheckStatus::Passed
+        } else {
+            CheckStatus::Failed("Not found on PATH".to_string())
+        },
+        cli_path: status.cli_path,
+        auth_status: CheckStatus::Skipped,
+        install_hint: status.install_hint,
+        install_url: String::new(),
+        auth_hint: status.auth_hint,
+    }
+}
+
 // --- State types ---
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -968,6 +993,7 @@ pub struct App {
     /// Latest accepted target while the current ACP transport is unwinding.
     pending_agent_reconnect: Option<AgentReconnectRequest>,
     agent_reconnect_disconnect_pending: bool,
+    agent_reconnect_preflight_pending: bool,
     suppress_next_failed_client_error: bool,
     /// Execution source paired with `current_agent_id`.
     pub current_agent_source: crate::agent_source::AgentSource,
@@ -1302,6 +1328,7 @@ impl App {
             last_agent_rebind_window_id: None,
             pending_agent_reconnect: None,
             agent_reconnect_disconnect_pending: false,
+            agent_reconnect_preflight_pending: false,
             suppress_next_failed_client_error: false,
             current_agent_source: crate::agent_source::AgentSource::Host,
             allowed_agent_ids: Vec::new(),
@@ -3512,6 +3539,7 @@ impl App {
         self.auth_recovery_generation = self.auth_recovery_generation.wrapping_add(1);
         self.needs_post_login_authenticate = false;
         self.preflight_setup_active = false;
+        self.agent_reconnect_preflight_pending = false;
         self.mode = AppMode::Chat;
         self.auth = None;
         self.setup = None;
@@ -3565,16 +3593,77 @@ impl App {
         self.publish_agent_status();
     }
 
-    fn complete_pending_agent_reconnect(&mut self) -> Option<AgentReconnectRequest> {
+    fn begin_pending_agent_reconnect_preflight(&mut self) -> Option<AgentReconnectRequest> {
         if !self.agent_reconnect_disconnect_pending {
             return None;
         }
 
         self.agent_reconnect_disconnect_pending = false;
-        let latest = self.pending_agent_reconnect.take()?;
+        let latest = self.pending_agent_reconnect.clone()?;
         self.reset_agent_scoped_state();
-        self.pending_acp_start = true;
+        self.agent_reconnect_preflight_pending = true;
+        if let Some(tx) = self.event_tx.clone() {
+            let operation_id = latest.operation_id.clone();
+            let generation = latest.generation;
+            let agent_id = latest.agent_id.clone();
+            let source = latest.agent_source.clone();
+            tokio::task::spawn_local(async move {
+                let result = preflight_agent_in_source(&agent_id, &source).await;
+                let _ = tx.send(AppEvent::AgentReconnectPreflightComplete {
+                    operation_id,
+                    generation,
+                    result,
+                });
+            });
+        }
         Some(latest)
+    }
+
+    fn show_preflight_setup(&mut self, result: PreflightResult) {
+        let reason = SetupReason::AgentMissing;
+        let current_status = if matches!(
+            self.current_agent_source,
+            crate::agent_source::AgentSource::Wsl { .. }
+        ) {
+            None
+        } else {
+            Some(crate::agent_check::AgentStatus {
+                id: result.agent_id.clone(),
+                display_name: result.display_name.clone(),
+                cli_found: result.cli_status == CheckStatus::Passed,
+                cli_path: result.cli_path.clone(),
+                install_hint: result.install_hint.clone(),
+                auth_hint: result.auth_hint.clone(),
+                auto_installable: result.agent_id.eq_ignore_ascii_case("copilot"),
+            })
+        };
+        let options = build_setup_options(&reason, current_status.as_ref());
+        let title = reason.title().to_string();
+        let subtitle = if current_status
+            .as_ref()
+            .is_some_and(crate::agent_check::AgentStatus::can_auto_install)
+        {
+            t!(
+                "setup.subtitle.copilot_missing",
+                agent = &result.display_name
+            )
+            .into_owned()
+        } else {
+            t!("setup.subtitle.agent_missing", agent = &result.display_name).into_owned()
+        };
+        self.mode = AppMode::Setup;
+        self.preflight_setup_active = true;
+        self.setup = Some(SetupState {
+            reason,
+            preflight: result,
+            selected_index: 0,
+            install_in_progress: false,
+            install_log: Vec::new(),
+            install_error: None,
+            options,
+            title,
+            subtitle,
+        });
     }
 
     pub fn set_event_tx(&mut self, tx: mpsc::UnboundedSender<AppEvent>) {
@@ -4252,6 +4341,9 @@ impl App {
             AppEvent::AuthRecoveryTimedOut { .. } => "auth_recovery_timed_out",
             AppEvent::AgentSourcesDiscovered { .. } => "agent_sources_discovered",
             AppEvent::PreflightComplete(_) => "preflight_complete",
+            AppEvent::AgentReconnectPreflightComplete { .. } => {
+                "agent_reconnect_preflight_complete"
+            }
             AppEvent::AgentSessionEvent(_) => "agent_session_event",
             AppEvent::AliveSnapshotLoaded(_) => "alive_snapshot_loaded",
             AppEvent::AliveSessionAdded(_) => "alive_session_added",

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -13,6 +13,7 @@ struct DeferredAcpParams {
     agent_cmd: String,
     agent_id: Option<String>,
     acp_model: Option<String>,
+    custom_model_selection: Option<String>,
     agent_source: crate::agent_source::AgentSource,
     source_cwd: Option<String>,
     prompt_rx: Option<mpsc::UnboundedReceiver<crate::protocol::acp::client::PromptSubmission>>,
@@ -1422,6 +1423,7 @@ impl App {
         agent_cmd: String,
         agent_id: Option<String>,
         acp_model: Option<String>,
+        custom_model_selection: Option<String>,
         agent_source: crate::agent_source::AgentSource,
         source_cwd: Option<String>,
         owner_tab_id: Option<String>,
@@ -1432,6 +1434,7 @@ impl App {
             agent_cmd,
             agent_id,
             acp_model,
+            custom_model_selection,
             agent_source,
             source_cwd,
             prompt_rx: None,
@@ -1525,6 +1528,7 @@ impl App {
                 params.master_ext_rx.take(),
             ) {
                 let acp_model = params.acp_model.clone();
+                let custom_model_selection = params.custom_model_selection.clone();
                 let agent_source = params.agent_source.clone();
                 let source_cwd = params.source_cwd.clone();
                 let event_tx = tx.clone();
@@ -1571,6 +1575,7 @@ impl App {
                         match crate::protocol::acp::client::run_acp_client_over_pipe(
                             pipe_name,
                             acp_model,
+                            custom_model_selection,
                             cloud_models,
                             agent_id_opt,
                             agent_source,
@@ -1964,6 +1969,9 @@ impl App {
         }
 
         self.acp_model = new_model.filter(|s| !s.trim().is_empty());
+        if let Some(params) = self.deferred_acp.as_mut() {
+            params.acp_model.clone_from(&self.acp_model);
+        }
         self.send_acp_model_update();
         self.publish_agent_status();
         true
@@ -3480,6 +3488,9 @@ impl App {
             params.agent_cmd.clone_from(&new_cmd);
             params.agent_id = Some(request.agent_id.clone());
             params.acp_model.clone_from(&request.acp_model);
+            params
+                .custom_model_selection
+                .clone_from(&request.custom_model_selection);
             params.agent_source = request.agent_source.clone();
             if matches!(request.agent_source, crate::agent_source::AgentSource::Host) {
                 params.source_cwd = None;
@@ -3490,6 +3501,8 @@ impl App {
         self.current_agent_source = request.agent_source.clone();
         self.delegate_base_agent_cmd = new_cmd;
         self.acp_model.clone_from(&request.acp_model);
+        self.custom_model_selection
+            .clone_from(&request.custom_model_selection);
         self.reset_agent_scoped_state();
     }
 

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -27,6 +27,11 @@ pub enum AppEvent {
         load_session_supported: bool,
         image_supported: bool,
     },
+    /// The old helper↔master ACP task has closed its pipe intentionally and
+    /// the stable helper process may start the replacement connection.
+    AgentReconnectReady(crate::protocol::acp::client::AgentReconnectRequest),
+    /// The ACP task exited before it could consume a queued reconnect request.
+    AgentClientFailed,
     SessionAttached {
         tab_id: String,
         session_id: String,

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -253,6 +253,11 @@ pub enum AppEvent {
         wsl_sources: Vec<AvailableAgent>,
     },
     PreflightComplete(PreflightResult),
+    AgentReconnectPreflightComplete {
+        operation_id: String,
+        generation: u64,
+        result: PreflightResult,
+    },
     AgentSessionEvent(crate::agent_sessions::SessionEvent),
     AliveSnapshotLoaded(Vec<crate::session_registry::SessionInfo>),
     AliveSessionAdded(crate::session_registry::SessionInfo),

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -107,8 +107,8 @@ pub enum AppEvent {
         failure: crate::protocol::acp::failure::AgentFailure,
         message: String,
     },
-    /// The helper's pipe to wta-master closed. The helper exits instead of
-    /// remaining degraded or attempting automatic session recovery.
+    /// The helper's pipe to wta-master closed. A retained helper reconnects
+    /// its existing immutable binding over the stable pipe.
     MasterDisconnected,
     AgentSoftStop {
         session_id: String,

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -16,6 +16,7 @@ struct AgentReconnectWire {
     acp_model: Option<String>,
     custom_model_selection: Option<String>,
     agent_source: String,
+    wsl_distro: Option<String>,
 }
 
 impl App {
@@ -901,11 +902,22 @@ impl App {
                 }
             }
             AppEvent::MasterDisconnected => {
-                tracing::warn!(
-                    target: "helper",
-                    "master disconnected; terminating helper without session recovery"
-                );
-                self.should_quit = true;
+                if self.deferred_acp.is_some() {
+                    tracing::warn!(
+                        target: "helper",
+                        agent_id = %self.current_agent_id,
+                        source = %self.current_agent_source,
+                        "master disconnected; reconnecting retained helper over stable pipe"
+                    );
+                    self.reset_agent_scoped_state();
+                    self.pending_acp_start = true;
+                } else {
+                    tracing::warn!(
+                        target: "helper",
+                        "master disconnected without deferred binding; terminating helper"
+                    );
+                    self.should_quit = true;
+                }
             }
             AppEvent::PostLoginAuthRecovery {
                 failure,
@@ -935,11 +947,10 @@ impl App {
                 self.auth_recovery_generation = self.auth_recovery_generation.wrapping_add(1);
                 let recovery_generation = self.auth_recovery_generation;
                 // (i) Transient "Reconnecting…" — NOT the sign-in screen. The
-                // restart below tears this pane down + respawns it, so the
-                // common (successful) case never flashes the setup screen
-                // between login and the fresh pane connecting. Only a dropped/
-                // slow restart leaves us alive long enough for the
-                // `AuthRecoveryTimedOut` fallback path to surface the sign-in screen.
+                // master restart below reconnects this retained helper, so the
+                // common path never flashes the setup screen. Only a dropped
+                // or slow restart leaves us in this state long enough for the
+                // `AuthRecoveryTimedOut` fallback to surface the sign-in screen.
                 self.mode = AppMode::Chat;
                 self.setup = None;
                 self.auth = None;
@@ -953,18 +964,17 @@ impl App {
                 // cached its unauthenticated state at spawn and `authenticate`
                 // does not refresh it; only a respawn (which re-reads the now
                 // valid on-disk credential) recovers. Reuse the tested
-                // `/restart` machinery; `tab_id` lets C++ reopen the failing
-                // tab rather than the active one.
-                let evt = serde_json::json!({
-                    "type": "event",
-                    "method": "restart_agent_stack",
-                    "params": { "reason": "auth_recovery", "tab_id": tab_id },
-                });
-                send_wt_protocol_event(evt.to_string());
-                // (iii) Dead-man fallback: if the restart actually respawned
-                // this pane, this helper process is gone before the timer
-                // fires. If it survives (dropped/slow restart), surface the
-                // sign-in screen so the user isn't stranded on "Reconnecting…".
+                // `/restart` machinery; `tab_id` identifies the failing tab.
+                send_wt_protocol_event(
+                    crate::wt_protocol_events::restart_agent_stack_event(
+                        Some("auth_recovery"),
+                        tab_id.as_deref(),
+                    ),
+                );
+                // (iii) Dead-man fallback: a successful retained-helper
+                // reconnect advances the recovery generation before this
+                // timer fires. A dropped/slow restart surfaces the sign-in
+                // screen instead of stranding the user on "Reconnecting…".
                 // Guarded on a live async runtime so unit tests (no LocalSet)
                 // don't panic in `spawn_local`.
                 if let Some(ref tx) = self.event_tx {
@@ -984,11 +994,9 @@ impl App {
                 agent_id,
                 generation,
             } => {
-                // Only reached when the auth-recovery restart did NOT tear this
-                // pane down within the window (dropped/slow delivery) — a
-                // successful restart kills this helper process first. Surface
-                // the sign-in fallback so the user can retry instead of being
-                // stranded on a perpetual "Reconnecting…".
+                // Only takes effect when the retained helper did not reconnect
+                // within the window. Surface the sign-in fallback so the user
+                // can retry instead of remaining on "Reconnecting…".
                 //
                 // The generation guard drops a stale timer: if a newer recovery
                 // started, or the reconnect already succeeded (AgentConnected
@@ -1727,17 +1735,6 @@ impl App {
                         );
                         return;
                     };
-                    if !wire
-                        .agent_source
-                        .eq_ignore_ascii_case(crate::agent_source::AgentSource::HOST_KIND)
-                    {
-                        tracing::warn!(
-                            target: "agent_rebind",
-                            source = %wire.agent_source,
-                            "ignoring non-Host agent rebind"
-                        );
-                        return;
-                    }
                     if wire.window_id.trim().is_empty()
                         || self.window_id.as_deref().is_some_and(|window_id| {
                             !window_id.is_empty() && window_id != wire.window_id
@@ -1745,6 +1742,38 @@ impl App {
                     {
                         return;
                     }
+                    let agent_source = if wire
+                        .agent_source
+                        .eq_ignore_ascii_case(crate::agent_source::AgentSource::HOST_KIND)
+                    {
+                        crate::agent_source::AgentSource::Host
+                    } else if wire
+                        .agent_source
+                        .eq_ignore_ascii_case(crate::agent_source::AgentSource::WSL_KIND)
+                    {
+                        let Some(distro) = wire
+                            .wsl_distro
+                            .as_deref()
+                            .map(str::trim)
+                            .filter(|distro| !distro.is_empty())
+                        else {
+                            tracing::warn!(
+                                target: "agent_rebind",
+                                "ignoring WSL agent rebind without a distro"
+                            );
+                            return;
+                        };
+                        crate::agent_source::AgentSource::Wsl {
+                            distro: distro.to_string(),
+                        }
+                    } else {
+                        tracing::warn!(
+                            target: "agent_rebind",
+                            source = %wire.agent_source,
+                            "ignoring agent rebind with an unknown source"
+                        );
+                        return;
+                    };
                     let mut request = AgentReconnectRequest {
                         operation_id: wire.operation_id,
                         window_id: wire.window_id,
@@ -1752,10 +1781,7 @@ impl App {
                         agent_id: wire.agent_id,
                         acp_model: wire.acp_model,
                         custom_model_selection: wire.custom_model_selection,
-                        agent_source: crate::agent_source::AgentSource::from_wire(
-                            Some(&wire.agent_source),
-                            None,
-                        ),
+                        agent_source,
                     };
                     if request.operation_id.trim().is_empty()
                         || (self.last_agent_rebind_window_id.as_deref()
@@ -1764,8 +1790,18 @@ impl App {
                     {
                         return;
                     }
-                    if !matches!(request.agent_source, crate::agent_source::AgentSource::Host)
-                        || !crate::agent_registry::is_known_id(&request.agent_id)
+                    if request.agent_source != self.current_agent_source {
+                        tracing::warn!(
+                            target: "agent_rebind",
+                            operation_id = %request.operation_id,
+                            generation = request.generation,
+                            current_source = %self.current_agent_source,
+                            requested_source = %request.agent_source,
+                            "ignoring execution-source-changing agent rebind"
+                        );
+                        return;
+                    }
+                    if !crate::agent_registry::is_known_id(&request.agent_id)
                         || (self.host_agent_allowlist_present
                             && !self
                                 .allowed_agent_ids
@@ -1792,8 +1828,9 @@ impl App {
                         .custom_model_selection
                         .take()
                         .filter(|selection| !selection.trim().is_empty());
-                    if crate::agent_registry::lookup_profile_by_id(&request.agent_id).byok_mode
-                        == crate::agent_registry::ByokMode::Unsupported
+                    if !matches!(request.agent_source, crate::agent_source::AgentSource::Host)
+                        || crate::agent_registry::lookup_profile_by_id(&request.agent_id).byok_mode
+                            == crate::agent_registry::ByokMode::Unsupported
                     {
                         request.custom_model_selection = None;
                     }

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -1870,17 +1870,27 @@ impl App {
                         .get("operation_id")
                         .and_then(|value| value.as_str())
                         .unwrap_or("");
-                    if !matches!(
+                    if request_id.is_empty() {
+                        return;
+                    }
+                    let completes_auth_recovery = matches!(
                         &self.auth_recovery_state,
                         AuthRecoveryState::WaitingForMaster {
                             request_id: expected
                         } if expected == request_id
-                    ) {
+                    );
+                    // Session retirement can fail an in-flight startup before
+                    // the old master exits, so no later transport-loss event
+                    // remains to trigger the retained helper's reconnect.
+                    let recovers_retirement_failure =
+                        matches!(&self.auth_recovery_state, AuthRecoveryState::Idle)
+                            && matches!(&self.state, ConnectionState::Failed(_));
+                    if !completes_auth_recovery && !recovers_retirement_failure {
                         return;
                     }
                     if self.deferred_acp.is_none() {
                         tracing::warn!(
-                            target: "auth_recovery",
+                            target: "helper",
                             %request_id,
                             "replacement master is ready but helper binding is unavailable"
                         );
@@ -1888,11 +1898,13 @@ impl App {
                     }
 
                     tracing::info!(
-                        target: "auth_recovery",
+                        target: "helper",
                         %request_id,
                         "replacement master is ready; reconnecting retained helper"
                     );
-                    self.auth_recovery_state = AuthRecoveryState::Connecting;
+                    if completes_auth_recovery {
+                        self.auth_recovery_state = AuthRecoveryState::Connecting;
+                    }
                     self.reset_agent_scoped_state();
                     self.pending_acp_start = true;
                     return;

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -376,7 +376,7 @@ impl App {
                 }
             }
             AppEvent::AgentReconnectReady(completed) => {
-                let Some(latest) = self.complete_pending_agent_reconnect() else {
+                let Some(latest) = self.begin_pending_agent_reconnect_preflight() else {
                     tracing::debug!(
                         target: "agent_rebind",
                         operation_id = %completed.operation_id,
@@ -392,18 +392,18 @@ impl App {
                     target_operation_id = %latest.operation_id,
                     target_generation = latest.generation,
                     target_agent_id = %latest.agent_id,
-                    "old ACP transport retired; reconnecting helper to latest target"
+                    "old ACP transport retired; preflighting latest target"
                 );
             }
             AppEvent::AgentClientFailed => {
-                if let Some(latest) = self.complete_pending_agent_reconnect() {
+                if let Some(latest) = self.begin_pending_agent_reconnect_preflight() {
                     self.suppress_next_failed_client_error = true;
                     tracing::info!(
                         target: "agent_rebind",
                         operation_id = %latest.operation_id,
                         generation = latest.generation,
                         agent_id = %latest.agent_id,
-                        "outgoing ACP client failed during startup; reconnecting to latest target"
+                        "outgoing ACP client failed during startup; preflighting latest target"
                     );
                 }
             }
@@ -1378,6 +1378,17 @@ impl App {
                 }
             }
             AppEvent::PreflightComplete(result) => {
+                if self.agent_reconnect_disconnect_pending
+                    || self.agent_reconnect_preflight_pending
+                {
+                    tracing::debug!(
+                        target: "preflight",
+                        stale_agent = %result.agent_id,
+                        current_agent = %self.current_agent_id,
+                        "ignoring startup preflight result during agent rebind"
+                    );
+                    return;
+                }
                 if !self.current_agent_id.is_empty()
                     && !result.agent_id.eq_ignore_ascii_case(&self.current_agent_id)
                 {
@@ -1397,44 +1408,44 @@ impl App {
                     "preflight result received"
                 );
                 if !result.all_passed() {
-                    let reason = SetupReason::AgentMissing;
-                    let current_status = if matches!(
-                        self.current_agent_source,
-                        crate::agent_source::AgentSource::Wsl { .. }
-                    ) {
-                        None
-                    } else {
-                        Some(crate::agent_check::check_agent(&result.agent_id))
-                    };
-                    let options = build_setup_options(&reason, current_status.as_ref());
-                    let title = reason.title().to_string();
-                    let subtitle = if current_status
-                        .as_ref()
-                        .is_some_and(crate::agent_check::AgentStatus::can_auto_install)
-                    {
-                        t!(
-                            "setup.subtitle.copilot_missing",
-                            agent = &result.display_name
-                        )
-                        .into_owned()
-                    } else {
-                        t!("setup.subtitle.agent_missing", agent = &result.display_name)
-                            .into_owned()
-                    };
-                    self.mode = AppMode::Setup;
-                    self.preflight_setup_active = true;
-                    self.setup = Some(SetupState {
-                        reason,
-
-                        preflight: result,
-                        selected_index: 0,
-                        install_in_progress: false,
-                        install_log: Vec::new(),
-                        install_error: None,
-                        options,
-                        title,
-                        subtitle,
+                    self.show_preflight_setup(result);
+                }
+            }
+            AppEvent::AgentReconnectPreflightComplete {
+                operation_id,
+                generation,
+                result,
+            } => {
+                let matches_pending = self.agent_reconnect_preflight_pending
+                    && self.pending_agent_reconnect.as_ref().is_some_and(|pending| {
+                        pending.operation_id == operation_id
+                            && pending.generation == generation
+                            && pending.agent_id.eq_ignore_ascii_case(&result.agent_id)
                     });
+                if !matches_pending {
+                    tracing::debug!(
+                        target: "agent_rebind",
+                        operation_id = %operation_id,
+                        generation,
+                        agent_id = %result.agent_id,
+                        "ignoring stale target preflight result"
+                    );
+                    return;
+                }
+
+                self.agent_reconnect_preflight_pending = false;
+                self.pending_agent_reconnect = None;
+                if result.all_passed() {
+                    self.pending_acp_start = true;
+                    tracing::info!(
+                        target: "agent_rebind",
+                        operation_id = %operation_id,
+                        generation,
+                        agent_id = %result.agent_id,
+                        "target preflight passed; reconnecting helper"
+                    );
+                } else {
+                    self.show_preflight_setup(result);
                 }
             }
             AppEvent::AgentSourcesDiscovered {
@@ -1795,12 +1806,10 @@ impl App {
                         self.agent_reconnect_disconnect_pending = true;
                         if self
                             .restart_tx
-                            .send(RestartRequest::RebindAgent(request))
+                            .send(RestartRequest::RebindAgent(request.clone()))
                             .is_err()
                         {
-                            self.agent_reconnect_disconnect_pending = false;
-                            self.pending_agent_reconnect = None;
-                            self.pending_acp_start = true;
+                            let _ = self.begin_pending_agent_reconnect_preflight();
                         }
                     }
                     return;

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -7,6 +7,16 @@
 
 use super::*;
 
+#[derive(serde::Deserialize)]
+struct AgentReconnectWire {
+    operation_id: String,
+    window_id: String,
+    generation: u64,
+    agent_id: String,
+    acp_model: Option<String>,
+    agent_source: String,
+}
+
 impl App {
     fn completed_turn_hit_at(&self, column: u16, row: u16) -> Option<CompletedTurnHitRegion> {
         let tab = self.current_tab();
@@ -364,6 +374,38 @@ impl App {
                     );
                 }
             }
+            AppEvent::AgentReconnectReady(completed) => {
+                let Some(latest) = self.complete_pending_agent_reconnect() else {
+                    tracing::debug!(
+                        target: "agent_rebind",
+                        operation_id = %completed.operation_id,
+                        generation = completed.generation,
+                        "ignoring reconnect-ready event with no disconnect pending"
+                    );
+                    return;
+                };
+                tracing::info!(
+                    target: "agent_rebind",
+                    completed_operation_id = %completed.operation_id,
+                    completed_generation = completed.generation,
+                    target_operation_id = %latest.operation_id,
+                    target_generation = latest.generation,
+                    target_agent_id = %latest.agent_id,
+                    "old ACP transport retired; reconnecting helper to latest target"
+                );
+            }
+            AppEvent::AgentClientFailed => {
+                if let Some(latest) = self.complete_pending_agent_reconnect() {
+                    self.suppress_next_failed_client_error = true;
+                    tracing::info!(
+                        target: "agent_rebind",
+                        operation_id = %latest.operation_id,
+                        generation = latest.generation,
+                        agent_id = %latest.agent_id,
+                        "outgoing ACP client failed during startup; reconnecting to latest target"
+                    );
+                }
+            }
             AppEvent::AgentConnected {
                 name,
                 model,
@@ -559,8 +601,7 @@ impl App {
                 let Some(target_tab) = target_tab else {
                     return;
                 };
-                if let Some((_, current_model_id)) =
-                    self.session_model_configs.get_mut(&session_id)
+                if let Some((_, current_model_id)) = self.session_model_configs.get_mut(&session_id)
                 {
                     *current_model_id = Some(model.clone());
                 }
@@ -750,6 +791,11 @@ impl App {
                 failure,
                 message,
             } => {
+                if session_id.is_none()
+                    && std::mem::take(&mut self.suppress_next_failed_client_error)
+                {
+                    return;
+                }
                 // Classification is typed (`AgentFailure`), done once at the
                 // helper boundary where the `acp::Error` code / transport
                 // signal is still available. No substring matching here — the
@@ -769,10 +815,11 @@ impl App {
                     return;
                 }
 
-                let session_survives = matches!(
-                    &failure,
-                    crate::protocol::acp::failure::AgentFailure::Protocol { .. }
-                );
+                let session_survives = session_id.is_some()
+                    && matches!(
+                        &failure,
+                        crate::protocol::acp::failure::AgentFailure::Protocol { .. }
+                    );
 
                 let is_auth_error = failure.is_auth();
                 if is_auth_error && !self.preflight_setup_active {
@@ -864,6 +911,9 @@ impl App {
                 tab_id,
                 agent_id,
             } => {
+                if std::mem::take(&mut self.suppress_next_failed_client_error) {
+                    return;
+                }
                 tracing::warn!(
                     target: "auth_recovery",
                     failure_class = failure.class(),
@@ -1327,6 +1377,17 @@ impl App {
                 }
             }
             AppEvent::PreflightComplete(result) => {
+                if !self.current_agent_id.is_empty()
+                    && !result.agent_id.eq_ignore_ascii_case(&self.current_agent_id)
+                {
+                    tracing::debug!(
+                        target: "preflight",
+                        stale_agent = %result.agent_id,
+                        current_agent = %self.current_agent_id,
+                        "ignoring stale preflight result after agent rebind"
+                    );
+                    return;
+                }
                 tracing::info!(
                     target: "preflight",
                     agent = %result.agent_id,
@@ -1635,6 +1696,101 @@ impl App {
                     tracing::info!(target: "autofix", prompt_len = prompt.len(), "agent_prompt: delegating");
                     if !prompt.is_empty() {
                         self.delegate_to_tab_agent(prompt);
+                    }
+                    return;
+                }
+
+                if method == "rebind_agent" {
+                    let target_tab = params.get("tab_id").and_then(|value| value.as_str());
+                    if target_tab != self.owner_tab_id.as_deref() {
+                        return;
+                    }
+
+                    let Ok(wire) = serde_json::from_value::<AgentReconnectWire>(params.clone())
+                    else {
+                        tracing::warn!(
+                            target: "agent_rebind",
+                            payload = %params,
+                            "ignoring malformed agent rebind event"
+                        );
+                        return;
+                    };
+                    if !wire
+                        .agent_source
+                        .eq_ignore_ascii_case(crate::agent_source::AgentSource::HOST_KIND)
+                    {
+                        tracing::warn!(
+                            target: "agent_rebind",
+                            source = %wire.agent_source,
+                            "ignoring non-Host agent rebind"
+                        );
+                        return;
+                    }
+                    if wire.window_id.trim().is_empty()
+                        || self.window_id.as_deref().is_some_and(|window_id| {
+                            !window_id.is_empty() && window_id != wire.window_id
+                        })
+                    {
+                        return;
+                    }
+                    let mut request = AgentReconnectRequest {
+                        operation_id: wire.operation_id,
+                        window_id: wire.window_id,
+                        generation: wire.generation,
+                        agent_id: wire.agent_id,
+                        acp_model: wire.acp_model,
+                        agent_source: crate::agent_source::AgentSource::from_wire(
+                            Some(&wire.agent_source),
+                            None,
+                        ),
+                    };
+                    if request.operation_id.trim().is_empty()
+                        || (self.last_agent_rebind_window_id.as_deref()
+                            == Some(request.window_id.as_str())
+                            && request.generation <= self.last_agent_rebind_generation)
+                    {
+                        return;
+                    }
+                    if !matches!(request.agent_source, crate::agent_source::AgentSource::Host)
+                        || !crate::agent_registry::is_known_id(&request.agent_id)
+                        || (self.host_agent_allowlist_present
+                            && !self
+                                .allowed_agent_ids
+                                .iter()
+                                .any(|id| id.eq_ignore_ascii_case(&request.agent_id)))
+                    {
+                        tracing::warn!(
+                            target: "agent_rebind",
+                            operation_id = %request.operation_id,
+                            generation = request.generation,
+                            agent_id = %request.agent_id,
+                            source = %request.agent_source,
+                            "ignoring unsupported or policy-blocked agent rebind"
+                        );
+                        return;
+                    }
+
+                    request.agent_id.make_ascii_lowercase();
+                    request.acp_model = request
+                        .acp_model
+                        .take()
+                        .filter(|model| !model.trim().is_empty());
+                    self.last_agent_rebind_window_id = Some(request.window_id.clone());
+                    self.last_agent_rebind_generation = request.generation;
+                    self.prepare_agent_reconnect(&request);
+                    self.pending_agent_reconnect = Some(request.clone());
+
+                    if !self.agent_reconnect_disconnect_pending {
+                        self.agent_reconnect_disconnect_pending = true;
+                        if self
+                            .restart_tx
+                            .send(RestartRequest::RebindAgent(request))
+                            .is_err()
+                        {
+                            self.agent_reconnect_disconnect_pending = false;
+                            self.pending_agent_reconnect = None;
+                            self.pending_acp_start = true;
+                        }
                     }
                     return;
                 }
@@ -2646,6 +2802,7 @@ impl App {
                         );
                         self.deferred_acp = Some(DeferredAcpParams {
                             agent_cmd: new_cmd,
+                            agent_id: Some(agent_id),
                             acp_model: None,
                             agent_source: self.current_agent_source.clone(),
                             source_cwd: self.source_cwd.clone(),

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -7,6 +7,13 @@
 
 use super::*;
 
+pub(super) const AUTH_RECOVERY_CONNECTION_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(8);
+// SharedWta grants retirement 16 seconds before replacing the master. Allow
+// one second for replacement readiness plus one second of scheduling margin.
+pub(super) const AUTH_RECOVERY_MASTER_READY_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(18);
+
 #[derive(serde::Deserialize)]
 struct AgentReconnectWire {
     operation_id: String,
@@ -21,6 +28,27 @@ struct AgentReconnectWire {
 }
 
 impl App {
+    fn arm_auth_recovery_timeout(
+        &self,
+        agent_id: String,
+        generation: u64,
+        timeout: std::time::Duration,
+    ) {
+        let Some(tx) = self.event_tx.clone() else {
+            return;
+        };
+        if tokio::runtime::Handle::try_current().is_err() {
+            return;
+        }
+        tokio::task::spawn_local(async move {
+            tokio::time::sleep(timeout).await;
+            let _ = tx.send(AppEvent::AuthRecoveryTimedOut {
+                agent_id,
+                generation,
+            });
+        });
+    }
+
     fn handle_agent_rebind(&mut self, params: serde_json::Value) {
         let Ok(wire) = serde_json::from_value::<AgentReconnectWire>(params.clone()) else {
             tracing::warn!(
@@ -1095,7 +1123,7 @@ impl App {
                 // master restart below reconnects this retained helper, so the
                 // common path never flashes the setup screen. Only a dropped
                 // or slow restart leaves us in this state long enough for the
-                // `AuthRecoveryTimedOut` fallback to surface the sign-in screen.
+                // `AuthRecoveryTimedOut` handler to fall back to the sign-in screen.
                 self.mode = AppMode::Chat;
                 self.setup = None;
                 self.auth = None;
@@ -1116,24 +1144,15 @@ impl App {
                         &restart_request_id,
                     ),
                 );
-                // (iii) Dead-man fallback: a successful retained-helper
-                // reconnect advances the recovery generation before this
-                // timer fires. A dropped/slow restart surfaces the sign-in
-                // screen instead of stranding the user on "Reconnecting…".
-                // Guarded on a live async runtime so unit tests (no LocalSet)
-                // don't panic in `spawn_local`.
-                if let Some(ref tx) = self.event_tx {
-                    if tokio::runtime::Handle::try_current().is_ok() {
-                        let tx = tx.clone();
-                        tokio::task::spawn_local(async move {
-                            tokio::time::sleep(std::time::Duration::from_secs(8)).await;
-                            let _ = tx.send(AppEvent::AuthRecoveryTimedOut {
-                                agent_id: resolved,
-                                generation: recovery_generation,
-                            });
-                        });
-                    }
-                }
+                // (iii) Dead-man fallback for replacement-master readiness.
+                // This phase must cover SharedWta's retirement budget. Once
+                // readiness arrives, a fresh generation gets the usual,
+                // shorter connection deadline.
+                self.arm_auth_recovery_timeout(
+                    resolved,
+                    recovery_generation,
+                    AUTH_RECOVERY_MASTER_READY_TIMEOUT,
+                );
             }
             AppEvent::AuthRecoveryTimedOut {
                 agent_id,
@@ -1147,15 +1166,25 @@ impl App {
                 // started, or the reconnect already succeeded (AgentConnected
                 // bumps the generation), this no longer matches the current
                 // recovery and must not force the sign-in screen.
-                if generation == self.auth_recovery_generation
+                let timed_out_phase = if generation == self.auth_recovery_generation
                     && self.mode != AppMode::Setup
                     && matches!(self.state, ConnectionState::Connecting(_))
                 {
+                    match &self.auth_recovery_state {
+                        AuthRecoveryState::WaitingForMaster { .. } => Some("master readiness"),
+                        AuthRecoveryState::Connecting => Some("retained-helper connection"),
+                        AuthRecoveryState::Idle => None,
+                    }
+                } else {
+                    None
+                };
+                if let Some(phase) = timed_out_phase {
                     self.auth_recovery_state = AuthRecoveryState::Idle;
                     tracing::warn!(
                         target: "auth_recovery",
                         agent_id = %agent_id,
-                        "auth-recovery restart did not take effect within the window; \
+                        %phase,
+                        "auth recovery phase did not complete within its deadline; \
                          falling back to the sign-in screen"
                     );
                     let resolved = if !agent_id.is_empty() {
@@ -1903,7 +1932,28 @@ impl App {
                         "replacement master is ready; reconnecting retained helper"
                     );
                     if completes_auth_recovery {
+                        // Invalidate the longer master-readiness timer and arm
+                        // the normal connection deadline for this new phase.
+                        self.auth_recovery_generation =
+                            self.auth_recovery_generation.wrapping_add(1);
                         self.auth_recovery_state = AuthRecoveryState::Connecting;
+                        let agent_id = self
+                            .deferred_acp
+                            .as_ref()
+                            .and_then(|params| params.agent_id.clone())
+                            .filter(|agent_id| !agent_id.is_empty())
+                            .unwrap_or_else(|| {
+                                if self.current_agent_id.is_empty() {
+                                    "copilot".to_string()
+                                } else {
+                                    self.current_agent_id.clone()
+                                }
+                            });
+                        self.arm_auth_recovery_timeout(
+                            agent_id,
+                            self.auth_recovery_generation,
+                            AUTH_RECOVERY_CONNECTION_TIMEOUT,
+                        );
                     }
                     self.reset_agent_scoped_state();
                     self.pending_acp_start = true;

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -11,6 +11,7 @@ use super::*;
 struct AgentReconnectWire {
     operation_id: String,
     window_id: String,
+    tab_id: String,
     generation: u64,
     agent_id: String,
     acp_model: Option<String>,
@@ -20,6 +21,137 @@ struct AgentReconnectWire {
 }
 
 impl App {
+    fn handle_agent_rebind(&mut self, params: serde_json::Value) {
+        let Ok(wire) = serde_json::from_value::<AgentReconnectWire>(params.clone()) else {
+            tracing::warn!(
+                target: "agent_rebind",
+                payload = %params,
+                "ignoring malformed agent rebind event"
+            );
+            return;
+        };
+        if self.owner_tab_id.as_deref() != Some(wire.tab_id.as_str())
+            || wire.window_id.trim().is_empty()
+            || self
+                .window_id
+                .as_deref()
+                .is_some_and(|window_id| !window_id.is_empty() && window_id != wire.window_id)
+        {
+            return;
+        }
+
+        let agent_source = if wire
+            .agent_source
+            .eq_ignore_ascii_case(crate::agent_source::AgentSource::HOST_KIND)
+        {
+            crate::agent_source::AgentSource::Host
+        } else if wire
+            .agent_source
+            .eq_ignore_ascii_case(crate::agent_source::AgentSource::WSL_KIND)
+        {
+            let Some(distro) = wire
+                .wsl_distro
+                .as_deref()
+                .map(str::trim)
+                .filter(|distro| !distro.is_empty())
+            else {
+                tracing::warn!(
+                    target: "agent_rebind",
+                    "ignoring WSL agent rebind without a distro"
+                );
+                return;
+            };
+            crate::agent_source::AgentSource::Wsl {
+                distro: distro.to_string(),
+            }
+        } else {
+            tracing::warn!(
+                target: "agent_rebind",
+                source = %wire.agent_source,
+                "ignoring agent rebind with an unknown source"
+            );
+            return;
+        };
+
+        let mut request = AgentReconnectRequest {
+            operation_id: wire.operation_id,
+            window_id: wire.window_id,
+            generation: wire.generation,
+            agent_id: wire.agent_id,
+            acp_model: wire.acp_model,
+            custom_model_selection: wire.custom_model_selection,
+            agent_source,
+        };
+        if request.operation_id.trim().is_empty()
+            || (self.last_agent_rebind_window_id.as_deref() == Some(request.window_id.as_str())
+                && request.generation <= self.last_agent_rebind_generation)
+        {
+            return;
+        }
+        if request.agent_source != self.current_agent_source {
+            tracing::warn!(
+                target: "agent_rebind",
+                operation_id = %request.operation_id,
+                generation = request.generation,
+                current_source = %self.current_agent_source,
+                requested_source = %request.agent_source,
+                "ignoring execution-source-changing agent rebind"
+            );
+            return;
+        }
+        if !crate::agent_registry::is_known_id(&request.agent_id)
+            || (self.host_agent_allowlist_present
+                && !self
+                    .allowed_agent_ids
+                    .iter()
+                    .any(|id| id.eq_ignore_ascii_case(&request.agent_id)))
+        {
+            tracing::warn!(
+                target: "agent_rebind",
+                operation_id = %request.operation_id,
+                generation = request.generation,
+                agent_id = %request.agent_id,
+                source = %request.agent_source,
+                "ignoring unsupported or policy-blocked agent rebind"
+            );
+            return;
+        }
+
+        request.agent_id.make_ascii_lowercase();
+        request.acp_model = request
+            .acp_model
+            .take()
+            .filter(|model| !model.trim().is_empty());
+        request.custom_model_selection = request
+            .custom_model_selection
+            .take()
+            .filter(|selection| !selection.trim().is_empty());
+        if !matches!(request.agent_source, crate::agent_source::AgentSource::Host)
+            || crate::agent_registry::lookup_profile_by_id(&request.agent_id).byok_mode
+                == crate::agent_registry::ByokMode::Unsupported
+        {
+            request.custom_model_selection = None;
+        }
+
+        self.last_agent_rebind_window_id = Some(request.window_id.clone());
+        self.last_agent_rebind_generation = request.generation;
+        self.prepare_agent_reconnect(&request);
+
+        let disconnect_in_progress = matches!(
+            &self.agent_reconnect_state,
+            AgentReconnectState::Disconnecting(_)
+        );
+        self.agent_reconnect_state = AgentReconnectState::Disconnecting(request.clone());
+        if !disconnect_in_progress
+            && self
+                .restart_tx
+                .send(AgentLifecycleRequest::RebindAgent(request))
+                .is_err()
+        {
+            let _ = self.begin_pending_agent_reconnect_preflight();
+        }
+    }
+
     fn completed_turn_hit_at(&self, column: u16, row: u16) -> Option<CompletedTurnHitRegion> {
         let tab = self.current_tab();
         if self.mode != AppMode::Chat
@@ -422,6 +554,7 @@ impl App {
                 self.agent_model = model;
                 self.agent_version = version;
                 self.session_id = session_id.clone();
+                self.auth_recovery_state = AuthRecoveryState::Idle;
                 let (available_models, current_model_id) = self
                     .session_model_configs
                     .entry(session_id.clone())
@@ -902,7 +1035,15 @@ impl App {
                 }
             }
             AppEvent::MasterDisconnected => {
+                self.agent_reconnect_state = AgentReconnectState::Idle;
                 if self.deferred_acp.is_some() {
+                    if !matches!(&self.auth_recovery_state, AuthRecoveryState::Idle) {
+                        tracing::warn!(
+                            target: "helper",
+                            "master disconnected during auth recovery; explicit restart barrier owns reconnect"
+                        );
+                        return;
+                    }
                     tracing::warn!(
                         target: "helper",
                         agent_id = %self.current_agent_id,
@@ -946,6 +1087,10 @@ impl App {
                 // Connecting state.
                 self.auth_recovery_generation = self.auth_recovery_generation.wrapping_add(1);
                 let recovery_generation = self.auth_recovery_generation;
+                let restart_request_id = uuid::Uuid::new_v4().to_string();
+                self.auth_recovery_state = AuthRecoveryState::WaitingForMaster {
+                    request_id: restart_request_id.clone(),
+                };
                 // (i) Transient "Reconnecting…" — NOT the sign-in screen. The
                 // master restart below reconnects this retained helper, so the
                 // common path never flashes the setup screen. Only a dropped
@@ -964,11 +1109,11 @@ impl App {
                 // cached its unauthenticated state at spawn and `authenticate`
                 // does not refresh it; only a respawn (which re-reads the now
                 // valid on-disk credential) recovers. Reuse the tested
-                // `/restart` machinery; `tab_id` identifies the failing tab.
+                // `/restart` machinery. C++ publishes agent_master_restarted
+                // only after the replacement has claimed the stable pipe.
                 send_wt_protocol_event(
-                    crate::wt_protocol_events::restart_agent_stack_event(
-                        Some("auth_recovery"),
-                        tab_id.as_deref(),
+                    crate::wt_protocol_events::restart_agent_stack_event_with_id(
+                        &restart_request_id,
                     ),
                 );
                 // (iii) Dead-man fallback: a successful retained-helper
@@ -1006,6 +1151,7 @@ impl App {
                     && self.mode != AppMode::Setup
                     && matches!(self.state, ConnectionState::Connecting(_))
                 {
+                    self.auth_recovery_state = AuthRecoveryState::Idle;
                     tracing::warn!(
                         target: "auth_recovery",
                         agent_id = %agent_id,
@@ -1386,9 +1532,7 @@ impl App {
                 }
             }
             AppEvent::PreflightComplete(result) => {
-                if self.agent_reconnect_disconnect_pending
-                    || self.agent_reconnect_preflight_pending
-                {
+                if !matches!(&self.agent_reconnect_state, AgentReconnectState::Idle) {
                     tracing::debug!(
                         target: "preflight",
                         stale_agent = %result.agent_id,
@@ -1424,12 +1568,14 @@ impl App {
                 generation,
                 result,
             } => {
-                let matches_pending = self.agent_reconnect_preflight_pending
-                    && self.pending_agent_reconnect.as_ref().is_some_and(|pending| {
+                let matches_pending = match &self.agent_reconnect_state {
+                    AgentReconnectState::Preflighting(pending) => {
                         pending.operation_id == operation_id
                             && pending.generation == generation
                             && pending.agent_id.eq_ignore_ascii_case(&result.agent_id)
-                    });
+                    }
+                    _ => false,
+                };
                 if !matches_pending {
                     tracing::debug!(
                         target: "agent_rebind",
@@ -1441,8 +1587,7 @@ impl App {
                     return;
                 }
 
-                self.agent_reconnect_preflight_pending = false;
-                self.pending_agent_reconnect = None;
+                self.agent_reconnect_state = AgentReconnectState::Idle;
                 if result.all_passed() {
                     self.pending_acp_start = true;
                     tracing::info!(
@@ -1720,135 +1865,41 @@ impl App {
                     return;
                 }
 
+                if method == "agent_master_restarted" {
+                    let request_id = params
+                        .get("operation_id")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("");
+                    if !matches!(
+                        &self.auth_recovery_state,
+                        AuthRecoveryState::WaitingForMaster {
+                            request_id: expected
+                        } if expected == request_id
+                    ) {
+                        return;
+                    }
+                    if self.deferred_acp.is_none() {
+                        tracing::warn!(
+                            target: "auth_recovery",
+                            %request_id,
+                            "replacement master is ready but helper binding is unavailable"
+                        );
+                        return;
+                    }
+
+                    tracing::info!(
+                        target: "auth_recovery",
+                        %request_id,
+                        "replacement master is ready; reconnecting retained helper"
+                    );
+                    self.auth_recovery_state = AuthRecoveryState::Connecting;
+                    self.reset_agent_scoped_state();
+                    self.pending_acp_start = true;
+                    return;
+                }
+
                 if method == "rebind_agent" {
-                    let target_tab = params.get("tab_id").and_then(|value| value.as_str());
-                    if target_tab != self.owner_tab_id.as_deref() {
-                        return;
-                    }
-
-                    let Ok(wire) = serde_json::from_value::<AgentReconnectWire>(params.clone())
-                    else {
-                        tracing::warn!(
-                            target: "agent_rebind",
-                            payload = %params,
-                            "ignoring malformed agent rebind event"
-                        );
-                        return;
-                    };
-                    if wire.window_id.trim().is_empty()
-                        || self.window_id.as_deref().is_some_and(|window_id| {
-                            !window_id.is_empty() && window_id != wire.window_id
-                        })
-                    {
-                        return;
-                    }
-                    let agent_source = if wire
-                        .agent_source
-                        .eq_ignore_ascii_case(crate::agent_source::AgentSource::HOST_KIND)
-                    {
-                        crate::agent_source::AgentSource::Host
-                    } else if wire
-                        .agent_source
-                        .eq_ignore_ascii_case(crate::agent_source::AgentSource::WSL_KIND)
-                    {
-                        let Some(distro) = wire
-                            .wsl_distro
-                            .as_deref()
-                            .map(str::trim)
-                            .filter(|distro| !distro.is_empty())
-                        else {
-                            tracing::warn!(
-                                target: "agent_rebind",
-                                "ignoring WSL agent rebind without a distro"
-                            );
-                            return;
-                        };
-                        crate::agent_source::AgentSource::Wsl {
-                            distro: distro.to_string(),
-                        }
-                    } else {
-                        tracing::warn!(
-                            target: "agent_rebind",
-                            source = %wire.agent_source,
-                            "ignoring agent rebind with an unknown source"
-                        );
-                        return;
-                    };
-                    let mut request = AgentReconnectRequest {
-                        operation_id: wire.operation_id,
-                        window_id: wire.window_id,
-                        generation: wire.generation,
-                        agent_id: wire.agent_id,
-                        acp_model: wire.acp_model,
-                        custom_model_selection: wire.custom_model_selection,
-                        agent_source,
-                    };
-                    if request.operation_id.trim().is_empty()
-                        || (self.last_agent_rebind_window_id.as_deref()
-                            == Some(request.window_id.as_str())
-                            && request.generation <= self.last_agent_rebind_generation)
-                    {
-                        return;
-                    }
-                    if request.agent_source != self.current_agent_source {
-                        tracing::warn!(
-                            target: "agent_rebind",
-                            operation_id = %request.operation_id,
-                            generation = request.generation,
-                            current_source = %self.current_agent_source,
-                            requested_source = %request.agent_source,
-                            "ignoring execution-source-changing agent rebind"
-                        );
-                        return;
-                    }
-                    if !crate::agent_registry::is_known_id(&request.agent_id)
-                        || (self.host_agent_allowlist_present
-                            && !self
-                                .allowed_agent_ids
-                                .iter()
-                                .any(|id| id.eq_ignore_ascii_case(&request.agent_id)))
-                    {
-                        tracing::warn!(
-                            target: "agent_rebind",
-                            operation_id = %request.operation_id,
-                            generation = request.generation,
-                            agent_id = %request.agent_id,
-                            source = %request.agent_source,
-                            "ignoring unsupported or policy-blocked agent rebind"
-                        );
-                        return;
-                    }
-
-                    request.agent_id.make_ascii_lowercase();
-                    request.acp_model = request
-                        .acp_model
-                        .take()
-                        .filter(|model| !model.trim().is_empty());
-                    request.custom_model_selection = request
-                        .custom_model_selection
-                        .take()
-                        .filter(|selection| !selection.trim().is_empty());
-                    if !matches!(request.agent_source, crate::agent_source::AgentSource::Host)
-                        || crate::agent_registry::lookup_profile_by_id(&request.agent_id).byok_mode
-                            == crate::agent_registry::ByokMode::Unsupported
-                    {
-                        request.custom_model_selection = None;
-                    }
-                    self.last_agent_rebind_window_id = Some(request.window_id.clone());
-                    self.last_agent_rebind_generation = request.generation;
-                    self.prepare_agent_reconnect(&request);
-                    self.pending_agent_reconnect = Some(request.clone());
-
-                    if !self.agent_reconnect_disconnect_pending {
-                        self.agent_reconnect_disconnect_pending = true;
-                        if self
-                            .restart_tx
-                            .send(RestartRequest::RebindAgent(request.clone()))
-                            .is_err()
-                        {
-                            let _ = self.begin_pending_agent_reconnect_preflight();
-                        }
-                    }
+                    self.handle_agent_rebind(params);
                     return;
                 }
 

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -14,6 +14,7 @@ struct AgentReconnectWire {
     generation: u64,
     agent_id: String,
     acp_model: Option<String>,
+    custom_model_selection: Option<String>,
     agent_source: String,
 }
 
@@ -1739,6 +1740,7 @@ impl App {
                         generation: wire.generation,
                         agent_id: wire.agent_id,
                         acp_model: wire.acp_model,
+                        custom_model_selection: wire.custom_model_selection,
                         agent_source: crate::agent_source::AgentSource::from_wire(
                             Some(&wire.agent_source),
                             None,
@@ -1775,6 +1777,15 @@ impl App {
                         .acp_model
                         .take()
                         .filter(|model| !model.trim().is_empty());
+                    request.custom_model_selection = request
+                        .custom_model_selection
+                        .take()
+                        .filter(|selection| !selection.trim().is_empty());
+                    if crate::agent_registry::lookup_profile_by_id(&request.agent_id).byok_mode
+                        == crate::agent_registry::ByokMode::Unsupported
+                    {
+                        request.custom_model_selection = None;
+                    }
                     self.last_agent_rebind_window_id = Some(request.window_id.clone());
                     self.last_agent_rebind_generation = request.generation;
                     self.prepare_agent_reconnect(&request);
@@ -1807,8 +1818,19 @@ impl App {
                     // dispatch: each field is optional and only present when
                     // it actually changed, so we apply exactly what's set
                     // — all in place, with NO agent-pane teardown/restart.
-                    // (Agent *identity* changes go through a master respawn
-                    // on the C++ side, not this event.)
+                    // Agent identity and launch-time model changes use the
+                    // separate same-helper rebind event.
+                    let target_window = params
+                        .get("window_id")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("");
+                    let owner_window = self.window_id.as_deref().unwrap_or("");
+                    if !target_window.is_empty()
+                        && !owner_window.is_empty()
+                        && target_window != owner_window
+                    {
+                        return;
+                    }
                     let target_tab = params
                         .get("tab_id")
                         .and_then(|value| value.as_str())
@@ -2804,6 +2826,7 @@ impl App {
                             agent_cmd: new_cmd,
                             agent_id: Some(agent_id),
                             acp_model: None,
+                            custom_model_selection: self.custom_model_selection.clone(),
                             agent_source: self.current_agent_source.clone(),
                             source_cwd: self.source_cwd.clone(),
                             prompt_rx: None, // try_start_acp will create fresh channels

--- a/tools/wta/src/app_status_projection.rs
+++ b/tools/wta/src/app_status_projection.rs
@@ -21,8 +21,8 @@ impl App {
             ConnectionState::Failed(_) => "failed",
             ConnectionState::Disconnected => "disconnected",
         };
-        // Include selected_agent only once — when connected after user selection.
-        // This avoids triggering _RebuildAgentStack mid-FRE.
+        // Include selected_agent only once, after the selected Agent connects,
+        // so C++ persists only a completed first-run selection.
         let selected = if self.state == ConnectionState::Connected {
             self.pending_agent_selection.take()
         } else {

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -174,6 +174,19 @@ fn agent_rebind_event_for_window(
     }
 }
 
+fn passed_preflight(agent_id: &str, display_name: &str) -> PreflightResult {
+    PreflightResult {
+        agent_id: agent_id.into(),
+        display_name: display_name.into(),
+        cli_status: CheckStatus::Passed,
+        cli_path: Some(format!(r"C:\Agents\{agent_id}.exe")),
+        auth_status: CheckStatus::Skipped,
+        install_hint: String::new(),
+        install_url: String::new(),
+        auth_hint: String::new(),
+    }
+}
+
 #[test]
 fn tab_close_drops_state_and_requests_acp_session_close() {
     let (mut app, mut drop_session_rx) = test_app_with_drop_session_rx();
@@ -3095,13 +3108,88 @@ fn settings_agent_rebind_targets_owner_and_resets_only_agent_state() {
         },
         message: "outgoing client failed".into(),
     });
-    assert!(app.pending_acp_start);
+    assert!(!app.pending_acp_start);
     assert!(!app.agent_reconnect_disconnect_pending);
-    assert!(app.pending_agent_reconnect.is_none());
+    assert!(app.agent_reconnect_preflight_pending);
+    assert!(app.pending_agent_reconnect.is_some());
     assert!(
         app.current_tab().messages.is_empty(),
         "the outgoing client's startup error must not leak into the new agent chat"
     );
+
+    app.handle_event(AppEvent::AgentReconnectPreflightComplete {
+        operation_id: "op-1".into(),
+        generation: 1,
+        result: passed_preflight("claude", "Claude"),
+    });
+    assert!(app.pending_acp_start);
+    assert!(!app.agent_reconnect_preflight_pending);
+    assert!(app.pending_agent_reconnect.is_none());
+}
+
+#[test]
+fn settings_agent_rebind_missing_target_enters_install_setup_after_retirement() {
+    let (mut app, mut restart_rx) = test_app_with_restart_rx();
+    app.owner_tab_id = Some("owner-tab".into());
+    app.window_id = Some("window-1".into());
+    app.tab_id = Some("owner-tab".into());
+    app.current_agent_id = "claude".into();
+    app.tab_mut("owner-tab");
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "claude --acp".into(),
+        Some("claude".into()),
+        None,
+        None,
+        crate::agent_source::AgentSource::Host,
+        None,
+        Some("owner-tab".into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
+
+    app.handle_event(agent_rebind_event("owner-tab", 1, "copilot"));
+    let retired = match restart_rx
+        .try_recv()
+        .expect("the old transport should be retired before target preflight")
+    {
+        RestartRequest::RebindAgent(request) => request,
+        other => panic!("expected RebindAgent, got {other:?}"),
+    };
+    assert_eq!(app.current_agent_id, "copilot");
+    assert!(!app.pending_acp_start);
+
+    app.handle_event(AppEvent::AgentReconnectReady(retired));
+    assert!(!app.agent_reconnect_disconnect_pending);
+    assert!(app.agent_reconnect_preflight_pending);
+    assert!(!app.pending_acp_start);
+
+    app.handle_event(AppEvent::AgentReconnectPreflightComplete {
+        operation_id: "op-1".into(),
+        generation: 1,
+        result: PreflightResult {
+            agent_id: "copilot".into(),
+            display_name: "GitHub Copilot".into(),
+            cli_status: CheckStatus::Failed("Not found on PATH".into()),
+            cli_path: None,
+            auth_status: CheckStatus::Skipped,
+            install_hint: "Install GitHub Copilot".into(),
+            install_url: String::new(),
+            auth_hint: String::new(),
+        },
+    });
+
+    assert_eq!(app.current_agent_id, "copilot");
+    assert_eq!(app.mode, AppMode::Setup);
+    assert!(app.preflight_setup_active);
+    assert!(!app.pending_acp_start);
+    assert!(!app.agent_reconnect_preflight_pending);
+    assert!(app.pending_agent_reconnect.is_none());
+    let setup = app.setup.as_ref().expect("missing target should show Setup");
+    assert_eq!(setup.reason, SetupReason::AgentMissing);
+    assert!(setup.options.iter().any(
+        |option| matches!(option, SetupOption::Install { agent_id, .. } if agent_id == "copilot")
+    ));
 }
 
 #[test]
@@ -3206,15 +3294,36 @@ fn settings_agent_rebind_ignores_stale_generation_and_converges_to_latest_target
 
     app.handle_event(AppEvent::AgentReconnectReady(first));
 
-    assert!(app.pending_acp_start);
+    assert!(!app.pending_acp_start);
     assert!(!app.agent_reconnect_disconnect_pending);
-    assert!(app.pending_agent_reconnect.is_none());
+    assert!(app.agent_reconnect_preflight_pending);
+    assert!(app.pending_agent_reconnect.is_some());
     assert_eq!(
         app.deferred_acp
             .as_ref()
             .and_then(|params| params.agent_id.as_deref()),
         Some("gemini"),
         "the reconnect must use the newest accepted Settings generation"
+    );
+
+    app.handle_event(AppEvent::AgentReconnectPreflightComplete {
+        operation_id: "op-11".into(),
+        generation: 11,
+        result: passed_preflight("gemini", "Gemini"),
+    });
+    assert!(app.pending_acp_start);
+    assert!(!app.agent_reconnect_preflight_pending);
+    assert!(app.pending_agent_reconnect.is_none());
+
+    app.pending_acp_start = false;
+    app.handle_event(AppEvent::AgentReconnectPreflightComplete {
+        operation_id: "op-11".into(),
+        generation: 11,
+        result: passed_preflight("gemini", "Gemini"),
+    });
+    assert!(
+        !app.pending_acp_start,
+        "a duplicate target preflight must not start a second reconnect"
     );
 
     app.window_id = Some("window-2".into());

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -149,7 +149,13 @@ fn test_app_with_drop_session_rx() -> (
 }
 
 fn agent_rebind_event(tab_id: &str, generation: u64, agent_id: &str) -> AppEvent {
-    agent_rebind_event_for_window("window-1", tab_id, generation, agent_id)
+    agent_rebind_event_for_window(
+        "window-1",
+        tab_id,
+        generation,
+        agent_id,
+        &crate::agent_source::AgentSource::Host,
+    )
 }
 
 fn agent_rebind_event_for_window(
@@ -157,6 +163,7 @@ fn agent_rebind_event_for_window(
     tab_id: &str,
     generation: u64,
     agent_id: &str,
+    source: &crate::agent_source::AgentSource,
 ) -> AppEvent {
     AppEvent::WtEvent {
         method: "rebind_agent".into(),
@@ -168,7 +175,8 @@ fn agent_rebind_event_for_window(
             "window_id": window_id,
             "tab_id": tab_id,
             "agent_id": agent_id,
-            "agent_source": "host",
+            "agent_source": source.kind(),
+            "wsl_distro": source.distro(),
             "acp_model": ""
         }),
     }
@@ -3128,6 +3136,77 @@ fn settings_agent_rebind_targets_owner_and_resets_only_agent_state() {
 }
 
 #[test]
+fn agent_rebind_accepts_only_the_helpers_current_execution_source() {
+    let (mut app, mut restart_rx) = test_app_with_restart_rx();
+    app.owner_tab_id = Some("owner-tab".into());
+    app.window_id = Some("window-1".into());
+    app.tab_id = Some("owner-tab".into());
+    app.current_agent_id = "copilot".into();
+    app.current_agent_source = crate::agent_source::AgentSource::Wsl {
+        distro: "Ubuntu".into(),
+    };
+    app.tab_mut("owner-tab");
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "copilot --acp".into(),
+        Some("copilot".into()),
+        None,
+        None,
+        app.current_agent_source.clone(),
+        Some("/home/user/project".into()),
+        Some("owner-tab".into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
+
+    app.handle_event(agent_rebind_event("owner-tab", 1, "claude"));
+    assert!(restart_rx.try_recv().is_err());
+    assert_eq!(app.current_agent_id, "copilot");
+
+    app.handle_event(agent_rebind_event_for_window(
+        "window-1",
+        "owner-tab",
+        1,
+        "claude",
+        &crate::agent_source::AgentSource::Wsl {
+            distro: "Debian".into(),
+        },
+    ));
+    assert!(restart_rx.try_recv().is_err());
+    assert_eq!(app.current_agent_id, "copilot");
+
+    app.handle_event(agent_rebind_event_for_window(
+        "window-1",
+        "owner-tab",
+        1,
+        "claude",
+        &crate::agent_source::AgentSource::Wsl {
+            distro: "Ubuntu".into(),
+        },
+    ));
+    let request = match restart_rx
+        .try_recv()
+        .expect("same-distro WSL rebind should reuse the helper")
+    {
+        RestartRequest::RebindAgent(request) => request,
+        other => panic!("expected RebindAgent, got {other:?}"),
+    };
+    assert_eq!(
+        request.agent_source,
+        crate::agent_source::AgentSource::Wsl {
+            distro: "Ubuntu".into()
+        }
+    );
+    assert_eq!(app.current_agent_id, "claude");
+    assert_eq!(
+        app.deferred_acp
+            .as_ref()
+            .and_then(|params| params.source_cwd.as_deref()),
+        Some("/home/user/project")
+    );
+}
+
+#[test]
 fn settings_agent_rebind_missing_target_enters_install_setup_after_retirement() {
     let (mut app, mut restart_rx) = test_app_with_restart_rx();
     app.owner_tab_id = Some("owner-tab".into());
@@ -3437,6 +3516,7 @@ fn settings_agent_rebind_ignores_stale_generation_and_converges_to_latest_target
         "owner-tab",
         1,
         "codex",
+        &crate::agent_source::AgentSource::Host,
     ));
     assert_eq!(app.current_agent_id, "codex");
     assert!(matches!(
@@ -5571,16 +5651,58 @@ fn post_login_auth_recovery_shows_reconnecting_then_signin_fallback() {
 }
 
 #[test]
-fn master_disconnect_terminates_helper_without_recovery() {
+fn master_disconnect_reconnects_retained_custom_wsl_helper() {
     let mut app = test_app();
+    app.current_agent_id = "custom:local".into();
+    app.current_agent_source = crate::agent_source::AgentSource::Wsl {
+        distro: "Ubuntu".into(),
+    };
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "custom-agent --serve".into(),
+        Some("custom:local".into()),
+        Some("custom-model".into()),
+        None,
+        app.current_agent_source.clone(),
+        Some("/home/user/project".into()),
+        Some("owner-tab".into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
     assert!(!app.should_quit);
 
     app.handle_event(AppEvent::MasterDisconnected);
 
+    assert!(!app.should_quit);
     assert!(
-        app.should_quit,
-        "master disconnect must terminate the helper instead of retaining a recoverable pane"
+        app.pending_acp_start,
+        "master disconnect must reconnect the existing immutable binding"
     );
+    assert_eq!(
+        app.deferred_acp
+            .as_ref()
+            .and_then(|params| params.agent_id.as_deref()),
+        Some("custom:local")
+    );
+    let deferred = app.deferred_acp.as_ref().unwrap();
+    assert_eq!(deferred.agent_cmd, "custom-agent --serve");
+    assert_eq!(deferred.acp_model.as_deref(), Some("custom-model"));
+    assert_eq!(deferred.source_cwd.as_deref(), Some("/home/user/project"));
+    assert_eq!(
+        deferred.agent_source,
+        crate::agent_source::AgentSource::Wsl {
+            distro: "Ubuntu".into()
+        }
+    );
+}
+
+#[test]
+fn master_disconnect_without_binding_terminates_helper() {
+    let mut app = test_app();
+
+    app.handle_event(AppEvent::MasterDisconnected);
+
+    assert!(app.should_quit);
 }
 
 /// A one-off protocol error ends the turn while preserving the live session.

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -3003,6 +3003,7 @@ fn settings_agent_rebind_targets_owner_and_resets_only_agent_state() {
         "copilot --acp".into(),
         Some("copilot".into()),
         Some("old-model".into()),
+        None,
         crate::agent_source::AgentSource::Host,
         None,
         Some("owner-tab".into()),
@@ -3104,6 +3105,62 @@ fn settings_agent_rebind_targets_owner_and_resets_only_agent_state() {
 }
 
 #[test]
+fn settings_model_rebind_preserves_custom_provider_selection() {
+    let (mut app, mut restart_rx) = test_app_with_restart_rx();
+    app.owner_tab_id = Some("owner-tab".into());
+    app.window_id = Some("window-1".into());
+    app.tab_id = Some("owner-tab".into());
+    app.current_agent_id = "copilot".into();
+    app.tab_mut("owner-tab");
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "copilot --acp".into(),
+        Some("copilot".into()),
+        None,
+        None,
+        crate::agent_source::AgentSource::Host,
+        None,
+        Some("owner-tab".into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
+
+    app.handle_event(AppEvent::WtEvent {
+        method: "rebind_agent".into(),
+        pane_id: String::new(),
+        tab_id: None,
+        params: json!({
+            "operation_id": "model-rebind",
+            "generation": 1,
+            "window_id": "window-1",
+            "tab_id": "owner-tab",
+            "agent_id": "copilot",
+            "agent_source": "host",
+            "acp_model": "",
+            "custom_model_selection": "custom:provider:model-a"
+        }),
+    });
+
+    let request = match restart_rx
+        .try_recv()
+        .expect("custom model selection should trigger a controlled reconnect")
+    {
+        RestartRequest::RebindAgent(request) => request,
+        other => panic!("expected RebindAgent, got {other:?}"),
+    };
+    assert_eq!(
+        request.custom_model_selection.as_deref(),
+        Some("custom:provider:model-a")
+    );
+    assert_eq!(
+        app.deferred_acp
+            .as_ref()
+            .and_then(|params| params.custom_model_selection.as_deref()),
+        Some("custom:provider:model-a")
+    );
+}
+
+#[test]
 fn settings_agent_rebind_ignores_stale_generation_and_converges_to_latest_target() {
     let (mut app, mut restart_rx) = test_app_with_restart_rx();
     app.owner_tab_id = Some("owner-tab".into());
@@ -3115,6 +3172,7 @@ fn settings_agent_rebind_ignores_stale_generation_and_converges_to_latest_target
         "master-pipe".into(),
         "copilot --acp".into(),
         Some("copilot".into()),
+        None,
         None,
         crate::agent_source::AgentSource::Host,
         None,
@@ -3188,9 +3246,22 @@ fn global_model_hot_update_is_scoped_to_matching_global_followers() {
     use crate::protocol::acp::client::MasterExtRequest;
 
     let (mut app, mut master_rx) = test_app_with_master_rx();
+    app.window_id = Some("window-1".into());
     app.current_agent_id = "gemini".into();
     app.follows_global_acp_model = true;
     app.current_tab_mut().session_id = Some("gemini-session".into());
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "copilot --acp".into(),
+        Some("copilot".into()),
+        None,
+        None,
+        crate::agent_source::AgentSource::Host,
+        None,
+        None,
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
 
     app.handle_event(AppEvent::WtEvent {
         method: "agent_config_changed".into(),
@@ -3227,11 +3298,35 @@ fn global_model_hot_update_is_scoped_to_matching_global_followers() {
         pane_id: String::new(),
         tab_id: None,
         params: serde_json::json!({
+            "window_id": "window-2",
+            "acp_model": "wrong-window-model",
+            "target_agent_id": "copilot"
+        }),
+    });
+    assert!(
+        app.acp_model.is_none(),
+        "another window's settings event must be ignored"
+    );
+    assert!(master_rx.try_recv().is_err());
+
+    app.handle_event(AppEvent::WtEvent {
+        method: "agent_config_changed".into(),
+        pane_id: String::new(),
+        tab_id: None,
+        params: serde_json::json!({
+            "window_id": "window-1",
             "acp_model": "copilot-only-model",
             "target_agent_id": "copilot"
         }),
     });
     assert_eq!(app.acp_model.as_deref(), Some("copilot-only-model"));
+    assert_eq!(
+        app.deferred_acp
+            .as_ref()
+            .and_then(|params| params.acp_model.as_deref()),
+        Some("copilot-only-model"),
+        "a later transport reconnect must retain the hot-updated model"
+    );
     match master_rx
         .try_recv()
         .expect("matching global-following helper should receive the model")

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -5,7 +5,7 @@
 //! this was an inline `mod tests { ... }` block.
 
 use super::*;
-use crate::app::tab_state::collapsed_prompt_preview;
+use crate::app::tab_state::{collapsed_prompt_preview, PendingTerminalActionProposal};
 use crate::app_contracts::{PermOption, PlanEntry};
 use serde_json::json;
 
@@ -78,6 +78,41 @@ pub(super) fn test_app() -> App {
     )
 }
 
+fn test_app_with_restart_rx() -> (
+    App,
+    tokio::sync::mpsc::UnboundedReceiver<crate::protocol::acp::client::RestartRequest>,
+) {
+    let (prompt_tx, _prompt_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (recommendation_tx, _recommendation_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (permission_tx, _permission_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (cancel_tx, _cancel_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (new_session_tx, _new_session_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (load_session_tx, _load_session_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (drop_session_tx, _drop_session_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (rename_session_tx, _rename_session_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (restart_tx, restart_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (master_tx, _master_rx) = tokio::sync::mpsc::unbounded_channel();
+    (
+        App::new(
+            prompt_tx,
+            recommendation_tx,
+            permission_tx,
+            cancel_tx,
+            new_session_tx,
+            load_session_tx,
+            drop_session_tx,
+            rename_session_tx,
+            restart_tx,
+            master_tx,
+            Arc::new(AtomicBool::new(false)),
+            true,
+            false,
+            Arc::new(crate::shell::ShellManager::new()),
+        ),
+        restart_rx,
+    )
+}
+
 fn test_app_with_drop_session_rx() -> (
     App,
     tokio::sync::mpsc::UnboundedReceiver<crate::protocol::acp::client::DropSessionRequest>,
@@ -111,6 +146,32 @@ fn test_app_with_drop_session_rx() -> (
         ),
         drop_session_rx,
     )
+}
+
+fn agent_rebind_event(tab_id: &str, generation: u64, agent_id: &str) -> AppEvent {
+    agent_rebind_event_for_window("window-1", tab_id, generation, agent_id)
+}
+
+fn agent_rebind_event_for_window(
+    window_id: &str,
+    tab_id: &str,
+    generation: u64,
+    agent_id: &str,
+) -> AppEvent {
+    AppEvent::WtEvent {
+        method: "rebind_agent".into(),
+        pane_id: String::new(),
+        tab_id: None,
+        params: json!({
+            "operation_id": format!("op-{generation}"),
+            "generation": generation,
+            "window_id": window_id,
+            "tab_id": tab_id,
+            "agent_id": agent_id,
+            "agent_source": "host",
+            "acp_model": ""
+        }),
+    }
 }
 
 #[test]
@@ -2886,6 +2947,243 @@ fn non_overridden_pane_follows_global_model() {
 }
 
 #[test]
+fn settings_agent_rebind_targets_owner_and_resets_only_agent_state() {
+    let (mut app, mut restart_rx) = test_app_with_restart_rx();
+    app.owner_tab_id = Some("owner-tab".into());
+    app.window_id = Some("window-1".into());
+    app.tab_id = Some("owner-tab".into());
+    app.current_agent_id = "copilot".into();
+    app.agent_name = "GitHub Copilot".into();
+    app.agent_model = Some("old-model".into());
+    app.session_id = "old-session".into();
+    app.available_models = vec![model_info("old-model")];
+    app.current_model_id = Some("old-model".into());
+    app.mode = AppMode::Setup;
+    app.preflight_setup_active = true;
+    {
+        let tab = app.tab_mut("owner-tab");
+        tab.input = "keep this draft".into();
+        tab.cursor_pos = tab.input.len();
+        tab.messages.push(ChatMessage::Agent("old response".into()));
+        tab.session_id = Some("old-session".into());
+        tab.usage = Some(usage_snapshot());
+        tab.loading_session = true;
+        tab.loading_target_session_id = Some("loading-old-session".into());
+        tab.model_picker_open = true;
+        tab.model_picker_selected = 3;
+        tab.config_picker = ConfigPickerState::Values {
+            option_id: "old-config".into(),
+            selected: 2,
+            parent_selected: Some(1),
+        };
+        tab.config_pending_id = Some("old-config".into());
+        tab.agent_picker_open = true;
+        tab.agent_picker_selected = 2;
+        tab.pending_terminal_action_proposal = Some(PendingTerminalActionProposal {
+            proposal_id: "old-proposal".into(),
+            session_id: "old-session".into(),
+            prompt_id: 42,
+            is_autofix: false,
+            recommendations: RecommendationSet {
+                recommended_choice: None,
+                choices: Vec::new(),
+            },
+        });
+        tab.active_direct_proposal_id = Some("old-direct-proposal".into());
+        tab.autofix.generation = 7;
+        tab.autofix.pane_id = Some("failing-pane".into());
+        tab.autofix.suggested_pane_id = Some("failing-pane".into());
+        tab.autofix.bar_snapshot = AutofixBarSnapshot::Pending {
+            pane_id: "failing-pane".into(),
+            summary: "old failure".into(),
+        };
+    }
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "copilot --acp".into(),
+        Some("copilot".into()),
+        Some("old-model".into()),
+        crate::agent_source::AgentSource::Host,
+        None,
+        Some("owner-tab".into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
+
+    app.handle_event(agent_rebind_event("other-tab", 1, "claude"));
+    assert!(restart_rx.try_recv().is_err());
+    assert_eq!(app.current_agent_id, "copilot");
+
+    app.handle_event(agent_rebind_event("owner-tab", 1, "claude"));
+
+    match restart_rx
+        .try_recv()
+        .expect("matching helper should begin a controlled reconnect")
+    {
+        RestartRequest::RebindAgent(request) => {
+            assert_eq!(request.agent_id, "claude");
+            assert_eq!(request.generation, 1);
+            assert!(request.acp_model.is_none());
+        }
+        other => panic!("expected RebindAgent, got {other:?}"),
+    }
+    assert_eq!(app.current_agent_id, "claude");
+    assert!(app.agent_name.is_empty());
+    assert!(app.agent_model.is_none());
+    assert!(app.session_id.is_empty());
+    assert!(app.available_models.is_empty());
+    assert!(app.current_model_id.is_none());
+    assert_eq!(app.current_tab().input, "keep this draft");
+    assert!(app.current_tab().messages.is_empty());
+    assert!(app.current_tab().session_id.is_none());
+    assert!(app.current_tab().usage.is_none());
+    assert!(!app.current_tab().loading_session);
+    assert!(app.current_tab().loading_target_session_id.is_none());
+    assert!(!app.current_tab().model_picker_open);
+    assert!(matches!(
+        app.current_tab().config_picker,
+        ConfigPickerState::Closed
+    ));
+    assert!(app.current_tab().config_pending_id.is_none());
+    assert!(!app.current_tab().agent_picker_open);
+    assert!(app
+        .current_tab()
+        .pending_terminal_action_proposal
+        .is_none());
+    assert!(app.current_tab().active_direct_proposal_id.is_none());
+    assert_eq!(app.current_tab().autofix.generation, 8);
+    assert!(app.current_tab().autofix.pane_id.is_none());
+    assert!(app.current_tab().autofix.suggested_pane_id.is_none());
+    assert!(matches!(
+        app.current_tab().autofix.bar_snapshot,
+        AutofixBarSnapshot::Idle
+    ));
+    assert_eq!(app.mode, AppMode::Chat);
+    assert!(!app.preflight_setup_active);
+    assert!(app.auth.is_none());
+    assert!(app.setup.is_none());
+    let deferred = app
+        .deferred_acp
+        .as_ref()
+        .expect("agent target should remain available for reconnect");
+    assert_eq!(deferred.agent_id.as_deref(), Some("claude"));
+    assert!(deferred.acp_model.is_none());
+
+    app.handle_event(AppEvent::PreflightComplete(PreflightResult {
+        agent_id: "copilot".into(),
+        display_name: "GitHub Copilot".into(),
+        cli_status: CheckStatus::Failed("stale result".into()),
+        cli_path: None,
+        auth_status: CheckStatus::Skipped,
+        install_hint: String::new(),
+        install_url: String::new(),
+        auth_hint: String::new(),
+    }));
+    assert_eq!(
+        app.mode,
+        AppMode::Chat,
+        "late setup results from the outgoing agent must be ignored"
+    );
+
+    app.handle_event(AppEvent::AgentClientFailed);
+    app.handle_event(AppEvent::AgentError {
+        session_id: None,
+        failure: crate::protocol::acp::failure::AgentFailure::HandshakeFailed {
+            stage: crate::protocol::acp::failure::HandshakeStage::Initialize,
+            detail: "outgoing client failed".into(),
+        },
+        message: "outgoing client failed".into(),
+    });
+    assert!(app.pending_acp_start);
+    assert!(!app.agent_reconnect_disconnect_pending);
+    assert!(app.pending_agent_reconnect.is_none());
+    assert!(
+        app.current_tab().messages.is_empty(),
+        "the outgoing client's startup error must not leak into the new agent chat"
+    );
+}
+
+#[test]
+fn settings_agent_rebind_ignores_stale_generation_and_converges_to_latest_target() {
+    let (mut app, mut restart_rx) = test_app_with_restart_rx();
+    app.owner_tab_id = Some("owner-tab".into());
+    app.window_id = Some("window-1".into());
+    app.tab_id = Some("owner-tab".into());
+    app.current_agent_id = "copilot".into();
+    app.tab_mut("owner-tab");
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "copilot --acp".into(),
+        Some("copilot".into()),
+        None,
+        crate::agent_source::AgentSource::Host,
+        None,
+        Some("owner-tab".into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
+
+    app.handle_event(agent_rebind_event("owner-tab", 10, "claude"));
+    let first = match restart_rx
+        .try_recv()
+        .expect("first target should trigger transport retirement")
+    {
+        RestartRequest::RebindAgent(request) => request,
+        other => panic!("expected RebindAgent, got {other:?}"),
+    };
+
+    app.handle_event(agent_rebind_event("owner-tab", 9, "codex"));
+    assert_eq!(app.current_agent_id, "claude");
+    assert!(restart_rx.try_recv().is_err());
+
+    app.handle_event(agent_rebind_event("owner-tab", 11, "gemini"));
+    assert_eq!(app.current_agent_id, "gemini");
+    assert!(restart_rx.try_recv().is_err());
+    assert_eq!(
+        app.deferred_acp
+            .as_ref()
+            .and_then(|params| params.agent_id.as_deref()),
+        Some("gemini")
+    );
+
+    app.handle_event(AppEvent::AgentReconnectReady(first));
+
+    assert!(app.pending_acp_start);
+    assert!(!app.agent_reconnect_disconnect_pending);
+    assert!(app.pending_agent_reconnect.is_none());
+    assert_eq!(
+        app.deferred_acp
+            .as_ref()
+            .and_then(|params| params.agent_id.as_deref()),
+        Some("gemini"),
+        "the reconnect must use the newest accepted Settings generation"
+    );
+
+    app.window_id = Some("window-2".into());
+    app.handle_event(agent_rebind_event_for_window(
+        "window-2",
+        "owner-tab",
+        1,
+        "codex",
+    ));
+    assert_eq!(app.current_agent_id, "codex");
+    assert!(matches!(
+        restart_rx.try_recv(),
+        Ok(RestartRequest::RebindAgent(AgentReconnectRequest {
+            window_id,
+            generation: 1,
+            ..
+        })) if window_id == "window-2"
+    ));
+
+    app.handle_event(agent_rebind_event("owner-tab", 12, "claude"));
+    assert_eq!(
+        app.current_agent_id, "codex",
+        "an event delayed from the helper's previous window must be ignored"
+    );
+}
+
+#[test]
 fn global_model_hot_update_is_scoped_to_matching_global_followers() {
     use crate::protocol::acp::client::MasterExtRequest;
 
@@ -4983,7 +5281,7 @@ fn protocol_error_ends_turn_without_failing_connection() {
     app.state = ConnectionState::Connected;
 
     app.handle_event(AppEvent::AgentError {
-        session_id: None,
+        session_id: Some("live-session".to_string()),
         failure: crate::protocol::acp::failure::AgentFailure::Protocol {
             code: -32603,
             message: "bad params".to_string(),
@@ -4995,6 +5293,31 @@ fn protocol_error_ends_turn_without_failing_connection() {
     assert!(matches!(
         app.current_tab().messages.last(),
         Some(ChatMessage::Error(message)) if message == "protocol error"
+    ));
+    assert_eq!(app.current_tab().turn, TurnState::Idle);
+}
+
+#[test]
+fn startup_protocol_error_fails_connection() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connecting("Creating session...".to_string());
+
+    app.handle_event(AppEvent::AgentError {
+        session_id: None,
+        failure: crate::protocol::acp::failure::AgentFailure::Protocol {
+            code: -32603,
+            message: "invalid provider configuration".to_string(),
+        },
+        message: "session creation failed".to_string(),
+    });
+
+    assert_eq!(
+        app.state,
+        ConnectionState::Failed("session creation failed".to_string())
+    );
+    assert!(matches!(
+        app.current_tab().messages.last(),
+        Some(ChatMessage::Error(message)) if message == "session creation failed"
     ));
     assert_eq!(app.current_tab().turn, TurnState::Idle);
 }

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -5688,31 +5688,136 @@ fn post_login_auth_recovery_shows_reconnecting_then_signin_fallback() {
         &app.auth_recovery_state,
         AuthRecoveryState::Connecting
     ));
+    let connecting_generation = app.auth_recovery_generation;
+    assert_ne!(
+        connecting_generation, generation,
+        "master readiness must start a separately correlated connection phase"
+    );
     app.pending_acp_start = false;
     app.handle_event(AppEvent::MasterDisconnected);
     assert!(
         !app.pending_acp_start,
         "a late disconnect from the replaced master must not start a duplicate ACP client"
     );
-    // A STALE timer (older generation) must be ignored — it must not force
-    // the sign-in screen onto the current Connecting state.
-    app.handle_event(AppEvent::AuthRecoveryTimedOut {
-        agent_id: "copilot".to_string(),
-        generation: generation.wrapping_sub(1),
-    });
-    assert!(
-        !matches!(app.mode, AppMode::Setup),
-        "a stale-generation timeout must be ignored"
-    );
-    // Dead-man fallback (restart never took effect) → sign-in screen.
+    // The master-readiness timer is stale after the matching restart event.
     app.handle_event(AppEvent::AuthRecoveryTimedOut {
         agent_id: "copilot".to_string(),
         generation,
     });
     assert!(
+        !matches!(app.mode, AppMode::Setup),
+        "a stale-generation timeout must be ignored"
+    );
+    // The connection-phase dead-man still surfaces the sign-in screen.
+    app.handle_event(AppEvent::AuthRecoveryTimedOut {
+        agent_id: "copilot".to_string(),
+        generation: connecting_generation,
+    });
+    assert!(
         matches!(app.mode, AppMode::Setup),
         "timeout fallback must surface the sign-in screen"
     );
+}
+
+fn start_timed_auth_recovery() -> (App, String) {
+    let mut app = test_app();
+    app.current_agent_id = "copilot".into();
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "copilot --acp".into(),
+        Some("copilot".into()),
+        None,
+        None,
+        crate::agent_source::AgentSource::Host,
+        None,
+        Some("owner-tab".into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
+    app.handle_event(AppEvent::PostLoginAuthRecovery {
+        failure: crate::protocol::acp::failure::AgentFailure::AuthRequired {
+            message: "auth".to_string(),
+        },
+        tab_id: None,
+        agent_id: "copilot".to_string(),
+    });
+    let request_id = match &app.auth_recovery_state {
+        AuthRecoveryState::WaitingForMaster { request_id } => request_id.clone(),
+        _ => panic!("auth recovery should wait for its replacement master"),
+    };
+    (app, request_id)
+}
+
+#[test]
+fn auth_recovery_accepts_master_readiness_after_connection_timeout_window() {
+    let (mut app, request_id) = start_timed_auth_recovery();
+    let readiness_generation = app.auth_recovery_generation;
+    assert!(
+        super::app_events::AUTH_RECOVERY_MASTER_READY_TIMEOUT
+            > super::app_events::AUTH_RECOVERY_CONNECTION_TIMEOUT,
+        "waiting for master must extend beyond the eight-second connection timeout"
+    );
+
+    app.handle_event(AppEvent::WtEvent {
+        method: "agent_master_restarted".into(),
+        pane_id: String::new(),
+        tab_id: None,
+        params: json!({ "operation_id": request_id }),
+    });
+
+    assert!(app.pending_acp_start);
+    assert!(matches!(
+        app.auth_recovery_state,
+        AuthRecoveryState::Connecting
+    ));
+    assert_ne!(
+        app.auth_recovery_generation, readiness_generation,
+        "master readiness must invalidate the readiness deadline"
+    );
+}
+
+#[test]
+fn auth_recovery_missing_master_readiness_times_out_after_retirement_budget() {
+    let (mut app, _) = start_timed_auth_recovery();
+    assert_eq!(
+        super::app_events::AUTH_RECOVERY_MASTER_READY_TIMEOUT,
+        std::time::Duration::from_secs(18),
+        "readiness deadline must cover the 17-second retirement path plus margin"
+    );
+    let generation = app.auth_recovery_generation;
+    app.handle_event(AppEvent::AuthRecoveryTimedOut {
+        agent_id: "copilot".into(),
+        generation,
+    });
+
+    assert!(matches!(app.mode, AppMode::Setup));
+    assert!(matches!(app.auth_recovery_state, AuthRecoveryState::Idle));
+}
+
+#[test]
+fn auth_recovery_connection_timeout_starts_when_master_is_ready() {
+    let (mut app, request_id) = start_timed_auth_recovery();
+    let readiness_generation = app.auth_recovery_generation;
+    app.handle_event(AppEvent::WtEvent {
+        method: "agent_master_restarted".into(),
+        pane_id: String::new(),
+        tab_id: None,
+        params: json!({ "operation_id": request_id }),
+    });
+    let connection_generation = app.auth_recovery_generation;
+    assert_eq!(
+        super::app_events::AUTH_RECOVERY_CONNECTION_TIMEOUT,
+        std::time::Duration::from_secs(8)
+    );
+    assert_ne!(connection_generation, readiness_generation);
+
+    app.handle_event(AppEvent::AuthRecoveryTimedOut {
+        agent_id: "copilot".into(),
+        generation: connection_generation,
+    });
+
+    assert!(matches!(app.mode, AppMode::Setup));
+    assert!(matches!(app.auth_recovery_state, AuthRecoveryState::Idle));
 }
 
 #[test]

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -80,7 +80,7 @@ pub(super) fn test_app() -> App {
 
 fn test_app_with_restart_rx() -> (
     App,
-    tokio::sync::mpsc::UnboundedReceiver<crate::protocol::acp::client::RestartRequest>,
+    tokio::sync::mpsc::UnboundedReceiver<crate::protocol::acp::client::AgentLifecycleRequest>,
 ) {
     let (prompt_tx, _prompt_rx) = tokio::sync::mpsc::unbounded_channel();
     let (recommendation_tx, _recommendation_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -3042,7 +3042,7 @@ fn settings_agent_rebind_targets_owner_and_resets_only_agent_state() {
         .try_recv()
         .expect("matching helper should begin a controlled reconnect")
     {
-        RestartRequest::RebindAgent(request) => {
+        AgentLifecycleRequest::RebindAgent(request) => {
             assert_eq!(request.agent_id, "claude");
             assert_eq!(request.generation, 1);
             assert!(request.acp_model.is_none());
@@ -3117,9 +3117,10 @@ fn settings_agent_rebind_targets_owner_and_resets_only_agent_state() {
         message: "outgoing client failed".into(),
     });
     assert!(!app.pending_acp_start);
-    assert!(!app.agent_reconnect_disconnect_pending);
-    assert!(app.agent_reconnect_preflight_pending);
-    assert!(app.pending_agent_reconnect.is_some());
+    assert!(matches!(
+        &app.agent_reconnect_state,
+        AgentReconnectState::Preflighting(_)
+    ));
     assert!(
         app.current_tab().messages.is_empty(),
         "the outgoing client's startup error must not leak into the new agent chat"
@@ -3131,8 +3132,10 @@ fn settings_agent_rebind_targets_owner_and_resets_only_agent_state() {
         result: passed_preflight("claude", "Claude"),
     });
     assert!(app.pending_acp_start);
-    assert!(!app.agent_reconnect_preflight_pending);
-    assert!(app.pending_agent_reconnect.is_none());
+    assert!(matches!(
+        &app.agent_reconnect_state,
+        AgentReconnectState::Idle
+    ));
 }
 
 #[test]
@@ -3188,7 +3191,7 @@ fn agent_rebind_accepts_only_the_helpers_current_execution_source() {
         .try_recv()
         .expect("same-distro WSL rebind should reuse the helper")
     {
-        RestartRequest::RebindAgent(request) => request,
+        AgentLifecycleRequest::RebindAgent(request) => request,
         other => panic!("expected RebindAgent, got {other:?}"),
     };
     assert_eq!(
@@ -3232,15 +3235,17 @@ fn settings_agent_rebind_missing_target_enters_install_setup_after_retirement() 
         .try_recv()
         .expect("the old transport should be retired before target preflight")
     {
-        RestartRequest::RebindAgent(request) => request,
+        AgentLifecycleRequest::RebindAgent(request) => request,
         other => panic!("expected RebindAgent, got {other:?}"),
     };
     assert_eq!(app.current_agent_id, "copilot");
     assert!(!app.pending_acp_start);
 
     app.handle_event(AppEvent::AgentReconnectReady(retired));
-    assert!(!app.agent_reconnect_disconnect_pending);
-    assert!(app.agent_reconnect_preflight_pending);
+    assert!(matches!(
+        &app.agent_reconnect_state,
+        AgentReconnectState::Preflighting(_)
+    ));
     assert!(!app.pending_acp_start);
 
     app.handle_event(AppEvent::AgentReconnectPreflightComplete {
@@ -3262,8 +3267,10 @@ fn settings_agent_rebind_missing_target_enters_install_setup_after_retirement() 
     assert_eq!(app.mode, AppMode::Setup);
     assert!(app.preflight_setup_active);
     assert!(!app.pending_acp_start);
-    assert!(!app.agent_reconnect_preflight_pending);
-    assert!(app.pending_agent_reconnect.is_none());
+    assert!(matches!(
+        &app.agent_reconnect_state,
+        AgentReconnectState::Idle
+    ));
     let setup = app.setup.as_ref().expect("missing target should show Setup");
     assert_eq!(setup.reason, SetupReason::AgentMissing);
     assert!(setup.options.iter().any(
@@ -3297,7 +3304,7 @@ fn settings_agent_rebind_invalidates_completed_older_target_preflight() {
         .try_recv()
         .expect("target A should retire the current transport")
     {
-        RestartRequest::RebindAgent(request) => request,
+        AgentLifecycleRequest::RebindAgent(request) => request,
         other => panic!("expected RebindAgent, got {other:?}"),
     };
     app.handle_event(AppEvent::AgentReconnectReady(first));
@@ -3314,19 +3321,16 @@ fn settings_agent_rebind_invalidates_completed_older_target_preflight() {
         !app.pending_acp_start,
         "accepting target B must invalidate target A's queued ACP startup"
     );
-    assert!(app.agent_reconnect_disconnect_pending);
-    assert!(!app.agent_reconnect_preflight_pending);
-    assert_eq!(
-        app.pending_agent_reconnect
-            .as_ref()
-            .map(|request| (request.agent_id.as_str(), request.generation)),
-        Some(("codex", 2))
-    );
+    assert!(matches!(
+        &app.agent_reconnect_state,
+        AgentReconnectState::Disconnecting(request)
+            if request.agent_id == "codex" && request.generation == 2
+    ));
     let second = match restart_rx
         .try_recv()
         .expect("target B must retire target A before its own preflight")
     {
-        RestartRequest::RebindAgent(request) => request,
+        AgentLifecycleRequest::RebindAgent(request) => request,
         other => panic!("expected RebindAgent, got {other:?}"),
     };
 
@@ -3336,17 +3340,20 @@ fn settings_agent_rebind_invalidates_completed_older_target_preflight() {
         result: passed_preflight("claude", "Claude"),
     });
     assert!(!app.pending_acp_start);
-    assert_eq!(
-        app.pending_agent_reconnect
-            .as_ref()
-            .map(|request| (request.agent_id.as_str(), request.generation)),
-        Some(("codex", 2)),
-        "a stale target A completion must not consume target B"
+    assert!(
+        matches!(
+            &app.agent_reconnect_state,
+            AgentReconnectState::Disconnecting(request)
+                if request.agent_id == "codex" && request.generation == 2
+        ),
+        "a stale target A completion must not consume target B",
     );
 
     app.handle_event(AppEvent::AgentReconnectReady(second));
-    assert!(!app.agent_reconnect_disconnect_pending);
-    assert!(app.agent_reconnect_preflight_pending);
+    assert!(matches!(
+        &app.agent_reconnect_state,
+        AgentReconnectState::Preflighting(_)
+    ));
     assert!(!app.pending_acp_start);
 
     app.handle_event(AppEvent::AgentReconnectPreflightComplete {
@@ -3372,8 +3379,10 @@ fn settings_agent_rebind_invalidates_completed_older_target_preflight() {
     );
     assert!(app.preflight_setup_active);
     assert!(!app.pending_acp_start);
-    assert!(!app.agent_reconnect_preflight_pending);
-    assert!(app.pending_agent_reconnect.is_none());
+    assert!(matches!(
+        &app.agent_reconnect_state,
+        AgentReconnectState::Idle
+    ));
 }
 
 #[test]
@@ -3417,7 +3426,7 @@ fn settings_model_rebind_preserves_custom_provider_selection() {
         .try_recv()
         .expect("custom model selection should trigger a controlled reconnect")
     {
-        RestartRequest::RebindAgent(request) => request,
+        AgentLifecycleRequest::RebindAgent(request) => request,
         other => panic!("expected RebindAgent, got {other:?}"),
     };
     assert_eq!(
@@ -3458,7 +3467,7 @@ fn settings_agent_rebind_ignores_stale_generation_and_converges_to_latest_target
         .try_recv()
         .expect("first target should trigger transport retirement")
     {
-        RestartRequest::RebindAgent(request) => request,
+        AgentLifecycleRequest::RebindAgent(request) => request,
         other => panic!("expected RebindAgent, got {other:?}"),
     };
 
@@ -3479,9 +3488,10 @@ fn settings_agent_rebind_ignores_stale_generation_and_converges_to_latest_target
     app.handle_event(AppEvent::AgentReconnectReady(first));
 
     assert!(!app.pending_acp_start);
-    assert!(!app.agent_reconnect_disconnect_pending);
-    assert!(app.agent_reconnect_preflight_pending);
-    assert!(app.pending_agent_reconnect.is_some());
+    assert!(matches!(
+        &app.agent_reconnect_state,
+        AgentReconnectState::Preflighting(_)
+    ));
     assert_eq!(
         app.deferred_acp
             .as_ref()
@@ -3496,8 +3506,10 @@ fn settings_agent_rebind_ignores_stale_generation_and_converges_to_latest_target
         result: passed_preflight("gemini", "Gemini"),
     });
     assert!(app.pending_acp_start);
-    assert!(!app.agent_reconnect_preflight_pending);
-    assert!(app.pending_agent_reconnect.is_none());
+    assert!(matches!(
+        &app.agent_reconnect_state,
+        AgentReconnectState::Idle
+    ));
 
     app.pending_acp_start = false;
     app.handle_event(AppEvent::AgentReconnectPreflightComplete {
@@ -3521,7 +3533,7 @@ fn settings_agent_rebind_ignores_stale_generation_and_converges_to_latest_target
     assert_eq!(app.current_agent_id, "codex");
     assert!(matches!(
         restart_rx.try_recv(),
-        Ok(RestartRequest::RebindAgent(AgentReconnectRequest {
+        Ok(AgentLifecycleRequest::RebindAgent(AgentReconnectRequest {
             window_id,
             generation: 1,
             ..
@@ -5612,6 +5624,19 @@ fn post_login_recovery_route_covers_pipe_connect_without_external_auth_gate() {
 #[test]
 fn post_login_auth_recovery_shows_reconnecting_then_signin_fallback() {
     let mut app = test_app();
+    app.current_agent_id = "copilot".into();
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "copilot --acp".into(),
+        Some("copilot".into()),
+        None,
+        None,
+        crate::agent_source::AgentSource::Host,
+        None,
+        Some("owner-tab".into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
     app.handle_event(AppEvent::PostLoginAuthRecovery {
         failure: crate::protocol::acp::failure::AgentFailure::AuthRequired {
             message: "auth".to_string(),
@@ -5619,6 +5644,10 @@ fn post_login_auth_recovery_shows_reconnecting_then_signin_fallback() {
         tab_id: None,
         agent_id: "copilot".to_string(),
     });
+    let restart_request_id = match &app.auth_recovery_state {
+        AuthRecoveryState::WaitingForMaster { request_id } => request_id.clone(),
+        _ => panic!("auth recovery should wait for its replacement master"),
+    };
     // Common case: transient Reconnecting, NOT the setup screen (no flash).
     assert!(
         !matches!(app.mode, AppMode::Setup),
@@ -5629,6 +5658,42 @@ fn post_login_auth_recovery_shows_reconnecting_then_signin_fallback() {
         "recovery must show a transient Reconnecting state"
     );
     let generation = app.auth_recovery_generation;
+    app.handle_event(AppEvent::MasterDisconnected);
+    assert!(
+        !app.pending_acp_start,
+        "auth recovery must wait until C++ confirms the replacement master"
+    );
+    assert_eq!(
+        app.auth_recovery_generation, generation,
+        "master disconnect must not invalidate the auth-recovery dead-man"
+    );
+    app.handle_event(AppEvent::WtEvent {
+        method: "agent_master_restarted".into(),
+        pane_id: String::new(),
+        tab_id: None,
+        params: json!({ "operation_id": "unrelated-restart" }),
+    });
+    assert!(
+        !app.pending_acp_start,
+        "another restart must not release this auth-recovery barrier"
+    );
+    app.handle_event(AppEvent::WtEvent {
+        method: "agent_master_restarted".into(),
+        pane_id: String::new(),
+        tab_id: None,
+        params: json!({ "operation_id": restart_request_id }),
+    });
+    assert!(app.pending_acp_start);
+    assert!(matches!(
+        &app.auth_recovery_state,
+        AuthRecoveryState::Connecting
+    ));
+    app.pending_acp_start = false;
+    app.handle_event(AppEvent::MasterDisconnected);
+    assert!(
+        !app.pending_acp_start,
+        "a late disconnect from the replaced master must not start a duplicate ACP client"
+    );
     // A STALE timer (older generation) must be ignored — it must not force
     // the sign-in screen onto the current Connecting state.
     app.handle_event(AppEvent::AuthRecoveryTimedOut {
@@ -5669,6 +5734,17 @@ fn master_disconnect_reconnects_retained_custom_wsl_helper() {
         Arc::clone(&app.shell_mgr),
         true,
     );
+    app.agent_reconnect_state = AgentReconnectState::Preflighting(AgentReconnectRequest {
+        operation_id: "stale-rebind".into(),
+        window_id: "window-1".into(),
+        generation: 1,
+        agent_id: "copilot".into(),
+        acp_model: None,
+        custom_model_selection: None,
+        agent_source: crate::agent_source::AgentSource::Wsl {
+            distro: "Ubuntu".into(),
+        },
+    });
     assert!(!app.should_quit);
 
     app.handle_event(AppEvent::MasterDisconnected);
@@ -5678,6 +5754,10 @@ fn master_disconnect_reconnects_retained_custom_wsl_helper() {
         app.pending_acp_start,
         "master disconnect must reconnect the existing immutable binding"
     );
+    assert!(matches!(
+        &app.agent_reconnect_state,
+        AgentReconnectState::Idle
+    ));
     assert_eq!(
         app.deferred_acp
             .as_ref()

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -5785,6 +5785,64 @@ fn master_disconnect_without_binding_terminates_helper() {
     assert!(app.should_quit);
 }
 
+#[test]
+fn replacement_master_recovers_helper_failed_during_session_retirement() {
+    let mut app = test_app();
+    app.current_agent_id = "copilot".into();
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "copilot --acp".into(),
+        Some("copilot".into()),
+        None,
+        None,
+        crate::agent_source::AgentSource::Host,
+        None,
+        Some("owner-tab".into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
+    app.state = ConnectionState::Failed("old master retired the startup session".into());
+
+    app.handle_event(AppEvent::WtEvent {
+        method: "agent_master_restarted".into(),
+        pane_id: String::new(),
+        tab_id: None,
+        params: json!({ "operation_id": "normal-restart" }),
+    });
+
+    assert!(app.pending_acp_start);
+    assert!(matches!(app.state, ConnectionState::Connecting(_)));
+    assert!(matches!(&app.auth_recovery_state, AuthRecoveryState::Idle));
+}
+
+#[test]
+fn replacement_master_does_not_duplicate_connected_helper() {
+    let mut app = test_app();
+    app.current_agent_id = "copilot".into();
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "copilot --acp".into(),
+        Some("copilot".into()),
+        None,
+        None,
+        crate::agent_source::AgentSource::Host,
+        None,
+        Some("owner-tab".into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
+    app.state = ConnectionState::Connected;
+
+    app.handle_event(AppEvent::WtEvent {
+        method: "agent_master_restarted".into(),
+        pane_id: String::new(),
+        tab_id: None,
+        params: json!({ "operation_id": "normal-restart" }),
+    });
+
+    assert!(!app.pending_acp_start);
+}
+
 /// A one-off protocol error ends the turn while preserving the live session.
 #[test]
 fn protocol_error_ends_turn_without_failing_connection() {

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -3193,6 +3193,111 @@ fn settings_agent_rebind_missing_target_enters_install_setup_after_retirement() 
 }
 
 #[test]
+fn settings_agent_rebind_invalidates_completed_older_target_preflight() {
+    let (mut app, mut restart_rx) = test_app_with_restart_rx();
+    app.owner_tab_id = Some("owner-tab".into());
+    app.window_id = Some("window-1".into());
+    app.tab_id = Some("owner-tab".into());
+    app.current_agent_id = "copilot".into();
+    app.tab_mut("owner-tab");
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "copilot --acp".into(),
+        Some("copilot".into()),
+        None,
+        None,
+        crate::agent_source::AgentSource::Host,
+        None,
+        Some("owner-tab".into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
+
+    app.handle_event(agent_rebind_event("owner-tab", 1, "claude"));
+    let first = match restart_rx
+        .try_recv()
+        .expect("target A should retire the current transport")
+    {
+        RestartRequest::RebindAgent(request) => request,
+        other => panic!("expected RebindAgent, got {other:?}"),
+    };
+    app.handle_event(AppEvent::AgentReconnectReady(first));
+    app.handle_event(AppEvent::AgentReconnectPreflightComplete {
+        operation_id: "op-1".into(),
+        generation: 1,
+        result: passed_preflight("claude", "Claude"),
+    });
+    assert!(app.pending_acp_start);
+
+    app.handle_event(agent_rebind_event("owner-tab", 2, "codex"));
+
+    assert!(
+        !app.pending_acp_start,
+        "accepting target B must invalidate target A's queued ACP startup"
+    );
+    assert!(app.agent_reconnect_disconnect_pending);
+    assert!(!app.agent_reconnect_preflight_pending);
+    assert_eq!(
+        app.pending_agent_reconnect
+            .as_ref()
+            .map(|request| (request.agent_id.as_str(), request.generation)),
+        Some(("codex", 2))
+    );
+    let second = match restart_rx
+        .try_recv()
+        .expect("target B must retire target A before its own preflight")
+    {
+        RestartRequest::RebindAgent(request) => request,
+        other => panic!("expected RebindAgent, got {other:?}"),
+    };
+
+    app.handle_event(AppEvent::AgentReconnectPreflightComplete {
+        operation_id: "op-1".into(),
+        generation: 1,
+        result: passed_preflight("claude", "Claude"),
+    });
+    assert!(!app.pending_acp_start);
+    assert_eq!(
+        app.pending_agent_reconnect
+            .as_ref()
+            .map(|request| (request.agent_id.as_str(), request.generation)),
+        Some(("codex", 2)),
+        "a stale target A completion must not consume target B"
+    );
+
+    app.handle_event(AppEvent::AgentReconnectReady(second));
+    assert!(!app.agent_reconnect_disconnect_pending);
+    assert!(app.agent_reconnect_preflight_pending);
+    assert!(!app.pending_acp_start);
+
+    app.handle_event(AppEvent::AgentReconnectPreflightComplete {
+        operation_id: "op-2".into(),
+        generation: 2,
+        result: PreflightResult {
+            agent_id: "codex".into(),
+            display_name: "Codex".into(),
+            cli_status: CheckStatus::Failed("Not found on PATH".into()),
+            cli_path: None,
+            auth_status: CheckStatus::Skipped,
+            install_hint: "Install Codex".into(),
+            install_url: String::new(),
+            auth_hint: String::new(),
+        },
+    });
+
+    assert_eq!(app.current_agent_id, "codex");
+    assert_eq!(app.mode, AppMode::Setup);
+    assert_eq!(
+        app.setup.as_ref().map(|setup| &setup.reason),
+        Some(&SetupReason::AgentMissing)
+    );
+    assert!(app.preflight_setup_active);
+    assert!(!app.pending_acp_start);
+    assert!(!app.agent_reconnect_preflight_pending);
+    assert!(app.pending_agent_reconnect.is_none());
+}
+
+#[test]
 fn settings_model_rebind_preserves_custom_provider_selection() {
     let (mut app, mut restart_rx) = test_app_with_restart_rx();
     app.owner_tab_id = Some("owner-tab".into());

--- a/tools/wta/src/commands.rs
+++ b/tools/wta/src/commands.rs
@@ -22,22 +22,17 @@ pub enum CommandKind {
     /// invoked manually. Any text after `/fix` is passed through as an
     /// extra hint to steer the diagnosis (`/fix the path looks wrong`).
     Fix,
-    /// Reset the agent CLI subprocess.
-    ///
-    /// * Standalone wta: tears down + respawns the agent CLI in-process;
-    ///   tabs lazily get fresh sessions on the next prompt.
-    /// * Helper mode: fires a `restart_agent_stack` event to C++, which
-    ///   replaces the shared master; each viable helper reconnects its existing
-    ///   immutable binding over the stable pipe with a clean session. Only a
-    ///   pane whose helper process is already unavailable requires recreation.
+    /// Replace the shared master and Agent CLI pool. Each viable helper keeps
+    /// its pane and reconnects its immutable binding over the stable pipe with
+    /// a clean session. Only an unavailable helper requires pane recreation.
     Restart,
     Sessions,
     /// Pick the ACP agent for this Windows Terminal tab.
     ///
     /// Bare `/agent` opens an interactive picker containing only agents that
     /// are both host-policy-allowed and installed on this machine;
-    /// `/agent <id>` switches directly. The helper asks Windows Terminal to
-    /// rebuild only its owning tab, so the choice remains a runtime per-tab
+    /// `/agent <id>` switches directly by rebinding the existing helper when
+    /// the execution source is unchanged. The choice remains a runtime per-tab
     /// override and never changes the global `acpAgent` setting.
     Agent,
     /// Pick the ACP model for *this* agent pane.

--- a/tools/wta/src/commands.rs
+++ b/tools/wta/src/commands.rs
@@ -26,11 +26,10 @@ pub enum CommandKind {
     ///
     /// * Standalone wta: tears down + respawns the agent CLI in-process;
     ///   tabs lazily get fresh sessions on the next prompt.
-    /// * Helper mode: fires a `restart_agent_stack` `SendEvent` to the C++
-    ///   side. This explicit recovery command tears down every agent pane,
-    ///   force-restarts the shared master on the same stable pipe name, and
-    ///   recreates the panes with clean sessions. Normal Settings agent/model
-    ///   changes use the non-destructive rebind or live-switch paths instead.
+    /// * Helper mode: fires a `restart_agent_stack` event to C++, which
+    ///   replaces the shared master; each viable helper reconnects its existing
+    ///   immutable binding over the stable pipe with a clean session. Only a
+    ///   pane whose helper process is already unavailable requires recreation.
     Restart,
     Sessions,
     /// Pick the ACP agent for this Windows Terminal tab.

--- a/tools/wta/src/commands.rs
+++ b/tools/wta/src/commands.rs
@@ -27,14 +27,10 @@ pub enum CommandKind {
     /// * Standalone wta: tears down + respawns the agent CLI in-process;
     ///   tabs lazily get fresh sessions on the next prompt.
     /// * Helper mode: fires a `restart_agent_stack` `SendEvent` to the C++
-    ///   side, which mirrors the path settings reload already takes when
-    ///   `acpAgent` changes: tear down every agent pane (master + helper
-    ///   processes die with them), force `SharedWta::Restart()` to bypass
-    ///   refcount and respawn master on the *same stable pipe name*, and
-    ///   re-toggle the active tab's agent pane. The new helper auto-
-    ///   connects to the new master. Visible UX: agent panes flash closed
-    ///   and reopen with a clean session; nothing requires the user to
-    ///   restart Windows Terminal.
+    ///   side. This explicit recovery command tears down every agent pane,
+    ///   force-restarts the shared master on the same stable pipe name, and
+    ///   recreates the panes with clean sessions. Normal Settings agent/model
+    ///   changes use the non-destructive rebind or live-switch paths instead.
     Restart,
     Sessions,
     /// Pick the ACP agent for this Windows Terminal tab.
@@ -48,8 +44,9 @@ pub enum CommandKind {
     /// Pick the ACP model for *this* agent pane.
     ///
     /// Bare `/model` opens an interactive picker listing configured BYOK
-    /// models. Cloud/native models are intentionally omitted; model changes
-    /// are made through Settings because they require an agent restart.
+    /// models. Cloud/native models are intentionally omitted; global model
+    /// changes remain managed through Settings and follow each agent's live
+    /// switch or reconnect capability.
     Model,
     /// Configure the current ACP session using Agent-provided config options.
     Config,

--- a/tools/wta/src/custom_model_provider.rs
+++ b/tools/wta/src/custom_model_provider.rs
@@ -55,6 +55,7 @@ const CLOUD_DISCOVERY_ENV_KEYS: &[&str] = &[
     PROVIDER_API_KEY,
 ];
 
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct Config {
     pub(crate) base_url: String,
     pub(crate) model: String,
@@ -83,7 +84,7 @@ impl Drop for SensitiveString {
 }
 
 impl Config {
-    fn shared_from_env() -> Self {
+    pub(crate) fn shared_from_env() -> Self {
         Self {
             base_url: trimmed_env(SHARED_BASE_URL).unwrap_or_default(),
             model: trimmed_env(SHARED_MODEL).unwrap_or_default(),
@@ -91,6 +92,75 @@ impl Config {
             api_key_required: bool_env(SHARED_API_KEY_REQUIRED),
             credential_resource: "IntelligentTerminal.LocalModelProvider",
         }
+    }
+
+    pub(crate) fn from_settings(
+        settings: &serde_json::Value,
+        selection_id: &str,
+    ) -> Result<Config> {
+        let Some(rest) = selection_id.strip_prefix("custom:") else {
+            bail!("custom model selection is malformed");
+        };
+        let Some((provider_id, model_id)) = rest.split_once(':') else {
+            bail!("custom model selection is malformed");
+        };
+        if provider_id.trim().is_empty() || model_id.trim().is_empty() {
+            bail!("custom model selection is malformed");
+        }
+
+        let providers = settings
+            .get("customModelProviders")
+            .and_then(serde_json::Value::as_array)
+            .context("custom model providers are missing from Terminal settings")?;
+        let provider = providers
+            .iter()
+            .find(|provider| {
+                provider.get("id").and_then(serde_json::Value::as_str) == Some(provider_id)
+            })
+            .context("selected custom model provider no longer exists")?;
+        let api_contract = provider
+            .get("apiContract")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+        normalize_api_contract(api_contract)
+            .context("selected custom model provider uses an unsupported API contract")?;
+        let model_exists = provider
+            .get("models")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|models| {
+                models.iter().any(|model| {
+                    model.get("id").and_then(serde_json::Value::as_str) == Some(model_id)
+                })
+            });
+        if !model_exists {
+            bail!("selected custom model no longer exists");
+        }
+
+        let base_url = provider
+            .get("baseUrl")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .context("selected custom model provider has no endpoint")?
+            .to_string();
+        let credential_id = provider
+            .get("apiKeyCredential")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let api_key_required = provider
+            .get("apiKeyRequired")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(credential_id.is_some());
+
+        Ok(Config {
+            base_url,
+            model: model_id.to_string(),
+            credential_id,
+            api_key_required,
+            credential_resource: "IntelligentTerminal.LocalModelProvider",
+        })
     }
 
     pub(crate) fn is_complete(&self) -> bool {
@@ -147,7 +217,7 @@ pub(crate) fn configure_child(cmd: &mut Command, byok_mode: ByokMode) -> Result<
     configure_child_with_config(cmd, byok_mode, &shared)
 }
 
-fn configure_child_with_config(
+pub(crate) fn configure_child_with_config(
     cmd: &mut Command,
     byok_mode: ByokMode,
     shared: &Config,
@@ -376,6 +446,63 @@ mod tests {
             ..complete
         }
         .is_complete());
+    }
+
+    #[test]
+    fn settings_selection_resolves_only_non_secret_launch_metadata() {
+        let settings = serde_json::json!({
+            "customModelProviders": [{
+                "id": "provider-openrouter",
+                "baseUrl": "https://openrouter.ai/api/v1",
+                "apiContract": "openai-compatible",
+                "apiKeyCredential": "credential-reference",
+                "apiKeyRequired": true,
+                "models": [
+                    { "id": "qwen/qwen3.5-9b" },
+                    { "id": "deepseek/deepseek-v3" }
+                ]
+            }]
+        });
+
+        let config = Config::from_settings(
+            &settings,
+            "custom:provider-openrouter:qwen/qwen3.5-9b",
+        )
+        .expect("configured provider/model should resolve");
+
+        assert_eq!(config.base_url, "https://openrouter.ai/api/v1");
+        assert_eq!(config.model, "qwen/qwen3.5-9b");
+        assert_eq!(config.credential_id.as_deref(), Some("credential-reference"));
+        assert!(config.api_key_required);
+    }
+
+    #[test]
+    fn settings_selection_rejects_missing_or_unsupported_entries() {
+        let settings = serde_json::json!({
+            "customModelProviders": [{
+                "id": "unsupported",
+                "baseUrl": "https://example.test/v1",
+                "apiContract": "future-contract",
+                "models": [{ "id": "model-a" }]
+            }, {
+                "id": "supported",
+                "baseUrl": "https://example.test/v1",
+                "apiContract": "openai-compatible",
+                "models": [{ "id": "model-a" }]
+            }]
+        });
+
+        for selection in [
+            "not-custom",
+            "custom:missing:model-a",
+            "custom:supported:missing",
+            "custom:unsupported:model-a",
+        ] {
+            assert!(
+                Config::from_settings(&settings, selection).is_err(),
+                "{selection} must not resolve"
+            );
+        }
     }
 
     #[test]

--- a/tools/wta/src/helper/runtime.rs
+++ b/tools/wta/src/helper/runtime.rs
@@ -296,20 +296,28 @@ async fn connect_to_wt_protocol(
 
 fn spawn_restart_agent_stack_forwarder(
     mut restart_rx: tokio::sync::mpsc::UnboundedReceiver<protocol::acp::client::RestartRequest>,
+    event_tx: tokio::sync::mpsc::UnboundedSender<app::AppEvent>,
 ) {
     tokio::task::spawn_local(async move {
         while let Some(req) = restart_rx.recv().await {
-            tracing::info!(
-                target: "helper",
-                new_agent = ?req.agent_cmd,
-                "restart requested before ACP task is running; asking WT to force-restart the agent stack"
-            );
-            let evt = serde_json::json!({
-                "type": "event",
-                "method": "restart_agent_stack",
-                "params": {},
-            });
-            crate::wt_protocol_events::send(evt.to_string());
+            match req {
+                protocol::acp::client::RestartRequest::RestartStack { agent_cmd } => {
+                    tracing::info!(
+                        target: "helper",
+                        new_agent = ?agent_cmd,
+                        "restart requested before ACP task is running; asking WT to force-restart the agent stack"
+                    );
+                    let evt = serde_json::json!({
+                        "type": "event",
+                        "method": "restart_agent_stack",
+                        "params": {},
+                    });
+                    crate::wt_protocol_events::send(evt.to_string());
+                }
+                protocol::acp::client::RestartRequest::RebindAgent(request) => {
+                    let _ = event_tx.send(app::AppEvent::AgentReconnectReady(request));
+                }
+            }
         }
     });
 }
@@ -684,7 +692,7 @@ async fn run_acp_app(
                 // running yet. The boot App holds the sole restart sender; when
                 // LoginComplete calls `try_start_acp`, it replaces that sender
                 // with a fresh channel and this forwarder exits.
-                spawn_restart_agent_stack_forwarder(restart_rx);
+                spawn_restart_agent_stack_forwarder(restart_rx, event_tx.clone());
                 drop((
                     prompt_rx,
                     cancel_rx,
@@ -709,7 +717,7 @@ async fn run_acp_app(
                 let initial_load_sid = config.initial_load_session_id.clone();
                 let proposal_channels_for_pipe = Arc::clone(&proposal_channels);
                 tokio::task::spawn_local(async move {
-                    if let Err(e) = protocol::acp::client::run_acp_client_over_pipe(
+                    match protocol::acp::client::run_acp_client_over_pipe(
                         pipe_name,
                         acp_model,
                         cloud_models_for_client,
@@ -735,33 +743,44 @@ async fn run_acp_app(
                     )
                     .await
                     {
-                        tracing::error!(
-                            target: "helper",
-                            error = %e,
-                            "run_acp_client_over_pipe failed"
-                        );
-                        // Recover the typed classification: an auth error
-                        // attached at the handshake `new_session` site survives
-                        // the `?`-collapse into `anyhow` via downcast, so it
-                        // still routes to the sign-in screen; other handshake
-                        // failures fall back to `HandshakeFailed`. The raw
-                        // `{e:#}` is also in the log above for diagnosis.
-                        let failure = protocol::acp::failure::classify_anyhow(
-                            &e,
-                            protocol::acp::failure::HandshakeStage::Initialize,
-                        );
-                        let message = match &failure {
-                            protocol::acp::failure::AgentFailure::HandshakeFailed {
-                                detail,
-                                ..
-                            } => detail.clone(),
-                            _ => format!("helper ACP transport failed: {e:#}"),
-                        };
-                        let _ = event_tx_for_pipe.send(app::AppEvent::AgentError {
-                            session_id: None,
-                            failure,
-                            message,
-                        });
+                        Ok(protocol::acp::client::AcpClientExit::RebindAgent(request)) => {
+                            let _ = event_tx_for_pipe
+                                .send(app::AppEvent::AgentReconnectReady(request));
+                        }
+                        Ok(protocol::acp::client::AcpClientExit::ChannelsClosed) => {}
+                        Err(e) => {
+                            tracing::error!(
+                                target: "helper",
+                                error = %e,
+                                "run_acp_client_over_pipe failed"
+                            );
+                            // Notify the App before the visible failure so a
+                            // queued Settings rebind can continue with its
+                            // latest target instead of becoming stranded.
+                            let _ = event_tx_for_pipe.send(app::AppEvent::AgentClientFailed);
+                            // Recover the typed classification: an auth error
+                            // attached at the handshake `new_session` site survives
+                            // the `?`-collapse into `anyhow` via downcast, so it
+                            // still routes to the sign-in screen; other handshake
+                            // failures fall back to `HandshakeFailed`. The raw
+                            // `{e:#}` is also in the log above for diagnosis.
+                            let failure = protocol::acp::failure::classify_anyhow(
+                                &e,
+                                protocol::acp::failure::HandshakeStage::Initialize,
+                            );
+                            let message = match &failure {
+                                protocol::acp::failure::AgentFailure::HandshakeFailed {
+                                    detail,
+                                    ..
+                                } => detail.clone(),
+                                _ => format!("helper ACP transport failed: {e:#}"),
+                            };
+                            let _ = event_tx_for_pipe.send(app::AppEvent::AgentError {
+                                session_id: None,
+                                failure,
+                                message,
+                            });
+                        }
                     }
                 });
             }
@@ -860,6 +879,7 @@ async fn run_acp_app(
             app_state.set_master_pipe_acp_params(
                 connect_master_pipe.clone(),
                 agent_cmd.clone(),
+                config.agent_id.clone(),
                 config.acp_model.clone(),
                 agent_source.clone(),
                 agent_source_cwd.clone(),

--- a/tools/wta/src/helper/runtime.rs
+++ b/tools/wta/src/helper/runtime.rs
@@ -294,24 +294,25 @@ async fn connect_to_wt_protocol(
     Ok(channel.with_debug_sender(debug_tx))
 }
 
-fn spawn_restart_agent_stack_forwarder(
-    mut restart_rx: tokio::sync::mpsc::UnboundedReceiver<protocol::acp::client::RestartRequest>,
+fn spawn_agent_lifecycle_forwarder(
+    mut restart_rx: tokio::sync::mpsc::UnboundedReceiver<
+        protocol::acp::client::AgentLifecycleRequest,
+    >,
     event_tx: tokio::sync::mpsc::UnboundedSender<app::AppEvent>,
 ) {
     tokio::task::spawn_local(async move {
         while let Some(req) = restart_rx.recv().await {
             match req {
-                protocol::acp::client::RestartRequest::RestartStack { agent_cmd } => {
+                protocol::acp::client::AgentLifecycleRequest::RestartMaster => {
                     tracing::info!(
                         target: "helper",
-                        new_agent = ?agent_cmd,
                         "restart requested before ACP task is running; asking WT to replace the shared master"
                     );
                     crate::wt_protocol_events::send(
-                        crate::wt_protocol_events::restart_agent_stack_event(None, None),
+                        crate::wt_protocol_events::restart_agent_stack_event(),
                     );
                 }
-                protocol::acp::client::RestartRequest::RebindAgent(request) => {
+                protocol::acp::client::AgentLifecycleRequest::RebindAgent(request) => {
                     let _ = event_tx.send(app::AppEvent::AgentReconnectReady(request));
                 }
             }
@@ -541,9 +542,9 @@ async fn run_acp_app(
             // its standard runtime arm — no race vs. a separate VT
             // `load_session` broadcast.
             let initial_load_tx = load_session_tx.clone();
-            // /restart channel: App emits a RestartRequest, the ACP client
-            // kills the agent child process, drops the connection, and
-            // respawns from scratch. State is cleaned up on both sides.
+            // Lifecycle channel: App either asks WT to replace the shared
+            // master or retires this helper's ACP transport for an Agent
+            // rebind. The helper process itself stays alive.
             let (restart_tx, restart_rx) = tokio::sync::mpsc::unbounded_channel();
             // reset_tab_session channel: App emits a DropSessionRequest when
             // WT tells us to release a tab's binding (Ctrl+C×2 hide path).
@@ -689,7 +690,7 @@ async fn run_acp_app(
                 // running yet. The boot App holds the sole restart sender; when
                 // LoginComplete calls `try_start_acp`, it replaces that sender
                 // with a fresh channel and this forwarder exits.
-                spawn_restart_agent_stack_forwarder(restart_rx, event_tx.clone());
+                spawn_agent_lifecycle_forwarder(restart_rx, event_tx.clone());
                 drop((
                     prompt_rx,
                     cancel_rx,
@@ -754,7 +755,7 @@ async fn run_acp_app(
                                 "run_acp_client_over_pipe failed"
                             );
                             // Notify the App before the visible failure so a
-                            // queued Settings rebind can continue with its
+                            // queued Agent rebind can continue with its
                             // latest target instead of becoming stranded.
                             let _ = event_tx_for_pipe.send(app::AppEvent::AgentClientFailed);
                             // Recover the typed classification: an auth error

--- a/tools/wta/src/helper/runtime.rs
+++ b/tools/wta/src/helper/runtime.rs
@@ -305,14 +305,11 @@ fn spawn_restart_agent_stack_forwarder(
                     tracing::info!(
                         target: "helper",
                         new_agent = ?agent_cmd,
-                        "restart requested before ACP task is running; asking WT to force-restart the agent stack"
+                        "restart requested before ACP task is running; asking WT to replace the shared master"
                     );
-                    let evt = serde_json::json!({
-                        "type": "event",
-                        "method": "restart_agent_stack",
-                        "params": {},
-                    });
-                    crate::wt_protocol_events::send(evt.to_string());
+                    crate::wt_protocol_events::send(
+                        crate::wt_protocol_events::restart_agent_stack_event(None, None),
+                    );
                 }
                 protocol::acp::client::RestartRequest::RebindAgent(request) => {
                     let _ = event_tx.send(app::AppEvent::AgentReconnectReady(request));

--- a/tools/wta/src/helper/runtime.rs
+++ b/tools/wta/src/helper/runtime.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use crate::shell::wt_channel::{CliChannel, WtChannel};
 use crate::shell::ShellManager;
 use crate::{
-    agent_check, agent_hooks_installer, agent_registry, app, event, logging, protocol, shell,
+    agent_hooks_installer, agent_registry, app, event, logging, protocol, shell,
 };
 
 use super::config::{HelperConfig, InitialView};
@@ -912,31 +912,7 @@ async fn run_acp_app(
             if config.setup.is_none() && !start_in_initial_auth {
                 let agent_id = canonical_agent_id.as_str();
                 let preflight_result =
-                    if agent_id.starts_with("custom:") || !agent_registry::is_known_id(agent_id) {
-                        // Custom/unknown agents: command is opaque (`.cmd`, `node script.js`,
-                        // shell function, …); a PATH probe would lie. The real spawn produces
-                        // the authoritative error via `ConnectionFailed`, so skip preflight.
-                        app::PreflightResult::passed_for_custom_agent(&canonical_agent_id)
-                    } else {
-                        let status =
-                            agent_check::check_agent_in_source(agent_id, &agent_source).await;
-                        app::PreflightResult {
-                            agent_id: canonical_agent_id.clone(),
-                            display_name: status.display_name.clone(),
-                            cli_status: if status.cli_found {
-                                app::CheckStatus::Passed
-                            } else {
-                                app::CheckStatus::Failed("Not found on PATH".to_string())
-                            },
-                            cli_path: status.cli_path.clone(),
-                            // Authentication is checked by the ACP handshake rather
-                            // than by a local credential-store preflight.
-                            auth_status: app::CheckStatus::Skipped,
-                            install_hint: status.install_hint.clone(),
-                            install_url: String::new(),
-                            auth_hint: status.auth_hint.clone(),
-                        }
-                    };
+                    app::preflight_agent_in_source(agent_id, &agent_source).await;
                 tracing::info!(
                     target: "preflight",
                     agent_id = %preflight_result.agent_id,

--- a/tools/wta/src/helper/runtime.rs
+++ b/tools/wta/src/helper/runtime.rs
@@ -708,6 +708,7 @@ async fn run_acp_app(
                 let event_tx_for_pipe = event_tx.clone();
                 let shell_mgr_for_pipe = Arc::clone(&shell_mgr);
                 let acp_model = config.acp_model.clone();
+                let custom_model_selection = config.custom_model_selection.clone();
                 let cloud_models_for_client = cloud_models.clone();
                 // Pass per-tab agent identity through the initialize handshake.
                 let agent_id = config.agent_id.clone();
@@ -720,6 +721,7 @@ async fn run_acp_app(
                     match protocol::acp::client::run_acp_client_over_pipe(
                         pipe_name,
                         acp_model,
+                        custom_model_selection,
                         cloud_models_for_client,
                         agent_id,
                         agent_source_for_client,
@@ -881,6 +883,7 @@ async fn run_acp_app(
                 agent_cmd.clone(),
                 config.agent_id.clone(),
                 config.acp_model.clone(),
+                config.custom_model_selection.clone(),
                 agent_source.clone(),
                 agent_source_cwd.clone(),
                 config.owner_tab_id.clone(),

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -85,6 +85,7 @@ struct CustomModelGeneration {
     generation: u64,
 }
 
+#[derive(Clone)]
 enum ProviderBinding {
     LegacyEnvironment,
     Native,
@@ -2662,7 +2663,12 @@ impl HelperHandler {
                 }
             })
             .unwrap_or_default();
-        let (agent_cmd, agent_id, agent_source) = resolve_agent_selection(
+        let ResolvedAgentSelection {
+            command: agent_cmd,
+            agent_id,
+            source: agent_source,
+            explicit_selection,
+        } = resolve_agent_selection(
             &self.state.default_agent_cmd,
             self.state.default_agent_id.as_deref(),
             self.state.allowed_agent_ids.as_ref(),
@@ -2703,6 +2709,7 @@ impl HelperHandler {
             agent_id.as_deref(),
             &agent_source,
             wta_meta.provider_binding.as_deref(),
+            explicit_selection,
         )
         .await
         .map_err(|error| {
@@ -2713,21 +2720,22 @@ impl HelperHandler {
                 agent_id = ?agent_id,
                 "failed to resolve custom model binding: {error:#}"
             );
-            acp::Error::internal_error().data(serde_json::json!(error.root_cause().to_string()))
+            helper_initialize_error(HelperInitializeFailure::ProviderResolution, &error)
         })?;
 
-        let agent = get_or_spawn_agent(
-            &self.state,
-            &agent_cmd,
-            agent_id.as_deref(),
-            &agent_source,
-            provider_binding,
-            supplied_cloud_models,
-        )
+        let agent = acquire_and_bind_agent(&self.state, self.helper_id, || {
+            get_or_spawn_agent(
+                &self.state,
+                &agent_cmd,
+                agent_id.as_deref(),
+                &agent_source,
+                provider_binding.clone(),
+                supplied_cloud_models.clone(),
+            )
+        })
         .await
         .map_err(|e| {
             let error_chain = format!("{e:#}");
-            let user_detail = e.root_cause().to_string();
             tracing::error!(
                 target: "master",
                 op = "initialize",
@@ -2736,7 +2744,7 @@ impl HelperHandler {
                 error = %error_chain,
                 "failed to spawn/resolve agent CLI for helper"
             );
-            acp::Error::internal_error().data(serde_json::json!(user_detail))
+            helper_initialize_error(HelperInitializeFailure::AgentStartup, &e)
         })?;
         // `set` is idempotent-by-error; a helper that (incorrectly) sent
         // initialize twice keeps its first binding, which is fine.
@@ -2745,11 +2753,6 @@ impl HelperHandler {
             .agent
             .get()
             .expect("helper agent binding is set before initialize response");
-        if !bind_helper_to_agent(&self.state, agent, self.helper_id).await {
-            return Err(acp::Error::internal_error().data(serde_json::json!(
-                "agent CLI exited while the helper was binding"
-            )));
-        }
         let session_mcp_available = if agent
             .cached_init_resp
             .agent_capabilities
@@ -4493,6 +4496,27 @@ fn normalize_allowed_agent_ids(raw: &[String]) -> Option<std::collections::HashS
     Some(set)
 }
 
+#[derive(Clone, Copy)]
+enum HelperInitializeFailure {
+    ProviderResolution,
+    AgentStartup,
+}
+
+fn helper_initialize_error(
+    failure: HelperInitializeFailure,
+    _internal_error: &anyhow::Error,
+) -> acp::Error {
+    let detail = match failure {
+        HelperInitializeFailure::ProviderResolution => {
+            "Unable to load the selected model provider. Review it in Settings and try again."
+        }
+        HelperInitializeFailure::AgentStartup => {
+            "Unable to start the selected AI agent. Verify the agent installation and model provider settings, then try again."
+        }
+    };
+    acp::Error::internal_error().data(serde_json::json!(detail))
+}
+
 /// Decide which agent command the master will spawn for a helper, given
 /// what the helper declared in `_meta.wta` and the master's trusted
 /// defaults / GPO allowlist.
@@ -4506,14 +4530,29 @@ fn normalize_allowed_agent_ids(raw: &[String]) -> Option<std::collections::HashS
 /// creation by choosing the command line — only by selecting among the
 /// host-approved agent ids.
 ///
-/// Returns `(command_line, agent_id_for_cli_source)`. The id is passed
-/// on to `spawn_one_agent` so the per-session `cli_source` is stamped
-/// correctly; `None` lets it be inferred from the command line.
+/// The returned id is passed on to `spawn_one_agent` so the per-session
+/// `cli_source` is stamped correctly; `None` lets it be inferred from the
+/// command line. The explicit-selection status keeps rejected helper metadata
+/// from influencing provider resolution after fallback.
 ///
 /// Fallback to the default happens when the helper declared no id, an
 /// *unknown* id (not in [`agent_registry::KNOWN_AGENTS`] — e.g. a
 /// `custom:` agent, which the global default already covers), or an id
 /// the host's GPO allowlist excludes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ExplicitAgentSelection {
+    ImplicitDefault,
+    Accepted,
+    Rejected,
+}
+
+struct ResolvedAgentSelection {
+    command: String,
+    agent_id: Option<String>,
+    source: crate::agent_source::AgentSource,
+    explicit_selection: ExplicitAgentSelection,
+}
+
 fn resolve_agent_selection(
     default_cmd: &str,
     default_id: Option<&str>,
@@ -4523,7 +4562,7 @@ fn resolve_agent_selection(
     requested_source: Option<&str>,
     requested_wsl_distro: Option<&str>,
     helper_id: HelperId,
-) -> (String, Option<String>, crate::agent_source::AgentSource) {
+) -> ResolvedAgentSelection {
     let requested = requested_id
         .map(str::trim)
         .filter(|s| !s.is_empty())
@@ -4546,7 +4585,12 @@ fn resolve_agent_selection(
             let cmd = crate::agent_registry::build_acp_command(id, launch_model);
             let source =
                 crate::agent_source::AgentSource::from_wire(requested_source, requested_wsl_distro);
-            return (cmd, Some(id.to_string()), source);
+            return ResolvedAgentSelection {
+                command: cmd,
+                agent_id: Some(id.to_string()),
+                source,
+                explicit_selection: ExplicitAgentSelection::Accepted,
+            };
         }
 
         // A real selection we refused — surface why, then fall back.
@@ -4561,11 +4605,16 @@ fn resolve_agent_selection(
         );
     }
 
-    (
-        default_cmd.to_string(),
-        default_id.map(str::to_string),
-        crate::agent_source::AgentSource::Host,
-    )
+    ResolvedAgentSelection {
+        command: default_cmd.to_string(),
+        agent_id: default_id.map(str::to_string),
+        source: crate::agent_source::AgentSource::Host,
+        explicit_selection: if requested.is_some() {
+            ExplicitAgentSelection::Rejected
+        } else {
+            ExplicitAgentSelection::ImplicitDefault
+        },
+    }
 }
 
 async fn resolve_provider_binding(
@@ -4573,7 +4622,12 @@ async fn resolve_provider_binding(
     agent_id: Option<&str>,
     source: &crate::agent_source::AgentSource,
     requested_binding: Option<&str>,
+    explicit_selection: ExplicitAgentSelection,
 ) -> Result<ProviderBinding> {
+    if explicit_selection == ExplicitAgentSelection::Rejected {
+        return Ok(ProviderBinding::Native);
+    }
+
     let Some(requested_binding) = requested_binding.map(str::trim).filter(|value| !value.is_empty())
     else {
         return Ok(ProviderBinding::LegacyEnvironment);
@@ -5430,6 +5484,23 @@ async fn bind_helper_to_agent(
     }
     agent.bound_helpers.lock().await.insert(helper_id);
     true
+}
+
+async fn acquire_and_bind_agent<F, Fut>(
+    state: &MasterStateInner,
+    helper_id: HelperId,
+    mut acquire: F,
+) -> Result<Arc<AgentCli>>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<Arc<AgentCli>>>,
+{
+    loop {
+        let agent = acquire().await?;
+        if bind_helper_to_agent(state, &agent, helper_id).await {
+            return Ok(agent);
+        }
+    }
 }
 
 struct DisconnectedHelperCleanup {

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -119,6 +119,16 @@ impl ProviderBinding {
     fn is_model_scoped(&self) -> bool {
         matches!(self, Self::Custom { .. })
     }
+
+    fn has_active_custom_provider(&self) -> bool {
+        match self {
+            Self::LegacyEnvironment => {
+                crate::custom_model_provider::shared_provider_is_complete()
+            }
+            Self::Native => false,
+            Self::Custom { .. } => true,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -1490,13 +1500,14 @@ fn cloud_catalog_plan(
 fn prepare_native_cloud_catalog(
     resolved_agent_id: &str,
     source: &crate::agent_source::AgentSource,
+    provider_binding: &ProviderBinding,
     supplied_models: Vec<crate::app::AcpModelInfo>,
 ) -> (NativeCloudCatalogState, bool) {
     let profile = crate::agent_registry::lookup_profile_by_id(resolved_agent_id);
     match cloud_catalog_plan(
         source,
         profile.byok_mode,
-        crate::custom_model_provider::shared_provider_is_complete(),
+        provider_binding.has_active_custom_provider(),
         supplied_models.is_empty(),
     ) {
         CloudCatalogPlan::None => (NativeCloudCatalogState::Unavailable, false),
@@ -5011,8 +5022,12 @@ async fn spawn_one_agent(
         "agent CLI initialize OK; cli_source resolved"
     );
 
-    let (cloud_catalog, start_clean_probe) =
-        prepare_native_cloud_catalog(&resolved_agent_id, source, supplied_cloud_models);
+    let (cloud_catalog, start_clean_probe) = prepare_native_cloud_catalog(
+        &resolved_agent_id,
+        source,
+        provider_binding,
+        supplied_cloud_models,
+    );
     let agent = Arc::new(AgentCli {
         instance_id,
         conn,

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -56,7 +56,7 @@ const MASTER_PIPE_DISCOVERY_FILE: &str = "master-pipe.txt";
 use agent_client_protocol as acp;
 use anyhow::{anyhow, Context, Result};
 use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
-use tokio::sync::{mpsc, watch, Mutex};
+use tokio::sync::{mpsc, watch, Mutex, OnceCell};
 use tokio::task::LocalSet;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
@@ -78,7 +78,7 @@ pub(crate) struct HelperId(u64);
 
 type AgentCmdKey = String;
 type AgentInstanceId = uuid::Uuid;
-type AgentCell = Arc<tokio::sync::OnceCell<Arc<AgentCli>>>;
+type AgentCell = Arc<OnceCell<Arc<AgentCli>>>;
 
 struct CustomModelGeneration {
     config: crate::custom_model_provider::Config,
@@ -2113,12 +2113,10 @@ struct HelperHandler {
     /// (+ `model`): the master reconstructs the command from that id and
     /// never executes a command string off the pipe (falling back to the
     /// master default when no / unknown id is declared). Reused by every
-    /// later request on this connection. `OnceLock` because the binding
-    /// can't be known
-    /// until the helper's `initialize` arrives, but the ACP protocol
-    /// guarantees `initialize` precedes `new_session`/`prompt`/…, so
-    /// `resolved_agent()` always finds it populated for those.
-    agent: Arc<OnceLock<Arc<AgentCli>>>,
+    /// later request on this connection. The async `OnceCell` serializes
+    /// concurrent `initialize` requests so only the published binding can
+    /// acquire an agent and register this helper.
+    agent: AgentCell,
     state: Arc<MasterStateInner>,
     /// Serializes complete session replacement transactions for this helper.
     /// Shared by every cloned request handler, while unrelated helpers retain
@@ -2589,6 +2587,18 @@ impl HelperHandler {
 }
 
 impl HelperHandler {
+    async fn get_or_initialize_agent<F, Fut>(&self, acquire: F) -> Result<Arc<AgentCli>>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = Result<Arc<AgentCli>>>,
+    {
+        let agent = self
+            .agent
+            .get_or_try_init(|| acquire_and_bind_agent(&self.state, self.helper_id, acquire))
+            .await?;
+        Ok(Arc::clone(agent))
+    }
+
     async fn session_mcp_endpoint_for_session(
         &self,
         agent: &AgentCli,
@@ -2723,36 +2733,30 @@ impl HelperHandler {
             helper_initialize_error(HelperInitializeFailure::ProviderResolution, &error)
         })?;
 
-        let agent = acquire_and_bind_agent(&self.state, self.helper_id, || {
-            get_or_spawn_agent(
-                &self.state,
-                &agent_cmd,
-                agent_id.as_deref(),
-                &agent_source,
-                provider_binding.clone(),
-                supplied_cloud_models.clone(),
-            )
-        })
-        .await
-        .map_err(|e| {
-            let error_chain = format!("{e:#}");
-            tracing::error!(
-                target: "master",
-                op = "initialize",
-                helper_id = ?self.helper_id,
-                agent_cmd = %agent_cmd,
-                error = %error_chain,
-                "failed to spawn/resolve agent CLI for helper"
-            );
-            helper_initialize_error(HelperInitializeFailure::AgentStartup, &e)
-        })?;
-        // `set` is idempotent-by-error; a helper that (incorrectly) sent
-        // initialize twice keeps its first binding, which is fine.
-        let _ = self.agent.set(Arc::clone(&agent));
         let agent = self
-            .agent
-            .get()
-            .expect("helper agent binding is set before initialize response");
+            .get_or_initialize_agent(|| {
+                get_or_spawn_agent(
+                    &self.state,
+                    &agent_cmd,
+                    agent_id.as_deref(),
+                    &agent_source,
+                    provider_binding.clone(),
+                    supplied_cloud_models.clone(),
+                )
+            })
+            .await
+            .map_err(|e| {
+                let error_chain = format!("{e:#}");
+                tracing::error!(
+                    target: "master",
+                    op = "initialize",
+                    helper_id = ?self.helper_id,
+                    agent_cmd = %agent_cmd,
+                    error = %error_chain,
+                    "failed to spawn/resolve agent CLI for helper"
+                );
+                helper_initialize_error(HelperInitializeFailure::AgentStartup, &e)
+            })?;
         let session_mcp_available = if agent
             .cached_init_resp
             .agent_capabilities
@@ -2780,7 +2784,7 @@ impl HelperHandler {
         // empty `agent_info` on most backends, blanking the agent bar), adding
         // only our private helper-facing cloud catalog metadata. The original
         // third-party response capabilities remain untouched.
-        match initialize_response_for_agent(agent, session_mcp_available).await {
+        match initialize_response_for_agent(&agent, session_mcp_available).await {
             Ok(response) => Ok(response),
             Err(error) => {
                 tracing::warn!(
@@ -5220,7 +5224,7 @@ async fn serve_helper(
         helper_id,
         // Resolved lazily during this helper's `initialize` (see
         // HelperHandler::initialize → get_or_spawn_agent).
-        agent: Arc::new(OnceLock::new()),
+        agent: Arc::new(OnceCell::new()),
         state: Arc::clone(&state),
         replacement_gate: Arc::new(Mutex::new(())),
         notif_tx,

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -62,7 +62,8 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::protocol::acp::conn;
 use crate::protocol::acp::spawn::{
-    spawn_agent_process_for_source, AgentStderrLog, ChildEnvironmentPolicy,
+    spawn_agent_process_for_source_with_provider, AgentStderrLog, ChildEnvironmentPolicy,
+    SharedProviderSelection,
 };
 
 pub(crate) mod config;
@@ -78,6 +79,47 @@ pub(crate) struct HelperId(u64);
 type AgentCmdKey = String;
 type AgentInstanceId = uuid::Uuid;
 type AgentCell = Arc<tokio::sync::OnceCell<Arc<AgentCli>>>;
+
+struct CustomModelGeneration {
+    config: crate::custom_model_provider::Config,
+    generation: u64,
+}
+
+enum ProviderBinding {
+    LegacyEnvironment,
+    Native,
+    Custom {
+        selection_id: String,
+        generation: u64,
+        config: crate::custom_model_provider::Config,
+    },
+}
+
+impl ProviderBinding {
+    fn pool_key(&self) -> String {
+        match self {
+            Self::LegacyEnvironment => "legacy".to_string(),
+            Self::Native => "native".to_string(),
+            Self::Custom {
+                selection_id,
+                generation,
+                ..
+            } => format!("{selection_id}@{generation}"),
+        }
+    }
+
+    fn spawn_selection(&self) -> SharedProviderSelection<'_> {
+        match self {
+            Self::LegacyEnvironment => SharedProviderSelection::Inherit,
+            Self::Native => SharedProviderSelection::Disabled,
+            Self::Custom { config, .. } => SharedProviderSelection::Custom(config),
+        }
+    }
+
+    fn is_model_scoped(&self) -> bool {
+        matches!(self, Self::Custom { .. })
+    }
+}
 
 #[derive(Clone)]
 enum RetirementOperationState {
@@ -304,6 +346,10 @@ struct MasterStateInner {
     /// a background process at the cost of cold-start latency for the next
     /// tab switch; that trade-off favors warm agents for a terminal app.
     pub(crate) agents: Mutex<HashMap<AgentCmdKey, AgentCell>>,
+    /// Master-only BYOK configurations keyed by the credential-free selection
+    /// ID. A changed endpoint/model/credential reference advances the
+    /// generation and therefore gets a new agent-pool entry.
+    custom_model_generations: Mutex<HashMap<String, CustomModelGeneration>>,
     /// Fallback agent command line + id for helpers that don't declare
     /// their own in `_meta.wta` (older helper builds, or the rare
     /// manual launch). Comes from the master's own `--agent` / `--agent-id`,
@@ -1294,7 +1340,25 @@ fn agent_cmd_key(
     agent_id: Option<&str>,
     source: &crate::agent_source::AgentSource,
 ) -> AgentCmdKey {
-    format!("{:?}", (source, agent_id, command))
+    agent_cmd_key_with_provider(command, agent_id, source, &ProviderBinding::Native)
+}
+
+fn agent_cmd_key_with_provider(
+    command: &str,
+    agent_id: Option<&str>,
+    source: &crate::agent_source::AgentSource,
+    provider_binding: &ProviderBinding,
+) -> AgentCmdKey {
+    let lifecycle =
+        if requested_model_is_explicit(command, agent_id) || provider_binding.is_model_scoped() {
+            "model:"
+        } else {
+            "warm:"
+        };
+    format!(
+        "{lifecycle}{:?}",
+        (source, agent_id, command, provider_binding.pool_key())
+    )
 }
 
 /// One spawned agent CLI subprocess and everything a helper needs to
@@ -2623,12 +2687,30 @@ impl HelperHandler {
                 }
                 Vec::new()
             };
+        let provider_binding = resolve_provider_binding(
+            &self.state,
+            agent_id.as_deref(),
+            &agent_source,
+            wta_meta.provider_binding.as_deref(),
+        )
+        .await
+        .map_err(|error| {
+            tracing::error!(
+                target: "master",
+                op = "initialize",
+                helper_id = ?self.helper_id,
+                agent_id = ?agent_id,
+                "failed to resolve custom model binding: {error:#}"
+            );
+            acp::Error::internal_error().data(serde_json::json!(error.root_cause().to_string()))
+        })?;
 
         let agent = get_or_spawn_agent(
             &self.state,
             &agent_cmd,
             agent_id.as_deref(),
             &agent_source,
+            provider_binding,
             supplied_cloud_models,
         )
         .await
@@ -2652,7 +2734,11 @@ impl HelperHandler {
             .agent
             .get()
             .expect("helper agent binding is set before initialize response");
-        agent.bound_helpers.lock().await.insert(self.helper_id);
+        if !bind_helper_to_agent(&self.state, agent, self.helper_id).await {
+            return Err(acp::Error::internal_error().data(serde_json::json!(
+                "agent CLI exited while the helper was binding"
+            )));
+        }
         let session_mcp_available = if agent
             .cached_init_resp
             .agent_capabilities
@@ -4152,6 +4238,7 @@ async fn run_master_loop(config: MasterConfig, pipe_name: String) -> Result<()> 
         helper_ext_subscribers: Mutex::new(HashMap::new()),
         wt,
         agents: Mutex::new(HashMap::new()),
+        custom_model_generations: Mutex::new(HashMap::new()),
         default_agent_cmd: config.agent.clone(),
         default_agent_id: config.agent_id.clone(),
         allowed_agent_ids,
@@ -4443,7 +4530,9 @@ fn resolve_agent_selection(
 
         if known && allowed {
             let model = requested_model.map(str::trim).filter(|s| !s.is_empty());
-            let cmd = crate::agent_registry::build_acp_command(id, model);
+            let launch_model =
+                model.filter(|_| !crate::agent_registry::supports_live_model_switch(id));
+            let cmd = crate::agent_registry::build_acp_command(id, launch_model);
             let source =
                 crate::agent_source::AgentSource::from_wire(requested_source, requested_wsl_distro);
             return (cmd, Some(id.to_string()), source);
@@ -4468,6 +4557,101 @@ fn resolve_agent_selection(
     )
 }
 
+async fn resolve_provider_binding(
+    state: &MasterStateInner,
+    agent_id: Option<&str>,
+    source: &crate::agent_source::AgentSource,
+    requested_binding: Option<&str>,
+) -> Result<ProviderBinding> {
+    let Some(requested_binding) = requested_binding.map(str::trim).filter(|value| !value.is_empty())
+    else {
+        return Ok(ProviderBinding::LegacyEnvironment);
+    };
+    if !matches!(source, crate::agent_source::AgentSource::Host)
+        || requested_binding.eq_ignore_ascii_case("default")
+    {
+        return Ok(ProviderBinding::Native);
+    }
+
+    let agent_id = agent_id.context("custom model binding requires a known agent")?;
+    if crate::agent_registry::lookup_profile_by_id(agent_id).byok_mode
+        == crate::agent_registry::ByokMode::Unsupported
+    {
+        tracing::warn!(
+            target: "master",
+            agent_id,
+            "ignoring custom model binding for an agent without BYOK support"
+        );
+        return Ok(ProviderBinding::Native);
+    }
+
+    let wt = state
+        .wt
+        .as_ref()
+        .context("Terminal settings are unavailable for custom model resolution")?;
+    let settings = wt
+        .request("get_settings", serde_json::Value::Null)
+        .await
+        .context("failed to read Terminal settings for custom model resolution")?;
+    let config = crate::custom_model_provider::Config::from_settings(&settings, requested_binding)?;
+
+    let mut generations = state.custom_model_generations.lock().await;
+    let generation = update_custom_model_generation(
+        &mut generations,
+        requested_binding,
+        config.clone(),
+    )?;
+
+    Ok(ProviderBinding::Custom {
+        selection_id: requested_binding.to_string(),
+        generation,
+        config,
+    })
+}
+
+fn update_custom_model_generation(
+    generations: &mut HashMap<String, CustomModelGeneration>,
+    selection_id: &str,
+    config: crate::custom_model_provider::Config,
+) -> Result<u64> {
+    let generation = match generations.get_mut(selection_id) {
+        Some(current) if current.config == config => current.generation,
+        Some(current) => {
+            current.generation = current
+                .generation
+                .checked_add(1)
+                .context("custom model provider generation exhausted")?;
+            current.config = config.clone();
+            current.generation
+        }
+        None => {
+            generations.insert(
+                selection_id.to_string(),
+                CustomModelGeneration {
+                    config,
+                    generation: 1,
+                },
+            );
+            1
+        }
+    };
+    Ok(generation)
+}
+
+fn requested_model_is_explicit(agent_cmd: &str, agent_id: Option<&str>) -> bool {
+    let resolved_agent_id =
+        agent_id.unwrap_or_else(|| crate::agent_registry::resolve_agent_id_from_cmd(agent_cmd));
+    if !crate::agent_registry::is_known_id(resolved_agent_id)
+        || crate::agent_registry::supports_live_model_switch(resolved_agent_id)
+    {
+        return false;
+    }
+    let profile = crate::agent_registry::lookup_profile_by_id(resolved_agent_id);
+    let tokens = crate::coordinator::split_windows_commandline(agent_cmd);
+    let args: Vec<&str> = tokens.iter().skip(1).map(String::as_str).collect();
+    crate::agent_registry::extract_model_from_args(&args, profile).is_some()
+}
+
 /// Get the agent CLI for `agent_cmd`, spawning + initializing it on
 /// first use and reusing it thereafter. Two helpers racing the same
 /// new agent serialize on the per-key `OnceCell`; helpers for different
@@ -4478,9 +4662,10 @@ async fn get_or_spawn_agent(
     agent_cmd: &str,
     agent_id: Option<&str>,
     source: &crate::agent_source::AgentSource,
+    provider_binding: ProviderBinding,
     supplied_cloud_models: Vec<crate::app::AcpModelInfo>,
 ) -> Result<Arc<AgentCli>> {
-    let key = agent_cmd_key(agent_cmd, agent_id, source);
+    let key = agent_cmd_key_with_provider(agent_cmd, agent_id, source, &provider_binding);
     let cell = {
         let mut agents = state.agents.lock().await;
         Arc::clone(
@@ -4503,6 +4688,7 @@ async fn get_or_spawn_agent(
                 agent_cmd,
                 agent_id,
                 source,
+                &provider_binding,
                 supplied_cloud_models,
             )
             .await
@@ -4567,18 +4753,20 @@ async fn spawn_one_agent(
     agent_cmd: &str,
     agent_id: Option<&str>,
     source: &crate::agent_source::AgentSource,
+    provider_binding: &ProviderBinding,
     supplied_cloud_models: Vec<crate::app::AcpModelInfo>,
 ) -> Result<Arc<AgentCli>> {
     let instance_id = AgentInstanceId::new_v4();
     let resolved_agent_id = agent_id
         .map(str::to_string)
         .unwrap_or_else(|| crate::agent_registry::resolve_agent_id_from_cmd(agent_cmd).to_string());
-    let mut spawn_result = spawn_agent_process_for_source(
+    let mut spawn_result = spawn_agent_process_for_source_with_provider(
         agent_cmd,
         None,
         agent_id,
         source,
         ChildEnvironmentPolicy::ApplySharedProvider,
+        provider_binding.spawn_selection(),
     )
     .with_context(|| format!("failed to spawn agent CLI: {agent_cmd}"))?;
     tracing::info!(
@@ -5169,6 +5357,9 @@ async fn serve_helper(
     }
 
     let cleanup = cleanup_disconnected_helper(&handler).await;
+    if let Some(agent) = handler.agent.get() {
+        retire_unbound_model_agent(&state, agent).await;
+    }
 
     tracing::info!(
         target: "master",
@@ -5180,6 +5371,50 @@ async fn serve_helper(
     );
 
     result
+}
+
+async fn retire_unbound_model_agent(state: &MasterStateInner, agent: &Arc<AgentCli>) {
+    if !agent.cmd_key.starts_with("model:") {
+        return;
+    }
+
+    let removed = {
+        let mut agents = state.agents.lock().await;
+        let matches_instance = agents
+            .get(&agent.cmd_key)
+            .and_then(|cell| cell.get())
+            .is_some_and(|current| Arc::ptr_eq(current, agent));
+        if !matches_instance || !agent.bound_helpers.lock().await.is_empty() {
+            false
+        } else {
+            agents.remove(&agent.cmd_key).is_some()
+        }
+    };
+    if removed {
+        tracing::info!(
+            target: "master",
+            agent = %agent.cmd_key,
+            "retiring unbound model-specific agent CLI"
+        );
+        agent.conn.shutdown();
+    }
+}
+
+async fn bind_helper_to_agent(
+    state: &MasterStateInner,
+    agent: &Arc<AgentCli>,
+    helper_id: HelperId,
+) -> bool {
+    let agents = state.agents.lock().await;
+    let matches_instance = agents
+        .get(&agent.cmd_key)
+        .and_then(|cell| cell.get())
+        .is_some_and(|current| Arc::ptr_eq(current, agent));
+    if !matches_instance {
+        return false;
+    }
+    agent.bound_helpers.lock().await.insert(helper_id);
+    true
 }
 
 struct DisconnectedHelperCleanup {

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -339,6 +339,43 @@ fn fresh_host_byok_startup_uses_clean_probe_only_when_needed() {
     assert!(matches!(catalog, NativeCloudCatalogState::Pending));
 }
 
+#[test]
+fn helper_initialize_errors_do_not_expose_provider_credentials() {
+    const CREDENTIAL_RESOURCE: &str = "sentinel-credential-resource";
+    const CREDENTIAL_ID: &str = "sentinel-credential-id";
+
+    let internal_error = anyhow::anyhow!(
+        "credential lookup failed for resource {CREDENTIAL_RESOURCE} and id {CREDENTIAL_ID}"
+    )
+    .context("custom provider initialization failed");
+
+    for failure in [
+        HelperInitializeFailure::ProviderResolution,
+        HelperInitializeFailure::AgentStartup,
+    ] {
+        let protocol_error = helper_initialize_error(failure, &internal_error);
+        let visible = format!(
+            "{} {}",
+            protocol_error.message,
+            protocol_error
+                .data
+                .as_ref()
+                .map(serde_json::Value::to_string)
+                .unwrap_or_default()
+        );
+        assert!(!visible.contains(CREDENTIAL_RESOURCE));
+        assert!(!visible.contains(CREDENTIAL_ID));
+        assert!(
+            protocol_error
+                .data
+                .as_ref()
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|detail| !detail.trim().is_empty() && detail.contains("try again")),
+            "helper-visible error detail must remain actionable: {visible}"
+        );
+    }
+}
+
 
 
 
@@ -507,7 +544,7 @@ fn resolve(
     requested_id: Option<&str>,
     model: Option<&str>,
 ) -> (String, Option<String>) {
-    let (command, agent_id, _source) = resolve_agent_selection(
+    let selection = resolve_agent_selection(
         DEFAULT_CMD,
         Some("copilot"),
         allowed,
@@ -517,7 +554,7 @@ fn resolve(
         None,
         HelperId(1),
     );
-    (command, agent_id)
+    (selection.command, selection.agent_id)
 }
 
 #[test]
@@ -531,7 +568,7 @@ fn known_id_with_no_allowlist_is_reconstructed_not_taken_from_pipe() {
 
 #[test]
 fn known_agent_selection_preserves_wsl_source() {
-    let (command, agent_id, source) = resolve_agent_selection(
+    let selection = resolve_agent_selection(
         DEFAULT_CMD,
         Some("copilot"),
         None,
@@ -541,21 +578,25 @@ fn known_agent_selection_preserves_wsl_source() {
         Some("Ubuntu"),
         HelperId(1),
     );
-    assert_eq!(command, "copilot --acp --stdio");
-    assert_eq!(agent_id.as_deref(), Some("copilot"));
+    assert_eq!(selection.command, "copilot --acp --stdio");
+    assert_eq!(selection.agent_id.as_deref(), Some("copilot"));
     assert_eq!(
-        source,
+        selection.explicit_selection,
+        ExplicitAgentSelection::Accepted
+    );
+    assert_eq!(
+        selection.source,
         crate::agent_source::AgentSource::Wsl {
             distro: "Ubuntu".to_string()
         }
     );
     assert_ne!(
         agent_cmd_key(
-            &command,
+            &selection.command,
             Some("copilot"),
             &crate::agent_source::AgentSource::Host,
         ),
-        agent_cmd_key(&command, Some("copilot"), &source),
+        agent_cmd_key(&selection.command, Some("copilot"), &selection.source),
         "host and WSL instances must occupy separate pool slots"
     );
 }
@@ -714,6 +755,73 @@ async fn model_scoped_agent_retires_only_after_its_final_helper_unbinds() {
             assert!(
                 !state.agents.lock().await.contains_key(&key),
                 "the final helper disconnect must retire the model generation"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn helper_claim_retries_when_captured_agent_cell_is_replaced() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_id = HelperId(603);
+            let key = "model:replaced-agent".to_string();
+            let make_agent = || {
+                Arc::new(AgentCli {
+                    instance_id: AgentInstanceId::new_v4(),
+                    conn: client_connection_to_model_agent(
+                        false,
+                        Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                        Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                    ),
+                    cached_init_resp: acp::schema::v1::InitializeResponse::new(
+                        acp::schema::ProtocolVersion::V1,
+                    ),
+                    cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                    source: crate::agent_source::AgentSource::Host,
+                    cmd_key: key.clone(),
+                    cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                    bound_helpers: Mutex::new(HashSet::new()),
+                    host_list_cache: Mutex::new(None),
+                    listed_ever: Mutex::new(HashSet::new()),
+                })
+            };
+            let stale = make_agent();
+            let replacement = make_agent();
+            let stale_cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(stale_cell.set(Arc::clone(&stale)).is_ok());
+            state.agents.lock().await.insert(key.clone(), stale_cell);
+
+            let replacement_cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(replacement_cell.set(Arc::clone(&replacement)).is_ok());
+            let mut attempts = 0;
+            let claimed = acquire_and_bind_agent(&state, helper_id, || {
+                attempts += 1;
+                let attempt = attempts;
+                let state = Arc::clone(&state);
+                let key = key.clone();
+                let stale = Arc::clone(&stale);
+                let replacement = Arc::clone(&replacement);
+                let replacement_cell = Arc::clone(&replacement_cell);
+                async move {
+                    if attempt == 1 {
+                        state.agents.lock().await.insert(key, replacement_cell);
+                        Ok(stale)
+                    } else {
+                        Ok(replacement)
+                    }
+                }
+            })
+            .await
+            .expect("replacement agent should be claimed");
+
+            assert_eq!(attempts, 2);
+            assert!(Arc::ptr_eq(&claimed, &replacement));
+            assert!(stale.bound_helpers.lock().await.is_empty());
+            assert!(
+                replacement.bound_helpers.lock().await.contains(&helper_id),
+                "the helper must bind only to the current pool entry"
             );
         })
         .await;
@@ -8918,6 +9026,7 @@ async fn custom_provider_binding_is_resolved_from_terminal_settings() {
         Some("copilot"),
         &crate::agent_source::AgentSource::Host,
         Some("default"),
+        ExplicitAgentSelection::Accepted,
     )
     .await
     .expect("the explicit native provider should resolve without settings");
@@ -8932,6 +9041,7 @@ async fn custom_provider_binding_is_resolved_from_terminal_settings() {
         Some("copilot"),
         &crate::agent_source::AgentSource::Host,
         Some("custom:provider:model-a"),
+        ExplicitAgentSelection::ImplicitDefault,
     )
     .await
     .expect("the master should resolve a configured custom provider");
@@ -8953,6 +9063,66 @@ async fn custom_provider_binding_is_resolved_from_terminal_settings() {
         mock.calls(),
         vec![("get_settings".to_string(), serde_json::Value::Null)]
     );
+}
+
+async fn assert_rejected_selection_uses_native_provider(
+    requested_id: &str,
+    allowed_ids: Option<&std::collections::HashSet<String>>,
+) {
+    let mock = Arc::new(MockWtChannel::responding(serde_json::json!({
+        "customModelProviders": [{
+            "id": "provider",
+            "baseUrl": "https://example.test/v1",
+            "apiContract": "openai-compatible",
+            "apiKeyCredential": "credential-reference",
+            "apiKeyRequired": true,
+            "models": [{ "id": "model-a" }]
+        }]
+    })));
+    let state = make_state_with_wt(mock.clone());
+    let selection = resolve_agent_selection(
+        DEFAULT_CMD,
+        Some("copilot"),
+        allowed_ids,
+        Some(requested_id),
+        None,
+        None,
+        None,
+        HelperId(1),
+    );
+
+    assert_eq!(selection.command, DEFAULT_CMD);
+    assert_eq!(selection.agent_id.as_deref(), Some("copilot"));
+    assert_eq!(
+        selection.explicit_selection,
+        ExplicitAgentSelection::Rejected
+    );
+
+    let binding = resolve_provider_binding(
+        &state,
+        selection.agent_id.as_deref(),
+        &selection.source,
+        Some("custom:provider:model-a"),
+        selection.explicit_selection,
+    )
+    .await
+    .expect("rejected selections should use the native provider");
+    assert!(matches!(binding, ProviderBinding::Native));
+    assert!(
+        mock.calls().is_empty(),
+        "rejected selections must not read custom provider settings"
+    );
+}
+
+#[tokio::test]
+async fn unknown_agent_with_custom_binding_falls_back_to_native_provider() {
+    assert_rejected_selection_uses_native_provider("custom:unknown", None).await;
+}
+
+#[tokio::test]
+async fn policy_blocked_agent_with_custom_binding_falls_back_to_native_provider() {
+    let allowed = allow_set(&["copilot"]);
+    assert_rejected_selection_uses_native_provider("gemini", Some(&allowed)).await;
 }
 
 fn focus_params_for(

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -8,6 +8,41 @@ use super::*;
 use acp::schema::v1::{ContentChunk, SessionId, SessionNotification, SessionUpdate};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
+fn empty_agent_cell() -> AgentCell {
+    Arc::new(OnceCell::new())
+}
+
+fn unbound_test_agent(key: &str) -> Arc<AgentCli> {
+    Arc::new(AgentCli {
+        instance_id: AgentInstanceId::new_v4(),
+        conn: client_connection_to_model_agent(
+            false,
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        ),
+        cached_init_resp: acp::schema::v1::InitializeResponse::new(
+            acp::schema::ProtocolVersion::V1,
+        ),
+        cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+        source: crate::agent_source::AgentSource::Host,
+        cmd_key: key.to_string(),
+        cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+        bound_helpers: Mutex::new(HashSet::new()),
+        host_list_cache: Mutex::new(None),
+        listed_ever: Mutex::new(HashSet::new()),
+    })
+}
+
+async fn add_test_agent_to_pool(state: &MasterStateInner, agent: &Arc<AgentCli>) {
+    let cell = Arc::new(OnceCell::new());
+    assert!(cell.set(Arc::clone(agent)).is_ok());
+    state
+        .agents
+        .lock()
+        .await
+        .insert(agent.cmd_key.clone(), cell);
+}
+
 #[derive(Clone)]
 struct PendingNewSessionAgent;
 
@@ -823,6 +858,132 @@ async fn helper_claim_retries_when_captured_agent_cell_is_replaced() {
                 replacement.bound_helpers.lock().await.contains(&helper_id),
                 "the helper must bind only to the current pool entry"
             );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn repeated_helper_initialization_acquires_and_binds_once() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+
+            let state = make_state();
+            let helper_id = HelperId(604);
+            let published = unbound_test_agent("model:published-repeated");
+            let unused = unbound_test_agent("model:unused-repeated");
+            add_test_agent_to_pool(&state, &published).await;
+            add_test_agent_to_pool(&state, &unused).await;
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let handler = HelperHandler {
+                helper_id,
+                agent: empty_agent_cell(),
+                state,
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx,
+                agent_side_slot: Arc::new(OnceLock::new()),
+            };
+            let acquisitions = AtomicUsize::new(0);
+
+            let first = handler
+                .get_or_initialize_agent(|| {
+                    acquisitions.fetch_add(1, Ordering::SeqCst);
+                    let agent = Arc::clone(&published);
+                    async move { Ok(agent) }
+                })
+                .await
+                .expect("first initialization should publish its agent");
+            let repeated = handler
+                .get_or_initialize_agent(|| {
+                    acquisitions.fetch_add(1, Ordering::SeqCst);
+                    let agent = Arc::clone(&unused);
+                    async move { Ok(agent) }
+                })
+                .await
+                .expect("repeated initialization should reuse the published agent");
+
+            assert_eq!(acquisitions.load(Ordering::SeqCst), 1);
+            assert!(Arc::ptr_eq(&first, &published));
+            assert!(Arc::ptr_eq(&repeated, &published));
+            assert_eq!(
+                *published.bound_helpers.lock().await,
+                HashSet::from([helper_id])
+            );
+            assert!(unused.bound_helpers.lock().await.is_empty());
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn concurrent_helper_initialization_publishes_only_the_winning_agent() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+
+            let state = make_state();
+            let helper_id = HelperId(605);
+            let published = unbound_test_agent("model:published-concurrent");
+            let unused = unbound_test_agent("model:unused-concurrent");
+            add_test_agent_to_pool(&state, &published).await;
+            add_test_agent_to_pool(&state, &unused).await;
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+            let handler = HelperHandler {
+                helper_id,
+                agent: empty_agent_cell(),
+                state,
+                replacement_gate: Arc::new(Mutex::new(())),
+                notif_tx,
+                agent_side_slot: Arc::new(OnceLock::new()),
+            };
+            let acquisitions = Arc::new(AtomicUsize::new(0));
+            let first_started = Arc::new(tokio::sync::Notify::new());
+            let release_first = Arc::new(tokio::sync::Notify::new());
+
+            let first = handler.get_or_initialize_agent({
+                let acquisitions = Arc::clone(&acquisitions);
+                let first_started = Arc::clone(&first_started);
+                let release_first = Arc::clone(&release_first);
+                let published = Arc::clone(&published);
+                move || {
+                    let acquisitions = Arc::clone(&acquisitions);
+                    let first_started = Arc::clone(&first_started);
+                    let release_first = Arc::clone(&release_first);
+                    let published = Arc::clone(&published);
+                    async move {
+                        acquisitions.fetch_add(1, Ordering::SeqCst);
+                        first_started.notify_one();
+                        release_first.notified().await;
+                        Ok(published)
+                    }
+                }
+            });
+            let concurrent = handler.get_or_initialize_agent({
+                let acquisitions = Arc::clone(&acquisitions);
+                let unused = Arc::clone(&unused);
+                move || {
+                    acquisitions.fetch_add(1, Ordering::SeqCst);
+                    let unused = Arc::clone(&unused);
+                    async move { Ok(unused) }
+                }
+            });
+            let release = async {
+                first_started.notified().await;
+                release_first.notify_one();
+            };
+
+            let (first, concurrent, ()) = tokio::join!(biased; first, concurrent, release);
+            let first = first.expect("winning initialization should publish its agent");
+            let concurrent =
+                concurrent.expect("concurrent initialization should reuse the published agent");
+
+            assert_eq!(acquisitions.load(Ordering::SeqCst), 1);
+            assert!(Arc::ptr_eq(&first, &published));
+            assert!(Arc::ptr_eq(&concurrent, &published));
+            assert_eq!(
+                *published.bound_helpers.lock().await,
+                HashSet::from([helper_id])
+            );
+            assert!(unused.bound_helpers.lock().await.is_empty());
         })
         .await;
 }
@@ -1799,7 +1960,7 @@ fn client_connection_to_model_agent(
 
 fn model_handler(agent: Arc<AgentCli>, helper_id: u64) -> HelperHandler {
     let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
-    let slot = Arc::new(OnceLock::new());
+    let slot = empty_agent_cell();
     let _ = slot.set(agent);
     HelperHandler {
         helper_id: HelperId(helper_id),
@@ -1962,7 +2123,7 @@ async fn new_session_timeout_is_enforced_by_master_forwarder() {
             // (hangs-on-session/new) connection so
             // `forward_new_session_to_agent` resolves it and exercises
             // the timeout path.
-            let agent = Arc::new(OnceLock::new());
+            let agent = empty_agent_cell();
             let _ = agent.set(Arc::new(AgentCli {
                 instance_id: AgentInstanceId::new_v4(),
                 conn: client_connection_to_pending_new_session_agent(),
@@ -2023,7 +2184,7 @@ async fn failed_pending_session_cleanup_retires_close_marked_recovery_state() {
     let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
     let handler = HelperHandler {
         helper_id,
-        agent: Arc::new(OnceLock::new()),
+        agent: empty_agent_cell(),
         state: Arc::clone(&state),
         replacement_gate: Arc::new(Mutex::new(())),
         notif_tx,
@@ -2067,7 +2228,7 @@ async fn failed_pending_cleanup_reads_destructive_marker_under_ownership_gate() 
             let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
             let handler = HelperHandler {
                 helper_id,
-                agent: Arc::new(OnceLock::new()),
+                agent: empty_agent_cell(),
                 state: Arc::clone(&state),
                 replacement_gate: Arc::new(Mutex::new(())),
                 notif_tx,
@@ -2112,7 +2273,7 @@ async fn load_session_gate_timeout_does_not_reach_agent_or_mutate_state() {
                 acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
             cached_init_resp.agent_capabilities.mcp_capabilities.http = true;
             let (load_arrivals_tx, mut load_arrivals_rx) = mpsc::unbounded_channel();
-            let agent = Arc::new(OnceLock::new());
+            let agent = empty_agent_cell();
             assert!(agent
                 .set(Arc::new(AgentCli {
                     instance_id: agent_instance,
@@ -2199,7 +2360,7 @@ async fn load_session_timeout_rolls_back_replacement_state_and_releases_gate() {
                 acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
             cached_init_resp.agent_capabilities.mcp_capabilities.http = true;
             let (load_arrivals_tx, mut load_arrivals_rx) = mpsc::unbounded_channel();
-            let agent = Arc::new(OnceLock::new());
+            let agent = empty_agent_cell();
             assert!(agent
                 .set(Arc::new(AgentCli {
                     instance_id: agent_instance,
@@ -2276,7 +2437,7 @@ fn cloned_helper_handlers_share_the_lazy_agent_binding() {
     let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
     let handler = HelperHandler {
         helper_id: HelperId(1),
-        agent: Arc::new(OnceLock::new()),
+        agent: empty_agent_cell(),
         state: make_state(),
         replacement_gate: Arc::new(Mutex::new(())),
         notif_tx,
@@ -2311,7 +2472,7 @@ async fn helper_close_session_physically_closes_and_retires_owned_session() {
                 .agent_capabilities
                 .session_capabilities
                 .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
-            let agent = Arc::new(OnceLock::new());
+            let agent = empty_agent_cell();
             assert!(agent
                 .set(Arc::new(AgentCli {
                     instance_id: agent_instance_id,
@@ -2763,7 +2924,7 @@ async fn no_owner_retirement_fences_outgoing_publication_and_allows_replacement(
     let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
     let outgoing_handler = HelperHandler {
         helper_id: outgoing,
-        agent: Arc::new(OnceLock::new()),
+        agent: empty_agent_cell(),
         state: Arc::clone(&state),
         replacement_gate: Arc::new(Mutex::new(())),
         notif_tx: notif_tx.clone(),
@@ -2793,7 +2954,7 @@ async fn no_owner_retirement_fences_outgoing_publication_and_allows_replacement(
     state.connected_helpers.lock().await.insert(replacement);
     let replacement_handler = HelperHandler {
         helper_id: replacement,
-        agent: Arc::new(OnceLock::new()),
+        agent: empty_agent_cell(),
         state: Arc::clone(&state),
         replacement_gate: Arc::new(Mutex::new(())),
         notif_tx,
@@ -2848,7 +3009,7 @@ async fn scope_all_fences_connected_helper_without_owner_after_completion() {
             let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
             let outgoing_handler = HelperHandler {
                 helper_id: outgoing,
-                agent: Arc::new(OnceLock::new()),
+                agent: empty_agent_cell(),
                 state: Arc::clone(&state),
                 replacement_gate: Arc::new(Mutex::new(())),
                 notif_tx: notif_tx.clone(),
@@ -2874,7 +3035,7 @@ async fn scope_all_fences_connected_helper_without_owner_after_completion() {
             state.connected_helpers.lock().await.insert(replacement);
             let replacement_handler = HelperHandler {
                 helper_id: replacement,
-                agent: Arc::new(OnceLock::new()),
+                agent: empty_agent_cell(),
                 state: Arc::clone(&state),
                 replacement_gate: Arc::new(Mutex::new(())),
                 notif_tx,
@@ -2928,7 +3089,7 @@ async fn helper_connecting_during_scope_all_is_outgoing_but_replacement_is_admit
     let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
     let outgoing_handler = HelperHandler {
         helper_id: outgoing,
-        agent: Arc::new(OnceLock::new()),
+        agent: empty_agent_cell(),
         state: Arc::clone(&state),
         replacement_gate: Arc::new(Mutex::new(())),
         notif_tx: notif_tx.clone(),
@@ -2949,7 +3110,7 @@ async fn helper_connecting_during_scope_all_is_outgoing_but_replacement_is_admit
     register_connected_helper(&state, replacement).await;
     let replacement_handler = HelperHandler {
         helper_id: replacement,
-        agent: Arc::new(OnceLock::new()),
+        agent: empty_agent_cell(),
         state: Arc::clone(&state),
         replacement_gate: Arc::new(Mutex::new(())),
         notif_tx,
@@ -3106,7 +3267,7 @@ async fn repeated_ownerless_stale_tab_retirement_keeps_fences_bounded() {
     let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
     let handler = HelperHandler {
         helper_id: unresolved,
-        agent: Arc::new(OnceLock::new()),
+        agent: empty_agent_cell(),
         state: Arc::clone(&state),
         replacement_gate: Arc::new(Mutex::new(())),
         notif_tx,
@@ -3142,7 +3303,7 @@ async fn ownerless_helper_cannot_claim_old_retired_tab_after_prior_fence_limits(
     let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
     let handler = HelperHandler {
         helper_id,
-        agent: Arc::new(OnceLock::new()),
+        agent: empty_agent_cell(),
         state: Arc::clone(&state),
         replacement_gate: Arc::new(Mutex::new(())),
         notif_tx,
@@ -3175,7 +3336,7 @@ async fn ownerless_helper_publishing_different_owner_clears_unrelated_safety() {
     let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
     let handler = HelperHandler {
         helper_id,
-        agent: Arc::new(OnceLock::new()),
+        agent: empty_agent_cell(),
         state: Arc::clone(&state),
         replacement_gate: Arc::new(Mutex::new(())),
         notif_tx,
@@ -4170,7 +4331,7 @@ async fn scope_all_waits_for_ownerless_pending_transaction_cleanup() {
                 .await
                 .insert(agent.cmd_key.clone(), cell);
             state.connected_helpers.lock().await.insert(helper_id);
-            let agent_slot = Arc::new(OnceLock::new());
+            let agent_slot = empty_agent_cell();
             assert!(agent_slot.set(Arc::clone(&agent)).is_ok());
             let agent_side_slot = Arc::new(OnceLock::new());
             agent_side_slot
@@ -4669,7 +4830,7 @@ async fn retirement_waits_for_and_retires_late_session_new() {
                 .lock()
                 .await
                 .insert(agent.cmd_key.clone(), cell);
-            let agent_slot = Arc::new(OnceLock::new());
+            let agent_slot = empty_agent_cell();
             assert!(agent_slot.set(Arc::clone(&agent)).is_ok());
             let agent_side_slot = Arc::new(OnceLock::new());
             agent_side_slot
@@ -4783,7 +4944,7 @@ async fn retirement_timeout_cleans_before_completion_and_fences_late_session_new
                 .lock()
                 .await
                 .insert(agent.cmd_key.clone(), cell);
-            let agent_slot = Arc::new(OnceLock::new());
+            let agent_slot = empty_agent_cell();
             assert!(agent_slot.set(Arc::clone(&agent)).is_ok());
             let agent_side_slot = Arc::new(OnceLock::new());
             agent_side_slot
@@ -5165,7 +5326,7 @@ async fn close_by_tab_retires_session_new_that_finishes_after_tab_destruction() 
                 .await
                 .insert(agent.cmd_key.clone(), cell);
 
-            let agent_slot = Arc::new(OnceLock::new());
+            let agent_slot = empty_agent_cell();
             assert!(agent_slot.set(Arc::clone(&agent)).is_ok());
             let agent_side_slot = Arc::new(OnceLock::new());
             agent_side_slot
@@ -5302,7 +5463,7 @@ async fn disconnect_during_session_new_fences_late_result() {
                 host_list_cache: Mutex::new(None),
                 listed_ever: Mutex::new(HashSet::new()),
             });
-            let agent_slot = Arc::new(OnceLock::new());
+            let agent_slot = empty_agent_cell();
             assert!(agent_slot.set(agent).is_ok());
             let agent_side_slot = Arc::new(OnceLock::new());
             agent_side_slot
@@ -5413,7 +5574,7 @@ async fn disconnect_tombstone_rejects_queued_replacement_after_in_flight_failure
                 host_list_cache: Mutex::new(None),
                 listed_ever: Mutex::new(HashSet::new()),
             });
-            let agent_slot = Arc::new(OnceLock::new());
+            let agent_slot = empty_agent_cell();
             assert!(agent_slot.set(agent).is_ok());
             let agent_side_slot = Arc::new(OnceLock::new());
             agent_side_slot
@@ -5541,7 +5702,7 @@ async fn disconnect_during_session_load_fences_late_result() {
                 host_list_cache: Mutex::new(None),
                 listed_ever: Mutex::new(HashSet::new()),
             });
-            let agent_slot = Arc::new(OnceLock::new());
+            let agent_slot = empty_agent_cell();
             assert!(agent_slot.set(agent).is_ok());
             let agent_side_slot = Arc::new(OnceLock::new());
             agent_side_slot
@@ -5685,7 +5846,7 @@ async fn session_new_result_is_closed_when_helper_forwarder_disappears() {
                 host_list_cache: Mutex::new(None),
                 listed_ever: Mutex::new(HashSet::new()),
             });
-            let agent_slot = Arc::new(OnceLock::new());
+            let agent_slot = empty_agent_cell();
             assert!(agent_slot.set(agent).is_ok());
             let handler = HelperHandler {
                 helper_id,
@@ -5933,7 +6094,7 @@ async fn overlapping_new_sessions_retire_the_intermediate_replacement() {
             agent_side_slot
                 .set(agent_link_to_noop_client())
                 .expect("agent-side forwarder should be set once");
-            let agent = Arc::new(OnceLock::new());
+            let agent = empty_agent_cell();
             let agent_instance_id = AgentInstanceId::new_v4();
             let mut cached_init_resp =
                 acp::schema::v1::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
@@ -6116,7 +6277,7 @@ async fn unsupported_session_close_capability_cancels_and_logically_retires_sess
             agent_side_slot
                 .set(agent_link_to_noop_client())
                 .expect("agent-side forwarder should be set once");
-            let agent = Arc::new(OnceLock::new());
+            let agent = empty_agent_cell();
             assert!(agent
                 .set(Arc::new(AgentCli {
                     instance_id: agent_instance_id,
@@ -6453,7 +6614,7 @@ async fn close_failure_keeps_predecessor_and_does_not_create_replacement() {
                 .agent_capabilities
                 .session_capabilities
                 .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
-            let agent = Arc::new(OnceLock::new());
+            let agent = empty_agent_cell();
             let agent_instance_id = AgentInstanceId::new_v4();
             assert!(agent
                 .set(Arc::new(AgentCli {
@@ -6651,7 +6812,7 @@ async fn load_close_failure_restores_target_route_and_capability() {
                 .session_capabilities
                 .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
             cached_init_resp.agent_capabilities.mcp_capabilities.http = true;
-            let agent = Arc::new(OnceLock::new());
+            let agent = empty_agent_cell();
             assert!(
                 agent
                     .set(Arc::new(AgentCli {
@@ -6798,7 +6959,7 @@ async fn load_close_failure_closes_target_when_restored_route_uses_another_agent
                 .agent_capabilities
                 .session_capabilities
                 .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
-            let agent = Arc::new(OnceLock::new());
+            let agent = empty_agent_cell();
             assert!(agent
                 .set(Arc::new(AgentCli {
                     instance_id: current_agent_instance,
@@ -6922,7 +7083,7 @@ async fn run_target_rebound_during_predecessor_close_failure(rebound_to_current_
         .agent_capabilities
         .session_capabilities
         .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
-    let agent = Arc::new(OnceLock::new());
+    let agent = empty_agent_cell();
     assert!(agent
         .set(Arc::new(AgentCli {
             instance_id: current_agent_instance,
@@ -7067,7 +7228,7 @@ async fn orphan_rebind_close_failure_does_not_mark_target_owned_by_another_helpe
                 .agent_capabilities
                 .session_capabilities
                 .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
-            let agent = Arc::new(OnceLock::new());
+            let agent = empty_agent_cell();
             assert!(agent
                 .set(Arc::new(AgentCli {
                     instance_id: current_agent_instance,
@@ -7198,7 +7359,7 @@ async fn load_reserves_time_to_close_loaded_target_after_predecessor_timeout() {
                 .agent_capabilities
                 .session_capabilities
                 .close = Some(acp::schema::v1::SessionCloseCapabilities::new());
-            let agent = Arc::new(OnceLock::new());
+            let agent = empty_agent_cell();
             assert!(agent
                 .set(Arc::new(AgentCli {
                     instance_id: agent_instance_id,
@@ -7587,7 +7748,7 @@ async fn prompt_forward_survives_reentrant_permission() {
 
             // ---- hop 2: master (helper-side agent) <-> mock helper client ----
             let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
-            let agent = Arc::new(OnceLock::new());
+            let agent = empty_agent_cell();
             let _ = agent.set(Arc::new(AgentCli {
                 instance_id: AgentInstanceId::new_v4(),
                 conn: agent_conn,

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -278,6 +278,23 @@ fn fresh_host_byok_startup_uses_clean_probe_only_when_needed() {
     use crate::agent_registry::ByokMode;
     use crate::agent_source::AgentSource;
 
+    let custom_binding = ProviderBinding::Custom {
+        selection_id: "custom:provider:model-a".to_string(),
+        generation: 1,
+        config: crate::custom_model_provider::Config {
+            base_url: "https://example.test/v1".to_string(),
+            model: "model-a".to_string(),
+            credential_id: Some("credential-a".to_string()),
+            api_key_required: true,
+            credential_resource: "test",
+        },
+    };
+    assert!(
+        custom_binding.has_active_custom_provider(),
+        "master-resolved Settings BYOK must not depend on legacy process environment"
+    );
+    assert!(!ProviderBinding::Native.has_active_custom_provider());
+
     assert_eq!(
         cloud_catalog_plan(
             &AgentSource::Host,
@@ -315,6 +332,11 @@ fn fresh_host_byok_startup_uses_clean_probe_only_when_needed() {
         CloudCatalogPlan::None,
         "unsupported agents must not trigger a BYOK cloud probe"
     );
+
+    let (catalog, should_probe) =
+        prepare_native_cloud_catalog("copilot", &AgentSource::Host, &custom_binding, Vec::new());
+    assert!(should_probe);
+    assert!(matches!(catalog, NativeCloudCatalogState::Pending));
 }
 
 

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -317,6 +317,10 @@ fn fresh_host_byok_startup_uses_clean_probe_only_when_needed() {
     );
 }
 
+
+
+
+
 #[tokio::test(flavor = "current_thread")]
 async fn delayed_clean_probe_does_not_block_initialize_and_notifies_bound_helper() {
     tokio::task::LocalSet::new()
@@ -558,16 +562,139 @@ fn agent_pool_key_includes_authoritative_identity() {
 }
 
 #[test]
-fn model_is_folded_in_for_native_agents_and_ignored_for_adapters() {
-    // Native agent (gemini) takes --model on the command line.
+fn model_is_folded_in_only_for_launch_time_agents() {
+    // Gemini does not implement live ACP model switching, so its model is part
+    // of the process identity.
     let (cmd, _) = resolve(None, Some("gemini"), Some("gemini-2.5-pro"));
     assert_eq!(cmd, "gemini --acp --model gemini-2.5-pro");
 
-    // Adapter agent (claude via npx) ignores the model here — it's
-    // applied later via setSessionModel — so the command is stable.
+    // Live-switching native and adapter agents keep a stable command so new
+    // tabs can join the existing warm process after a global model update.
+    let (cmd, _) = resolve(None, Some("copilot"), Some("gpt-5.5"));
+    assert_eq!(cmd, "copilot --acp --stdio");
+
     let (cmd, id) = resolve(None, Some("claude"), Some("opus-4"));
     assert_eq!(cmd, "npx -y @agentclientprotocol/claude-agent-acp@0.65.0");
     assert_eq!(id.as_deref(), Some("claude"));
+}
+
+#[test]
+fn custom_model_generation_changes_only_when_launch_configuration_changes() {
+    let selection = "custom:provider:model-a";
+    let config = crate::custom_model_provider::Config {
+        base_url: "https://example.test/v1".to_string(),
+        model: "model-a".to_string(),
+        credential_id: Some("credential-a".to_string()),
+        api_key_required: true,
+        credential_resource: "test",
+    };
+    let mut generations = HashMap::new();
+
+    assert_eq!(
+        update_custom_model_generation(&mut generations, selection, config.clone()).unwrap(),
+        1
+    );
+    assert_eq!(
+        update_custom_model_generation(&mut generations, selection, config.clone()).unwrap(),
+        1,
+        "an unchanged provider must reuse its process generation"
+    );
+
+    let changed = crate::custom_model_provider::Config {
+        credential_id: Some("credential-b".to_string()),
+        ..config
+    };
+    assert_eq!(
+        update_custom_model_generation(&mut generations, selection, changed).unwrap(),
+        2,
+        "a credential-reference change must select a fresh process generation"
+    );
+}
+
+#[test]
+fn provider_binding_isolated_pool_keys_do_not_expose_configuration() {
+    let source = crate::agent_source::AgentSource::Host;
+    let command = "copilot --acp --stdio";
+    let custom = ProviderBinding::Custom {
+        selection_id: "custom:provider:model-a".to_string(),
+        generation: 7,
+        config: crate::custom_model_provider::Config {
+            base_url: "https://secret-endpoint.test/v1".to_string(),
+            model: "model-a".to_string(),
+            credential_id: Some("secret-credential-reference".to_string()),
+            api_key_required: true,
+            credential_resource: "test",
+        },
+    };
+
+    let native_key =
+        agent_cmd_key_with_provider(command, Some("copilot"), &source, &ProviderBinding::Native);
+    let custom_key = agent_cmd_key_with_provider(command, Some("copilot"), &source, &custom);
+
+    assert!(native_key.starts_with("warm:"));
+    assert!(custom_key.starts_with("model:"));
+    assert_ne!(native_key, custom_key);
+    assert!(custom_key.contains("custom:provider:model-a@7"));
+    assert!(!custom_key.contains("secret-endpoint"));
+    assert!(!custom_key.contains("secret-credential"));
+    assert!(
+        agent_cmd_key(
+            "custom-agent --model pinned",
+            Some("custom:local"),
+            &source
+        )
+        .starts_with("warm:"),
+        "trusted custom commands are not transient model generations"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn model_scoped_agent_retires_only_after_its_final_helper_unbinds() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let helper_a = HelperId(601);
+            let helper_b = HelperId(602);
+            let key = "model:test-agent".to_string();
+            let agent = Arc::new(AgentCli {
+                instance_id: AgentInstanceId::new_v4(),
+                conn: client_connection_to_model_agent(
+                    false,
+                    Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                    Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                ),
+                cached_init_resp: acp::schema::v1::InitializeResponse::new(
+                    acp::schema::ProtocolVersion::V1,
+                ),
+                cli_source: Some(crate::agent_sessions::CliSource::Copilot),
+                source: crate::agent_source::AgentSource::Host,
+                cmd_key: key.clone(),
+                cloud_catalog: Mutex::new(NativeCloudCatalogState::Unavailable),
+                bound_helpers: Mutex::new(HashSet::new()),
+                host_list_cache: Mutex::new(None),
+                listed_ever: Mutex::new(HashSet::new()),
+            });
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&agent)).is_ok());
+            state.agents.lock().await.insert(key.clone(), cell);
+
+            assert!(bind_helper_to_agent(&state, &agent, helper_a).await);
+            assert!(bind_helper_to_agent(&state, &agent, helper_b).await);
+            agent.bound_helpers.lock().await.remove(&helper_a);
+            retire_unbound_model_agent(&state, &agent).await;
+            assert!(
+                state.agents.lock().await.contains_key(&key),
+                "one remaining helper must keep the model generation alive"
+            );
+
+            agent.bound_helpers.lock().await.remove(&helper_b);
+            retire_unbound_model_agent(&state, &agent).await;
+            assert!(
+                !state.agents.lock().await.contains_key(&key),
+                "the final helper disconnect must retire the model generation"
+            );
+        })
+        .await;
 }
 
 #[test]
@@ -788,6 +915,7 @@ fn make_state_with_retirement_pending_timeout(
         helper_ext_subscribers: Mutex::new(HashMap::new()),
         wt: None,
         agents: Mutex::new(HashMap::new()),
+        custom_model_generations: Mutex::new(HashMap::new()),
         default_agent_cmd: "copilot --acp --stdio".to_string(),
         default_agent_id: Some("copilot".to_string()),
         allowed_agent_ids: None,
@@ -3242,10 +3370,6 @@ async fn scope_all_retirement_captures_orphan_after_route_drop_before_connected_
         })
         .await;
 }
-
-
-
-
 
 #[tokio::test(flavor = "current_thread")]
 async fn orphan_retirement_blocked_lifecycle_gate_uses_total_budget() {
@@ -8660,6 +8784,7 @@ fn session_focus_params_for(
 struct MockWtChannel {
     calls: std::sync::Mutex<Vec<(String, serde_json::Value)>>,
     fail_with: Option<String>,
+    response: serde_json::Value,
 }
 
 impl MockWtChannel {
@@ -8667,12 +8792,21 @@ impl MockWtChannel {
         Self {
             calls: std::sync::Mutex::new(Vec::new()),
             fail_with: None,
+            response: serde_json::json!({ "ok": true }),
+        }
+    }
+    fn responding(response: serde_json::Value) -> Self {
+        Self {
+            calls: std::sync::Mutex::new(Vec::new()),
+            fail_with: None,
+            response,
         }
     }
     fn failing(message: &str) -> Self {
         Self {
             calls: std::sync::Mutex::new(Vec::new()),
             fail_with: Some(message.to_string()),
+            response: serde_json::Value::Null,
         }
     }
     fn calls(&self) -> Vec<(String, serde_json::Value)> {
@@ -8693,7 +8827,7 @@ impl crate::shell::wt_channel::WtChannel for MockWtChannel {
             .push((method.to_string(), params));
         match &self.fail_with {
             Some(msg) => Err(anyhow::anyhow!("{msg}")),
-            None => Ok(serde_json::json!({ "ok": true })),
+            None => Ok(self.response.clone()),
         }
     }
     fn is_available(&self) -> bool {
@@ -8713,6 +8847,7 @@ fn make_state_with_wt(wt: Arc<dyn crate::shell::wt_channel::WtChannel>) -> Arc<M
         helper_ext_subscribers: Mutex::new(HashMap::new()),
         wt: Some(wt),
         agents: Mutex::new(HashMap::new()),
+        custom_model_generations: Mutex::new(HashMap::new()),
         default_agent_cmd: "copilot --acp --stdio".to_string(),
         default_agent_id: Some("copilot".to_string()),
         allowed_agent_ids: None,
@@ -8740,6 +8875,62 @@ fn make_state_with_wt(wt: Arc<dyn crate::shell::wt_channel::WtChannel>) -> Arc<M
         orphaned_sessions: Mutex::new(HashMap::new()),
         orphaned_tabs: Mutex::new(HashMap::new()),
     })
+}
+
+#[tokio::test]
+async fn custom_provider_binding_is_resolved_from_terminal_settings() {
+    let mock = Arc::new(MockWtChannel::responding(serde_json::json!({
+        "customModelProviders": [{
+            "id": "provider",
+            "baseUrl": "https://example.test/v1",
+            "apiContract": "openai-compatible",
+            "apiKeyCredential": "credential-reference",
+            "apiKeyRequired": true,
+            "models": [{ "id": "model-a" }]
+        }]
+    })));
+    let state = make_state_with_wt(mock.clone());
+
+    let native = resolve_provider_binding(
+        &state,
+        Some("copilot"),
+        &crate::agent_source::AgentSource::Host,
+        Some("default"),
+    )
+    .await
+    .expect("the explicit native provider should resolve without settings");
+    assert!(matches!(native, ProviderBinding::Native));
+    assert!(
+        mock.calls().is_empty(),
+        "native provider selection must not read the custom provider catalog"
+    );
+
+    let binding = resolve_provider_binding(
+        &state,
+        Some("copilot"),
+        &crate::agent_source::AgentSource::Host,
+        Some("custom:provider:model-a"),
+    )
+    .await
+    .expect("the master should resolve a configured custom provider");
+
+    match binding {
+        ProviderBinding::Custom {
+            selection_id,
+            generation,
+            config,
+        } => {
+            assert_eq!(selection_id, "custom:provider:model-a");
+            assert_eq!(generation, 1);
+            assert_eq!(config.base_url, "https://example.test/v1");
+            assert_eq!(config.credential_id.as_deref(), Some("credential-reference"));
+        }
+        _ => panic!("expected a custom provider binding"),
+    }
+    assert_eq!(
+        mock.calls(),
+        vec![("get_settings".to_string(), serde_json::Value::Null)]
+    );
 }
 
 fn focus_params_for(

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -143,7 +143,7 @@ pub struct AgentReconnectRequest {
 /// Control requests that end or replace the helper's current ACP connection.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RestartRequest {
-    /// `/restart` still asks C++ to replace the complete shared stack.
+    /// `/restart` asks C++ to replace the shared master and agent CLI pool.
     RestartStack { agent_cmd: Option<String> },
     /// Settings agent changes keep the helper process and reconnect it to the
     /// same master with a fresh immutable per-connection agent binding.
@@ -2125,12 +2125,11 @@ async fn probe_private_usage(
 /// `pipe_name` and speaks ACP over that pipe. The master (from this
 /// helper's perspective) plays the role of the agent.
 ///
-/// Wires the App-facing select-loop, minus the
-/// restart-loop wrapper: helper mode doesn't own the agent CLI lifetime
-/// (master does). `/restart` is delegated to the C++ side via a
-/// `restart_agent_stack` `SendEvent`; that path tears down every agent
-/// pane, force-restarts master under the same stable pipe name, and
-/// re-toggles the active pane so the user lands on a fresh session.
+/// Wires the App-facing select-loop, minus the restart-loop wrapper: helper
+/// mode doesn't own the agent CLI lifetime (master does). `/restart` is
+/// delegated to C++ via `restart_agent_stack`; C++ replaces the master while
+/// retaining viable panes, and each helper reconnects its saved binding over
+/// the stable pipe when the old transport closes.
 ///
 /// See doc/specs/Multi-window-agent-pane.md for the helper+master
 /// architecture, and `tools/wta/src/master/mod.rs` for the peer.
@@ -3191,11 +3190,8 @@ pub async fn run_acp_client_over_pipe(
 
     // Main event loop. The select arms are extracted into `dispatch_*`
     // free fns (so they're unit-testable). No restart-loop wrapper here:
-    // helper mode can't restart in-process — master
-    // owns the agent CLI. `/restart` fires a `restart_agent_stack`
-    // `SendEvent` to the C++ side; that path force-restarts the whole
-    // agent stack (tear down panes → `SharedWta::Restart()` → respawn on
-    // the same stable pipe name → re-toggle active pane).
+    // helper mode can't restart the master in-process, so `/restart` asks C++
+    // to replace it. The retained helper reconnects when the old pipe closes.
     loop {
         tokio::select! {
             biased;
@@ -3232,14 +3228,11 @@ pub async fn run_acp_client_over_pipe(
                         tracing::info!(
                             target: "helper",
                             new_agent = ?agent_cmd,
-                            "restart requested — asking WT to force-restart the agent stack"
+                            "restart requested — asking WT to replace the shared master"
                         );
-                        let evt = serde_json::json!({
-                            "type": "event",
-                            "method": "restart_agent_stack",
-                            "params": {},
-                        });
-                        crate::wt_protocol_events::send(evt.to_string());
+                        crate::wt_protocol_events::send(
+                            crate::wt_protocol_events::restart_agent_stack_event(None, None),
+                        );
                     }
                     RestartRequest::RebindAgent(request) => {
                         tracing::info!(

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -142,17 +142,17 @@ pub struct AgentReconnectRequest {
 
 /// Control requests that end or replace the helper's current ACP connection.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum RestartRequest {
+pub enum AgentLifecycleRequest {
     /// `/restart` asks C++ to replace the shared master and agent CLI pool.
-    RestartStack { agent_cmd: Option<String> },
-    /// Settings agent changes keep the helper process and reconnect it to the
-    /// same master with a fresh immutable per-connection agent binding.
+    RestartMaster,
+    /// Agent binding changes keep the helper process and reconnect it to the
+    /// same master with a fresh immutable per-connection binding.
     RebindAgent(AgentReconnectRequest),
 }
 
-impl Default for RestartRequest {
+impl Default for AgentLifecycleRequest {
     fn default() -> Self {
-        Self::RestartStack { agent_cmd: None }
+        Self::RestartMaster
     }
 }
 
@@ -2401,7 +2401,7 @@ pub async fn run_acp_client_over_pipe(
     mut load_session_rx: mpsc::UnboundedReceiver<LoadSessionForTab>,
     mut drop_session_rx: mpsc::UnboundedReceiver<DropSessionRequest>,
     mut rename_session_rx: mpsc::UnboundedReceiver<RenameSessionRequest>,
-    mut restart_rx: mpsc::UnboundedReceiver<RestartRequest>,
+    mut restart_rx: mpsc::UnboundedReceiver<AgentLifecycleRequest>,
     mut session_hook_rx: mpsc::UnboundedReceiver<crate::agent_sessions::SessionEvent>,
     mut master_ext_rx: mpsc::UnboundedReceiver<MasterExtRequest>,
     shell_mgr: Arc<ShellManager>,
@@ -2656,7 +2656,7 @@ pub async fn run_acp_client_over_pipe(
         }
         if !io_intentional_shutdown.load(Ordering::Acquire) {
             // An unexpected transport loss terminates the helper so Terminal
-            // can recover its pane. A settings rebind closes this transport
+            // can recover its pane. An Agent rebind closes this transport
             // intentionally and reconnects in the existing helper process.
             let _ = io_event_tx.send(AppEvent::MasterDisconnected);
         }
@@ -3223,24 +3223,23 @@ pub async fn run_acp_client_over_pipe(
             }
             Some(req) = restart_rx.recv() => {
                 match req {
-                    RestartRequest::RestartStack { agent_cmd } => {
+                    AgentLifecycleRequest::RestartMaster => {
                         // Helper can't restart the shared master in-process.
                         tracing::info!(
                             target: "helper",
-                            new_agent = ?agent_cmd,
                             "restart requested — asking WT to replace the shared master"
                         );
                         crate::wt_protocol_events::send(
-                            crate::wt_protocol_events::restart_agent_stack_event(None, None),
+                            crate::wt_protocol_events::restart_agent_stack_event(),
                         );
                     }
-                    RestartRequest::RebindAgent(request) => {
+                    AgentLifecycleRequest::RebindAgent(request) => {
                         tracing::info!(
                             target: "helper",
                             operation_id = %request.operation_id,
                             generation = request.generation,
                             agent_id = %request.agent_id,
-                            "ending helper ACP connection for settings agent rebind"
+                            "ending helper ACP connection for Agent rebind"
                         );
                         stop_prompt_tasks(
                             &mut prompt_tasks,

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -9,7 +9,7 @@ use agent_client_protocol as acp;
 use anyhow::Result;
 use std::collections::{HashMap, HashSet};
 use std::sync::{
-    atomic::{AtomicU64, Ordering},
+    atomic::{AtomicBool, AtomicU64, Ordering},
     Arc, Mutex,
 };
 use tokio::sync::mpsc;
@@ -129,14 +129,50 @@ pub struct NewSessionForTab {
     pub cwd: Option<String>,
 }
 
-/// User-initiated full reconnect of the ACP client. Emitted by the
-/// `/restart` slash command. The ACP client task kills the agent child
-/// process, drops the connection, then respawns the agent and
-/// re-initializes from scratch. If `agent_cmd` is set, the supervisor
-/// switches to a different agent on restart.
-#[derive(Debug, Clone, Default)]
-pub struct RestartRequest {
-    pub agent_cmd: Option<String>,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentReconnectRequest {
+    pub operation_id: String,
+    pub window_id: String,
+    pub generation: u64,
+    pub agent_id: String,
+    pub acp_model: Option<String>,
+    pub agent_source: crate::agent_source::AgentSource,
+}
+
+/// Control requests that end or replace the helper's current ACP connection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RestartRequest {
+    /// `/restart` still asks C++ to replace the complete shared stack.
+    RestartStack { agent_cmd: Option<String> },
+    /// Settings agent changes keep the helper process and reconnect it to the
+    /// same master with a fresh immutable per-connection agent binding.
+    RebindAgent(AgentReconnectRequest),
+}
+
+impl Default for RestartRequest {
+    fn default() -> Self {
+        Self::RestartStack { agent_cmd: None }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AcpClientExit {
+    ChannelsClosed,
+    RebindAgent(AgentReconnectRequest),
+}
+
+struct ClientTransportGuard {
+    conn: conn::ClientLink,
+    suppress_transport_error: Arc<AtomicBool>,
+}
+
+impl Drop for ClientTransportGuard {
+    fn drop(&mut self) {
+        // Direct setup failures are reported by this task's caller. Close the
+        // separately owned connection task without a second TransportLost.
+        self.suppress_transport_error.store(true, Ordering::Release);
+        self.conn.shutdown();
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -2371,7 +2407,7 @@ pub async fn run_acp_client_over_pipe(
     wt_connected: bool,
     post_login_reconnect: bool,
     proposal_channels: Arc<crate::agent_tools::action_proposal::channel::ProposalChannelManager>,
-) -> Result<()> {
+) -> Result<AcpClientExit> {
     let startup_probe = StartupProbe::new();
     let usage_family_id = agent_id.as_deref().and_then(|agent_id| {
         let family_id = agent_id.trim().to_ascii_lowercase();
@@ -2591,9 +2627,15 @@ pub async fn run_acp_client_over_pipe(
     let (conn, handle_io) = conn::spawn_client(builder, conn::byte_streams(outgoing, incoming));
     startup_probe.log("ACP client connection created (over pipe)");
 
+    let intentional_shutdown = Arc::new(AtomicBool::new(false));
+    let _transport_guard = ClientTransportGuard {
+        conn: conn.clone(),
+        suppress_transport_error: Arc::clone(&intentional_shutdown),
+    };
+    let io_intentional_shutdown = Arc::clone(&intentional_shutdown);
     let io_probe = startup_probe.clone();
     let io_event_tx = event_tx.clone();
-    tokio::task::spawn_local(async move {
+    let mut io_task = Some(tokio::task::spawn_local(async move {
         io_probe.log("ACP handle_io task started (over pipe)");
         // The I/O loop only ends when the pipe to wta-master is gone. Crucially,
         // a *killed* master resolves this as **Ok(())** (clean EOF on the pipe),
@@ -2611,10 +2653,13 @@ pub async fn run_acp_client_over_pipe(
                 tracing::warn!(target: "helper", "ACP I/O loop to master ended — pipe closed (master gone)");
             }
         }
-        // Either way the transport is dead. Terminate the helper instead of
-        // retaining a disconnected pane or attempting to restore its session.
-        let _ = io_event_tx.send(AppEvent::MasterDisconnected);
-    });
+        if !io_intentional_shutdown.load(Ordering::Acquire) {
+            // An unexpected transport loss terminates the helper so Terminal
+            // can recover its pane. A settings rebind closes this transport
+            // intentionally and reconnects in the existing helper process.
+            let _ = io_event_tx.send(AppEvent::MasterDisconnected);
+        }
+    }));
 
     // Initialize — same as the child-process path. We use a 60s timeout
     // here because the first helper to connect to a fresh master may
@@ -3122,6 +3167,7 @@ pub async fn run_acp_client_over_pipe(
         Arc::new(std::sync::Mutex::new(HashSet::new()));
     let cancel_signals: Arc<std::sync::Mutex<HashMap<String, tokio::sync::oneshot::Sender<()>>>> =
         Arc::new(std::sync::Mutex::new(HashMap::new()));
+    let mut prompt_tasks: Vec<tokio::task::JoinHandle<()>> = Vec::new();
 
     let conn = Arc::new(conn);
 
@@ -3172,31 +3218,43 @@ pub async fn run_acp_client_over_pipe(
                 dispatch_master_ext_request(req, &conn, &event_tx, &tab_to_session);
             }
             Some(req) = restart_rx.recv() => {
-                // Helper can't restart the agent CLI in-process — master owns
-                // its lifetime, and master itself is a singleton owned by
-                // `SharedWta` on the C++ side. Ask the C++ side to do a full
-                // force-restart of the agent stack: tear down every agent
-                // pane, kill master via `SharedWta::Restart()` (bypassing
-                // refcount), respawn master under the same stable pipe name,
-                // and re-toggle the active tab's pane. The new wta-helper
-                // that gets spawned will reconnect to the new master and
-                // the user sees a fresh session.
-                //
-                // Signal travels: helper → `wtcli publish` (see
-                // `wt_protocol_events::send`) → `IProtocolServer::SendEvent`
-                // (route `RestartAgentStack`) →
-                // `TerminalPage::OnRestartAgentStackRequested`.
-                tracing::info!(
-                    target: "helper",
-                    new_agent = ?req.agent_cmd,
-                    "restart requested — asking WT to force-restart the agent stack"
-                );
-                let evt = serde_json::json!({
-                    "type": "event",
-                    "method": "restart_agent_stack",
-                    "params": {},
-                });
-                crate::wt_protocol_events::send(evt.to_string());
+                match req {
+                    RestartRequest::RestartStack { agent_cmd } => {
+                        // Helper can't restart the shared master in-process.
+                        tracing::info!(
+                            target: "helper",
+                            new_agent = ?agent_cmd,
+                            "restart requested — asking WT to force-restart the agent stack"
+                        );
+                        let evt = serde_json::json!({
+                            "type": "event",
+                            "method": "restart_agent_stack",
+                            "params": {},
+                        });
+                        crate::wt_protocol_events::send(evt.to_string());
+                    }
+                    RestartRequest::RebindAgent(request) => {
+                        tracing::info!(
+                            target: "helper",
+                            operation_id = %request.operation_id,
+                            generation = request.generation,
+                            agent_id = %request.agent_id,
+                            "ending helper ACP connection for settings agent rebind"
+                        );
+                        stop_prompt_tasks(
+                            &mut prompt_tasks,
+                            &in_flight_tabs,
+                            &cancel_signals,
+                        )
+                        .await;
+                        intentional_shutdown.store(true, Ordering::Release);
+                        conn.shutdown();
+                        if let Some(task) = io_task.take() {
+                            let _ = task.await;
+                        }
+                        return Ok(AcpClientExit::RebindAgent(request));
+                    }
+                }
             }
             Some(req) = cancel_rx.recv() => {
                 dispatch_cancel(req, &conn, &cancel_signals);
@@ -3243,7 +3301,8 @@ pub async fn run_acp_client_over_pipe(
                 dispatch_rename_session(req, &tab_to_session).await;
             }
             Some(prompt) = prompt_rx.recv() => {
-                dispatch_prompt(
+                prompt_tasks.retain(|task| !task.is_finished());
+                if let Some(task) = dispatch_prompt(
                     prompt,
                     &conn,
                     &tab_to_session,
@@ -3259,14 +3318,17 @@ pub async fn run_acp_client_over_pipe(
                     is_agent_pane,
                     proposal_commands_supported,
                     &proposal_channels,
-                );
+                ) {
+                    prompt_tasks.push(task);
+                }
             }
             else => break,
         }
     }
 
+    stop_prompt_tasks(&mut prompt_tasks, &in_flight_tabs, &cancel_signals).await;
     startup_probe.log("run_acp_client_over_pipe loop ended");
-    Ok(())
+    Ok(AcpClientExit::ChannelsClosed)
 }
 
 /// Spawn a per-prompt task that resolves the tab's ACP session (lazily
@@ -4099,6 +4161,23 @@ fn build_prompt_content(
     content
 }
 
+async fn stop_prompt_tasks(
+    prompt_tasks: &mut Vec<tokio::task::JoinHandle<()>>,
+    in_flight_tabs: &Arc<std::sync::Mutex<HashSet<String>>>,
+    cancel_signals: &Arc<std::sync::Mutex<HashMap<String, tokio::sync::oneshot::Sender<()>>>>,
+) {
+    let signals = std::mem::take(&mut *cancel_signals.lock().unwrap());
+    for (_, signal) in signals {
+        let _ = signal.send(());
+    }
+    for task in prompt_tasks.drain(..) {
+        task.abort();
+        let _ = task.await;
+    }
+    in_flight_tabs.lock().unwrap().clear();
+    cancel_signals.lock().unwrap().clear();
+}
+
 fn dispatch_prompt(
     prompt: PromptSubmission,
     conn: &conn::ClientLink,
@@ -4115,7 +4194,7 @@ fn dispatch_prompt(
     is_agent_pane: bool,
     proposal_commands_supported: bool,
     proposal_channels: &Arc<crate::agent_tools::action_proposal::channel::ProposalChannelManager>,
-) {
+) -> Option<tokio::task::JoinHandle<()>> {
     let tab_key = prompt
         .pane_context
         .as_ref()
@@ -4128,7 +4207,7 @@ fn dispatch_prompt(
             let _ = event_tx.send(AppEvent::AgentBusy {
                 tab_id: tab_key.clone(),
             });
-            return;
+            return None;
         }
     }
 
@@ -4145,7 +4224,7 @@ fn dispatch_prompt(
     let proposal_channels_task = Arc::clone(proposal_channels);
     let tab_key_task = tab_key.clone();
 
-    tokio::task::spawn_local(dispatch_prompt_body(
+    Some(tokio::task::spawn_local(dispatch_prompt_body(
         prompt,
         conn_task,
         tab_to_session_task,
@@ -4162,7 +4241,7 @@ fn dispatch_prompt(
         is_agent_pane,
         proposal_commands_supported,
         proposal_channels_task,
-    ));
+    )))
 }
 
 /// The per-prompt task body: lazily resolves the tab's ACP session,
@@ -4447,9 +4526,9 @@ mod tests {
     use super::{
         acp_error_detail, acp_result_failure_fields, bounded_tool_output_parts,
         complete_prompt_request, inject_wta_pane_meta, is_redundant_startup_model_error,
-        post_login_authenticate_error, session_mcp_tool_from_title, timeout_result_failure_fields,
-        tool_call_exit_code, tool_call_kind_label, ClientState, PromptTimingState,
-        PromptUsageIdentity, SessionMcpTool, SoftStopReason, WtaClient,
+        post_login_authenticate_error, session_mcp_tool_from_title, stop_prompt_tasks,
+        timeout_result_failure_fields, tool_call_exit_code, tool_call_kind_label, ClientState,
+        PromptTimingState, PromptUsageIdentity, SessionMcpTool, SoftStopReason, WtaClient,
     };
     use crate::app_contracts::AppEvent;
     use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
@@ -4457,6 +4536,44 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::sync::{Arc, Mutex};
     use tokio::sync::mpsc;
+
+    #[test]
+    fn stop_prompt_tasks_aborts_pre_prompt_work_and_clears_tracking() {
+        struct DropFlag(Arc<std::sync::atomic::AtomicBool>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, std::sync::atomic::Ordering::Release);
+            }
+        }
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        tokio::task::LocalSet::new().block_on(&runtime, async {
+            let dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let dropped_for_task = Arc::clone(&dropped);
+            let mut tasks = vec![tokio::task::spawn_local(async move {
+                let _flag = DropFlag(dropped_for_task);
+                std::future::pending::<()>().await;
+            })];
+            tokio::task::yield_now().await;
+
+            let in_flight_tabs = Arc::new(Mutex::new(HashSet::from(["tab-1".to_string()])));
+            let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel();
+            let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
+                "session-1".to_string(),
+                cancel_tx,
+            )])));
+
+            stop_prompt_tasks(&mut tasks, &in_flight_tabs, &cancel_signals).await;
+
+            assert!(tasks.is_empty());
+            assert!(in_flight_tabs.lock().unwrap().is_empty());
+            assert!(cancel_signals.lock().unwrap().is_empty());
+            assert!(dropped.load(std::sync::atomic::Ordering::Acquire));
+        });
+    }
 
     #[test]
     fn acp_error_detail_prefers_actionable_data() {

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -165,15 +165,32 @@ pub enum AcpClientExit {
 struct ClientTransportGuard {
     conn: conn::ClientLink,
     suppress_transport_error: Arc<AtomicBool>,
+    event_tx: mpsc::UnboundedSender<AppEvent>,
 }
 
 impl Drop for ClientTransportGuard {
     fn drop(&mut self) {
-        // Direct setup failures are reported by this task's caller. Close the
-        // separately owned connection task without a second TransportLost.
-        self.suppress_transport_error.store(true, Ordering::Release);
+        // A master can disappear while a setup request is in flight. In that
+        // race the request fails and unwinds this guard before the separately
+        // scheduled I/O task reports EOF. Claim and report the already-tripped
+        // transport latch here so the retained helper still reconnects.
+        let report_master_disconnect = claim_unexpected_transport_loss(
+            self.conn.transport_ended(),
+            &self.suppress_transport_error,
+        );
         self.conn.shutdown();
+        if report_master_disconnect {
+            let _ = self.event_tx.send(AppEvent::MasterDisconnected);
+        }
     }
+}
+
+fn claim_unexpected_transport_loss(
+    transport_ended: bool,
+    suppress_transport_error: &AtomicBool,
+) -> bool {
+    let already_suppressed = suppress_transport_error.swap(true, Ordering::AcqRel);
+    transport_ended && !already_suppressed
 }
 
 #[derive(Debug, Clone)]
@@ -2632,6 +2649,7 @@ pub async fn run_acp_client_over_pipe(
     let _transport_guard = ClientTransportGuard {
         conn: conn.clone(),
         suppress_transport_error: Arc::clone(&intentional_shutdown),
+        event_tx: event_tx.clone(),
     };
     let io_intentional_shutdown = Arc::clone(&intentional_shutdown);
     let io_probe = startup_probe.clone();
@@ -2654,10 +2672,10 @@ pub async fn run_acp_client_over_pipe(
                 tracing::warn!(target: "helper", "ACP I/O loop to master ended — pipe closed (master gone)");
             }
         }
-        if !io_intentional_shutdown.load(Ordering::Acquire) {
-            // An unexpected transport loss terminates the helper so Terminal
-            // can recover its pane. An Agent rebind closes this transport
-            // intentionally and reconnects in the existing helper process.
+        if claim_unexpected_transport_loss(true, &io_intentional_shutdown) {
+            // An unexpected transport loss reconnects the retained helper over
+            // the stable master pipe. Agent rebind owns its intentional
+            // transport retirement and reconnect sequence separately.
             let _ = io_event_tx.send(AppEvent::MasterDisconnected);
         }
     }));
@@ -4525,10 +4543,11 @@ mod tests {
     use super::acp;
     use super::{
         acp_error_detail, acp_result_failure_fields, bounded_tool_output_parts,
-        complete_prompt_request, inject_wta_pane_meta, is_redundant_startup_model_error,
-        post_login_authenticate_error, session_mcp_tool_from_title, stop_prompt_tasks,
-        timeout_result_failure_fields, tool_call_exit_code, tool_call_kind_label, ClientState,
-        PromptTimingState, PromptUsageIdentity, SessionMcpTool, SoftStopReason, WtaClient,
+        claim_unexpected_transport_loss, complete_prompt_request, inject_wta_pane_meta,
+        is_redundant_startup_model_error, post_login_authenticate_error,
+        session_mcp_tool_from_title, stop_prompt_tasks, timeout_result_failure_fields,
+        tool_call_exit_code, tool_call_kind_label, ClientState, PromptTimingState,
+        PromptUsageIdentity, SessionMcpTool, SoftStopReason, WtaClient,
     };
     use crate::app_contracts::AppEvent;
     use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
@@ -4536,6 +4555,22 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::sync::{Arc, Mutex};
     use tokio::sync::mpsc;
+
+    #[test]
+    fn unexpected_transport_loss_is_claimed_exactly_once() {
+        let claimed = std::sync::atomic::AtomicBool::new(false);
+
+        assert!(claim_unexpected_transport_loss(true, &claimed));
+        assert!(!claim_unexpected_transport_loss(true, &claimed));
+    }
+
+    #[test]
+    fn direct_setup_failure_suppresses_guard_induced_transport_loss() {
+        let claimed = std::sync::atomic::AtomicBool::new(false);
+
+        assert!(!claim_unexpected_transport_loss(false, &claimed));
+        assert!(!claim_unexpected_transport_loss(true, &claimed));
+    }
 
     #[test]
     fn stop_prompt_tasks_aborts_pre_prompt_work_and_clears_tracking() {

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -136,6 +136,7 @@ pub struct AgentReconnectRequest {
     pub generation: u64,
     pub agent_id: String,
     pub acp_model: Option<String>,
+    pub custom_model_selection: Option<String>,
     pub agent_source: crate::agent_source::AgentSource,
 }
 
@@ -2382,6 +2383,7 @@ async fn handle_load_failure(
 pub async fn run_acp_client_over_pipe(
     pipe_name: String,
     acp_model_override: Option<String>,
+    custom_model_selection: Option<String>,
     supplied_cloud_models: Vec<AcpModelInfo>,
     // Per-tab agent identity. Forwarded to the multi-agent master in the
     // `initialize` handshake's `_meta.wta.agent_id` so master selects and
@@ -2708,6 +2710,12 @@ pub async fn run_acp_client_over_pipe(
                 // silent (master applies its own `--agent` default).
                 agent_id: usage_family_id.clone(),
                 model: acp_model_override.clone().filter(|s| !s.trim().is_empty()),
+                provider_binding: Some(
+                    custom_model_selection
+                        .clone()
+                        .filter(|selection| !selection.trim().is_empty())
+                        .unwrap_or_else(|| "default".to_string()),
+                ),
                 agent_source: Some(agent_source.kind().to_string()),
                 wsl_distro: agent_source.distro().map(str::to_string),
                 cloud_models: if supplied_cloud_models.is_empty() {

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -193,6 +193,24 @@ fn claim_unexpected_transport_loss(
     transport_ended && !already_suppressed
 }
 
+fn complete_transport_io_task(
+    io_result: std::result::Result<(), tokio::task::JoinError>,
+    suppress_transport_error: &AtomicBool,
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+) -> AcpClientExit {
+    if let Err(error) = io_result {
+        tracing::warn!(
+            target: "helper",
+            %error,
+            "ACP I/O task to master failed"
+        );
+    }
+    if claim_unexpected_transport_loss(true, suppress_transport_error) {
+        let _ = event_tx.send(AppEvent::MasterDisconnected);
+    }
+    AcpClientExit::ChannelsClosed
+}
+
 #[derive(Debug, Clone)]
 pub enum MasterExtRequest {
     SessionsList {
@@ -2651,10 +2669,8 @@ pub async fn run_acp_client_over_pipe(
         suppress_transport_error: Arc::clone(&intentional_shutdown),
         event_tx: event_tx.clone(),
     };
-    let io_intentional_shutdown = Arc::clone(&intentional_shutdown);
     let io_probe = startup_probe.clone();
-    let io_event_tx = event_tx.clone();
-    let mut io_task = Some(tokio::task::spawn_local(async move {
+    let mut io_task = tokio::task::spawn_local(async move {
         io_probe.log("ACP handle_io task started (over pipe)");
         // The I/O loop only ends when the pipe to wta-master is gone. Crucially,
         // a *killed* master resolves this as **Ok(())** (clean EOF on the pipe),
@@ -2672,13 +2688,7 @@ pub async fn run_acp_client_over_pipe(
                 tracing::warn!(target: "helper", "ACP I/O loop to master ended — pipe closed (master gone)");
             }
         }
-        if claim_unexpected_transport_loss(true, &io_intentional_shutdown) {
-            // An unexpected transport loss reconnects the retained helper over
-            // the stable master pipe. Agent rebind owns its intentional
-            // transport retirement and reconnect sequence separately.
-            let _ = io_event_tx.send(AppEvent::MasterDisconnected);
-        }
-    }));
+    });
 
     // Initialize — same as the child-process path. We use a 60s timeout
     // here because the first helper to connect to a fresh master may
@@ -3267,12 +3277,23 @@ pub async fn run_acp_client_over_pipe(
                         .await;
                         intentional_shutdown.store(true, Ordering::Release);
                         conn.shutdown();
-                        if let Some(task) = io_task.take() {
-                            let _ = task.await;
-                        }
+                        let _ = (&mut io_task).await;
                         return Ok(AcpClientExit::RebindAgent(request));
                     }
                 }
+            }
+            io_result = &mut io_task => {
+                let exit = complete_transport_shutdown(
+                    io_result,
+                    &intentional_shutdown,
+                    &event_tx,
+                    &mut prompt_tasks,
+                    &in_flight_tabs,
+                    &cancel_signals,
+                )
+                .await;
+                startup_probe.log("run_acp_client_over_pipe transport ended");
+                return Ok(exit);
             }
             Some(req) = cancel_rx.recv() => {
                 dispatch_cancel(req, &conn, &cancel_signals);
@@ -3345,6 +3366,9 @@ pub async fn run_acp_client_over_pipe(
     }
 
     stop_prompt_tasks(&mut prompt_tasks, &in_flight_tabs, &cancel_signals).await;
+    intentional_shutdown.store(true, Ordering::Release);
+    conn.shutdown();
+    let _ = io_task.await;
     startup_probe.log("run_acp_client_over_pipe loop ended");
     Ok(AcpClientExit::ChannelsClosed)
 }
@@ -4196,6 +4220,18 @@ async fn stop_prompt_tasks(
     cancel_signals.lock().unwrap().clear();
 }
 
+async fn complete_transport_shutdown(
+    io_result: std::result::Result<(), tokio::task::JoinError>,
+    suppress_transport_error: &AtomicBool,
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+    prompt_tasks: &mut Vec<tokio::task::JoinHandle<()>>,
+    in_flight_tabs: &Arc<std::sync::Mutex<HashSet<String>>>,
+    cancel_signals: &Arc<std::sync::Mutex<HashMap<String, tokio::sync::oneshot::Sender<()>>>>,
+) -> AcpClientExit {
+    stop_prompt_tasks(prompt_tasks, in_flight_tabs, cancel_signals).await;
+    complete_transport_io_task(io_result, suppress_transport_error, event_tx)
+}
+
 fn dispatch_prompt(
     prompt: PromptSubmission,
     conn: &conn::ClientLink,
@@ -4543,10 +4579,10 @@ mod tests {
     use super::acp;
     use super::{
         acp_error_detail, acp_result_failure_fields, bounded_tool_output_parts,
-        claim_unexpected_transport_loss, complete_prompt_request, inject_wta_pane_meta,
-        is_redundant_startup_model_error, post_login_authenticate_error,
+        claim_unexpected_transport_loss, complete_prompt_request, complete_transport_shutdown,
+        inject_wta_pane_meta, is_redundant_startup_model_error, post_login_authenticate_error,
         session_mcp_tool_from_title, stop_prompt_tasks, timeout_result_failure_fields,
-        tool_call_exit_code, tool_call_kind_label, ClientState, PromptTimingState,
+        tool_call_exit_code, tool_call_kind_label, AcpClientExit, ClientState, PromptTimingState,
         PromptUsageIdentity, SessionMcpTool, SoftStopReason, WtaClient,
     };
     use crate::app_contracts::AppEvent;
@@ -4570,6 +4606,84 @@ mod tests {
 
         assert!(!claim_unexpected_transport_loss(false, &claimed));
         assert!(!claim_unexpected_transport_loss(true, &claimed));
+    }
+
+    #[tokio::test]
+    async fn transport_completion_exits_despite_perpetual_refetch_and_cleans_prompts() {
+        struct DropFlag(Arc<std::sync::atomic::AtomicBool>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, std::sync::atomic::Ordering::Release);
+            }
+        }
+
+        let dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let dropped_for_task = Arc::clone(&dropped);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let mut prompt_tasks = vec![tokio::spawn(async move {
+            let _flag = DropFlag(dropped_for_task);
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+        })];
+        started_rx.await.expect("prompt task started");
+
+        let in_flight_tabs = Arc::new(Mutex::new(HashSet::from(["tab-1".to_string()])));
+        let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel();
+        let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
+            "session-1".to_string(),
+            cancel_tx,
+        )])));
+        let intentional_shutdown = std::sync::atomic::AtomicBool::new(false);
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let mut io_task = tokio::spawn(async {});
+
+        let io_result = tokio::select! {
+            result = &mut io_task => result,
+            _ = std::future::pending::<()>() => unreachable!("perpetual refetch cannot win"),
+        };
+        let exit = complete_transport_shutdown(
+            io_result,
+            &intentional_shutdown,
+            &event_tx,
+            &mut prompt_tasks,
+            &in_flight_tabs,
+            &cancel_signals,
+        )
+        .await;
+
+        assert_eq!(exit, AcpClientExit::ChannelsClosed);
+        assert!(matches!(
+            event_rx.try_recv(),
+            Ok(AppEvent::MasterDisconnected)
+        ));
+        assert!(event_rx.try_recv().is_err(), "disconnect must be sent once");
+        assert!(prompt_tasks.is_empty());
+        assert!(in_flight_tabs.lock().unwrap().is_empty());
+        assert!(cancel_signals.lock().unwrap().is_empty());
+        assert!(dropped.load(std::sync::atomic::Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn intentional_transport_completion_exits_without_disconnect_notification() {
+        let intentional_shutdown = std::sync::atomic::AtomicBool::new(true);
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let mut prompt_tasks = Vec::new();
+        let in_flight_tabs = Arc::new(Mutex::new(HashSet::new()));
+        let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
+        let io_result = tokio::spawn(async {}).await;
+
+        let exit = complete_transport_shutdown(
+            io_result,
+            &intentional_shutdown,
+            &event_tx,
+            &mut prompt_tasks,
+            &in_flight_tabs,
+            &cancel_signals,
+        )
+        .await;
+
+        assert_eq!(exit, AcpClientExit::ChannelsClosed);
+        assert!(event_rx.try_recv().is_err());
     }
 
     #[test]

--- a/tools/wta/src/protocol/acp/conn.rs
+++ b/tools/wta/src/protocol/acp/conn.rs
@@ -221,6 +221,12 @@ impl ClientLink {
     pub fn shutdown(&self) {
         self.shutdown.signal();
     }
+
+    /// Whether the transport latch has already observed peer death or an
+    /// intentional shutdown.
+    pub fn transport_ended(&self) -> bool {
+        self.shutdown.dead.load(std::sync::atomic::Ordering::Acquire)
+    }
 }
 
 /// Agent-side connection handle (master → one helper). Forwards server→client
@@ -811,8 +817,10 @@ mod transport_death_tests {
             shutdown: death.clone(),
         };
 
+        assert!(!link.transport_ended());
         link.shutdown();
 
+        assert!(link.transport_ended());
         assert!(is_dead(&death));
     }
 }

--- a/tools/wta/src/protocol/acp/conn.rs
+++ b/tools/wta/src/protocol/acp/conn.rs
@@ -26,20 +26,20 @@
 
 use std::future::Future;
 
-use agent_client_protocol as acp;
 use acp::schema::v1::{
     self, AuthenticateRequest, AuthenticateResponse, CancelNotification, CloseSessionRequest,
     CloseSessionResponse, CreateTerminalRequest, CreateTerminalResponse, ExtNotification,
-    ExtRequest, ExtResponse, InitializeRequest, InitializeResponse,
-    KillTerminalRequest, KillTerminalResponse, ListSessionsRequest, ListSessionsResponse,
-    LoadSessionRequest, LoadSessionResponse, NewSessionRequest, NewSessionResponse,
-    PromptRequest, PromptResponse, ReadTextFileRequest, ReadTextFileResponse,
-    ReleaseTerminalRequest, ReleaseTerminalResponse, RequestPermissionRequest,
-    RequestPermissionResponse, SessionId, SessionNotification, SetSessionConfigOptionRequest,
-    SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModeResponse,
-    TerminalOutputRequest, TerminalOutputResponse, WaitForTerminalExitRequest,
-    WaitForTerminalExitResponse, WriteTextFileRequest, WriteTextFileResponse,
+    ExtRequest, ExtResponse, InitializeRequest, InitializeResponse, KillTerminalRequest,
+    KillTerminalResponse, ListSessionsRequest, ListSessionsResponse, LoadSessionRequest,
+    LoadSessionResponse, NewSessionRequest, NewSessionResponse, PromptRequest, PromptResponse,
+    ReadTextFileRequest, ReadTextFileResponse, ReleaseTerminalRequest, ReleaseTerminalResponse,
+    RequestPermissionRequest, RequestPermissionResponse, SessionId, SessionNotification,
+    SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest,
+    SetSessionModeResponse, TerminalOutputRequest, TerminalOutputResponse,
+    WaitForTerminalExitRequest, WaitForTerminalExitResponse, WriteTextFileRequest,
+    WriteTextFileResponse,
 };
+use agent_client_protocol as acp;
 use serde::{Deserialize, Serialize};
 
 /// Legacy `session/set_model` request, removed from schema 1.1 but still spoken
@@ -95,7 +95,9 @@ async fn await_ready<T: Clone>(ready: &Ready<T>) -> acp::Result<T> {
             return Ok(v.clone());
         }
         if ready.failed.load(std::sync::atomic::Ordering::Acquire) {
-            return Err(acp::Error::internal_error().data("ACP connection setup failed before ready"));
+            return Err(
+                acp::Error::internal_error().data("ACP connection setup failed before ready")
+            );
         }
         notified.await;
     }
@@ -107,6 +109,7 @@ async fn await_ready<T: Clone>(ready: &Ready<T>) -> acp::Result<T> {
 #[derive(Clone, Debug)]
 pub struct ClientLink {
     cell: std::sync::Arc<Ready<acp::ConnectionTo<acp::Agent>>>,
+    shutdown: std::sync::Arc<TransportDeath>,
 }
 
 impl ClientLink {
@@ -118,7 +121,10 @@ impl ClientLink {
         self.cx().await?.send_request(req).block_task().await
     }
 
-    pub async fn authenticate(&self, req: AuthenticateRequest) -> acp::Result<AuthenticateResponse> {
+    pub async fn authenticate(
+        &self,
+        req: AuthenticateRequest,
+    ) -> acp::Result<AuthenticateResponse> {
         self.cx().await?.send_request(req).block_task().await
     }
 
@@ -191,16 +197,29 @@ impl ClientLink {
         self.cx().await?.send_request(req).block_task().await
     }
 
-    pub async fn list_sessions(&self, req: ListSessionsRequest) -> acp::Result<ListSessionsResponse> {
+    pub async fn list_sessions(
+        &self,
+        req: ListSessionsRequest,
+    ) -> acp::Result<ListSessionsResponse> {
         self.cx().await?.send_request(req).block_task().await
     }
 
     pub async fn ext_method(&self, req: ExtRequest) -> acp::Result<ExtResponse> {
-        let value = self.cx().await?.send_request(v1::ClientRequest::ExtMethodRequest(req))
+        let value = self
+            .cx()
+            .await?
+            .send_request(v1::ClientRequest::ExtMethodRequest(req))
             .block_task()
             .await?;
         serde_json::from_value(value)
             .map_err(|e| acp::Error::internal_error().data(format!("ext response decode: {e}")))
+    }
+
+    /// End this client transport intentionally. The connection task owns the
+    /// pipe, so dropping a `ClientLink` alone cannot close it; signaling the
+    /// shared transport latch lets `connect_with` unwind and release the pipe.
+    pub fn shutdown(&self) {
+        self.shutdown.signal();
     }
 }
 
@@ -265,7 +284,10 @@ impl AgentLink {
         self.cx().await?.send_request(req).block_task().await
     }
 
-    pub async fn kill_terminal(&self, req: KillTerminalRequest) -> acp::Result<KillTerminalResponse> {
+    pub async fn kill_terminal(
+        &self,
+        req: KillTerminalRequest,
+    ) -> acp::Result<KillTerminalResponse> {
         self.cx().await?.send_request(req).block_task().await
     }
 
@@ -388,6 +410,7 @@ where
     let WatchedTransport { inner, death } = transport;
     let cell = std::sync::Arc::new(Ready::default());
     let fill = cell.clone();
+    let shutdown = death.clone();
     let (done_tx, done_rx) = tokio::sync::oneshot::channel();
     tokio::task::spawn_local(async move {
         let result = builder
@@ -418,12 +441,13 @@ where
             });
             // Connection ended; if it never became ready, wake waiters so they
             // surface an error instead of spinning/blocking forever.
-            cell.failed.store(true, std::sync::atomic::Ordering::Release);
+            cell.failed
+                .store(true, std::sync::atomic::Ordering::Release);
             cell.notify.notify_waiters();
             r
         }
     };
-    (ClientLink { cell }, handle_io)
+    (ClientLink { cell, shutdown }, handle_io)
 }
 
 /// Drive a pre-wired agent builder over `transport`, returning an [`AgentLink`]
@@ -467,7 +491,8 @@ where
                 Err(acp::Error::internal_error()
                     .data("ACP connection task ended without reporting a result"))
             });
-            cell.failed.store(true, std::sync::atomic::Ordering::Release);
+            cell.failed
+                .store(true, std::sync::atomic::Ordering::Release);
             cell.notify.notify_waiters();
             r
         }
@@ -540,28 +565,32 @@ mod transport_death_tests {
             let (near, far) = tokio::io::duplex(64 * 1024);
             let (near_r, near_w) = tokio::io::split(near);
 
-            let builder = acp::Client
-                .builder()
-                .name("test-client")
-                .on_receive_request(
-                    |_req: v1::AgentRequest, responder: acp::Responder<serde_json::Value>, _cx| async move {
-                        responder.respond_with_error(acp::Error::method_not_found())
-                    },
-                    acp::on_receive_request!(),
-                )
-                .on_receive_notification(
-                    |_notif: v1::AgentNotification, _cx| async move { Ok(()) },
-                    acp::on_receive_notification!(),
-                );
+            let builder =
+                acp::Client
+                    .builder()
+                    .name("test-client")
+                    .on_receive_request(
+                        |_req: v1::AgentRequest,
+                         responder: acp::Responder<serde_json::Value>,
+                         _cx| async move {
+                            responder.respond_with_error(acp::Error::method_not_found())
+                        },
+                        acp::on_receive_request!(),
+                    )
+                    .on_receive_notification(
+                        |_notif: v1::AgentNotification, _cx| async move { Ok(()) },
+                        acp::on_receive_notification!(),
+                    );
 
-            let (_link, handle_io) =
-                spawn_client(builder, byte_streams(near_w.compat_write(), near_r.compat()));
+            let (_link, handle_io) = spawn_client(
+                builder,
+                byte_streams(near_w.compat_write(), near_r.compat()),
+            );
 
             // Simulate wta-master death: closing the far end makes `near` read EOF.
             drop(far);
 
-            let res =
-                tokio::time::timeout(std::time::Duration::from_secs(3), handle_io).await;
+            let res = tokio::time::timeout(std::time::Duration::from_secs(3), handle_io).await;
             assert!(
                 res.is_ok(),
                 "client handle_io must resolve when the master (transport far end) \
@@ -583,27 +612,31 @@ mod transport_death_tests {
             let (near, far) = tokio::io::duplex(64 * 1024);
             let (near_r, near_w) = tokio::io::split(near);
 
-            let builder = acp::Agent
-                .builder()
-                .name("test-agent")
-                .on_receive_request(
-                    |_req: v1::ClientRequest, responder: acp::Responder<serde_json::Value>, _cx| async move {
-                        responder.respond_with_error(acp::Error::method_not_found())
-                    },
-                    acp::on_receive_request!(),
-                )
-                .on_receive_notification(
-                    |_notif: v1::ClientNotification, _cx| async move { Ok(()) },
-                    acp::on_receive_notification!(),
-                );
+            let builder =
+                acp::Agent
+                    .builder()
+                    .name("test-agent")
+                    .on_receive_request(
+                        |_req: v1::ClientRequest,
+                         responder: acp::Responder<serde_json::Value>,
+                         _cx| async move {
+                            responder.respond_with_error(acp::Error::method_not_found())
+                        },
+                        acp::on_receive_request!(),
+                    )
+                    .on_receive_notification(
+                        |_notif: v1::ClientNotification, _cx| async move { Ok(()) },
+                        acp::on_receive_notification!(),
+                    );
 
-            let (_link, handle_io) =
-                spawn_agent(builder, byte_streams(near_w.compat_write(), near_r.compat()));
+            let (_link, handle_io) = spawn_agent(
+                builder,
+                byte_streams(near_w.compat_write(), near_r.compat()),
+            );
 
             drop(far);
 
-            let res =
-                tokio::time::timeout(std::time::Duration::from_secs(3), handle_io).await;
+            let res = tokio::time::timeout(std::time::Duration::from_secs(3), handle_io).await;
             assert!(
                 res.is_ok(),
                 "agent handle_io must resolve when the peer (transport far end) dies"
@@ -768,5 +801,18 @@ mod transport_death_tests {
         d.signal();
         d.signal(); // a second signal must be a harmless no-op
         assert!(is_dead(&d));
+    }
+
+    #[test]
+    fn client_link_shutdown_signals_its_transport() {
+        let death = std::sync::Arc::new(TransportDeath::default());
+        let link = ClientLink {
+            cell: std::sync::Arc::new(Ready::default()),
+            shutdown: death.clone(),
+        };
+
+        link.shutdown();
+
+        assert!(is_dead(&death));
     }
 }

--- a/tools/wta/src/protocol/acp/probe.rs
+++ b/tools/wta/src/protocol/acp/probe.rs
@@ -171,7 +171,11 @@ async fn probe_models_impl(
 
     let cwd = std::env::current_dir().unwrap_or_default();
     let session_started = std::time::Instant::now();
-    let session_timeout_secs = 10;
+    // Native CLIs may fetch their cloud model catalog during session/new.
+    // Copilot can legitimately take longer than 10 seconds under load, while
+    // adapter probes already receive a larger initialize budget and must keep
+    // the full three-attempt probe within the Settings caller's 120s ceiling.
+    let session_timeout_secs = if spawned.is_npx { 10 } else { 20 };
     let session_result = tokio::time::timeout(
         Duration::from_secs(session_timeout_secs),
         conn.new_session(acp::schema::v1::NewSessionRequest::new(cwd)),

--- a/tools/wta/src/protocol/acp/spawn.rs
+++ b/tools/wta/src/protocol/acp/spawn.rs
@@ -32,6 +32,17 @@ pub(crate) enum ChildEnvironmentPolicy {
     CleanCloudDiscovery,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum SharedProviderSelection<'a> {
+    /// Backward-compatible behavior for callers that do not declare whether
+    /// they follow Terminal's current provider selection.
+    Inherit,
+    /// The helper authoritatively selected the agent's native provider.
+    Disabled,
+    /// Apply the master-resolved Terminal custom-provider configuration.
+    Custom(&'a crate::custom_model_provider::Config),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StderrPhase {
     Startup,
@@ -226,6 +237,22 @@ pub(crate) fn spawn_agent_process(
     agent_id: Option<&str>,
     environment_policy: ChildEnvironmentPolicy,
 ) -> Result<AgentSpawn> {
+    spawn_agent_process_with_provider(
+        agent_cmd,
+        cwd,
+        agent_id,
+        environment_policy,
+        SharedProviderSelection::Inherit,
+    )
+}
+
+pub(crate) fn spawn_agent_process_with_provider(
+    agent_cmd: &str,
+    cwd: Option<&Path>,
+    agent_id: Option<&str>,
+    environment_policy: ChildEnvironmentPolicy,
+    provider_selection: SharedProviderSelection<'_>,
+) -> Result<AgentSpawn> {
     let parts: Vec<&str> = agent_cmd.split_whitespace().collect();
     let raw_program = parts
         .first()
@@ -261,7 +288,13 @@ pub(crate) fn spawn_agent_process(
     // `claude` shells from sharing runtime, but doesn't apply to an
     // ACP host. Scrub unconditionally; other agents don't care.
     cmd.env_remove("CLAUDECODE");
-    configure_child_environment(&mut cmd, agent_cmd, agent_id, environment_policy)?;
+    configure_child_environment(
+        &mut cmd,
+        agent_cmd,
+        agent_id,
+        environment_policy,
+        provider_selection,
+    )?;
     if is_npx && should_omit_optional_dependencies(agent_cmd, agent_id) {
         cmd.arg("--omit=optional");
     }
@@ -413,12 +446,26 @@ fn configure_child_environment(
     agent_cmd: &str,
     agent_id: Option<&str>,
     environment_policy: ChildEnvironmentPolicy,
+    provider_selection: SharedProviderSelection<'_>,
 ) -> Result<Option<crate::agent_registry::ByokMode>> {
     let profile = resolve_spawn_profile(agent_cmd, agent_id);
     let configured_provider = match environment_policy {
-        ChildEnvironmentPolicy::ApplySharedProvider => {
-            crate::custom_model_provider::configure_child(command, profile.byok_mode)
-        }
+        ChildEnvironmentPolicy::ApplySharedProvider => match provider_selection {
+            SharedProviderSelection::Inherit => {
+                crate::custom_model_provider::configure_child(command, profile.byok_mode)
+            }
+            SharedProviderSelection::Disabled => {
+                crate::custom_model_provider::scrub_child_for_cloud_discovery(command);
+                Ok(None)
+            }
+            SharedProviderSelection::Custom(config) => {
+                crate::custom_model_provider::configure_child_with_config(
+                    command,
+                    profile.byok_mode,
+                    config,
+                )
+            }
+        },
         ChildEnvironmentPolicy::CleanCloudDiscovery => {
             crate::custom_model_provider::scrub_child_for_cloud_discovery(command);
             Ok(None)
@@ -465,10 +512,32 @@ pub(crate) fn spawn_agent_process_for_source(
     source: &crate::agent_source::AgentSource,
     environment_policy: ChildEnvironmentPolicy,
 ) -> Result<AgentSpawn> {
+    spawn_agent_process_for_source_with_provider(
+        agent_cmd,
+        cwd,
+        agent_id,
+        source,
+        environment_policy,
+        SharedProviderSelection::Inherit,
+    )
+}
+
+pub(crate) fn spawn_agent_process_for_source_with_provider(
+    agent_cmd: &str,
+    cwd: Option<&Path>,
+    agent_id: Option<&str>,
+    source: &crate::agent_source::AgentSource,
+    environment_policy: ChildEnvironmentPolicy,
+    provider_selection: SharedProviderSelection<'_>,
+) -> Result<AgentSpawn> {
     match source {
-        crate::agent_source::AgentSource::Host => {
-            spawn_agent_process(agent_cmd, cwd, agent_id, environment_policy)
-        }
+        crate::agent_source::AgentSource::Host => spawn_agent_process_with_provider(
+            agent_cmd,
+            cwd,
+            agent_id,
+            environment_policy,
+            provider_selection,
+        ),
         crate::agent_source::AgentSource::Wsl { distro } => {
             spawn_wsl_agent_process(agent_cmd, distro, agent_id, environment_policy)
         }
@@ -669,6 +738,7 @@ mod tests {
             "copilot --acp --stdio",
             Some("copilot"),
             ChildEnvironmentPolicy::CleanCloudDiscovery,
+            SharedProviderSelection::Inherit,
         )
         .expect("clean cloud policy should not require shared configuration");
 
@@ -679,6 +749,33 @@ mod tests {
                 configured_env.get(std::ffi::OsStr::new(key)),
                 Some(&None),
                 "cloud policy must scrub {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn native_provider_selection_scrubs_inherited_byok_environment() {
+        let mut command = tokio::process::Command::new("copilot");
+        for key in crate::custom_model_provider::cloud_discovery_environment_keys() {
+            command.env(key, "stale-provider-value");
+        }
+
+        let applied = configure_child_environment(
+            &mut command,
+            "copilot --acp --stdio",
+            Some("copilot"),
+            ChildEnvironmentPolicy::ApplySharedProvider,
+            SharedProviderSelection::Disabled,
+        )
+        .expect("native provider selection should not require BYOK configuration");
+
+        assert_eq!(applied, None);
+        let configured_env: std::collections::HashMap<_, _> = command.as_std().get_envs().collect();
+        for key in crate::custom_model_provider::cloud_discovery_environment_keys() {
+            assert_eq!(
+                configured_env.get(std::ffi::OsStr::new(key)),
+                Some(&None),
+                "native provider selection must scrub stale {key}"
             );
         }
     }

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -58,6 +58,11 @@ pub struct WtaMeta {
     /// model later via `setSessionModel`). Carried as its own field
     /// because the master no longer trusts `agent_cmd` to carry it.
     pub model: Option<String>,
+    /// Authoritative custom-provider binding for this helper generation.
+    /// `"default"` explicitly disables the master's inherited provider;
+    /// `custom:<provider>:<model>` asks the master to resolve that selection
+    /// from Terminal settings. The helper never receives credential metadata.
+    pub provider_binding: Option<String>,
     /// Execution environment selected for this tab (`host` or `wsl`).
     pub agent_source: Option<String>,
     /// WSL distribution paired with `agent_source=wsl`.
@@ -98,6 +103,7 @@ impl WtaMeta {
             && blank(&self.agent_cmd)
             && blank(&self.agent_id)
             && blank(&self.model)
+            && blank(&self.provider_binding)
             && blank(&self.agent_source)
             && blank(&self.wsl_distro)
             && blank(&self.owner_tab_id)
@@ -148,6 +154,7 @@ pub fn extract_wta_meta(meta: &mut Option<acp::schema::v1::Meta>) -> WtaMeta {
         agent_cmd: str_field("agent_cmd"),
         agent_id: str_field("agent_id"),
         model: str_field("model"),
+        provider_binding: str_field("provider_binding"),
         agent_source: str_field("agent_source"),
         wsl_distro: str_field("wsl_distro"),
         owner_tab_id: str_field("owner_tab_id"),
@@ -188,6 +195,7 @@ pub fn inject_wta_meta(meta: &mut Option<acp::schema::v1::Meta>, wta: &WtaMeta) 
     put("agent_cmd", &wta.agent_cmd);
     put("agent_id", &wta.agent_id);
     put("model", &wta.model);
+    put("provider_binding", &wta.provider_binding);
     put("agent_source", &wta.agent_source);
     put("wsl_distro", &wta.wsl_distro);
     put("owner_tab_id", &wta.owner_tab_id);
@@ -3738,6 +3746,7 @@ mod tests {
             agent_cmd: Some("npx -y @agentclientprotocol/claude-agent-acp@0.65.0".to_string()),
             agent_id: Some("gemini".to_string()),
             model: Some("gemini-2.5-pro".to_string()),
+            provider_binding: Some("custom:provider-openrouter:qwen/qwen3.5-9b".to_string()),
             agent_source: Some("wsl".to_string()),
             wsl_distro: Some("Ubuntu".to_string()),
             cloud_models: Some(r#"[{"id":"cloud-native","name":"Cloud Native"}]"#.to_string()),
@@ -3792,6 +3801,7 @@ mod tests {
                 agent_cmd: Some(String::new()),
                 agent_id: Some("\t".to_string()),
                 model: Some(" ".to_string()),
+                provider_binding: Some(" ".to_string()),
                 agent_source: Some(" ".to_string()),
                 wsl_distro: Some("\t".to_string()),
                 owner_tab_id: Some("\n".to_string()),
@@ -3833,6 +3843,7 @@ mod tests {
                 agent_cmd: Some(String::new()),
                 agent_id: Some("\t".to_string()),
                 model: Some(" ".to_string()),
+                provider_binding: Some(" ".to_string()),
                 agent_source: Some(" ".to_string()),
                 wsl_distro: Some("\t".to_string()),
                 owner_tab_id: Some("\n".to_string()),

--- a/tools/wta/src/shell/wt_channel/cli_channel.rs
+++ b/tools/wta/src/shell/wt_channel/cli_channel.rs
@@ -734,6 +734,7 @@ impl WtChannel for CliChannel {
                 self.run_wtcli(&args).await
             }
             "get_active_pane" => self.run_wtcli(&["active-pane"]).await,
+            "get_settings" => self.run_wtcli(&["get-settings"]).await,
             "read_pane_output" => {
                 let pane_id = params
                     .get("session_id")

--- a/tools/wta/src/wt_protocol_events.rs
+++ b/tools/wta/src/wt_protocol_events.rs
@@ -3,6 +3,27 @@ pub fn send(json_payload: String) {
     let _ = publisher_sender().send(json_payload);
 }
 
+pub(crate) fn restart_agent_stack_event(reason: Option<&str>, tab_id: Option<&str>) -> String {
+    let mut params = serde_json::Map::new();
+    params.insert(
+        "request_id".into(),
+        serde_json::Value::String(uuid::Uuid::new_v4().to_string()),
+    );
+    if let Some(reason) = reason {
+        params.insert("reason".into(), serde_json::Value::String(reason.into()));
+    }
+    if let Some(tab_id) = tab_id {
+        params.insert("tab_id".into(), serde_json::Value::String(tab_id.into()));
+    }
+
+    serde_json::json!({
+        "type": "event",
+        "method": "restart_agent_stack",
+        "params": params,
+    })
+    .to_string()
+}
+
 fn publisher_sender() -> &'static std::sync::mpsc::Sender<String> {
     static SENDER: std::sync::OnceLock<std::sync::mpsc::Sender<String>> =
         std::sync::OnceLock::new();
@@ -131,6 +152,24 @@ fn publish_blocking(json_payload: &str) {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn restart_event_has_unique_shared_request_id_and_optional_scope() {
+        let first: serde_json::Value =
+            serde_json::from_str(&super::restart_agent_stack_event(None, None)).unwrap();
+        let second: serde_json::Value = serde_json::from_str(
+            &super::restart_agent_stack_event(Some("auth_recovery"), Some("tab-1")),
+        )
+        .unwrap();
+
+        let first_request_id = first["params"]["request_id"].as_str().unwrap();
+        let second_request_id = second["params"]["request_id"].as_str().unwrap();
+        assert!(uuid::Uuid::parse_str(first_request_id).is_ok());
+        assert!(uuid::Uuid::parse_str(second_request_id).is_ok());
+        assert_ne!(first_request_id, second_request_id);
+        assert_eq!(second["params"]["reason"], "auth_recovery");
+        assert_eq!(second["params"]["tab_id"], "tab-1");
+    }
+
     #[test]
     fn publish_command_selects_stdin_transport() {
         let command = super::publish_command(std::path::Path::new("wtcli.exe"));

--- a/tools/wta/src/wt_protocol_events.rs
+++ b/tools/wta/src/wt_protocol_events.rs
@@ -3,23 +3,17 @@ pub fn send(json_payload: String) {
     let _ = publisher_sender().send(json_payload);
 }
 
-pub(crate) fn restart_agent_stack_event(reason: Option<&str>, tab_id: Option<&str>) -> String {
-    let mut params = serde_json::Map::new();
-    params.insert(
-        "request_id".into(),
-        serde_json::Value::String(uuid::Uuid::new_v4().to_string()),
-    );
-    if let Some(reason) = reason {
-        params.insert("reason".into(), serde_json::Value::String(reason.into()));
-    }
-    if let Some(tab_id) = tab_id {
-        params.insert("tab_id".into(), serde_json::Value::String(tab_id.into()));
-    }
+pub(crate) fn restart_agent_stack_event() -> String {
+    restart_agent_stack_event_with_id(&uuid::Uuid::new_v4().to_string())
+}
 
+pub(crate) fn restart_agent_stack_event_with_id(request_id: &str) -> String {
     serde_json::json!({
         "type": "event",
         "method": "restart_agent_stack",
-        "params": params,
+        "params": {
+            "request_id": request_id,
+        },
     })
     .to_string()
 }
@@ -153,21 +147,26 @@ fn publish_blocking(json_payload: &str) {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn restart_event_has_unique_shared_request_id_and_optional_scope() {
+    fn restart_event_has_unique_shared_request_id() {
         let first: serde_json::Value =
-            serde_json::from_str(&super::restart_agent_stack_event(None, None)).unwrap();
-        let second: serde_json::Value = serde_json::from_str(
-            &super::restart_agent_stack_event(Some("auth_recovery"), Some("tab-1")),
-        )
-        .unwrap();
+            serde_json::from_str(&super::restart_agent_stack_event()).unwrap();
+        let second: serde_json::Value =
+            serde_json::from_str(&super::restart_agent_stack_event()).unwrap();
 
         let first_request_id = first["params"]["request_id"].as_str().unwrap();
         let second_request_id = second["params"]["request_id"].as_str().unwrap();
         assert!(uuid::Uuid::parse_str(first_request_id).is_ok());
         assert!(uuid::Uuid::parse_str(second_request_id).is_ok());
         assert_ne!(first_request_id, second_request_id);
-        assert_eq!(second["params"]["reason"], "auth_recovery");
-        assert_eq!(second["params"]["tab_id"], "tab-1");
+    }
+
+    #[test]
+    fn restart_event_preserves_supplied_request_id() {
+        let event: serde_json::Value =
+            serde_json::from_str(&super::restart_agent_stack_event_with_id("auth-recovery-1"))
+                .unwrap();
+
+        assert_eq!(event["params"]["request_id"], "auth-recovery-1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve the existing pane, TermControl, ConPTY, `wta-helper`, and shared `wta-master` when built-in Agent or Model settings change
- retire and reconnect ACP sessions in place for Agent changes, model reset, Gemini, and BYOK changes; hot-update supported native models without replacing the session
- recreate only never-started dormant Agent panes so they launch with current settings; connected helpers continue to rebind in place
- preflight replacement built-in Agents before reconnect so missing CLIs use the existing setup and auto-install experience
- scope BYOK Agent generations by credential-free provider configuration and retire each generation after its final helper disconnects
- resolve provider settings and credentials only in the master process, and consolidate profile/default-profile Agent detection into one background probe
- bypass active-tab focus deferral for non-destructive rebinds so background tabs and windows update without pane reconstruction or focus stealing

## Validation

- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools\wta\Cargo.toml` — 1666 passed, 0 failed
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools\wta\Cargo.toml`
- `cmd.exe /c "tools\razzle.cmd && bcz no_clean"` — 0 errors
- Debug package deployment and launch