### PR TITLE
Auto-name durable tab sessions from shell-integration context

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -14,6 +14,7 @@
 #include "../TerminalApp/CommandPalette.h"
 #include "../TerminalApp/ContentManager.h"
 #include "../TerminalApp/DurableSessionHelpers.h"
+#include "../TerminalApp/TabAutoNaming.h"
 #include "../UnitTests_Control/MockControlSettings.h"
 #include "CppWinrtTailored.h"
 
@@ -122,9 +123,8 @@ namespace TerminalAppLocalTests
         if (Json::parseFromStream(builder, stream, &evt, &errors) &&
             evt["method"].asString() == "connection_state")
         {
-            connectionStates.push_back({
-                evt["params"]["pane_id"].asString(),
-                evt["params"]["state"].asString() });
+            connectionStates.push_back({ evt["params"]["pane_id"].asString(),
+                                         evt["params"]["state"].asString() });
         }
     }
 
@@ -194,6 +194,9 @@ namespace TerminalAppLocalTests
 
         TEST_METHOD(CreateTerminalPage);
         TEST_METHOD(DurableTabSessionCloseActionsFollowStartupPreference);
+        TEST_METHOD(TabAutoNameParsesGitHeadForms);
+        TEST_METHOD(TabAutoNameMapsCommandsToLabels);
+        TEST_METHOD(TabAutoNameComposesAndFallsBack);
         TEST_METHOD(DurableTabSessionAgentBindingQualifiesForPersistence);
         TEST_METHOD(AgentSessionRestoreRequiresDurableRestoreContext);
         TEST_METHOD(PersistedLayoutAgentSessionsReceiveRestorePaths);
@@ -378,6 +381,135 @@ namespace TerminalAppLocalTests
         const auto layoutAndContent = winrt::TerminalApp::implementation::GetDurableTabSessionCloseActions(FirstWindowPreference::PersistedLayoutAndContent);
         VERIFY_IS_TRUE(layoutAndContent.save);
         VERIFY_IS_TRUE(layoutAndContent.persistScrollback);
+    }
+
+    void TabTests::TabAutoNameParsesGitHeadForms()
+    {
+        using namespace winrt::TerminalApp::implementation;
+
+        // The common case: a checked-out branch.
+        VERIFY_ARE_EQUAL(std::wstring{ L"main" }, ParseGitHeadContent(L"ref: refs/heads/main\n").value());
+
+        // Branch names legitimately contain slashes, and the whole thing after
+        // refs/heads/ is the name - not just the trailing segment.
+        VERIFY_ARE_EQUAL(std::wstring{ L"dev/yuazha/tab-auto-naming" },
+                         ParseGitHeadContent(L"ref: refs/heads/dev/yuazha/tab-auto-naming\n").value());
+
+        // Detached HEAD: git writes a bare object id, which we shorten.
+        VERIFY_ARE_EQUAL(std::wstring{ L"0bd62e4" },
+                         ParseGitHeadContent(L"0bd62e4750123456789012345678901234567890\n").value());
+
+        // Unusable inputs yield no branch rather than a guess.
+        VERIFY_IS_FALSE(ParseGitHeadContent(L"").has_value());
+        VERIFY_IS_FALSE(ParseGitHeadContent(L"   \r\n").has_value());
+        VERIFY_IS_FALSE(ParseGitHeadContent(L"garbage").has_value());
+
+        // `.git` file pointer, used by linked worktrees and submodules.
+        VERIFY_ARE_EQUAL(std::wstring{ L"C:/repo/.git/worktrees/feature" },
+                         ParseGitDirPointer(L"gitdir: C:/repo/.git/worktrees/feature\n").value());
+        VERIFY_IS_FALSE(ParseGitDirPointer(L"not a pointer").has_value());
+
+        // End-to-end over a real worktree layout, where `.git` is a *file*
+        // pointing elsewhere. This is the shape this repository itself uses,
+        // so a regression here would break naming for anyone developing in
+        // a `.worktree/<name>` checkout.
+        std::error_code error;
+        const auto root = std::filesystem::temp_directory_path(error) /
+                          (L"tab-auto-naming-" + std::to_wstring(GetCurrentProcessId()));
+        const auto realGitDirectory = root / L"realgit";
+        const auto checkout = root / L"checkout";
+        const auto nested = checkout / L"src" / L"deep";
+
+        std::filesystem::remove_all(root, error);
+        std::filesystem::create_directories(realGitDirectory, error);
+        std::filesystem::create_directories(nested, error);
+        VERIFY_IS_FALSE(!!error);
+
+        {
+            std::ofstream head{ realGitDirectory / L"HEAD", std::ios::binary };
+            head << "ref: refs/heads/worktree-branch\n";
+            std::ofstream pointer{ checkout / L".git", std::ios::binary };
+            pointer << "gitdir: " << realGitDirectory.string() << "\n";
+        }
+
+        // Found from the checkout root, and from a nested subdirectory via the
+        // upward walk.
+        VERIFY_ARE_EQUAL(std::wstring{ L"worktree-branch" }, TryReadGitBranch(checkout).value());
+        VERIFY_ARE_EQUAL(std::wstring{ L"worktree-branch" }, TryReadGitBranch(nested).value());
+
+        // A directory with no repository above it has no branch.
+        const auto orphan = root / L"orphan";
+        std::filesystem::create_directories(orphan, error);
+        const auto orphanBranch = TryReadGitBranch(orphan);
+        VERIFY_IS_TRUE(!orphanBranch.has_value() || !orphanBranch->empty());
+
+        std::filesystem::remove_all(root, error);
+    }
+
+    void TabTests::TabAutoNameMapsCommandsToLabels()
+    {
+        using winrt::TerminalApp::implementation::FriendlyCommandLabel;
+
+        // Package-manager scripts, across the managers and both `run` forms.
+        VERIFY_ARE_EQUAL(std::wstring{ L"dev server" }, FriendlyCommandLabel(L"npm run dev"));
+        VERIFY_ARE_EQUAL(std::wstring{ L"dev server" }, FriendlyCommandLabel(L"yarn dev"));
+        VERIFY_ARE_EQUAL(std::wstring{ L"dev server" }, FriendlyCommandLabel(L"pnpm run start"));
+        VERIFY_ARE_EQUAL(std::wstring{ L"build" }, FriendlyCommandLabel(L"npm run build"));
+        VERIFY_ARE_EQUAL(std::wstring{ L"tests" }, FriendlyCommandLabel(L"npm test"));
+
+        // Table entries, longest-key-wins.
+        VERIFY_ARE_EQUAL(std::wstring{ L"compose" }, FriendlyCommandLabel(L"docker compose up"));
+        VERIFY_ARE_EQUAL(std::wstring{ L"python tests" }, FriendlyCommandLabel(L"python -m pytest"));
+        VERIFY_ARE_EQUAL(std::wstring{ L"cargo tests" }, FriendlyCommandLabel(L"cargo test --all"));
+
+        // ssh reads as its destination, which is what the user recognizes.
+        VERIFY_ARE_EQUAL(std::wstring{ L"box01" }, FriendlyCommandLabel(L"ssh box01"));
+        VERIFY_ARE_EQUAL(std::wstring{ L"box01" }, FriendlyCommandLabel(L"ssh user@box01"));
+        VERIFY_ARE_EQUAL(std::wstring{ L"box01" }, FriendlyCommandLabel(L"ssh -p 2222 user@box01"));
+
+        // Invocation-only prefixes are stripped before matching.
+        VERIFY_ARE_EQUAL(std::wstring{ L"compose" }, FriendlyCommandLabel(L"sudo docker compose up"));
+        VERIFY_ARE_EQUAL(std::wstring{ L"dev server" }, FriendlyCommandLabel(L"NODE_ENV=production npm run dev"));
+
+        // Only the first command of a chain describes the tab.
+        VERIFY_ARE_EQUAL(std::wstring{ L"build" }, FriendlyCommandLabel(L"npm run build && npm test"));
+
+        // An unrecognized command is shown verbatim - never guessed at.
+        VERIFY_ARE_EQUAL(std::wstring{ L"./weird-script.sh" }, FriendlyCommandLabel(L"./weird-script.sh"));
+
+        // Nothing in, nothing out.
+        VERIFY_ARE_EQUAL(std::wstring{ L"" }, FriendlyCommandLabel(L"   "));
+
+        // Long unrecognized commands are cut rather than allowed to dominate.
+        const auto longLabel = FriendlyCommandLabel(
+            L"./some-extremely-long-script-name-that-keeps-going.sh --with --many --flags");
+        VERIFY_IS_LESS_THAN_OR_EQUAL(longLabel.size(),
+                                     winrt::TerminalApp::implementation::TabAutoNameMaxTaskLength);
+    }
+
+    void TabTests::TabAutoNameComposesAndFallsBack()
+    {
+        using winrt::TerminalApp::implementation::ComposeTabAutoName;
+
+        // Both segments present.
+        VERIFY_ARE_EQUAL(std::wstring{ L"main \u00B7 dev server" },
+                         ComposeTabAutoName(L"main", L"dev server", L"PowerShell"));
+
+        // Either segment alone still beats the shell title.
+        VERIFY_ARE_EQUAL(std::wstring{ L"main" }, ComposeTabAutoName(L"main", L"", L"PowerShell"));
+        VERIFY_ARE_EQUAL(std::wstring{ L"dev server" }, ComposeTabAutoName(L"", L"dev server", L"PowerShell"));
+
+        // With no shell-integration context at all we keep the old behavior.
+        VERIFY_ARE_EQUAL(std::wstring{ L"PowerShell" }, ComposeTabAutoName(L"", L"", L"PowerShell"));
+        VERIFY_ARE_EQUAL(std::wstring{ L"PowerShell" }, ComposeTabAutoName(L"  ", L"  ", L"PowerShell"));
+
+        // The name shares its row with the working directory, so it stays capped.
+        const auto composed = ComposeTabAutoName(
+            L"dev/yuazha/a-very-long-branch-name-that-goes-on",
+            L"dev server",
+            L"PowerShell");
+        VERIFY_IS_LESS_THAN_OR_EQUAL(composed.size(),
+                                     winrt::TerminalApp::implementation::TabAutoNameMaxLength);
     }
 
     void TabTests::DurableTabSessionAgentBindingQualifiesForPersistence()

--- a/src/cascadia/TerminalApp/TabAutoNaming.h
+++ b/src/cascadia/TerminalApp/TabAutoNaming.h
@@ -1,0 +1,654 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- TabAutoNaming.h
+
+Abstract:
+- Deterministic, offline helpers that turn a tab's shell-integration context
+  into a readable durable-session name, so the recents list stops being a wall
+  of identical shell names.
+- Everything here is either a pure transform over data we already own, or one
+  cheap read of `.git/HEAD`. No AI, no network, no `git.exe`, no libgit2 - the
+  same inputs always produce the same name.
+- Consumed by TerminalPage::_PersistDurableTabSession at tab-close time only.
+  Nothing on this path runs per-frame, which is why it can afford to call the
+  (relatively expensive) TermControl::CommandHistory() once.
+
+Author(s):
+- Intelligent Terminal contributors
+--*/
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace winrt::TerminalApp::implementation
+{
+    // U+00B7 MIDDLE DOT, spaced. Written as an escape so the meaning of this
+    // literal does not depend on how the file is decoded.
+    inline constexpr std::wstring_view TabAutoNameSeparator{ L" \u00B7 " };
+
+    // A generated name shares its row with the working directory (see
+    // durable_tab_sessions_view.rs), and that row drops the cwd column entirely
+    // once the name gets too wide. Cap the name so the cwd stays visible.
+    inline constexpr size_t TabAutoNameMaxLength{ 48 };
+
+    // An unrecognized command is shown verbatim rather than guessed at, but a
+    // full command line can be arbitrarily long.
+    inline constexpr size_t TabAutoNameMaxTaskLength{ 32 };
+
+    // Upward search for a `.git` entry is bounded: a deep or unlucky path
+    // should never turn tab close into a directory walk.
+    inline constexpr size_t TabAutoNameMaxGitWalkDepth{ 32 };
+
+#pragma region string helpers
+
+    inline std::wstring_view TrimAscii(std::wstring_view value) noexcept
+    {
+        constexpr std::wstring_view whitespace{ L" \t\r\n" };
+        const auto begin = value.find_first_not_of(whitespace);
+        if (begin == std::wstring_view::npos)
+        {
+            return {};
+        }
+        const auto end = value.find_last_not_of(whitespace);
+        return value.substr(begin, end - begin + 1);
+    }
+
+    inline std::wstring ToLowerAscii(std::wstring_view value)
+    {
+        std::wstring lowered{ value };
+        std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](wchar_t c) noexcept {
+            return (c >= L'A' && c <= L'Z') ? static_cast<wchar_t>(c - L'A' + L'a') : c;
+        });
+        return lowered;
+    }
+
+    // Truncates on a character boundary, appending an ellipsis when it cuts.
+    // Guards against splitting a surrogate pair, which would emit a lone
+    // surrogate into the session name.
+    inline std::wstring TruncateForName(std::wstring_view value, const size_t maxLength)
+    {
+        if (value.size() <= maxLength || maxLength == 0)
+        {
+            return std::wstring{ value };
+        }
+
+        auto cut = maxLength - 1;
+        if (cut > 0 && value[cut - 1] >= 0xD800 && value[cut - 1] <= 0xDBFF)
+        {
+            // Never leave a high surrogate as the last retained unit.
+            --cut;
+        }
+
+        std::wstring truncated{ value.substr(0, cut) };
+        while (!truncated.empty() && (truncated.back() == L' ' || truncated.back() == L'\t'))
+        {
+            truncated.pop_back();
+        }
+        truncated.push_back(L'\u2026');
+        return truncated;
+    }
+
+    // Splits off the leading whitespace-delimited token, honoring double quotes
+    // so a quoted path stays one token. Returns {token, remainder}.
+    inline std::pair<std::wstring_view, std::wstring_view> SplitLeadingToken(std::wstring_view commandline) noexcept
+    {
+        const auto trimmed = TrimAscii(commandline);
+        if (trimmed.empty())
+        {
+            return { {}, {} };
+        }
+
+        size_t index = 0;
+        auto inQuotes = false;
+        for (; index < trimmed.size(); ++index)
+        {
+            const auto c = trimmed[index];
+            if (c == L'"')
+            {
+                inQuotes = !inQuotes;
+                continue;
+            }
+            if (!inQuotes && (c == L' ' || c == L'\t'))
+            {
+                break;
+            }
+        }
+
+        return { trimmed.substr(0, index), TrimAscii(trimmed.substr(index)) };
+    }
+
+#pragma endregion
+
+#pragma region git
+
+    inline bool IsHexRun(std::wstring_view value) noexcept
+    {
+        return !value.empty() && std::all_of(value.begin(), value.end(), [](wchar_t c) noexcept {
+            return (c >= L'0' && c <= L'9') || (c >= L'a' && c <= L'f') || (c >= L'A' && c <= L'F');
+        });
+    }
+
+    // Parses the contents of a `.git/HEAD`.
+    // - "ref: refs/heads/main"       -> "main"
+    // - "ref: refs/heads/feat/x"     -> "feat/x"  (slashes in branch names are kept)
+    // - a bare object id             -> short form, e.g. "a1b2c3d" (detached HEAD)
+    // Kept separate from any file IO so it is directly unit-testable.
+    inline std::optional<std::wstring> ParseGitHeadContent(std::wstring_view headContent)
+    {
+        const auto trimmed = TrimAscii(headContent);
+        if (trimmed.empty())
+        {
+            return std::nullopt;
+        }
+
+        constexpr std::wstring_view refPrefix{ L"ref:" };
+        if (trimmed.starts_with(refPrefix))
+        {
+            const auto ref = TrimAscii(trimmed.substr(refPrefix.size()));
+            if (ref.empty())
+            {
+                return std::nullopt;
+            }
+
+            constexpr std::wstring_view headsPrefix{ L"refs/heads/" };
+            if (ref.starts_with(headsPrefix))
+            {
+                const auto branch = ref.substr(headsPrefix.size());
+                return branch.empty() ? std::nullopt : std::optional{ std::wstring{ branch } };
+            }
+
+            // Some other ref namespace (refs/tags/..., a bare name, ...). The
+            // trailing segment is still the most meaningful part.
+            const auto lastSlash = ref.find_last_of(L'/');
+            const auto tail = lastSlash == std::wstring_view::npos ? ref : ref.substr(lastSlash + 1);
+            return tail.empty() ? std::nullopt : std::optional{ std::wstring{ tail } };
+        }
+
+        // Detached HEAD: git writes the raw object id. SHA-1 repositories use
+        // 40 hex digits, SHA-256 repositories use 64.
+        if ((trimmed.size() == 40 || trimmed.size() == 64) && IsHexRun(trimmed))
+        {
+            return std::wstring{ trimmed.substr(0, 7) };
+        }
+
+        return std::nullopt;
+    }
+
+    // Parses the contents of a `.git` *file*, which git writes instead of a
+    // directory for linked worktrees and submodules:
+    //     gitdir: C:/repo/.git/worktrees/feature
+    // This is not an edge case for this repository - development happens in
+    // `.worktree/<name>` checkouts, where `.git` is always a file.
+    inline std::optional<std::wstring> ParseGitDirPointer(std::wstring_view gitFileContent)
+    {
+        const auto trimmed = TrimAscii(gitFileContent);
+        constexpr std::wstring_view gitdirPrefix{ L"gitdir:" };
+        if (!trimmed.starts_with(gitdirPrefix))
+        {
+            return std::nullopt;
+        }
+
+        const auto target = TrimAscii(trimmed.substr(gitdirPrefix.size()));
+        return target.empty() ? std::nullopt : std::optional{ std::wstring{ target } };
+    }
+
+    // Reads a small text file without throwing. Returns nullopt for anything
+    // unreadable, oversized, or not valid UTF-8.
+    inline std::optional<std::wstring> TryReadSmallTextFile(const std::filesystem::path& path)
+    {
+        std::error_code error;
+        if (!std::filesystem::is_regular_file(path, error) || error)
+        {
+            return std::nullopt;
+        }
+
+        const auto size = std::filesystem::file_size(path, error);
+        if (error || size > 64u * 1024u)
+        {
+            return std::nullopt;
+        }
+
+        std::string bytes;
+        try
+        {
+            std::ifstream stream{ path, std::ios::binary };
+            if (!stream)
+            {
+                return std::nullopt;
+            }
+            bytes.assign(std::istreambuf_iterator<char>{ stream }, std::istreambuf_iterator<char>{});
+        }
+        catch (...)
+        {
+            return std::nullopt;
+        }
+
+        // Branch names may be UTF-8; decode properly rather than widening bytes.
+        std::wstring wide;
+        if (FAILED(til::u8u16(bytes, wide)))
+        {
+            return std::nullopt;
+        }
+        return wide;
+    }
+
+    inline bool IsNetworkPath(const std::filesystem::path& path)
+    {
+        const auto native = path.native();
+        return native.starts_with(L"\\\\") || native.starts_with(L"//");
+    }
+
+    inline std::optional<std::wstring> ReadBranchFromGitDir(const std::filesystem::path& gitDirectory)
+    {
+        if (const auto head = TryReadSmallTextFile(gitDirectory / L"HEAD"))
+        {
+            return ParseGitHeadContent(*head);
+        }
+        return std::nullopt;
+    }
+
+    // Walks up from `startingDirectory` looking for a `.git` entry and returns
+    // the checked-out branch (or a short object id when detached).
+    //
+    // Deliberately cheap and best-effort: any failure yields nullopt and the
+    // caller simply omits the branch segment. Network paths are skipped so a
+    // disconnected share cannot stall closing a tab.
+    inline std::optional<std::wstring> TryReadGitBranch(const std::filesystem::path& startingDirectory)
+    {
+        if (startingDirectory.empty() || IsNetworkPath(startingDirectory))
+        {
+            return std::nullopt;
+        }
+
+        std::error_code error;
+        auto current = std::filesystem::absolute(startingDirectory, error);
+        if (error)
+        {
+            current = startingDirectory;
+        }
+
+        for (size_t depth = 0; depth < TabAutoNameMaxGitWalkDepth && !current.empty(); ++depth)
+        {
+            const auto gitEntry = current / L".git";
+
+            if (std::filesystem::is_directory(gitEntry, error) && !error)
+            {
+                return ReadBranchFromGitDir(gitEntry);
+            }
+
+            if (std::filesystem::is_regular_file(gitEntry, error) && !error)
+            {
+                const auto pointer = TryReadSmallTextFile(gitEntry);
+                if (!pointer)
+                {
+                    return std::nullopt;
+                }
+                const auto target = ParseGitDirPointer(*pointer);
+                if (!target)
+                {
+                    return std::nullopt;
+                }
+
+                std::filesystem::path realGitDirectory{ *target };
+                if (realGitDirectory.is_relative())
+                {
+                    realGitDirectory = current / realGitDirectory;
+                }
+                return ReadBranchFromGitDir(realGitDirectory);
+            }
+
+            auto parent = current.parent_path();
+            if (parent == current)
+            {
+                break;
+            }
+            current = std::move(parent);
+        }
+
+        return std::nullopt;
+    }
+
+#pragma endregion
+
+#pragma region command labels
+
+    // Prefixes that describe *how* a command runs rather than what it is, and
+    // so are stripped before matching. `env`-style KEY=VALUE assignments are
+    // handled separately below.
+    inline constexpr std::array<std::wstring_view, 6> TabAutoNameIgnoredPrefixes{
+        L"sudo",
+        L"doas",
+        L"env",
+        L"time",
+        L"command",
+        L"npx",
+    };
+
+    // Package managers whose `run <script>` form should be read as the script.
+    inline constexpr std::array<std::wstring_view, 4> TabAutoNamePackageManagers{
+        L"npm",
+        L"pnpm",
+        L"yarn",
+        L"bun",
+    };
+
+    // Scripts common enough across ecosystems to deserve a friendly label.
+    // English literals by design: the underlying commands are English too, and
+    // localizing these would cost far more than the table itself is worth.
+    inline constexpr std::array<std::pair<std::wstring_view, std::wstring_view>, 8> TabAutoNameScriptLabels{ {
+        { L"dev", L"dev server" },
+        { L"start", L"dev server" },
+        { L"serve", L"dev server" },
+        { L"watch", L"watch" },
+        { L"build", L"build" },
+        { L"test", L"tests" },
+        { L"lint", L"lint" },
+        { L"typecheck", L"typecheck" },
+    } };
+
+    // Exact matches on the first one-to-three lowercased tokens. Longest key
+    // wins, so "docker compose up" beats "docker".
+    inline constexpr std::array<std::pair<std::wstring_view, std::wstring_view>, 24> TabAutoNameCommandLabels{ {
+        { L"docker compose up", L"compose" },
+        { L"docker compose", L"compose" },
+        { L"docker build", L"docker build" },
+        { L"python -m pytest", L"python tests" },
+        { L"python -m http.server", L"http server" },
+        { L"pytest", L"python tests" },
+        { L"cargo run", L"cargo run" },
+        { L"cargo build", L"cargo build" },
+        { L"cargo test", L"cargo tests" },
+        { L"cargo watch", L"cargo watch" },
+        { L"go run", L"go run" },
+        { L"go test", L"go tests" },
+        { L"dotnet run", L"dotnet run" },
+        { L"dotnet test", L"dotnet tests" },
+        { L"dotnet watch", L"dotnet watch" },
+        { L"msbuild", L"build" },
+        { L"make", L"make" },
+        { L"terraform apply", L"terraform apply" },
+        { L"terraform plan", L"terraform plan" },
+        { L"kubectl logs", L"kubectl logs" },
+        { L"git rebase", L"rebase" },
+        { L"git bisect", L"bisect" },
+        { L"vim", L"vim" },
+        { L"nvim", L"nvim" },
+    } };
+
+    inline bool IsEnvironmentAssignment(std::wstring_view token) noexcept
+    {
+        if (token.empty() || token.front() == L'-' || token.front() == L'=')
+        {
+            return false;
+        }
+        return token.find(L'=') != std::wstring_view::npos;
+    }
+
+    // Keeps only the first command of a chain/pipeline. Quote-aware so a
+    // separator inside a quoted argument is not treated as a break.
+    inline std::wstring_view FirstCommandSegment(std::wstring_view commandline) noexcept
+    {
+        auto inQuotes = false;
+        for (size_t index = 0; index < commandline.size(); ++index)
+        {
+            const auto c = commandline[index];
+            if (c == L'"')
+            {
+                inQuotes = !inQuotes;
+                continue;
+            }
+            if (inQuotes)
+            {
+                continue;
+            }
+            if (c == L'|' || c == L';' || c == L'&')
+            {
+                return TrimAscii(commandline.substr(0, index));
+            }
+        }
+        return TrimAscii(commandline);
+    }
+
+    // Strips leading tokens that only describe how the command is invoked.
+    inline std::wstring_view StripInvocationPrefixes(std::wstring_view commandline)
+    {
+        auto remaining = TrimAscii(commandline);
+
+        // Bounded so a pathological line of assignments cannot spin here.
+        for (size_t iteration = 0; iteration < 8; ++iteration)
+        {
+            const auto [token, rest] = SplitLeadingToken(remaining);
+            if (token.empty() || rest.empty())
+            {
+                break;
+            }
+
+            const auto lowered = ToLowerAscii(token);
+            const auto isIgnored = std::find(TabAutoNameIgnoredPrefixes.begin(),
+                                             TabAutoNameIgnoredPrefixes.end(),
+                                             std::wstring_view{ lowered }) != TabAutoNameIgnoredPrefixes.end();
+
+            if (isIgnored || IsEnvironmentAssignment(token))
+            {
+                remaining = rest;
+                continue;
+            }
+            break;
+        }
+
+        return remaining;
+    }
+
+    // `ssh user@host`, `ssh -p 22 host` -> "host". The destination is what the
+    // user actually recognizes, so it beats any generic "ssh" label.
+    inline std::optional<std::wstring> TryLabelSshTarget(std::wstring_view commandline)
+    {
+        auto [token, rest] = SplitLeadingToken(commandline);
+        if (ToLowerAscii(token) != L"ssh")
+        {
+            return std::nullopt;
+        }
+
+        // Options that consume the following argument.
+        constexpr std::array<std::wstring_view, 8> valueFlags{
+            L"-p", L"-i", L"-l", L"-o", L"-F", L"-J", L"-L", L"-R"
+        };
+
+        while (!rest.empty())
+        {
+            auto [candidate, next] = SplitLeadingToken(rest);
+            if (candidate.empty())
+            {
+                break;
+            }
+
+            if (candidate.front() == L'-')
+            {
+                const auto loweredFlag = ToLowerAscii(candidate);
+                const auto consumesValue = std::find(valueFlags.begin(),
+                                                     valueFlags.end(),
+                                                     std::wstring_view{ loweredFlag }) != valueFlags.end();
+                if (consumesValue)
+                {
+                    rest = SplitLeadingToken(next).second;
+                }
+                else
+                {
+                    rest = next;
+                }
+                continue;
+            }
+
+            // First non-flag argument is the destination.
+            const auto at = candidate.find(L'@');
+            const auto host = at == std::wstring_view::npos ? candidate : candidate.substr(at + 1);
+            return host.empty() ? std::nullopt : std::optional{ std::wstring{ host } };
+        }
+
+        return std::nullopt;
+    }
+
+    // `npm run dev`, `yarn dev`, `pnpm run build` -> the script's label.
+    inline std::optional<std::wstring> TryLabelPackageManagerScript(std::wstring_view commandline)
+    {
+        auto [manager, rest] = SplitLeadingToken(commandline);
+        const auto loweredManager = ToLowerAscii(manager);
+        const auto isPackageManager = std::find(TabAutoNamePackageManagers.begin(),
+                                                TabAutoNamePackageManagers.end(),
+                                                std::wstring_view{ loweredManager }) != TabAutoNamePackageManagers.end();
+        if (!isPackageManager || rest.empty())
+        {
+            return std::nullopt;
+        }
+
+        auto [second, afterSecond] = SplitLeadingToken(rest);
+        auto loweredSecond = ToLowerAscii(second);
+
+        // `npm run dev` / `npm run-script dev` -> the script is the next token.
+        if (loweredSecond == L"run" || loweredSecond == L"run-script")
+        {
+            const auto script = SplitLeadingToken(afterSecond).first;
+            if (script.empty())
+            {
+                return std::nullopt;
+            }
+            loweredSecond = ToLowerAscii(script);
+        }
+
+        for (const auto& [script, label] : TabAutoNameScriptLabels)
+        {
+            if (loweredSecond == script)
+            {
+                return std::wstring{ label };
+            }
+        }
+
+        // Unknown script: still more useful than the raw line.
+        return loweredSecond.empty() ? std::nullopt : std::optional{ loweredSecond };
+    }
+
+    inline std::optional<std::wstring> TryLabelFromTable(std::wstring_view commandline)
+    {
+        // Build the lowercased first three tokens once, then probe longest-first.
+        std::wstring probe;
+        auto rest = commandline;
+        std::array<std::wstring, 3> prefixes;
+        size_t built = 0;
+
+        for (; built < prefixes.size(); ++built)
+        {
+            auto [token, next] = SplitLeadingToken(rest);
+            if (token.empty())
+            {
+                break;
+            }
+            if (!probe.empty())
+            {
+                probe.push_back(L' ');
+            }
+            probe += ToLowerAscii(token);
+            prefixes[built] = probe;
+            rest = next;
+        }
+
+        for (size_t index = built; index > 0; --index)
+        {
+            const auto& candidate = prefixes[index - 1];
+            for (const auto& [key, label] : TabAutoNameCommandLabels)
+            {
+                if (candidate == key)
+                {
+                    return std::wstring{ label };
+                }
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    // Maps a raw command line to a short, friendly label.
+    //
+    // Intentionally *not* a general parser: it normalizes, then matches a small
+    // hand-maintained table. Anything unrecognized falls back to the truncated
+    // original, so the worst case is "shows the command you ran" - never an
+    // empty or wrong label.
+    inline std::wstring FriendlyCommandLabel(std::wstring_view commandline)
+    {
+        const auto trimmed = TrimAscii(commandline);
+        if (trimmed.empty())
+        {
+            return {};
+        }
+
+        const auto segment = FirstCommandSegment(trimmed);
+        const auto stripped = StripInvocationPrefixes(segment);
+        if (stripped.empty())
+        {
+            return TruncateForName(trimmed, TabAutoNameMaxTaskLength);
+        }
+
+        if (auto ssh = TryLabelSshTarget(stripped))
+        {
+            return TruncateForName(*ssh, TabAutoNameMaxTaskLength);
+        }
+        if (auto script = TryLabelPackageManagerScript(stripped))
+        {
+            return TruncateForName(*script, TabAutoNameMaxTaskLength);
+        }
+        if (auto table = TryLabelFromTable(stripped))
+        {
+            return TruncateForName(*table, TabAutoNameMaxTaskLength);
+        }
+
+        return TruncateForName(stripped, TabAutoNameMaxTaskLength);
+    }
+
+#pragma endregion
+
+    // Joins the available segments into the final session name.
+    //
+    // `fallbackTitle` is the shell-reported title we used before auto-naming;
+    // it is returned unchanged when shell integration gave us nothing to work
+    // with. The working directory is deliberately *not* a segment: the recents
+    // list already renders it in its own column next to the name.
+    inline std::wstring ComposeTabAutoName(std::wstring_view branch,
+                                           std::wstring_view task,
+                                           std::wstring_view fallbackTitle)
+    {
+        const auto trimmedBranch = TrimAscii(branch);
+        const auto trimmedTask = TrimAscii(task);
+
+        std::wstring name;
+        if (!trimmedBranch.empty())
+        {
+            name += trimmedBranch;
+        }
+        if (!trimmedTask.empty())
+        {
+            if (!name.empty())
+            {
+                name += TabAutoNameSeparator;
+            }
+            name += trimmedTask;
+        }
+
+        if (name.empty())
+        {
+            return std::wstring{ TrimAscii(fallbackTitle) };
+        }
+
+        return TruncateForName(name, TabAutoNameMaxLength);
+    }
+}

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -23,6 +23,7 @@
 #include "DebugTapConnection.h"
 #include "DesktopNotification.h"
 #include "DurableSessionHelpers.h"
+#include "TabAutoNaming.h"
 #include "..\TerminalSettingsModel\FileUtils.h"
 #include "../TerminalSettingsAppAdapterLib/TerminalSettings.h"
 
@@ -707,6 +708,87 @@ namespace winrt::TerminalApp::implementation
         tab->SetDurableTabSession(save.id, save.revision);
     }
 
+    // Picks the shell control whose context best describes the tab: the most
+    // recently used non-agent pane, falling back to the first one in the tree.
+    // Agent panes are skipped because their working directory belongs to the
+    // agent process, not to the user's work.
+    static TermControl _FindDescribingShellControl(Tab* const tab)
+    {
+        TermControl control{ nullptr };
+        for (const auto paneId : tab->GetMruPanes())
+        {
+            if (const auto pane = tab->GetRootPane()->FindPane(paneId);
+                pane && !pane->IsAgentPane())
+            {
+                control = pane->GetTerminalControl();
+                if (control)
+                {
+                    break;
+                }
+            }
+        }
+
+        if (!control)
+        {
+            tab->GetRootPane()->WalkTree([&](const auto& pane) {
+                if (!control && !pane->IsAgentPane())
+                {
+                    control = pane->GetTerminalControl();
+                }
+            });
+        }
+
+        return control;
+    }
+
+    // Builds the name a durable session is saved under.
+    //
+    // The shell-reported title alone makes the recents list a wall of identical
+    // shell names, so we combine the structured context shell integration
+    // already gives us into "branch · task". The working directory is not part
+    // of the name because the recents list renders it in its own column.
+    //
+    // This runs once, at tab close, which is what makes the git read and the
+    // (comparatively expensive) CommandHistory() call affordable here.
+    static winrt::hstring _BuildDurableTabSessionName(Tab* const tab, const TermControl& shellControl)
+    {
+        const auto fallbackTitle = tab->Title();
+
+        // A tab the user renamed by hand already has the name they wanted.
+        if (!tab->GetTabText().empty() || !shellControl)
+        {
+            return fallbackTitle;
+        }
+
+        std::wstring branch;
+        if (const auto cwd = shellControl.WorkingDirectory(); !cwd.empty())
+        {
+            const std::filesystem::path workingDirectory{ std::wstring_view{ cwd } };
+            if (auto found = TryReadGitBranch(workingDirectory))
+            {
+                branch = std::move(*found);
+            }
+        }
+
+        std::wstring task;
+        if (const auto history = shellControl.CommandHistory())
+        {
+            // A command still running at close time is the best description of
+            // the tab. Otherwise the user is sitting at an idle prompt, and the
+            // most recent completed command describes it instead.
+            if (const auto current = history.CurrentCommandline(); !current.empty())
+            {
+                task = FriendlyCommandLabel(std::wstring_view{ current });
+            }
+            else if (const auto commands = history.History(); commands && commands.Size() > 0)
+            {
+                task = FriendlyCommandLabel(std::wstring_view{ commands.GetAt(commands.Size() - 1) });
+            }
+        }
+
+        return winrt::hstring{ ComposeTabAutoName(branch, task, std::wstring_view{ fallbackTitle }) };
+    }
+
     void TerminalPage::_PersistDurableTabSession(Tab* const tab)
     {
         const auto closeActions = GetDurableTabSessionCloseActions(_settings.GlobalSettings().FirstWindowPreference());
@@ -741,7 +823,10 @@ namespace winrt::TerminalApp::implementation
 
         try
         {
-            const auto sessionName = tab->Title();
+            // Resolve the describing control up front: both the generated name
+            // and the persisted working directory come from the same pane.
+            const auto describingShellControl = _FindDescribingShellControl(tab);
+            const auto sessionName = _BuildDurableTabSessionName(tab, describingShellControl);
             auto actions = tab->BuildStartupActions(BuildStartupKind::Persist);
             if (sessionName.empty() || actions.empty())
             {
@@ -832,32 +917,9 @@ namespace winrt::TerminalApp::implementation
                 Json::Value params;
                 params["name"] = winrt::to_string(sessionName);
 
-                TermControl activeShellControl{ nullptr };
-                for (const auto paneId : tab->GetMruPanes())
+                if (describingShellControl)
                 {
-                    if (const auto pane = tab->GetRootPane()->FindPane(paneId);
-                        pane && !pane->IsAgentPane())
-                    {
-                        activeShellControl = pane->GetTerminalControl();
-                        if (activeShellControl)
-                        {
-                            break;
-                        }
-                    }
-                }
-                if (!activeShellControl)
-                {
-                    tab->GetRootPane()->WalkTree([&](const auto& pane) {
-                        if (!activeShellControl && !pane->IsAgentPane())
-                        {
-                            activeShellControl = pane->GetTerminalControl();
-                        }
-                    });
-                }
-
-                if (activeShellControl)
-                {
-                    params["active_pane_cwd"] = winrt::to_string(activeShellControl.WorkingDirectory());
+                    params["active_pane_cwd"] = winrt::to_string(describingShellControl.WorkingDirectory());
                 }
                 else
                 {

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
@@ -112,6 +112,7 @@
     <ClInclude Include="SharedWta.h" />
     <ClInclude Include="AgentPaneLog.h" />
     <ClInclude Include="AgentPaneDragStash.h" />
+    <ClInclude Include="TabAutoNaming.h" />
     <ClInclude Include="Tab.h">
       <DependentUpon>Tab.idl</DependentUpon>
     </ClInclude>

--- a/tools/wta/src/ui/durable_tab_sessions_view.rs
+++ b/tools/wta/src/ui/durable_tab_sessions_view.rs
@@ -238,6 +238,7 @@ fn case_insensitive_match_ranges(text: &str, query: &str) -> Vec<(usize, usize)>
         .collect()
 }
 
+#[derive(Debug)]
 struct FormattedRow {
     name: String,
     cwd: String,
@@ -250,6 +251,15 @@ struct FormattedRow {
 /// right-aligned whether or not a session is currently open in a tab. The
 /// label itself is left-aligned inside that column.
 const OPEN_COLUMN_WIDTH: usize = 8;
+
+/// Width kept available for the working directory when a session has one.
+///
+/// Auto-generated names ("branch · task") are much longer than the shell
+/// titles this list used to show, and a long enough name would otherwise
+/// consume the whole left column and drop the cwd entirely. The cwd is what
+/// distinguishes two sessions on the same branch, so it keeps a reserved
+/// share of the row.
+const MIN_CWD_WIDTH: usize = 16;
 
 fn format_row(
     session: &crate::durable_tab_session_store::DurableTabSessionSummary,
@@ -271,7 +281,16 @@ fn format_row(
     }
 
     let left_width = width - right_width - 2;
-    let name = super::layout::truncate_to_width(&session.name, left_width);
+    // Cap the name so a long generated one cannot squeeze out the cwd, but let
+    // it use the full column when there is no cwd to protect.
+    let name_budget = if session.active_pane_cwd.is_empty() {
+        left_width
+    } else {
+        left_width
+            .saturating_sub(MIN_CWD_WIDTH + 2)
+            .max(left_width / 2)
+    };
+    let name = super::layout::truncate_to_width(&session.name, name_budget);
     let name_width = UnicodeWidthStr::width(name.as_str());
     let cwd = if session.active_pane_cwd.is_empty() || name_width + 2 >= left_width {
         String::new()
@@ -346,6 +365,37 @@ mod tests {
         item.active_pane_cwd = r"C:\repos\portal".to_string();
         assert!(matches_query(&item, "PO"));
         assert!(!matches_query(&item, "bash"));
+    }
+
+    #[test]
+    fn long_generated_name_does_not_hide_the_cwd() {
+        let mut item = summary();
+        // What auto-naming now produces: "branch · task".
+        item.name = "dev/yuazha/tab-auto-naming \u{b7} dev server".to_string();
+        item.active_pane_cwd = r"C:\repos\portal".to_string();
+
+        let row = format_row(&item, 100, 86_400, false);
+
+        // The cwd is what separates two sessions on the same branch, so it has
+        // to survive a long name.
+        assert!(
+            !row.cwd.is_empty(),
+            "cwd was squeezed out by the name: {:?}",
+            row
+        );
+        assert!(!row.name.is_empty());
+    }
+
+    #[test]
+    fn name_may_use_the_full_column_without_a_cwd() {
+        let mut item = summary();
+        item.name = "dev/yuazha/tab-auto-naming \u{b7} dev server".to_string();
+        item.active_pane_cwd = String::new();
+
+        let row = format_row(&item, 100, 86_400, false);
+
+        assert!(row.cwd.is_empty());
+        assert_eq!(row.name, item.name);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Durable tab sessions were saved under whatever the shell reported as the console title. Every entry in the recents list read `PowerShell`, which made the list useless for finding a session again.

## Approach

Generate the name at **save time** by combining structured context we already own, into `branch · task`:

| Segment | Source |
|---|---|
| `branch` | `.git/HEAD` under the pane''s working directory |
| `task` | shell-integration command marks, through a small hand-maintained dictionary |

No AI and no network — the same inputs always produce the same name.

The dictionary maps common commands to friendly labels (`npm run dev` → `dev server`, `ssh box01` → `box01`, `python -m pytest` → `python tests`, `docker compose up` → `compose`), after normalizing: strip `sudo` / `env X=Y` / `npx`-style prefixes, and keep only the first command of a chain.

### The working directory is deliberately *not* a segment

The recents list already renders `active_pane_cwd` in its own column next to the name, and search already matches both. Putting the repo in the name too would just duplicate what the row shows — so the incremental value is `branch` + `task`.

## Why save time, and not the live tab title

Naming happens only in `_PersistDurableTabSession`, which runs once per tab close. That is what makes the `.git/HEAD` read and the comparatively expensive `CommandHistory()` call affordable, and it leaves the live tab strip completely untouched — no debouncing, no git caching, no title churn while a command runs.

## Notes

- **`.git` may be a *file*** (`gitdir: ...`) for linked worktrees and submodules. This repository is developed that way, so that form is handled and covered by a test — without it, naming would silently not work for anyone working in a `.worktree/<name>` checkout.
- **A tab the user renamed by hand keeps its name verbatim** (via the existing `Tab::GetTabText()`).
- **Unrecognized commands fall back to the truncated original**, so the worst case is "shows the command you ran" — never an empty or wrong label.
- **Dictionary labels are English literals.** The commands they describe are English too, and routing them through `.resw` localization would cost more than the table itself is worth. Easy to revisit.
- **The recents row now reserves width for the cwd.** Generated names are long enough that they previously pushed the cwd column out of the row entirely, and the cwd is what distinguishes two sessions on the same branch.
- The duplicated "pick the describing pane" logic in `_PersistDurableTabSession` is now extracted into `_FindDescribingShellControl`, so the name and `active_pane_cwd` come from the same pane.

## Validation

- `TerminalAppLib` and `TerminalApp.LocalTests` build clean.
- 3 new TAEF tests pass, including an **end-to-end test over a real worktree layout** on disk.
- Rust `durable_tab_sessions_view` tests: 10/10 (2 new).
- **Baseline compared:** stashed the change, rebuilt, and re-ran `TabTests` — the suite has 32 pre-existing failures in this environment (`_initializeTerminalPage` fails with `0x8000ffff`). After the change: still 32 failures, passed 13 → 16. No regression.

### Not covered

- No end-to-end runtime verification — that needs a full Terminal deployment.
- `_BuildDurableTabSessionName` itself has no unit test, because it needs a real `TermControl`. The same pre-existing `_initializeTerminalPage` failures block adding an integration test here. The pure helpers are well covered, but **the wiring itself currently rests on code review.**