### PR TITLE
Virtualize agent pane chat history and add scrollbar

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -79,12 +79,12 @@ use autofix::*;
 pub use crate::turn_context::TurnContext;
 #[cfg(test)]
 use input_edit::{next_word_boundary, prev_word_boundary, INPUT_HISTORY_MAX_ENTRIES};
-pub(crate) use tab_state::DEFAULT_TAB_ID;
 pub use tab_state::{
     ChatMessage, CompletedTurn, ConfigPickerState, NoticeKind, PermissionState,
     RecommendationFocus, TabSession, ToolCallContent, ToolCallKind, ToolCallLocation,
     ToolCallOutput, UserInputState, View,
 };
+pub(crate) use tab_state::{CompletedTurnViewportAnchor, DEFAULT_TAB_ID};
 pub use turn_state::{AutofixContext, ChunkKind, SubmittedPrompt, TurnOutcome, TurnState};
 
 // ─── MVP sessions origin filter ────────────────────────────────────────────────────
@@ -3565,7 +3565,7 @@ impl App {
             tab.clear_chat_history();
             tab.usage = None;
             tab.usage_staleness = crate::usage::UsageStaleness::default();
-            tab.completed_turns.clear();
+            tab.clear_completed_turns();
             tab.session_id = None;
             tab.loading_session = false;
             tab.loading_target_session_id = None;
@@ -5133,7 +5133,7 @@ impl App {
     fn cmd_clear(&mut self) {
         let tab = self.current_tab_mut();
         tab.clear_chat_history();
-        tab.completed_turns.clear();
+        tab.clear_completed_turns();
         tab.scroll_to_bottom();
     }
 
@@ -5189,7 +5189,7 @@ impl App {
         tab.clear_chat_history();
         tab.usage = None;
         tab.usage_staleness = crate::usage::UsageStaleness::default();
-        tab.completed_turns.clear();
+        tab.clear_completed_turns();
         tab.session_id = None;
         tab.scroll_to_bottom();
     }
@@ -5365,7 +5365,7 @@ impl App {
             tab.clear_chat_history();
             tab.usage = None;
             tab.usage_staleness = crate::usage::UsageStaleness::default();
-            tab.completed_turns.clear();
+            tab.clear_completed_turns();
             tab.session_id = None;
         }
         let _ = self.restart_tx.send(AgentLifecycleRequest::RestartMaster);
@@ -5754,7 +5754,7 @@ impl App {
             tab.clear_chat_history();
             tab.usage = None;
             tab.usage_staleness = crate::usage::UsageStaleness::default();
-            tab.completed_turns.clear();
+            tab.clear_completed_turns();
             tab.scroll_to_bottom();
         }
         if let Some(session_id) = removed_session_id {

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::collections::VecDeque;
 
 use serde::{Deserialize, Serialize};
@@ -270,11 +271,92 @@ pub enum RecommendationFocus {
 ///
 /// `by` deliberately does NOT clamp to `max` — the bound may be stale at
 /// input time (the lazy chat build only learns `max` after exhausting
-/// history). Clamping happens on the next `set_max`.
+/// history). Rendering clamps and retries in the same frame when it discovers
+/// that the requested offset exceeds the real history.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Scroll {
     pub offset: usize,
     pub max: usize,
+}
+
+#[derive(Debug, Default)]
+struct CompletedTurnHeightCache {
+    wrap_width: usize,
+    turn_count: usize,
+    heights: Vec<Option<usize>>,
+    known_height_sum: usize,
+    known_height_count: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CompletedTurnViewportAnchor {
+    pub index: usize,
+    pub row: usize,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct CompletedTurnLayoutState {
+    height_cache: RefCell<CompletedTurnHeightCache>,
+    visible_anchors: Vec<CompletedTurnViewportAnchor>,
+    viewport_anchor: Option<CompletedTurnViewportAnchor>,
+}
+
+impl CompletedTurnHeightCache {
+    fn sync(&mut self, wrap_width: usize, turn_count: usize) {
+        if self.wrap_width != wrap_width || turn_count < self.turn_count {
+            self.wrap_width = wrap_width;
+            self.heights.clear();
+            self.known_height_sum = 0;
+            self.known_height_count = 0;
+        }
+        self.turn_count = turn_count;
+        self.heights.resize(turn_count, None);
+    }
+
+    fn get(&mut self, index: usize, wrap_width: usize, turn_count: usize) -> Option<usize> {
+        self.sync(wrap_width, turn_count);
+        self.heights.get(index).copied().flatten()
+    }
+
+    fn set(&mut self, index: usize, height: usize, wrap_width: usize, turn_count: usize) {
+        self.sync(wrap_width, turn_count);
+        if let Some(entry) = self.heights.get_mut(index) {
+            if let Some(previous) = entry.replace(height) {
+                self.known_height_sum = self
+                    .known_height_sum
+                    .saturating_sub(previous)
+                    .saturating_add(height);
+            } else {
+                self.known_height_sum = self.known_height_sum.saturating_add(height);
+                self.known_height_count = self.known_height_count.saturating_add(1);
+            }
+        }
+    }
+
+    fn invalidate(&mut self, index: usize) {
+        if let Some(entry) = self.heights.get_mut(index) {
+            if let Some(height) = entry.take() {
+                self.known_height_sum = self.known_height_sum.saturating_sub(height);
+                self.known_height_count = self.known_height_count.saturating_sub(1);
+            }
+        }
+    }
+
+    fn estimated_total(&mut self, wrap_width: usize, turn_count: usize) -> usize {
+        self.sync(wrap_width, turn_count);
+        if self.known_height_count == 0 {
+            return turn_count;
+        }
+        let average_height = self
+            .known_height_sum
+            .saturating_add(self.known_height_count - 1)
+            / self.known_height_count;
+        self.known_height_sum.saturating_add(
+            turn_count
+                .saturating_sub(self.known_height_count)
+                .saturating_mul(average_height),
+        )
+    }
 }
 
 impl Scroll {
@@ -400,6 +482,7 @@ pub struct TabSession {
     // Conversation history
     pub messages: Vec<ChatMessage>,
     pub completed_turns: Vec<CompletedTurn>,
+    pub(crate) completed_turn_layout: CompletedTurnLayoutState,
     /// Tab/Shift+Tab selects a past turn (most recent first). Enter then
     /// toggles `CompletedTurn.expanded`. None means no selection — Enter
     /// goes to the input/prompt path as before.
@@ -516,6 +599,63 @@ pub struct TabSession {
 }
 
 impl TabSession {
+    pub(crate) fn cached_completed_turn_height(
+        &self,
+        index: usize,
+        wrap_width: usize,
+    ) -> Option<usize> {
+        self.completed_turn_layout.height_cache.borrow_mut().get(
+            index,
+            wrap_width,
+            self.completed_turns.len(),
+        )
+    }
+
+    pub(crate) fn cache_completed_turn_height(
+        &self,
+        index: usize,
+        wrap_width: usize,
+        height: usize,
+    ) {
+        self.completed_turn_layout.height_cache.borrow_mut().set(
+            index,
+            height,
+            wrap_width,
+            self.completed_turns.len(),
+        );
+    }
+
+    pub(crate) fn invalidate_completed_turn_height(&self, index: usize) {
+        self.completed_turn_layout
+            .height_cache
+            .borrow_mut()
+            .invalidate(index);
+    }
+
+    pub(crate) fn estimated_completed_turn_height(&self, wrap_width: usize) -> usize {
+        self.completed_turn_layout
+            .height_cache
+            .borrow_mut()
+            .estimated_total(wrap_width, self.completed_turns.len())
+    }
+
+    pub(crate) fn completed_turn_viewport_anchor(&self) -> Option<CompletedTurnViewportAnchor> {
+        self.completed_turn_layout.viewport_anchor
+    }
+
+    pub(crate) fn finish_completed_turn_layout(
+        &mut self,
+        visible_anchors: Vec<CompletedTurnViewportAnchor>,
+    ) {
+        self.completed_turn_layout.visible_anchors = visible_anchors;
+        self.completed_turn_layout.viewport_anchor = None;
+    }
+
+    pub(crate) fn clear_completed_turns(&mut self) {
+        self.completed_turns.clear();
+        self.completed_turn_layout = CompletedTurnLayoutState::default();
+    }
+
     pub(crate) fn invalidate_pending_paste(&mut self) {
         self.paste_pending = false;
         self.paste_generation = self.paste_generation.wrapping_add(1);
@@ -751,7 +891,17 @@ impl TabSession {
         let Some(turn) = self.completed_turns.get_mut(index) else {
             return false;
         };
+        self.completed_turn_layout.viewport_anchor = self
+            .completed_turn_layout
+            .visible_anchors
+            .iter()
+            .copied()
+            .find(|anchor| anchor.index == index);
         turn.expanded = !turn.expanded;
+        self.completed_turn_layout
+            .height_cache
+            .get_mut()
+            .invalidate(index);
         true
     }
 

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -233,10 +233,12 @@ impl App {
             return;
         };
         let tab = self.current_tab_mut();
-        let Some(turn) = tab.completed_turns.get_mut(click.turn_index) else {
+        let Some(turn) = tab.completed_turns.get(click.turn_index) else {
             return;
         };
-        turn.expanded = click.previous_expanded;
+        if turn.expanded != click.previous_expanded {
+            tab.toggle_completed_turn(click.turn_index);
+        }
         tab.selected_completed_turn_idx = click.previous_selected_index;
         tab.completed_turn_selection_visible_pending = click.previous_selection_pending;
     }
@@ -1408,7 +1410,7 @@ impl App {
                 exit_code,
             } => {
                 let tab = self.session_tab_mut(&session_id);
-                let update_content = |message: &mut ChatMessage| {
+                let update_content = |message: &mut ChatMessage| -> bool {
                     let ChatMessage::ToolCall {
                         output: card_output,
                         exit_code: card_exit_code,
@@ -1416,7 +1418,7 @@ impl App {
                         ..
                     } = message
                     else {
-                        return;
+                        return false;
                     };
                     let mut contains_terminal = false;
                     for item in content {
@@ -1441,14 +1443,23 @@ impl App {
                             *card_exit_code = exit_code;
                         }
                     }
+                    contains_terminal
                 };
                 for message in &mut tab.messages {
                     update_content(message);
                 }
-                for turn in &mut tab.completed_turns {
+                let mut invalidated_turns = Vec::new();
+                for (index, turn) in tab.completed_turns.iter_mut().enumerate() {
+                    let mut changed = false;
                     for message in &mut turn.details {
-                        update_content(message);
+                        changed |= update_content(message);
                     }
+                    if changed {
+                        invalidated_turns.push(index);
+                    }
+                }
+                for index in invalidated_turns {
+                    tab.invalidate_completed_turn_height(index);
                 }
             }
             AppEvent::HideToolCall { session_id, id } => {
@@ -2321,7 +2332,7 @@ impl App {
                         tab.clear_chat_history();
                         tab.usage = None;
                         tab.usage_staleness = crate::usage::UsageStaleness::default();
-                        tab.completed_turns.clear();
+                        tab.clear_completed_turns();
                         // Open the replay window: chunk handlers will
                         // now accept session/update events for this
                         // tab even though `turn` stays Idle. Closed by

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -10735,7 +10735,7 @@ fn completed_tool_output_update_invalidates_cached_turn_height() {
         session_id: DEFAULT_TAB_ID.into(),
         terminal_id: "terminal-cache-id".into(),
         output: ToolCallOutput {
-            text: "TERMINAL_CACHE_NEW_OUTPUT\nsecond line".into(),
+            text: concat!("TERMINAL_CACHE_NEW_OUTPUT", "\n", "second line").into(),
             truncated: false,
         },
         exit_code: Some(0),

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -9933,6 +9933,13 @@ fn completed_turn_triangle_hits_follow_visible_scrolled_turns() {
         assert_eq!(turn.expanded, index == target.turn_index);
     }
 
+    render_to_text(&mut app, 80, 10);
+    let expanded_hits: Vec<_> = app
+        .completed_turn_hits
+        .iter()
+        .copied()
+        .filter(|hit| hit.kind == CompletedTurnHitKind::Triangle)
+        .collect();
     app.current_tab_mut().chat_scroll.by(3);
     let after_scroll = render_to_text(&mut app, 80, 10);
     let scrolled_hits: Vec<_> = app
@@ -9941,7 +9948,7 @@ fn completed_turn_triangle_hits_follow_visible_scrolled_turns() {
         .copied()
         .filter(|hit| hit.kind == CompletedTurnHitKind::Triangle)
         .collect();
-    assert_ne!(scrolled_hits, initial_hits);
+    assert_ne!(scrolled_hits, expanded_hits);
     for hit in &scrolled_hits {
         assert!(after_scroll.contains(&format!("MOUSE_VISIBLE_TURN_{:02}", hit.turn_index)));
         assert!(hit.row < 10);
@@ -10273,6 +10280,473 @@ fn render_large_mixed_chat_keeps_latest_content_and_width_correct() {
     assert!(
         scrolled.contains("OLD_TURN_"),
         "older mixed history must remain renderable after lazy height estimation",
+    );
+}
+
+#[test]
+fn repeated_deep_scroll_reuses_intermediate_turn_heights() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    for index in 0..200 {
+        app.current_tab_mut().completed_turns.push(CompletedTurn {
+            prompt: format!("CACHED_SCROLL_TURN_{index:03}"),
+            details: vec![ChatMessage::Agent(format!(
+                "CACHED_SCROLL_DETAIL_{index:03}"
+            ))],
+            expanded: true,
+            trailing_marker: None,
+        });
+    }
+    app.current_tab_mut().chat_scroll.offset = 300;
+
+    crate::ui::chat::reset_completed_turn_line_build_count();
+    let first = render_to_text(&mut app, 80, 20);
+    let first_builds = crate::ui::chat::completed_turn_line_build_count();
+    assert!(first.contains("CACHED_SCROLL_TURN_"));
+    assert!(!first.contains("CACHED_SCROLL_TURN_199"));
+
+    crate::ui::chat::reset_completed_turn_line_build_count();
+    let second = render_to_text(&mut app, 80, 20);
+    let second_builds = crate::ui::chat::completed_turn_line_build_count();
+
+    assert_eq!(second, first);
+    assert!(
+        second_builds < first_builds,
+        "the second frame must reuse intermediate heights: first={first_builds}, second={second_builds}",
+    );
+    assert!(
+        second_builds < 20,
+        "deep-scroll redraw must only build viewport-adjacent turns; built {second_builds}",
+    );
+}
+
+#[test]
+fn wrapped_live_message_stops_before_completed_history() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut()
+        .messages
+        .push(ChatMessage::Agent(format!(
+            "{}LIVE_WRAP_BOTTOM",
+            "word ".repeat(1_000),
+        )));
+    app.current_tab_mut().completed_turns.push(CompletedTurn {
+        prompt: "OLDER_COMPLETED_TURN".into(),
+        details: vec![ChatMessage::Agent("older detail".into())],
+        expanded: true,
+        trailing_marker: None,
+    });
+
+    crate::ui::chat::reset_completed_turn_line_build_count();
+    let rendered = render_to_text(&mut app, 40, 10);
+
+    assert!(rendered.contains("LIVE_WRAP_BOTTOM"));
+    assert!(!rendered.contains("OLDER_COMPLETED_TURN"));
+    assert_eq!(
+        crate::ui::chat::completed_turn_line_build_count(),
+        0,
+        "wrapped live rows that fill the viewport must stop before completed history",
+    );
+}
+
+#[test]
+fn completed_turn_height_cache_invalidates_for_width_and_expansion() {
+    let mut app = test_app();
+    app.current_tab_mut().completed_turns.push(CompletedTurn {
+        prompt: "CACHE_INVALIDATION_PROMPT".into(),
+        details: vec![ChatMessage::Agent(
+            "detail text that wraps differently after the pane becomes narrow".repeat(4),
+        )],
+        expanded: false,
+        trailing_marker: None,
+    });
+
+    let collapsed = crate::ui::chat::estimated_block_height(&app, 80, 100);
+    crate::ui::chat::reset_completed_turn_line_build_count();
+    assert_eq!(
+        crate::ui::chat::estimated_block_height(&app, 80, 100),
+        collapsed,
+    );
+    assert_eq!(
+        crate::ui::chat::completed_turn_line_build_count(),
+        0,
+        "unchanged width and content must use the cached height",
+    );
+
+    app.current_tab_mut().toggle_completed_turn(0);
+    crate::ui::chat::reset_completed_turn_line_build_count();
+    let expanded = crate::ui::chat::estimated_block_height(&app, 80, 100);
+    assert!(expanded > collapsed);
+    assert_eq!(crate::ui::chat::completed_turn_line_build_count(), 1);
+
+    crate::ui::chat::reset_completed_turn_line_build_count();
+    let narrow = crate::ui::chat::estimated_block_height(&app, 30, 100);
+    assert!(narrow > expanded);
+    assert_eq!(
+        crate::ui::chat::completed_turn_line_build_count(),
+        1,
+        "a width change must invalidate cached wrapping",
+    );
+}
+
+#[test]
+fn completed_turn_height_estimate_tracks_cache_updates_and_width() {
+    let mut tab = TabSession::default();
+    for index in 0..4 {
+        tab.completed_turns.push(CompletedTurn {
+            prompt: format!("ESTIMATED_HEIGHT_TURN_{index}"),
+            details: Vec::new(),
+            expanded: false,
+            trailing_marker: None,
+        });
+    }
+
+    assert_eq!(
+        tab.estimated_completed_turn_height(80),
+        4,
+        "without measurements, every turn contributes its one-row minimum",
+    );
+
+    tab.cache_completed_turn_height(0, 80, 3);
+    tab.cache_completed_turn_height(1, 80, 5);
+    assert_eq!(
+        tab.estimated_completed_turn_height(80),
+        16,
+        "unknown turns use the rounded-up mean of known heights",
+    );
+
+    tab.cache_completed_turn_height(1, 80, 7);
+    assert_eq!(
+        tab.estimated_completed_turn_height(80),
+        20,
+        "replacing a cached height must update rather than double-count it",
+    );
+
+    tab.invalidate_completed_turn_height(0);
+    assert_eq!(
+        tab.estimated_completed_turn_height(80),
+        28,
+        "invalidated heights must leave both aggregate count and sum",
+    );
+    assert_eq!(
+        tab.estimated_completed_turn_height(40),
+        4,
+        "changing wrap width must discard incompatible measurements",
+    );
+}
+
+#[test]
+fn scrollbar_metrics_map_bottom_based_offsets_to_ratatui_state() {
+    use crate::ui::chat::ScrollbarMetrics;
+
+    assert_eq!(crate::ui::chat::scrollbar_metrics(10, 10, 0), None);
+    assert_eq!(
+        crate::ui::chat::scrollbar_metrics(100, 20, 0),
+        Some(ScrollbarMetrics {
+            content_length: 81,
+            position: 80,
+        }),
+    );
+    assert_eq!(
+        crate::ui::chat::scrollbar_metrics(100, 20, 30),
+        Some(ScrollbarMetrics {
+            content_length: 81,
+            position: 50,
+        }),
+    );
+    assert_eq!(
+        crate::ui::chat::scrollbar_metrics(100, 20, 80),
+        Some(ScrollbarMetrics {
+            content_length: 81,
+            position: 0,
+        }),
+    );
+    assert_eq!(
+        crate::ui::chat::scrollbar_metrics(100, 20, usize::MAX),
+        Some(ScrollbarMetrics {
+            content_length: 81,
+            position: 0,
+        }),
+        "overscroll must clamp to the top",
+    );
+}
+
+#[test]
+fn collapsing_old_turn_immediately_restores_newer_collapsed_turn() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    for index in 0..2 {
+        app.current_tab_mut().completed_turns.push(CompletedTurn {
+            prompt: format!("COLLAPSE_SCROLL_TURN_{index}"),
+            details: vec![ChatMessage::Agent("detail\n".repeat(20))],
+            expanded: false,
+            trailing_marker: None,
+        });
+    }
+
+    let initial = render_to_text(&mut app, 80, 8);
+    assert!(initial.contains("COLLAPSE_SCROLL_TURN_0"));
+    assert!(initial.contains("COLLAPSE_SCROLL_TURN_1"));
+
+    app.current_tab_mut().select_completed_turn(0);
+    app.current_tab_mut().toggle_selected_completed_turn();
+    render_to_text(&mut app, 80, 8);
+    assert!(
+        app.current_tab().chat_scroll.offset > 0,
+        "expanding the old turn must scroll enough to keep its header visible",
+    );
+
+    app.current_tab_mut().toggle_selected_completed_turn();
+    let collapsed = render_to_text(&mut app, 80, 8);
+    assert!(collapsed.contains("COLLAPSE_SCROLL_TURN_0"));
+    assert!(
+        collapsed.contains("COLLAPSE_SCROLL_TURN_1"),
+        "the newer collapsed turn must return on the first frame after collapse:\n{collapsed}",
+    );
+    assert_eq!(
+        app.current_tab().chat_scroll.offset,
+        0,
+        "the collapsed two-row history fits in the viewport",
+    );
+}
+
+#[test]
+fn expanding_completed_turn_keeps_prompt_and_older_buffer_rows_anchored() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    for index in 0..4 {
+        app.current_tab_mut().completed_turns.push(CompletedTurn {
+            prompt: format!("ANCHOR_TOGGLE_TURN_{index}"),
+            details: vec![ChatMessage::Agent("expanded detail\n".repeat(20))],
+            expanded: false,
+            trailing_marker: None,
+        });
+    }
+
+    let initial = render_to_text(&mut app, 80, 16);
+    let row_of = |rendered: &str, index: usize| {
+        rendered
+            .lines()
+            .position(|line| line.contains(&format!("ANCHOR_TOGGLE_TURN_{index}")))
+            .expect("anchored prompt must be visible")
+    };
+    let anchored_rows = (0..=1)
+        .map(|index| row_of(&initial, index))
+        .collect::<Vec<_>>();
+
+    app.current_tab_mut().select_completed_turn(1);
+    render_to_text(&mut app, 80, 16);
+    app.current_tab_mut().toggle_selected_completed_turn();
+    let expanded = render_to_text(&mut app, 80, 16);
+    for (index, expected_row) in anchored_rows.iter().copied().enumerate() {
+        assert_eq!(
+            row_of(&expanded, index),
+            expected_row,
+            "expanding turn 1 must not move its prompt or older buffer row {index}",
+        );
+    }
+
+    app.current_tab_mut().toggle_selected_completed_turn();
+    let collapsed = render_to_text(&mut app, 80, 16);
+    for (index, expected_row) in anchored_rows.iter().copied().enumerate() {
+        assert_eq!(
+            row_of(&collapsed, index),
+            expected_row,
+            "collapsing turn 1 must restore without moving older buffer row {index}",
+        );
+    }
+}
+
+#[test]
+fn wheel_up_does_not_hide_collapsed_turns_when_history_fits() {
+    use crossterm::event::{KeyModifiers, MouseEvent, MouseEventKind};
+
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    for index in 0..2 {
+        app.current_tab_mut().completed_turns.push(CompletedTurn {
+            prompt: format!("FITTING_SCROLL_TURN_{index}"),
+            details: vec![ChatMessage::Agent("detail".into())],
+            expanded: false,
+            trailing_marker: None,
+        });
+    }
+
+    let initial = render_to_text(&mut app, 80, 8);
+    assert!(initial.contains("FITTING_SCROLL_TURN_0"));
+    assert!(initial.contains("FITTING_SCROLL_TURN_1"));
+
+    app.handle_event(AppEvent::Mouse(MouseEvent {
+        kind: MouseEventKind::ScrollUp,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    }));
+    let after_scroll = render_to_text(&mut app, 80, 8);
+
+    assert_eq!(app.current_tab().chat_scroll.offset, 0);
+    assert!(after_scroll.contains("FITTING_SCROLL_TURN_0"));
+    assert!(
+        after_scroll.contains("FITTING_SCROLL_TURN_1"),
+        "overscroll must not virtualize a row when all history fits:\n{after_scroll}",
+    );
+}
+
+#[test]
+fn chat_scrollbar_appears_only_for_overflow_and_tracks_scroll_position() {
+    let mut fitting = test_app();
+    fitting.state = ConnectionState::Connected;
+    fitting
+        .current_tab_mut()
+        .completed_turns
+        .push(CompletedTurn {
+            prompt: "SCROLLBAR_FITTING_TURN".into(),
+            details: Vec::new(),
+            expanded: false,
+            trailing_marker: None,
+        });
+    let fitting_buffer = render_to_buffer(&mut fitting, 80, 16);
+    assert!(
+        !fitting_buffer
+            .content
+            .iter()
+            .any(|cell| cell.symbol() == "┃"),
+        "the scrollbar must stay hidden when all chat content fits",
+    );
+
+    let mut overflowing = test_app();
+    overflowing.state = ConnectionState::Connected;
+    for index in 0..80 {
+        overflowing
+            .current_tab_mut()
+            .completed_turns
+            .push(CompletedTurn {
+                prompt: format!("SCROLLBAR_OVERFLOW_TURN_{index}"),
+                details: Vec::new(),
+                expanded: false,
+                trailing_marker: None,
+            });
+    }
+
+    let thumb_rows = |buffer: &ratatui::buffer::Buffer| {
+        (0..buffer.area.height)
+            .filter(|row| {
+                buffer
+                    .cell((buffer.area.width - 1, *row))
+                    .is_some_and(|cell| cell.symbol() == "┃")
+            })
+            .collect::<Vec<_>>()
+    };
+
+    let bottom_buffer = render_to_buffer(&mut overflowing, 80, 16);
+    let bottom_thumb = thumb_rows(&bottom_buffer);
+    assert!(
+        !bottom_thumb.is_empty(),
+        "overflowing chat must paint a scrollbar in the right padding",
+    );
+    let input_top = (0..bottom_buffer.area.height)
+        .find(|row| {
+            bottom_buffer
+                .cell((bottom_buffer.area.width - 1, *row))
+                .is_some_and(|cell| cell.symbol() == "┐")
+        })
+        .expect("input dialog must paint its top-right corner");
+    assert_eq!(
+        bottom_thumb.last().copied(),
+        input_top.checked_sub(1),
+        "bottom scroll position must place the thumb against the end of the chat track",
+    );
+
+    overflowing.current_tab_mut().chat_scroll.offset = 30;
+    let scrolled_buffer = render_to_buffer(&mut overflowing, 80, 16);
+    let scrolled_thumb = thumb_rows(&scrolled_buffer);
+    assert!(!scrolled_thumb.is_empty());
+    assert!(
+        scrolled_thumb[0] < bottom_thumb[0],
+        "scrolling toward older turns must move the thumb upward",
+    );
+}
+
+#[test]
+fn completed_turn_toggle_render_is_stable_after_first_frame() {
+    for height in 6..=16 {
+        for selected_index in 0..4 {
+            let mut app = test_app();
+            app.state = ConnectionState::Connected;
+            for index in 0..4 {
+                app.current_tab_mut().completed_turns.push(CompletedTurn {
+                    prompt: format!("STABLE_TOGGLE_TURN_{index}"),
+                    details: vec![ChatMessage::Agent("detail\n".repeat(20))],
+                    expanded: false,
+                    trailing_marker: None,
+                });
+            }
+            render_to_text(&mut app, 80, height);
+
+            app.current_tab_mut().select_completed_turn(selected_index);
+            app.current_tab_mut().toggle_selected_completed_turn();
+            let first_expanded = render_to_text(&mut app, 80, height);
+            let second_expanded = render_to_text(&mut app, 80, height);
+            assert_eq!(
+                first_expanded, second_expanded,
+                "expanded render changed without an event at height={height}, turn={selected_index}",
+            );
+
+            app.current_tab_mut().toggle_selected_completed_turn();
+            let first_collapsed = render_to_text(&mut app, 80, height);
+            let second_collapsed = render_to_text(&mut app, 80, height);
+            assert_eq!(
+                first_collapsed, second_collapsed,
+                "collapsed render changed without an event at height={height}, turn={selected_index}",
+            );
+        }
+    }
+}
+
+#[test]
+fn completed_tool_output_update_invalidates_cached_turn_height() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().completed_turns.push(CompletedTurn {
+        prompt: "TERMINAL_CACHE_PROMPT".into(),
+        details: vec![ChatMessage::ToolCall {
+            id: "terminal-cache-tool".into(),
+            title: "Run cached command".into(),
+            status: "Completed".into(),
+            kind: ToolCallKind::Execute,
+            location: Some("echo cached".into()),
+            location_is_command: true,
+            cwd: None,
+            output: None,
+            exit_code: None,
+            content: vec![ToolCallContent::Terminal {
+                id: "terminal-cache-id".into(),
+                output: None,
+                exit_code: None,
+            }],
+            locations: Vec::new(),
+        }],
+        expanded: true,
+        trailing_marker: None,
+    });
+    render_to_text(&mut app, 80, 20);
+
+    app.handle_event(AppEvent::ToolTerminalOutput {
+        session_id: DEFAULT_TAB_ID.into(),
+        terminal_id: "terminal-cache-id".into(),
+        output: ToolCallOutput {
+            text: "TERMINAL_CACHE_NEW_OUTPUT\nsecond line".into(),
+            truncated: false,
+        },
+        exit_code: Some(0),
+    });
+
+    crate::ui::chat::reset_completed_turn_line_build_count();
+    let rendered = render_to_text(&mut app, 80, 20);
+    assert!(rendered.contains("TERMINAL_CACHE_NEW_OUTPUT"));
+    assert!(
+        crate::ui::chat::completed_turn_line_build_count() > 0,
+        "completed tool updates must invalidate the cached turn",
     );
 }
 
@@ -11972,12 +12446,8 @@ fn render_chat_keeps_keyboard_selected_completed_turn_visible() {
     let after = render_to_text(&mut app, 80, 16);
     let built_turns = crate::ui::chat::completed_turn_line_build_count();
     assert!(
-        built_turns >= app.current_tab().completed_turns.len(),
-        "selection-follow rendering must build enough turns to reach the oldest selection",
-    );
-    assert!(
-        built_turns < app.current_tab().completed_turns.len() * 2,
-        "height estimation must stop before rebuilding all completed turns; built {built_turns}",
+        built_turns < app.current_tab().completed_turns.len(),
+        "selection-follow rendering must reuse cached heights for intermediate turns; built {built_turns}",
     );
     assert!(
         after.contains("SELECT_SCROLL_TURN_00"),

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -703,8 +703,9 @@ impl App {
         } else {
             // AgentMessageEnd already committed this turn while the card was
             // visible, so only annotate that existing history entry.
-            if let Some(last) = tab.completed_turns.last_mut() {
+            if let Some((index, last)) = tab.completed_turns.iter_mut().enumerate().next_back() {
                 last.trailing_marker = Some(marker);
+                tab.invalidate_completed_turn_height(index);
             }
             TurnOutcome::Empty
         };
@@ -823,8 +824,9 @@ impl App {
             });
             tab.scroll_to_bottom();
         } else if annotate_card {
-            if let Some(last) = tab.completed_turns.last_mut() {
+            if let Some((index, last)) = tab.completed_turns.iter_mut().enumerate().next_back() {
                 last.trailing_marker = Some(canceled_marker);
+                tab.invalidate_completed_turn_height(index);
             }
         }
         tab.autofix.pane_id = None;

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -3,7 +3,9 @@ use std::borrow::Cow;
 use std::cell::Cell;
 
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use ratatui::widgets::{
+    Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap,
+};
 use unicode_width::UnicodeWidthStr;
 
 #[cfg(test)]
@@ -242,11 +244,8 @@ pub fn estimated_block_height(app: &App, area_width: u16, max_height: u16) -> u1
         }
     }
 
-    for turn in tab.completed_turns.iter().rev() {
-        height = height.saturating_add(rendered_lines_height(
-            &build_completed_turn_lines(turn, false, false, wrap_width),
-            wrap_width,
-        ));
+    for index in (0..tab.completed_turns.len()).rev() {
+        height = height.saturating_add(completed_turn_height(tab, index, wrap_width));
         if height >= max_height {
             return max_height as u16;
         }
@@ -296,6 +295,21 @@ fn rendered_lines_height(lines: &[Line<'_>], wrap_width: usize) -> usize {
             }
         })
         .sum()
+}
+
+fn completed_turn_height(tab: &crate::app::TabSession, index: usize, wrap_width: usize) -> usize {
+    if let Some(height) = tab.cached_completed_turn_height(index, wrap_width) {
+        return height;
+    }
+    let Some(turn) = tab.completed_turns.get(index) else {
+        return 0;
+    };
+    let height = rendered_lines_height(
+        &build_completed_turn_lines(turn, false, false, wrap_width),
+        wrap_width,
+    );
+    tab.cache_completed_turn_height(index, wrap_width, height);
+    height
 }
 
 fn starts_with_ignore_ascii_case(value: &str, prefix: &str) -> bool {
@@ -359,7 +373,163 @@ fn breathing_dot(frame: usize) -> &'static str {
     }
 }
 
-pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
+const CHAT_RENDER_OVERSCAN_ROWS: usize = 32;
+
+struct CompletedTurnHitOffset {
+    turn_index: usize,
+    rows_below: usize,
+    turn_height: usize,
+    expanded: bool,
+    prompt_rows: Vec<PromptRowGeometry>,
+}
+
+struct PlannedCompletedTurn {
+    index: usize,
+    rows_below: usize,
+    height: usize,
+}
+
+struct CompletedTurnViewportPlan {
+    turns: Vec<PlannedCompletedTurn>,
+    skip_base_lines: bool,
+    skipped_rows_below: usize,
+    effective_offset: usize,
+    requested_rows: usize,
+    truncated: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ScrollbarMetrics {
+    pub content_length: usize,
+    pub position: usize,
+}
+
+pub(crate) fn scrollbar_metrics(
+    total_rows: usize,
+    visible_rows: usize,
+    offset_from_bottom: usize,
+) -> Option<ScrollbarMetrics> {
+    if visible_rows == 0 || total_rows <= visible_rows {
+        return None;
+    }
+    let max_offset = total_rows - visible_rows;
+    Some(ScrollbarMetrics {
+        content_length: max_offset.saturating_add(1),
+        position: max_offset.saturating_sub(offset_from_bottom.min(max_offset)),
+    })
+}
+
+fn plan_completed_turn_viewport(
+    tab: &crate::app::TabSession,
+    base_rendered_rows: usize,
+    visible_height: usize,
+    wrap_width: usize,
+    mut effective_offset: usize,
+    selection_target_idx: Option<usize>,
+    viewport_anchor: Option<crate::app::CompletedTurnViewportAnchor>,
+) -> CompletedTurnViewportPlan {
+    let mut turns = Vec::new();
+    let mut skip_base_lines;
+    let mut skipped_rows_below;
+    let mut requested_rows;
+    let mut truncated;
+
+    let target_idx = viewport_anchor
+        .map(|anchor| anchor.index)
+        .or(selection_target_idx)
+        .filter(|index| *index < tab.completed_turns.len());
+    if let Some(target_idx) = target_idx {
+        let mut target_rows_below = base_rendered_rows;
+        for index in ((target_idx + 1)..tab.completed_turns.len()).rev() {
+            target_rows_below =
+                target_rows_below.saturating_add(completed_turn_height(tab, index, wrap_width));
+        }
+        let target_height = completed_turn_height(tab, target_idx, wrap_width);
+        if let Some(anchor) = viewport_anchor.filter(|anchor| anchor.index == target_idx) {
+            effective_offset = anchor
+                .row
+                .saturating_add(target_rows_below)
+                .saturating_add(target_height)
+                .saturating_sub(visible_height);
+        } else {
+            let target_end = target_rows_below.saturating_add(target_height);
+            let viewport_height = visible_height.max(1);
+            effective_offset = if target_rows_below < effective_offset {
+                target_rows_below
+            } else if target_end > effective_offset.saturating_add(viewport_height) {
+                target_end.saturating_sub(viewport_height)
+            } else {
+                effective_offset
+            };
+        }
+    }
+
+    loop {
+        turns.clear();
+        skipped_rows_below = 0;
+        truncated = false;
+        skip_base_lines = false;
+        let mut rendered_rows_below = base_rendered_rows;
+
+        if rendered_rows_below <= effective_offset {
+            skipped_rows_below = rendered_rows_below;
+            skip_base_lines = true;
+        }
+        requested_rows = visible_height
+            .saturating_add(effective_offset.saturating_sub(skipped_rows_below))
+            .saturating_add(CHAT_RENDER_OVERSCAN_ROWS);
+        let mut built_rows = if skip_base_lines {
+            0
+        } else {
+            base_rendered_rows
+        };
+
+        for index in (0..tab.completed_turns.len()).rev() {
+            let turn_height = completed_turn_height(tab, index, wrap_width);
+            let turn_end = rendered_rows_below.saturating_add(turn_height);
+            if turn_end <= effective_offset {
+                skipped_rows_below = turn_end;
+                rendered_rows_below = turn_end;
+                requested_rows = visible_height
+                    .saturating_add(effective_offset.saturating_sub(skipped_rows_below))
+                    .saturating_add(CHAT_RENDER_OVERSCAN_ROWS);
+                continue;
+            }
+
+            turns.push(PlannedCompletedTurn {
+                index,
+                rows_below: rendered_rows_below.saturating_sub(skipped_rows_below),
+                height: turn_height,
+            });
+            rendered_rows_below = turn_end;
+            built_rows = built_rows.saturating_add(turn_height);
+            if built_rows >= requested_rows && index > 0 {
+                truncated = true;
+                break;
+            }
+        }
+
+        if !truncated {
+            let max_offset = rendered_rows_below.saturating_sub(visible_height);
+            if effective_offset > max_offset {
+                effective_offset = max_offset;
+                continue;
+            }
+        }
+        break;
+    }
+
+    CompletedTurnViewportPlan {
+        turns,
+        skip_base_lines,
+        skipped_rows_below,
+        effective_offset,
+        requested_rows,
+        truncated,
+    }
+}
+
+pub fn render(frame: &mut Frame, app: &mut App, area: Rect, scrollbar_area: Rect) {
     let render_started = std::time::Instant::now();
 
     let inner = Block::default().borders(Borders::NONE);
@@ -371,15 +541,18 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         .then_some(app.current_tab().selected_completed_turn_idx)
         .flatten()
         .filter(|index| *index < app.current_tab().completed_turns.len());
+    let viewport_anchor = app.current_tab().completed_turn_viewport_anchor();
     let mut effective_offset = app.current_tab().chat_scroll.offset;
-    let mut requested_lines = visible_height
+    let mut requested_rows = visible_height
         .saturating_add(effective_offset)
-        .saturating_add(32);
+        .saturating_add(CHAT_RENDER_OVERSCAN_ROWS);
 
     let mut reversed_lines: Vec<Line> = Vec::new();
     let mut turn_hit_offsets = Vec::new();
+    let mut skipped_rows_below = 0;
 
     let mut pending_lines = build_pending_stream_lines(app, wrap_width);
+    let mut newer_rows = rendered_lines_height(&pending_lines, wrap_width);
     reversed_lines.extend(pending_lines.drain(..).rev());
 
     let mut truncated = false;
@@ -400,56 +573,52 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             tab.activity_frame,
             wrap_width,
         );
+        newer_rows = newer_rows.saturating_add(rendered_lines_height(&message_lines, wrap_width));
         reversed_lines.extend(message_lines.drain(..).rev());
-        if reversed_lines.len() >= requested_lines && selection_target_idx.is_none() {
+        if newer_rows >= requested_rows
+            && selection_target_idx.is_none()
+            && viewport_anchor.is_none()
+        {
             truncated = true;
             break;
         }
     }
 
     if !truncated {
-        let selected_idx = app.current_tab().selected_completed_turn_idx;
-        let pane_focused = app.pane_focused;
-        let mut selection_reached = selection_target_idx.is_none();
-        let mut rendered_rows_below = rendered_lines_height(&reversed_lines, wrap_width);
-        for (idx, turn) in app.current_tab().completed_turns.iter().enumerate().rev() {
-            let is_selected = selected_idx == Some(idx);
+        let plan = plan_completed_turn_viewport(
+            app.current_tab(),
+            newer_rows,
+            visible_height,
+            wrap_width,
+            effective_offset,
+            selection_target_idx,
+            viewport_anchor,
+        );
+        if plan.skip_base_lines {
+            reversed_lines.clear();
+        }
+        let tab = app.current_tab();
+        for planned in plan.turns {
+            let turn = &tab.completed_turns[planned.index];
             let (mut turn_lines, prompt_rows) = build_completed_turn_lines_with_prompt_rows(
                 turn,
-                is_selected,
-                pane_focused,
+                tab.selected_completed_turn_idx == Some(planned.index),
+                app.pane_focused,
                 wrap_width,
             );
-            let turn_height = rendered_lines_height(&turn_lines, wrap_width);
-            turn_hit_offsets.push((
-                idx,
-                rendered_rows_below,
-                turn_height,
-                turn.expanded,
+            turn_hit_offsets.push(CompletedTurnHitOffset {
+                turn_index: planned.index,
+                rows_below: planned.rows_below,
+                turn_height: planned.height,
+                expanded: turn.expanded,
                 prompt_rows,
-            ));
-            if selection_target_idx == Some(idx) {
-                let selected_end = rendered_rows_below.saturating_add(turn_height);
-                let viewport_height = visible_height.max(1);
-                effective_offset = if rendered_rows_below < effective_offset {
-                    rendered_rows_below
-                } else if selected_end > effective_offset.saturating_add(viewport_height) {
-                    selected_end.saturating_sub(viewport_height)
-                } else {
-                    effective_offset
-                };
-                requested_lines = visible_height
-                    .saturating_add(effective_offset)
-                    .saturating_add(32);
-                selection_reached = true;
-            }
+            });
             reversed_lines.extend(turn_lines.drain(..).rev());
-            rendered_rows_below = rendered_rows_below.saturating_add(turn_height);
-            if reversed_lines.len() >= requested_lines && selection_reached {
-                truncated = true;
-                break;
-            }
         }
+        skipped_rows_below = plan.skipped_rows_below;
+        effective_offset = plan.effective_offset;
+        requested_rows = plan.requested_rows;
+        truncated = plan.truncated;
     }
 
     // First-run welcome: shown once until user sends first message
@@ -470,7 +639,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let lines: Vec<Line> = reversed_lines.into_iter().rev().collect();
 
     let total_lines = rendered_lines_height(&lines, wrap_width);
-    let scroll = total_lines.saturating_sub(visible_height.saturating_add(effective_offset));
+    let local_offset = effective_offset.saturating_sub(skipped_rows_below);
+    let scroll = total_lines.saturating_sub(visible_height.saturating_add(local_offset));
 
     let paragraph = Paragraph::new(lines)
         .block(inner)
@@ -481,13 +651,25 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(paragraph, area);
 
     let mut completed_turn_hits = Vec::new();
+    let mut visible_completed_turn_anchors = Vec::with_capacity(turn_hit_offsets.len());
     let buffer = frame.buffer_mut();
-    for (turn_index, rows_below, turn_height, expanded, prompt_rows) in turn_hit_offsets {
+    for hit_offset in turn_hit_offsets {
+        let CompletedTurnHitOffset {
+            turn_index,
+            rows_below,
+            turn_height,
+            expanded,
+            prompt_rows,
+        } = hit_offset;
         let header_from_top = total_lines.saturating_sub(rows_below.saturating_add(turn_height));
         if let Some(header_row) = header_from_top
             .checked_sub(scroll)
             .filter(|row| *row < visible_height)
         {
+            visible_completed_turn_anchors.push(crate::app::CompletedTurnViewportAnchor {
+                index: turn_index,
+                row: header_row,
+            });
             let row = inner_area.y.saturating_add(header_row as u16);
             let symbol = if expanded { "▼" } else { "▶" };
             if let Some(column) = (inner_area.x..inner_area.x.saturating_add(inner_area.width))
@@ -543,6 +725,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         }
     }
     app.completed_turn_hits = completed_turn_hits;
+    app.current_tab_mut()
+        .finish_completed_turn_layout(visible_completed_turn_anchors);
 
     if selection_pending {
         let tab = app.current_tab_mut();
@@ -552,23 +736,56 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 
     // Update the scroll bound only when the build saw all of history;
     // otherwise the true max is still unknown and the stored value (possibly
-    // stale) is the best we have. Either way `Scroll::by` itself doesn't
-    // clamp, so wheel-up keeps working even with a stale bound.
+    // stale) is the best we have.
     if !truncated {
-        app.current_tab_mut()
-            .chat_scroll
-            .set_max(total_lines.saturating_sub(visible_height));
+        app.current_tab_mut().chat_scroll.set_max(
+            total_lines
+                .saturating_add(effective_offset.saturating_sub(local_offset))
+                .saturating_sub(visible_height),
+        );
+    }
+
+    let rendered_total_rows = total_lines.saturating_add(skipped_rows_below);
+    let estimated_total_rows = if truncated {
+        newer_rows
+            .saturating_add(
+                app.current_tab()
+                    .estimated_completed_turn_height(wrap_width),
+            )
+            .max(rendered_total_rows)
+            .max(
+                effective_offset
+                    .saturating_add(visible_height)
+                    .saturating_add(1),
+            )
+    } else {
+        rendered_total_rows
+    };
+    if let Some(metrics) = scrollbar_metrics(estimated_total_rows, visible_height, effective_offset)
+        .filter(|_| scrollbar_area.width > 0)
+    {
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(None)
+            .end_symbol(None)
+            .track_symbol(Some("│"))
+            .thumb_symbol("┃")
+            .track_style(Style::default().fg(Color::DarkGray))
+            .thumb_style(Style::default().fg(Color::Gray));
+        let mut scrollbar_state = ScrollbarState::new(metrics.content_length)
+            .position(metrics.position)
+            .viewport_content_length(visible_height);
+        frame.render_stateful_widget(scrollbar, scrollbar_area, &mut scrollbar_state);
     }
 
     ui_trace::log_slow("chat_render", render_started.elapsed(), || {
         format!(
-            "messages={} pending_chars={} requested_lines={} visible_height={} area={}x{}",
+            "messages={} pending_chars={} requested_rows={} visible_height={} area={}x{}",
             app.current_tab().messages.len(),
             app.current_tab()
                 .streaming_agent_text()
                 .map(|text| text.chars().count())
                 .unwrap_or(0),
-            requested_lines,
+            requested_rows,
             visible_height,
             area.width,
             area.height

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -373,7 +373,7 @@ fn breathing_dot(frame: usize) -> &'static str {
     }
 }
 
-const CHAT_RENDER_OVERSCAN_ROWS: usize = 32;
+const CHAT_RENDER_MARGIN_ROWS: usize = 32;
 
 struct CompletedTurnHitOffset {
     turn_index: usize,
@@ -477,7 +477,7 @@ fn plan_completed_turn_viewport(
         }
         requested_rows = visible_height
             .saturating_add(effective_offset.saturating_sub(skipped_rows_below))
-            .saturating_add(CHAT_RENDER_OVERSCAN_ROWS);
+            .saturating_add(CHAT_RENDER_MARGIN_ROWS);
         let mut built_rows = if skip_base_lines {
             0
         } else {
@@ -492,7 +492,7 @@ fn plan_completed_turn_viewport(
                 rendered_rows_below = turn_end;
                 requested_rows = visible_height
                     .saturating_add(effective_offset.saturating_sub(skipped_rows_below))
-                    .saturating_add(CHAT_RENDER_OVERSCAN_ROWS);
+                    .saturating_add(CHAT_RENDER_MARGIN_ROWS);
                 continue;
             }
 
@@ -545,7 +545,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect, scrollbar_area: Rect
     let mut effective_offset = app.current_tab().chat_scroll.offset;
     let mut requested_rows = visible_height
         .saturating_add(effective_offset)
-        .saturating_add(CHAT_RENDER_OVERSCAN_ROWS);
+        .saturating_add(CHAT_RENDER_MARGIN_ROWS);
 
     let mut reversed_lines: Vec<Line> = Vec::new();
     let mut turn_hit_offsets = Vec::new();

--- a/tools/wta/src/ui/layout.rs
+++ b/tools/wta/src/ui/layout.rs
@@ -128,8 +128,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     // height prediction and rendering in sync when a short pane switches
     // permission/recommendation content between full and compact forms.
     let chat_content_width = main_area.width.saturating_sub(2); // h_chat 1+1 padding
-    let chat_estimate =
-        chat::estimated_block_height(app, chat_content_width, main_area.height);
+    let chat_estimate = chat::estimated_block_height(app, chat_content_width, main_area.height);
     let recommendation_natural_height =
         app.current_tab()
             .turn
@@ -223,7 +222,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         ])
         .split(chunks[6]);
 
-    chat::render(frame, app, h_chat[1]);
+    chat::render(frame, app, h_chat[1], h_chat[2]);
     app.sync_rec_scroll_max(main_area.width, panel_layout.recommendation_height);
     recommendations::render(frame, app, h_rec[1], panel_layout.recommendation_mode);
     if !app.current_tab().permission.is_empty() {


### PR DESCRIPTION
## Summary
- cache completed-turn heights by wrap width and materialize only viewport-adjacent history
- preserve the prompt row across expand/collapse and clamp discovered overscroll in the same frame
- add an overflow-only scrollbar with exact bottom alignment and estimated deep-history metrics
- invalidate cached geometry for turn expansion, terminal output, markers, width changes, and history resets
- cover deep scrolling, wrapped/CJK/tool content, selection and mouse hit regions, anchoring, scrollbar behavior, and prior disappearing-row regressions

## Testing
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- 1707 passed, 0 failed