### PR TITLE
Collapse completed tool details by default

### DIFF
--- a/tools/wta/README.md
+++ b/tools/wta/README.md
@@ -129,6 +129,8 @@ shell, so any pane-launched process — including wta and wtcli — inherits it.
 | Ctrl+C | Copy selected text; otherwise cancel streaming / quit |
 | Up / Down | Browse prompt input history |
 | Mouse wheel | Scroll chat (hold Alt to scroll one line) |
+| Click a completed tool status marker | Expand or collapse that tool's details |
+| Ctrl+O | Expand or collapse all completed tool details |
 | Mouse drag | Select a continuous text range |
 | Double / triple click | Select a word / line |
 | PageUp / PageDown | Scroll chat |

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -3922,7 +3922,7 @@ impl App {
                     self.handle_setup_enter(opt);
                 }
             }
-            KeyCode::Char('o') | KeyCode::Char('O') => {
+            KeyCode::Char('o') | KeyCode::Char('O') if key.modifiers.is_empty() => {
                 // Open install URL if the selected option is an install-related one
                 if let Some(ref setup) = self.setup {
                     if let Some(opt) = setup.options.get(setup.selected_index) {

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -4631,6 +4631,7 @@ impl App {
 pub(crate) enum CompletedTurnHitKind {
     Triangle,
     UserInput,
+    ToolCall { detail_index: usize },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 
 use serde::{Deserialize, Serialize};
 
@@ -302,6 +302,10 @@ pub(crate) struct CompletedTurnLayoutState {
 }
 
 impl CompletedTurnHeightCache {
+    fn clear(&mut self) {
+        *self = Self::default();
+    }
+
     fn sync(&mut self, wrap_width: usize, turn_count: usize) {
         if self.wrap_width != wrap_width || turn_count < self.turn_count {
             self.wrap_width = wrap_width;
@@ -482,6 +486,8 @@ pub struct TabSession {
     // Conversation history
     pub messages: Vec<ChatMessage>,
     pub completed_turns: Vec<CompletedTurn>,
+    /// UI-only disclosure state keyed by the ACP session's tool-call IDs.
+    pub(crate) expanded_completed_tool_calls: HashSet<String>,
     pub(crate) completed_turn_layout: CompletedTurnLayoutState,
     /// Tab/Shift+Tab selects a past turn (most recent first). Enter then
     /// toggles `CompletedTurn.expanded`. None means no selection — Enter
@@ -653,7 +659,66 @@ impl TabSession {
 
     pub(crate) fn clear_completed_turns(&mut self) {
         self.completed_turns.clear();
+        self.expanded_completed_tool_calls.clear();
         self.completed_turn_layout = CompletedTurnLayoutState::default();
+    }
+
+    pub(crate) fn completed_tool_call_expanded(&self, id: &str) -> bool {
+        self.expanded_completed_tool_calls.contains(id)
+    }
+
+    pub(crate) fn toggle_completed_tool_call(
+        &mut self,
+        turn_index: usize,
+        detail_index: usize,
+    ) -> bool {
+        let Some(ChatMessage::ToolCall { id, .. }) = self
+            .completed_turns
+            .get(turn_index)
+            .and_then(|turn| turn.details.get(detail_index))
+        else {
+            return false;
+        };
+        let id = id.clone();
+        self.completed_turn_layout.viewport_anchor = self
+            .completed_turn_layout
+            .visible_anchors
+            .iter()
+            .copied()
+            .find(|anchor| anchor.index == turn_index);
+        if !self.expanded_completed_tool_calls.insert(id.clone()) {
+            self.expanded_completed_tool_calls.remove(&id);
+        }
+        self.invalidate_completed_turn_height(turn_index);
+        true
+    }
+
+    pub(crate) fn toggle_all_completed_tool_calls(&mut self) -> bool {
+        let tool_calls = self
+            .completed_turns
+            .iter()
+            .flat_map(|turn| &turn.details)
+            .filter_map(|message| match message {
+                ChatMessage::ToolCall { id, .. } => Some(id.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        if tool_calls.is_empty() {
+            return false;
+        }
+
+        self.completed_turn_layout.viewport_anchor =
+            self.completed_turn_layout.visible_anchors.last().copied();
+        let expand = tool_calls
+            .iter()
+            .any(|id| !self.expanded_completed_tool_calls.contains(id));
+        if expand {
+            self.expanded_completed_tool_calls.extend(tool_calls);
+        } else {
+            self.expanded_completed_tool_calls.clear();
+        }
+        self.completed_turn_layout.height_cache.get_mut().clear();
+        true
     }
 
     pub(crate) fn invalidate_pending_paste(&mut self) {

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -417,9 +417,16 @@ impl App {
                     self.text_selection.handle_mouse(mouse);
                     if let Some(pressed) = pressed.filter(|pressed| {
                         pressed.tab_id == active_tab_id
-                            && released.is_some_and(|hit| hit.turn_index == pressed.hit.turn_index)
+                            && released.is_some_and(|hit| {
+                                hit.turn_index == pressed.hit.turn_index
+                                    && hit.kind == pressed.hit.kind
+                            })
                     }) {
                         let tab = self.current_tab_mut();
+                        if let CompletedTurnHitKind::ToolCall { detail_index } = pressed.hit.kind {
+                            tab.toggle_completed_tool_call(pressed.hit.turn_index, detail_index);
+                            return;
+                        }
                         let previous_selected_index = tab.selected_completed_turn_idx;
                         let previous_selection_pending =
                             tab.completed_turn_selection_visible_pending;

--- a/tools/wta/src/app_keys.rs
+++ b/tools/wta/src/app_keys.rs
@@ -634,6 +634,9 @@ impl App {
                 // Recommendation focus is arrow-only. Consume Tab so a
                 // slash-command popup cannot edit the input behind a card.
             }
+            KeyCode::Char('o') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.current_tab_mut().toggle_all_completed_tool_calls();
+            }
             KeyCode::F(12) => {
                 self.show_debug_panel = !self.show_debug_panel;
                 self.debug_capture_enabled

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -10049,6 +10049,77 @@ fn completed_turn_triangle_hit_uses_header_glyph_not_prompt_glyphs() {
     assert!(!app.current_tab().completed_turns[0].expanded);
 }
 
+#[test]
+fn clicking_completed_tool_status_marker_toggles_only_that_tool() {
+    use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().completed_turns.push(CompletedTurn {
+        prompt: "Inspect".into(),
+        details: vec![
+            ChatMessage::ToolCall {
+                id: "first-tool".into(),
+                title: "Read first".into(),
+                status: "Completed".into(),
+                kind: ToolCallKind::Read,
+                location: Some(r"C:\first.txt".into()),
+                location_is_command: false,
+                cwd: None,
+                output: Some(ToolCallOutput {
+                    text: "FIRST_DETAIL".into(),
+                    truncated: false,
+                }),
+                exit_code: None,
+                content: Vec::new(),
+                locations: Vec::new(),
+            },
+            ChatMessage::ToolCall {
+                id: "second-tool".into(),
+                title: "Read second".into(),
+                status: "Completed".into(),
+                kind: ToolCallKind::Read,
+                location: Some(r"C:\second.txt".into()),
+                location_is_command: false,
+                cwd: None,
+                output: Some(ToolCallOutput {
+                    text: "SECOND_DETAIL".into(),
+                    truncated: false,
+                }),
+                exit_code: None,
+                content: Vec::new(),
+                locations: Vec::new(),
+            },
+        ],
+        expanded: true,
+        trailing_marker: None,
+    });
+
+    render_to_text(&mut app, 80, 20);
+    let hit = app
+        .completed_turn_hits
+        .iter()
+        .copied()
+        .find(|hit| hit.kind == (CompletedTurnHitKind::ToolCall { detail_index: 0 }))
+        .expect("first tool status-marker hit must exist");
+    for kind in [
+        MouseEventKind::Down(MouseButton::Left),
+        MouseEventKind::Up(MouseButton::Left),
+    ] {
+        app.handle_event(AppEvent::Mouse(MouseEvent {
+            kind,
+            column: hit.start_column,
+            row: hit.row,
+            modifiers: KeyModifiers::NONE,
+        }));
+    }
+
+    let expanded = render_to_text(&mut app, 80, 20);
+    assert!(expanded.contains("FIRST_DETAIL"));
+    assert!(!expanded.contains("SECOND_DETAIL"));
+    assert!(app.current_tab().completed_turns[0].expanded);
+}
+
 /// Render: while the helper is still connecting, the fixed activity row must
 /// paint the animated "Connecting…" label.
 #[test]
@@ -10232,8 +10303,14 @@ fn render_large_mixed_chat_keeps_latest_content_and_width_correct() {
         expanded: true,
         trailing_marker: None,
     });
+    let latest_turn = app.current_tab().completed_turns.len() - 1;
+    for detail_index in [1, 2, 3] {
+        app.current_tab_mut()
+            .toggle_completed_tool_call(latest_turn, detail_index);
+    }
 
     crate::ui::chat::reset_completed_turn_line_build_count();
+    crate::ui::chat::reset_tool_detail_build_count();
     let width = 56;
     let buffer = render_to_buffer(&mut app, width, 38);
     let rendered = buffer_to_text(&buffer);
@@ -10259,8 +10336,13 @@ fn render_large_mixed_chat_keeps_latest_content_and_width_correct() {
     }
     assert!(!rendered.contains("OLD_TURN_000"));
     assert!(
-        built_turns < 20,
+        built_turns < 50,
         "layout and bottom-up rendering must not build all 201 turns; built {built_turns}",
+    );
+    assert_eq!(
+        crate::ui::chat::tool_detail_build_count(),
+        6,
+        "only the three explicitly expanded latest tools may build details for height and paint",
     );
 
     for row in buffer.content.chunks(width as usize) {
@@ -10729,6 +10811,7 @@ fn completed_tool_output_update_invalidates_cached_turn_height() {
         expanded: true,
         trailing_marker: None,
     });
+    app.current_tab_mut().toggle_completed_tool_call(0, 0);
     render_to_text(&mut app, 80, 20);
 
     app.handle_event(AppEvent::ToolTerminalOutput {
@@ -11322,7 +11405,7 @@ fn legacy_tool_call_deserialization_defaults_standard_details() {
 }
 
 #[test]
-fn expanded_tool_call_renders_typed_details() {
+fn completed_tool_call_defaults_compact_and_expands_independently() {
     let mut app = test_app();
     app.state = ConnectionState::Connected;
     app.current_tab_mut().completed_turns.push(CompletedTurn {
@@ -11371,7 +11454,22 @@ fn expanded_tool_call_renders_typed_details() {
         trailing_marker: None,
     });
 
+    crate::ui::chat::reset_tool_detail_build_count();
+    let compact = render_to_text(&mut app, 100, 40);
+    assert!(compact.contains("✓ Edit source"));
+    assert!(!compact.contains("OLD_TYPED_LINE"));
+    assert_eq!(
+        crate::ui::chat::tool_detail_build_count(),
+        0,
+        "successful completed tools must skip detail materialization while collapsed",
+    );
+
+    assert!(
+        app.current_tab_mut().toggle_completed_tool_call(0, 0),
+        "tool detail must be independently expandable",
+    );
     let text = render_to_text(&mut app, 100, 40);
+    assert!(text.contains("✓ Edit source"));
     for needle in [
         r"C:\src\main.rs:42",
         "OLD_TYPED_LINE",
@@ -11385,6 +11483,142 @@ fn expanded_tool_call_renders_typed_details() {
             "missing {needle:?}; rendered:\n{text}"
         );
     }
+}
+
+#[test]
+fn failed_completed_tool_keeps_bounded_diagnostic_preview() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().completed_turns.push(CompletedTurn {
+        prompt: "Run checks".into(),
+        details: vec![ChatMessage::ToolCall {
+            id: "failed-tool".into(),
+            title: "Run checks".into(),
+            status: "Failed: tests failed".into(),
+            kind: ToolCallKind::Execute,
+            location: Some("cargo test".into()),
+            location_is_command: true,
+            cwd: None,
+            output: Some(ToolCallOutput {
+                text: "diagnostic one\ndiagnostic two".into(),
+                truncated: false,
+            }),
+            exit_code: Some(1),
+            content: Vec::new(),
+            locations: Vec::new(),
+        }],
+        expanded: true,
+        trailing_marker: None,
+    });
+
+    let text = render_to_text(&mut app, 80, 20);
+    assert!(text.contains("✗ Run checks"));
+    assert!(text.contains("tests failed"));
+    assert!(text.contains("diagnostic one"));
+    assert!(text.contains("diagnostic two"));
+}
+
+#[test]
+fn ctrl_o_toggles_all_completed_tool_details_without_folding_turns() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().completed_turns.push(CompletedTurn {
+        prompt: "Inspect files".into(),
+        details: (0..2)
+            .map(|index| ChatMessage::ToolCall {
+                id: format!("tool-{index}"),
+                title: format!("Read file {index}"),
+                status: "Completed".into(),
+                kind: ToolCallKind::Read,
+                location: Some(format!(r"C:\repo\file-{index}.txt")),
+                location_is_command: false,
+                cwd: None,
+                output: Some(ToolCallOutput {
+                    text: format!("DETAIL_{index}"),
+                    truncated: false,
+                }),
+                exit_code: None,
+                content: Vec::new(),
+                locations: Vec::new(),
+            })
+            .collect(),
+        expanded: true,
+        trailing_marker: None,
+    });
+
+    let compact = render_to_text(&mut app, 80, 20);
+    assert!(!compact.contains("DETAIL_0"));
+    assert!(!compact.contains("DETAIL_1"));
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL));
+    let expanded = render_to_text(&mut app, 80, 20);
+    assert!(expanded.contains("DETAIL_0"));
+    assert!(expanded.contains("DETAIL_1"));
+    assert!(app.current_tab().completed_turns[0].expanded);
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL));
+    let collapsed = render_to_text(&mut app, 80, 20);
+    assert!(!collapsed.contains("DETAIL_0"));
+    assert!(!collapsed.contains("DETAIL_1"));
+    assert!(app.current_tab().completed_turns[0].expanded);
+}
+
+#[test]
+fn completed_tool_expansion_preserves_its_header_row_and_rebuilds_height() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().completed_turns.push(CompletedTurn {
+        prompt: "Anchored tool".into(),
+        details: vec![
+            ChatMessage::ToolCall {
+                id: "anchored-tool".into(),
+                title: "Run anchored command".into(),
+                status: "Completed".into(),
+                kind: ToolCallKind::Execute,
+                location: Some("run anchored".into()),
+                location_is_command: true,
+                cwd: None,
+                output: Some(ToolCallOutput {
+                    text: (0..10)
+                        .map(|index| format!("ANCHORED_OUTPUT_{index}"))
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                    truncated: false,
+                }),
+                exit_code: Some(0),
+                content: Vec::new(),
+                locations: Vec::new(),
+            },
+            ChatMessage::Agent("answer below the tool".repeat(8)),
+        ],
+        expanded: true,
+        trailing_marker: None,
+    });
+
+    let compact = render_to_text(&mut app, 60, 12);
+    let compact_row = compact
+        .lines()
+        .position(|line| line.contains("Run anchored command"))
+        .expect("compact tool header must be visible");
+
+    assert!(app.current_tab_mut().toggle_completed_tool_call(0, 0));
+    crate::ui::chat::reset_completed_turn_line_build_count();
+    let expanded = render_to_text(&mut app, 60, 12);
+    let expanded_row = expanded
+        .lines()
+        .position(|line| line.contains("Run anchored command"))
+        .expect("expanded tool header must stay visible");
+    assert_eq!(expanded_row, compact_row);
+    assert!(
+        expanded.contains("ANCHORED_OUTPUT_0"),
+        "expanded details must open below the stable tool header:\n{expanded}",
+    );
+    assert!(
+        crate::ui::chat::completed_turn_line_build_count() > 0,
+        "tool disclosure changes must invalidate the containing turn height",
+    );
 }
 
 #[test]

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -11500,7 +11500,7 @@ fn failed_completed_tool_keeps_bounded_diagnostic_preview() {
             location_is_command: true,
             cwd: None,
             output: Some(ToolCallOutput {
-                text: "diagnostic one\ndiagnostic two".into(),
+                text: concat!("diagnostic one", "\n", "diagnostic two").into(),
                 truncated: false,
             }),
             exit_code: Some(1),

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -10120,6 +10120,37 @@ fn clicking_completed_tool_status_marker_toggles_only_that_tool() {
     assert!(app.current_tab().completed_turns[0].expanded);
 }
 
+#[test]
+fn pending_tool_in_completed_turn_keeps_clickable_status_marker() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().completed_turns.push(CompletedTurn {
+        prompt: "Interrupted turn".into(),
+        details: vec![ChatMessage::ToolCall {
+            id: "pending-tool".into(),
+            title: "Pending operation".into(),
+            status: "Pending".into(),
+            kind: ToolCallKind::Other,
+            location: None,
+            location_is_command: false,
+            cwd: None,
+            output: None,
+            exit_code: None,
+            content: Vec::new(),
+            locations: Vec::new(),
+        }],
+        expanded: true,
+        trailing_marker: None,
+    });
+
+    let rendered = render_to_text(&mut app, 80, 16);
+    assert!(rendered.contains("● Pending operation"));
+    assert!(app
+        .completed_turn_hits
+        .iter()
+        .any(|hit| matches!(hit.kind, CompletedTurnHitKind::ToolCall { detail_index: 0 })));
+}
+
 /// Render: while the helper is still connecting, the fixed activity row must
 /// paint the animated "Connecting…" label.
 #[test]

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -22,6 +22,58 @@ fn activity_label() -> String {
     t!("chat.activity_thinking").into_owned()
 }
 
+fn is_successful_tool_call_status(status: &str) -> bool {
+    status.eq_ignore_ascii_case("completed") || status.eq_ignore_ascii_case("exited (0)")
+}
+
+fn tool_content_truncated(content: &[ToolCallContent]) -> bool {
+    content.iter().any(|item| match item {
+        ToolCallContent::Text(output) => output.truncated,
+        ToolCallContent::Diff {
+            old_text, new_text, ..
+        } => old_text.as_ref().is_some_and(|output| output.truncated) || new_text.truncated,
+        ToolCallContent::Terminal { output, .. } => {
+            output.as_ref().is_some_and(|output| output.truncated)
+        }
+        ToolCallContent::Attachment { .. } => false,
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ToolDetailLevel {
+    Compact,
+    Preview,
+    Detailed,
+}
+
+#[derive(Clone, Copy)]
+enum ToolDisplay {
+    Live,
+    Completed { expanded: bool },
+}
+
+impl ToolDisplay {
+    fn detail_level(
+        self,
+        status: &str,
+        output: Option<&ToolCallOutput>,
+        content: &[ToolCallContent],
+    ) -> ToolDetailLevel {
+        match self {
+            Self::Live => ToolDetailLevel::Preview,
+            Self::Completed { expanded: true } => ToolDetailLevel::Detailed,
+            Self::Completed { expanded: false }
+                if !is_successful_tool_call_status(status)
+                    || output.is_some_and(|output| output.truncated)
+                    || tool_content_truncated(content) =>
+            {
+                ToolDetailLevel::Preview
+            }
+            Self::Completed { expanded: false } => ToolDetailLevel::Compact,
+        }
+    }
+}
+
 const MAX_RENDER_LINE_CHARS: usize = 4096;
 const MAX_TOOL_OUTPUT_LINES: usize = 4;
 const MAX_TOOL_OUTPUT_LINE_CHARS: usize = 240;
@@ -32,6 +84,7 @@ const MAX_TOOL_DETAIL_LINES: usize = 32;
 #[cfg(test)]
 thread_local! {
     static COMPLETED_TURN_LINE_BUILD_COUNT: Cell<usize> = const { Cell::new(0) };
+    static TOOL_DETAIL_BUILD_COUNT: Cell<usize> = const { Cell::new(0) };
 }
 
 #[cfg(test)]
@@ -42,6 +95,16 @@ pub(crate) fn reset_completed_turn_line_build_count() {
 #[cfg(test)]
 pub(crate) fn completed_turn_line_build_count() -> usize {
     COMPLETED_TURN_LINE_BUILD_COUNT.with(Cell::get)
+}
+
+#[cfg(test)]
+pub(crate) fn reset_tool_detail_build_count() {
+    TOOL_DETAIL_BUILD_COUNT.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn tool_detail_build_count() -> usize {
+    TOOL_DETAIL_BUILD_COUNT.with(Cell::get)
 }
 
 #[cfg(test)]
@@ -123,6 +186,9 @@ fn tool_detail_lines(
     locations: &[ToolCallLocation],
     detailed: bool,
 ) -> Vec<String> {
+    #[cfg(test)]
+    TOOL_DETAIL_BUILD_COUNT.with(|count| count.set(count.get() + 1));
+
     let mut lines = Vec::new();
     let mut omitted = false;
     if detailed {
@@ -301,11 +367,11 @@ fn completed_turn_height(tab: &crate::app::TabSession, index: usize, wrap_width:
     if let Some(height) = tab.cached_completed_turn_height(index, wrap_width) {
         return height;
     }
-    let Some(turn) = tab.completed_turns.get(index) else {
+    if tab.completed_turns.get(index).is_none() {
         return 0;
-    };
+    }
     let height = rendered_lines_height(
-        &build_completed_turn_lines(turn, false, false, wrap_width),
+        &build_completed_turn_lines_for_tab(tab, index, false, false, wrap_width).0,
         wrap_width,
     );
     tab.cache_completed_turn_height(index, wrap_width, height);
@@ -323,8 +389,7 @@ fn tool_call_presentation(status: &str) -> (&'static str, Style, Option<&str>) {
         ("○", theme::TOOL_CALL_PENDING, None)
     } else if status.eq_ignore_ascii_case("inprogress") || status.eq_ignore_ascii_case("running") {
         ("●", theme::TOOL_CALL_RUNNING, None)
-    } else if status.eq_ignore_ascii_case("completed") || status.eq_ignore_ascii_case("exited (0)")
-    {
+    } else if is_successful_tool_call_status(status) {
         ("✓", theme::TOOL_CALL_SUCCESS, None)
     } else if status.eq_ignore_ascii_case("failed") {
         ("✗", theme::TOOL_CALL_FAILURE, None)
@@ -381,6 +446,14 @@ struct CompletedTurnHitOffset {
     turn_height: usize,
     expanded: bool,
     prompt_rows: Vec<PromptRowGeometry>,
+    tool_rows: Vec<ToolRowGeometry>,
+}
+
+struct ToolRowGeometry {
+    detail_index: usize,
+    row_offset: usize,
+    expanded: bool,
+    marker: &'static str,
 }
 
 struct PlannedCompletedTurn {
@@ -600,8 +673,9 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect, scrollbar_area: Rect
         let tab = app.current_tab();
         for planned in plan.turns {
             let turn = &tab.completed_turns[planned.index];
-            let (mut turn_lines, prompt_rows) = build_completed_turn_lines_with_prompt_rows(
-                turn,
+            let (mut turn_lines, prompt_rows, tool_rows) = build_completed_turn_lines_for_tab(
+                tab,
+                planned.index,
                 tab.selected_completed_turn_idx == Some(planned.index),
                 app.pane_focused,
                 wrap_width,
@@ -612,6 +686,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect, scrollbar_area: Rect
                 turn_height: planned.height,
                 expanded: turn.expanded,
                 prompt_rows,
+                tool_rows,
             });
             reversed_lines.extend(turn_lines.drain(..).rev());
         }
@@ -660,6 +735,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect, scrollbar_area: Rect
             turn_height,
             expanded,
             prompt_rows,
+            tool_rows,
         } = hit_offset;
         let header_from_top = total_lines.saturating_sub(rows_below.saturating_add(turn_height));
         if let Some(header_row) = header_from_top
@@ -715,6 +791,48 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect, scrollbar_area: Rect
                         end_column: end as u16,
                         row: inner_area.y.saturating_add(visible_row as u16),
                         action: if expanded {
+                            crate::action_links::CompletedTurnAction::Collapse
+                        } else {
+                            crate::action_links::CompletedTurnAction::Expand
+                        },
+                    },
+                );
+            }
+        }
+
+        for tool_row in tool_rows {
+            let Some(visible_row) = header_from_top
+                .saturating_add(tool_row.row_offset)
+                .checked_sub(scroll)
+            else {
+                continue;
+            };
+            if visible_row >= visible_height {
+                continue;
+            }
+            let row = inner_area.y.saturating_add(visible_row as u16);
+            if let Some(column) = (inner_area.x..inner_area.x.saturating_add(inner_area.width))
+                .find(|column| {
+                    buffer
+                        .cell((*column, row))
+                        .is_some_and(|cell| cell.symbol() == tool_row.marker)
+                })
+            {
+                completed_turn_hits.push(crate::app::CompletedTurnHitRegion {
+                    start_column: column,
+                    end_column: column.saturating_add(1),
+                    row,
+                    turn_index,
+                    kind: crate::app::CompletedTurnHitKind::ToolCall {
+                        detail_index: tool_row.detail_index,
+                    },
+                });
+                app.completed_turn_action_links.push(
+                    crate::action_links::CompletedTurnActionLink {
+                        start_column: column,
+                        end_column: column.saturating_add(1),
+                        row,
+                        action: if tool_row.expanded {
                             crate::action_links::CompletedTurnAction::Collapse
                         } else {
                             crate::action_links::CompletedTurnAction::Expand
@@ -853,6 +971,7 @@ fn completed_turn_prompt_rows(lines: &[Line<'_>], wrap_width: usize) -> Vec<Prom
     rows
 }
 
+#[cfg(test)]
 fn build_completed_turn_lines<'a>(
     turn: &'a crate::app::CompletedTurn,
     is_selected: bool,
@@ -862,12 +981,43 @@ fn build_completed_turn_lines<'a>(
     build_completed_turn_lines_with_prompt_rows(turn, is_selected, pane_focused, wrap_width).0
 }
 
+#[cfg(test)]
 fn build_completed_turn_lines_with_prompt_rows<'a>(
     turn: &'a crate::app::CompletedTurn,
     is_selected: bool,
     pane_focused: bool,
     wrap_width: usize,
 ) -> (Vec<Line<'a>>, Vec<PromptRowGeometry>) {
+    let (lines, prompt_rows, _) = build_completed_turn_lines_with_geometry(
+        turn,
+        is_selected,
+        pane_focused,
+        wrap_width,
+        |_| false,
+    );
+    (lines, prompt_rows)
+}
+
+fn build_completed_turn_lines_for_tab<'a>(
+    tab: &'a crate::app::TabSession,
+    turn_index: usize,
+    is_selected: bool,
+    pane_focused: bool,
+    wrap_width: usize,
+) -> (Vec<Line<'a>>, Vec<PromptRowGeometry>, Vec<ToolRowGeometry>) {
+    let turn = &tab.completed_turns[turn_index];
+    build_completed_turn_lines_with_geometry(turn, is_selected, pane_focused, wrap_width, |id| {
+        tab.completed_tool_call_expanded(id)
+    })
+}
+
+fn build_completed_turn_lines_with_geometry<'a>(
+    turn: &'a crate::app::CompletedTurn,
+    is_selected: bool,
+    pane_focused: bool,
+    wrap_width: usize,
+    tool_expanded: impl Fn(&str) -> bool,
+) -> (Vec<Line<'a>>, Vec<PromptRowGeometry>, Vec<ToolRowGeometry>) {
     #[cfg(test)]
     record_completed_turn_line_build();
 
@@ -944,15 +1094,29 @@ fn build_completed_turn_lines_with_prompt_rows<'a>(
         Some(0)
     };
 
+    let mut tool_rows = Vec::new();
     if turn.expanded {
         // Render the captured details — the agent reply, tool calls,
         // plans, etc. — using the same builder as the active turn so the
         // formatting matches. `is_last_message=false` and
         // `agent_streaming=false` together suppress the streaming-cursor
         // path; details are always finalized by the time they land here.
-        for msg in turn.details.iter() {
+        for (detail_index, msg) in turn.details.iter().enumerate() {
+            let display = match msg {
+                ChatMessage::ToolCall { id, status, .. } => {
+                    let expanded = tool_expanded(id);
+                    tool_rows.push(ToolRowGeometry {
+                        detail_index,
+                        row_offset: rendered_lines_height(&lines, wrap_width),
+                        expanded,
+                        marker: tool_call_presentation(status).0,
+                    });
+                    ToolDisplay::Completed { expanded }
+                }
+                _ => ToolDisplay::Live,
+            };
             lines.extend(build_message_lines_with_details(
-                msg, false, false, None, 0, wrap_width, true,
+                msg, false, false, None, 0, wrap_width, display,
             ));
         }
     }
@@ -972,7 +1136,7 @@ fn build_completed_turn_lines_with_prompt_rows<'a>(
     if lines.last().map_or(true, |l| !l.spans.is_empty()) {
         lines.push(Line::default());
     }
-    (lines, prompt_rows)
+    (lines, prompt_rows, tool_rows)
 }
 
 pub fn render_activity(frame: &mut Frame, app: &App, area: Rect) {
@@ -1055,7 +1219,7 @@ fn build_message_lines<'a>(
         permission_tool_call_id,
         activity_frame,
         wrap_width,
-        false,
+        ToolDisplay::Live,
     )
 }
 
@@ -1066,7 +1230,7 @@ fn build_message_lines_with_details<'a>(
     permission_tool_call_id: Option<&str>,
     activity_frame: usize,
     wrap_width: usize,
-    detailed_tools: bool,
+    tool_display: ToolDisplay,
 ) -> Vec<Line<'a>> {
     let mut lines = Vec::new();
     match msg {
@@ -1118,6 +1282,8 @@ fn build_message_lines_with_details<'a>(
             content,
             locations,
         } => {
+            let detail_level =
+                tool_display.detail_level(status, output.as_ref(), content.as_slice());
             let (marker, marker_style, detail) = tool_call_presentation(status);
             let marker = if permission_tool_call_id == Some(id.as_str())
                 || is_active_tool_call_status(status)
@@ -1145,6 +1311,13 @@ fn build_message_lines_with_details<'a>(
                         theme::DIM,
                     ));
                 }
+            } else if detail_level == ToolDetailLevel::Compact {
+                if let Some(command) = location {
+                    spans.push(Span::styled(
+                        format!(" · {}", truncate_render_text(command)),
+                        theme::DIM,
+                    ));
+                }
             }
             if *kind == ToolCallKind::Execute {
                 if let Some(cwd) = cwd
@@ -1164,7 +1337,9 @@ fn build_message_lines_with_details<'a>(
                     theme::DIM,
                 ));
             }
-            if !detailed_tools && (*kind == ToolCallKind::Execute || *location_is_command) {
+            if detail_level != ToolDetailLevel::Detailed
+                && (*kind == ToolCallKind::Execute || *location_is_command)
+            {
                 if let Some(exit_code) = exit_code.filter(|_| {
                     !starts_with_ignore_ascii_case(status, "exited (")
                         && !starts_with_ignore_ascii_case(status, "failed:")
@@ -1184,7 +1359,7 @@ fn build_message_lines_with_details<'a>(
             // opencode); a long remainder folds into a single "+N more"
             // row instead of growing the card unboundedly.
             let mut rendered_command = false;
-            if *location_is_command {
+            if *location_is_command && detail_level != ToolDetailLevel::Compact {
                 if let Some(command) = location {
                     for entry in crate::ui::command_format::command_display_lines(command) {
                         rendered_command = true;
@@ -1196,7 +1371,9 @@ fn build_message_lines_with_details<'a>(
                 }
             }
             let mut rendered_output = false;
-            if !detailed_tools && (*kind == ToolCallKind::Execute || *location_is_command) {
+            if detail_level == ToolDetailLevel::Preview
+                && (*kind == ToolCallKind::Execute || *location_is_command)
+            {
                 if let Some(output) = output {
                     for line in tool_output_lines(output) {
                         rendered_output = true;
@@ -1210,10 +1387,14 @@ fn build_message_lines_with_details<'a>(
             let has_text_content = content
                 .iter()
                 .any(|item| matches!(item, ToolCallContent::Text(_)));
-            let mut detail_lines = tool_detail_lines(content, locations, detailed_tools);
-            if !has_text_content {
+            let mut detail_lines = match detail_level {
+                ToolDetailLevel::Compact => Vec::new(),
+                ToolDetailLevel::Preview => tool_detail_lines(content, locations, false),
+                ToolDetailLevel::Detailed => tool_detail_lines(content, locations, true),
+            };
+            if !has_text_content && detail_level != ToolDetailLevel::Compact {
                 if let Some(output) = output {
-                    if detailed_tools {
+                    if detail_level == ToolDetailLevel::Detailed {
                         detail_lines.extend(full_output_lines(output, "    │ "));
                     } else if *kind != ToolCallKind::Execute && !*location_is_command {
                         detail_lines.extend(preview_output_lines(output, "    │ "));

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -85,6 +85,7 @@ const MAX_TOOL_DETAIL_LINES: usize = 32;
 thread_local! {
     static COMPLETED_TURN_LINE_BUILD_COUNT: Cell<usize> = const { Cell::new(0) };
     static TOOL_DETAIL_BUILD_COUNT: Cell<usize> = const { Cell::new(0) };
+    static RENDERED_HEIGHT_LINE_SCAN_COUNT: Cell<usize> = const { Cell::new(0) };
 }
 
 #[cfg(test)]
@@ -105,6 +106,16 @@ pub(crate) fn reset_tool_detail_build_count() {
 #[cfg(test)]
 pub(crate) fn tool_detail_build_count() -> usize {
     TOOL_DETAIL_BUILD_COUNT.with(Cell::get)
+}
+
+#[cfg(test)]
+fn reset_rendered_height_line_scan_count() {
+    RENDERED_HEIGHT_LINE_SCAN_COUNT.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+fn rendered_height_line_scan_count() -> usize {
+    RENDERED_HEIGHT_LINE_SCAN_COUNT.with(Cell::get)
 }
 
 #[cfg(test)]
@@ -337,6 +348,9 @@ fn turn_height(turn: &CompletedTurn, wrap_width: usize) -> usize {
 }
 
 fn rendered_lines_height(lines: &[Line<'_>], wrap_width: usize) -> usize {
+    #[cfg(test)]
+    RENDERED_HEIGHT_LINE_SCAN_COUNT.with(|count| count.set(count.get() + lines.len()));
+
     let width = wrap_width.max(1);
     lines
         .iter()
@@ -1101,13 +1115,14 @@ fn build_completed_turn_lines_with_geometry<'a>(
         // formatting matches. `is_last_message=false` and
         // `agent_streaming=false` together suppress the streaming-cursor
         // path; details are always finalized by the time they land here.
+        let mut rendered_height = rendered_lines_height(&lines, wrap_width);
         for (detail_index, msg) in turn.details.iter().enumerate() {
             let display = match msg {
                 ChatMessage::ToolCall { id, status, .. } => {
                     let expanded = tool_expanded(id);
                     tool_rows.push(ToolRowGeometry {
                         detail_index,
-                        row_offset: rendered_lines_height(&lines, wrap_width),
+                        row_offset: rendered_height,
                         expanded,
                         marker: tool_call_presentation(status).0,
                     });
@@ -1115,9 +1130,11 @@ fn build_completed_turn_lines_with_geometry<'a>(
                 }
                 _ => ToolDisplay::Live,
             };
-            lines.extend(build_message_lines_with_details(
-                msg, false, false, None, 0, wrap_width, display,
-            ));
+            let message_lines =
+                build_message_lines_with_details(msg, false, false, None, 0, wrap_width, display);
+            rendered_height =
+                rendered_height.saturating_add(rendered_lines_height(&message_lines, wrap_width));
+            lines.extend(message_lines);
         }
     }
 
@@ -1664,6 +1681,38 @@ mod tests {
         .expect("counter thread must finish");
 
         assert_eq!(completed_turn_line_build_count(), 0);
+    }
+
+    #[test]
+    fn completed_tool_geometry_scans_rendered_lines_linearly() {
+        let turn = CompletedTurn {
+            prompt: "tools".into(),
+            details: (0..100)
+                .map(|index| ChatMessage::ToolCall {
+                    id: format!("tool-{index}"),
+                    title: format!("Read file {index}"),
+                    status: "Completed".into(),
+                    kind: ToolCallKind::Read,
+                    location: Some(format!(r"C:\repo\file-{index}.txt")),
+                    location_is_command: false,
+                    cwd: None,
+                    output: None,
+                    exit_code: None,
+                    content: Vec::new(),
+                    locations: Vec::new(),
+                })
+                .collect(),
+            expanded: true,
+            trailing_marker: None,
+        };
+
+        reset_rendered_height_line_scan_count();
+        build_completed_turn_lines_with_geometry(&turn, false, false, 80, |_| false);
+
+        assert!(
+            rendered_height_line_scan_count() <= 110,
+            "tool geometry must measure the prompt once and each message once",
+        );
     }
 
     #[test]

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -26,29 +26,6 @@ fn is_successful_tool_call_status(status: &str) -> bool {
     status.eq_ignore_ascii_case("completed") || status.eq_ignore_ascii_case("exited (0)")
 }
 
-fn tool_content_truncated(content: &[ToolCallContent]) -> bool {
-    content.iter().any(|item| match item {
-        ToolCallContent::Text(output) => output.truncated,
-        ToolCallContent::Diff {
-            old_text, new_text, ..
-        } => old_text.as_ref().is_some_and(|output| output.truncated) || new_text.truncated,
-        ToolCallContent::Terminal { output, .. } => {
-            output.as_ref().is_some_and(|output| output.truncated)
-        }
-        ToolCallContent::Attachment { .. } => false,
-    })
-}
-
-fn tool_call_needs_preview(
-    status: &str,
-    output: Option<&ToolCallOutput>,
-    content: &[ToolCallContent],
-) -> bool {
-    !is_successful_tool_call_status(status)
-        || output.is_some_and(|output| output.truncated)
-        || tool_content_truncated(content)
-}
-
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ToolDetailLevel {
     Compact,
@@ -63,16 +40,11 @@ enum ToolDisplay {
 }
 
 impl ToolDisplay {
-    fn detail_level(
-        self,
-        status: &str,
-        output: Option<&ToolCallOutput>,
-        content: &[ToolCallContent],
-    ) -> ToolDetailLevel {
+    fn detail_level(self, status: &str) -> ToolDetailLevel {
         match self {
             Self::Completed { expanded: true } => ToolDetailLevel::Detailed,
-            _ if tool_call_needs_preview(status, output, content) => ToolDetailLevel::Preview,
-            _ => ToolDetailLevel::Compact,
+            _ if is_successful_tool_call_status(status) => ToolDetailLevel::Compact,
+            _ => ToolDetailLevel::Preview,
         }
     }
 }
@@ -1302,8 +1274,7 @@ fn build_message_lines_with_details<'a>(
             content,
             locations,
         } => {
-            let detail_level =
-                tool_display.detail_level(status, output.as_ref(), content.as_slice());
+            let detail_level = tool_display.detail_level(status);
             let (marker, marker_style, detail) = tool_call_presentation(status);
             let marker = if permission_tool_call_id == Some(id.as_str())
                 || is_active_tool_call_status(status)
@@ -2066,31 +2037,65 @@ mod tests {
     }
 
     #[test]
-    fn active_tool_call_keeps_preview_for_failure_or_truncation() {
-        for (status, truncated) in [("Failed", false), ("Completed", true)] {
-            let message = ChatMessage::ToolCall {
-                id: "tool".into(),
-                title: "Run tests".into(),
-                status: status.into(),
-                kind: ToolCallKind::Execute,
-                location: Some("cargo test".into()),
-                location_is_command: true,
-                cwd: None,
-                output: Some(ToolCallOutput {
-                    text: "diagnostic".into(),
-                    truncated,
-                }),
-                exit_code: Some(1),
-                content: Vec::new(),
-                locations: Vec::new(),
-            };
+    fn failed_active_tool_call_keeps_diagnostic_preview() {
+        let message = ChatMessage::ToolCall {
+            id: "tool".into(),
+            title: "Run tests".into(),
+            status: "Failed".into(),
+            kind: ToolCallKind::Execute,
+            location: Some("cargo test".into()),
+            location_is_command: true,
+            cwd: None,
+            output: Some(ToolCallOutput {
+                text: "diagnostic".into(),
+                truncated: false,
+            }),
+            exit_code: Some(1),
+            content: Vec::new(),
+            locations: Vec::new(),
+        };
 
-            let rendered: Vec<String> = build_message_lines(&message, false, false, None, 0, 120)
-                .iter()
-                .map(line_text)
-                .collect();
+        let rendered: Vec<String> = build_message_lines(&message, false, false, None, 0, 120)
+            .iter()
+            .map(line_text)
+            .collect();
 
-            assert!(rendered.iter().any(|line| line.contains("diagnostic")));
+        assert!(rendered.iter().any(|line| line.contains("diagnostic")));
+    }
+
+    #[test]
+    fn successful_truncated_tool_call_is_compact_before_and_after_turn_completion() {
+        let message = ChatMessage::ToolCall {
+            id: "tool".into(),
+            title: "Locate project directory".into(),
+            status: "Completed".into(),
+            kind: ToolCallKind::Execute,
+            location: Some("Get-ChildItem".into()),
+            location_is_command: true,
+            cwd: None,
+            output: Some(ToolCallOutput {
+                text: "truncated output".into(),
+                truncated: true,
+            }),
+            exit_code: Some(0),
+            content: Vec::new(),
+            locations: Vec::new(),
+        };
+
+        for display in [
+            ToolDisplay::ActiveTurn,
+            ToolDisplay::Completed { expanded: false },
+        ] {
+            let rendered: Vec<String> =
+                build_message_lines_with_details(&message, false, false, None, 0, 120, display)
+                    .iter()
+                    .map(line_text)
+                    .collect();
+
+            assert_eq!(
+                rendered,
+                vec!["✓ Locate project directory · Get-ChildItem · exit 0"]
+            );
         }
     }
 

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -26,6 +26,29 @@ fn is_successful_tool_call_status(status: &str) -> bool {
     status.eq_ignore_ascii_case("completed") || status.eq_ignore_ascii_case("exited (0)")
 }
 
+fn tool_content_truncated(content: &[ToolCallContent]) -> bool {
+    content.iter().any(|item| match item {
+        ToolCallContent::Text(output) => output.truncated,
+        ToolCallContent::Diff {
+            old_text, new_text, ..
+        } => old_text.as_ref().is_some_and(|output| output.truncated) || new_text.truncated,
+        ToolCallContent::Terminal { output, .. } => {
+            output.as_ref().is_some_and(|output| output.truncated)
+        }
+        ToolCallContent::Attachment { .. } => false,
+    })
+}
+
+fn tool_call_needs_preview(
+    status: &str,
+    output: Option<&ToolCallOutput>,
+    content: &[ToolCallContent],
+) -> bool {
+    !is_successful_tool_call_status(status)
+        || output.is_some_and(|output| output.truncated)
+        || tool_content_truncated(content)
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ToolDetailLevel {
     Compact,
@@ -40,11 +63,16 @@ enum ToolDisplay {
 }
 
 impl ToolDisplay {
-    fn detail_level(self, status: &str) -> ToolDetailLevel {
+    fn detail_level(
+        self,
+        status: &str,
+        output: Option<&ToolCallOutput>,
+        content: &[ToolCallContent],
+    ) -> ToolDetailLevel {
         match self {
             Self::Completed { expanded: true } => ToolDetailLevel::Detailed,
-            _ if is_successful_tool_call_status(status) => ToolDetailLevel::Compact,
-            _ => ToolDetailLevel::Preview,
+            _ if tool_call_needs_preview(status, output, content) => ToolDetailLevel::Preview,
+            _ => ToolDetailLevel::Compact,
         }
     }
 }
@@ -401,6 +429,18 @@ fn is_active_tool_call_status(status: &str) -> bool {
     status.eq_ignore_ascii_case("pending")
         || status.eq_ignore_ascii_case("inprogress")
         || status.eq_ignore_ascii_case("running")
+}
+
+fn rendered_tool_call_marker(
+    status: &str,
+    permission_active: bool,
+    activity_frame: usize,
+) -> &'static str {
+    if permission_active || is_active_tool_call_status(status) {
+        breathing_dot(activity_frame)
+    } else {
+        tool_call_presentation(status).0
+    }
 }
 
 fn should_show_turn_activity(tab: &crate::app::TabSession) -> bool {
@@ -1099,7 +1139,7 @@ fn build_completed_turn_lines_with_geometry<'a>(
                         detail_index,
                         row_offset: rendered_height,
                         expanded,
-                        marker: tool_call_presentation(status).0,
+                        marker: rendered_tool_call_marker(status, false, 0),
                     });
                     ToolDisplay::Completed { expanded }
                 }
@@ -1274,15 +1314,14 @@ fn build_message_lines_with_details<'a>(
             content,
             locations,
         } => {
-            let detail_level = tool_display.detail_level(status);
-            let (marker, marker_style, detail) = tool_call_presentation(status);
-            let marker = if permission_tool_call_id == Some(id.as_str())
-                || is_active_tool_call_status(status)
-            {
-                breathing_dot(activity_frame)
-            } else {
-                marker
-            };
+            let detail_level =
+                tool_display.detail_level(status, output.as_ref(), content.as_slice());
+            let (_, marker_style, detail) = tool_call_presentation(status);
+            let marker = rendered_tool_call_marker(
+                status,
+                permission_tool_call_id == Some(id.as_str()),
+                activity_frame,
+            );
             let mut spans = vec![
                 Span::styled(marker, marker_style),
                 Span::raw(" "),
@@ -2064,7 +2103,7 @@ mod tests {
     }
 
     #[test]
-    fn successful_truncated_tool_call_is_compact_before_and_after_turn_completion() {
+    fn successful_truncated_tool_call_keeps_preview_before_and_after_turn_completion() {
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
             title: "Locate project directory".into(),
@@ -2092,10 +2131,10 @@ mod tests {
                     .map(line_text)
                     .collect();
 
-            assert_eq!(
-                rendered,
-                vec!["✓ Locate project directory · Get-ChildItem · exit 0"]
-            );
+            assert_eq!(rendered[0], "✓ Locate project directory · exit 0");
+            assert_eq!(rendered[1], "    $ Get-ChildItem");
+            assert_eq!(rendered[2], "    │ …");
+            assert_eq!(rendered[3], "    │ truncated output");
         }
     }
 

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -39,6 +39,16 @@ fn tool_content_truncated(content: &[ToolCallContent]) -> bool {
     })
 }
 
+fn tool_call_needs_preview(
+    status: &str,
+    output: Option<&ToolCallOutput>,
+    content: &[ToolCallContent],
+) -> bool {
+    !is_successful_tool_call_status(status)
+        || output.is_some_and(|output| output.truncated)
+        || tool_content_truncated(content)
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ToolDetailLevel {
     Compact,
@@ -48,7 +58,7 @@ enum ToolDetailLevel {
 
 #[derive(Clone, Copy)]
 enum ToolDisplay {
-    Live,
+    ActiveTurn,
     Completed { expanded: bool },
 }
 
@@ -60,16 +70,9 @@ impl ToolDisplay {
         content: &[ToolCallContent],
     ) -> ToolDetailLevel {
         match self {
-            Self::Live => ToolDetailLevel::Preview,
             Self::Completed { expanded: true } => ToolDetailLevel::Detailed,
-            Self::Completed { expanded: false }
-                if !is_successful_tool_call_status(status)
-                    || output.is_some_and(|output| output.truncated)
-                    || tool_content_truncated(content) =>
-            {
-                ToolDetailLevel::Preview
-            }
-            Self::Completed { expanded: false } => ToolDetailLevel::Compact,
+            _ if tool_call_needs_preview(status, output, content) => ToolDetailLevel::Preview,
+            _ => ToolDetailLevel::Compact,
         }
     }
 }
@@ -1128,7 +1131,7 @@ fn build_completed_turn_lines_with_geometry<'a>(
                     });
                     ToolDisplay::Completed { expanded }
                 }
-                _ => ToolDisplay::Live,
+                _ => ToolDisplay::ActiveTurn,
             };
             let message_lines =
                 build_message_lines_with_details(msg, false, false, None, 0, wrap_width, display);
@@ -1236,7 +1239,7 @@ fn build_message_lines<'a>(
         permission_tool_call_id,
         activity_frame,
         wrap_width,
-        ToolDisplay::Live,
+        ToolDisplay::ActiveTurn,
     )
 }
 
@@ -1965,7 +1968,7 @@ mod tests {
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
             title: "Check installed PowerToys and Foundry Local packages".into(),
-            status: "Completed".into(),
+            status: "Running".into(),
             kind: ToolCallKind::Execute,
             location: Some(
                 "winget list --name PowerToys 2>$null; winget list --name Foundry 2>$null".into(),
@@ -2001,12 +2004,12 @@ mod tests {
     }
 
     #[test]
-    fn execute_tool_call_renders_cwd_reported_output_tail_and_exit_code() {
+    fn running_execute_tool_call_renders_cwd_reported_output_tail() {
         let cwd = concat!("C:", "\\", "repo");
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
             title: "bash".into(),
-            status: "Completed".into(),
+            status: "Running".into(),
             kind: ToolCallKind::Execute,
             location: Some("cargo test".into()),
             location_is_command: true,
@@ -2022,7 +2025,7 @@ mod tests {
         let lines = build_message_lines(&message, false, false, None, 0, 120);
         let rendered: Vec<String> = lines.iter().map(line_text).collect();
 
-        assert_eq!(rendered[0], format!("✓ bash ({cwd}) · exit 0"));
+        assert_eq!(rendered[0], format!("● bash ({cwd}) · exit 0"));
         assert_eq!(rendered[1], "    $ cargo test");
         assert_eq!(rendered[2], "    │ …");
         assert_eq!(rendered[3], "    │ line 2");
@@ -2032,12 +2035,72 @@ mod tests {
     }
 
     #[test]
-    fn completed_non_execute_tool_call_shows_bounded_output_preview() {
+    fn successful_active_tool_call_collapses_immediately() {
+        let cwd = concat!("C:", "\\", "repo");
+        let message = ChatMessage::ToolCall {
+            id: "tool".into(),
+            title: "Run tests".into(),
+            status: "Completed".into(),
+            kind: ToolCallKind::Execute,
+            location: Some("cargo test".into()),
+            location_is_command: true,
+            cwd: Some(cwd.into()),
+            output: Some(ToolCallOutput {
+                text: ["line 1", "line 2", "line 3"].join("\n"),
+                truncated: false,
+            }),
+            exit_code: Some(0),
+            content: Vec::new(),
+            locations: Vec::new(),
+        };
+
+        let rendered: Vec<String> = build_message_lines(&message, false, false, None, 0, 120)
+            .iter()
+            .map(line_text)
+            .collect();
+
+        assert_eq!(
+            rendered,
+            vec![format!("✓ Run tests · cargo test ({cwd}) · exit 0")]
+        );
+    }
+
+    #[test]
+    fn active_tool_call_keeps_preview_for_failure_or_truncation() {
+        for (status, truncated) in [("Failed", false), ("Completed", true)] {
+            let message = ChatMessage::ToolCall {
+                id: "tool".into(),
+                title: "Run tests".into(),
+                status: status.into(),
+                kind: ToolCallKind::Execute,
+                location: Some("cargo test".into()),
+                location_is_command: true,
+                cwd: None,
+                output: Some(ToolCallOutput {
+                    text: "diagnostic".into(),
+                    truncated,
+                }),
+                exit_code: Some(1),
+                content: Vec::new(),
+                locations: Vec::new(),
+            };
+
+            let rendered: Vec<String> = build_message_lines(&message, false, false, None, 0, 120)
+                .iter()
+                .map(line_text)
+                .collect();
+
+            assert!(rendered.iter().any(|line| line.contains("diagnostic")));
+        }
+    }
+
+    #[test]
+    fn running_non_execute_tool_call_shows_bounded_output_preview() {
         let location = concat!("C:", "\\", "repo", "\\", "large.txt");
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
             title: "Read file".into(),
-            status: "Completed".into(),
+            status: "Running".into(),
             kind: ToolCallKind::Read,
             location: Some(location.into()),
             location_is_command: false,


### PR DESCRIPTION
## Summary
- keep completed turns readable while collapsing successful tool details to compact summaries
- preserve bounded previews for failed, unknown, or truncated tool calls
- support per-tool status-marker clicks and Ctrl+O global disclosure with stable viewport anchoring
- avoid materializing collapsed tool details and document the controls

## Testing
- `cargo fmt --manifest-path tools/wta/Cargo.toml -- --check`
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml` (1711 passed)
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- hot-refreshed Debug AppX and verified WTA master/helper startup