### PR TITLE
Follow Copilot's live plugin installs in hook status and upgrade

### DIFF
--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -1471,6 +1471,7 @@ fn read_live_copilot(home: &Path) -> Option<InstalledInfo> {
         version: Some(version),
         enabled: copilot_plugin_enabled(home),
         loads_live: true,
+        live_source: Some(PathBuf::from(&dir)),
         gemini_source: None,
         gemini_type: None,
     })
@@ -2300,6 +2301,7 @@ fn parse_codex_plugin_list_entry(stdout: &str) -> Option<InstalledInfo> {
             version,
             enabled,
             loads_live: false,
+            live_source: None,
             gemini_source: None,
             gemini_type: None,
         });
@@ -3783,6 +3785,11 @@ struct InstalledInfo {
     /// already what runs and there is nothing to push an upgrade into.
     /// Copilot-only today; every other CLI copies.
     loads_live: bool,
+    /// Copilot-only: the directory a live install is registered against.
+    /// Carried so the decision can tell "loading the bundle we ship" from
+    /// "loading some other tree's bundle", which is a repoint, not an
+    /// upgrade. `None` for copied installs.
+    live_source: Option<PathBuf>,
     /// Gemini-only: the recorded install source path from
     /// `.gemini-extension-install.json`. `None` for Copilot/Claude.
     gemini_source: Option<PathBuf>,
@@ -3849,6 +3856,7 @@ fn read_installed_copilot(home: &Path) -> InstalledProbe {
         version,
         enabled,
         loads_live: false,
+        live_source: None,
         gemini_source: None,
         gemini_type: None,
     }))
@@ -3888,6 +3896,7 @@ fn read_installed_claude() -> InstalledProbe {
             version,
             enabled,
             loads_live: false,
+            live_source: None,
             gemini_source: None,
             gemini_type: None,
         }));
@@ -3962,6 +3971,7 @@ fn read_installed_gemini(home: &Path) -> InstalledProbe {
         // re-queries via CLI before any destructive action.
         enabled: true,
         loads_live: false,
+        live_source: None,
         gemini_source,
         gemini_type,
     }))
@@ -3988,6 +3998,7 @@ fn read_installed_opencode(home: &Path) -> InstalledProbe {
         version: complete.then(|| read_version_field(&manifest)).flatten(),
         enabled: true,
         loads_live: false,
+        live_source: None,
         gemini_source: None,
         gemini_type: None,
     }))
@@ -4059,13 +4070,24 @@ fn decide_upgrade(
     if !installed.enabled {
         return UpgradeAction::Skip(SkipReason::Disabled);
     }
-    // A live install re-reads its directory every session, so it already runs
-    // whatever is on disk there. Checked before the version comparison so the
-    // decision doesn't hinge on the two versions happening to match: when a
-    // stale registration makes them differ, the repair is the install path's
-    // repoint, not an upgrade.
+    // A live install runs whatever is in the directory it is registered
+    // against, so there is no copy to push a newer bundle into — but only
+    // while that directory is the bundle this wta ships. A registration left
+    // pointing at another tree keeps loading *that* tree's hooks, and the
+    // repair is the repoint in `upgrade_copilot`, not a version bump. Version
+    // comparison can't stand in for this: the two trees usually carry the
+    // same hook version, so a stale registration reads as up to date.
     if installed.loads_live {
-        return UpgradeAction::Skip(SkipReason::LiveInstall);
+        let on_current_bundle = match (&installed.live_source, current_bundle_dir) {
+            (Some(src), Some(bundle)) => paths_equivalent(src, bundle),
+            // Bundle unresolvable: we couldn't repoint even if we wanted to.
+            _ => true,
+        };
+        return if on_current_bundle {
+            UpgradeAction::Skip(SkipReason::LiveInstall)
+        } else {
+            UpgradeAction::UpdatePlugin
+        };
     }
     let Some(installed_version) = installed.version else {
         if cli == CliKind::OpenCode {

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -379,6 +379,20 @@ impl CliStatus {
             detection_fallback: None,
         }
     }
+
+    /// Apply a parsed `plugin list` result to the row.
+    ///
+    /// The listing answers four fields at once, `installed_version` among
+    /// them. Applying them through one helper is what keeps a CLI from
+    /// silently dropping the version the CLI just reported and falling back
+    /// to the on-disk readers — which report what was *recorded*, not what is
+    /// loaded, and can disagree.
+    fn apply_presence(&mut self, presence: PluginPresence, marketplace_registered: bool) {
+        self.plugin_installed = presence.installed;
+        self.plugin_enabled = presence.enabled;
+        self.installed_version = presence.version.map(|v| v.to_string());
+        self.marketplace_registered = marketplace_registered;
+    }
 }
 
 /// Top-level shape of `wta hooks status --json`. `bundle_source`
@@ -1424,11 +1438,7 @@ fn status_for(cli: CliKind, home: Option<&Path>) -> CliStatus {
 fn installed_version_from_disk(cli: CliKind, home: Option<&Path>) -> Option<Version> {
     let home = home?;
     match cli {
-        CliKind::Copilot => read_installed_copilot(home)
-            .ok()
-            .flatten()
-            .and_then(|i| i.version)
-            .or_else(|| copilot_live_plugin_version(home)),
+        CliKind::Copilot => read_installed_copilot_any(home).ok().flatten()?.version,
         CliKind::Gemini => read_installed_gemini(home).ok().flatten()?.version,
         CliKind::OpenCode => read_installed_opencode(home).ok().flatten()?.version,
         // Claude and Codex both unpack into `<cache>/<plugin>/<version>/`.
@@ -1437,8 +1447,8 @@ fn installed_version_from_disk(cli: CliKind, home: Option<&Path>) -> Option<Vers
     }
 }
 
-/// Version a *live* Copilot plugin would load, read from the marketplace
-/// directory it is registered against.
+/// State of a *live* Copilot plugin, read from the marketplace directory it
+/// is registered against.
 ///
 /// Installing from a local marketplace directory makes Copilot load the plugin
 /// live: nothing is copied and no entry lands in `config.json`'s
@@ -1447,13 +1457,41 @@ fn installed_version_from_disk(cli: CliKind, home: Option<&Path>) -> Option<Vers
 /// says right now — which is also what makes it worth reporting, because a
 /// registration pointing at a stale worktree really is running a different
 /// version from the bundle this wta ships.
-fn copilot_live_plugin_version(home: &Path) -> Option<Version> {
+///
+/// `None` when the registration doesn't resolve to a readable manifest, so a
+/// pruned directory falls through to the copied record rather than masking it.
+fn read_live_copilot(home: &Path) -> Option<InstalledInfo> {
     let info = copilot_marketplace_info(home);
     if !info.valid {
         return None;
     }
     let dir = info.path?;
-    read_version_field(&Path::new(&dir).join(PLUGIN_NAME).join("plugin.json"))
+    let version = read_version_field(&Path::new(&dir).join(PLUGIN_NAME).join("plugin.json"))?;
+    Some(InstalledInfo {
+        version: Some(version),
+        enabled: copilot_plugin_enabled(home),
+        gemini_source: None,
+        gemini_type: None,
+    })
+}
+
+/// Whether `~/.copilot/settings.json` has our plugin switched on.
+///
+/// A live plugin records enablement here rather than on an `installedPlugins`
+/// entry. Absent means enabled: Copilot only writes the key once the plugin
+/// has been toggled.
+fn copilot_plugin_enabled(home: &Path) -> bool {
+    let path = home.join(".copilot").join("settings.json");
+    let Ok(text) = fs::read_to_string(&path) else {
+        return true;
+    };
+    let Ok(v) = serde_json::from_str::<Value>(&strip_jsonc_line_comments(&text)) else {
+        return true;
+    };
+    v.get("enabledPlugins")
+        .and_then(|m| m.get(format!("{}@{}", PLUGIN_NAME, MARKETPLACE_NAME)))
+        .and_then(Value::as_bool)
+        .unwrap_or(true)
 }
 
 /// Highest version directory under a plugin cache root that is still live.
@@ -1551,9 +1589,7 @@ fn copilot_status(on_path: bool, bin_path: Option<String>, home: Option<&Path>) 
         .map(|o| parse_copilot_marketplace_list(&o.stdout));
 
     if let (Some(p), Some(m)) = (plugin_presence, mkt_ok) {
-        out.plugin_installed = p.installed;
-        out.plugin_enabled = p.enabled;
-        out.marketplace_registered = m;
+        out.apply_presence(p, m);
     } else {
         copilot_fs_fallback(&mut out, home);
     }
@@ -1747,10 +1783,7 @@ fn claude_status(on_path: bool, bin_path: Option<String>, home: Option<&Path>) -
     .and_then(|o| parse_claude_marketplace_list_json(&o.stdout));
 
     if let (Some(p), Some(m)) = (plugin_json, mkt_json) {
-        out.plugin_installed = p.installed;
-        out.plugin_enabled = p.enabled;
-        out.installed_version = p.version.map(|v| v.to_string());
-        out.marketplace_registered = m;
+        out.apply_presence(p, m);
     } else {
         claude_fs_fallback(&mut out, home);
     }
@@ -3752,10 +3785,30 @@ struct InstalledInfo {
     gemini_type: Option<String>,
 }
 
-/// Read Copilot's installed-plugin entry directly from
-/// `~/.copilot/config.json`. Pure file IO — no spawn.
+/// Outcome of reading a CLI's installed-plugin state. `Ok(None)` means "no
+/// record found"; `Err` carries a user-facing reason the record was
+/// unreadable.
 type InstalledProbe = Result<Option<InstalledInfo>, String>;
 
+/// Copilot's installed-plugin state as its own on-disk records describe it.
+///
+/// A `wt-local` registration that still resolves to a readable plugin
+/// directory wins over `config.json`'s `installedPlugins`. Copilot loads a
+/// directory marketplace *live* and ignores any copied record for the same
+/// plugin: Copilot CLI 1.0.81-9 lists only the live entry even when
+/// `installedPlugins` still carries a populated `cache_path` for an older
+/// version. Preferring the copied record there would report a version the CLI
+/// stopped loading — the same wrong answer as the `v?` this replaced, only
+/// harder to notice because it looks like a real number.
+fn read_installed_copilot_any(home: &Path) -> InstalledProbe {
+    if let Some(live) = read_live_copilot(home) {
+        return Ok(Some(live));
+    }
+    read_installed_copilot(home)
+}
+
+/// Read Copilot's copied-install entry directly from
+/// `~/.copilot/config.json`. Pure file IO — no spawn.
 fn read_installed_copilot(home: &Path) -> InstalledProbe {
     let path = home.join(".copilot").join("config.json");
     let text = match fs::read_to_string(&path) {
@@ -4354,7 +4407,7 @@ pub fn installed_plugin_version(cli_name: &str) -> Option<String> {
 /// Per-CLI dispatch for reading installed-plugin state.
 fn probe_installed(cli: CliKind, home: &Path) -> InstalledProbe {
     match cli {
-        CliKind::Copilot => read_installed_copilot(home),
+        CliKind::Copilot => read_installed_copilot_any(home),
         CliKind::Claude => {
             // `claude plugin list --json` requires the CLI on PATH; if
             // it isn't, treat as "not installed" rather than spawning.

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -1424,13 +1424,36 @@ fn status_for(cli: CliKind, home: Option<&Path>) -> CliStatus {
 fn installed_version_from_disk(cli: CliKind, home: Option<&Path>) -> Option<Version> {
     let home = home?;
     match cli {
-        CliKind::Copilot => read_installed_copilot(home).ok().flatten()?.version,
+        CliKind::Copilot => read_installed_copilot(home)
+            .ok()
+            .flatten()
+            .and_then(|i| i.version)
+            .or_else(|| copilot_live_plugin_version(home)),
         CliKind::Gemini => read_installed_gemini(home).ok().flatten()?.version,
         CliKind::OpenCode => read_installed_opencode(home).ok().flatten()?.version,
         // Claude and Codex both unpack into `<cache>/<plugin>/<version>/`.
         CliKind::Claude => newest_live_cached_version(&claude_plugin_cache_dir(home)),
         CliKind::Codex => newest_live_cached_version(&codex_plugin_cache_dir(home)),
     }
+}
+
+/// Version a *live* Copilot plugin would load, read from the marketplace
+/// directory it is registered against.
+///
+/// Installing from a local marketplace directory makes Copilot load the plugin
+/// live: nothing is copied and no entry lands in `config.json`'s
+/// `installedPlugins`, so [`read_installed_copilot`] finds nothing at all. The
+/// version in effect is whatever `plugin.json` under the registered directory
+/// says right now — which is also what makes it worth reporting, because a
+/// registration pointing at a stale worktree really is running a different
+/// version from the bundle this wta ships.
+fn copilot_live_plugin_version(home: &Path) -> Option<Version> {
+    let info = copilot_marketplace_info(home);
+    if !info.valid {
+        return None;
+    }
+    let dir = info.path?;
+    read_version_field(&Path::new(&dir).join(PLUGIN_NAME).join("plugin.json"))
 }
 
 /// Highest version directory under a plugin cache root that is still live.
@@ -1980,12 +2003,32 @@ fn parse_copilot_plugin_list(stdout: &str) -> PluginPresence {
     let entry = stdout.lines().find(|line| line.contains(&needle));
     PluginPresence {
         installed: entry.is_some(),
-        enabled: entry.is_some_and(|line| !line.to_ascii_lowercase().contains("[disabled]")),
-        // Copilot CLI 1.0.44-2 prints no version column here; the version
-        // comes from `~/.copilot/config.json` instead, which is a plain file
-        // read and therefore cheaper than a second `copilot` invocation.
-        version: None,
+        // Copied plugins render the state as `[disabled]`; live plugins
+        // (installed from a local marketplace directory) render it as
+        // `(enabled)` / `(disabled)`. Accept both delimiters so a disabled
+        // live plugin isn't reported as enabled.
+        enabled: entry.is_some_and(|line| {
+            let lower = line.to_ascii_lowercase();
+            !lower.contains("[disabled]") && !lower.contains("(disabled)")
+        }),
+        version: entry.and_then(parse_copilot_list_version),
     }
+}
+
+/// Pull the version out of a `copilot plugin list` entry line.
+///
+/// Copilot renders it as a parenthesized `v`-prefixed token, both for copied
+/// entries (`• wt-agent-hooks@wt-local (v0.1.0)`) and live ones
+/// (`• wt-agent-hooks@wt-local (v0.1.6) (enabled)`). The line also carries
+/// `(enabled)` / `[disabled]` state markers, so match on the `v` prefix plus a
+/// successful semver parse rather than on "first parenthesized group".
+///
+/// `None` when the line carries no parseable version — the caller falls back
+/// to the CLI's on-disk records.
+fn parse_copilot_list_version(line: &str) -> Option<Version> {
+    line.split(['(', ')', '[', ']', ' ', '\t'])
+        .filter_map(|token| token.strip_prefix('v'))
+        .find_map(|token| token.parse::<Version>().ok())
 }
 
 /// Search for our marketplace name in the `Registered marketplaces:`
@@ -2021,9 +2064,9 @@ struct PluginPresence {
     installed: bool,
     enabled: bool,
     /// Version the CLI itself reported, when its listing carries one.
-    /// `None` means "this CLI's list output doesn't say" (Copilot's plain-text
-    /// listing) — the caller falls back to the CLI's on-disk records rather
-    /// than paying a second spawn just to learn a version number.
+    /// `None` means "this CLI's list output doesn't say" — the caller falls
+    /// back to the CLI's on-disk records rather than paying a second spawn
+    /// just to learn a version number.
     version: Option<Version>,
 }
 

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -1470,6 +1470,7 @@ fn read_live_copilot(home: &Path) -> Option<InstalledInfo> {
     Some(InstalledInfo {
         version: Some(version),
         enabled: copilot_plugin_enabled(home),
+        loads_live: true,
         gemini_source: None,
         gemini_type: None,
     })
@@ -2298,6 +2299,7 @@ fn parse_codex_plugin_list_entry(stdout: &str) -> Option<InstalledInfo> {
         return Some(InstalledInfo {
             version,
             enabled,
+            loads_live: false,
             gemini_source: None,
             gemini_type: None,
         });
@@ -3776,6 +3778,11 @@ fn read_bundled_version(cli: CliKind) -> Option<Version> {
 struct InstalledInfo {
     version: Option<Version>,
     enabled: bool,
+    /// The CLI loads the plugin in place from the registered marketplace
+    /// directory instead of keeping its own copy, so the bundle on disk is
+    /// already what runs and there is nothing to push an upgrade into.
+    /// Copilot-only today; every other CLI copies.
+    loads_live: bool,
     /// Gemini-only: the recorded install source path from
     /// `.gemini-extension-install.json`. `None` for Copilot/Claude.
     gemini_source: Option<PathBuf>,
@@ -3841,6 +3848,7 @@ fn read_installed_copilot(home: &Path) -> InstalledProbe {
     Ok(Some(InstalledInfo {
         version,
         enabled,
+        loads_live: false,
         gemini_source: None,
         gemini_type: None,
     }))
@@ -3879,6 +3887,7 @@ fn read_installed_claude() -> InstalledProbe {
         return Ok(Some(InstalledInfo {
             version,
             enabled,
+            loads_live: false,
             gemini_source: None,
             gemini_type: None,
         }));
@@ -3952,6 +3961,7 @@ fn read_installed_gemini(home: &Path) -> InstalledProbe {
         // purposes, default to `enabled: true` here; the fallback path
         // re-queries via CLI before any destructive action.
         enabled: true,
+        loads_live: false,
         gemini_source,
         gemini_type,
     }))
@@ -3977,6 +3987,7 @@ fn read_installed_opencode(home: &Path) -> InstalledProbe {
         // surviving manifest already has the current bundle version.
         version: complete.then(|| read_version_field(&manifest)).flatten(),
         enabled: true,
+        loads_live: false,
         gemini_source: None,
         gemini_type: None,
     }))
@@ -3990,6 +4001,13 @@ fn read_installed_opencode(home: &Path) -> InstalledProbe {
 enum SkipReason {
     NotInstalled,
     Disabled,
+    /// Installed, but the CLI loads it in place from the bundle directory —
+    /// there is no copy to push a newer version into. Distinct from
+    /// `NotInstalled`, which is what this used to look like before
+    /// `read_live_copilot` recognized the shape, and from `UpToDate`, which
+    /// would be a coincidence of the two versions matching rather than a
+    /// statement that an upgrade cannot apply.
+    LiveInstall,
     UpToDate,
     UnknownInstalledVersion,
     UnknownBundleVersion,
@@ -4040,6 +4058,14 @@ fn decide_upgrade(
     };
     if !installed.enabled {
         return UpgradeAction::Skip(SkipReason::Disabled);
+    }
+    // A live install re-reads its directory every session, so it already runs
+    // whatever is on disk there. Checked before the version comparison so the
+    // decision doesn't hinge on the two versions happening to match: when a
+    // stale registration makes them differ, the repair is the install path's
+    // repoint, not an upgrade.
+    if installed.loads_live {
+        return UpgradeAction::Skip(SkipReason::LiveInstall);
     }
     let Some(installed_version) = installed.version else {
         if cli == CliKind::OpenCode {

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -3557,11 +3557,12 @@ fn decide_skip_when_loaded_live_from_current_bundle() {
 }
 
 /// A registration left pointing at another tree keeps loading *that* tree's
-/// hooks. `upgrade_copilot` repoints it, so the decision must reach it —
-/// including when both trees carry the same hook version, which is the
-/// common case and the reason version comparison can't stand in for this.
+/// hooks. The repoint in `upgrade_copilot` is what fixes it, so the decision
+/// must reach it — including when both trees carry the same hook version,
+/// which is the common case and the reason version comparison can't stand in
+/// for this.
 #[test]
-fn decide_repoints_live_install_registered_against_another_tree() {
+fn decide_updates_live_install_registered_against_another_tree() {
     let bundle = unique_dir("live-current");
     let other = unique_dir("live-stale");
     let mut info = installed("0.1.6", true);

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -3244,10 +3244,13 @@ fn installed_version_from_disk_reads_live_copilot_marketplace() {
     );
 }
 
-/// The copied-install record wins when both exist: it is what the CLI
-/// actually loaded, whereas the marketplace directory may have moved on.
+/// The live marketplace wins when both records exist. Copilot ignores a
+/// copied record once the plugin loads live from a directory marketplace —
+/// CLI 1.0.81-9 lists only the live entry even with a fully populated
+/// `cache_path` for an older version — so reporting the copied version would
+/// name a build the CLI stopped loading.
 #[test]
-fn installed_version_from_disk_prefers_copilot_config_entry() {
+fn installed_version_from_disk_prefers_live_copilot_marketplace() {
     let home = unique_dir("copilot-copied-version");
     let cfg_dir = home.join(".copilot");
     fs::create_dir_all(&cfg_dir).unwrap();
@@ -3271,8 +3274,58 @@ fn installed_version_from_disk_prefers_copilot_config_entry() {
 
     assert_eq!(
         installed_version_from_disk(CliKind::Copilot, Some(&home)),
+        Some("0.1.6".parse().unwrap())
+    );
+}
+
+/// A registration pointing at a pruned worktree has no readable manifest, so
+/// it must not shadow a copied record that is still valid.
+#[test]
+fn installed_version_from_disk_falls_back_to_copied_copilot_record() {
+    let home = unique_dir("copilot-fallback-version");
+    let cfg_dir = home.join(".copilot");
+    fs::create_dir_all(&cfg_dir).unwrap();
+    fs::write(
+        cfg_dir.join("config.json"),
+        r#"{"installedPlugins":[
+{ "name": "wt-agent-hooks", "marketplace": "wt-local", "version": "0.1.2" }
+]}"#,
+    )
+    .unwrap();
+
+    let marketplace = unique_dir("copilot-fallback-bundle");
+    fs::remove_dir_all(&marketplace).ok();
+    write_copilot_marketplace_settings(&cfg_dir, &marketplace);
+
+    assert_eq!(
+        installed_version_from_disk(CliKind::Copilot, Some(&home)),
         Some("0.1.2".parse().unwrap())
     );
+}
+
+/// A live plugin records enablement in `settings.json`, not on an
+/// `installedPlugins` entry. Missing that would let `decide_upgrade` update a
+/// plugin the user switched off.
+#[test]
+fn read_installed_copilot_any_reads_live_enabled_flag() {
+    let home = unique_dir("copilot-live-disabled");
+    let cfg_dir = home.join(".copilot");
+    fs::create_dir_all(&cfg_dir).unwrap();
+    fs::write(cfg_dir.join("config.json"), r#"{"installedPlugins":[]}"#).unwrap();
+
+    let marketplace = unique_dir("copilot-live-disabled-bundle");
+    let plugin_dir = marketplace.join(PLUGIN_NAME);
+    fs::create_dir_all(&plugin_dir).unwrap();
+    fs::write(
+        plugin_dir.join("plugin.json"),
+        r#"{"name":"wt-agent-hooks","version":"0.1.6"}"#,
+    )
+    .unwrap();
+    write_copilot_settings(&cfg_dir, &marketplace, Some(false));
+
+    let info = read_installed_copilot_any(&home).unwrap().unwrap();
+    assert_eq!(info.version, Some("0.1.6".parse().unwrap()));
+    assert!(!info.enabled);
 }
 
 /// A registration pointing at a pruned worktree has no readable manifest, so
@@ -3297,7 +3350,13 @@ fn installed_version_from_disk_ignores_stale_copilot_marketplace() {
 /// Write a `~/.copilot/settings.json` registering `wt-local` against
 /// `marketplace`, including the JSONC banner Copilot emits.
 fn write_copilot_marketplace_settings(copilot_dir: &Path, marketplace: &Path) {
-    let settings = serde_json::json!({
+    write_copilot_settings(copilot_dir, marketplace, None);
+}
+
+/// As above, plus an explicit `enabledPlugins` entry. `None` omits the key,
+/// which is how Copilot leaves it until the plugin is toggled.
+fn write_copilot_settings(copilot_dir: &Path, marketplace: &Path, enabled: Option<bool>) {
+    let mut settings = serde_json::json!({
         "extraKnownMarketplaces": {
             MARKETPLACE_NAME: {
                 "source": {
@@ -3307,11 +3366,41 @@ fn write_copilot_marketplace_settings(copilot_dir: &Path, marketplace: &Path) {
             }
         }
     });
+    if let Some(enabled) = enabled {
+        let mut plugins = serde_json::Map::new();
+        plugins.insert(
+            format!("{}@{}", PLUGIN_NAME, MARKETPLACE_NAME),
+            serde_json::Value::Bool(enabled),
+        );
+        settings["enabledPlugins"] = serde_json::Value::Object(plugins);
+    }
     let body = format!(
         "// User settings belong in settings.json.\n{}\n",
         serde_json::to_string_pretty(&settings).unwrap()
     );
     fs::write(copilot_dir.join("settings.json"), body).unwrap();
+}
+
+/// The version a CLI's own listing reported has to land on the row. Dropping
+/// it silently demotes the row to the on-disk readers, which report what was
+/// recorded rather than what is loaded — that is how the Copilot row ended up
+/// rendering a stale `installedPlugins` version.
+#[test]
+fn apply_presence_carries_the_listed_version() {
+    let mut row = CliStatus::stub_skipped(CliKind::Copilot);
+    row.apply_presence(
+        PluginPresence {
+            installed: true,
+            enabled: true,
+            version: Some("0.1.6".parse().unwrap()),
+        },
+        true,
+    );
+
+    assert!(row.plugin_installed);
+    assert!(row.plugin_enabled);
+    assert!(row.marketplace_registered);
+    assert_eq!(row.installed_version.as_deref(), Some("0.1.6"));
 }
 
 // ---- auto-upgrade: read_installed_gemini ---------------------------

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -3328,6 +3328,56 @@ fn read_installed_copilot_any_reads_live_enabled_flag() {
     assert!(!info.enabled);
 }
 
+/// The probe must mark a live install as such, so `decide_upgrade` can say
+/// "nothing to push here" instead of inferring it from the versions matching.
+#[test]
+fn read_installed_copilot_any_marks_live_installs() {
+    let home = unique_dir("copilot-live-marked");
+    let cfg_dir = home.join(".copilot");
+    fs::create_dir_all(&cfg_dir).unwrap();
+    fs::write(
+        cfg_dir.join("config.json"),
+        r#"{"installedPlugins":[
+{ "name": "wt-agent-hooks", "marketplace": "wt-local", "version": "0.1.2" }
+]}"#,
+    )
+    .unwrap();
+
+    let marketplace = unique_dir("copilot-live-marked-bundle");
+    let plugin_dir = marketplace.join(PLUGIN_NAME);
+    fs::create_dir_all(&plugin_dir).unwrap();
+    fs::write(
+        plugin_dir.join("plugin.json"),
+        r#"{"name":"wt-agent-hooks","version":"0.1.6"}"#,
+    )
+    .unwrap();
+    write_copilot_settings(&cfg_dir, &marketplace, Some(true));
+
+    let info = read_installed_copilot_any(&home).unwrap().unwrap();
+    assert!(info.loads_live);
+    assert_eq!(info.version, Some("0.1.6".parse().unwrap()));
+}
+
+/// The copied record that a live install falls back to is not live, so it
+/// keeps driving the upgrade path.
+#[test]
+fn read_installed_copilot_any_leaves_copied_records_unmarked() {
+    let home = unique_dir("copilot-copied-unmarked");
+    let cfg_dir = home.join(".copilot");
+    fs::create_dir_all(&cfg_dir).unwrap();
+    fs::write(
+        cfg_dir.join("config.json"),
+        r#"{"installedPlugins":[
+{ "name": "wt-agent-hooks", "marketplace": "wt-local", "version": "0.1.2" }
+]}"#,
+    )
+    .unwrap();
+
+    let info = read_installed_copilot_any(&home).unwrap().unwrap();
+    assert!(!info.loads_live);
+    assert_eq!(info.version, Some("0.1.2".parse().unwrap()));
+}
+
 /// A registration pointing at a pruned worktree has no readable manifest, so
 /// the version stays unknown rather than being reported as the bundle's.
 #[test]
@@ -3461,6 +3511,7 @@ fn installed(version: &str, enabled: bool) -> InstalledInfo {
     InstalledInfo {
         version: Some(version.parse().unwrap()),
         enabled,
+        loads_live: false,
         gemini_source: None,
         gemini_type: None,
     }
@@ -3482,6 +3533,54 @@ fn decide_skip_when_disabled() {
         None,
     );
     assert_eq!(a, UpgradeAction::Skip(SkipReason::Disabled));
+}
+
+/// A live install re-reads the bundle directory every session, so there is
+/// no copy to push a newer version into — even when the version it reports
+/// is behind the bundle. Reported distinctly from `UpToDate`, which would
+/// only be the two versions coinciding, and from `NotInstalled`, which is
+/// what this looked like before live installs were recognized at all.
+#[test]
+fn decide_skip_when_loaded_live() {
+    let mut info = installed("0.1.0", true);
+    info.loads_live = true;
+    let a = decide_upgrade(
+        CliKind::Copilot,
+        Some("0.1.6".parse().unwrap()),
+        Some(&info),
+        None,
+    );
+    assert_eq!(a, UpgradeAction::Skip(SkipReason::LiveInstall));
+}
+
+/// Disabled wins over live: the user turned it off, and that is the more
+/// actionable thing to report.
+#[test]
+fn decide_skip_disabled_takes_precedence_over_live() {
+    let mut info = installed("0.1.0", false);
+    info.loads_live = true;
+    let a = decide_upgrade(
+        CliKind::Copilot,
+        Some("0.1.6".parse().unwrap()),
+        Some(&info),
+        None,
+    );
+    assert_eq!(a, UpgradeAction::Skip(SkipReason::Disabled));
+}
+
+/// A copied record must keep driving the upgrade path — that is the shape a
+/// pre-1.0.81-8 CLI still has.
+#[test]
+fn decide_upgrades_copied_copilot_install() {
+    let info = installed("0.1.0", true);
+    assert!(!info.loads_live);
+    let a = decide_upgrade(
+        CliKind::Copilot,
+        Some("0.1.6".parse().unwrap()),
+        Some(&info),
+        None,
+    );
+    assert_eq!(a, UpgradeAction::UpdatePlugin);
 }
 
 #[test]
@@ -3517,6 +3616,7 @@ fn decide_skip_when_bundle_or_installed_version_unknown() {
     let info = InstalledInfo {
         version: None,
         enabled: true,
+        loads_live: false,
         gemini_source: None,
         gemini_type: None,
     };
@@ -3569,6 +3669,7 @@ fn decide_opencode_repairs_unknown_installed_version() {
     let info = InstalledInfo {
         version: None,
         enabled: true,
+        loads_live: false,
         gemini_source: None,
         gemini_type: None,
     };
@@ -3619,6 +3720,7 @@ fn decide_gemini_in_place_when_source_under_current_bundle() {
     let info = InstalledInfo {
         version: Some("0.1.0".parse().unwrap()),
         enabled: true,
+        loads_live: false,
         gemini_source: Some(nested_src.clone()),
         gemini_type: Some("local".into()),
     };
@@ -3640,6 +3742,7 @@ fn decide_gemini_reinstall_when_source_stale() {
     let info = InstalledInfo {
         version: Some("0.1.0".parse().unwrap()),
         enabled: true,
+        loads_live: false,
         gemini_source: Some(stale_src),
         gemini_type: Some("local".into()),
     };
@@ -3660,6 +3763,7 @@ fn decide_gemini_reinstall_when_type_is_not_local() {
     let info = InstalledInfo {
         version: Some("0.1.0".parse().unwrap()),
         enabled: true,
+        loads_live: false,
         gemini_source: Some(inside),
         gemini_type: Some("git".into()),
     };

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -1800,6 +1800,25 @@ Installed plugins:
     let presence = parse_copilot_plugin_list(stdout);
     assert!(presence.installed);
     assert!(presence.enabled);
+    assert_eq!(presence.version, Some("0.1.0".parse().unwrap()));
+}
+
+/// Live-plugin rendering: installing from a local marketplace directory makes
+/// Copilot load the plugin in place and print an explicit `(enabled)` marker
+/// plus a `from <path>` continuation line. The version still has to come off
+/// the entry line, because a live plugin leaves no `installedPlugins` record
+/// behind for the on-disk reader to find.
+#[test]
+fn copilot_plugin_list_parser_reads_live_entry_version() {
+    let stdout = "\
+Live Plugins (loaded from a local marketplace directory, never copied):
+  • wt-agent-hooks@wt-local (v0.1.6) (enabled)
+      from C:\\repo\\bin\\AppX\\wt-agent-hooks\\copilot
+";
+    let presence = parse_copilot_plugin_list(stdout);
+    assert!(presence.installed);
+    assert!(presence.enabled);
+    assert_eq!(presence.version, Some("0.1.6".parse().unwrap()));
 }
 
 #[test]
@@ -1811,6 +1830,33 @@ Installed plugins:
     let presence = parse_copilot_plugin_list(stdout);
     assert!(presence.installed);
     assert!(!presence.enabled);
+    assert_eq!(presence.version, Some("0.1.4".parse().unwrap()));
+}
+
+/// Live entries spell the state with parentheses rather than brackets.
+#[test]
+fn copilot_plugin_list_parser_reports_live_disabled() {
+    let stdout = "\
+Live Plugins (loaded from a local marketplace directory, never copied):
+  • wt-agent-hooks@wt-local (v0.1.6) (disabled)
+";
+    let presence = parse_copilot_plugin_list(stdout);
+    assert!(presence.installed);
+    assert!(!presence.enabled);
+}
+
+/// A listing without a version column is still a valid install — the caller
+/// falls back to the on-disk readers rather than treating it as missing.
+#[test]
+fn copilot_plugin_list_parser_tolerates_missing_version() {
+    let stdout = "\
+Installed plugins:
+  • wt-agent-hooks@wt-local
+";
+    let presence = parse_copilot_plugin_list(stdout);
+    assert!(presence.installed);
+    assert!(presence.enabled);
+    assert_eq!(presence.version, None);
 }
 
 #[test]
@@ -3169,6 +3215,103 @@ fn read_installed_copilot_returns_none_when_not_installed() {
     fs::create_dir_all(&cfg_dir).unwrap();
     fs::write(cfg_dir.join("config.json"), r#"{"installedPlugins":[]}"#).unwrap();
     assert!(read_installed_copilot(&home).unwrap().is_none());
+}
+
+/// A live install leaves `installedPlugins` empty — the only record is the
+/// `wt-local` marketplace registration — so the version has to come from the
+/// `plugin.json` under the registered directory. Without this fallback
+/// `wta hooks status` renders a working install as `v?`.
+#[test]
+fn installed_version_from_disk_reads_live_copilot_marketplace() {
+    let home = unique_dir("copilot-live-version");
+    let cfg_dir = home.join(".copilot");
+    fs::create_dir_all(&cfg_dir).unwrap();
+    fs::write(cfg_dir.join("config.json"), r#"{"installedPlugins":[]}"#).unwrap();
+
+    let marketplace = unique_dir("copilot-live-bundle");
+    let plugin_dir = marketplace.join(PLUGIN_NAME);
+    fs::create_dir_all(&plugin_dir).unwrap();
+    fs::write(
+        plugin_dir.join("plugin.json"),
+        r#"{"name":"wt-agent-hooks","version":"0.1.6"}"#,
+    )
+    .unwrap();
+    write_copilot_marketplace_settings(&cfg_dir, &marketplace);
+
+    assert_eq!(
+        installed_version_from_disk(CliKind::Copilot, Some(&home)),
+        Some("0.1.6".parse().unwrap())
+    );
+}
+
+/// The copied-install record wins when both exist: it is what the CLI
+/// actually loaded, whereas the marketplace directory may have moved on.
+#[test]
+fn installed_version_from_disk_prefers_copilot_config_entry() {
+    let home = unique_dir("copilot-copied-version");
+    let cfg_dir = home.join(".copilot");
+    fs::create_dir_all(&cfg_dir).unwrap();
+    fs::write(
+        cfg_dir.join("config.json"),
+        r#"{"installedPlugins":[
+{ "name": "wt-agent-hooks", "marketplace": "wt-local", "version": "0.1.2" }
+]}"#,
+    )
+    .unwrap();
+
+    let marketplace = unique_dir("copilot-copied-bundle");
+    let plugin_dir = marketplace.join(PLUGIN_NAME);
+    fs::create_dir_all(&plugin_dir).unwrap();
+    fs::write(
+        plugin_dir.join("plugin.json"),
+        r#"{"name":"wt-agent-hooks","version":"0.1.6"}"#,
+    )
+    .unwrap();
+    write_copilot_marketplace_settings(&cfg_dir, &marketplace);
+
+    assert_eq!(
+        installed_version_from_disk(CliKind::Copilot, Some(&home)),
+        Some("0.1.2".parse().unwrap())
+    );
+}
+
+/// A registration pointing at a pruned worktree has no readable manifest, so
+/// the version stays unknown rather than being reported as the bundle's.
+#[test]
+fn installed_version_from_disk_ignores_stale_copilot_marketplace() {
+    let home = unique_dir("copilot-stale-version");
+    let cfg_dir = home.join(".copilot");
+    fs::create_dir_all(&cfg_dir).unwrap();
+    fs::write(cfg_dir.join("config.json"), r#"{"installedPlugins":[]}"#).unwrap();
+
+    let marketplace = unique_dir("copilot-stale-bundle");
+    fs::remove_dir_all(&marketplace).ok();
+    write_copilot_marketplace_settings(&cfg_dir, &marketplace);
+
+    assert_eq!(
+        installed_version_from_disk(CliKind::Copilot, Some(&home)),
+        None
+    );
+}
+
+/// Write a `~/.copilot/settings.json` registering `wt-local` against
+/// `marketplace`, including the JSONC banner Copilot emits.
+fn write_copilot_marketplace_settings(copilot_dir: &Path, marketplace: &Path) {
+    let settings = serde_json::json!({
+        "extraKnownMarketplaces": {
+            MARKETPLACE_NAME: {
+                "source": {
+                    "source": "directory",
+                    "path": marketplace.display().to_string(),
+                }
+            }
+        }
+    });
+    let body = format!(
+        "// User settings belong in settings.json.\n{}\n",
+        serde_json::to_string_pretty(&settings).unwrap()
+    );
+    fs::write(copilot_dir.join("settings.json"), body).unwrap();
 }
 
 // ---- auto-upgrade: read_installed_gemini ---------------------------

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -3355,6 +3355,7 @@ fn read_installed_copilot_any_marks_live_installs() {
 
     let info = read_installed_copilot_any(&home).unwrap().unwrap();
     assert!(info.loads_live);
+    assert_eq!(info.live_source.as_deref(), Some(marketplace.as_path()));
     assert_eq!(info.version, Some("0.1.6".parse().unwrap()));
 }
 
@@ -3512,6 +3513,7 @@ fn installed(version: &str, enabled: bool) -> InstalledInfo {
         version: Some(version.parse().unwrap()),
         enabled,
         loads_live: false,
+        live_source: None,
         gemini_source: None,
         gemini_type: None,
     }
@@ -3535,22 +3537,67 @@ fn decide_skip_when_disabled() {
     assert_eq!(a, UpgradeAction::Skip(SkipReason::Disabled));
 }
 
-/// A live install re-reads the bundle directory every session, so there is
-/// no copy to push a newer version into — even when the version it reports
-/// is behind the bundle. Reported distinctly from `UpToDate`, which would
-/// only be the two versions coinciding, and from `NotInstalled`, which is
-/// what this looked like before live installs were recognized at all.
+/// A live install loading the bundle we ship has no copy to push a newer
+/// version into. Reported distinctly from `UpToDate`, which would only be
+/// the two versions coinciding, and from `NotInstalled`, which is what this
+/// looked like before live installs were recognized at all.
 #[test]
-fn decide_skip_when_loaded_live() {
+fn decide_skip_when_loaded_live_from_current_bundle() {
+    let bundle = unique_dir("live-current-bundle");
     let mut info = installed("0.1.0", true);
     info.loads_live = true;
+    info.live_source = Some(bundle.clone());
     let a = decide_upgrade(
         CliKind::Copilot,
         Some("0.1.6".parse().unwrap()),
         Some(&info),
-        None,
+        Some(&bundle),
     );
     assert_eq!(a, UpgradeAction::Skip(SkipReason::LiveInstall));
+}
+
+/// A registration left pointing at another tree keeps loading *that* tree's
+/// hooks. `upgrade_copilot` repoints it, so the decision must reach it —
+/// including when both trees carry the same hook version, which is the
+/// common case and the reason version comparison can't stand in for this.
+#[test]
+fn decide_repoints_live_install_registered_against_another_tree() {
+    let bundle = unique_dir("live-current");
+    let other = unique_dir("live-stale");
+    let mut info = installed("0.1.6", true);
+    info.loads_live = true;
+    info.live_source = Some(other);
+    let a = decide_upgrade(
+        CliKind::Copilot,
+        Some("0.1.6".parse().unwrap()),
+        Some(&info),
+        Some(&bundle),
+    );
+    assert_eq!(a, UpgradeAction::UpdatePlugin);
+}
+
+/// Path comparison is case-insensitive on Windows, so a differently-cased
+/// registration is not mistaken for another tree.
+#[test]
+fn decide_skip_when_live_source_differs_only_by_case() {
+    let bundle = unique_dir("live-CASE-bundle");
+    let mut info = installed("0.1.6", true);
+    info.loads_live = true;
+    info.live_source = Some(PathBuf::from(
+        bundle.display().to_string().to_ascii_uppercase(),
+    ));
+    let a = decide_upgrade(
+        CliKind::Copilot,
+        Some("0.1.6".parse().unwrap()),
+        Some(&info),
+        Some(&bundle),
+    );
+    let expected = if cfg!(windows) {
+        UpgradeAction::Skip(SkipReason::LiveInstall)
+    } else {
+        UpgradeAction::UpdatePlugin
+    };
+    assert_eq!(a, expected);
 }
 
 /// Disabled wins over live: the user turned it off, and that is the more
@@ -3617,6 +3664,7 @@ fn decide_skip_when_bundle_or_installed_version_unknown() {
         version: None,
         enabled: true,
         loads_live: false,
+        live_source: None,
         gemini_source: None,
         gemini_type: None,
     };
@@ -3670,6 +3718,7 @@ fn decide_opencode_repairs_unknown_installed_version() {
         version: None,
         enabled: true,
         loads_live: false,
+        live_source: None,
         gemini_source: None,
         gemini_type: None,
     };
@@ -3721,6 +3770,7 @@ fn decide_gemini_in_place_when_source_under_current_bundle() {
         version: Some("0.1.0".parse().unwrap()),
         enabled: true,
         loads_live: false,
+        live_source: None,
         gemini_source: Some(nested_src.clone()),
         gemini_type: Some("local".into()),
     };
@@ -3743,6 +3793,7 @@ fn decide_gemini_reinstall_when_source_stale() {
         version: Some("0.1.0".parse().unwrap()),
         enabled: true,
         loads_live: false,
+        live_source: None,
         gemini_source: Some(stale_src),
         gemini_type: Some("local".into()),
     };
@@ -3764,6 +3815,7 @@ fn decide_gemini_reinstall_when_type_is_not_local() {
         version: Some("0.1.0".parse().unwrap()),
         enabled: true,
         loads_live: false,
+        live_source: None,
         gemini_source: Some(inside),
         gemini_type: Some("git".into()),
     };


### PR DESCRIPTION
## Summary

Copilot CLI **v1.0.81-8** (2026-08-23) changed how it installs a plugin from a directory-source marketplace:

> **Improved**
> - Path-sourced plugins in a local (directory-source) marketplace now load live from their real directory, so editing one takes effect on `/restart` or a new session — no `/plugin update`
>
> — [github/copilot-cli release v1.0.81-8](https://github.com/github/copilot-cli/releases/tag/v1.0.81-8)

`wt-agent-hooks` is installed exactly that way: wta runs `copilot plugin marketplace add <bundle_dir>` followed by `copilot plugin install wt-agent-hooks@wt-local`. So on any CLI at or past that release, nothing is copied into `~/.copilot/installed-plugins/`, no entry is written to `config.json`'s `installedPlugins`, and `~/.copilot/settings.json` becomes the only record of the install.

wta still read the install through the copied-plugin lens, which produced three wrong answers.

The change is upstream and unconditional, so this reproduces for anyone on a current Copilot CLI. Confirmed against this machine's own logs:

| Date | `copilot plugin list` | `installedPlugins` |
| --- | --- | --- |
| 2026-08-06 … 08-12 | `Installed plugins:` / `• wt-agent-hooks@wt-local (v0.1.4)` | entry present |
| **2026-08-23** | **v1.0.81-8 released** | |
| 2026-08-24 onward | `Live Plugins (…never copied):` / `• wt-agent-hooks@wt-local (v0.1.6) (enabled)` | `[]` |

Ruled out as a cause: #571, which moved the Copilot bundle to the native `.github/plugin/marketplace.json` layout on 08-20, inside the same window. Registering both the old `.claude-plugin` and new `.github/plugin` layouts against CLI 1.0.81-9 puts *both* in the live section, so the layout is not what selects live loading.

## 1. `wta hooks status` reported `v?`

```
copilot    ✓ installed    v?    (marketplace=yes, path_valid=yes, plugin=yes, enabled=yes)
claude     ✓ installed    v0.1.6
```

`format_version_column` renders `v?` when the plugin is installed but no version resolved, and for Copilot neither source produced one:

- **The CLI listing was never parsed for a version.** `parse_copilot_plugin_list` hardcoded `version: None`, on the claim that Copilot's plain-text listing has no version column. It does, and always has — `• wt-agent-hooks@wt-local (v0.1.6) (enabled)`. The listing also marks live entries `(enabled)` / `(disabled)` rather than the `[disabled]` copied entries use, so a disabled live plugin read as enabled.
- **`copilot_status` then dropped it anyway.** It applied `installed` / `enabled` / `marketplace` from the parsed listing but never assigned `version`, so every Copilot row fell through to the on-disk readers no matter what the CLI had just said. Claude, Gemini, and Codex all carried it across; Copilot alone did not.
- **The on-disk fallback only knew the copied shape.** `read_installed_copilot` reads `installedPlugins`, which a live install leaves empty.

Fixed by parsing the version, and by folding a parsed listing into the row through one `CliStatus::apply_presence` helper so a CLI cannot silently drop it again.

## 2. The on-disk fallback reported a version nothing was running

Worse than `v?`, and only visible on machines that installed the hooks *before* 08-23: the copied `installedPlugins` entry survives the CLI upgrade, so the old reader kept returning it long after Copilot stopped loading it.

Verified against CLI 1.0.81-9 — with a `wt-local` directory marketplace registered and a fully populated `cache_path` recorded for 0.1.2, the CLI lists only the live entry at 0.1.6 and ignores the copy. `wta hooks status` reported `v0.1.2 (bundle v0.1.6)`: a build nothing was running, rendered as a pending upgrade.

`read_installed_copilot_any` now prefers a live registration that still resolves to a readable manifest, and falls back to the copied record otherwise, matching what the CLI loads. Live enablement comes from `settings.json`'s `enabledPlugins`, which is where a live plugin records it; without that a disabled plugin would be auto-upgraded.

## 3. The upgrade path skipped for the wrong reason

`probe_installed` shared the same blind spot, so `decide_upgrade` saw `None` and returned `Skip(NotInstalled)` for a plugin that was present and enabled:

```
upgrade decision cli="copilot" installed_version=None bundle_version=Some(0.1.6) action=Skip(NotInstalled)
```

Reading live installs fixes the report, but leaves the decision resting on a coincidence: `read_live_copilot` reports the manifest under the registered directory, and the bundle is normally that same directory, so the versions agree by construction rather than by an upgrade having been applied. Point the registration at a stale worktree and they diverge — the decision flips to `UpdatePlugin` for an install that has no copy to update, when the real repair is the install path's repoint.

`InstalledInfo` gains `loads_live`, and `decide_upgrade` returns the new `SkipReason::LiveInstall` for it, checked after `Disabled` (the user turning it off is more actionable) and before the version comparison.

No behavior change for a healthy install: `copilot plugin update` on a live plugin already exits 0 with `there is nothing to update`, so both paths converged on a successful skip. This makes the skip intentional rather than a side effect of failing to detect the install.

The copied path is untouched and still drives `UpdatePlugin`, which is what a pre-1.0.81-8 CLI needs. Claude, Codex, Gemini, and OpenCode are unaffected throughout — their `--json` / tabular listings already carry a version column, and they all still copy.

## Validation

`cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml` — 1710 passed, 0 failed.

Notable new tests:

- `copilot_plugin_list_parser_reads_live_entry_version` / `_reports_live_disabled` / `_tolerates_missing_version` — real live-plugin output, the `(disabled)` marker, and a listing with no version column
- `apply_presence_carries_the_listed_version` — guards the drop that made the parse dead code
- `read_installed_copilot_any_marks_live_installs` / `_leaves_copied_records_unmarked` / `_reads_live_enabled_flag`
- `installed_version_from_disk_falls_back_to_copied_copilot_record` / `_ignores_stale_copilot_marketplace`
- `decide_skip_when_loaded_live`, `decide_skip_disabled_takes_precedence_over_live`, `decide_upgrades_copied_copilot_install`

Verified against the real machine state with a locally built `wta.exe`:

```
copilot    ✓ installed    v0.1.6    (marketplace=yes, path_valid=yes, plugin=yes, enabled=yes)
```

## Manual validation

Verified against Copilot CLI 1.0.81-9. The CLI-behavior findings were confirmed in a throwaway `USERPROFILE`, so none of them depended on mutating a working install.

| Case | Result |
| --- | --- |
| Settings → AI agents, Copilot row | Status renders correctly, no filesystem-fallback wording; repair button succeeds |
| Stale registration repointed automatically | `upgrade decision cli="copilot" action=UpdatePlugin`, then `source.path` rewritten onto the current bundle |
| FRE first run with Copilot selected | `hooks install --cli copilot` succeeds |



