### PR TITLE
Agent pane: Add ACP slash commands and metadata-driven completion

### DIFF
--- a/doc/specs/acp-v1-support-completion-plan.md
+++ b/doc/specs/acp-v1-support-completion-plan.md
@@ -1,10 +1,10 @@
 # ACP v1 Support Completion Plan
 
-**Status**: Implementation in progress; Phase 1 core tool details are on `main`;
-Phase 4 select-option support is implemented locally
+**Status**: Implementation in progress; Phase 1 core tool details and Phase 4
+select-option support are on `main`; Phase 4 Agent Commands are implemented locally
 **Scope**: `tools/wta`, the agent-pane TUI, and the helper/master ACP bridge  
 **Baseline**: ACP wire `protocolVersion: 1`  
-**Last updated**: 2026-08-12
+**Last updated**: 2026-08-25
 
 ## Summary
 
@@ -56,7 +56,7 @@ additional ACP v1 work after PR #601.
 | Client Terminals | Commands can run in a WT pane or local subprocess. | `outputByteLimit`, retained-output semantics, accurate truncation, final output after kill, and display retention after release. |
 | Session lifecycle | New, load, cancel, and partial list flows exist. | Capability-gated resume, close, delete, list pagination/filtering, and `session_info_update`. |
 | Session config | Model select options are extracted. | Generic select options, boolean options, mode/reasoning/model-config categories, ordering, and dependent option updates. |
-| Agent commands | WTA has its own slash commands. | `available_commands_update` is ignored instead of contributing session-scoped Agent commands. |
+| Agent commands | Session-scoped Agent commands are merged into the slash-command popup. | No remaining stable ACP v1 gap in the current unstructured command surface. |
 | Authentication | CLI-specific login plus first-method post-login authenticate. | Auth-method selection, standard logout, and clearer capability-driven state. |
 | Cancellation | `session/cancel` stops the active prompt locally and notifies the Agent. | Stable request-ID `$/cancel_request` and consistent cancellation of pending reverse requests. |
 | Structured input | Permission cards handle approval choices. | Stable ACP elicitation form and URL modes. |
@@ -203,11 +203,15 @@ not currently have a safe file-handler selection model.
 
 ### Phase 4: Generic config options and Agent commands
 
-**Implementation status**: The first Config Options slice is implemented
-locally. WTA preserves ordered select options per Session, replaces complete
+**Implementation status**: The first Config Options slice is on `main`. WTA
+preserves ordered select options per Session, replaces complete
 snapshots from new/load/update/set responses, exposes a generic `/config`
 two-level picker, and routes `/model` through the standard model option when
-one exists. Boolean options and Agent commands remain follow-ups.
+one exists. Agent Commands are implemented locally: complete Session-scoped
+snapshots are merged after WTA-reserved commands, reserved-name collisions stay
+client-owned, commands removed by later snapshots disappear, and popup Enter
+behavior follows explicit completion metadata instead of treating the optional
+ACP input hint as argument cardinality. Boolean options remain a follow-up.
 
 1. Store the complete ordered `configOptions` collection per session.
 2. Render all supported select options, not only the `model` category.
@@ -226,12 +230,43 @@ one exists. Boolean options and Agent commands remain follow-ups.
 7. Merge `available_commands_update` into the command popup per session while
    keeping WTA-reserved commands deterministic and collision-safe.
 
+#### Slash-command completion behavior
+
+Every command candidate carries one of four completion behaviors:
+
+| Behavior | Popup Enter result |
+|---|---|
+| `ExecuteImmediately` | Complete and execute the command. |
+| `OpenPicker` | Execute the bare client command and open its picker. |
+| `RequireFreeText` | Complete to `/<name> ` and wait for text input. |
+| `OptionalFreeText` | Complete to `/<name> ` and wait; a second Enter may submit the bare command. |
+
+ACP `input.hint` remains presentation-only ghost text. ACP v1 does not express
+whether unstructured input is required, so an Agent command that advertises it
+defaults to `OptionalFreeText`. `RequireFreeText` is available for command
+registrations that explicitly carry that product-level contract; it is not
+inferred from a command name.
+
+Both free-text behaviors enter a Prepared Command state. The input renderer
+styles the `/<name>` prefix as a command token, while arguments remain ordinary
+editable text. The styling is derived from the current input and Session-scoped
+command registry, so editing the name, deleting the separating whitespace, or
+removing the command from a later snapshot clears the state without a separate
+lifecycle flag.
+
+Client and Agent candidates are ranked together: every prefix match precedes
+every substring-only match while preserving source order within each group.
+This prevents a synthetic Agent prefix such as `/del` → `/delta` from losing
+to an unrelated client substring such as `/model`.
+
 **Exit criteria**
 
 - An Agent can add, remove, reorder, and update options dynamically.
 - Model, reasoning, mode, and boolean settings use one reusable picker/control
   model.
 - Agent slash commands disappear when a later update removes them.
+- Selecting a free-text command never submits the bare command on the same
+  Enter that accepts the popup candidate.
 
 ### Phase 5: Elicitation, authentication, and cancellation
 

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -128,8 +128,8 @@ pub fn resolve_sessions_origin_filter() -> crate::agent_sessions::OriginFilter {
 }
 
 pub use crate::app_contracts::{
-    AcpModelInfo, AppEvent, AvailableAgent, CheckStatus, DebugDir, DebugMessage, PlanEntryStatus,
-    PreflightResult,
+    AcpModelInfo, AcpSessionCommand, AppEvent, AvailableAgent, CheckStatus, DebugDir, DebugMessage,
+    PlanEntryStatus, PreflightResult,
 };
 use crate::commands::{self, CommandKind, ParseOutcome, ParsedCommand};
 use crate::coordinator::{recommended_choice_index, RecommendationChoice, RecommendationSet};
@@ -1044,6 +1044,8 @@ pub struct App {
     session_model_configs: HashMap<String, (Vec<AcpModelInfo>, Option<String>)>,
     /// Complete ordered ACP select config options, keyed by SessionId.
     session_config_options: HashMap<String, Vec<crate::app_contracts::AcpSessionConfigOption>>,
+    /// Complete ordered Agent command snapshots, keyed by SessionId.
+    session_commands: HashMap<String, Vec<AcpSessionCommand>>,
     pub prompt_name: Option<String>,
     pub session_id: String,
     #[allow(dead_code)]
@@ -1362,6 +1364,7 @@ impl App {
             current_model_id: None,
             session_model_configs: HashMap::new(),
             session_config_options: HashMap::new(),
+            session_commands: HashMap::new(),
             prompt_name: None,
             session_id: String::new(),
             wt_connected,
@@ -3560,6 +3563,7 @@ impl App {
         self.session_to_tab.clear();
         self.session_model_configs.clear();
         self.session_config_options.clear();
+        self.session_commands.clear();
         let active_tab_id = self.active_tab_key().to_string();
         for tab in self.tab_sessions.values_mut() {
             tab.clear_chat_history();
@@ -4301,6 +4305,7 @@ impl App {
             AppEvent::ModelSetCompleted { .. } => "model_set_completed",
             AppEvent::ModelSetFailed { .. } => "model_set_failed",
             AppEvent::SessionConfigUpdated { .. } => "session_config_updated",
+            AppEvent::SessionCommandsUpdated { .. } => "session_commands_updated",
             AppEvent::SessionConfigSetCompleted { .. } => "session_config_set_completed",
             AppEvent::SessionConfigSetFailed { .. } => "session_config_set_failed",
             AppEvent::TabError { .. } => "tab_error",
@@ -4834,6 +4839,61 @@ impl App {
             .map(|n| (n.summary.as_str(), &n.severity))
     }
 
+    fn current_session_commands(&self) -> &[AcpSessionCommand] {
+        self.current_tab()
+            .session_id
+            .as_deref()
+            .and_then(|session_id| self.session_commands.get(session_id))
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    fn agent_slash_command_candidates(&self) -> Vec<&AcpSessionCommand> {
+        let input = self.current_tab().input.trim_start();
+        if !commands::is_command_prefix(input) {
+            return Vec::new();
+        }
+        let query = input
+            .strip_prefix('/')
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        let (prefix, contains): (Vec<_>, Vec<_>) = self
+            .current_session_commands()
+            .iter()
+            .filter(|command| {
+                commands::lookup(&command.name).is_none()
+                    && command.name.to_ascii_lowercase().contains(&query)
+            })
+            .partition(|command| command.name.to_ascii_lowercase().starts_with(&query));
+        prefix.into_iter().chain(contains).collect()
+    }
+
+    fn slash_command_candidates(&self) -> Vec<crate::ui::CommandCandidate<'_>> {
+        let query = self
+            .current_tab()
+            .input
+            .trim_start()
+            .strip_prefix('/')
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        let candidates = self
+            .current_tab()
+            .command_popup_candidates
+            .iter()
+            .copied()
+            .map(crate::ui::CommandCandidate::Client)
+            .chain(
+                self.agent_slash_command_candidates()
+                    .into_iter()
+                    .map(crate::ui::CommandCandidate::Agent),
+            )
+            .collect::<Vec<_>>();
+        let (prefix, contains): (Vec<_>, Vec<_>) = candidates
+            .into_iter()
+            .partition(|candidate| candidate.name().to_ascii_lowercase().starts_with(&query));
+        prefix.into_iter().chain(contains).collect()
+    }
+
     /// Visible popup state for the renderer. Returns `None` when the
     /// popup should not be drawn this frame. Reads from the active tab.
     pub fn command_popup_state(&self) -> Option<crate::ui::PopupState<'_>> {
@@ -4843,15 +4903,13 @@ impl App {
         }
         // Static command and move candidates borrow the tab's lists. Agent
         // candidates are filtered from the small cached available-agent list.
-        let agent_candidates: Vec<_> = self.agent_command_candidates().collect();
+        let agent_candidates: Vec<_> = self.available_agent_command_candidates().collect();
         let candidates = if !agent_candidates.is_empty() {
             crate::ui::PopupCandidates::Agents(agent_candidates)
         } else if !tab.move_position_candidates.is_empty() {
             crate::ui::PopupCandidates::MovePositions(tab.move_position_candidates.as_slice())
         } else {
-            crate::ui::PopupCandidates::Commands(std::borrow::Cow::Borrowed(
-                tab.command_popup_candidates.as_slice(),
-            ))
+            crate::ui::PopupCandidates::Commands(self.slash_command_candidates())
         };
         Some(crate::ui::PopupState {
             candidates,
@@ -4859,6 +4917,11 @@ impl App {
             pane_focused: self.pane_focused,
             command_query: tab.input.trim_start().strip_prefix('/').unwrap_or_default(),
             current_model: self.current_model_display(),
+            agent_label: if self.agent_name.is_empty() {
+                self.current_agent_id.as_str()
+            } else {
+                self.agent_name.as_str()
+            },
         })
     }
 
@@ -4905,10 +4968,11 @@ impl App {
     /// Whether the command popup is effectively visible this frame.
     pub(super) fn command_popup_visible(&self) -> bool {
         self.current_tab().command_popup_visible()
-            || self.agent_command_candidates().next().is_some()
+            || self.available_agent_command_candidates().next().is_some()
+            || !self.agent_slash_command_candidates().is_empty()
     }
 
-    fn agent_command_candidates(&self) -> impl Iterator<Item = &AvailableAgent> {
+    fn available_agent_command_candidates(&self) -> impl Iterator<Item = &AvailableAgent> {
         let prefix = commands::agent_id_prefix(&self.current_tab().input);
         self.available_agents.iter().filter(move |agent| {
             prefix.is_some_and(|prefix| {
@@ -4922,18 +4986,45 @@ impl App {
 
     fn selected_agent_command_candidate(&self) -> Option<&AvailableAgent> {
         let selected = self.current_tab().command_popup_selected;
-        self.agent_command_candidates()
+        self.available_agent_command_candidates()
             .take(selected.saturating_add(1))
             .last()
     }
 
+    fn selected_slash_command_candidate(&self) -> Option<crate::ui::CommandCandidate<'_>> {
+        let candidates = self.slash_command_candidates();
+        let selected = self
+            .current_tab()
+            .command_popup_selected
+            .min(candidates.len().saturating_sub(1));
+        candidates.get(selected).copied()
+    }
+
+    fn agent_command_for_input(&self, input: &str) -> Option<&AcpSessionCommand> {
+        let rest = input.trim_start().strip_prefix('/')?;
+        if rest.starts_with('/') {
+            return None;
+        }
+        let name = rest.split_whitespace().next()?;
+        if commands::lookup(name).is_some() {
+            return None;
+        }
+        self.current_session_commands()
+            .iter()
+            .find(|command| command.name.eq_ignore_ascii_case(name))
+    }
+
     fn command_popup_candidate_count(&self) -> usize {
-        let agent_count = self.agent_command_candidates().count();
+        let agent_count = self.available_agent_command_candidates().count();
         if agent_count > 0 {
             agent_count
         } else {
             let tab = self.current_tab();
-            tab.command_popup_candidates.len() + tab.move_position_candidates.len()
+            if !tab.move_position_candidates.is_empty() {
+                tab.move_position_candidates.len()
+            } else {
+                self.slash_command_candidates().len()
+            }
         }
     }
 
@@ -4954,12 +5045,42 @@ impl App {
         if tab.cursor_pos != tab.input.len() {
             return None;
         }
-        let prefix = commands::agent_id_prefix(&tab.input)?;
-        let candidate = self.selected_agent_command_candidate()?;
-        candidate
-            .id
-            .get(prefix.len()..)
-            .filter(|suffix| !suffix.is_empty())
+        if let Some(prefix) = commands::agent_id_prefix(&tab.input) {
+            let candidate = self.selected_agent_command_candidate()?;
+            return candidate
+                .id
+                .get(prefix.len()..)
+                .filter(|suffix| !suffix.is_empty());
+        }
+        let command = self.agent_command_for_input(&tab.input)?;
+        let rest = tab.input.trim_start().strip_prefix('/')?;
+        let name = rest.split_whitespace().next()?;
+        let after_name = rest.get(name.len()..)?;
+        (after_name.chars().all(char::is_whitespace) && !after_name.is_empty())
+            .then_some(command.input_hint.as_deref())
+            .flatten()
+            .filter(|hint| !hint.is_empty())
+    }
+
+    pub(crate) fn prepared_command_range(&self) -> Option<std::ops::Range<usize>> {
+        let input = &self.current_tab().input;
+        let trimmed = input.trim_start();
+        let leading_whitespace = input.len() - trimmed.len();
+        let rest = trimmed.strip_prefix('/')?;
+        if rest.starts_with('/') {
+            return None;
+        }
+        let name_end = rest.find(char::is_whitespace)?;
+        let name = &rest[..name_end];
+        let behavior = commands::lookup(name)
+            .map(|spec| spec.completion_behavior)
+            .or_else(|| {
+                self.agent_command_for_input(input)
+                    .map(|command| command.completion_behavior)
+            })?;
+        behavior
+            .prepares_free_text()
+            .then_some(leading_whitespace..leading_whitespace + 1 + name.len())
     }
 
     /// Per-frame state for the `/model` picker modal, or `None` when it's not
@@ -5054,9 +5175,23 @@ impl App {
                 self.handle_slash_command(parsed);
                 return true;
             }
-
-            match self.current_tab().selected_command_spec() {
-                Some(spec) => {
+            if let Some(candidate) = self.selected_slash_command_candidate() {
+                let name = candidate.name().to_string();
+                if candidate.completion_behavior().prepares_free_text() {
+                    let tab = self.current_tab_mut();
+                    tab.input = format!("/{name} ");
+                    tab.cursor_pos = tab.input.len();
+                    tab.refresh_command_popup();
+                    return true;
+                }
+                if matches!(candidate, crate::ui::CommandCandidate::Agent(_)) {
+                    let tab = self.current_tab_mut();
+                    tab.input = format!("/{name}");
+                    tab.cursor_pos = tab.input.len();
+                    tab.refresh_command_popup();
+                    return false;
+                }
+                if let crate::ui::CommandCandidate::Client(spec) = candidate {
                     let parsed = ParsedCommand {
                         kind: spec.kind,
                         spec,
@@ -5064,11 +5199,11 @@ impl App {
                     };
                     self.current_tab_mut().clear_input();
                     self.handle_slash_command(parsed);
-                }
-                None => {
-                    self.current_tab_mut().clear_input();
+                    return true;
                 }
             }
+
+            self.current_tab_mut().clear_input();
             return true;
         }
 
@@ -5083,6 +5218,27 @@ impl App {
                 true
             }
             ParseOutcome::Unknown(name) => {
+                if let Some(command) = self.agent_command_for_input(&self.current_tab().input) {
+                    if command.completion_behavior
+                        == crate::app_contracts::CompletionBehavior::RequireFreeText
+                    {
+                        let input = self.current_tab().input.trim_start();
+                        let rest = input
+                            .strip_prefix('/')
+                            .and_then(|rest| {
+                                rest.find(char::is_whitespace).map(|index| &rest[index..])
+                            })
+                            .unwrap_or_default();
+                        if rest.trim().is_empty() {
+                            let message = command.description.clone();
+                            let tab = self.current_tab_mut();
+                            tab.messages.push(ChatMessage::warning(message));
+                            tab.scroll_to_bottom();
+                            return true;
+                        }
+                    }
+                    return false;
+                }
                 // Warn but fall through: the raw line (leading `/` intact) is
                 // still sent so the user doesn't lose what they typed.
                 let tab = self.current_tab_mut();
@@ -5184,6 +5340,7 @@ impl App {
         if let Some(session_id) = self.current_tab().session_id.clone() {
             self.session_model_configs.remove(&session_id);
             self.session_config_options.remove(&session_id);
+            self.session_commands.remove(&session_id);
         }
         let tab = self.current_tab_mut();
         tab.clear_chat_history();
@@ -5360,6 +5517,7 @@ impl App {
         self.session_to_tab.clear();
         self.session_model_configs.clear();
         self.session_config_options.clear();
+        self.session_commands.clear();
         self.session_id.clear();
         for (_, tab) in self.tab_sessions.iter_mut() {
             tab.clear_chat_history();
@@ -5531,6 +5689,7 @@ impl App {
         if let Some(session_id) = removed.as_ref().and_then(|tab| tab.session_id.as_ref()) {
             self.session_model_configs.remove(session_id);
             self.session_config_options.remove(session_id);
+            self.session_commands.remove(session_id);
         }
         self.session_to_tab.retain(|_, tab| tab != closed_tab_id);
 
@@ -5760,6 +5919,7 @@ impl App {
         if let Some(session_id) = removed_session_id {
             self.session_model_configs.remove(&session_id);
             self.session_config_options.remove(&session_id);
+            self.session_commands.remove(&session_id);
         }
 
         // Prune the reverse SessionId → tab routing so late ACP chunks for

--- a/tools/wta/src/app/input_edit.rs
+++ b/tools/wta/src/app/input_edit.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use crate::commands::{self, CommandSpec, MovePositionSpec};
+use crate::commands::{self, MovePositionSpec};
 
 use super::tab_state::TabSession;
 
@@ -273,12 +273,6 @@ impl TabSession {
         if self.command_popup_selected > 0 {
             self.command_popup_selected -= 1;
         }
-    }
-
-    pub fn selected_command_spec(&self) -> Option<&'static CommandSpec> {
-        self.command_popup_candidates
-            .get(self.command_popup_selected)
-            .copied()
     }
 
     pub fn selected_move_position(&self) -> Option<&'static MovePositionSpec> {

--- a/tools/wta/src/app_contracts/command.rs
+++ b/tools/wta/src/app_contracts/command.rs
@@ -1,0 +1,21 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompletionBehavior {
+    ExecuteImmediately,
+    OpenPicker,
+    RequireFreeText,
+    OptionalFreeText,
+}
+
+impl CompletionBehavior {
+    pub fn prepares_free_text(self) -> bool {
+        matches!(self, Self::RequireFreeText | Self::OptionalFreeText)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpSessionCommand {
+    pub name: String,
+    pub description: String,
+    pub input_hint: Option<String>,
+    pub completion_behavior: CompletionBehavior,
+}

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -1,8 +1,8 @@
 use crossterm::event::{KeyEvent, MouseEvent};
 
 use super::{
-    AcpModelInfo, AcpSessionConfigOption, AvailableAgent, DebugMessage, PermOption, PlanEntry,
-    PreflightResult,
+    AcpModelInfo, AcpSessionCommand, AcpSessionConfigOption, AvailableAgent, DebugMessage,
+    PermOption, PlanEntry, PreflightResult,
 };
 
 pub enum AppEvent {
@@ -64,6 +64,10 @@ pub enum AppEvent {
     SessionConfigUpdated {
         session_id: String,
         options: Vec<AcpSessionConfigOption>,
+    },
+    SessionCommandsUpdated {
+        session_id: String,
+        commands: Vec<AcpSessionCommand>,
     },
     SessionConfigSetCompleted {
         session_id: String,

--- a/tools/wta/src/app_contracts/mod.rs
+++ b/tools/wta/src/app_contracts/mod.rs
@@ -4,6 +4,7 @@
 //! boundaries. Mutable UI state remains owned by `app`.
 
 mod agent;
+mod command;
 mod config;
 mod diagnostics;
 mod event;
@@ -13,6 +14,7 @@ mod plan;
 mod preflight;
 
 pub use agent::AvailableAgent;
+pub use command::{AcpSessionCommand, CompletionBehavior};
 pub use config::{AcpSessionConfigOption, AcpSessionConfigValue};
 pub use diagnostics::{DebugDir, DebugMessage};
 pub use event::AppEvent;

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -662,6 +662,7 @@ impl App {
                     self.session_to_tab.remove(&replaced_session_id);
                     self.session_model_configs.remove(&replaced_session_id);
                     self.session_config_options.remove(&replaced_session_id);
+                    self.session_commands.remove(&replaced_session_id);
                 }
                 self.session_to_tab
                     .insert(session_id.clone(), tab_id.clone());
@@ -829,6 +830,12 @@ impl App {
                     .unwrap_or_default();
                 picker.reconcile(options);
                 self.tab_mut(&target_tab).config_picker = picker;
+            }
+            AppEvent::SessionCommandsUpdated {
+                session_id,
+                commands,
+            } => {
+                self.session_commands.insert(session_id, commands);
             }
             AppEvent::SessionConfigSetCompleted {
                 session_id,

--- a/tools/wta/src/app_keys.rs
+++ b/tools/wta/src/app_keys.rs
@@ -865,6 +865,9 @@ impl App {
                         tab.scroll_to_bottom();
                         return;
                     }
+                    let is_agent_command = self
+                        .agent_command_for_input(&self.current_tab().input)
+                        .is_some();
                     let tab = self.current_tab_mut();
                     let display_text = std::mem::take(&mut tab.input);
                     let (text, images) = tab.attachments.take_for_submission(display_text.clone());
@@ -890,8 +893,12 @@ impl App {
                         cwd: self.source_cwd.clone(),
                         source_pane_id: self.source_session_id.clone(),
                     };
-                    let prompt =
-                        PromptSubmission::new(text.clone(), Some(pane_context)).with_images(images);
+                    let prompt = if is_agent_command {
+                        PromptSubmission::new_agent_command(text.clone(), Some(pane_context))
+                    } else {
+                        PromptSubmission::new(text.clone(), Some(pane_context))
+                    }
+                    .with_images(images);
                     prompt_timing_log(
                         prompt.id,
                         prompt.submitted_at_unix_s,

--- a/tools/wta/src/commands.rs
+++ b/tools/wta/src/commands.rs
@@ -8,6 +8,8 @@
 //! See `tools/wta/src/app.rs` `App::handle_slash_command` for dispatch and
 //! `tools/wta/src/ui/command_popup.rs` for rendering.
 
+use crate::app_contracts::CompletionBehavior;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandKind {
     Help,
@@ -56,6 +58,7 @@ pub struct CommandSpec {
     /// time so the popup follows the current locale.
     pub summary_key: &'static str,
     pub kind: CommandKind,
+    pub completion_behavior: CompletionBehavior,
 }
 
 impl CommandSpec {
@@ -76,57 +79,68 @@ pub const REGISTRY: &[CommandSpec] = &[
         name: "help",
         summary_key: "commands.help.summary",
         kind: CommandKind::Help,
+        completion_behavior: CompletionBehavior::ExecuteImmediately,
     },
     CommandSpec {
         name: "clear",
         summary_key: "commands.clear.summary",
         kind: CommandKind::Clear,
+        completion_behavior: CompletionBehavior::ExecuteImmediately,
     },
     CommandSpec {
         name: "new",
         summary_key: "commands.new.summary",
         kind: CommandKind::New,
+        completion_behavior: CompletionBehavior::ExecuteImmediately,
     },
     CommandSpec {
         name: "fix",
         summary_key: "commands.fix.summary",
         kind: CommandKind::Fix,
+        completion_behavior: CompletionBehavior::OptionalFreeText,
     },
     CommandSpec {
         name: "restart",
         summary_key: "commands.restart.summary",
         kind: CommandKind::Restart,
+        completion_behavior: CompletionBehavior::ExecuteImmediately,
     },
     CommandSpec {
         name: "stop",
         summary_key: "commands.stop.summary",
         kind: CommandKind::Stop,
+        completion_behavior: CompletionBehavior::ExecuteImmediately,
     },
     CommandSpec {
         name: "sessions",
         summary_key: "commands.sessions.summary",
         kind: CommandKind::Sessions,
+        completion_behavior: CompletionBehavior::ExecuteImmediately,
     },
     CommandSpec {
         name: "agent",
         summary_key: "commands.agent.summary",
         kind: CommandKind::Agent,
+        completion_behavior: CompletionBehavior::OpenPicker,
     },
     CommandSpec {
         name: "model",
         summary_key: "commands.model.summary",
         // `/model <id>` switches directly; bare `/model` opens the picker.
         kind: CommandKind::Model,
+        completion_behavior: CompletionBehavior::OpenPicker,
     },
     CommandSpec {
         name: "config",
         summary_key: "commands.config.summary",
         kind: CommandKind::Config,
+        completion_behavior: CompletionBehavior::OpenPicker,
     },
     CommandSpec {
         name: "move",
         summary_key: "commands.move.summary",
         kind: CommandKind::Move,
+        completion_behavior: CompletionBehavior::OpenPicker,
     },
 ];
 
@@ -474,6 +488,41 @@ mod tests {
         let sessions = matches("IONS");
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].name, "sessions");
+    }
+
+    #[test]
+    fn registry_declares_completion_behavior_for_every_command() {
+        use CompletionBehavior::{
+            ExecuteImmediately, OpenPicker, OptionalFreeText, RequireFreeText,
+        };
+
+        let actual = REGISTRY
+            .iter()
+            .map(|spec| (spec.name, spec.completion_behavior))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            actual,
+            vec![
+                ("help", ExecuteImmediately),
+                ("clear", ExecuteImmediately),
+                ("new", ExecuteImmediately),
+                ("fix", OptionalFreeText),
+                ("restart", ExecuteImmediately),
+                ("stop", ExecuteImmediately),
+                ("sessions", ExecuteImmediately),
+                ("agent", OpenPicker),
+                ("model", OpenPicker),
+                ("config", OpenPicker),
+                ("move", OpenPicker),
+            ]
+        );
+        assert!(
+            !actual
+                .iter()
+                .any(|(_, behavior)| *behavior == RequireFreeText),
+            "required free-text commands currently come from the ACP session registry"
+        );
     }
 
     #[test]

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -78,6 +78,9 @@ pub struct PromptSubmission {
     /// inputs. Automatic summaries are untrusted diagnostic context, while
     /// text supplied to `/fix` is user intent.
     pub autofix_text_kind: Option<AutofixTextKind>,
+    /// Agent-advertised slash commands are sent verbatim, without planner
+    /// templates or terminal context.
+    agent_command: bool,
     /// Images pasted into the input via Alt+V. Sent to the agent as ACP
     /// `ContentBlock::Image` blocks appended after the text block (only when
     /// the agent advertised `promptCapabilities.image`). Empty for the common
@@ -338,6 +341,12 @@ impl PromptSubmission {
         Self::new_with_kind(text, pane_context, Some(AutofixTextKind::FailureSummary))
     }
 
+    pub fn new_agent_command(text: String, pane_context: Option<PaneContext>) -> Self {
+        let mut prompt = Self::new_with_kind(text, pane_context, None);
+        prompt.agent_command = true;
+        prompt
+    }
+
     fn new_with_kind(
         text: String,
         pane_context: Option<PaneContext>,
@@ -350,12 +359,17 @@ impl PromptSubmission {
             pane_context,
             submitted_at_unix_s: now_unix_s(),
             autofix_text_kind,
+            agent_command: false,
             images: Vec::new(),
         }
     }
 
     pub fn is_autofix(&self) -> bool {
         self.autofix_text_kind.is_some()
+    }
+
+    pub fn is_agent_command(&self) -> bool {
+        self.agent_command
     }
 
     /// Attach pasted images (Alt+V) to a human-entered prompt.
@@ -909,6 +923,7 @@ fn session_update_kind(update: &acp::schema::v1::SessionUpdate) -> &'static str 
         acp::schema::v1::SessionUpdate::ToolCallUpdate(_) => "tool_call_update",
         acp::schema::v1::SessionUpdate::Plan(_) => "plan",
         acp::schema::v1::SessionUpdate::UsageUpdate(_) => "usage_update",
+        acp::schema::v1::SessionUpdate::AvailableCommandsUpdate(_) => "available_commands_update",
         _ => "other",
     }
 }
@@ -1588,6 +1603,14 @@ impl WtaClient {
                 let _ = self.state.event_tx.send(AppEvent::UsageReported {
                     session_id: sid,
                     snapshot,
+                });
+            }
+            acp::schema::v1::SessionUpdate::AvailableCommandsUpdate(update) => {
+                let commands =
+                    crate::protocol::acp::session_commands::normalize(&update.available_commands);
+                let _ = self.state.event_tx.send(AppEvent::SessionCommandsUpdated {
+                    session_id: sid,
+                    commands,
                 });
             }
             acp::schema::v1::SessionUpdate::ConfigOptionUpdate(update) => {
@@ -4403,7 +4426,11 @@ async fn dispatch_prompt_body(
     } else {
         TemplateKind::Planner
     };
-    let include_base_prompt = template_memo.should_ship_base(&prompt_session_id_str).await;
+    let include_base_prompt = if prompt.is_agent_command() {
+        false
+    } else {
+        template_memo.should_ship_base(&prompt_session_id_str).await
+    };
 
     prompt_timing_task.activate(
         &prompt_session_id_str,
@@ -4411,17 +4438,23 @@ async fn dispatch_prompt_body(
         &prompt.text,
         prompt.submitted_at_unix_s,
     );
-    let (text, prompt_source, prompt_name, resolved_target_pane) = build_prompt_text(
-        prompt.id,
-        prompt.submitted_at_unix_s,
-        &prompt.text,
-        prompt.autofix_text_kind,
-        include_base_prompt,
-        &shell_mgr_task,
-        wt_connected,
-        prompt.pane_context.as_ref(),
-    )
-    .await;
+    let (text, prompt_source, resolved_target_pane) = if prompt.is_agent_command() {
+        (prompt.text.clone(), "agent_command".to_string(), None)
+    } else {
+        let (text, source, name, target) = build_prompt_text(
+            prompt.id,
+            prompt.submitted_at_unix_s,
+            &prompt.text,
+            prompt.autofix_text_kind,
+            include_base_prompt,
+            &shell_mgr_task,
+            wt_connected,
+            prompt.pane_context.as_ref(),
+        )
+        .await;
+        let _ = event_tx_task.send(AppEvent::PromptTemplateLoaded { name });
+        (text, source, target)
+    };
     if proposal_commands_supported {
         match proposal_channels.issue(
             prompt_session_id_str.clone(),
@@ -4449,7 +4482,6 @@ async fn dispatch_prompt_body(
             pane_id,
         });
     }
-    let _ = event_tx_task.send(AppEvent::PromptTemplateLoaded { name: prompt_name });
     prompt_timing_task.mark_context_ready(&prompt_session_id_str, text.len());
     acp_log_built_prompt(
         &prompt.text,
@@ -4457,13 +4489,23 @@ async fn dispatch_prompt_body(
         &prompt_source,
         &text,
     );
-    log_turn_trace(
-        prompt.id,
-        &prompt_session_id_str,
-        kind,
-        include_base_prompt,
-        &text,
-    );
+    if prompt.is_agent_command() {
+        tracing::info!(
+            target: "acp",
+            prompt_id = prompt.id,
+            session_id = %prompt_session_id_str,
+            prompt_len = text.len(),
+            "sending Agent command verbatim"
+        );
+    } else {
+        log_turn_trace(
+            prompt.id,
+            &prompt_session_id_str,
+            kind,
+            include_base_prompt,
+            &text,
+        );
+    }
     prompt_timing_task.mark_prompt_sent(&prompt_session_id_str);
 
     // Telemetry: prompt dispatched over ACP. WTA emits `AgentPromptSent`
@@ -4476,6 +4518,7 @@ async fn dispatch_prompt_body(
         prompt.is_autofix(),
         match kind {
             TemplateKind::Autofix => "Autofix",
+            TemplateKind::Planner if prompt.is_agent_command() => "AgentCommand",
             TemplateKind::Planner => "Planner",
         },
     );

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -779,6 +779,7 @@ fn test_prompt(id: u64, text: &str, is_autofix: bool) -> PromptSubmission {
         pane_context: None,
         submitted_at_unix_s: 0.0,
         autofix_text_kind: is_autofix.then_some(AutofixTextKind::UserRequest),
+        agent_command: false,
         images: Vec::new(),
     }
 }
@@ -918,6 +919,51 @@ async fn dispatch_prompt_round_trips_through_agent() {
             assert!(
                 in_flight.lock().unwrap().is_empty(),
                 "single-flight slot must be released when the turn completes"
+            );
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn dispatch_agent_command_reaches_agent_verbatim() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let mut h = connect_for_dispatch(MockBehavior::Reply);
+            h.conn
+                .initialize(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .await
+                .expect("initialize failed");
+
+            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let mut prompt = test_prompt(1, "/usage", false);
+            prompt.agent_command = true;
+
+            dispatch_prompt(
+                prompt,
+                &h.conn,
+                &tab_to_session,
+                &memo,
+                &in_flight,
+                &cancel_signals,
+                &h.event_tx,
+                &h.shell_mgr,
+                &h.prompt_timing,
+                &h.client,
+                &PromptUsageIdentity::default(),
+                false,
+                false,
+                true,
+                &h.proposal_channels,
+            );
+
+            let _ = next_agent_chunk(&mut h.event_rx).await;
+            assert_eq!(
+                h.seen_prompts.lock().unwrap().as_slice(),
+                ["/usage"],
+                "Agent commands must bypass terminal templates and runtime context"
             );
         })
         .await;
@@ -2780,6 +2826,57 @@ async fn session_notification_routes_plan_with_status_mapping() {
             );
         }
         _ => panic!("expected Plan"),
+    }
+}
+
+#[tokio::test]
+async fn session_notification_routes_complete_available_command_snapshot() {
+    let (client, mut rx) = bare_client();
+    let commands = vec![
+        acp::schema::v1::AvailableCommand::new("plan", "Build a plan"),
+        acp::schema::v1::AvailableCommand::new("review", "Review changes").input(
+            acp::schema::v1::AvailableCommandInput::Unstructured(
+                acp::schema::v1::UnstructuredCommandInput::new("focus area"),
+            ),
+        ),
+    ];
+    client
+        .session_notification(notif(
+            "s1",
+            acp::schema::v1::SessionUpdate::AvailableCommandsUpdate(
+                acp::schema::v1::AvailableCommandsUpdate::new(commands),
+            ),
+        ))
+        .await
+        .unwrap();
+
+    match rx.try_recv() {
+        Ok(AppEvent::SessionCommandsUpdated {
+            session_id,
+            commands,
+        }) => {
+            assert_eq!(session_id, "s1");
+            assert_eq!(
+                commands,
+                vec![
+                    crate::app_contracts::AcpSessionCommand {
+                        name: "plan".into(),
+                        description: "Build a plan".into(),
+                        input_hint: None,
+                        completion_behavior:
+                            crate::app_contracts::CompletionBehavior::ExecuteImmediately,
+                    },
+                    crate::app_contracts::AcpSessionCommand {
+                        name: "review".into(),
+                        description: "Review changes".into(),
+                        input_hint: Some("focus area".into()),
+                        completion_behavior:
+                            crate::app_contracts::CompletionBehavior::OptionalFreeText,
+                    },
+                ]
+            );
+        }
+        _ => panic!("expected SessionCommandsUpdated"),
     }
 }
 

--- a/tools/wta/src/protocol/acp/mod.rs
+++ b/tools/wta/src/protocol/acp/mod.rs
@@ -6,6 +6,7 @@ pub mod probe;
 pub mod prompt;
 pub(crate) mod prompt_builder;
 pub(crate) mod prompt_context;
+pub(crate) mod session_commands;
 pub(crate) mod session_config;
 pub(crate) mod session_list;
 pub mod soft_stop;

--- a/tools/wta/src/protocol/acp/session_commands.rs
+++ b/tools/wta/src/protocol/acp/session_commands.rs
@@ -1,0 +1,82 @@
+use agent_client_protocol::schema::v1::{AvailableCommand, AvailableCommandInput};
+use std::collections::HashSet;
+
+use crate::app_contracts::{AcpSessionCommand, CompletionBehavior};
+
+pub(crate) fn normalize(commands: &[AvailableCommand]) -> Vec<AcpSessionCommand> {
+    let mut seen = HashSet::new();
+    commands
+        .iter()
+        .filter_map(|command| {
+            let name = command.name.trim().trim_start_matches('/');
+            if name.is_empty()
+                || name.chars().any(char::is_whitespace)
+                || !seen.insert(name.to_ascii_lowercase())
+            {
+                return None;
+            }
+            let input_hint = match command.input.as_ref() {
+                Some(AvailableCommandInput::Unstructured(input)) => {
+                    Some(input.hint.trim().to_string())
+                }
+                _ => None,
+            };
+            let completion_behavior = if command.input.is_some() {
+                CompletionBehavior::OptionalFreeText
+            } else {
+                CompletionBehavior::ExecuteImmediately
+            };
+            Some(AcpSessionCommand {
+                name: name.to_string(),
+                description: command.description.trim().to_string(),
+                input_hint,
+                completion_behavior,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalization_preserves_order_and_drops_unusable_duplicates() {
+        let commands = vec![
+            AvailableCommand::new(" plan ", " Build a plan "),
+            AvailableCommand::new("/review", "Review changes"),
+            AvailableCommand::new("explain", "Explain code").input(
+                AvailableCommandInput::Unstructured(
+                    agent_client_protocol::schema::v1::UnstructuredCommandInput::new(""),
+                ),
+            ),
+            AvailableCommand::new("PLAN", "Duplicate"),
+            AvailableCommand::new("two words", "Unaddressable"),
+            AvailableCommand::new("", "Empty"),
+        ];
+
+        assert_eq!(
+            normalize(&commands),
+            vec![
+                AcpSessionCommand {
+                    name: "plan".into(),
+                    description: "Build a plan".into(),
+                    input_hint: None,
+                    completion_behavior: CompletionBehavior::ExecuteImmediately,
+                },
+                AcpSessionCommand {
+                    name: "review".into(),
+                    description: "Review changes".into(),
+                    input_hint: None,
+                    completion_behavior: CompletionBehavior::ExecuteImmediately,
+                },
+                AcpSessionCommand {
+                    name: "explain".into(),
+                    description: "Explain code".into(),
+                    input_hint: Some(String::new()),
+                    completion_behavior: CompletionBehavior::OptionalFreeText,
+                },
+            ]
+        );
+    }
+}

--- a/tools/wta/src/protocol/acp/session_commands.rs
+++ b/tools/wta/src/protocol/acp/session_commands.rs
@@ -15,16 +15,12 @@ pub(crate) fn normalize(commands: &[AvailableCommand]) -> Vec<AcpSessionCommand>
             {
                 return None;
             }
-            let input_hint = match command.input.as_ref() {
-                Some(AvailableCommandInput::Unstructured(input)) => {
-                    Some(input.hint.trim().to_string())
-                }
-                _ => None,
-            };
-            let completion_behavior = if command.input.is_some() {
-                CompletionBehavior::OptionalFreeText
-            } else {
-                CompletionBehavior::ExecuteImmediately
+            let (input_hint, completion_behavior) = match command.input.as_ref() {
+                Some(AvailableCommandInput::Unstructured(input)) => (
+                    Some(input.hint.trim().to_string()),
+                    CompletionBehavior::OptionalFreeText,
+                ),
+                _ => (None, CompletionBehavior::ExecuteImmediately),
             };
             Some(AcpSessionCommand {
                 name: name.to_string(),

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -36,6 +36,46 @@ fn last_notice(app: &App) -> (NoticeKind, &str) {
     }
 }
 
+fn session_command(
+    name: &str,
+    description: &str,
+    input_hint: Option<&str>,
+) -> crate::app_contracts::AcpSessionCommand {
+    let completion_behavior = if input_hint.is_some() {
+        crate::app_contracts::CompletionBehavior::OptionalFreeText
+    } else {
+        crate::app_contracts::CompletionBehavior::ExecuteImmediately
+    };
+    session_command_with_behavior(name, description, input_hint, completion_behavior)
+}
+
+fn session_command_with_behavior(
+    name: &str,
+    description: &str,
+    input_hint: Option<&str>,
+    completion_behavior: crate::app_contracts::CompletionBehavior,
+) -> crate::app_contracts::AcpSessionCommand {
+    crate::app_contracts::AcpSessionCommand {
+        name: name.into(),
+        description: description.into(),
+        input_hint: input_hint.map(str::to_string),
+        completion_behavior,
+    }
+}
+
+fn popup_command_names(app: &App) -> Vec<String> {
+    match app.command_popup_state().expect("command popup").candidates {
+        crate::ui::PopupCandidates::Commands(candidates) => candidates
+            .into_iter()
+            .map(|candidate| match candidate {
+                crate::ui::CommandCandidate::Client(spec) => spec.name.to_string(),
+                crate::ui::CommandCandidate::Agent(command) => command.name.clone(),
+            })
+            .collect(),
+        _ => panic!("expected slash-command candidates"),
+    }
+}
+
 // ---- commands::classify — the pure input → intent mapping ----
 
 #[test]
@@ -84,6 +124,207 @@ fn classify_not_a_command() {
         commands::classify("run cmd /flag"),
         ParseOutcome::NotCommand
     );
+}
+
+#[test]
+fn agent_commands_merge_after_reserved_commands_and_replace_by_session() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionCommandsUpdated {
+        session_id: "session-1".into(),
+        commands: vec![
+            session_command("plan", "Build a plan", None),
+            session_command("clear", "Agent collision", None),
+        ],
+    });
+    app.handle_event(AppEvent::SessionCommandsUpdated {
+        session_id: "session-2".into(),
+        commands: vec![session_command("research", "Research", None)],
+    });
+    type_input(&mut app, "/");
+
+    let names = popup_command_names(&app);
+    assert_eq!(&names[..commands::REGISTRY.len()], {
+        &commands::REGISTRY
+            .iter()
+            .map(|spec| spec.name.to_string())
+            .collect::<Vec<_>>()[..]
+    });
+    assert_eq!(
+        names.iter().filter(|name| name.as_str() == "clear").count(),
+        1,
+        "an Agent command must not shadow a reserved WTA command"
+    );
+    assert!(names.contains(&"plan".to_string()));
+    assert!(!names.contains(&"research".to_string()));
+
+    app.current_tab_mut().clear_input();
+    app.handle_event(AppEvent::SessionCommandsUpdated {
+        session_id: "session-1".into(),
+        commands: vec![session_command("review", "Review changes", None)],
+    });
+    type_input(&mut app, "/");
+    let names = popup_command_names(&app);
+    assert!(!names.contains(&"plan".to_string()));
+    assert!(names.contains(&"review".to_string()));
+}
+
+#[test]
+fn agent_command_without_input_submits_as_a_normal_prompt() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionCommandsUpdated {
+        session_id: "session-1".into(),
+        commands: vec![session_command("plan", "Build a plan", None)],
+    });
+    type_input(&mut app, "/pla");
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert!(app.current_tab().input.is_empty());
+    assert!(app.current_tab().turn.is_in_flight());
+    assert!(!app.current_tab().messages.iter().any(|message| matches!(
+        message,
+        ChatMessage::Notice {
+            kind: NoticeKind::Warning,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn agent_command_with_optional_input_enters_prepared_mode() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionCommandsUpdated {
+        session_id: "session-1".into(),
+        commands: vec![session_command(
+            "review",
+            "Review changes",
+            Some("focus area"),
+        )],
+    });
+    type_input(&mut app, "/rev");
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert_eq!(app.current_tab().input, "/review ");
+    assert_eq!(app.command_ghost_suffix(), Some("focus area"));
+    assert_eq!(app.prepared_command_range(), Some(0..7));
+    assert!(app.current_tab().turn.is_idle());
+}
+
+#[test]
+fn required_free_text_metadata_drives_the_complete_prepared_flow() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionCommandsUpdated {
+        session_id: "session-1".into(),
+        commands: vec![session_command_with_behavior(
+            "intent",
+            "Provide an intent",
+            None,
+            crate::app_contracts::CompletionBehavior::RequireFreeText,
+        )],
+    });
+    type_input(&mut app, "/int");
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert_eq!(app.current_tab().input, "/intent ");
+    assert_eq!(app.prepared_command_range(), Some(0..7));
+    assert!(app.current_tab().turn.is_idle());
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert_eq!(app.current_tab().input, "/intent ");
+    assert!(app.current_tab().turn.is_idle());
+    assert_eq!(
+        last_notice(&app),
+        (NoticeKind::Warning, "Provide an intent")
+    );
+
+    type_input(&mut app, "describe the task");
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert!(app.current_tab().input.is_empty());
+    assert!(app.current_tab().turn.is_in_flight());
+}
+
+#[test]
+fn agent_prefix_match_ranks_before_client_substring_match() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.model_picker_models = vec![AcpModelInfo {
+        id: "test-model".into(),
+        name: "Test model".into(),
+        description: None,
+    }];
+    app.handle_event(AppEvent::SessionCommandsUpdated {
+        session_id: "session-1".into(),
+        commands: vec![session_command("delta", "Synthetic command", None)],
+    });
+    type_input(&mut app, "/del");
+
+    let names = popup_command_names(&app);
+
+    assert_eq!(names, vec!["delta", "model"]);
+
+    app.command_popup_down();
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert!(
+        app.current_tab().model_picker_open,
+        "the selected Client candidate must dispatch from the combined ranking"
+    );
+}
+
+#[test]
+fn optional_fix_completion_prepares_then_second_enter_runs() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    type_input(&mut app, "/fi");
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert_eq!(app.current_tab().input, "/fix ");
+    assert_eq!(app.prepared_command_range(), Some(0..4));
+    assert!(app.current_tab().turn.is_idle());
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert!(app.current_tab().input.is_empty());
+    assert!(!app.current_tab().turn.is_idle());
+}
+
+#[test]
+fn typed_agent_command_with_arguments_has_no_unknown_warning() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().session_id = Some("session-1".into());
+    app.handle_event(AppEvent::SessionCommandsUpdated {
+        session_id: "session-1".into(),
+        commands: vec![session_command(
+            "review",
+            "Review changes",
+            Some("focus area"),
+        )],
+    });
+    type_input(&mut app, "/review parser");
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert!(app.current_tab().turn.is_in_flight());
+    assert!(!app.current_tab().messages.iter().any(|message| matches!(
+        message,
+        ChatMessage::Notice {
+            kind: NoticeKind::Warning,
+            ..
+        }
+    )));
 }
 
 // ---- App dispatch — state effects via handle_slash_command ----

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -178,7 +178,7 @@ fn agent_command_without_input_submits_as_a_normal_prompt() {
         session_id: "session-1".into(),
         commands: vec![session_command("plan", "Build a plan", None)],
     });
-    type_input(&mut app, "/pla");
+    type_input(&mut app, "/plan");
 
     app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
 

--- a/tools/wta/src/theme.rs
+++ b/tools/wta/src/theme.rs
@@ -6,6 +6,7 @@ pub const USER_PROMPT: Style = Style::new().fg(Color::DarkGray);
 // a hardcoded white would be invisible in the box on a light scheme (#234).
 pub const INPUT_TEXT: Style = Style::new().fg(Color::Reset);
 pub const ATTACHMENT_TOKEN: Style = Style::new().fg(Color::Cyan);
+pub const COMMAND_TOKEN: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
 // Default foreground (Color::Reset) so the agent's reply text tracks the
 // pane's color scheme — light text on dark schemes, dark text on light
 // schemes. A hardcoded white was invisible on light color schemes (#234).

--- a/tools/wta/src/ui/command_popup.rs
+++ b/tools/wta/src/ui/command_popup.rs
@@ -5,17 +5,18 @@
 //! a filtered list of `CommandSpec`s. `/help` opens a centered overlay that
 //! lists every command with full descriptions.
 
-use std::borrow::Cow;
-
 use ratatui::prelude::*;
 use ratatui::widgets::{Clear, List, ListItem, ListState, Paragraph};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::popup;
 use crate::app::{App, AvailableAgent};
+use crate::app_contracts::{AcpSessionCommand, CompletionBehavior};
 use crate::commands::{CommandSpec, MovePositionSpec, REGISTRY};
 use crate::theme;
 
 const POPUP_MAX_VISIBLE: usize = 6;
+const SOURCE_LABEL_MAX_WIDTH: usize = 12;
 
 /// Per-frame state captured from the [`App`] so callers don't need to know
 /// the popup internals.
@@ -31,12 +32,37 @@ pub struct PopupState<'a> {
     /// they're currently on while typing the command. `None` when no model
     /// is known yet.
     pub current_model: Option<String>,
+    /// Friendly name of the connected Agent, used to identify commands
+    /// advertised through ACP.
+    pub agent_label: &'a str,
 }
 
 pub enum PopupCandidates<'a> {
-    Commands(Cow<'a, [&'static CommandSpec]>),
+    Commands(Vec<CommandCandidate<'a>>),
     MovePositions(&'a [&'static MovePositionSpec]),
     Agents(Vec<&'a AvailableAgent>),
+}
+
+#[derive(Clone, Copy)]
+pub enum CommandCandidate<'a> {
+    Client(&'static CommandSpec),
+    Agent(&'a AcpSessionCommand),
+}
+
+impl<'a> CommandCandidate<'a> {
+    pub fn name(self) -> &'a str {
+        match self {
+            Self::Client(spec) => spec.name,
+            Self::Agent(command) => command.name.as_str(),
+        }
+    }
+
+    pub fn completion_behavior(self) -> CompletionBehavior {
+        match self {
+            Self::Client(spec) => spec.completion_behavior,
+            Self::Agent(command) => command.completion_behavior,
+        }
+    }
 }
 
 /// Render the autocomplete popup just above `input_area`. If there isn't
@@ -59,22 +85,44 @@ pub fn render_popup(frame: &mut Frame, state: PopupState<'_>, input_area: Rect) 
     frame.render_widget(Clear, area);
 
     let items: Vec<ListItem> = match &state.candidates {
-        PopupCandidates::Commands(candidates) => candidates
-            .iter()
-            .map(|spec| {
-                let mut spans = command_name_spans(spec.name, state.command_query);
-                spans.push(Span::styled(spec.summary(), theme::DIM));
-                // The `/model` row shows the pane's current model so the user can
-                // see what they're on before opening the picker.
-                if spec.name == "model" {
-                    if let Some(model) = state.current_model.as_deref() {
-                        spans.push(Span::styled("  → ", theme::DIM));
-                        spans.push(Span::styled(model, theme::INPUT_TEXT));
+        PopupCandidates::Commands(candidates) => {
+            let agent_label = truncate_source_label(state.agent_label);
+            let source_width = candidates
+                .iter()
+                .map(|candidate| match candidate {
+                    CommandCandidate::Client(_) => UnicodeWidthStr::width("IT"),
+                    CommandCandidate::Agent(_) => UnicodeWidthStr::width(agent_label.as_str()),
+                })
+                .max()
+                .unwrap_or_default();
+            candidates
+                .iter()
+                .map(|candidate| {
+                    let (name, summary) = match candidate {
+                        CommandCandidate::Client(spec) => (spec.name, spec.summary()),
+                        CommandCandidate::Agent(command) => {
+                            (command.name.as_str(), command.description.clone().into())
+                        }
+                    };
+                    let mut spans = command_name_spans(name, state.command_query);
+                    spans.push(source_badge_span(
+                        candidate,
+                        agent_label.as_str(),
+                        source_width,
+                    ));
+                    spans.push(Span::styled(summary, theme::DIM));
+                    // The `/model` row shows the pane's current model so the user can
+                    // see what they're on before opening the picker.
+                    if matches!(candidate, CommandCandidate::Client(spec) if spec.name == "model") {
+                        if let Some(model) = state.current_model.as_deref() {
+                            spans.push(Span::styled("  → ", theme::DIM));
+                            spans.push(Span::styled(model, theme::INPUT_TEXT));
+                        }
                     }
-                }
-                ListItem::new(Line::from(spans))
-            })
-            .collect(),
+                    ListItem::new(Line::from(spans))
+                })
+                .collect()
+        }
         PopupCandidates::MovePositions(candidates) => candidates
             .iter()
             .map(|position| {
@@ -109,6 +157,41 @@ pub fn render_popup(frame: &mut Frame, state: PopupState<'_>, input_area: Rect) 
     list_state.select(popup_highlight(candidate_count, state.selected));
 
     frame.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn source_badge_span(
+    candidate: &CommandCandidate<'_>,
+    agent_label: &str,
+    column_width: usize,
+) -> Span<'static> {
+    let label = match candidate {
+        CommandCandidate::Client(_) => "IT",
+        CommandCandidate::Agent(_) => agent_label,
+    };
+    let padding = column_width.saturating_sub(UnicodeWidthStr::width(label));
+    Span::styled(format!("[{label}]{}  ", " ".repeat(padding)), theme::DIM)
+}
+
+fn truncate_source_label(label: &str) -> String {
+    let label = label.trim();
+    let label = if label.is_empty() { "Agent" } else { label };
+    if UnicodeWidthStr::width(label) <= SOURCE_LABEL_MAX_WIDTH {
+        return label.to_string();
+    }
+
+    let budget = SOURCE_LABEL_MAX_WIDTH - 1;
+    let mut truncated = String::new();
+    let mut width = 0;
+    for character in label.chars() {
+        let character_width = UnicodeWidthChar::width(character).unwrap_or(0);
+        if width + character_width > budget {
+            break;
+        }
+        truncated.push(character);
+        width += character_width;
+    }
+    truncated.push('…');
+    truncated
 }
 
 fn command_name_spans(name: &str, query: &str) -> Vec<Span<'static>> {
@@ -188,9 +271,14 @@ pub fn render_help_overlay(frame: &mut Frame, app: &App, area: Rect) {
 
 #[cfg(test)]
 mod tests {
-    use super::{command_name_spans, popup_highlight};
+    use super::{
+        command_name_spans, popup_highlight, source_badge_span, truncate_source_label,
+        CommandCandidate,
+    };
+    use crate::app_contracts::{AcpSessionCommand, CompletionBehavior};
     use crate::commands;
     use crate::theme;
+    use unicode_width::UnicodeWidthStr;
 
     fn spec(name: &str) -> &'static commands::CommandSpec {
         commands::lookup(name).expect("registered command")
@@ -233,5 +321,33 @@ mod tests {
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].content, " /clear    ");
         assert_eq!(spans[0].style, theme::INPUT_TEXT);
+    }
+
+    #[test]
+    fn source_badges_distinguish_client_and_agent_commands() {
+        let client = CommandCandidate::Client(spec("model"));
+        let agent_command = AcpSessionCommand {
+            name: "usage".into(),
+            description: "Show usage".into(),
+            input_hint: None,
+            completion_behavior: CompletionBehavior::ExecuteImmediately,
+        };
+        let agent = CommandCandidate::Agent(&agent_command);
+
+        assert_eq!(
+            source_badge_span(&client, "Copilot", 7).content,
+            "[IT]       "
+        );
+        assert_eq!(
+            source_badge_span(&agent, "Copilot", 7).content,
+            "[Copilot]  "
+        );
+    }
+
+    #[test]
+    fn source_label_is_width_limited() {
+        let label = truncate_source_label("Very Long Agent Name");
+        assert_eq!(label, "Very Long A…");
+        assert!(UnicodeWidthStr::width(label.as_str()) <= 12);
     }
 }

--- a/tools/wta/src/ui/input.rs
+++ b/tools/wta/src/ui/input.rs
@@ -55,6 +55,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         area.height.saturating_sub(2) as usize,
     );
     let attachment_ranges = tab.attachments.token_ranges().collect::<Vec<_>>();
+    let prepared_command_range = app.prepared_command_range();
     let ghost_suffix = app.command_ghost_suffix();
 
     // The caret is painted as a buffer cell (not the OS cursor) in every
@@ -126,6 +127,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                         line,
                         viewport.visible_line_starts[i],
                         &attachment_ranges,
+                        prepared_command_range.as_ref(),
                         viewport.cursor_col,
                         ghost_suffix,
                     );
@@ -137,6 +139,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                         line,
                         viewport.visible_line_starts[i],
                         &attachment_ranges,
+                        prepared_command_range.as_ref(),
                     );
                     if i == viewport.cursor_row {
                         if let Some(suffix) = ghost_suffix {
@@ -172,6 +175,7 @@ fn push_caret_spans(
     line: &str,
     line_start: usize,
     attachment_ranges: &[std::ops::Range<usize>],
+    prepared_command_range: Option<&std::ops::Range<usize>>,
     caret_col: usize,
     ghost_suffix: Option<&str>,
 ) {
@@ -199,7 +203,13 @@ fn push_caret_spans(
         .map(|c| c.to_string())
         .unwrap_or_else(|| " ".to_string());
 
-    push_styled_input(spans, &before, line_start, attachment_ranges);
+    push_styled_input(
+        spans,
+        &before,
+        line_start,
+        attachment_ranges,
+        prepared_command_range,
+    );
     // Reverse video so the caret block uses the scheme's own fg/bg and stays
     // visible on light schemes too (a hardcoded white block vanished on a
     // light background once the pane follows the scheme — #234).
@@ -214,7 +224,13 @@ fn push_caret_spans(
     if !after.is_empty() {
         let after_start =
             line_start + before.len() + caret_ch.map(|ch| ch.len_utf8()).unwrap_or_default();
-        push_styled_input(spans, &after, after_start, attachment_ranges);
+        push_styled_input(
+            spans,
+            &after,
+            after_start,
+            attachment_ranges,
+            prepared_command_range,
+        );
     }
 
     let ghost_rest: String = ghost_chars.collect();
@@ -228,35 +244,36 @@ fn push_styled_input(
     text: &str,
     source_start: usize,
     attachment_ranges: &[std::ops::Range<usize>],
+    prepared_command_range: Option<&std::ops::Range<usize>>,
 ) {
     if text.is_empty() {
         return;
     }
 
     let mut run = String::new();
-    let mut run_is_attachment = None;
+    let mut run_style = None;
     for (offset, ch) in text.char_indices() {
         let source_pos = source_start + offset;
-        let is_attachment = attachment_ranges
+        let style = if attachment_ranges
             .iter()
-            .any(|range| range.contains(&source_pos));
-        if run_is_attachment.is_some_and(|current| current != is_attachment) {
-            let style = if run_is_attachment == Some(true) {
-                theme::ATTACHMENT_TOKEN
-            } else {
-                theme::INPUT_TEXT
-            };
-            spans.push(Span::styled(std::mem::take(&mut run), style));
+            .any(|range| range.contains(&source_pos))
+        {
+            theme::ATTACHMENT_TOKEN
+        } else if prepared_command_range.is_some_and(|range| range.contains(&source_pos)) {
+            theme::COMMAND_TOKEN
+        } else {
+            theme::INPUT_TEXT
+        };
+        if run_style.is_some_and(|current| current != style) {
+            spans.push(Span::styled(
+                std::mem::take(&mut run),
+                run_style.unwrap_or(theme::INPUT_TEXT),
+            ));
         }
-        run_is_attachment = Some(is_attachment);
+        run_style = Some(style);
         run.push(ch);
     }
-    let style = if run_is_attachment == Some(true) {
-        theme::ATTACHMENT_TOKEN
-    } else {
-        theme::INPUT_TEXT
-    };
-    spans.push(Span::styled(run, style));
+    spans.push(Span::styled(run, run_style.unwrap_or(theme::INPUT_TEXT)));
 }
 
 pub(crate) fn input_viewport(input: &str, cursor_pos: usize, total_width: u16) -> InputViewport {
@@ -460,7 +477,7 @@ mod tests {
     fn caret_past_end_of_short_line_uses_blank_cell() {
         // Short line: the caret sits in the blank cell right after the text.
         let mut spans = Vec::new();
-        push_caret_spans(&mut spans, "ab", 0, &[], 2, None);
+        push_caret_spans(&mut spans, "ab", 0, &[], None, 2, None);
 
         assert_eq!(spans.len(), 2);
         assert_eq!(spans[0].content.as_ref(), "ab");
@@ -470,7 +487,7 @@ mod tests {
     #[test]
     fn caret_in_middle_splits_before_glyph_after() {
         let mut spans = Vec::new();
-        push_caret_spans(&mut spans, "abcd", 0, &[], 1, None);
+        push_caret_spans(&mut spans, "abcd", 0, &[], None, 1, None);
 
         assert_eq!(spans.len(), 3);
         assert_eq!(spans[0].content.as_ref(), "a");
@@ -481,7 +498,7 @@ mod tests {
     #[test]
     fn ghost_suffix_starts_under_end_caret() {
         let mut spans = Vec::new();
-        push_caret_spans(&mut spans, "/agent co", 0, &[], 9, Some("pilot"));
+        push_caret_spans(&mut spans, "/agent co", 0, &[], None, 9, Some("pilot"));
 
         assert_eq!(spans.len(), 3);
         assert_eq!(spans[0].content.as_ref(), "/agent co");
@@ -495,12 +512,25 @@ mod tests {
         let text = format!("a{token}b");
         let mut spans = Vec::new();
 
-        push_styled_input(&mut spans, &text, 0, &[1..1 + token.len()]);
+        push_styled_input(&mut spans, &text, 0, &[1..1 + token.len()], None);
 
         assert_eq!(spans.len(), 3);
         assert_eq!(spans[0].content.as_ref(), "a");
         assert_eq!(spans[1].content.as_ref(), token);
         assert_eq!(spans[1].style, theme::ATTACHMENT_TOKEN);
         assert_eq!(spans[2].content.as_ref(), "b");
+    }
+
+    #[test]
+    fn prepared_command_range_renders_as_a_distinct_token() {
+        let mut spans = Vec::new();
+
+        push_styled_input(&mut spans, "/intent describe it", 0, &[], Some(&(0..7)));
+
+        assert_eq!(spans.len(), 2);
+        assert_eq!(spans[0].content.as_ref(), "/intent");
+        assert_eq!(spans[0].style, theme::COMMAND_TOKEN);
+        assert_eq!(spans[1].content.as_ref(), " describe it");
+        assert_eq!(spans[1].style, theme::INPUT_TEXT);
     }
 }

--- a/tools/wta/src/ui/mod.rs
+++ b/tools/wta/src/ui/mod.rs
@@ -19,7 +19,7 @@ pub mod shimmer;
 mod user_input;
 
 pub use agent_popup::AgentPopupState;
-pub use command_popup::{PopupCandidates, PopupState};
+pub use command_popup::{CommandCandidate, PopupCandidates, PopupState};
 pub use config_popup::ConfigPopupState;
 #[cfg(test)]
 pub(crate) use input::input_height;


### PR DESCRIPTION
## Problem

The slash-command popup previously gave Enter one universal meaning: immediately dispatch the selected command. That works for commands such as `/help` and picker commands such as `/model`, but it is incorrect for commands that expect the user to continue typing free-form text.

The agent pane also did not surface session-scoped commands advertised through ACP `available_commands_update`, so Agent commands could not participate in the same autocomplete experience as built-in WTA commands.

## What changed

### Define command completion behavior explicitly

Every slash command now declares one of four behaviors:

| Behavior | Popup Enter | Examples |
| --- | --- | --- |
| `ExecuteImmediately` | Dispatch the selected command | `/help`, `/clear`, `/stop` |
| `OpenPicker` | Dispatch the bare command and open its picker | `/agent`, `/model`, `/config`, `/move` |
| `RequireFreeText` | Complete to `/<name> ` and wait for input | Available for explicit product metadata |
| `OptionalFreeText` | Complete to `/<name> `; a later Enter may submit it empty | `/fix`, ACP unstructured-input commands |

This removes the previous implicit coupling between autocomplete behavior and presentation hints.

For example, `/fi` now behaves as follows:

1. The first Enter completes it to `/fix ` and does not dispatch.
2. `/fix` is rendered as a prepared command token.
3. The user may type a hint, or press Enter again to execute bare `/fix`.

Required free-text commands use the same preparation flow but block empty submission.

### Add session-scoped ACP commands

- Normalize ACP `AvailableCommand` snapshots and store them by ACP SessionId.
- Update or remove snapshots with the owning session lifecycle so commands never leak between tabs or sessions.
- Merge Agent commands with built-in Client commands in the popup while preventing Agent commands from shadowing reserved WTA commands.
- Rank all prefix matches before substring-only matches across the combined Client and Agent candidate set.
- Send selected Agent commands to `session/prompt` verbatim, without planner templates or terminal runtime context.

ACP v1 identifies free text through `AvailableCommandInput::Unstructured` but does not encode whether that text is required. Those commands therefore default to `OptionalFreeText`; `RequireFreeText` remains available only when explicit product metadata can state that contract.

### Show a prepared-command state

After a free-text command is completed, its `/<name>` prefix is rendered in cyan and bold while argument text retains the normal input style. The style is derived from the current command registry and input contents, so it disappears automatically when the command is edited into an invalid state.

The styling is visual only: prepared commands do not inherit image-attachment cursor or deletion semantics.

## Test coverage

The tests cover:

- completion metadata for every built-in WTA command;
- immediate, picker, required-text, and optional-text Enter behavior;
- `/fi` → `/fix ` preparation followed by bare execution;
- required free-text empty-submission blocking;
- per-session ACP command replacement and cleanup;
- reserved-command collision handling;
- combined Client/Agent prefix-before-substring ranking and dispatch;
- ACP command normalization and unstructured-input handling;
- verbatim Agent command transport without planner context;
- prepared-command input rendering and popup source badges.

## Validation

- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools\wta\Cargo.toml`
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools\wta\Cargo.toml`
- `cmd.exe /c "tools\razzle.cmd && bcz no_clean"`
- Deployed the matching Debug Terminal and WTA binaries.
- Verified live WTA master/helper startup, ACP initialization, session creation, and Agent pane launch.