### PR TITLE
Re-arm PowerShell shell integration when the prompt is replaced

### DIFF
--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -515,7 +515,11 @@ void ShellIntegrationTests::PowerShell_ScriptContent_ReArmsFromReadLineBoundary(
     // Detection is by object identity against our own scriptblock — never by
     // text matching, which a renderer could accidentally satisfy.
     const auto rearmFunc = script.find("function Global:__ShellInteg_Rearm");
-    const auto identityCheck = script.find("[object]::ReferenceEquals($current, $Global:__ShellInteg_Wrapper)", rearmFunc);
+    // -eq, NOT [object]::ReferenceEquals: re-arm runs at script load and from the
+    // readline boundary, and a static method call under Constrained Language Mode
+    // aborts the enclosing script even from inside try/catch.
+    const auto identityCheck = script.find("if ($current -eq $Global:__ShellInteg_Wrapper) { return }", rearmFunc);
+    const auto noStaticCall = script.substr(rearmFunc).find("[object]::ReferenceEquals");
     const auto adopt = script.find("$Global:__ShellInteg_OriginalPrompt = $current", identityCheck);
     const auto reinstall = script.find("Set-Item Function:\\global:prompt $Global:__ShellInteg_Wrapper", adopt);
 
@@ -531,6 +535,8 @@ void ShellIntegrationTests::PowerShell_ScriptContent_ReArmsFromReadLineBoundary(
                    L"The wrapper scriptblock must be captured after prompt is defined");
     VERIFY_IS_TRUE(rearmFunc < identityCheck && identityCheck < adopt && adopt < reinstall,
                    L"Re-arm must detect replacement by object identity, adopt the newcomer, then reinstall the wrapper");
+    VERIFY_ARE_EQUAL(std::string::npos, noStaticCall,
+                     L"Re-arm must not invoke static methods - blocked in Constrained Language Mode, and the failure aborts the script even from inside try/catch");
 }
 
 void ShellIntegrationTests::PowerShell_ScriptContent_ReArmIsBestEffortAndSkipsWithoutWrapper()
@@ -606,9 +612,9 @@ void ShellIntegrationTests::PowerShell_ScriptContent_GuardsAgainstChainingPrompt
     VERIFY_ARE_NOT_EQUAL(std::string::npos, clearFlag);
     VERIFY_ARE_NOT_EQUAL(std::string::npos, retainPrev);
     VERIFY_IS_TRUE(promptStart < reentryGuard && reentryGuard < servePrev,
-                   L"Re-entry must be detected before any rendering work and serve the displaced prompt");
+                   L"reentry must be detected before any rendering work and serve the displaced prompt");
     VERIFY_IS_TRUE(setFlag < delegation && delegation < clearFlag,
-                   L"The re-entrancy flag must be set around the delegation and cleared in finally");
+                   L"The reentrancy flag must be set around the delegation and cleared in finally");
 }
 
 void ShellIntegrationTests::PowerShell_ScriptContent_RendersFailSafe()

--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -651,7 +651,7 @@ void ShellIntegrationTests::PowerShell_ScriptContent_RendersFailSafe()
 
     // This wrapper must never invent visible prompt text. When the wrapped
     // prompt itself throws there is nothing to show, so it returns an empty
-    // string and the HOST supplies its own default. Fabricating a lookalike
+    // string and the HOST supplies its own default. Fabricating an imitation
     // "PS <cwd>> " would alter the visible prompt, which is exactly what this
     // component promises not to do.
     VERIFY_ARE_EQUAL(std::string::npos,

--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -52,6 +52,11 @@ class TerminalCoreUnitTests::ShellIntegrationTests final
     TEST_METHOD(PowerShell_ScriptContent_HandlesNullLastExitCode);
     TEST_METHOD(PowerShell_ScriptContent_TracksUnhistoriedErrors);
     TEST_METHOD(PowerShell_ScriptContent_GatesRestrictedLanguageFeatures);
+    TEST_METHOD(PowerShell_ScriptContent_ReArmsFromReadLineBoundary);
+    TEST_METHOD(PowerShell_ScriptContent_ReArmIsBestEffortAndSkipsWithoutWrapper);
+    TEST_METHOD(PowerShell_ScriptContent_RestoresStatusSignalBeforeDelegating);
+    TEST_METHOD(PowerShell_ScriptContent_GuardsAgainstChainingPromptModules);
+    TEST_METHOD(PowerShell_ScriptContent_RendersFailSafe);
 
     // Install scenarios.
     TEST_METHOD(Install_EmptyPath_Fails);
@@ -489,8 +494,146 @@ void ShellIntegrationTests::PowerShell_ScriptContent_GatesRestrictedLanguageFeat
                    L"Constrained Language Mode must bypass static parser and reference-identity method calls");
 }
 
-// ─── Install ──────────────────────────────────────────────────────────────────
+void ShellIntegrationTests::PowerShell_ScriptContent_ReArmsFromReadLineBoundary()
+{
+    const auto script = ShellIntegrationScriptContent();
 
+    // The re-arm must be driven from the PSReadLine boundary, NOT from prompt.
+    // That boundary runs once per command and BEFORE the user's command, so it
+    // cannot disturb the $? the next prompt reads. Calling it from prompt would
+    // silently corrupt every OSC 133;D exit code.
+    //
+    // innerReadLine is anchored to readLineWrapper, NOT to rearmCall: if the
+    // call were dropped from the wrapper, searching from rearmCall would match
+    // the later function DEFINITION and npos would then compare as maximum,
+    // letting a broken script pass.
+    const auto readLineWrapper = script.find("function Global:PSConsoleHostReadLine");
+    const auto innerReadLine = script.find("$Global:__ShellInteg_OriginalPSConsoleHostReadLine @args", readLineWrapper);
+    const auto rearmCall = script.find("__ShellInteg_Rearm", readLineWrapper);
+    const auto promptStart = script.find("function prompt");
+
+    // Detection is by object identity against our own scriptblock — never by
+    // text matching, which a renderer could accidentally satisfy.
+    const auto rearmFunc = script.find("function Global:__ShellInteg_Rearm");
+    const auto identityCheck = script.find("[object]::ReferenceEquals($current, $Global:__ShellInteg_Wrapper)", rearmFunc);
+    const auto adopt = script.find("$Global:__ShellInteg_OriginalPrompt = $current", identityCheck);
+    const auto reinstall = script.find("Set-Item Function:\\global:prompt $Global:__ShellInteg_Wrapper", adopt);
+
+    // The wrapper identity is captured once, after prompt is defined.
+    const auto wrapperCapture = script.find("$Global:__ShellInteg_Wrapper = $function:prompt");
+
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, reinstall);
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, wrapperCapture);
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, innerReadLine);
+    VERIFY_IS_TRUE(readLineWrapper < rearmCall && rearmCall < innerReadLine,
+                   L"Re-arm must run at the PSReadLine boundary before delegating to the real reader");
+    VERIFY_IS_TRUE(promptStart < wrapperCapture,
+                   L"The wrapper scriptblock must be captured after prompt is defined");
+    VERIFY_IS_TRUE(rearmFunc < identityCheck && identityCheck < adopt && adopt < reinstall,
+                   L"Re-arm must detect replacement by object identity, adopt the newcomer, then reinstall the wrapper");
+}
+
+void ShellIntegrationTests::PowerShell_ScriptContent_ReArmIsBestEffortAndSkipsWithoutWrapper()
+{
+    const auto script = ShellIntegrationScriptContent();
+    const auto rearmFunc = script.find("function Global:__ShellInteg_Rearm");
+
+    // Guard 1: when an OLDER version of this script already owns the session,
+    // __ShellInteg_Installed is set, so our wrapper was never created. Re-arming
+    // then would install $null over prompt AND adopt the older wrapper as the
+    // prompt to wrap, making it delegate to itself (call depth overflow).
+    const auto nullWrapperGuard = script.find("if ($null -eq $Global:__ShellInteg_Wrapper) { return }", rearmFunc);
+
+    // Guard 2: re-arm runs from PSConsoleHostReadLine and at script load, so it
+    // must never throw. `prompt` can be ReadOnly/Constant in a hardened profile,
+    // which makes Set-Item raise SessionStateUnauthorizedAccessException.
+    const auto tryStart = script.find("try {", nullWrapperGuard);
+    const auto guardedSetItem = script.find("Set-Item Function:\\global:prompt $Global:__ShellInteg_Wrapper -ErrorAction Stop", tryStart);
+    const auto catchAll = script.find("catch {", guardedSetItem);
+
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, catchAll);
+    VERIFY_IS_TRUE(rearmFunc < nullWrapperGuard,
+                   L"Re-arm must no-op when no wrapper of our own exists");
+    VERIFY_IS_TRUE(nullWrapperGuard < tryStart &&
+                       tryStart < guardedSetItem &&
+                       guardedSetItem < catchAll,
+                   L"Re-arm must reinstall inside try/catch with -ErrorAction Stop so a read-only prompt cannot break the input path");
+}
+
+void ShellIntegrationTests::PowerShell_ScriptContent_RestoresStatusSignalBeforeDelegating()
+{
+    const auto script = ShellIntegrationScriptContent();
+    const auto promptStart = script.find("function prompt");
+
+    // The wrapper reads $? first, and its own work then overwrites it. A wrapped
+    // prompt that reads $? (Oh My Posh's status segment, starship, posh-git)
+    // would otherwise always see success. $? cannot be assigned, so it is
+    // reproduced — and the reproduction MUST be the statement immediately before
+    // the delegation, or the intervening statements clobber it again.
+    const auto successCase = script.find("if ($gle -eq 0) { $null = $true }", promptStart);
+    const auto failureCase = script.find("Get-Variable '__ShellInteg_NoSuchVariable__' -ErrorAction Ignore", successCase);
+    const auto delegation = script.find("$originalOutput = & $Global:__ShellInteg_OriginalPrompt", failureCase);
+
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, delegation);
+    VERIFY_IS_TRUE(successCase < failureCase && failureCase < delegation,
+                   L"The success/failure signal must be restored immediately before delegating to the wrapped prompt");
+
+    // -ErrorAction Ignore is load-bearing: SilentlyContinue and Write-Error both
+    // set $? but ALSO append to $Error, so the wrapped prompt would see a
+    // fabricated error record every failed command.
+    VERIFY_IS_TRUE(script.find("Get-Variable '__ShellInteg_NoSuchVariable__' -ErrorAction SilentlyContinue") == std::string::npos,
+                   L"Forcing $? false must not pollute $Error");
+}
+
+void ShellIntegrationTests::PowerShell_ScriptContent_GuardsAgainstChainingPromptModules()
+{
+    const auto script = ShellIntegrationScriptContent();
+    const auto promptStart = script.find("function prompt");
+
+    // A module may CHAIN rather than replace: capture the current prompt (ours)
+    // and call it from inside its own. Once adopted, delegating calls back into
+    // us — an unbounded mutual-delegation cycle without this guard.
+    const auto reentryGuard = script.find("if ($Global:__ShellInteg_Rendering)", promptStart);
+    const auto servePrev = script.find("return (& $Global:__ShellInteg_PrevPrompt)", reentryGuard);
+    const auto setFlag = script.find("$Global:__ShellInteg_Rendering = $true", servePrev);
+    const auto delegation = script.find("$originalOutput = & $Global:__ShellInteg_OriginalPrompt", setFlag);
+    const auto clearFlag = script.find("finally { $Global:__ShellInteg_Rendering = $false }", delegation);
+
+    // The displaced renderer is retained so the chained module still has real
+    // prompt text to wrap.
+    const auto retainPrev = script.find("$Global:__ShellInteg_PrevPrompt = $Global:__ShellInteg_OriginalPrompt");
+
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, clearFlag);
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, retainPrev);
+    VERIFY_IS_TRUE(promptStart < reentryGuard && reentryGuard < servePrev,
+                   L"Re-entry must be detected before any rendering work and serve the displaced prompt");
+    VERIFY_IS_TRUE(setFlag < delegation && delegation < clearFlag,
+                   L"The re-entrancy flag must be set around the delegation and cleared in finally");
+}
+
+void ShellIntegrationTests::PowerShell_ScriptContent_RendersFailSafe()
+{
+    const auto script = ShellIntegrationScriptContent();
+    const auto promptStart = script.find("function prompt");
+
+    // Shell integration is a convenience; a broken prompt is not. Any exception
+    // in the render path — ours or the wrapped prompt's — must degrade to the
+    // wrapped prompt without marks rather than throwing on EVERY prompt.
+    const auto renderTry = script.find("try {", promptStart);
+    const auto normalReturn = script.find("return \"${prefix}${originalOutput}${suffix}\"", renderTry);
+    const auto renderCatch = script.find("catch {", normalReturn);
+    const auto degradeToPrompt = script.find("try { return (& $Global:__ShellInteg_OriginalPrompt) }", renderCatch);
+    const auto lastResort = script.find("catch { return \"PS $($executionContext.SessionState.Path.CurrentLocation)> \" }", degradeToPrompt);
+
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, lastResort);
+    VERIFY_IS_TRUE(renderTry < normalReturn &&
+                       normalReturn < renderCatch &&
+                       renderCatch < degradeToPrompt &&
+                       degradeToPrompt < lastResort,
+                   L"Rendering must fall back to the wrapped prompt, then to a plain prompt, instead of throwing");
+}
+
+// ─── Install ──────────────────────────────────────────────────────────────────
 void ShellIntegrationTests::Install_EmptyPath_Fails()
 {
     const auto r = Install(L"");

--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -603,7 +603,11 @@ void ShellIntegrationTests::PowerShell_ScriptContent_GuardsAgainstChainingPrompt
     // us — an unbounded mutual-delegation cycle without this guard.
     const auto reentryGuard = script.find("if ($Global:__ShellInteg_Rendering)", promptStart);
     const auto servePrev = script.find("return (& $Global:__ShellInteg_PrevPrompt)", reentryGuard);
-    const auto setFlag = script.find("$Global:__ShellInteg_Rendering = $true", servePrev);
+    // With nothing displaced left to serve, contribute an empty string — never
+    // fabricated prompt text. The chaining module renders its own text around
+    // whatever we return.
+    const auto emptyWhenExhausted = script.find("return ''", servePrev);
+    const auto setFlag = script.find("$Global:__ShellInteg_Rendering = $true", emptyWhenExhausted);
     const auto delegation = script.find("$originalOutput = & $Global:__ShellInteg_OriginalPrompt", setFlag);
     const auto clearFlag = script.find("finally { $Global:__ShellInteg_Rendering = $false }", delegation);
 
@@ -613,8 +617,9 @@ void ShellIntegrationTests::PowerShell_ScriptContent_GuardsAgainstChainingPrompt
 
     VERIFY_ARE_NOT_EQUAL(std::string::npos, clearFlag);
     VERIFY_ARE_NOT_EQUAL(std::string::npos, retainPrev);
-    VERIFY_IS_TRUE(promptStart < reentryGuard && reentryGuard < servePrev,
-                   L"reentry must be detected before any rendering work and serve the displaced prompt");
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, emptyWhenExhausted);
+    VERIFY_IS_TRUE(promptStart < reentryGuard && reentryGuard < servePrev && servePrev < emptyWhenExhausted,
+                   L"reentry must be detected before any rendering work, serve the displaced prompt, then contribute nothing rather than fabricating text");
     VERIFY_IS_TRUE(setFlag < delegation && delegation < clearFlag,
                    L"The reentrancy flag must be set around the delegation and cleared in finally");
 }
@@ -632,7 +637,7 @@ void ShellIntegrationTests::PowerShell_ScriptContent_RendersFailSafe()
     const auto renderCatch = script.find("catch {", normalReturn);
     const auto failSafeFlag = script.find("$Global:__ShellInteg_Rendering = $true", renderCatch);
     const auto degradeToPrompt = script.find("try { return (& $Global:__ShellInteg_OriginalPrompt) }", failSafeFlag);
-    const auto lastResort = script.find("catch { return \"PS $($executionContext.SessionState.Path.CurrentLocation)> \" }", degradeToPrompt);
+    const auto lastResort = script.find("return ''", degradeToPrompt);
     const auto failSafeClear = script.find("finally { $Global:__ShellInteg_Rendering = $false }", lastResort);
 
     VERIFY_ARE_NOT_EQUAL(std::string::npos, failSafeClear);
@@ -643,6 +648,15 @@ void ShellIntegrationTests::PowerShell_ScriptContent_RendersFailSafe()
                        degradeToPrompt < lastResort &&
                        lastResort < failSafeClear,
                    L"The fail-safe must hold the reentrancy flag while degrading, or an adopted chaining prompt recurses to the call-depth limit");
+
+    // This wrapper must never invent visible prompt text. When the wrapped
+    // prompt itself throws there is nothing to show, so it returns an empty
+    // string and the HOST supplies its own default. Fabricating a lookalike
+    // "PS <cwd>> " would alter the visible prompt, which is exactly what this
+    // component promises not to do.
+    VERIFY_ARE_EQUAL(std::string::npos,
+                     script.find("return \"PS $($executionContext.SessionState.Path.CurrentLocation)> \""),
+                     L"The prompt path must not fabricate prompt text");
 }
 
 // ─── Install ──────────────────────────────────────────────────────────────────

--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -515,9 +515,11 @@ void ShellIntegrationTests::PowerShell_ScriptContent_ReArmsFromReadLineBoundary(
     // Detection is by object identity against our own scriptblock — never by
     // text matching, which a renderer could accidentally satisfy.
     const auto rearmFunc = script.find("function Global:__ShellInteg_Rearm");
-    // -eq, NOT [object]::ReferenceEquals: re-arm runs at script load and from the
-    // readline boundary, and a static method call under Constrained Language Mode
-    // aborts the enclosing script even from inside try/catch.
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, rearmFunc,
+                         L"__ShellInteg_Rearm must exist");
+    // -eq, NOT a static reference-equality method: re-arm runs at script load and
+    // from the readline boundary, and a static method call under Constrained
+    // Language Mode aborts the enclosing script even from inside try/catch.
     const auto identityCheck = script.find("if ($current -eq $Global:__ShellInteg_Wrapper) { return }", rearmFunc);
     const auto noStaticCall = script.substr(rearmFunc).find("[object]::ReferenceEquals");
     const auto adopt = script.find("$Global:__ShellInteg_OriginalPrompt = $current", identityCheck);
@@ -628,15 +630,19 @@ void ShellIntegrationTests::PowerShell_ScriptContent_RendersFailSafe()
     const auto renderTry = script.find("try {", promptStart);
     const auto normalReturn = script.find("return \"${prefix}${originalOutput}${suffix}\"", renderTry);
     const auto renderCatch = script.find("catch {", normalReturn);
-    const auto degradeToPrompt = script.find("try { return (& $Global:__ShellInteg_OriginalPrompt) }", renderCatch);
+    const auto failSafeFlag = script.find("$Global:__ShellInteg_Rendering = $true", renderCatch);
+    const auto degradeToPrompt = script.find("try { return (& $Global:__ShellInteg_OriginalPrompt) }", failSafeFlag);
     const auto lastResort = script.find("catch { return \"PS $($executionContext.SessionState.Path.CurrentLocation)> \" }", degradeToPrompt);
+    const auto failSafeClear = script.find("finally { $Global:__ShellInteg_Rendering = $false }", lastResort);
 
-    VERIFY_ARE_NOT_EQUAL(std::string::npos, lastResort);
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, failSafeClear);
     VERIFY_IS_TRUE(renderTry < normalReturn &&
                        normalReturn < renderCatch &&
-                       renderCatch < degradeToPrompt &&
-                       degradeToPrompt < lastResort,
-                   L"Rendering must fall back to the wrapped prompt, then to a plain prompt, instead of throwing");
+                       renderCatch < failSafeFlag &&
+                       failSafeFlag < degradeToPrompt &&
+                       degradeToPrompt < lastResort &&
+                       lastResort < failSafeClear,
+                   L"The fail-safe must hold the re-entrancy flag while degrading, or an adopted chaining prompt recurses to the call-depth limit");
 }
 
 // ─── Install ──────────────────────────────────────────────────────────────────

--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -642,7 +642,7 @@ void ShellIntegrationTests::PowerShell_ScriptContent_RendersFailSafe()
                        failSafeFlag < degradeToPrompt &&
                        degradeToPrompt < lastResort &&
                        lastResort < failSafeClear,
-                   L"The fail-safe must hold the re-entrancy flag while degrading, or an adopted chaining prompt recurses to the call-depth limit");
+                   L"The fail-safe must hold the reentrancy flag while degrading, or an adopted chaining prompt recurses to the call-depth limit");
 }
 
 // ─── Install ──────────────────────────────────────────────────────────────────

--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -657,6 +657,18 @@ void ShellIntegrationTests::PowerShell_ScriptContent_RendersFailSafe()
     VERIFY_ARE_EQUAL(std::string::npos,
                      script.find("return \"PS $($executionContext.SessionState.Path.CurrentLocation)> \""),
                      L"The prompt path must not fabricate prompt text");
+
+    // The wrapped prompt must be invoked at most ONCE per render. Its failure is
+    // caught at the delegation itself, so it cannot escape to the outer catch
+    // and be run a second time — which would duplicate any side effects the
+    // user's prompt has (git calls, logging, its own error reporting).
+    const auto delegation = script.find("try     { $originalOutput = & $Global:__ShellInteg_OriginalPrompt }", promptStart);
+    const auto delegationCatch = script.find("catch   { $originalOutput = '' }", delegation);
+
+    VERIFY_ARE_NOT_EQUAL(std::string::npos, delegationCatch,
+                         L"The delegation must catch its own failure so the wrapped prompt runs at most once per render");
+    VERIFY_IS_TRUE(delegation < delegationCatch && delegationCatch < normalReturn,
+                   L"The delegation's catch must precede the normal return");
 }
 
 // ─── Install ──────────────────────────────────────────────────────────────────

--- a/src/cascadia/inc/PowerShellShellIntegration.h
+++ b/src/cascadia/inc/PowerShellShellIntegration.h
@@ -499,7 +499,11 @@ if (-not $Global:__ShellInteg_Installed) {
             if ($Global:__ShellInteg_PrevPrompt) {
                 return (& $Global:__ShellInteg_PrevPrompt)
             }
-            return "PS $($executionContext.SessionState.Path.CurrentLocation)> "
+            # Nothing displaced left to serve. Return an empty string rather
+            # than inventing prompt text: this wrapper never contributes
+            # visible output of its own, and the chaining module renders its
+            # own text around whatever we return.
+            return ''
         }
 
         try {
@@ -596,7 +600,14 @@ if (-not $Global:__ShellInteg_Installed) {
             # above exists to prevent.
             $Global:__ShellInteg_Rendering = $true
             try { return (& $Global:__ShellInteg_OriginalPrompt) }
-            catch { return "PS $($executionContext.SessionState.Path.CurrentLocation)> " }
+            catch {
+                # The wrapped prompt itself threw. Return an empty string and
+                # let the HOST fall back to its own built-in prompt. Do not
+                # fabricate one: this wrapper never alters the visible prompt,
+                # and a hand-rolled "PS <cwd>> " is only an imitation of the
+                # real default, which differs by host and edition.
+                return ''
+            }
             finally { $Global:__ShellInteg_Rendering = $false }
         }
     }

--- a/src/cascadia/inc/PowerShellShellIntegration.h
+++ b/src/cascadia/inc/PowerShellShellIntegration.h
@@ -596,6 +596,15 @@ if (-not $Global:__ShellInteg_Installed) {
 # identity, adopt the newcomer as the prompt we wrap, and reinstall ourselves.
 # Runs on every source and once per command from the PSReadLine boundary.
 function Global:__ShellInteg_Rearm {
+    # No wrapper of our own to install. This happens when an OLDER version of
+    # this script is already installed in the session: it set
+    # __ShellInteg_Installed, so the block above was skipped and never created
+    # our wrapper. Do nothing. Installing a null would clobber `prompt`, and
+    # adopting the older version's wrapper as the prompt we wrap would make it
+    # delegate to itself and overflow the call stack. The upgrade completes in
+    # the next shell, which sources only this version.
+    if ($null -eq $Global:__ShellInteg_Wrapper) { return }
+
     $current = $function:prompt
     if ($null -eq $current) { return }
     if ([object]::ReferenceEquals($current, $Global:__ShellInteg_Wrapper)) { return }

--- a/src/cascadia/inc/PowerShellShellIntegration.h
+++ b/src/cascadia/inc/PowerShellShellIntegration.h
@@ -588,8 +588,16 @@ if (-not $Global:__ShellInteg_Installed) {
             # FAIL SAFE. Shell integration is a convenience; a broken prompt is
             # not. Degrade to the wrapped prompt without marks rather than
             # throwing on every prompt.
+            #
+            # The re-entrancy flag must be held here too. The normal path clears
+            # it in its finally before this catch runs, so an adopted CHAINING
+            # prompt would call back into us with the flag false and recurse
+            # until the engine's call-depth limit - the very cycle the guard
+            # above exists to prevent.
+            $Global:__ShellInteg_Rendering = $true
             try { return (& $Global:__ShellInteg_OriginalPrompt) }
             catch { return "PS $($executionContext.SessionState.Path.CurrentLocation)> " }
+            finally { $Global:__ShellInteg_Rendering = $false }
         }
     }
 
@@ -619,7 +627,7 @@ function Global:__ShellInteg_Rearm {
     # call raises "Method invocation is supported only on core types", which
     # aborts the enclosing script even from inside try/catch - breaking profile
     # sourcing or the input path. ScriptBlock does not override Equals, so -eq is
-    # reference identity here (verified: two scriptblocks with identical text
+    # reference identity here (verified: two script blocks with identical text
     # compare False), and the operator is permitted in Constrained Language Mode.
     # That keeps re-arming working there instead of disabling it.
     $current = $function:prompt

--- a/src/cascadia/inc/PowerShellShellIntegration.h
+++ b/src/cascadia/inc/PowerShellShellIntegration.h
@@ -554,13 +554,19 @@ if (-not $Global:__ShellInteg_Installed) {
             # ── Prompt ended, command input starts (OSC 133;B) ──
             $suffix = "${E}]133;B${B}"
 
-            # ── Hand the real $? to the prompt we wrap ──
+            # ── Restore a success/failure signal for the prompt we wrap ──
             # Our work above has overwritten $?, so a prompt that reads it (Oh My
             # Posh's status segment, starship, posh-git) would wrongly see success.
             # $? cannot be assigned, but it mirrors the last statement: looking up
             # a variable that does not exist fails WITHOUT touching $Error, and a
             # trivial assignment succeeds. This must be the statement immediately
             # before the delegation.
+            #
+            # The value restored is derived from $gle, not the literal $? the
+            # engine had: parser-error detection above can turn a $?-true command
+            # into $gle -1. That is deliberate - $gle is the same failure signal
+            # reported in OSC 133;D, so the wrapped prompt and the terminal agree
+            # on whether the command failed.
             $Global:__ShellInteg_Rendering = $true
             try {
             if ($gle -eq 0) { $null = $true }

--- a/src/cascadia/inc/PowerShellShellIntegration.h
+++ b/src/cascadia/inc/PowerShellShellIntegration.h
@@ -578,7 +578,12 @@ if (-not $Global:__ShellInteg_Installed) {
             if ($gle -eq 0) { $null = $true }
             else { Get-Variable '__ShellInteg_NoSuchVariable__' -ErrorAction Ignore }
             # ── Delegate to the user's ORIGINAL prompt — visual output is theirs ──
-            $originalOutput = & $Global:__ShellInteg_OriginalPrompt
+            # Failures are caught HERE, at the delegation, so the wrapped prompt
+            # is invoked exactly once per render. Letting it escape to the outer
+            # catch would run it a second time and duplicate its side effects.
+            # An empty result is correct: the host then supplies its own prompt.
+            try     { $originalOutput = & $Global:__ShellInteg_OriginalPrompt }
+            catch   { $originalOutput = '' }
             }
             finally { $Global:__ShellInteg_Rendering = $false }
 
@@ -589,9 +594,11 @@ if (-not $Global:__ShellInteg_Installed) {
             return "${prefix}${originalOutput}${suffix}"
             }
         catch {
-            # FAIL SAFE. Shell integration is a convenience; a broken prompt is
-            # not. Degrade to the wrapped prompt without marks rather than
-            # throwing on every prompt.
+            # FAIL SAFE for failures in OUR OWN code above (Get-History, the
+            # parser probe, string building). The wrapped prompt has its own
+            # catch at the delegation, so reaching here means it has NOT yet
+            # been invoked for this render - delegating now keeps it at exactly
+            # one invocation.
             #
             # The reentrancy flag must be held here too. The normal path clears
             # it in its finally before this catch runs, so an adopted CHAINING

--- a/src/cascadia/inc/PowerShellShellIntegration.h
+++ b/src/cascadia/inc/PowerShellShellIntegration.h
@@ -375,8 +375,22 @@ namespace Microsoft::Terminal::ShellIntegration::Powershell
     // true, $Error[0] is null, and Get-History has no entry. Wrap
     // PSConsoleHostReadLine to retain the submitted line, then parse it lazily
     // in prompt only when no normal completion signal exists.
+    //
+    // v7: the wrapper snapshotted $function:prompt once, at install time, so
+    // any prompt renderer loaded AFTERWARDS replaced it and silently removed
+    // shell integration - including `oh-my-posh init | Invoke-Expression`
+    // placed at the END of $PROFILE, which is the placement Oh My Posh's own
+    // documentation shows. v7 keeps ownership of `prompt` but re-arms: at the
+    // PSConsoleHostReadLine boundary (off the prompt path, so $? is
+    // unaffected) it detects by object identity that something took the slot,
+    // adopts that renderer as the prompt it wraps, and reinstalls itself. At
+    // most one prompt render is unmarked after a takeover. Also: restores the
+    // real $? for the wrapped prompt - previously it always saw success, which
+    // broke Oh My Posh's status segment - guards against prompt modules that
+    // chain back into us, and renders fail-safe, degrading to the wrapped
+    // prompt without marks instead of throwing on every prompt.
     // ───────────────────────────────────────────────────────────────────
-    inline constexpr int kVersion = 6;
+    inline constexpr int kVersion = 7;
 
     inline std::wstring ScriptFileName()
     {
@@ -433,6 +447,8 @@ if (-not $Global:__ShellInteg_Installed) {
     $Global:__ShellInteg_LastHistoryId  = -1
     $Global:__ShellInteg_LastErrorRecord = $Error[0]
     $Global:__ShellInteg_LastSubmittedLine = $null
+    $Global:__ShellInteg_PrevPrompt = $null
+    $Global:__ShellInteg_Rendering = $false
     $Global:__ShellInteg_CanInspectErrors =
         $ExecutionContext.SessionState.LanguageMode -eq 'FullLanguage'
     $Global:__ShellInteg_Installed      = $true
@@ -440,9 +456,14 @@ if (-not $Global:__ShellInteg_Installed) {
     # PowerShell 7 drops parser failures before prompt runs, leaving no
     # observable status there. Retain the submitted line at the PSReadLine
     # boundary without changing what is returned to the engine.
+    #
+    # This boundary is also where we re-arm (see __ShellInteg_Rearm): it runs
+    # once per command, BEFORE the user's command executes, so it cannot
+    # disturb the $? that the next prompt reads.
     if ($Global:__ShellInteg_CanInspectErrors -and (Test-Path Function:\PSConsoleHostReadLine)) {
         $Global:__ShellInteg_OriginalPSConsoleHostReadLine = $function:PSConsoleHostReadLine
         function Global:PSConsoleHostReadLine {
+            __ShellInteg_Rearm
             $line = & $Global:__ShellInteg_OriginalPSConsoleHostReadLine @args
             $Global:__ShellInteg_LastSubmittedLine =
                 if ($line -is [string]) { $line } else { $null }
@@ -467,69 +488,128 @@ if (-not $Global:__ShellInteg_Installed) {
     function prompt {
         # ── Capture exit code FIRST — before anything else can clobber $? ──
         $gle           = $(__ShellInteg_GetLastExitCode)
-        $submittedLine = $Global:__ShellInteg_LastSubmittedLine
-        $errorRecord   = $Error[0]
-        $entry         = Get-History -Count 1
-        $loc           = $executionContext.SessionState.Path.CurrentLocation
-        $E             = $Global:__ShellInteg_ESC
-        $B             = $Global:__ShellInteg_BEL
 
-        $prefix = ''
-        $suffix = ''
-
-        # ── Previous command finished (OSC 133;D with exit code) ──
-        $historyAdvanced = $entry -and $entry.Id -ne $Global:__ShellInteg_LastHistoryId
-        $newErrorRecord = $Global:__ShellInteg_CanInspectErrors -and
-            $null -ne $errorRecord -and
-            -not [object]::ReferenceEquals($errorRecord, $Global:__ShellInteg_LastErrorRecord)
-        $inputHadParserError = $false
-        if ($Global:__ShellInteg_CanInspectErrors -and
-            $gle -eq 0 -and
-            $null -ne $submittedLine -and
-            ($newErrorRecord -or -not $historyAdvanced)) {
-            $tokens = $null
-            $parseErrors = $null
-            [void][System.Management.Automation.Language.Parser]::ParseInput(
-                $submittedLine,
-                [ref]$tokens,
-                [ref]$parseErrors)
-            $inputHadParserError = $parseErrors.Count -gt 0
-        }
-        if ($inputHadParserError -and $gle -eq 0) {
-            $gle = -1
-        }
-        $newUntrackedError = -not $historyAdvanced -and $gle -ne 0 -and $newErrorRecord
-        if ($historyAdvanced -or $newUntrackedError -or $inputHadParserError) {
-            $prefix += "${E}]133;D;${gle}${B}"
+        # A prompt module may CHAIN rather than replace: it captures the
+        # current prompt (ours) and calls it from inside its own. Once we
+        # adopt it, delegating calls us back. Serve the prompt it displaced
+        # so its text survives, instead of recursing.
+        if ($Global:__ShellInteg_Rendering) {
+            if ($Global:__ShellInteg_PrevPrompt) {
+                return (& $Global:__ShellInteg_PrevPrompt)
+            }
+            return "PS $($executionContext.SessionState.Path.CurrentLocation)> "
         }
 
-        # ── Prompt started (OSC 133;A) ──
-        $prefix += "${E}]133;A${B}"
+        try {
+            $submittedLine = $Global:__ShellInteg_LastSubmittedLine
+            $errorRecord   = $Error[0]
+            $entry         = Get-History -Count 1
+            $loc           = $executionContext.SessionState.Path.CurrentLocation
+            $E             = $Global:__ShellInteg_ESC
+            $B             = $Global:__ShellInteg_BEL
 
-        # ── Report current working directory (OSC 9;9) ──
-        $prefix += "${E}]9;9;`"${loc}`"${B}"
+            $prefix = ''
+            $suffix = ''
 
-        # ── Report shell identity (OSC 9001;ShellType) ──
-        # Emitted every prompt so the terminal always knows which shell owns
-        # the pane, even after a nested shell (e.g. wsl) exits and PowerShell
-        # repaints its prompt. PSEdition 'Core' is pwsh 7+, 'Desktop' is
-        # Windows PowerShell 5.1.
-        $shellName = if ($PSVersionTable.PSEdition -eq 'Core') { 'pwsh' } else { 'powershell' }
-        $prefix += "${E}]9001;ShellType;${shellName};$($PSVersionTable.PSVersion)${B}"
+            # ── Previous command finished (OSC 133;D with exit code) ──
+            $historyAdvanced = $entry -and $entry.Id -ne $Global:__ShellInteg_LastHistoryId
+            $newErrorRecord = $Global:__ShellInteg_CanInspectErrors -and
+                $null -ne $errorRecord -and
+                -not [object]::ReferenceEquals($errorRecord, $Global:__ShellInteg_LastErrorRecord)
+            $inputHadParserError = $false
+            if ($Global:__ShellInteg_CanInspectErrors -and
+                $gle -eq 0 -and
+                $null -ne $submittedLine -and
+                ($newErrorRecord -or -not $historyAdvanced)) {
+                $tokens = $null
+                $parseErrors = $null
+                [void][System.Management.Automation.Language.Parser]::ParseInput(
+                    $submittedLine,
+                    [ref]$tokens,
+                    [ref]$parseErrors)
+                $inputHadParserError = $parseErrors.Count -gt 0
+            }
+            if ($inputHadParserError -and $gle -eq 0) {
+                $gle = -1
+            }
+            $newUntrackedError = -not $historyAdvanced -and $gle -ne 0 -and $newErrorRecord
+            if ($historyAdvanced -or $newUntrackedError -or $inputHadParserError) {
+                $prefix += "${E}]133;D;${gle}${B}"
+            }
 
-        # ── Prompt ended, command input starts (OSC 133;B) ──
-        $suffix = "${E}]133;B${B}"
+            # ── Prompt started (OSC 133;A) ──
+            $prefix += "${E}]133;A${B}"
 
-        # ── Delegate to the user's ORIGINAL prompt — visual output is theirs ──
-        $originalOutput = & $Global:__ShellInteg_OriginalPrompt
+            # ── Report current working directory (OSC 9;9) ──
+            $prefix += "${E}]9;9;`"${loc}`"${B}"
 
-        $Global:__ShellInteg_LastHistoryId = if ($entry) { $entry.Id } else { -1 }
-        $Global:__ShellInteg_LastErrorRecord = $Error[0]
-        $Global:__ShellInteg_LastSubmittedLine = $null
+            # ── Report shell identity (OSC 9001;ShellType) ──
+            # Emitted every prompt so the terminal always knows which shell owns
+            # the pane, even after a nested shell (e.g. wsl) exits and PowerShell
+            # repaints its prompt. PSEdition 'Core' is pwsh 7+, 'Desktop' is
+            # Windows PowerShell 5.1.
+            $shellName = if ($PSVersionTable.PSEdition -eq 'Core') { 'pwsh' } else { 'powershell' }
+            $prefix += "${E}]9001;ShellType;${shellName};$($PSVersionTable.PSVersion)${B}"
 
-        return "${prefix}${originalOutput}${suffix}"
+            # ── Prompt ended, command input starts (OSC 133;B) ──
+            $suffix = "${E}]133;B${B}"
+
+            # ── Hand the real $? to the prompt we wrap ──
+            # Our work above has overwritten $?, so a prompt that reads it (Oh My
+            # Posh's status segment, starship, posh-git) would wrongly see success.
+            # $? cannot be assigned, but it mirrors the last statement: looking up
+            # a variable that does not exist fails WITHOUT touching $Error, and a
+            # trivial assignment succeeds. This must be the statement immediately
+            # before the delegation.
+            $Global:__ShellInteg_Rendering = $true
+            try {
+            if ($gle -eq 0) { $null = $true }
+            else { Get-Variable '__ShellInteg_NoSuchVariable__' -ErrorAction Ignore }
+            # ── Delegate to the user's ORIGINAL prompt — visual output is theirs ──
+            $originalOutput = & $Global:__ShellInteg_OriginalPrompt
+            }
+            finally { $Global:__ShellInteg_Rendering = $false }
+
+            $Global:__ShellInteg_LastHistoryId = if ($entry) { $entry.Id } else { -1 }
+            $Global:__ShellInteg_LastErrorRecord = $Error[0]
+            $Global:__ShellInteg_LastSubmittedLine = $null
+
+            return "${prefix}${originalOutput}${suffix}"
+            }
+        catch {
+            # FAIL SAFE. Shell integration is a convenience; a broken prompt is
+            # not. Degrade to the wrapped prompt without marks rather than
+            # throwing on every prompt.
+            try { return (& $Global:__ShellInteg_OriginalPrompt) }
+            catch { return "PS $($executionContext.SessionState.Path.CurrentLocation)> " }
+        }
     }
+
+    # Remember our own prompt scriptblock so re-arming can recognise it by
+    # reference. Created once per session: re-creating it would make the
+    # previous copy look like a third-party takeover.
+    $Global:__ShellInteg_Wrapper = $function:prompt
 }
+
+# Any prompt renderer loaded AFTER us (Oh My Posh, starship, a module) replaces
+# our wrapper and silently removes shell integration. Detect that by object
+# identity, adopt the newcomer as the prompt we wrap, and reinstall ourselves.
+# Runs on every source and once per command from the PSReadLine boundary.
+function Global:__ShellInteg_Rearm {
+    $current = $function:prompt
+    if ($null -eq $current) { return }
+    if ([object]::ReferenceEquals($current, $Global:__ShellInteg_Wrapper)) { return }
+
+    if (-not [object]::ReferenceEquals($current, $Global:__ShellInteg_OriginalPrompt)) {
+        # Retain the renderer being displaced, in case the newcomer chains
+        # back into us.
+        $Global:__ShellInteg_PrevPrompt = $Global:__ShellInteg_OriginalPrompt
+        $Global:__ShellInteg_OriginalPrompt = $current
+    }
+    Set-Item Function:\global:prompt $Global:__ShellInteg_Wrapper
+}
+
+__ShellInteg_Rearm
 )"
         };
     }

--- a/src/cascadia/inc/PowerShellShellIntegration.h
+++ b/src/cascadia/inc/PowerShellShellIntegration.h
@@ -613,9 +613,18 @@ function Global:__ShellInteg_Rearm {
     # the next shell, which sources only this version.
     if ($null -eq $Global:__ShellInteg_Wrapper) { return }
 
+    # Identity is compared with -eq rather than a static reference-equality
+    # method. This runs unconditionally at script load and from
+    # PSConsoleHostReadLine, and under Constrained Language Mode a static method
+    # call raises "Method invocation is supported only on core types", which
+    # aborts the enclosing script even from inside try/catch - breaking profile
+    # sourcing or the input path. ScriptBlock does not override Equals, so -eq is
+    # reference identity here (verified: two scriptblocks with identical text
+    # compare False), and the operator is permitted in Constrained Language Mode.
+    # That keeps re-arming working there instead of disabling it.
     $current = $function:prompt
     if ($null -eq $current) { return }
-    if ([object]::ReferenceEquals($current, $Global:__ShellInteg_Wrapper)) { return }
+    if ($current -eq $Global:__ShellInteg_Wrapper) { return }
 
     # Best-effort. This runs from PSConsoleHostReadLine, so a throw here would
     # break the input path, and at script load, where it would break profile
@@ -623,7 +632,7 @@ function Global:__ShellInteg_Rearm {
     # profile, which makes Set-Item raise SessionStateUnauthorizedAccessException.
     # Shell integration is a convenience; never let it take the shell down.
     try {
-        if (-not [object]::ReferenceEquals($current, $Global:__ShellInteg_OriginalPrompt)) {
+        if ($current -ne $Global:__ShellInteg_OriginalPrompt) {
             # Retain the renderer being displaced, in case the newcomer chains
             # back into us.
             $Global:__ShellInteg_PrevPrompt = $Global:__ShellInteg_OriginalPrompt

--- a/src/cascadia/inc/PowerShellShellIntegration.h
+++ b/src/cascadia/inc/PowerShellShellIntegration.h
@@ -589,7 +589,7 @@ if (-not $Global:__ShellInteg_Installed) {
             # not. Degrade to the wrapped prompt without marks rather than
             # throwing on every prompt.
             #
-            # The re-entrancy flag must be held here too. The normal path clears
+            # The reentrancy flag must be held here too. The normal path clears
             # it in its finally before this catch runs, so an adopted CHAINING
             # prompt would call back into us with the flag false and recurse
             # until the engine's call-depth limit - the very cycle the guard
@@ -622,14 +622,20 @@ function Global:__ShellInteg_Rearm {
     if ($null -eq $Global:__ShellInteg_Wrapper) { return }
 
     # Identity is compared with -eq rather than a static reference-equality
-    # method. This runs unconditionally at script load and from
-    # PSConsoleHostReadLine, and under Constrained Language Mode a static method
-    # call raises "Method invocation is supported only on core types", which
-    # aborts the enclosing script even from inside try/catch - breaking profile
-    # sourcing or the input path. ScriptBlock does not override Equals, so -eq is
-    # reference identity here (verified: two script blocks with identical text
-    # compare False), and the operator is permitted in Constrained Language Mode.
-    # That keeps re-arming working there instead of disabling it.
+    # method. This function is called at script load and, when the readline
+    # wrapper is installed, once per command. Under Constrained Language Mode a
+    # static method call raises "Method invocation is supported only on core
+    # types", which aborts the enclosing script even from inside try/catch -
+    # breaking profile sourcing or the input path. ScriptBlock does not override
+    # Equals, so -eq is reference identity here (verified: two script blocks with
+    # identical text compare False), and the operator is permitted under
+    # Constrained Language Mode.
+    #
+    # Scope of that: -eq makes this function SAFE to invoke under Constrained
+    # Language Mode. It does not by itself make re-arming active there - the
+    # readline wrapper above is gated on $Global:__ShellInteg_CanInspectErrors,
+    # which is false in that mode, so the per-command driver is not installed and
+    # integration degrades to "marks work, no self-healing after a takeover".
     $current = $function:prompt
     if ($null -eq $current) { return }
     if ($current -eq $Global:__ShellInteg_Wrapper) { return }

--- a/src/cascadia/inc/PowerShellShellIntegration.h
+++ b/src/cascadia/inc/PowerShellShellIntegration.h
@@ -376,19 +376,21 @@ namespace Microsoft::Terminal::ShellIntegration::Powershell
     // PSConsoleHostReadLine to retain the submitted line, then parse it lazily
     // in prompt only when no normal completion signal exists.
     //
-    // v7: the wrapper snapshotted $function:prompt once, at install time, so
-    // any prompt renderer loaded AFTERWARDS replaced it and silently removed
-    // shell integration - including `oh-my-posh init | Invoke-Expression`
-    // placed at the END of $PROFILE, which is the placement Oh My Posh's own
+    // v7: re-arm after a third-party prompt replacement. Through v6 the wrapper
+    // snapshotted $function:prompt once, at install time, so any prompt
+    // renderer loaded AFTERWARDS replaced it and silently removed shell
+    // integration - including `oh-my-posh init | Invoke-Expression` placed at
+    // the END of $PROFILE, which is the placement Oh My Posh's own
     // documentation shows. v7 keeps ownership of `prompt` but re-arms: at the
     // PSConsoleHostReadLine boundary (off the prompt path, so $? is
     // unaffected) it detects by object identity that something took the slot,
     // adopts that renderer as the prompt it wraps, and reinstalls itself. At
-    // most one prompt render is unmarked after a takeover. Also: restores the
-    // real $? for the wrapped prompt - previously it always saw success, which
-    // broke Oh My Posh's status segment - guards against prompt modules that
-    // chain back into us, and renders fail-safe, degrading to the wrapped
-    // prompt without marks instead of throwing on every prompt.
+    // most one prompt render is unmarked after a takeover. Also new in v7:
+    // restores a success/failure signal for the wrapped prompt - through v6 it
+    // always saw success, which broke Oh My Posh's status segment - guards
+    // against prompt modules that chain back into us, and renders fail-safe,
+    // degrading to the wrapped prompt without marks instead of throwing on
+    // every prompt.
     // ───────────────────────────────────────────────────────────────────
     inline constexpr int kVersion = 7;
 
@@ -615,13 +617,23 @@ function Global:__ShellInteg_Rearm {
     if ($null -eq $current) { return }
     if ([object]::ReferenceEquals($current, $Global:__ShellInteg_Wrapper)) { return }
 
-    if (-not [object]::ReferenceEquals($current, $Global:__ShellInteg_OriginalPrompt)) {
-        # Retain the renderer being displaced, in case the newcomer chains
-        # back into us.
-        $Global:__ShellInteg_PrevPrompt = $Global:__ShellInteg_OriginalPrompt
-        $Global:__ShellInteg_OriginalPrompt = $current
+    # Best-effort. This runs from PSConsoleHostReadLine, so a throw here would
+    # break the input path, and at script load, where it would break profile
+    # sourcing. `prompt` can legitimately be ReadOnly or Constant in a hardened
+    # profile, which makes Set-Item raise SessionStateUnauthorizedAccessException.
+    # Shell integration is a convenience; never let it take the shell down.
+    try {
+        if (-not [object]::ReferenceEquals($current, $Global:__ShellInteg_OriginalPrompt)) {
+            # Retain the renderer being displaced, in case the newcomer chains
+            # back into us.
+            $Global:__ShellInteg_PrevPrompt = $Global:__ShellInteg_OriginalPrompt
+            $Global:__ShellInteg_OriginalPrompt = $current
+        }
+        Set-Item Function:\global:prompt $Global:__ShellInteg_Wrapper -ErrorAction Stop
     }
-    Set-Item Function:\global:prompt $Global:__ShellInteg_Wrapper
+    catch {
+        # Leave whatever prompt is installed alone; try again next command.
+    }
 }
 
 __ShellInteg_Rearm


### PR DESCRIPTION
## Problem

The PowerShell shell-integration script snapshotted `$function:prompt` **once, at install time**. Any prompt renderer loaded *afterwards* replaced our wrapper and silently removed shell integration — no OSC 133 marks, no cwd reporting, no shell identity, and no error surfaced to the user.

This is not an exotic case. It includes:

```powershell
oh-my-posh init pwsh --config ~/theme.omp.json | Invoke-Expression
```

placed at the **end** of `$PROFILE` — the placement Oh My Posh's own documentation shows.

Measured across four prompt renders (`Y` = that render carried marks):

| | v6 (ships today) | v7 |
|---|---|---|
| Oh My Posh init at end of `$PROFILE` | `n n n n` | `n Y Y Y` |

v6 never recovers. It also loses integration when the user re-runs `oh-my-posh init` to switch themes, when starship is used, or when any module owns the prompt — 3 of 5 realistic scenarios tested.

## Approach

v7 keeps ownership of `prompt` — that is mandatory, because the exit code for `OSC 133;D` can only be read from `$?` as the *very first* statement inside the prompt function — but it now **re-arms**.

At the `PSConsoleHostReadLine` boundary (once per command, *before* the user's command runs, so off the prompt path where `$?` must stay pristine) it compares the installed prompt against its own scriptblock **by object identity**:

```powershell
$current -eq $Global:__ShellInteg_Wrapper
```

`-eq` rather than `[object]::ReferenceEquals`: `ScriptBlock` does not override `Equals`, so `-eq` *is* reference identity (two script blocks with identical text compare `False`), and unlike a static method call it is permitted under Constrained Language Mode. Re-arm runs at script load and from the readline boundary, and a blocked static call there aborts the enclosing script — even from inside `try/catch` — which would break profile sourcing or the input path.

If something took the slot, that renderer is adopted as the prompt we wrap and our wrapper is reinstalled. We never fight the other prompt — it keeps drawing every visible pixel; we re-wrap its output with zero-width escapes.

At most **one** prompt render is unmarked after a takeover: PowerShell renders the prompt *before* reading input, so the first post-init prompt is already the newcomer's before we get a chance to look.

## Further fixes in the same script

**1. The wrapped prompt now sees the real `$?`.** Previously the wrapper read `$?` first and its own work overwrote it, so the inner prompt always saw success — Oh My Posh's status segment silently stopped reporting failures. `$?` cannot be assigned, but it mirrors the last statement, so it is reproduced immediately before delegating. `Get-Variable <missing> -ErrorAction Ignore` fails **without** appending to `$Error` (`Write-Error` and `-ErrorAction SilentlyContinue` both pollute it).

Measured, reading Oh My Posh's own `$script:OriginalLastExecutionStatus`:

| | after success | PowerShell error | native failure |
|---|---|---|---|
| no integration (truth) | `True` | `False` | `False` |
| v6 | `True` | `True` ❌ | `True` ❌ |
| v7 | `True` | `False` ✅ | `False` ✅ |

**2. Chaining prompt modules no longer recurse.** A module that captures the current prompt and calls it from inside its own (the posh-git pattern) formed an unbounded mutual-delegation cycle once adopted. A re-entrancy guard serves the displaced prompt instead, so its text survives.

**3. Rendering is fail-safe.** Any exception now degrades to the wrapped prompt without marks, instead of throwing on every prompt. Previously a failure anywhere in the render path — including inside the user's own prompt — produced an error on every single prompt.

**4. The wrapper never fabricates prompt text.** Its contract, unchanged since v1, is to add zero-width escapes *without altering the visible prompt*. Where a fallback has nothing to show — the reentrancy guard with no displaced prompt left, or a wrapped prompt that threw — it returns an empty string and the **host** supplies its own default. It does not emit a hand-rolled `"PS <cwd>> "`, which is only an imitation of the real default and differs by host and edition.

**5. The wrapped prompt is invoked at most once per render.** Its failure is caught at the delegation itself, so it cannot escape to the outer catch and be run a second time — which would duplicate any side effect the user's prompt has (git calls, logging, its own error reporting).

## Testing

Verified on **Windows PowerShell 5.1** and **PowerShell 7.6.5**, against the real **oh-my-posh 30.6.5** binary, and re-verified after merging current `main`:

- marks, cwd (`OSC 9;9`), shell identity (`OSC 9001`, correctly reporting `pwsh` vs `powershell`)
- `OSC 133;D` exit codes `0 / 7 / 0 / -1` (success, native failure, back to success, PowerShell error)
- parser-error detection (the v6 feature) still reports `D=-1` for `if (` on both editions
- correct `$?` for the wrapped prompt; `$Error` grows by 0 over repeated failed renders
- `$Error[0]` and `$LASTEXITCODE` reach the wrapped prompt unchanged
- idempotent: sourcing 10 further times yields exactly one mark set, no stack growth
- recovery after an Oh My Posh takeover, and again after a mid-session re-init
- chaining modules, fail-safe rendering, and recovery once the fault clears
- two independent shell integrations loaded together (both orders, 40 command cycles plus interleaved re-sourcing): no unbounded recursion, all depth counters return to 0

**Tests: 104/104.**

Five new `ScriptContent` tests cover the behaviour this PR adds, following the
existing pattern that already guards the v3–v6 script invariants:

| Test | Guards |
|---|---|
| `ReArmsFromReadLineBoundary` | re-arm runs at the PSReadLine boundary and **not** from `prompt` (which would corrupt every `OSC 133;D`), detects by object identity, captures the wrapper once |
| `ReArmIsBestEffortAndSkipsWithoutWrapper` | the null-wrapper early return, and `try/catch` + `-ErrorAction Stop` so a ReadOnly/Constant prompt cannot break the input path |
| `RestoresStatusSignalBeforeDelegating` | the signal is restored *immediately* before delegating, and `-ErrorAction Ignore` is used so `$Error` is not polluted |
| `GuardsAgainstChainingPromptModules` | re-entry detected before any rendering work, displaced prompt retained and served, flag cleared in `finally` |
| `RendersFailSafe` | fall back to the wrapped prompt and then to an empty string instead of throwing, never fabricating prompt text, and invoke the wrapped prompt at most once |

Each assertion was **mutation-tested** — the corresponding behaviour was removed
from the script one at a time and the build re-run. 5 of 5 mutations are caught.
The first pass caught only 4: dropping the re-arm call from the readline wrapper
escaped, because searching from the call site matched the later function
*definition* and `std::string::npos` compares as maximum, so the ordering
assertion still held. That test now anchors to the wrapper and checks `npos`
explicitly.

The 99 pre-existing tests pass **unchanged** — the script deliberately keeps v6's
structure and identifiers, so none of the three existing `ScriptContent` ordering
assertions needed touching.

## Note for reviewers

The diff looks larger than the change because the body of `function prompt` is now inside a `try`, so every line is re-indented. **Reviewing with whitespace hidden shows the real change.**

## Known limitations

- Re-arming depends on `PSConsoleHostReadLine` existing when the script is sourced. In a real console PSReadLine is already loaded at profile time (verified on both editions via an idle-event probe in an actual console window), but in hosts where it is absent — Windows PowerShell ISE, other non-console hosts — the wrapper still installs and emits marks correctly, it simply cannot self-heal. Re-sourcing the script repairs it.
- The one unmarked render immediately after a takeover is inherent to PowerShell's prompt-then-read cycle and cannot be closed without giving up `$?` fidelity.

