### PR TITLE
Use Agent in the connecting pane title

### DIFF
--- a/src/cascadia/TerminalApp/Resources/af-ZA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/af-ZA/Resources.resw
@@ -263,7 +263,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>KI-assistent · Koppel tans</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Koppel tans</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/am-ET/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/am-ET/Resources.resw
@@ -263,7 +263,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI ረዳት · በመገናኘት ላይ</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>ኤጅንት · በመገናኘት ላይ</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ar-SA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ar-SA/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>مساعد الذكاء الاصطناعي · جارٍ الاتصال</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>الوكيل · جارٍ الاتصال</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/as-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/as-IN/Resources.resw
@@ -380,7 +380,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI সহায়ক · সংযোগ হৈ আছে</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>এজেণ্ট · সংযোগ হৈ আছে</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/az-Latn-AZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/az-Latn-AZ/Resources.resw
@@ -376,7 +376,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI köməkçisi · Qoşulur</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Qoşulur</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/bg-BG/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bg-BG/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI асистент · Свързване</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Агент · Свързване</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/bn-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bn-IN/Resources.resw
@@ -379,7 +379,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI সহকারী · সংযোগ হচ্ছে</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>এজেন্ট · সংযোগ হচ্ছে</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/bs-Latn-BA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bs-Latn-BA/Resources.resw
@@ -264,7 +264,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI pomoćnik · Povezivanje</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Povezivanje</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ca-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ca-ES/Resources.resw
@@ -195,7 +195,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Assistent d'IA · Connectant</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Connectant</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ca-Es-VALENCIA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ca-Es-VALENCIA/Resources.resw
@@ -195,7 +195,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Assistent d'IA · Connectant</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Connectant</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/cs-CZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/cs-CZ/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Asistent AI · Připojování</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Připojování</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/cy-GB/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/cy-GB/Resources.resw
@@ -263,7 +263,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Cynorthwyydd AI · Yn cysylltu</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Asiant · Yn cysylltu</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/da-DK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/da-DK/Resources.resw
@@ -377,7 +377,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI-assistent · Forbinder</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Forbinder</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
@@ -1290,7 +1290,7 @@ Für alle verfügbaren Optionen führen Sie 'wt new-tab --help' aus.</value>
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>KI-Assistent · Verbindung wird hergestellt</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Verbindung wird hergestellt</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/el-GR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/el-GR/Resources.resw
@@ -264,7 +264,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Βοηθός AI · Σύνδεση</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Πράκτορας · Σύνδεση</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-GB/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-GB/Resources.resw
@@ -371,7 +371,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI assistant · Connecting</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Connecting</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1358,7 +1358,7 @@ For all available options, run 'wt new-tab --help'.</value>
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI assistant · Connecting</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Connecting</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
@@ -1287,7 +1287,7 @@ Para todas las opciones disponibles, ejecute 'wt new-tab --help'.</value>
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Asistente de IA · Conectando</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agente · Conectando</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/es-MX/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-MX/Resources.resw
@@ -371,7 +371,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Asistente de IA · Conectando</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agente · Conectando</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/et-EE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/et-EE/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Tehisintellekti abimees · Ühendamine</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Ühendamine</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/eu-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/eu-ES/Resources.resw
@@ -195,7 +195,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>IA laguntzailea · Konektatzen</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agentea · Konektatzen</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fa-IR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fa-IR/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>دستیار هوش مصنوعی · در حال اتصال</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>عامل · در حال اتصال</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fi-FI/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fi-FI/Resources.resw
@@ -376,7 +376,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Tekoälyavustaja · Yhdistetään</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agentti · Yhdistetään</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fil-PH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fil-PH/Resources.resw
@@ -308,7 +308,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI assistant · Kumokonekta</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Kumokonekta</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fr-CA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-CA/Resources.resw
@@ -371,7 +371,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Assistant IA · Connexion en cours</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Connexion en cours</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
@@ -1288,7 +1288,7 @@ Pour toutes les options disponibles, exécutez « wt new-tab --help ».</value
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Assistant IA · Connexion en cours</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Connexion en cours</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ga-IE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ga-IE/Resources.resw
@@ -263,7 +263,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Cúntóir AI · Ag ceangal</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Gníomhaire · Ag ceangal</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/gd-gb/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gd-gb/Resources.resw
@@ -263,7 +263,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Neach-cuideachaidh AI · A' ceangal</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Neach-gnìomha · A' ceangal</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/gl-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gl-ES/Resources.resw
@@ -195,7 +195,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Asistente de IA · Conectando</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Axente · Conectando</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/gu-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gu-IN/Resources.resw
@@ -379,7 +379,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI સહાયક · કનેક્ટ થઈ રહ્યું છે</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>એજન્ટ · કનેક્ટ થઈ રહ્યું છે</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/he-IL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/he-IL/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>עוזר בינה מלאכותית · מתחבר</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>סוכן · מתחבר</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hi-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hi-IN/Resources.resw
@@ -379,7 +379,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI सहायक · कनेक्ट हो रहा है</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>एजेंट · कनेक्ट हो रहा है</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hr-HR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hr-HR/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI pomoćnik · Povezivanje</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Povezivanje</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hu-HU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hu-HU/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI-asszisztens · Csatlakozás</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Ügynök · Csatlakozás</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/hy-AM/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hy-AM/Resources.resw
@@ -263,7 +263,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI օգնական · Միանում</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Գործակալ · Միանում</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/id-ID/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/id-ID/Resources.resw
@@ -308,7 +308,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Asisten AI · Menyambungkan</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agen · Menyambungkan</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/is-IS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/is-IS/Resources.resw
@@ -376,7 +376,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Gervigreindaraðstoð · Tengist</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Tengist</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
@@ -1287,7 +1287,7 @@ Per tutte le opzioni disponibili, esegui 'wt new-tab --help'.</value>
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Assistente IA · Connessione in corso</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agente · Connessione in corso</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
@@ -1296,7 +1296,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI アシスタント · 接続中</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>エージェント · 接続中</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ka-GE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ka-GE/Resources.resw
@@ -263,7 +263,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI ასისტენტი · დაკავშირება</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>აგენტი · დაკავშირება</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/kk-KZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kk-KZ/Resources.resw
@@ -376,7 +376,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI көмекшісі · Қосылуда</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Агент · Қосылуда</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/km-KH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/km-KH/Resources.resw
@@ -195,7 +195,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>ជំនួយការ AI · កំពុងតភ្ជាប់</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>ភ្នាក់ងារ · កំពុងតភ្ជាប់</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/kn-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kn-IN/Resources.resw
@@ -379,7 +379,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI ಸಹಾಯಕ · ಸಂಪರ್ಕಿಸಲಾಗುತ್ತಿದೆ</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>ಏಜೆಂಟ್ · ಸಂಪರ್ಕಿಸಲಾಗುತ್ತಿದೆ</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
@@ -1327,7 +1327,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI 어시스턴트 · 연결 중</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>에이전트 · 연결 중</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/kok-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kok-IN/Resources.resw
@@ -380,7 +380,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI सहाय्यक · जोडटा</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>एजेंट · जोडटा</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lb-LU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lb-LU/Resources.resw
@@ -263,7 +263,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>KI-Assistent · Verbënnt</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Verbënnt</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lo-LA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lo-LA/Resources.resw
@@ -195,7 +195,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>ຜູ້ຊ່ວຍ AI · ກຳລັງເຊື່ອມຕໍ່</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · ກຳລັງເຊື່ອມຕໍ່</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lt-LT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lt-LT/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>DI pagelbiklis · Jungiamasi</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agentas · Jungiamasi</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/lv-LV/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lv-LV/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>MI palīgs · Savienojas</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Aģents · Savienojas</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mi-NZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mi-NZ/Resources.resw
@@ -263,7 +263,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Kaitiaki AI · E hono ana</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Kaitiaki · E hono ana</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mk-MK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mk-MK/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI помошник · Поврзување</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Агент · Поврзување</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ml-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ml-IN/Resources.resw
@@ -379,7 +379,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI അസിസ്റ്റന്റ് · കണക്ട് ചെയ്യുന്നു</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>ഏജന്റ് · കണക്ട് ചെയ്യുന്നു</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mr-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mr-IN/Resources.resw
@@ -379,7 +379,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI सहाय्यक · कनेक्ट होत आहे</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>एजंट · कनेक्ट होत आहे</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ms-MY/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ms-MY/Resources.resw
@@ -308,7 +308,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Pembantu AI · Menyambung</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Ejen · Menyambung</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/mt-MT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mt-MT/Resources.resw
@@ -263,7 +263,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Assistent tal-IA · Qed jikkonnettja</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Aġent · Qed jikkonnettja</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/nb-NO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nb-NO/Resources.resw
@@ -377,7 +377,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI-assistent · Kobler til</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Kobler til</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ne-NP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ne-NP/Resources.resw
@@ -380,7 +380,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI सहायक · जडान हुँदैछ</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>एजेन्ट · जडान हुँदैछ</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/nl-NL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nl-NL/Resources.resw
@@ -371,7 +371,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI-assistent · Verbinden</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Verbinden</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/nn-NO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nn-NO/Resources.resw
@@ -377,7 +377,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>KI-assistent · Koplar til</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Koplar til</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/or-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/or-IN/Resources.resw
@@ -380,7 +380,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI ସହାୟକ · ସଂଯୋଗ ହେଉଛି</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>ଏଜେଣ୍ଟ · ସଂଯୋଗ ହେଉଛି</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pa-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pa-IN/Resources.resw
@@ -379,7 +379,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI ਸਹਾਇਕ · ਕਨੈਕਟ ਹੋ ਰਿਹਾ ਹੈ</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>ਏਜੰਟ · ਕਨੈਕਟ ਹੋ ਰਿਹਾ ਹੈ</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pl-PL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pl-PL/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Asystent AI · Łączenie</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Łączenie</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
@@ -1315,7 +1315,7 @@ Para todas as opções disponíveis, execute 'wt new-tab --help'.</value>
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Assistente de IA · Conectando</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agente · Conectando</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/pt-PT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-PT/Resources.resw
@@ -371,7 +371,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Assistente de IA · A ligar</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agente · A ligar</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
@@ -1284,7 +1284,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI assistant · Connecting</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Connecting</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
@@ -1284,7 +1284,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI assistant · Connecting</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Connecting</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
@@ -1284,7 +1284,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI assistant · Connecting</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Connecting</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/quz-PE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/quz-PE/Resources.resw
@@ -263,7 +263,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI yanapaq · T'inkichkan</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agente · T'inkichkan</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ro-RO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ro-RO/Resources.resw
@@ -376,7 +376,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Asistent AI · Se conectează</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Se conectează</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
@@ -1322,7 +1322,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>ИИ-помощник · Подключение</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Агент · Подключение</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sk-SK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sk-SK/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Asistent AI · Pripájanie</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Pripájanie</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sl-SI/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sl-SI/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Pomočnik AI · Povezovanje</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Povezovanje</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sq-AL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sq-AL/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Asistent AI · Po lidhet</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agjenti · Po lidhet</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-BA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-BA/Resources.resw
@@ -264,7 +264,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI помоћник · Повезивање</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Агент · Повезивање</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
@@ -1296,7 +1296,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI помоћник · Повезивање</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Агент · Повезивање</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sr-Latn-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Latn-RS/Resources.resw
@@ -264,7 +264,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI pomoćnik · Povezivanje</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Povezivanje</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/sv-SE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sv-SE/Resources.resw
@@ -377,7 +377,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI-assistent · Ansluter</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Ansluter</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ta-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ta-IN/Resources.resw
@@ -379,7 +379,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI உதவியாளர் · இணைக்கப்படுகிறது</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>முகவர் · இணைக்கப்படுகிறது</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/te-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/te-IN/Resources.resw
@@ -379,7 +379,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI సహాయకుడు · కనెక్ట్ అవుతోంది</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>ఏజెంట్ · కనెక్ట్ అవుతోంది</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/th-TH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/th-TH/Resources.resw
@@ -308,7 +308,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>ผู้ช่วย AI · กำลังเชื่อมต่อ</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>เอเจนต์ · กำลังเชื่อมต่อ</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/tr-TR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/tr-TR/Resources.resw
@@ -377,7 +377,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Yapay zeka asistanı · Bağlanıyor</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Aracı · Bağlanıyor</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/tt-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/tt-RU/Resources.resw
@@ -376,7 +376,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>ЯИ ярдәмчесе · Тоташа</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Агент · Тоташа</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ug-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ug-CN/Resources.resw
@@ -263,7 +263,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI ياردەمچى · باغلىنىۋاتىدۇ</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>ۋەكىل · باغلىنىۋاتىدۇ</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
@@ -1281,7 +1281,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>ШІ-помічник · Підключення</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Агент · Підключення</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/ur-PK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ur-PK/Resources.resw
@@ -380,7 +380,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI اسسٹنٹ · جڑ رہا ہے</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>ایجنٹ · جڑ رہا ہے</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/uz-Latn-UZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uz-Latn-UZ/Resources.resw
@@ -376,7 +376,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI yordamchisi · Ulanilmoqda</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Agent · Ulanilmoqda</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/vi-VN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/vi-VN/Resources.resw
@@ -308,7 +308,7 @@
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>Trợ lý AI · Đang kết nối</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>Tác tử · Đang kết nối</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
@@ -1329,7 +1329,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI 助手 · 连接中</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>智能体 · 连接中</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
@@ -1295,7 +1295,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Default title shown in the agent pane title bar before an agent reports its name. "AI assistant" refers to the built-in AI coding assistant, not a human assistant.</comment>
   </data>
   <data name="AgentPane_ConnectingTitle" xml:space="preserve">
-    <value>AI 助理 · 連線中</value>
-    <comment>Status shown in the agent pane title bar while the built-in AI coding assistant is connecting. Preserve the centered dot separator.</comment>
+    <value>智能體 · 連線中</value>
+    <comment>Status shown in the agent pane title bar while the AI agent is connecting. Preserve the centered dot separator. Here "agent" means an AI intelligent agent, not a proxy or human agent.</comment>
   </data>
 </root>


### PR DESCRIPTION
## Summary

- replace the generic \AI assistant\ label with the localized \Agent\ term while the agent pane connects
- preserve each locale's existing translation of the connecting status
- update translator guidance to clarify that Agent means an AI intelligent agent

## Validation

- validated all 89 TerminalApp resource files as well-formed XML with UTF-8 BOMs
- built WTA for \x86_64-pc-windows-msvc\`n- built the full Debug solution