### PR TITLE
Improve type-specific agent activity presentation

### DIFF
--- a/tools/wta/README.md
+++ b/tools/wta/README.md
@@ -124,7 +124,10 @@ shell, so any pane-launched process — including wta and wtcli — inherits it.
 ## TUI Controls
 
 Tool rows keep a localized type label such as **Run**, **Read**, **Search**, or
-**Edit** visible across pending, running, and completed states.
+**Edit** visible across pending, running, and completed states. Consecutive
+successful Read, Search, Edit, and Delete calls collapse into one summary row;
+click that row to inspect each call. ACP thought chunks stream as temporary
+**Think** activity and disappear when the visible answer begins.
 
 | Key | Action |
 |-----|--------|

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -4689,7 +4689,7 @@ impl App {
             // has caught up (or nothing is streaming) this is a cheap no-op
             // tick that doesn't redraw — so idle/no-backlog costs nothing.
             AppEvent::RevealTick => self.has_reveal_backlog(),
-            AppEvent::AgentMessageChunk { .. } => true,
+            AppEvent::AgentThoughtChunk { .. } | AppEvent::AgentMessageChunk { .. } => true,
             AppEvent::DebugPipeMessage(_) => self.show_debug_panel,
             _ => true,
         }
@@ -4697,8 +4697,7 @@ impl App {
 
     /// Number of user-visible characters in the active assistant segment.
     fn tab_visible_stream_len(tab: &TabSession) -> Option<usize> {
-        crate::ui::chat::user_visible_stream_text(tab.streaming_agent_text()?)
-            .map(|text| text.chars().count())
+        crate::ui::chat::pending_render_text(tab).map(|text| text.chars().count())
     }
 
     /// True iff the current (visible) tab has streaming text that the reveal

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -524,10 +524,12 @@ pub struct TabSession {
     // (see `doc/specs/turn-state-refactor.md`).
     pub turn: TurnState,
     pub activity_frame: usize,
-    /// Typewriter reveal cursor for the final assistant-text item in the
-    /// active transcript. Advanced toward its full length by `RevealTick`
-    /// (`advance_reveal`), reset to 0 when a new turn starts streaming, and
-    /// made irrelevant on finalize (the committed message renders in full).
+    /// Ephemeral ACP thought text shown only until visible assistant output
+    /// or another structured activity begins. It never enters `messages` or
+    /// `completed_turns`.
+    pub(crate) streaming_thought: String,
+    /// Typewriter reveal cursor for the currently visible thought or final
+    /// assistant-text item. Advanced toward its full length by `RevealTick`.
     pub reveal_chars: usize,
     pub timing_note: Option<String>,
     pub selection_visible_pending: bool,
@@ -606,6 +608,8 @@ pub struct TabSession {
 }
 
 impl TabSession {
+    const MAX_STREAMING_THOUGHT_CHARS: usize = 4000;
+
     pub(crate) fn cached_completed_turn_height(
         &self,
         index: usize,
@@ -779,7 +783,7 @@ impl TabSession {
         self.chat_scroll.offset = 0;
     }
 
-    pub(crate) fn should_show_thinking(&self) -> bool {
+    fn can_show_turn_activity(&self) -> bool {
         self.turn.is_in_flight()
             && self.turn.recommendations().is_none()
             && self.permission.is_empty()
@@ -796,6 +800,17 @@ impl TabSession {
                             || status.eq_ignore_ascii_case("running")
                 )
             })
+    }
+
+    pub(crate) fn should_show_streaming_thought(&self) -> bool {
+        self.can_show_turn_activity()
+            && self
+                .streaming_thought_text()
+                .is_some_and(|text| !text.trim().is_empty())
+    }
+
+    pub(crate) fn should_show_thinking(&self) -> bool {
+        self.can_show_turn_activity() && !self.should_show_streaming_thought()
     }
 
     /// Whether the input box is the live, enterable caret target.
@@ -845,6 +860,7 @@ impl TabSession {
 
     pub fn clear_chat_history(&mut self) {
         self.messages.clear();
+        self.clear_streaming_thought();
         self.permission.clear();
         self.user_input.clear();
         self.activity_frame = 0;
@@ -881,6 +897,38 @@ impl TabSession {
                 self.reveal_chars = 0;
             }
         }
+    }
+
+    pub fn append_thought_chunk(&mut self, text: &str) {
+        if text.is_empty() {
+            self.clear_streaming_thought();
+            return;
+        }
+        if self.streaming_thought.is_empty() {
+            self.reveal_chars = 0;
+        }
+        self.streaming_thought.push_str(text);
+
+        let char_count = self.streaming_thought.chars().count();
+        let remove_chars = char_count.saturating_sub(Self::MAX_STREAMING_THOUGHT_CHARS);
+        if remove_chars > 0 {
+            let cut_at = self
+                .streaming_thought
+                .char_indices()
+                .nth(remove_chars)
+                .map_or(self.streaming_thought.len(), |(index, _)| index);
+            self.streaming_thought.drain(..cut_at);
+            self.reveal_chars = self.reveal_chars.saturating_sub(remove_chars);
+        }
+    }
+
+    pub fn clear_streaming_thought(&mut self) {
+        self.streaming_thought.clear();
+        self.reveal_chars = 0;
+    }
+
+    pub fn streaming_thought_text(&self) -> Option<&str> {
+        (!self.streaming_thought.is_empty()).then_some(self.streaming_thought.as_str())
     }
 
     pub fn streaming_agent_message_index(&self) -> Option<usize> {

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -11278,17 +11278,44 @@ fn first_message_chunk_transitions_to_streaming_with_transcript_text() {
 }
 
 #[test]
-fn thought_chunk_first_transitions_without_visible_text() {
+fn thought_chunks_stream_ephemerally_until_visible_message_text_arrives() {
     let mut app = test_app();
     submit_test_prompt(&mut app, "hi");
     let advanced = app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, "thinking…");
-    assert!(!advanced, "thought chunks never advance the buffer");
+    assert!(advanced, "visible thought chunks advance the live buffer");
     let tab = app.current_tab();
     assert!(tab.turn.is_streaming());
     assert_eq!(tab.streaming_agent_text(), None);
-    assert!(
-        tab.should_show_thinking(),
-        "hidden thought chunks are not user-visible feedback"
+    assert_eq!(tab.streaming_thought_text(), Some("thinking…"));
+    assert!(!tab.should_show_thinking());
+    assert!(render_to_text(&mut app, 80, 20).contains("Think · t"));
+
+    app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Message, "Final answer");
+    let tab = app.current_tab();
+    assert_eq!(tab.streaming_thought_text(), None);
+    assert_eq!(tab.streaming_agent_text(), Some("Final answer"));
+    assert!(!app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, "late hidden thought"));
+    assert_eq!(app.current_tab().streaming_thought_text(), None);
+    app.current_tab_mut().reveal_chars = "Final answer".chars().count();
+    let rendered = render_to_text(&mut app, 80, 20);
+    assert!(rendered.contains("Final"));
+    assert!(!rendered.contains("thinking"));
+    assert!(!rendered.contains("late hidden thought"));
+}
+
+#[test]
+fn live_thought_buffer_is_bounded_without_splitting_unicode() {
+    let mut app = test_app();
+    submit_test_prompt(&mut app, "hi");
+    app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, &"思".repeat(4100));
+
+    assert_eq!(
+        app.current_tab()
+            .streaming_thought_text()
+            .expect("thought stream")
+            .chars()
+            .count(),
+        4000
     );
 }
 
@@ -11317,6 +11344,7 @@ fn structured_stream_hides_thinking_after_response_is_visible() {
 fn running_tool_replaces_thinking_until_tool_completes() {
     let mut app = test_app();
     submit_test_prompt(&mut app, "inspect");
+    app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, "Choosing files");
     app.handle_event(AppEvent::ToolCall {
         session_id: DEFAULT_TAB_ID.into(),
         id: "tool".into(),
@@ -11335,6 +11363,7 @@ fn running_tool_replaces_thinking_until_tool_completes() {
         !app.current_tab().should_show_thinking(),
         "the running tool card is already visible progress"
     );
+    assert_eq!(app.current_tab().streaming_thought_text(), None);
 
     app.handle_event(AppEvent::ToolCallUpdate {
         session_id: DEFAULT_TAB_ID.into(),

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -58,6 +58,7 @@ impl App {
         // these orthogonal fields rather than relying on side effects from a
         // grab-bag helper.
         tab.messages.clear();
+        tab.clear_streaming_thought();
         // Dropping any in-flight responders signals Cancelled back to
         // the agent — appropriate when the user starts a new turn.
         tab.permission.clear();
@@ -126,14 +127,24 @@ impl App {
                     tab.append_agent_chunk(text);
                     true
                 } else {
-                    false
+                    tab.append_thought_chunk(text);
+                    !text.is_empty()
                 }
             }
             (TurnState::Streaming { .. }, ChunkKind::Message) => {
+                if tab.streaming_thought_text().is_some() {
+                    tab.clear_streaming_thought();
+                }
                 tab.append_agent_chunk(text);
                 true
             }
-            (TurnState::Streaming { .. }, ChunkKind::Thought) => false,
+            (TurnState::Streaming { .. }, ChunkKind::Thought) => {
+                if tab.streaming_agent_text().is_some() {
+                    return false;
+                }
+                tab.append_thought_chunk(text);
+                !text.is_empty()
+            }
             // A direct proposal may complete before the agent emits its final
             // message chunks. Keep those chunks visible alongside the card.
             (TurnState::Surfaced { .. }, ChunkKind::Message)
@@ -604,6 +615,7 @@ impl App {
     fn turn_clear_agent_activity(&mut self, session_id: &str) {
         let tab = self.session_tab_mut(session_id);
         tab.activity_frame = 0;
+        tab.clear_streaming_thought();
     }
 
     /// User pressed Enter while a card was visible — dispatch the selected
@@ -835,6 +847,7 @@ impl App {
         tab.recommendation_focus = RecommendationFocus::Button;
         tab.rec_scroll.reset();
         tab.activity_frame = 0;
+        tab.clear_streaming_thought();
         tab.user_input.clear();
         tab.turn = TurnState::Idle;
         tab.pending_terminal_action_proposal = None;
@@ -882,6 +895,7 @@ impl App {
         tab.selection_visible_pending = true;
         tab.clear_completed_turn_selection();
         tab.activity_frame = 0;
+        tab.clear_streaming_thought();
         tab.turn = TurnState::Surfaced {
             prompt,
             outcome: TurnOutcome::Recommendation(recommendations),
@@ -945,6 +959,7 @@ impl App {
         tab.recommendation_focus = RecommendationFocus::Button;
         tab.selection_visible_pending = true;
         tab.activity_frame = 0;
+        tab.clear_streaming_thought();
         tab.turn = TurnState::Surfaced {
             prompt,
             outcome: TurnOutcome::Recommendation(recommendations),
@@ -1018,6 +1033,7 @@ impl App {
         tab.recommendation_focus = RecommendationFocus::Button;
         tab.rec_scroll.reset();
         tab.activity_frame = 0;
+        tab.clear_streaming_thought();
         tab.turn = TurnState::Surfaced {
             prompt,
             outcome: TurnOutcome::ChatTurn,

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -781,8 +781,9 @@ fn tool_call_exit_code(raw_output: Option<&serde_json::Value>) -> Option<i64> {
 }
 
 /// Best-effort extraction of *what* a tool call is touching: a file path
-/// (from `locations`/`raw_input.path`/`raw_input.file_path`) or a shell
-/// command (from `raw_input.command`/`commands`). Returns
+/// (from `locations`/`raw_input.path`/`raw_input.file_path`), a shell
+/// command (from `raw_input.command`/`commands`), or a sanitized Fetch URL.
+/// Returns
 /// `(text, is_command)` so callers can decide how to render it — a path
 /// reads fine inline, but a command can be long and benefits from its own
 /// code-styled line (see `ChatMessage::ToolCall::location_is_command`,
@@ -792,6 +793,7 @@ fn tool_call_exit_code(raw_output: Option<&serde_json::Value>) -> Option<i64> {
 /// which would be noisy and could leak large payloads (e.g. file contents
 /// for a write/edit call) into the chat scrollback.
 fn tool_call_target(
+    kind: Option<&acp::schema::v1::ToolKind>,
     locations: &[acp::schema::v1::ToolCallLocation],
     raw_input: Option<&serde_json::Value>,
 ) -> Option<(String, bool)> {
@@ -832,7 +834,40 @@ fn tool_call_target(
     {
         return Some((c.to_string(), true));
     }
+    let fetch_target = matches!(kind, Some(acp::schema::v1::ToolKind::Fetch))
+        || (kind.is_none()
+            && ["url", "uri"]
+                .into_iter()
+                .any(|key| raw_input.get(key).is_some()));
+    if fetch_target {
+        let target = ["url", "uri"]
+            .into_iter()
+            .find_map(|key| raw_input.get(key)?.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())?;
+        return sanitize_fetch_target(target).map(|target| (target, false));
+    }
     None
+}
+
+fn sanitize_fetch_target(target: &str) -> Option<String> {
+    let (scheme, remainder) = target
+        .split_once("://")
+        .map_or(("", target), |(scheme, remainder)| (scheme, remainder));
+    let safe_end = remainder.find(['?', '#']).unwrap_or(remainder.len());
+    let safe = &remainder[..safe_end];
+    let (authority, path) = safe.split_once('/').unwrap_or((safe, ""));
+    let authority = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    if authority.is_empty() {
+        return None;
+    }
+    let separator = if scheme.is_empty() { "" } else { "://" };
+    let path_separator = if path.is_empty() { "" } else { "/" };
+    Some(format!(
+        "{scheme}{separator}{authority}{path_separator}{path}"
+    ))
 }
 
 /// Truncates a `tool_call_target` string to `TOOL_CALL_LOCATION_MAX_CHARS`,
@@ -863,10 +898,11 @@ fn truncate_target(mut text: String) -> String {
 /// it repeats what a preceding chat tool-call card already showed.
 fn tool_call_location_hint(
     title: &str,
+    kind: Option<&acp::schema::v1::ToolKind>,
     locations: &[acp::schema::v1::ToolCallLocation],
     raw_input: Option<&serde_json::Value>,
 ) -> Option<(String, bool)> {
-    let (hint, is_command) = tool_call_target(locations, raw_input)?;
+    let (hint, is_command) = tool_call_target(kind, locations, raw_input)?;
     let hint = truncate_target(hint);
     let comparison_hint = hint.strip_suffix('…').unwrap_or(&hint);
 
@@ -874,7 +910,15 @@ fn tool_call_location_hint(
     // "Viewing C:\...\rust-app" still dedupes against a locations path that
     // differs only in case (e.g. drive-letter casing from a different code
     // path).
-    if !title.is_empty()
+    let fetch_target = matches!(kind, Some(acp::schema::v1::ToolKind::Fetch))
+        || (kind.is_none()
+            && raw_input.is_some_and(|input| {
+                ["url", "uri"]
+                    .into_iter()
+                    .any(|key| input.get(key).is_some())
+            }));
+    if !fetch_target
+        && !title.is_empty()
         && title
             .to_lowercase()
             .contains(&comparison_hint.to_lowercase())
@@ -1181,6 +1225,7 @@ impl WtaClient {
         // so restating exactly what path/command is involved is
         // intentional even if it repeats a preceding tool-call card.
         let target_hint = tool_call_target(
+            args.tool_call.fields.kind.as_ref(),
             args.tool_call.fields.locations.as_deref().unwrap_or(&[]),
             args.tool_call.fields.raw_input.as_ref(),
         )
@@ -1406,6 +1451,11 @@ impl WtaClient {
             }
             acp::schema::v1::SessionUpdate::AgentThoughtChunk(chunk) => {
                 if let acp::schema::v1::ContentBlock::Text(text_content) = chunk.content {
+                    if !text_content.text.trim().is_empty() {
+                        self.state
+                            .prompt_timing
+                            .observe_first_text(&sid, text_content.text.len());
+                    }
                     let _ = self.state.event_tx.send(AppEvent::AgentThoughtChunk {
                         session_id: sid,
                         text: text_content.text,
@@ -1449,6 +1499,7 @@ impl WtaClient {
                     .observe_first_tool_call(&sid, Some(tool_call.title.as_str()));
                 let (location, location_is_command) = match tool_call_location_hint(
                     &tool_call.title,
+                    Some(&tool_call.kind),
                     &tool_call.locations,
                     tool_call.raw_input.as_ref(),
                 ) {
@@ -1532,6 +1583,7 @@ impl WtaClient {
                     if update.fields.locations.is_some() || update.fields.raw_input.is_some() {
                         match tool_call_location_hint(
                             update.fields.title.as_deref().unwrap_or(""),
+                            update.fields.kind.as_ref(),
                             update.fields.locations.as_deref().unwrap_or(&[]),
                             update.fields.raw_input.as_ref(),
                         ) {
@@ -4625,8 +4677,9 @@ mod tests {
         claim_unexpected_transport_loss, complete_prompt_request, complete_transport_shutdown,
         inject_wta_pane_meta, is_redundant_startup_model_error, post_login_authenticate_error,
         session_mcp_tool_from_title, stop_prompt_tasks, timeout_result_failure_fields,
-        tool_call_exit_code, tool_call_kind_label, AcpClientExit, ClientState, PromptTimingState,
-        PromptUsageIdentity, SessionMcpTool, SoftStopReason, WtaClient,
+        tool_call_exit_code, tool_call_kind_label, tool_call_location_hint, tool_call_target,
+        AcpClientExit, ClientState, PromptTimingState, PromptUsageIdentity, SessionMcpTool,
+        SoftStopReason, WtaClient,
     };
     use crate::app_contracts::AppEvent;
     use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
@@ -4634,6 +4687,35 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::sync::{Arc, Mutex};
     use tokio::sync::mpsc;
+
+    #[test]
+    fn fetch_target_strips_credentials_query_and_fragment() {
+        let raw_input = serde_json::json!({
+            "url": "https://user:secret@example.com/api/items?token=secret#result"
+        });
+
+        assert_eq!(
+            tool_call_target(
+                Some(&acp::schema::v1::ToolKind::Fetch),
+                &[],
+                Some(&raw_input)
+            ),
+            Some(("https://example.com/api/items".to_string(), false))
+        );
+        assert_eq!(
+            tool_call_target(None, &[], Some(&raw_input)),
+            Some(("https://example.com/api/items".to_string(), false))
+        );
+        assert_eq!(
+            tool_call_location_hint(
+                "Fetching https://user:secret@example.com/api/items?token=secret#result",
+                Some(&acp::schema::v1::ToolKind::Fetch),
+                &[],
+                Some(&raw_input),
+            ),
+            Some(("https://example.com/api/items".to_string(), false))
+        );
+    }
 
     #[test]
     fn unexpected_transport_loss_is_claimed_exactly_once() {

--- a/tools/wta/src/telemetry.rs
+++ b/tools/wta/src/telemetry.rs
@@ -169,7 +169,8 @@ pub fn log_agent_prompt_sent(
     );
 }
 
-/// Emitted when the agent's first text chunk arrives back over ACP.
+/// Emitted when the agent's first user-visible text chunk arrives over ACP,
+/// including an ephemeral thought chunk when the provider reports one first.
 /// `first_token_latency_ms` is a monotonic duration (`Instant::elapsed`)
 /// from prompt dispatch to first token, not wall-clock.
 ///

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -80,7 +80,10 @@ fn compact_group_kind(message: &ChatMessage, expanded: bool) -> Option<ToolCallK
     let ChatMessage::ToolCall { status, kind, .. } = message else {
         return None;
     };
-    let groupable_kind = matches!(kind, ToolCallKind::Read | ToolCallKind::Search);
+    let groupable_kind = matches!(
+        kind,
+        ToolCallKind::Read | ToolCallKind::Edit | ToolCallKind::Delete | ToolCallKind::Search
+    );
     (groupable_kind && ToolPhase::from_status(status).is_successful()).then_some(*kind)
 }
 
@@ -110,7 +113,10 @@ fn build_compact_tool_group_lines<'a>(messages: &'a [ChatMessage]) -> Vec<Line<'
     let Some(first) = messages.first().and_then(tool_presentation_from_message) else {
         return Vec::new();
     };
-    let (mut summary, represented) = if first.kind == ToolCallKind::Read {
+    let (mut summary, represented) = if matches!(
+        first.kind,
+        ToolCallKind::Read | ToolCallKind::Edit | ToolCallKind::Delete
+    ) {
         let presentations = messages
             .iter()
             .filter_map(tool_presentation_from_message)
@@ -1365,8 +1371,15 @@ pub(crate) fn user_visible_stream_text(text: &str) -> Option<Cow<'_, str>> {
     (!text.trim().is_empty()).then_some(Cow::Borrowed(text))
 }
 
-fn pending_render_text(tab: &crate::app::TabSession) -> Option<Cow<'_, str>> {
-    user_visible_stream_text(tab.streaming_agent_text()?)
+pub(crate) fn pending_render_text(tab: &crate::app::TabSession) -> Option<Cow<'_, str>> {
+    tab.streaming_agent_text()
+        .and_then(user_visible_stream_text)
+        .or_else(|| {
+            tab.should_show_streaming_thought()
+                .then(|| tab.streaming_thought_text())
+                .flatten()
+                .and_then(user_visible_stream_text)
+        })
 }
 
 fn build_pending_stream_lines<'a>(app: &App, wrap_width: usize) -> Vec<Line<'a>> {
@@ -1374,6 +1387,10 @@ fn build_pending_stream_lines<'a>(app: &App, wrap_width: usize) -> Vec<Line<'a>>
     let Some(text) = pending_render_text(tab) else {
         return Vec::new();
     };
+    let is_thought = tab
+        .streaming_agent_text()
+        .and_then(user_visible_stream_text)
+        .is_none();
     // Typewriter smoothing: only reveal the first `reveal_chars` characters of
     // the streaming text. The reveal cursor is advanced toward the full length
     // by the `RevealTick` animation (`App::advance_reveal`), turning the
@@ -1390,12 +1407,25 @@ fn build_pending_stream_lines<'a>(app: &App, wrap_width: usize) -> Vec<Line<'a>>
         }
     };
     let mut lines = Vec::new();
+    let rendered = if is_thought {
+        Cow::Owned(format!(
+            "{} · {}",
+            t!("chat.tool_kind.think"),
+            revealed.as_ref()
+        ))
+    } else {
+        revealed
+    };
     push_dot_prefixed_lines(
         &mut lines,
-        &revealed,
+        &rendered,
         wrap_width,
         theme::DOT_AGENT,
-        theme::AGENT_TEXT,
+        if is_thought {
+            theme::DIM
+        } else {
+            theme::AGENT_TEXT
+        },
     );
     lines
 }
@@ -2483,6 +2513,66 @@ mod tests {
         assert_eq!(previous_message_group_start(&messages, messages.len()), 0);
         let rendered = build_compact_tool_group_lines(&messages);
         assert_eq!(line_text(&rendered[0]), "✓ Read · rust-app · +3");
+    }
+
+    #[test]
+    fn successful_file_mutations_group_by_kind_and_deduplicate_targets() {
+        for (kind, label) in [
+            (ToolCallKind::Edit, "Edit"),
+            (ToolCallKind::Delete, "Delete"),
+        ] {
+            let messages = [
+                (r"C:\repo\src\chat.rs", "Completed"),
+                (r"C:\repo\src\chat.rs", "Completed"),
+                (r"C:\repo\src\app.rs", "Completed"),
+            ]
+            .into_iter()
+            .enumerate()
+            .map(|(index, (path, status))| ChatMessage::ToolCall {
+                id: format!("mutation-{index}"),
+                title: "Mutate file".into(),
+                status: status.into(),
+                kind,
+                location: Some(path.into()),
+                location_is_command: false,
+                cwd: None,
+                output: None,
+                exit_code: None,
+                content: Vec::new(),
+                locations: Vec::new(),
+            })
+            .collect::<Vec<_>>();
+
+            assert_eq!(previous_message_group_start(&messages, messages.len()), 0);
+            let rendered = build_compact_tool_group_lines(&messages);
+            assert_eq!(
+                line_text(&rendered[0]),
+                format!("✓ {label} · chat.rs, app.rs · +1")
+            );
+        }
+    }
+
+    #[test]
+    fn failed_file_mutation_breaks_compact_group() {
+        let messages = ["Completed", "Failed", "Completed"]
+            .into_iter()
+            .enumerate()
+            .map(|(index, status)| ChatMessage::ToolCall {
+                id: format!("edit-{index}"),
+                title: "Edit file".into(),
+                status: status.into(),
+                kind: ToolCallKind::Edit,
+                location: Some(format!("file-{index}.rs")),
+                location_is_command: false,
+                cwd: None,
+                output: None,
+                exit_code: None,
+                content: Vec::new(),
+                locations: Vec::new(),
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(previous_message_group_start(&messages, messages.len()), 2);
     }
 
     #[test]

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -1706,7 +1706,7 @@ fn push_dot_prefixed_lines<'a>(
     let body_width = wrap_width.saturating_sub(2).max(1);
     let mut first_row = true;
 
-    for paragraph in text.split('\n') {
+    for paragraph in text.trim_end_matches(['\r', '\n']).split('\n') {
         if paragraph.is_empty() {
             // Skip leading blanks so the dot lands on the first content row
             // — many models prefix prose with `\n` / `\n\n`, which would
@@ -2927,6 +2927,15 @@ mod tests {
             texts,
             vec!["● A".to_string(), String::new(), "  B".to_string()]
         );
+    }
+
+    #[test]
+    fn dot_prefix_discards_trailing_blank_lines() {
+        let mut lines = Vec::new();
+        push_dot_prefixed_lines(&mut lines, "A\n\n", 40, theme::DOT_AGENT, theme::AGENT_TEXT);
+
+        assert_eq!(lines.len(), 1);
+        assert_eq!(line_text(&lines[0]), "● A");
     }
 
     #[test]

--- a/tools/wta/src/ui/tool_presentation.rs
+++ b/tools/wta/src/ui/tool_presentation.rs
@@ -225,6 +225,9 @@ fn ascii_case_insensitive_range(haystack: &str, needle: &str) -> Option<Range<us
 }
 
 fn compact_target(kind: ToolCallKind, target: &str) -> Cow<'_, str> {
+    if kind == ToolCallKind::Fetch {
+        return compact_fetch_target(target);
+    }
     if !matches!(
         kind,
         ToolCallKind::Read
@@ -246,6 +249,41 @@ fn compact_target(kind: ToolCallKind, target: &str) -> Cow<'_, str> {
     }
     let separator = if target.contains('\\') { "\\" } else { "/" };
     Cow::Owned(parts[parts.len() - keep..].join(separator))
+}
+
+fn compact_fetch_target(target: &str) -> Cow<'_, str> {
+    let trimmed = target.trim();
+    let without_scheme = trimmed
+        .split_once("://")
+        .map_or(trimmed, |(_, remainder)| remainder);
+    let safe_end = without_scheme
+        .find(['?', '#'])
+        .unwrap_or(without_scheme.len());
+    let safe = &without_scheme[..safe_end];
+    let (authority, path) = safe.split_once('/').unwrap_or((safe, ""));
+    let authority = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    let path_parts = path
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+
+    let compact = match path_parts.as_slice() {
+        [] => authority.to_string(),
+        [only] => format!("{authority}/{only}"),
+        [first, second] => format!("{authority}/{first}/{second}"),
+        parts => format!(
+            "{authority}/…/{}/{}",
+            parts[parts.len() - 2],
+            parts[parts.len() - 1]
+        ),
+    };
+    if compact == target {
+        Cow::Borrowed(target)
+    } else {
+        Cow::Owned(compact)
+    }
 }
 
 #[cfg(test)]
@@ -281,6 +319,21 @@ mod tests {
         assert_eq!(
             compact_target(ToolCallKind::Execute, "cargo test"),
             "cargo test"
+        );
+    }
+
+    #[test]
+    fn compacts_fetch_targets_without_credentials_or_query_data() {
+        assert_eq!(
+            compact_target(
+                ToolCallKind::Fetch,
+                "https://user:secret@api.example.com/v1/repos/terminal/issues?token=secret#result"
+            ),
+            "api.example.com/…/terminal/issues"
+        );
+        assert_eq!(
+            compact_target(ToolCallKind::Fetch, "https://example.com/status"),
+            "example.com/status"
         );
     }
 


### PR DESCRIPTION
## Summary
- group consecutive successful Edit and Delete calls with compact, deduplicated file summaries
- show sanitized, compact Fetch targets without credentials, query strings, or fragments
- stream ACP thought chunks immediately as ephemeral `Think` activity, replacing them when visible answer text or structured activity begins
- bound live thought state to 4,000 characters and count its first visible chunk in first-token latency

## Validation
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml` (1798 passed)
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- live verification with an ACP session emitting 2,262 thought chunks