### PR TITLE
Follow Copilot's live plugin installs: repair agent hook registrations

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -1421,6 +1421,8 @@ reparenting
 REPH
 replatformed
 Replymessage
+repointed
+repointing
 reportfileaccesses
 repositorypath
 rerasterize

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -1471,7 +1471,7 @@ fn read_live_copilot(home: &Path) -> Option<InstalledInfo> {
         version: Some(version),
         enabled: copilot_plugin_enabled(home),
         loads_live: true,
-        live_source: Some(PathBuf::from(&dir)),
+        registered_source: Some(PathBuf::from(&dir)),
         gemini_source: None,
         gemini_type: None,
     })
@@ -2251,10 +2251,11 @@ fn parse_codex_plugin_list(stdout: &str) -> bool {
 
 /// Parse `codex plugin list` for the auto-upgrade flow. Returns
 /// `Some(InstalledInfo)` only when the wt-agent-hooks row reports an
-/// `installed*` status, extracting the version (column 3) and the
-/// enabled flag (`installed, enabled` vs `installed, disabled`).
-/// Returns `None` for "not installed" / "available" / missing rows so
-/// the caller treats the plugin as absent.
+/// `installed*` status, extracting the version (column 3), the enabled
+/// flag (`installed, enabled` vs `installed, disabled`), and the PATH
+/// column (which lives under the marketplace directory Codex is
+/// registered against). Returns `None` for "not installed" /
+/// "available" / missing rows so the caller treats the plugin as absent.
 ///
 /// Sibling of [`parse_codex_plugin_list`]; that function returns a
 /// bool used by the install verifier, this one returns the richer
@@ -2272,17 +2273,17 @@ fn parse_codex_plugin_list_entry(stdout: &str) -> Option<InstalledInfo> {
         {
             continue;
         }
-        let mut cols = line.split_whitespace();
-        let name = cols.next()?;
+        let cols = whitespace_tokens(line);
+        let (_, name) = *cols.first()?;
         if name != PLUGIN_NAME && name != qualified {
             continue;
         }
-        let rest: Vec<&str> = cols.collect();
+        let rest = &cols[1..];
         // Must start with "installed" (rules out "not installed",
         // "available", etc.).
         if !rest
             .first()
-            .map(|s| s.starts_with("installed"))
+            .map(|(_, s)| s.starts_with("installed"))
             .unwrap_or(false)
         {
             return None;
@@ -2292,21 +2293,60 @@ fn parse_codex_plugin_list_entry(stdout: &str) -> Option<InstalledInfo> {
         // subcommand, but be defensive in case that changes.
         let enabled = rest
             .get(1)
-            .map(|s| !s.starts_with("disabled"))
+            .map(|(_, s)| !s.starts_with("disabled"))
             .unwrap_or(true);
-        // Version: first token after the status column that parses as
-        // semver. Skips past the status word(s) and any "-" placeholder.
-        let version = rest.iter().skip(1).find_map(|t| t.parse::<Version>().ok());
+        // Version column: first token after the status word(s) that parses
+        // as semver, or the "-" Codex prints when it has no version to
+        // report. Its offset also anchors the PATH column below.
+        let version_at = rest
+            .iter()
+            .skip(1)
+            .position(|(_, t)| t.parse::<Version>().is_ok() || *t == "-")
+            .map(|i| i + 1);
+        let version = version_at.and_then(|i| rest[i].1.parse::<Version>().ok());
+        // PATH column: everything left on the line after the version token,
+        // so a directory containing spaces survives (the packaged bundle
+        // lives under `C:\Program Files\WindowsApps\...`). Splitting on
+        // whitespace and taking one token would truncate exactly the paths
+        // real users have.
+        let registered_source = version_at
+            .map(|i| {
+                let (start, token) = rest[i];
+                line[start + token.len()..].trim()
+            })
+            .filter(|path| !path.is_empty() && *path != "-")
+            .map(PathBuf::from);
         return Some(InstalledInfo {
             version,
             enabled,
             loads_live: false,
-            live_source: None,
+            registered_source,
             gemini_source: None,
             gemini_type: None,
         });
     }
     None
+}
+
+/// Whitespace-separated tokens of `line` paired with their byte offsets.
+///
+/// Column-formatted CLI output has a trailing free-form column (a path)
+/// that may itself contain whitespace. Keeping each token's offset lets a
+/// parser consume the fixed columns and then take the rest of the line
+/// verbatim.
+fn whitespace_tokens(line: &str) -> Vec<(usize, &str)> {
+    let mut out = Vec::new();
+    let mut cursor = 0;
+    for token in line.split_whitespace() {
+        // `token` is a subslice of `line[cursor..]` and they are visited in
+        // order, so the search always succeeds; the offset is the point.
+        if let Some(relative) = line[cursor..].find(token) {
+            let start = cursor + relative;
+            out.push((start, token));
+            cursor = start + token.len();
+        }
+    }
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -3401,7 +3441,8 @@ fn cleanup_stale_copilot_marketplace(
 }
 
 /// Compare two filesystem paths for equivalence. Trailing path
-/// separators are normalized away and on Windows the comparison is
+/// separators are normalized away, the Windows `\\?\` extended-length
+/// prefix is folded to its plain form, and on Windows the comparison is
 /// case-insensitive (ASCII-fold; matches typical NTFS semantics for the
 /// kinds of paths we deal with — drive letters, ASCII directory names).
 /// We avoid `canonicalize` because the stale path may no longer exist
@@ -3410,6 +3451,22 @@ fn paths_equivalent(a: &Path, b: &Path) -> bool {
     fn normalize(p: &Path) -> Vec<String> {
         p.components()
             .map(|c| {
+                // `\\?\C:\x` and `C:\x` name the same directory, and CLIs
+                // differ on which form they record: Codex stores the
+                // verbatim form in config.toml even though it was handed the
+                // plain one. Comparing the raw prefixes would report every
+                // such registration as moved and reinstall on every check.
+                #[cfg(windows)]
+                let s = match c {
+                    std::path::Component::Prefix(prefix) => match prefix.kind() {
+                        std::path::Prefix::VerbatimDisk(disk) => {
+                            format!("{}:", disk as char)
+                        }
+                        _ => prefix.as_os_str().to_string_lossy().into_owned(),
+                    },
+                    _ => c.as_os_str().to_string_lossy().into_owned(),
+                };
+                #[cfg(not(windows))]
                 let s = c.as_os_str().to_string_lossy().into_owned();
                 if cfg!(windows) {
                     s.to_ascii_lowercase()
@@ -3691,6 +3748,20 @@ fn uninstall_for_codex(home: Option<&Path>) -> CliUninstallResult {
 // produced by the pure `decide_upgrade` function (testable without spawning
 // any CLI).
 //
+// Moved registrations
+// -------------------
+//
+// The version comparison above is blind to the failure an Intelligent
+// Terminal upgrade actually causes. The package directory is versioned, so a
+// new build lands the same hook version at a new path while each CLI's
+// `wt-local` registration still names the old one. Copilot loads that
+// directory live and silently drops the plugin once it is gone; Claude and
+// Codex keep running their cached copy but have no path back to a bundle for
+// any later update. So `decide_upgrade` also compares the registered path
+// against the directory we expect it to name, and routes a mismatch to the
+// same repair a version bump would take (`plugin update` for Copilot/Claude,
+// uninstall + reinstall for Codex, which has no `plugin update`).
+//
 // Trigger-point caveat
 // --------------------
 //
@@ -3785,11 +3856,16 @@ struct InstalledInfo {
     /// already what runs and there is nothing to push an upgrade into.
     /// Copilot-only today; every other CLI copies.
     loads_live: bool,
-    /// Copilot-only: the directory a live install is registered against.
-    /// Carried so the decision can tell "loading the bundle we ship" from
-    /// "loading some other tree's bundle", which is a repoint, not an
-    /// upgrade. `None` for copied installs.
-    live_source: Option<PathBuf>,
+    /// The directory the CLI's `wt-local` registration names, or a path
+    /// underneath it. Carried so the decision can tell "registered against
+    /// the bundle we ship" from "registered against some other tree", which
+    /// is a repoint, not an upgrade — and which version comparison cannot
+    /// see, because both trees usually carry the same hook version.
+    ///
+    /// Populated for Copilot, Claude, and Codex. `None` means the probe
+    /// could not determine the registration, which is treated as "don't
+    /// repoint" rather than as evidence of staleness.
+    registered_source: Option<PathBuf>,
     /// Gemini-only: the recorded install source path from
     /// `.gemini-extension-install.json`. `None` for Copilot/Claude.
     gemini_source: Option<PathBuf>,
@@ -3852,7 +3928,7 @@ fn read_stale_live_copilot(home: &Path) -> Option<InstalledInfo> {
         version: None,
         enabled,
         loads_live: true,
-        live_source: Some(PathBuf::from(dir)),
+        registered_source: Some(PathBuf::from(dir)),
         gemini_source: None,
         gemini_type: None,
     })
@@ -3907,7 +3983,7 @@ fn read_installed_copilot(home: &Path) -> InstalledProbe {
         version,
         enabled,
         loads_live: false,
-        live_source: None,
+        registered_source: None,
         gemini_source: None,
         gemini_type: None,
     }))
@@ -3916,7 +3992,11 @@ fn read_installed_copilot(home: &Path) -> InstalledProbe {
 /// Spawn `claude plugin list --json` and locate our plugin. One-shot
 /// Node spawn; the fast-path short-circuit in `upgrade_installed_hooks`
 /// ensures this only runs after a bundle version change.
-fn read_installed_claude() -> InstalledProbe {
+///
+/// The listing describes the copy under `~/.claude/plugins/cache/`, which
+/// says nothing about the marketplace directory that copy came from, so
+/// the registration is read separately from `known_marketplaces.json`.
+fn read_installed_claude(home: &Path) -> InstalledProbe {
     let outcome = run_plugin_cli_capture("claude", &["plugin", "list", "--json"])
         .map_err(|error| format!("claude plugin list failed to start: {}", error))?;
     if !outcome.success {
@@ -3947,7 +4027,10 @@ fn read_installed_claude() -> InstalledProbe {
             version,
             enabled,
             loads_live: false,
-            live_source: None,
+            // Recorded path, not a validated one: a registration naming a
+            // directory that no longer exists is exactly the state that
+            // needs repointing.
+            registered_source: claude_marketplace_info(home).path.map(PathBuf::from),
             gemini_source: None,
             gemini_type: None,
         }));
@@ -4022,7 +4105,7 @@ fn read_installed_gemini(home: &Path) -> InstalledProbe {
         // re-queries via CLI before any destructive action.
         enabled: true,
         loads_live: false,
-        live_source: None,
+        registered_source: None,
         gemini_source,
         gemini_type,
     }))
@@ -4049,7 +4132,7 @@ fn read_installed_opencode(home: &Path) -> InstalledProbe {
         version: complete.then(|| read_version_field(&manifest)).flatten(),
         enabled: true,
         loads_live: false,
-        live_source: None,
+        registered_source: None,
         gemini_source: None,
         gemini_type: None,
     }))
@@ -4104,13 +4187,17 @@ enum UpgradeAction {
 /// installed state. Pure function — no IO. All branches covered by
 /// `upgrade_decision_*` tests.
 ///
-/// `current_bundle_dir` is only consulted for Gemini (to decide whether
-/// the recorded install source still lives under the current bundle).
+/// `expected_dir` is the directory a `wt-local` registration should name
+/// for this CLI on this machine — the resolved bundle, or the staging copy
+/// when the bundle lives under WindowsApps (see
+/// [`expected_registration_dir`]). It is consulted to tell a registration
+/// that moved from one that is still correct, and by Gemini to decide
+/// whether an in-place `extensions update` can work.
 fn decide_upgrade(
     cli: CliKind,
     bundle_version: Option<Version>,
     installed: Option<&InstalledInfo>,
-    current_bundle_dir: Option<&Path>,
+    expected_dir: Option<&Path>,
 ) -> UpgradeAction {
     let Some(bundle_version) = bundle_version else {
         return UpgradeAction::Skip(SkipReason::UnknownBundleVersion);
@@ -4121,6 +4208,14 @@ fn decide_upgrade(
     if !installed.enabled {
         return UpgradeAction::Skip(SkipReason::Disabled);
     }
+    // Whether the CLI's `wt-local` registration still names the directory we
+    // expect. `None` when either side is unknown: an unresolvable bundle
+    // couldn't be repointed to even if we wanted to, and a probe that can't
+    // read the registration has produced no evidence of staleness.
+    let registration_moved = match (&installed.registered_source, expected_dir) {
+        (Some(src), Some(expected)) => Some(!path_under_dir(src, expected)),
+        _ => None,
+    };
     // A live install runs whatever is in the directory it is registered
     // against, so there is no copy to push a newer bundle into — but only
     // while that directory is the bundle this wta ships. A registration left
@@ -4129,16 +4224,32 @@ fn decide_upgrade(
     // comparison can't stand in for this: the two trees usually carry the
     // same hook version, so a stale registration reads as up to date.
     if installed.loads_live {
-        let on_current_bundle = match (&installed.live_source, current_bundle_dir) {
-            (Some(src), Some(bundle)) => paths_equivalent(src, bundle),
-            // Bundle unresolvable: we couldn't repoint even if we wanted to.
-            _ => true,
-        };
-        return if on_current_bundle {
-            UpgradeAction::Skip(SkipReason::LiveInstall)
-        } else {
+        return if registration_moved.unwrap_or(false) {
             UpgradeAction::UpdatePlugin
+        } else {
+            UpgradeAction::Skip(SkipReason::LiveInstall)
         };
+    }
+    // A copied install keeps running out of its own cache, so a moved
+    // registration doesn't break it today — but the marketplace it was
+    // installed from is what every later update resolves against, and an
+    // Intelligent Terminal upgrade lands the new bundle at a new versioned
+    // path. Once the old path is gone the CLI has no way back to a bundle,
+    // and the version comparison below can't see any of this because both
+    // trees carry the same hook version. Repair it the same way a version
+    // bump would be delivered.
+    if registration_moved.unwrap_or(false) {
+        match cli {
+            CliKind::Claude => return UpgradeAction::UpdatePlugin,
+            // Codex has no `plugin update`, and `marketplace add` is a no-op
+            // against an already-registered name, so the repoint has to go
+            // through the uninstall + reinstall in `upgrade_codex`.
+            CliKind::Codex => return UpgradeAction::CodexReinstall,
+            // Copilot copied installs predate the live-install shape and
+            // record no marketplace path; Gemini and OpenCode have no
+            // marketplace at all. Nothing to repoint.
+            CliKind::Copilot | CliKind::Gemini | CliKind::OpenCode => {}
+        }
     }
     let Some(installed_version) = installed.version else {
         if cli == CliKind::OpenCode {
@@ -4156,10 +4267,8 @@ fn decide_upgrade(
             // Auto-update only `local` installs; `git`/`link` are user
             // configurations we don't second-guess.
             let is_local = installed.gemini_type.as_deref() == Some("local");
-            let source_under_bundle = match (&installed.gemini_source, current_bundle_dir) {
-                (Some(src), Some(bundle_dir)) => {
-                    src.is_dir() && gemini_source_under_bundle(src, bundle_dir)
-                }
+            let source_under_bundle = match (&installed.gemini_source, expected_dir) {
+                (Some(src), Some(bundle_dir)) => src.is_dir() && path_under_dir(src, bundle_dir),
                 _ => false,
             };
             if is_local && source_under_bundle {
@@ -4172,16 +4281,55 @@ fn decide_upgrade(
     }
 }
 
-/// True when `source` resolves under (or equals) `bundle_dir`. Used to
-/// detect when Gemini's recorded install source still points into the
-/// currently-resolved MSIX bundle dir — only then is in-place
-/// `extensions update` safe. Uses `paths_equivalent` semantics
-/// (case-insensitive on Windows, no canonicalize).
-fn gemini_source_under_bundle(source: &Path, bundle_dir: &Path) -> bool {
-    // Walk `source`'s ancestors and check for path equivalence.
-    let mut cur = Some(source);
+/// The directory a CLI's `wt-local` registration is expected to name.
+///
+/// Usually the resolved bundle itself. Claude and Codex re-stage a bundle
+/// that lives under WindowsApps before handing it to the CLI
+/// (`maybe_stage_bundle_for_claude` / `maybe_stage_bundle_for_codex`), so a
+/// packaged install is legitimately registered against the staging copy.
+/// Comparing those against the bundle alone would read every packaged
+/// registration as moved and reinstall on each upgrade check.
+///
+/// Staging is best-effort at install time and falls back to the original
+/// path, so the bundle itself stays acceptable: callers use
+/// [`path_under_dir`], and a registration naming the bundle is rejected
+/// only when staging actually happened and produced a directory.
+fn expected_registration_dir(cli: CliKind, bundle_dir: &Path) -> PathBuf {
+    if !matches!(cli, CliKind::Claude | CliKind::Codex) || !is_under_windows_apps(bundle_dir) {
+        return bundle_dir.to_path_buf();
+    }
+    let root = match cli {
+        // Mirrors the per-CLI staging roots; Claude stages into the cache
+        // root and Codex into the state root.
+        CliKind::Claude => crate::runtime_paths::intelligent_terminal_local_root(),
+        _ => crate::runtime_paths::intelligent_terminal_root(),
+    };
+    match root {
+        Some(root) => {
+            let staged = root.join(STAGING_SUBDIR).join(cli.dir_name());
+            if staged.is_dir() {
+                staged
+            } else {
+                bundle_dir.to_path_buf()
+            }
+        }
+        None => bundle_dir.to_path_buf(),
+    }
+}
+
+/// True when `path` resolves under (or equals) `dir`.
+///
+/// Used to test a recorded install source or plugin location against the
+/// directory it is expected to live in: Gemini records the extension source
+/// it installed from, and Codex reports the plugin directory rather than the
+/// marketplace root. Uses `paths_equivalent` semantics (case-insensitive on
+/// Windows, no canonicalize) because the recorded path may no longer exist,
+/// which is precisely the case worth detecting.
+fn path_under_dir(path: &Path, dir: &Path) -> bool {
+    // Walk `path`'s ancestors and check for path equivalence.
+    let mut cur = Some(path);
     while let Some(c) = cur {
-        if paths_equivalent(c, bundle_dir) {
+        if paths_equivalent(c, dir) {
             return true;
         }
         cur = c.parent();
@@ -4535,7 +4683,7 @@ fn probe_installed(cli: CliKind, home: &Path) -> InstalledProbe {
             if which::which("claude").is_err() {
                 Ok(None)
             } else {
-                read_installed_claude()
+                read_installed_claude(home)
             }
         }
         CliKind::Codex => {
@@ -4575,11 +4723,14 @@ fn upgrade_one_cli(
     };
 
     let current_bundle_dir = bundle::resolve_cli_dir(cli);
+    let expected_dir = current_bundle_dir
+        .as_deref()
+        .map(|dir| expected_registration_dir(cli, dir));
     let action = decide_upgrade(
         cli,
         bundle_version,
         installed.as_ref(),
-        current_bundle_dir.as_deref(),
+        expected_dir.as_deref(),
     );
 
     tracing::info!(
@@ -4587,6 +4738,8 @@ fn upgrade_one_cli(
         cli = cli.name(),
         installed_version = ?installed.as_ref().and_then(|i| i.version),
         bundle_version = ?bundle_version,
+        registered_source = ?installed.as_ref().and_then(|i| i.registered_source.as_deref()),
+        expected_dir = ?expected_dir.as_deref(),
         action = ?action,
         "upgrade decision",
     );

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -2462,11 +2462,18 @@ fn whitespace_tokens(line: &str) -> Vec<(usize, &str)> {
     for token in line.split_whitespace() {
         // `token` is a slice of `line[cursor..]` and they are visited in
         // order, so the search always succeeds; the offset is the point.
-        if let Some(relative) = line[cursor..].find(token) {
-            let start = cursor + relative;
-            out.push((start, token));
-            cursor = start + token.len();
-        }
+        //
+        // Give up on the whole line rather than skipping a token if it ever
+        // doesn't: a dropped column shifts every reading after it, so the
+        // version and PATH would be taken from the wrong places and land as a
+        // confident but wrong upgrade decision. An empty list instead makes
+        // the caller read the row as absent, which is the conservative answer.
+        let Some(relative) = line[cursor..].find(token) else {
+            return Vec::new();
+        };
+        let start = cursor + relative;
+        out.push((start, token));
+        cursor = start + token.len();
     }
     out
 }

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -1588,8 +1588,13 @@ fn read_live_copilot(home: &Path) -> Option<InstalledInfo> {
 /// Whether `~/.copilot/settings.json` has our plugin switched on.
 ///
 /// A live plugin records enablement here rather than on an `installedPlugins`
-/// entry. Absent means enabled: Copilot only writes the key once the plugin
-/// has been toggled.
+/// entry. `copilot plugin install` writes the entry as `true` on its own —
+/// verified against CLI 1.0.81-9 with a fresh profile, where `marketplace add`
+/// alone leaves no `enabledPlugins` key and the install adds one without any
+/// toggle. Defaulting a missing key to enabled here is tolerance for a future
+/// CLI that stops writing it, not a claim that the key is normally absent:
+/// [`read_stale_live_copilot`] relies on the entry to tell an install from a
+/// marketplace that was only ever registered.
 fn copilot_plugin_enabled(home: &Path) -> bool {
     let path = home.join(".copilot").join("settings.json");
     let Ok(text) = fs::read_to_string(&path) else {
@@ -2455,7 +2460,7 @@ fn whitespace_tokens(line: &str) -> Vec<(usize, &str)> {
     let mut out = Vec::new();
     let mut cursor = 0;
     for token in line.split_whitespace() {
-        // `token` is a subslice of `line[cursor..]` and they are visited in
+        // `token` is a slice of `line[cursor..]` and they are visited in
         // order, so the search always succeeds; the offset is the point.
         if let Some(relative) = line[cursor..].find(token) {
             let start = cursor + relative;
@@ -3568,10 +3573,12 @@ fn cleanup_stale_copilot_marketplace(
 }
 
 /// Compare two filesystem paths for equivalence. Trailing path
-/// separators are normalized away, the Windows `\\?\` extended-length
-/// prefix is folded to its plain form, and on Windows the comparison is
+/// separators are normalized away, a Windows `\\?\C:` verbatim-disk prefix is
+/// folded to its plain `C:` form, and on Windows the comparison is
 /// case-insensitive (ASCII-fold; matches typical NTFS semantics for the
 /// kinds of paths we deal with — drive letters, ASCII directory names).
+/// Other verbatim prefixes (`\\?\UNC\…`) are compared as-is; no CLI we
+/// register with has been seen to record one.
 /// We avoid `canonicalize` because the stale path may no longer exist
 /// on disk, which is precisely the case we want to detect and rewrite.
 fn paths_equivalent(a: &Path, b: &Path) -> bool {

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -1023,7 +1023,8 @@ fn maybe_stage_bundle_for_codex(source: &Path) -> Option<PathBuf> {
     if !is_under_windows_apps(source) {
         return None;
     }
-    let root = crate::runtime_paths::intelligent_terminal_root()?;
+    // Staging copy is transient cache → the `LocalCache\Local` root.
+    let root = crate::runtime_paths::intelligent_terminal_local_root()?;
     let staged = root.join(STAGING_SUBDIR).join(CliKind::Codex.dir_name());
     match restage_bundle_dir(source, &staged) {
         Ok(()) => {
@@ -2799,10 +2800,20 @@ fn legacy_staging_dirs(cli: CliKind) -> Vec<PathBuf> {
     }
     // #20-first-commit-style embedded-fallback materialization.
     dirs.push(root.join("hook-bundle-fallback").join(cli.dir_name()));
-    // Active WindowsApps-workaround staging (Claude only — Copilot and
-    // Gemini don't trip the `cpSync` EPERM that motivated this).
-    if matches!(cli, CliKind::Claude) {
+    // Active WindowsApps-workaround staging (Claude and Codex only —
+    // Copilot and Gemini don't trip the `cpSync` EPERM that motivated this).
+    if matches!(cli, CliKind::Claude | CliKind::Codex) {
         dirs.push(root.join(STAGING_SUBDIR).join(cli.dir_name()));
+        // Pre-#124 staging lived under the `LocalState` root, before staging
+        // was reclassified as cache. Codex kept writing there until the root
+        // fix, so an install predating it leaves a copy behind that the cache
+        // root alone never sweeps.
+        if let Some(state_root) = crate::runtime_paths::intelligent_terminal_root() {
+            let legacy = state_root.join(STAGING_SUBDIR).join(cli.dir_name());
+            if !dirs.iter().any(|d| paths_equivalent(d, &legacy)) {
+                dirs.push(legacy);
+            }
+        }
     }
     dirs
 }
@@ -4298,13 +4309,7 @@ fn expected_registration_dir(cli: CliKind, bundle_dir: &Path) -> PathBuf {
     if !matches!(cli, CliKind::Claude | CliKind::Codex) || !is_under_windows_apps(bundle_dir) {
         return bundle_dir.to_path_buf();
     }
-    let root = match cli {
-        // Mirrors the per-CLI staging roots; Claude stages into the cache
-        // root and Codex into the state root.
-        CliKind::Claude => crate::runtime_paths::intelligent_terminal_local_root(),
-        _ => crate::runtime_paths::intelligent_terminal_root(),
-    };
-    match root {
+    match crate::runtime_paths::intelligent_terminal_local_root() {
         Some(root) => {
             let staged = root.join(STAGING_SUBDIR).join(cli.dir_name());
             if staged.is_dir() {

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -1034,12 +1034,7 @@ fn install_for_codex(_home: &Path) -> InstallOutcome {
     let bundle_dir = staged_dir.as_deref().unwrap_or(&bundle_dir);
 
     let bundle_path = bundle_dir.to_string_lossy().into_owned();
-    if let Err(e) = run_plugin_cli(
-        "codex",
-        &["plugin", "marketplace", "add", &bundle_path],
-        "agent_hooks",
-        &["already registered"],
-    ) {
+    if let Err(e) = codex_marketplace_add(&bundle_path) {
         tracing::warn!(
             target: "agent_hooks",
             err = %e,
@@ -1060,6 +1055,71 @@ fn install_for_codex(_home: &Path) -> InstallOutcome {
             );
             InstallOutcome::Failed(format!("codex plugin add {plugin_ref} failed: {e}"))
         }
+    }
+}
+
+/// `codex plugin marketplace add`, dropping a conflicting `wt-local`
+/// registration first.
+///
+/// Codex refuses to repoint an existing marketplace — "marketplace 'wt-local'
+/// is already added from a different source; remove it before adding this
+/// source" — where Copilot's entry is rewritten in place beforehand and Claude
+/// simply overwrites its own. That refusal is reached through the ordinary
+/// install flow whenever an Intelligent Terminal upgrade has pruned the
+/// package directory the old registration named: the status row reads
+/// incomplete, the plan says `Install`, and the add then fails, leaving Codex
+/// hooks broken with no path to recovery.
+///
+/// So do what the error asks. The registered root is read first rather than
+/// matched out of stderr, because the wording is Codex's to change and the
+/// listing is already parsed elsewhere. A registration that already names
+/// `bundle_path` is left alone — removing and re-adding it would drop the
+/// plugin's enabled state for no reason.
+fn codex_marketplace_add(bundle_path: &str) -> Result<(), std::io::Error> {
+    if let Some(registered) = codex_registered_marketplace_root() {
+        if !paths_equivalent(Path::new(&registered), Path::new(bundle_path)) {
+            tracing::info!(
+                target: "agent_hooks",
+                old = %registered,
+                new = %bundle_path,
+                "codex marketplace registered from another source; removing before re-adding",
+            );
+            // Best-effort: if the remove fails the add below reports the real
+            // problem, and there is nothing better to do with the error here.
+            let _ = run_plugin_cli(
+                "codex",
+                &["plugin", "marketplace", "remove", MARKETPLACE_NAME],
+                "agent_hooks",
+                &[
+                    "not registered",
+                    "not found",
+                    "not configured",
+                    "not installed",
+                ],
+            );
+        }
+    }
+    run_plugin_cli(
+        "codex",
+        &["plugin", "marketplace", "add", bundle_path],
+        "agent_hooks",
+        &["already registered"],
+    )
+}
+
+/// The directory Codex has `wt-local` registered against, per
+/// `codex plugin marketplace list`. `None` when the listing can't be read or
+/// carries no entry for us — both mean "nothing to repoint".
+fn codex_registered_marketplace_root() -> Option<String> {
+    let outcome = run_plugin_cli_capture("codex", &["plugin", "marketplace", "list"]).ok()?;
+    if !outcome.success {
+        return None;
+    }
+    let (registered, path) = parse_codex_marketplace_list(&outcome.stdout);
+    if registered {
+        path
+    } else {
+        None
     }
 }
 

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -3818,7 +3818,58 @@ fn read_installed_copilot_any(home: &Path) -> InstalledProbe {
     if let Some(live) = read_live_copilot(home) {
         return Ok(Some(live));
     }
-    read_installed_copilot(home)
+    let copied = read_installed_copilot(home)?;
+    if copied.is_some() {
+        return Ok(copied);
+    }
+    Ok(read_stale_live_copilot(home))
+}
+
+/// A `wt-local` registration that no longer resolves to a readable plugin
+/// directory.
+///
+/// This is what an Intelligent Terminal upgrade leaves behind. The package
+/// directory is versioned, so a new build lands beside `wta.exe` at a new
+/// path while the registration still names the old one, and the moment the
+/// old package is removed Copilot silently drops the plugin: `copilot plugin
+/// list` reports "No plugins installed" and exits 0, and no hook fires again.
+///
+/// The install itself survives — `enabledPlugins` still carries it, and
+/// rewriting `source.path` alone brings the plugin straight back with no
+/// reinstall. So this has to reach `decide_upgrade` as a live install whose
+/// source has moved, not as "nothing installed", which would skip the one
+/// repair that runs without the user opening Settings.
+///
+/// The `enabledPlugins` entry is required: a marketplace registered but never
+/// installed from is genuinely not installed, and treating it otherwise would
+/// send `upgrade_copilot` after a plugin that was never there.
+fn read_stale_live_copilot(home: &Path) -> Option<InstalledInfo> {
+    let enabled = copilot_enabled_plugin_entry(home)?;
+    let dir = copilot_marketplace_info(home).path?;
+    Some(InstalledInfo {
+        // Unreadable, and deliberately not guessed: the decision below turns
+        // on the source path, not on the version.
+        version: None,
+        enabled,
+        loads_live: true,
+        live_source: Some(PathBuf::from(dir)),
+        gemini_source: None,
+        gemini_type: None,
+    })
+}
+
+/// Our `enabledPlugins` entry, or `None` when Copilot has no record of the
+/// plugin at all. `Some(false)` means installed but switched off.
+fn copilot_enabled_plugin_entry(home: &Path) -> Option<bool> {
+    let path = home.join(".copilot").join("settings.json");
+    let text = fs::read_to_string(&path).ok()?;
+    let v = serde_json::from_str::<Value>(&strip_jsonc_line_comments(&text)).ok()?;
+    Some(
+        v.get("enabledPlugins")?
+            .get(format!("{}@{}", PLUGIN_NAME, MARKETPLACE_NAME))?
+            .as_bool()
+            .unwrap_or(true),
+    )
 }
 
 /// Read Copilot's copied-install entry directly from
@@ -4226,6 +4277,25 @@ fn upgrade_state_path() -> Option<PathBuf> {
         .map(|root| root.join("hooks-upgrade-state.json"))
 }
 
+/// Cache token standing for "this CLI has already been checked against this
+/// bundle".
+///
+/// The hook version alone is not enough. An Intelligent Terminal upgrade
+/// installs to a versioned package directory, so the bundle moves to a new
+/// path on every release while the hook version usually stays put — and a
+/// live install registered against the old path stops loading the moment that
+/// package is removed. Folding the resolved directory into the token makes
+/// the package move a cache miss, which is the only automatic signal that a
+/// registration needs repointing.
+///
+/// `None` when either half is unresolvable, which keeps the full check
+/// running rather than caching an answer we can't describe.
+fn bundle_fingerprint(version: Option<&Version>, dir: Option<&Path>) -> Option<String> {
+    let version = version?;
+    let dir = dir?;
+    Some(format!("{} {}", version, dir.display()))
+}
+
 /// Load the cached bundle versions. Crash-safe: any IO/parse failure
 /// returns the empty state (= forces a full upgrade check next run).
 fn load_upgrade_state(path: &Path) -> UpgradeState {
@@ -4393,16 +4463,19 @@ pub fn upgrade_installed_hooks() {
     let mut state_dirty = false;
     for cli in CliKind::ALL.iter().copied() {
         let bundle_version = read_bundled_version(cli);
-        let bundle_version_str = bundle_version.map(|v| v.to_string());
+        let fingerprint = bundle_fingerprint(
+            bundle_version.as_ref(),
+            bundle::resolve_cli_dir(cli).as_deref(),
+        );
 
-        // Fast path: bundle version matches the cached entry → nothing
+        // Fast path: bundle fingerprint matches the cached entry → nothing
         // changed since last time we checked this CLI. Skip without any
         // further IO or spawn.
-        if bundle_version_str.is_some() && bundle_version_str.as_deref() == state.get(cli) {
+        if fingerprint.is_some() && fingerprint.as_deref() == state.get(cli) {
             tracing::debug!(
                 target: "agent_hooks",
                 cli = cli.name(),
-                bundle = ?bundle_version_str,
+                bundle = ?fingerprint,
                 "fast-path cache hit; no upgrade needed",
             );
             continue;
@@ -4413,7 +4486,7 @@ pub fn upgrade_installed_hooks() {
 
         // Cache completed checks, including intentional skips. Failed
         // OpenCode file copies must retry on the next startup.
-        if state.record_completed(cli, bundle_version_str, completed) {
+        if state.record_completed(cli, fingerprint, completed) {
             state_dirty = true;
         } else {
             tracing::warn!(

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -3965,7 +3965,17 @@ fn read_version_field(path: &Path) -> Option<Version> {
 /// / malformed.
 fn read_bundled_version(cli: CliKind) -> Option<Version> {
     let dir = bundle::resolve_cli_dir(cli)?;
-    let manifest = match cli {
+    read_version_field(&bundle_manifest_path(cli, &dir))
+}
+
+/// Path of the manifest carrying the bundle version, within a per-CLI bundle
+/// directory.
+///
+/// Doubles as the marker for a complete copy of that directory: it is the
+/// deepest file every layout has, so its presence is evidence a recursive
+/// copy reached the end rather than the shell of one that failed partway.
+fn bundle_manifest_path(cli: CliKind, dir: &Path) -> PathBuf {
+    match cli {
         CliKind::Copilot => dir.join("wt-agent-hooks").join("plugin.json"),
         CliKind::Claude => dir
             .join("wt-agent-hooks")
@@ -3977,8 +3987,19 @@ fn read_bundled_version(cli: CliKind) -> Option<Version> {
             .join("plugin.json"),
         CliKind::Gemini => dir.join("gemini-extension.json"),
         CliKind::OpenCode => dir.join(OPENCODE_MANIFEST),
-    };
-    read_version_field(&manifest)
+    }
+}
+
+/// Whether a staging directory holds a usable copy of the bundle.
+///
+/// `copy_dir_recursive` creates the destination before writing into it and
+/// `maybe_stage_bundle_for_*` falls back to the package path when the copy
+/// errors, so a half-written staging directory can outlive a failed staging
+/// attempt. Treating its mere existence as proof would point
+/// [`expected_registration_dir`] at a directory the install never registered
+/// against, and read a correct registration as moved on every check.
+fn staged_bundle_is_usable(cli: CliKind, staged: &Path) -> bool {
+    bundle_manifest_path(cli, staged).is_file()
 }
 
 // ---- Installed-state readers ----------------------------------------------
@@ -4433,8 +4454,10 @@ fn decide_upgrade(
 ///
 /// Staging is best-effort at install time and falls back to the original
 /// path, so the bundle itself stays acceptable: callers use
-/// [`path_under_dir`], and a registration naming the bundle is rejected
-/// only when staging actually happened and produced a directory.
+/// [`path_under_dir`], and a registration naming the bundle is rejected only
+/// when staging actually produced a usable copy — see
+/// [`staged_bundle_is_usable`], which is what keeps a failed staging attempt
+/// from making a correct registration look moved.
 fn expected_registration_dir(cli: CliKind, bundle_dir: &Path) -> PathBuf {
     if !matches!(cli, CliKind::Claude | CliKind::Codex) || !is_under_windows_apps(bundle_dir) {
         return bundle_dir.to_path_buf();
@@ -4442,7 +4465,7 @@ fn expected_registration_dir(cli: CliKind, bundle_dir: &Path) -> PathBuf {
     match crate::runtime_paths::intelligent_terminal_local_root() {
         Some(root) => {
             let staged = root.join(STAGING_SUBDIR).join(cli.dir_name());
-            if staged.is_dir() {
+            if staged_bundle_is_usable(cli, &staged) {
                 staged
             } else {
                 bundle_dir.to_path_buf()

--- a/tools/wta/src/agent_hooks_installer.rs
+++ b/tools/wta/src/agent_hooks_installer.rs
@@ -709,22 +709,33 @@ pub enum InstallAction {
 
 /// Decide what an install pass should do for one CLI, from its status row.
 ///
-/// Pure — no IO, no spawns. Splits the three cases the Settings "Install
-/// hooks" button has to tell apart:
+/// Pure — no IO, no spawns. Splits the cases the Settings "Install hooks"
+/// button has to tell apart:
 ///
 ///   * incomplete in any way (not on PATH, marketplace missing or pointing at
 ///     a pruned path, plugin missing or disabled, or a verdict that came from
 ///     filesystem heuristics rather than the CLI itself) → [`InstallAction::Install`];
-///   * complete but a release behind the bundle → [`InstallAction::Upgrade`],
-///     because `install` cannot upgrade — that needs `plugin update` /
-///     `extensions update` / a Codex reinstall;
-///   * complete and not provably behind → [`InstallAction::Skip`].
+///   * complete but registered against a directory other than the bundle this
+///     wta ships, or a release behind it → [`InstallAction::Upgrade`], because
+///     `install` cannot do either: a second `plugin install` reports "already
+///     installed" and `marketplace add` no-ops on an already-registered name,
+///     so neither the version nor the path would move;
+///   * complete, current, and correctly registered → [`InstallAction::Skip`].
 ///
 /// An unreadable version on either side lands in `Skip`: we can't prove the
 /// bridge is stale, running `install` against it would no-op anyway, and
 /// [`upgrade_installed_hooks`] re-checks it at master startup with a richer
 /// probe than [`CliStatus`] carries.
-pub fn decide_install_action(status: &CliStatus) -> InstallAction {
+///
+/// `expected_dir` is the directory `cli`'s registration should name — see
+/// [`expected_registration_dir_for`]. `None` disables the path check, which is
+/// the right default when no bundle is resolvable: there is nothing to point a
+/// registration at.
+pub fn decide_install_action(
+    cli: CliKind,
+    status: &CliStatus,
+    expected_dir: Option<&Path>,
+) -> InstallAction {
     let complete = status.binary_on_path
         && status.marketplace_registered
         && status.marketplace_path_valid
@@ -734,6 +745,15 @@ pub fn decide_install_action(status: &CliStatus) -> InstallAction {
     if !complete {
         return InstallAction::Install;
     }
+    // A complete, current install can still be registered against the bundle
+    // a previous Intelligent Terminal build shipped. `marketplace_path_valid`
+    // above misses it whenever that directory still exists — another worktree,
+    // a package version not yet cleaned up — and the version comparison below
+    // misses it always, because both trees carry the same hook version. Route
+    // it to the upgrade flow, whose per-CLI probe picks the right repair.
+    if registration_moved(cli, status, expected_dir) {
+        return InstallAction::Upgrade;
+    }
     let parse = |v: &Option<String>| v.as_deref().and_then(|s| s.parse::<Version>().ok());
     match (
         parse(&status.installed_version),
@@ -742,6 +762,33 @@ pub fn decide_install_action(status: &CliStatus) -> InstallAction {
         (Some(installed), Some(bundled)) if installed < bundled => InstallAction::Upgrade,
         _ => InstallAction::Skip,
     }
+}
+
+/// True when the CLI's recorded `wt-local` registration names a directory
+/// outside the one this wta expects.
+///
+/// Only Copilot, Claude and Codex record a marketplace source in
+/// `marketplace_path`. Gemini and OpenCode reuse the field for the directory
+/// they install *into*, which is never the bundle, so comparing it would
+/// report them as moved on every pass.
+fn registration_moved(cli: CliKind, status: &CliStatus, expected_dir: Option<&Path>) -> bool {
+    if !matches!(cli, CliKind::Copilot | CliKind::Claude | CliKind::Codex) {
+        return false;
+    }
+    let (Some(recorded), Some(expected)) = (status.marketplace_path.as_deref(), expected_dir)
+    else {
+        return false;
+    };
+    !path_under_dir(Path::new(recorded), expected)
+}
+
+/// The directory `cli`'s `wt-local` registration is expected to name, or
+/// `None` when no bundle is resolvable.
+///
+/// Shared by the install planner and the startup upgrade check so both judge
+/// a registration against the same directory.
+pub fn expected_registration_dir_for(cli: CliKind) -> Option<PathBuf> {
+    bundle::resolve_cli_dir(cli).map(|dir| expected_registration_dir(cli, &dir))
 }
 
 /// Execute a per-CLI plan of [`InstallAction`]s.
@@ -1915,6 +1962,15 @@ struct MarketplaceInfo {
 /// the CLI's on-disk source-of-truth file. Side-effect free; missing /
 /// unreadable files leave the defaults (`None` / `false`) in place.
 fn populate_marketplace_path(out: &mut CliStatus, cli: CliKind, home: Option<&Path>) {
+    if let Some(recorded) = out.marketplace_path.as_deref() {
+        // The CLI itself already named the registered root. Its answer wins:
+        // for Codex the fallback reader below can only see the plugin cache
+        // directory, which is not the registration this field documents, and
+        // overwriting the CLI's answer with it loses the one path that says
+        // where the plugin was installed from.
+        out.marketplace_path_valid = Path::new(recorded).is_dir();
+        return;
+    }
     let Some(home) = home else { return };
     let info = match cli {
         CliKind::Copilot => copilot_marketplace_info(home),
@@ -4727,10 +4783,7 @@ fn upgrade_one_cli(
         }
     };
 
-    let current_bundle_dir = bundle::resolve_cli_dir(cli);
-    let expected_dir = current_bundle_dir
-        .as_deref()
-        .map(|dir| expected_registration_dir(cli, dir));
+    let expected_dir = expected_registration_dir_for(cli);
     let action = decide_upgrade(
         cli,
         bundle_version,

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -2231,6 +2231,14 @@ fn gemini_extensions_list_json_parser_reports_the_installed_version() {
 
 // ---- decide_install_action (`hooks install --only-missing`) ----------
 
+/// Most of these cases predate the registration check and carry no
+/// `marketplace_path`, so they are decided on completeness and version alone.
+/// The cases that do exercise the path check call `decide_install_action`
+/// directly.
+fn install_action(status: &CliStatus) -> InstallAction {
+    decide_install_action(CliKind::Copilot, status, None)
+}
+
 fn installed_status(name: &'static str) -> CliStatus {
     CliStatus {
         name,
@@ -2253,11 +2261,11 @@ fn installed_status(name: &'static str) -> CliStatus {
 #[test]
 fn install_action_skips_a_complete_current_bridge() {
     assert_eq!(
-        decide_install_action(&installed_status("copilot")),
+        install_action(&installed_status("copilot")),
         InstallAction::Skip
     );
     assert_eq!(
-        decide_install_action(&CliStatus {
+        install_action(&CliStatus {
             installed_version: Some("0.2.0".into()),
             ..installed_status("copilot")
         }),
@@ -2271,7 +2279,7 @@ fn install_action_skips_a_complete_current_bridge() {
 #[test]
 fn install_action_upgrades_a_complete_but_outdated_bridge() {
     assert_eq!(
-        decide_install_action(&CliStatus {
+        install_action(&CliStatus {
             installed_version: Some("0.1.5".into()),
             ..installed_status("copilot")
         }),
@@ -2299,11 +2307,7 @@ fn install_action_skips_when_a_version_is_unreadable() {
             ..installed_status("copilot")
         },
     ] {
-        assert_eq!(
-            decide_install_action(&status),
-            InstallAction::Skip,
-            "{status:?}"
-        );
+        assert_eq!(install_action(&status), InstallAction::Skip, "{status:?}");
     }
 }
 
@@ -2332,7 +2336,7 @@ fn install_action_installs_any_partial_bridge() {
     ];
     for status in partials {
         assert_eq!(
-            decide_install_action(&status),
+            install_action(&status),
             InstallAction::Install,
             "{status:?} must stay installable"
         );
@@ -2345,7 +2349,7 @@ fn install_action_installs_any_partial_bridge() {
 #[test]
 fn install_action_prefers_install_over_upgrade_for_a_broken_outdated_bridge() {
     assert_eq!(
-        decide_install_action(&CliStatus {
+        install_action(&CliStatus {
             plugin_enabled: false,
             installed_version: Some("0.1.5".into()),
             ..installed_status("copilot")
@@ -2360,7 +2364,7 @@ fn install_action_prefers_install_over_upgrade_for_a_broken_outdated_bridge() {
 #[test]
 fn install_action_installs_when_the_cli_is_not_on_path() {
     assert_eq!(
-        decide_install_action(&CliStatus {
+        install_action(&CliStatus {
             binary_on_path: false,
             ..installed_status("copilot")
         }),
@@ -2374,10 +2378,110 @@ fn install_action_installs_when_the_cli_is_not_on_path() {
 #[test]
 fn install_action_installs_when_the_verdict_came_from_the_fs_fallback() {
     assert_eq!(
-        decide_install_action(&CliStatus {
+        install_action(&CliStatus {
             detection_fallback: Some("fs"),
             ..installed_status("copilot")
         }),
+        InstallAction::Install
+    );
+}
+
+/// The gap this closes: an Intelligent Terminal upgrade leaves the
+/// registration naming the previous package directory, and while that
+/// directory still exists -- another worktree, a package version not yet
+/// cleaned up -- every field the Settings button looks at reads healthy.
+/// `install` cannot fix it either, because `marketplace add` no-ops against
+/// an already-registered name, so the plan has to route to the upgrade flow.
+#[test]
+fn install_action_upgrades_a_registration_naming_another_tree() {
+    let bundle = unique_dir("install-action-current");
+    let stale = unique_dir("install-action-stale");
+    for cli in [CliKind::Copilot, CliKind::Claude, CliKind::Codex] {
+        let status = CliStatus {
+            marketplace_path: Some(stale.display().to_string()),
+            ..installed_status(cli.name())
+        };
+        assert_eq!(
+            decide_install_action(cli, &status, Some(&bundle)),
+            InstallAction::Upgrade,
+            "{:?} must repair a registration pointing at {}",
+            cli,
+            stale.display(),
+        );
+    }
+}
+
+/// Codex reports the plugin directory under the marketplace root rather than
+/// the root itself, so the check has to accept a path below the expected
+/// directory or it would reinstall on every pass.
+#[test]
+fn install_action_skips_a_registration_under_the_expected_dir() {
+    let bundle = unique_dir("install-action-nested");
+    let status = CliStatus {
+        marketplace_path: Some(bundle.join("wt-agent-hooks").display().to_string()),
+        ..installed_status("codex")
+    };
+    assert_eq!(
+        decide_install_action(CliKind::Codex, &status, Some(&bundle)),
+        InstallAction::Skip
+    );
+}
+
+/// Gemini and OpenCode reuse `marketplace_path` for the directory they
+/// install *into*, which is never the bundle. Comparing it would report them
+/// as moved on every pass and reinstall forever.
+#[test]
+fn install_action_ignores_the_path_for_clis_without_a_marketplace() {
+    let bundle = unique_dir("install-action-no-marketplace");
+    for (cli, installed_into) in [
+        (
+            CliKind::Gemini,
+            r"C:\Users\someone\.gemini\extensions\wt-agent-hooks",
+        ),
+        (
+            CliKind::OpenCode,
+            r"C:\Users\someone\.config\opencode\plugins",
+        ),
+    ] {
+        let status = CliStatus {
+            marketplace_path: Some(installed_into.to_string()),
+            ..installed_status(cli.name())
+        };
+        assert_eq!(
+            decide_install_action(cli, &status, Some(&bundle)),
+            InstallAction::Skip,
+            "{cli:?} has no marketplace to compare",
+        );
+    }
+}
+
+/// No resolvable bundle means no directory to point a registration at, so the
+/// check must stay out of the way rather than declaring everything moved.
+#[test]
+fn install_action_ignores_the_path_when_no_bundle_resolves() {
+    let status = CliStatus {
+        marketplace_path: Some(r"C:\somewhere\else".to_string()),
+        ..installed_status("copilot")
+    };
+    assert_eq!(
+        decide_install_action(CliKind::Copilot, &status, None),
+        InstallAction::Skip
+    );
+}
+
+/// A partial bridge still needs the first-run install; the registration check
+/// must not divert it to an upgrade flow that refuses incomplete state.
+#[test]
+fn install_action_prefers_install_over_a_moved_registration() {
+    let bundle = unique_dir("install-action-partial");
+    let stale = unique_dir("install-action-partial-stale");
+    let status = CliStatus {
+        plugin_enabled: false,
+        marketplace_path: Some(stale.display().to_string()),
+        ..installed_status("copilot")
+    };
+    assert_eq!(
+        decide_install_action(CliKind::Copilot, &status, Some(&bundle)),
         InstallAction::Install
     );
 }

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -3379,6 +3379,91 @@ fn read_installed_copilot_any_leaves_copied_records_unmarked() {
     assert_eq!(info.version, Some("0.1.2".parse().unwrap()));
 }
 
+/// What an Intelligent Terminal upgrade leaves behind: the registration names
+/// a package directory that no longer exists. Copilot drops the plugin
+/// silently, but `enabledPlugins` still records the install and repointing
+/// `source.path` restores it — so this has to surface as a live install whose
+/// source moved, not as "nothing installed".
+#[test]
+fn read_installed_copilot_any_surfaces_a_registration_whose_directory_is_gone() {
+    let home = unique_dir("copilot-pruned-pkg");
+    let cfg_dir = home.join(".copilot");
+    fs::create_dir_all(&cfg_dir).unwrap();
+    fs::write(cfg_dir.join("config.json"), r#"{"installedPlugins":[]}"#).unwrap();
+
+    let old_pkg = unique_dir("copilot-old-package");
+    write_copilot_settings(&cfg_dir, &old_pkg, Some(true));
+    fs::remove_dir_all(&old_pkg).unwrap();
+
+    let info = read_installed_copilot_any(&home).unwrap().unwrap();
+    assert!(info.loads_live);
+    assert_eq!(info.live_source.as_deref(), Some(old_pkg.as_path()));
+    assert_eq!(info.version, None);
+}
+
+/// The repair has to actually be reachable: a gone-directory registration
+/// must resolve to `UpdatePlugin` so `cleanup_stale_copilot_marketplace`
+/// rewrites the path.
+#[test]
+fn decide_repairs_a_registration_whose_directory_is_gone() {
+    let home = unique_dir("copilot-pruned-decide");
+    let cfg_dir = home.join(".copilot");
+    fs::create_dir_all(&cfg_dir).unwrap();
+    let old_pkg = unique_dir("copilot-old-package-decide");
+    write_copilot_settings(&cfg_dir, &old_pkg, Some(true));
+    fs::remove_dir_all(&old_pkg).unwrap();
+    let new_pkg = unique_dir("copilot-new-package-decide");
+
+    let info = read_installed_copilot_any(&home).unwrap().unwrap();
+    let a = decide_upgrade(
+        CliKind::Copilot,
+        Some("0.1.6".parse().unwrap()),
+        Some(&info),
+        Some(&new_pkg),
+    );
+    assert_eq!(a, UpgradeAction::UpdatePlugin);
+}
+
+/// A marketplace registered but never installed from is genuinely not
+/// installed — chasing it would send `upgrade_copilot` after a plugin that
+/// was never there.
+#[test]
+fn read_installed_copilot_any_ignores_a_gone_directory_without_an_install() {
+    let home = unique_dir("copilot-pruned-noinstall");
+    let cfg_dir = home.join(".copilot");
+    fs::create_dir_all(&cfg_dir).unwrap();
+    fs::write(cfg_dir.join("config.json"), r#"{"installedPlugins":[]}"#).unwrap();
+
+    let old_pkg = unique_dir("copilot-old-package-noinstall");
+    write_copilot_settings(&cfg_dir, &old_pkg, None);
+    fs::remove_dir_all(&old_pkg).unwrap();
+
+    assert!(read_installed_copilot_any(&home).unwrap().is_none());
+}
+
+/// A surviving copied record still outranks a gone registration: it is a real
+/// install the CLI can still load, so it keeps driving the upgrade path.
+#[test]
+fn read_installed_copilot_any_prefers_a_copied_record_over_a_gone_directory() {
+    let home = unique_dir("copilot-pruned-vs-copied");
+    let cfg_dir = home.join(".copilot");
+    fs::create_dir_all(&cfg_dir).unwrap();
+    fs::write(
+        cfg_dir.join("config.json"),
+        r#"{"installedPlugins":[
+{ "name": "wt-agent-hooks", "marketplace": "wt-local", "version": "0.1.2" }
+]}"#,
+    )
+    .unwrap();
+    let old_pkg = unique_dir("copilot-old-package-vs-copied");
+    write_copilot_settings(&cfg_dir, &old_pkg, Some(true));
+    fs::remove_dir_all(&old_pkg).unwrap();
+
+    let info = read_installed_copilot_any(&home).unwrap().unwrap();
+    assert!(!info.loads_live);
+    assert_eq!(info.version, Some("0.1.2".parse().unwrap()));
+}
+
 /// A registration pointing at a pruned worktree has no readable manifest, so
 /// the version stays unknown rather than being reported as the bundle's.
 #[test]
@@ -3830,6 +3915,42 @@ fn decide_gemini_reinstall_when_type_is_not_local() {
 }
 
 // ---- auto-upgrade: state file --------------------------------------
+
+/// An Intelligent Terminal upgrade ships the same hook version from a new
+/// versioned package directory. Keying the cache on the version alone would
+/// hit the fast path and never notice, leaving a registration pointing at the
+/// removed package — and the plugin silently unloaded.
+#[test]
+fn bundle_fingerprint_changes_when_only_the_package_directory_moves() {
+    let v: Version = "0.1.6".parse().unwrap();
+    let old_pkg = Path::new(r"C:\pkg\IntelligentTerminal_0.8.0.2_x64\wt-agent-hooks\copilot");
+    let new_pkg = Path::new(r"C:\pkg\IntelligentTerminal_0.9.0.0_x64\wt-agent-hooks\copilot");
+
+    let before = bundle_fingerprint(Some(&v), Some(old_pkg));
+    let after = bundle_fingerprint(Some(&v), Some(new_pkg));
+    assert!(before.is_some());
+    assert_ne!(before, after);
+}
+
+/// The version still has to participate: a hook bump in place must not be
+/// mistaken for an already-checked bundle.
+#[test]
+fn bundle_fingerprint_changes_when_only_the_version_moves() {
+    let dir = Path::new(r"C:\pkg\wt-agent-hooks\copilot");
+    let before = bundle_fingerprint(Some(&"0.1.6".parse().unwrap()), Some(dir));
+    let after = bundle_fingerprint(Some(&"0.1.7".parse().unwrap()), Some(dir));
+    assert_ne!(before, after);
+}
+
+/// Either half missing means we can't describe what was checked, so no entry
+/// is cached and the full check runs again next startup.
+#[test]
+fn bundle_fingerprint_is_none_when_either_half_is_unresolvable() {
+    let v: Version = "0.1.6".parse().unwrap();
+    let dir = Path::new(r"C:\pkg\wt-agent-hooks\copilot");
+    assert_eq!(bundle_fingerprint(None, Some(dir)), None);
+    assert_eq!(bundle_fingerprint(Some(&v), None), None);
+}
 
 #[test]
 fn upgrade_state_round_trips_through_disk() {

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -456,11 +456,11 @@ fn read_installed_opencode_uses_managed_manifest_version() {
     assert!(read_installed_opencode(&home).unwrap().is_none());
 }
 
-/// Uninstall must sweep the active `hook-bundle-staging\claude\`
+/// Uninstall must sweep the active `hook-bundle-staging\<cli>\`
 /// directory in addition to the historical staging dirs, so a clean
 /// uninstall doesn't leave the MSIX workaround copy behind.
 #[test]
-fn legacy_staging_dirs_includes_active_claude_staging() {
+fn legacy_staging_dirs_includes_active_staging_for_staging_clis() {
     let Some(root) = crate::runtime_paths::intelligent_terminal_local_root() else {
         // No LOCALAPPDATA on this host (extremely unusual) — nothing to
         // assert. The function would return an empty Vec in that case
@@ -468,24 +468,58 @@ fn legacy_staging_dirs_includes_active_claude_staging() {
         // behaviour.
         return;
     };
-    let expected = root.join(STAGING_SUBDIR).join(CliKind::Claude.dir_name());
 
-    let claude_dirs = legacy_staging_dirs(CliKind::Claude);
-    assert!(
-        claude_dirs.iter().any(|p| p == &expected),
-        "Claude sweep list should contain the active staging dir {} but was {:?}",
-        expected.display(),
-        claude_dirs,
-    );
+    for cli in [CliKind::Claude, CliKind::Codex] {
+        let expected = root.join(STAGING_SUBDIR).join(cli.dir_name());
+        let dirs = legacy_staging_dirs(cli);
+        assert!(
+            dirs.iter().any(|p| p == &expected),
+            "{:?} sweep list should contain the active staging dir {} but was {:?}",
+            cli,
+            expected.display(),
+            dirs,
+        );
+    }
 
-    // Copilot and Gemini don't trigger the workaround, so the active
-    // staging path must NOT appear in their sweep lists.
+    // Copilot and Gemini don't trigger the workaround, so no active
+    // staging path may appear in their sweep lists.
+    let claude_staging = root.join(STAGING_SUBDIR).join(CliKind::Claude.dir_name());
     for cli in [CliKind::Copilot, CliKind::Gemini] {
         let dirs = legacy_staging_dirs(cli);
         assert!(
-            dirs.iter().all(|p| p != &expected),
+            dirs.iter().all(|p| p != &claude_staging),
             "{:?} sweep list must not include Claude's active staging dir but was {:?}",
             cli,
+            dirs,
+        );
+    }
+}
+
+/// Staging moved from the `LocalState` root to the `LocalCache\Local` root
+/// when it was reclassified as cache, and Codex kept writing to the old
+/// location until that was corrected. Uninstall has to sweep both or an
+/// install predating the fix leaves a materialized bundle behind.
+#[test]
+fn legacy_staging_dirs_includes_the_pre_cache_root_staging() {
+    let (Some(cache_root), Some(state_root)) = (
+        crate::runtime_paths::intelligent_terminal_local_root(),
+        crate::runtime_paths::intelligent_terminal_root(),
+    ) else {
+        return;
+    };
+    if paths_equivalent(&cache_root, &state_root) {
+        // Unpackaged: both roots collapse onto bare `%LOCALAPPDATA%`, so
+        // there is no second location to sweep.
+        return;
+    }
+    for cli in [CliKind::Claude, CliKind::Codex] {
+        let legacy = state_root.join(STAGING_SUBDIR).join(cli.dir_name());
+        let dirs = legacy_staging_dirs(cli);
+        assert!(
+            dirs.iter().any(|p| p == &legacy),
+            "{:?} sweep list should contain the pre-cache-root staging dir {} but was {:?}",
+            cli,
+            legacy.display(),
             dirs,
         );
     }

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -4193,6 +4193,38 @@ fn expected_registration_dir_is_the_bundle_outside_windows_apps() {
     }
 }
 
+/// `copy_dir_recursive` creates the destination before writing into it, so a
+/// staging attempt that fails partway leaves a directory the install never
+/// registered against. Preferring it would read a correct registration as
+/// moved on every check and repair it back and forth forever.
+#[test]
+fn a_half_written_staging_dir_is_not_usable() {
+    for cli in [CliKind::Claude, CliKind::Codex] {
+        let staged = unique_dir("staging-partial");
+        assert!(
+            !staged_bundle_is_usable(cli, &staged),
+            "{cli:?} must reject an empty staging dir",
+        );
+
+        // The plugin directory alone is not enough — the copy can stop
+        // anywhere inside it.
+        fs::create_dir_all(staged.join("wt-agent-hooks")).unwrap();
+        assert!(
+            !staged_bundle_is_usable(cli, &staged),
+            "{cli:?} must reject a staging dir without a manifest",
+        );
+
+        let manifest = bundle_manifest_path(cli, &staged);
+        fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+        fs::write(&manifest, r#"{"version":"0.1.6"}"#).unwrap();
+        assert!(
+            staged_bundle_is_usable(cli, &staged),
+            "{cli:?} must accept a staging dir carrying {}",
+            manifest.display(),
+        );
+    }
+}
+
 /// Codex records the extended-length form of the path it was handed, so a
 /// literal comparison would read every Codex registration as moved and
 /// reinstall on each upgrade check.

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -3314,6 +3314,40 @@ fn parse_codex_plugin_list_entry_has_no_path_for_a_placeholder_column() {
 /// has to be removed before the new source can be added. The listing parser
 /// is what supplies the recorded root for that comparison, so it has to
 /// survive Codex's real column layout.
+/// The offsets are what let the PATH column keep its spaces, so they have to
+/// be the real byte positions in the line, not a running count that assumes
+/// single-space separators.
+#[test]
+fn whitespace_tokens_reports_real_byte_offsets() {
+    let line = "wt-agent-hooks@wt-local  installed, enabled   0.1.6  C:\\Program Files\\x";
+    let tokens = whitespace_tokens(line);
+    for (start, token) in &tokens {
+        assert_eq!(
+            &line[*start..*start + token.len()],
+            *token,
+            "offset {start} does not point at {token}",
+        );
+    }
+    assert_eq!(
+        tokens.iter().map(|(_, t)| *t).collect::<Vec<_>>(),
+        vec![
+            "wt-agent-hooks@wt-local",
+            "installed,",
+            "enabled",
+            "0.1.6",
+            "C:\\Program",
+            "Files\\x",
+        ],
+    );
+    // The remainder after the version token is what `parse_codex_plugin_list_entry`
+    // takes as the PATH column.
+    let (version_start, version) = tokens[3];
+    assert_eq!(
+        line[version_start + version.len()..].trim(),
+        "C:\\Program Files\\x"
+    );
+}
+
 #[test]
 fn parse_codex_marketplace_list_reads_the_registered_root() {
     let sample = "MARKETPLACE     ROOT\n\

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -3640,12 +3640,12 @@ fn decide_repairs_a_registration_whose_directory_is_gone() {
 /// was never there.
 #[test]
 fn read_installed_copilot_any_ignores_a_gone_directory_without_an_install() {
-    let home = unique_dir("copilot-pruned-noinstall");
+    let home = unique_dir("copilot-pruned-no-install");
     let cfg_dir = home.join(".copilot");
     fs::create_dir_all(&cfg_dir).unwrap();
     fs::write(cfg_dir.join("config.json"), r#"{"installedPlugins":[]}"#).unwrap();
 
-    let old_pkg = unique_dir("copilot-old-package-noinstall");
+    let old_pkg = unique_dir("copilot-old-package-no-install");
     write_copilot_settings(&cfg_dir, &old_pkg, None);
     fs::remove_dir_all(&old_pkg).unwrap();
 
@@ -4164,7 +4164,7 @@ fn expected_registration_dir_is_the_bundle_outside_windows_apps() {
 /// reinstall on each upgrade check.
 #[cfg(windows)]
 #[test]
-fn paths_equivalent_folds_the_verbatim_prefix() {
+fn paths_equivalent_folds_the_verbatim_disk_prefix() {
     assert!(paths_equivalent(
         Path::new(r"\\?\C:\bundle\codex"),
         Path::new(r"C:\bundle\codex"),

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -481,14 +481,15 @@ fn legacy_staging_dirs_includes_active_staging_for_staging_clis() {
         );
     }
 
-    // Copilot and Gemini don't trigger the workaround, so no active
-    // staging path may appear in their sweep lists.
-    let claude_staging = root.join(STAGING_SUBDIR).join(CliKind::Claude.dir_name());
-    for cli in [CliKind::Copilot, CliKind::Gemini] {
+    // Copilot, Gemini and OpenCode don't trigger the workaround, so no
+    // `hook-bundle-staging` entry may appear in their sweep lists at all —
+    // neither their own nor another CLI's.
+    for cli in [CliKind::Copilot, CliKind::Gemini, CliKind::OpenCode] {
         let dirs = legacy_staging_dirs(cli);
         assert!(
-            dirs.iter().all(|p| p != &claude_staging),
-            "{:?} sweep list must not include Claude's active staging dir but was {:?}",
+            dirs.iter()
+                .all(|p| !p.components().any(|c| c.as_os_str() == STAGING_SUBDIR)),
+            "{:?} sweep list must not include any active staging dir but was {:?}",
             cli,
             dirs,
         );

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -3310,6 +3310,34 @@ fn parse_codex_plugin_list_entry_has_no_path_for_a_placeholder_column() {
     assert!(info.registered_source.is_none());
 }
 
+/// Codex refuses to repoint an existing marketplace, so a stale registration
+/// has to be removed before the new source can be added. The listing parser
+/// is what supplies the recorded root for that comparison, so it has to
+/// survive Codex's real column layout.
+#[test]
+fn parse_codex_marketplace_list_reads_the_registered_root() {
+    let sample = "MARKETPLACE     ROOT\n\
+                  openai-curated  C:\\Users\\someone\\.codex\\.tmp\\plugins\n\
+                  wt-local        C:\\Program Files\\WindowsApps\\pkg\\wt-agent-hooks\\codex\n";
+    let (registered, root) = parse_codex_marketplace_list(sample);
+    assert!(registered);
+    assert_eq!(
+        root.as_deref(),
+        Some("C:\\Program Files\\WindowsApps\\pkg\\wt-agent-hooks\\codex")
+    );
+}
+
+/// No `wt-local` row means nothing to repoint, which must not be confused
+/// with "registered somewhere else".
+#[test]
+fn parse_codex_marketplace_list_reports_no_registration() {
+    let sample = "MARKETPLACE     ROOT\n\
+                  openai-curated  C:\\Users\\someone\\.codex\\.tmp\\plugins\n";
+    let (registered, root) = parse_codex_marketplace_list(sample);
+    assert!(!registered);
+    assert!(root.is_none());
+}
+
 #[test]
 fn uninstall_for_codex_skips_when_home_absent() {
     let parent = unique_dir("uninstall_codex_absent");

--- a/tools/wta/src/agent_hooks_installer_tests.rs
+++ b/tools/wta/src/agent_hooks_installer_tests.rs
@@ -3130,6 +3130,47 @@ fn parse_codex_plugin_list_entry_returns_none_when_version_unparseable() {
     assert!(info.enabled);
 }
 
+/// The PATH column names the directory Codex resolves the plugin from,
+/// which lives under the marketplace it is registered against. Without it
+/// `decide_upgrade` cannot tell a registration that survived an
+/// Intelligent Terminal upgrade from one still naming the old package.
+#[test]
+fn parse_codex_plugin_list_entry_captures_the_plugin_path() {
+    let sample = "PLUGIN                   STATUS              VERSION  PATH\n\
+                  wt-agent-hooks@wt-local  installed, enabled  0.1.6    C:\\bundle\\codex\\wt-agent-hooks\n";
+    let info = parse_codex_plugin_list_entry(sample).expect("expected entry");
+    assert_eq!(
+        info.registered_source.as_deref(),
+        Some(Path::new("C:\\bundle\\codex\\wt-agent-hooks")),
+    );
+}
+
+/// The packaged bundle lives under `C:\Program Files\WindowsApps\...`, so
+/// taking a single whitespace-delimited token would truncate the path every
+/// shipping install actually has.
+#[test]
+fn parse_codex_plugin_list_entry_keeps_a_path_containing_spaces() {
+    let sample = "PLUGIN                   STATUS              VERSION  PATH\n\
+                  wt-agent-hooks@wt-local  installed, enabled  0.1.6    C:\\Program Files\\WindowsApps\\pkg\\wt-agent-hooks\\codex\\wt-agent-hooks\n";
+    let info = parse_codex_plugin_list_entry(sample).expect("expected entry");
+    assert_eq!(
+        info.registered_source.as_deref(),
+        Some(Path::new(
+            "C:\\Program Files\\WindowsApps\\pkg\\wt-agent-hooks\\codex\\wt-agent-hooks"
+        )),
+    );
+}
+
+/// A "-" placeholder is not a path. Reporting it as one would make every
+/// such row look like a registration pointing somewhere else.
+#[test]
+fn parse_codex_plugin_list_entry_has_no_path_for_a_placeholder_column() {
+    let sample = "PLUGIN                   STATUS              VERSION  PATH\n\
+                  wt-agent-hooks@wt-local  installed, enabled  0.1.6    -\n";
+    let info = parse_codex_plugin_list_entry(sample).expect("expected entry");
+    assert!(info.registered_source.is_none());
+}
+
 #[test]
 fn uninstall_for_codex_skips_when_home_absent() {
     let parent = unique_dir("uninstall_codex_absent");
@@ -3355,7 +3396,10 @@ fn read_installed_copilot_any_marks_live_installs() {
 
     let info = read_installed_copilot_any(&home).unwrap().unwrap();
     assert!(info.loads_live);
-    assert_eq!(info.live_source.as_deref(), Some(marketplace.as_path()));
+    assert_eq!(
+        info.registered_source.as_deref(),
+        Some(marketplace.as_path())
+    );
     assert_eq!(info.version, Some("0.1.6".parse().unwrap()));
 }
 
@@ -3397,7 +3441,7 @@ fn read_installed_copilot_any_surfaces_a_registration_whose_directory_is_gone() 
 
     let info = read_installed_copilot_any(&home).unwrap().unwrap();
     assert!(info.loads_live);
-    assert_eq!(info.live_source.as_deref(), Some(old_pkg.as_path()));
+    assert_eq!(info.registered_source.as_deref(), Some(old_pkg.as_path()));
     assert_eq!(info.version, None);
 }
 
@@ -3598,7 +3642,7 @@ fn installed(version: &str, enabled: bool) -> InstalledInfo {
         version: Some(version.parse().unwrap()),
         enabled,
         loads_live: false,
-        live_source: None,
+        registered_source: None,
         gemini_source: None,
         gemini_type: None,
     }
@@ -3631,7 +3675,7 @@ fn decide_skip_when_loaded_live_from_current_bundle() {
     let bundle = unique_dir("live-current-bundle");
     let mut info = installed("0.1.0", true);
     info.loads_live = true;
-    info.live_source = Some(bundle.clone());
+    info.registered_source = Some(bundle.clone());
     let a = decide_upgrade(
         CliKind::Copilot,
         Some("0.1.6".parse().unwrap()),
@@ -3652,7 +3696,7 @@ fn decide_updates_live_install_registered_against_another_tree() {
     let other = unique_dir("live-stale");
     let mut info = installed("0.1.6", true);
     info.loads_live = true;
-    info.live_source = Some(other);
+    info.registered_source = Some(other);
     let a = decide_upgrade(
         CliKind::Copilot,
         Some("0.1.6".parse().unwrap()),
@@ -3665,11 +3709,11 @@ fn decide_updates_live_install_registered_against_another_tree() {
 /// Path comparison is case-insensitive on Windows, so a differently-cased
 /// registration is not mistaken for another tree.
 #[test]
-fn decide_skip_when_live_source_differs_only_by_case() {
+fn decide_skip_when_registered_source_differs_only_by_case() {
     let bundle = unique_dir("live-CASE-bundle");
     let mut info = installed("0.1.6", true);
     info.loads_live = true;
-    info.live_source = Some(PathBuf::from(
+    info.registered_source = Some(PathBuf::from(
         bundle.display().to_string().to_ascii_uppercase(),
     ));
     let a = decide_upgrade(
@@ -3750,7 +3794,7 @@ fn decide_skip_when_bundle_or_installed_version_unknown() {
         version: None,
         enabled: true,
         loads_live: false,
-        live_source: None,
+        registered_source: None,
         gemini_source: None,
         gemini_type: None,
     };
@@ -3804,7 +3848,7 @@ fn decide_opencode_repairs_unknown_installed_version() {
         version: None,
         enabled: true,
         loads_live: false,
-        live_source: None,
+        registered_source: None,
         gemini_source: None,
         gemini_type: None,
     };
@@ -3847,6 +3891,123 @@ fn decide_codex_skip_when_not_installed() {
     assert_eq!(a, UpgradeAction::Skip(SkipReason::NotInstalled));
 }
 
+/// A copied install keeps running out of its own cache, so the registration
+/// moving breaks nothing today — but it is what every later update resolves
+/// against, and the old package directory goes away. Both trees carry the
+/// same hook version, which is why the version comparison reports this as up
+/// to date and the repair has to be driven by the path.
+#[test]
+fn decide_codex_reinstall_when_registration_moved() {
+    let bundle = unique_dir("codex-bundle-current");
+    let stale = unique_dir("codex-bundle-old").join("wt-agent-hooks");
+    let mut info = installed("0.1.6", true);
+    info.registered_source = Some(stale);
+    let a = decide_upgrade(
+        CliKind::Codex,
+        Some("0.1.6".parse().unwrap()),
+        Some(&info),
+        Some(&bundle),
+    );
+    assert_eq!(a, UpgradeAction::CodexReinstall);
+}
+
+/// Codex reports the plugin directory, not the marketplace root, so the
+/// comparison has to accept a path *under* the expected directory. Exact
+/// equality would reinstall on every check.
+#[test]
+fn decide_codex_skip_when_plugin_path_is_under_expected_dir() {
+    let bundle = unique_dir("codex-bundle-nested");
+    let plugin_dir = bundle.join("wt-agent-hooks");
+    let mut info = installed("0.1.6", true);
+    info.registered_source = Some(plugin_dir);
+    let a = decide_upgrade(
+        CliKind::Codex,
+        Some("0.1.6".parse().unwrap()),
+        Some(&info),
+        Some(&bundle),
+    );
+    assert_eq!(a, UpgradeAction::Skip(SkipReason::UpToDate));
+}
+
+/// Claude has the same stale-registration failure, and
+/// `cleanup_stale_claude_marketplace` in `upgrade_claude` is the repair —
+/// but it only runs on `UpdatePlugin`, which a version comparison alone
+/// never produces when both trees ship the same hooks.
+#[test]
+fn decide_claude_update_when_registration_moved() {
+    let bundle = unique_dir("claude-bundle-current");
+    let stale = unique_dir("claude-bundle-old");
+    let mut info = installed("0.1.6", true);
+    info.registered_source = Some(stale);
+    let a = decide_upgrade(
+        CliKind::Claude,
+        Some("0.1.6".parse().unwrap()),
+        Some(&info),
+        Some(&bundle),
+    );
+    assert_eq!(a, UpgradeAction::UpdatePlugin);
+}
+
+/// A probe that could not read the registration has produced no evidence of
+/// staleness. Treating "unknown" as "moved" would reinstall on every upgrade
+/// check for any CLI whose listing shape we don't fully parse.
+#[test]
+fn decide_skip_when_registration_is_unknown() {
+    let bundle = unique_dir("codex-bundle-unknown");
+    let info = installed("0.1.6", true);
+    assert!(info.registered_source.is_none());
+    let a = decide_upgrade(
+        CliKind::Codex,
+        Some("0.1.6".parse().unwrap()),
+        Some(&info),
+        Some(&bundle),
+    );
+    assert_eq!(a, UpgradeAction::Skip(SkipReason::UpToDate));
+}
+
+/// A moved registration must not override the user having switched the
+/// plugin off.
+#[test]
+fn decide_skip_disabled_takes_precedence_over_moved_registration() {
+    let bundle = unique_dir("codex-bundle-disabled");
+    let stale = unique_dir("codex-bundle-disabled-old");
+    let mut info = installed("0.1.6", false);
+    info.registered_source = Some(stale);
+    let a = decide_upgrade(
+        CliKind::Codex,
+        Some("0.1.6".parse().unwrap()),
+        Some(&info),
+        Some(&bundle),
+    );
+    assert_eq!(a, UpgradeAction::Skip(SkipReason::Disabled));
+}
+
+/// Only Claude and Codex re-stage a WindowsApps bundle, and only when it is
+/// actually under WindowsApps. Everything else registers the bundle itself.
+#[test]
+fn expected_registration_dir_is_the_bundle_outside_windows_apps() {
+    let bundle = unique_dir("expected-dir-plain");
+    for cli in CliKind::ALL.iter().copied() {
+        assert_eq!(expected_registration_dir(cli, &bundle), bundle);
+    }
+}
+
+/// Codex records the extended-length form of the path it was handed, so a
+/// literal comparison would read every Codex registration as moved and
+/// reinstall on each upgrade check.
+#[cfg(windows)]
+#[test]
+fn paths_equivalent_folds_the_verbatim_prefix() {
+    assert!(paths_equivalent(
+        Path::new(r"\\?\C:\bundle\codex"),
+        Path::new(r"C:\bundle\codex"),
+    ));
+    assert!(!paths_equivalent(
+        Path::new(r"\\?\C:\bundle\codex"),
+        Path::new(r"C:\bundle\claude"),
+    ));
+}
+
 #[test]
 fn decide_gemini_in_place_when_source_under_current_bundle() {
     let bundle_dir = unique_dir("gemini-bundle-current");
@@ -3856,7 +4017,7 @@ fn decide_gemini_in_place_when_source_under_current_bundle() {
         version: Some("0.1.0".parse().unwrap()),
         enabled: true,
         loads_live: false,
-        live_source: None,
+        registered_source: None,
         gemini_source: Some(nested_src.clone()),
         gemini_type: Some("local".into()),
     };
@@ -3879,7 +4040,7 @@ fn decide_gemini_reinstall_when_source_stale() {
         version: Some("0.1.0".parse().unwrap()),
         enabled: true,
         loads_live: false,
-        live_source: None,
+        registered_source: None,
         gemini_source: Some(stale_src),
         gemini_type: Some("local".into()),
     };
@@ -3901,7 +4062,7 @@ fn decide_gemini_reinstall_when_type_is_not_local() {
         version: Some("0.1.0".parse().unwrap()),
         enabled: true,
         loads_live: false,
-        live_source: None,
+        registered_source: None,
         gemini_source: Some(inside),
         gemini_type: Some("git".into()),
     };
@@ -4113,15 +4274,15 @@ fn cleanup_stale_claude_marketplace_skips_github_source() {
     assert_eq!(fs::read_to_string(&path).unwrap(), original);
 }
 
-// ---- auto-upgrade: gemini_source_under_bundle ---------------------
+// ---- auto-upgrade: path_under_dir ---------------------
 
 #[test]
-fn gemini_source_under_bundle_walks_ancestors() {
+fn path_under_dir_walks_ancestors() {
     let bundle = unique_dir("gemini-under-bundle");
     let nested = bundle.join("a").join("b").join("c");
     fs::create_dir_all(&nested).unwrap();
-    assert!(gemini_source_under_bundle(&nested, &bundle));
-    assert!(gemini_source_under_bundle(&bundle, &bundle)); // equality
+    assert!(path_under_dir(&nested, &bundle));
+    assert!(path_under_dir(&bundle, &bundle)); // equality
     let outside = unique_dir("gemini-outside");
-    assert!(!gemini_source_under_bundle(&outside, &bundle));
+    assert!(!path_under_dir(&outside, &bundle));
 }

--- a/tools/wta/src/cli/hooks.rs
+++ b/tools/wta/src/cli/hooks.rs
@@ -125,7 +125,9 @@ fn plan_install(
     crate::agent_hooks_installer::CliKind,
     crate::agent_hooks_installer::InstallAction,
 )> {
-    use crate::agent_hooks_installer::{decide_install_action, CliKind, CliScope, InstallAction};
+    use crate::agent_hooks_installer::{
+        decide_install_action, expected_registration_dir_for, CliKind, CliScope, InstallAction,
+    };
 
     CliKind::ALL
         .iter()
@@ -138,11 +140,14 @@ fn plan_install(
             let Some(status) = pre_status else {
                 return Some((kind, InstallAction::Install));
             };
+            let expected_dir = expected_registration_dir_for(kind);
             let action = status
                 .clis
                 .iter()
                 .find(|c| c.name == kind.name())
-                .map_or(InstallAction::Install, decide_install_action);
+                .map_or(InstallAction::Install, |c| {
+                    decide_install_action(kind, c, expected_dir.as_deref())
+                });
             tracing::info!(
                 target: "agent_hooks",
                 cli = kind.name(),


### PR DESCRIPTION
## Summary

Copilot CLI **v1.0.81-8** (2026-08-23) changed how a plugin installed from a directory-source marketplace is loaded:

> **Improved**
> - Path-sourced plugins in a local (directory-source) marketplace now load live from their real directory, so editing one takes effect on `/restart` or a new session — no `/plugin update`
>
> — [github/copilot-cli release v1.0.81-8](https://github.com/github/copilot-cli/releases/tag/v1.0.81-8)

`wt-agent-hooks` is installed exactly that way, so nothing is copied: the registered directory is what actually runs, and `~/.copilot/settings.json` is the only record of the install.

Intelligent Terminal installs to a versioned package directory:

```
C:\Program Files\WindowsApps\Microsoft.IntelligentTerminal_0.1.1841.0_x64__8wekyb3d8bbwe
```

The hook bundle sits beside `wta.exe`, so **its path changes on every IT release** while each CLI keeps naming the old one.

For Copilot that is fatal and silent — once the old package is gone, `copilot plugin list` prints `No plugins installed` and exits 0, no hook fires again, and nothing in any log says why. Claude and Codex copy rather than load live, so they keep running, but the marketplace they were installed from is what every later update resolves against and it is just as stale.

A version comparison cannot see any of this: both package directories ship the same hook version.

## What this fixes

| Gap | Fix |
| --- | --- |
| The startup check never ran | The fast-path cache keyed on the hook version, which an IT upgrade does not change. It now keys on the version **and** the resolved bundle directory. |
| A gone registration read as "not installed" | A live install leaves no copied record, so `decide_upgrade` saw `None` and skipped. `read_installed_copilot_any` gains a tier for a registration whose directory is gone. |
| A moved-but-alive registration read as up to date | `decide_upgrade` now compares the registered directory against the one this build ships from — `plugin update` for Copilot and Claude, uninstall + reinstall for Codex, which has no `plugin update` subcommand. |
| Settings → Install hooks could not repair it either | `decide_install_action` judged a registration by whether the recorded path still exists, which is true whenever the old package is merely superseded. Both paths now share `expected_registration_dir_for`. |
| Codex install refused to repoint | `codex plugin marketplace add` fails with `marketplace 'wt-local' is already added from a different source`, which was treated as a hard error. The conflicting entry is now removed first. |
| Codex staged into the wrong root | Staging became cache data when the package roots were split; Codex kept writing to `LocalState` and nothing ever swept its copy on uninstall. |

Gemini and OpenCode have no marketplace to repoint and are deliberately excluded from the path comparison.

## Validation

`cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml` — 1762 passed, 0 failed.

Manual, against real CLIs (Copilot 1.0.81-9, Claude, Codex), using two copies of the same bundle to stand in for an old and a new package directory:

| Case | Result |
| --- | --- |
| Master startup after the "upgrade" | `copilot=UpdatePlugin`, `claude=UpdatePlugin`, `codex=CodexReinstall`, `gemini`/`opencode` untouched; all three registrations rewritten onto the new directory |
| Second startup | Every CLI `Skip` — no reinstall loop. Codex records the `\\?\` form of the path it is handed, so `paths_equivalent` folds that prefix |
| Old package deleted while registered | Copilot recovers from `Skip(NotInstalled)` to `UpdatePlugin` and loads again |
| `hooks install --only-missing` with a moved registration | Plan reports `Upgrade` where it previously reported `Skip`, and the registration is repaired |
| Codex registered against another valid directory | Previous binary returns `outcome: failed`; this one removes, re-adds, and reports `installed` |