### PR TITLE
Show bounded line-level edit diffs

### DIFF
--- a/tools/wta/README.md
+++ b/tools/wta/README.md
@@ -127,7 +127,8 @@ Tool rows keep a localized type label such as **Run**, **Read**, **Search**, or
 **Edit** visible across pending, running, and completed states. Consecutive
 successful Read, Search, Edit, and Delete calls collapse into one summary row;
 click that row to inspect each call. ACP thought chunks stream as temporary
-**Think** activity and disappear when the visible answer begins.
+**Think** activity and disappear when the visible answer begins. Expanded Edit
+details show bounded line-level `+`/`-` hunks computed from ACP snapshots.
 
 | Key | Action |
 |-----|--------|

--- a/tools/wta/src/theme.rs
+++ b/tools/wta/src/theme.rs
@@ -26,6 +26,9 @@ pub const TOOL_CALL_FAILURE: Style = Style::new().fg(Color::Red).add_modifier(Mo
 pub const TOOL_CALL_CANCELED: Style = Style::new()
     .fg(Color::DarkGray)
     .add_modifier(Modifier::ITALIC);
+pub const TOOL_DIFF_ADDED: Style = Style::new().fg(Color::Green);
+pub const TOOL_DIFF_REMOVED: Style = Style::new().fg(Color::Red);
+pub const TOOL_DIFF_HEADER: Style = Style::new().fg(Color::Cyan);
 pub const PLAN_STYLE: Style = Style::new().fg(Color::Cyan);
 pub const ERROR_STYLE: Style = Style::new().fg(Color::Red);
 pub const IN_PROGRESS: Style = Style::new()

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -428,15 +428,11 @@ fn restyle_tool_detail_lines(lines: &mut [String], has_prior_child: bool) {
 }
 
 fn tool_detail_line_style(line: &str) -> Style {
-    let content = line
-        .strip_prefix("  └ ")
-        .or_else(|| line.strip_prefix("    "))
-        .unwrap_or(line);
-    if content.starts_with("+ ") {
+    if line.starts_with("    + ") {
         theme::TOOL_DIFF_ADDED
-    } else if content.starts_with("- ") {
+    } else if line.starts_with("    - ") {
         theme::TOOL_DIFF_REMOVED
-    } else if content.starts_with("Δ ") {
+    } else if line.starts_with("    Δ ") {
         theme::TOOL_DIFF_HEADER
     } else {
         theme::DIM
@@ -1699,10 +1695,13 @@ fn build_message_lines_with_details<'a>(
                 }
             }
             cap_tool_detail_lines(&mut detail_lines);
+            let detail_styles = detail_lines
+                .iter()
+                .map(|line| tool_detail_line_style(line))
+                .collect::<Vec<_>>();
             restyle_tool_detail_lines(&mut detail_lines, rendered_command || rendered_output);
             let rendered_details = !detail_lines.is_empty();
-            for line in detail_lines {
-                let style = tool_detail_line_style(&line);
+            for (line, style) in detail_lines.into_iter().zip(detail_styles) {
                 lines.push(Line::from(Span::styled(line, style)));
             }
             if rendered_command || rendered_output || rendered_details {
@@ -2745,12 +2744,16 @@ mod tests {
             ]
         );
         assert_eq!(
-            tool_detail_line_style("  └ - old value"),
+            tool_detail_line_style("    - old value"),
             theme::TOOL_DIFF_REMOVED
         );
         assert_eq!(
             tool_detail_line_style("    + new value"),
             theme::TOOL_DIFF_ADDED
+        );
+        assert_eq!(
+            tool_detail_line_style("    │ - ordinary output"),
+            theme::DIM
         );
     }
 

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -292,17 +292,34 @@ fn truncate_tool_detail_text(text: &str) -> Cow<'_, str> {
     }
 }
 
+struct ToolDetailLine {
+    text: String,
+    style: Style,
+}
+
+impl ToolDetailLine {
+    fn dim(text: String) -> Self {
+        Self {
+            text,
+            style: theme::DIM,
+        }
+    }
+}
+
 fn diff_detail_lines(
     path: &str,
     old_text: Option<&ToolCallOutput>,
     new_text: &ToolCallOutput,
     detailed: bool,
     max_lines: usize,
-) -> Vec<String> {
+) -> Vec<ToolDetailLine> {
     if max_lines == 0 {
         return Vec::new();
     }
-    let mut lines = vec![format!("    Δ {path}")];
+    let mut lines = vec![ToolDetailLine {
+        text: format!("    Δ {}", truncate_tool_detail_text(path)),
+        style: theme::TOOL_DIFF_HEADER,
+    }];
     if !detailed || max_lines == 1 {
         return lines;
     }
@@ -317,13 +334,24 @@ fn diff_detail_lines(
         )
         .into_iter()
         .map(|line| {
-            let (marker, text) = match line.kind {
-                DiffLineKind::Context => ("│ ", truncate_tool_detail_text(line.text)),
-                DiffLineKind::Added => ("+ ", truncate_tool_detail_text(line.text)),
-                DiffLineKind::Removed => ("- ", truncate_tool_detail_text(line.text)),
-                DiffLineKind::Omitted => ("│ ", Cow::Borrowed("…")),
+            let (marker, text, style) = match line.kind {
+                DiffLineKind::Context => ("│ ", truncate_tool_detail_text(line.text), theme::DIM),
+                DiffLineKind::Added => (
+                    "+ ",
+                    truncate_tool_detail_text(line.text),
+                    theme::TOOL_DIFF_ADDED,
+                ),
+                DiffLineKind::Removed => (
+                    "- ",
+                    truncate_tool_detail_text(line.text),
+                    theme::TOOL_DIFF_REMOVED,
+                ),
+                DiffLineKind::Omitted => ("│ ", Cow::Borrowed("…"), theme::DIM),
             };
-            format!("    {marker}{text}")
+            ToolDetailLine {
+                text: format!("    {marker}{text}"),
+                style,
+            }
         }),
     );
     lines
@@ -333,7 +361,7 @@ fn tool_detail_lines(
     content: &[ToolCallContent],
     locations: &[ToolCallLocation],
     detailed: bool,
-) -> Vec<String> {
+) -> Vec<ToolDetailLine> {
     #[cfg(test)]
     TOOL_DETAIL_BUILD_COUNT.with(|count| count.set(count.get() + 1));
 
@@ -344,7 +372,10 @@ fn tool_detail_lines(
             let suffix = location
                 .line
                 .map_or_else(String::new, |line| format!(":{line}"));
-            lines.push(format!("    {}{suffix}", location.path));
+            lines.push(ToolDetailLine::dim(format!(
+                "    {}{suffix}",
+                location.path
+            )));
         }
         omitted = locations.len() > MAX_TOOL_DETAIL_LINES;
     }
@@ -356,9 +387,17 @@ fn tool_detail_lines(
         match item {
             ToolCallContent::Text(output) => {
                 if detailed {
-                    lines.extend(full_output_lines(output, "    │ "));
+                    lines.extend(
+                        full_output_lines(output, "    │ ")
+                            .into_iter()
+                            .map(ToolDetailLine::dim),
+                    );
                 } else {
-                    lines.extend(preview_output_lines(output, "    │ "));
+                    lines.extend(
+                        preview_output_lines(output, "    │ ")
+                            .into_iter()
+                            .map(ToolDetailLine::dim),
+                    );
                 }
             }
             ToolCallContent::Diff {
@@ -380,10 +419,14 @@ fn tool_detail_lines(
                 exit_code,
             } => {
                 let status = exit_code.map_or_else(String::new, |code| format!(" · exit {code}"));
-                lines.push(format!("    $ {id}{status}"));
+                lines.push(ToolDetailLine::dim(format!("    $ {id}{status}")));
                 if detailed {
                     if let Some(output) = output {
-                        lines.extend(full_output_lines(output, "    │ "));
+                        lines.extend(
+                            full_output_lines(output, "    │ ")
+                                .into_iter()
+                                .map(ToolDetailLine::dim),
+                        );
                     }
                 }
             }
@@ -391,7 +434,7 @@ fn tool_detail_lines(
                 let target = uri
                     .as_deref()
                     .map_or_else(String::new, |uri| format!(" · {uri}"));
-                lines.push(format!("    ↳ {label}{target}"));
+                lines.push(ToolDetailLine::dim(format!("    ↳ {label}{target}")));
             }
         }
         if lines.len() > MAX_TOOL_DETAIL_LINES {
@@ -401,41 +444,29 @@ fn tool_detail_lines(
     }
     if omitted {
         lines.truncate(MAX_TOOL_DETAIL_LINES.saturating_sub(1));
-        lines.push("    …".to_string());
+        lines.push(ToolDetailLine::dim("    …".to_string()));
     }
     lines
 }
 
-fn cap_tool_detail_lines(lines: &mut Vec<String>) {
+fn cap_tool_detail_lines(lines: &mut Vec<ToolDetailLine>) {
     if lines.len() > MAX_TOOL_DETAIL_LINES {
         lines.truncate(MAX_TOOL_DETAIL_LINES.saturating_sub(1));
-        lines.push("    …".to_string());
+        lines.push(ToolDetailLine::dim("    …".to_string()));
     }
 }
 
-fn restyle_tool_detail_lines(lines: &mut [String], has_prior_child: bool) {
+fn restyle_tool_detail_lines(lines: &mut [ToolDetailLine], has_prior_child: bool) {
     let mut needs_branch = !has_prior_child;
     for line in lines {
-        if let Some(content) = line.strip_prefix("    │ ").map(str::to_string) {
-            *line = format!("{}{content}", if needs_branch { "  └ " } else { "    " });
+        if let Some(content) = line.text.strip_prefix("    │ ").map(str::to_string) {
+            line.text = format!("{}{content}", if needs_branch { "  └ " } else { "    " });
         } else if needs_branch {
-            if let Some(content) = line.strip_prefix("    ").map(str::to_string) {
-                *line = format!("  └ {content}");
+            if let Some(content) = line.text.strip_prefix("    ").map(str::to_string) {
+                line.text = format!("  └ {content}");
             }
         }
         needs_branch = false;
-    }
-}
-
-fn tool_detail_line_style(line: &str) -> Style {
-    if line.starts_with("    + ") {
-        theme::TOOL_DIFF_ADDED
-    } else if line.starts_with("    - ") {
-        theme::TOOL_DIFF_REMOVED
-    } else if line.starts_with("    Δ ") {
-        theme::TOOL_DIFF_HEADER
-    } else {
-        theme::DIM
     }
 }
 
@@ -1688,21 +1719,25 @@ fn build_message_lines_with_details<'a>(
             if !has_text_content && detail_level != ToolDetailLevel::Compact {
                 if let Some(output) = output {
                     if detail_level == ToolDetailLevel::Detailed {
-                        detail_lines.extend(full_output_lines(output, "    │ "));
+                        detail_lines.extend(
+                            full_output_lines(output, "    │ ")
+                                .into_iter()
+                                .map(ToolDetailLine::dim),
+                        );
                     } else if *kind != ToolCallKind::Execute && !*location_is_command {
-                        detail_lines.extend(preview_output_lines(output, "    │ "));
+                        detail_lines.extend(
+                            preview_output_lines(output, "    │ ")
+                                .into_iter()
+                                .map(ToolDetailLine::dim),
+                        );
                     }
                 }
             }
             cap_tool_detail_lines(&mut detail_lines);
-            let detail_styles = detail_lines
-                .iter()
-                .map(|line| tool_detail_line_style(line))
-                .collect::<Vec<_>>();
             restyle_tool_detail_lines(&mut detail_lines, rendered_command || rendered_output);
             let rendered_details = !detail_lines.is_empty();
-            for (line, style) in detail_lines.into_iter().zip(detail_styles) {
-                lines.push(Line::from(Span::styled(line, style)));
+            for line in detail_lines {
+                lines.push(Line::from(Span::styled(line.text, line.style)));
             }
             if rendered_command || rendered_output || rendered_details {
                 lines.push(Line::default());
@@ -2693,10 +2728,10 @@ mod tests {
         let lines = tool_detail_lines(&[ToolCallContent::Text(output)], &[], true);
 
         assert_eq!(lines.len(), MAX_TOOL_DETAIL_OUTPUT_LINES + 1);
-        assert_eq!(lines[0], "    │ …");
+        assert_eq!(lines[0].text, "    │ …");
         assert!(lines
             .last()
-            .is_some_and(|line| line.ends_with("object-199.o")));
+            .is_some_and(|line| line.text.ends_with("object-199.o")));
     }
 
     #[test]
@@ -2711,7 +2746,7 @@ mod tests {
         let lines = tool_detail_lines(&[], &locations, true);
 
         assert_eq!(lines.len(), MAX_TOOL_DETAIL_LINES);
-        assert_eq!(lines.last().map(String::as_str), Some("    …"));
+        assert_eq!(lines.last().map(|line| line.text.as_str()), Some("    …"));
     }
 
     #[test]
@@ -2733,7 +2768,10 @@ mod tests {
         let lines = tool_detail_lines(&[content], &[], true);
 
         assert_eq!(
-            lines,
+            lines
+                .iter()
+                .map(|line| line.text.as_str())
+                .collect::<Vec<_>>(),
             vec![
                 "    Δ src/main.rs",
                 "    │ before",
@@ -2743,18 +2781,9 @@ mod tests {
                 "    │ after",
             ]
         );
-        assert_eq!(
-            tool_detail_line_style("    - old value"),
-            theme::TOOL_DIFF_REMOVED
-        );
-        assert_eq!(
-            tool_detail_line_style("    + new value"),
-            theme::TOOL_DIFF_ADDED
-        );
-        assert_eq!(
-            tool_detail_line_style("    │ - ordinary output"),
-            theme::DIM
-        );
+        assert_eq!(lines[2].style, theme::DIM);
+        assert_eq!(lines[3].style, theme::TOOL_DIFF_REMOVED);
+        assert_eq!(lines[4].style, theme::TOOL_DIFF_ADDED);
     }
 
     #[test]
@@ -2771,7 +2800,10 @@ mod tests {
         let lines = tool_detail_lines(&[content], &[], true);
 
         assert_eq!(
-            lines,
+            lines
+                .iter()
+                .map(|line| line.text.as_str())
+                .collect::<Vec<_>>(),
             vec!["    Δ src/new.rs", "    + first", "    + second",]
         );
     }
@@ -2800,17 +2832,48 @@ mod tests {
 
         let removed = lines
             .iter()
-            .filter(|line| line.starts_with("    - "))
+            .filter(|line| line.text.starts_with("    - "))
             .count();
         let added = lines
             .iter()
-            .filter(|line| line.starts_with("    + "))
+            .filter(|line| line.text.starts_with("    + "))
             .count();
         assert!(lines.len() <= MAX_TOOL_DETAIL_LINES);
         assert!(removed > 0);
         assert!(added > 0);
         assert!(removed.abs_diff(added) <= 1);
-        assert!(lines.iter().any(|line| line == "    │ …"));
+        assert!(lines.iter().any(|line| line.text == "    │ …"));
+    }
+
+    #[test]
+    fn ordinary_marker_like_location_keeps_dim_style() {
+        let locations = vec![ToolCallLocation {
+            path: "+ notes.txt".into(),
+            line: None,
+        }];
+
+        let lines = tool_detail_lines(&[], &locations, true);
+
+        assert_eq!(lines[0].text, "    + notes.txt");
+        assert_eq!(lines[0].style, theme::DIM);
+    }
+
+    #[test]
+    fn diff_header_path_is_bounded() {
+        let path = "x".repeat(MAX_TOOL_OUTPUT_LINE_CHARS + 20);
+        let new_text = ToolCallOutput {
+            text: "content".into(),
+            truncated: false,
+        };
+
+        let lines = diff_detail_lines(&path, None, &new_text, true, 4);
+
+        assert!(lines[0].text.ends_with('…'));
+        assert_eq!(
+            lines[0].text.chars().count(),
+            "    Δ ".chars().count() + MAX_TOOL_OUTPUT_LINE_CHARS + 1
+        );
+        assert_eq!(lines[0].style, theme::TOOL_DIFF_HEADER);
     }
 
     #[test]

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -406,6 +406,13 @@ fn tool_detail_lines(
     lines
 }
 
+fn cap_tool_detail_lines(lines: &mut Vec<String>) {
+    if lines.len() > MAX_TOOL_DETAIL_LINES {
+        lines.truncate(MAX_TOOL_DETAIL_LINES.saturating_sub(1));
+        lines.push("    …".to_string());
+    }
+}
+
 fn restyle_tool_detail_lines(lines: &mut [String], has_prior_child: bool) {
     let mut needs_branch = !has_prior_child;
     for line in lines {
@@ -1691,6 +1698,7 @@ fn build_message_lines_with_details<'a>(
                     }
                 }
             }
+            cap_tool_detail_lines(&mut detail_lines);
             restyle_tool_detail_lines(&mut detail_lines, rendered_command || rendered_output);
             let rendered_details = !detail_lines.is_empty();
             for line in detail_lines {
@@ -2709,14 +2717,16 @@ mod tests {
 
     #[test]
     fn expanded_diff_details_render_only_real_changes() {
+        let old = ["before", "same", "old value", "after"].join("\n");
+        let new = ["before", "same", "new value", "after"].join("\n");
         let content = ToolCallContent::Diff {
             path: "src/main.rs".into(),
             old_text: Some(ToolCallOutput {
-                text: "before\nsame\nold value\nafter".into(),
+                text: old,
                 truncated: false,
             }),
             new_text: ToolCallOutput {
-                text: "before\nsame\nnew value\nafter".into(),
+                text: new,
                 truncated: false,
             },
         };
@@ -2750,7 +2760,7 @@ mod tests {
             path: "src/new.rs".into(),
             old_text: None,
             new_text: ToolCallOutput {
-                text: "first\nsecond".into(),
+                text: ["first", "second"].join("\n"),
                 truncated: false,
             },
         };
@@ -2798,6 +2808,64 @@ mod tests {
         assert!(added > 0);
         assert!(removed.abs_diff(added) <= 1);
         assert!(lines.iter().any(|line| line == "    │ …"));
+    }
+
+    #[test]
+    fn diff_with_fallback_output_respects_the_global_detail_cap() {
+        let old = (0..100)
+            .map(|index| format!("old {index}"))
+            .collect::<Vec<_>>();
+        let new = (0..100)
+            .map(|index| format!("new {index}"))
+            .collect::<Vec<_>>();
+        let message = ChatMessage::ToolCall {
+            id: "tool".into(),
+            title: "Update source".into(),
+            status: "Completed".into(),
+            kind: ToolCallKind::Edit,
+            location: Some("src/main.rs".into()),
+            location_is_command: false,
+            cwd: None,
+            output: Some(ToolCallOutput {
+                text: (0..MAX_TOOL_DETAIL_OUTPUT_LINES)
+                    .map(|index| format!("raw output {index}"))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+                truncated: false,
+            }),
+            exit_code: None,
+            content: vec![ToolCallContent::Diff {
+                path: "src/main.rs".into(),
+                old_text: Some(ToolCallOutput {
+                    text: old.join("\n"),
+                    truncated: false,
+                }),
+                new_text: ToolCallOutput {
+                    text: new.join("\n"),
+                    truncated: false,
+                },
+            }],
+            locations: Vec::new(),
+        };
+
+        let rendered = build_message_lines_with_details(
+            &message,
+            false,
+            false,
+            None,
+            0,
+            120,
+            ToolDisplay::Completed { expanded: true },
+        )
+        .iter()
+        .map(line_text)
+        .collect::<Vec<_>>();
+
+        assert_eq!(rendered.len(), MAX_TOOL_DETAIL_LINES + 2);
+        assert_eq!(
+            rendered.get(rendered.len() - 2).map(String::as_str),
+            Some("    …")
+        );
     }
 
     #[test]

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -15,6 +15,7 @@ use crate::app::{
     ToolCallOutput,
 };
 use crate::theme;
+use crate::ui::line_diff::{self, DiffLineKind};
 use crate::ui::shimmer;
 use crate::ui::tool_presentation::{ToolPhase, ToolPresentation};
 use crate::ui_trace;
@@ -278,6 +279,56 @@ fn preview_output_lines(output: &ToolCallOutput, prefix: &str) -> Vec<String> {
     lines
 }
 
+fn truncate_tool_detail_text(text: &str) -> Cow<'_, str> {
+    let mut chars = text.chars();
+    let head = chars
+        .by_ref()
+        .take(MAX_TOOL_OUTPUT_LINE_CHARS)
+        .collect::<String>();
+    if chars.next().is_some() {
+        Cow::Owned(format!("{head}…"))
+    } else {
+        Cow::Borrowed(text)
+    }
+}
+
+fn diff_detail_lines(
+    path: &str,
+    old_text: Option<&ToolCallOutput>,
+    new_text: &ToolCallOutput,
+    detailed: bool,
+    max_lines: usize,
+) -> Vec<String> {
+    if max_lines == 0 {
+        return Vec::new();
+    }
+    let mut lines = vec![format!("    Δ {path}")];
+    if !detailed || max_lines == 1 {
+        return lines;
+    }
+
+    let source_truncated = old_text.is_some_and(|output| output.truncated) || new_text.truncated;
+    lines.extend(
+        line_diff::preview(
+            old_text.map(|output| output.text.as_str()),
+            &new_text.text,
+            source_truncated,
+            max_lines - 1,
+        )
+        .into_iter()
+        .map(|line| {
+            let (marker, text) = match line.kind {
+                DiffLineKind::Context => ("│ ", truncate_tool_detail_text(line.text)),
+                DiffLineKind::Added => ("+ ", truncate_tool_detail_text(line.text)),
+                DiffLineKind::Removed => ("- ", truncate_tool_detail_text(line.text)),
+                DiffLineKind::Omitted => ("│ ", Cow::Borrowed("…")),
+            };
+            format!("    {marker}{text}")
+        }),
+    );
+    lines
+}
+
 fn tool_detail_lines(
     content: &[ToolCallContent],
     locations: &[ToolCallLocation],
@@ -315,13 +366,13 @@ fn tool_detail_lines(
                 old_text,
                 new_text,
             } => {
-                lines.push(format!("    Δ {path}"));
-                if detailed {
-                    if let Some(old_text) = old_text {
-                        lines.extend(full_output_lines(old_text, "    - "));
-                    }
-                    lines.extend(full_output_lines(new_text, "    + "));
-                }
+                lines.extend(diff_detail_lines(
+                    path,
+                    old_text.as_ref(),
+                    new_text,
+                    detailed,
+                    MAX_TOOL_DETAIL_LINES.saturating_sub(lines.len()),
+                ));
             }
             ToolCallContent::Terminal {
                 id,
@@ -366,6 +417,22 @@ fn restyle_tool_detail_lines(lines: &mut [String], has_prior_child: bool) {
             }
         }
         needs_branch = false;
+    }
+}
+
+fn tool_detail_line_style(line: &str) -> Style {
+    let content = line
+        .strip_prefix("  └ ")
+        .or_else(|| line.strip_prefix("    "))
+        .unwrap_or(line);
+    if content.starts_with("+ ") {
+        theme::TOOL_DIFF_ADDED
+    } else if content.starts_with("- ") {
+        theme::TOOL_DIFF_REMOVED
+    } else if content.starts_with("Δ ") {
+        theme::TOOL_DIFF_HEADER
+    } else {
+        theme::DIM
     }
 }
 
@@ -1627,7 +1694,8 @@ fn build_message_lines_with_details<'a>(
             restyle_tool_detail_lines(&mut detail_lines, rendered_command || rendered_output);
             let rendered_details = !detail_lines.is_empty();
             for line in detail_lines {
-                lines.push(Line::from(Span::styled(line, theme::DIM)));
+                let style = tool_detail_line_style(&line);
+                lines.push(Line::from(Span::styled(line, style)));
             }
             if rendered_command || rendered_output || rendered_details {
                 lines.push(Line::default());
@@ -2637,6 +2705,99 @@ mod tests {
 
         assert_eq!(lines.len(), MAX_TOOL_DETAIL_LINES);
         assert_eq!(lines.last().map(String::as_str), Some("    …"));
+    }
+
+    #[test]
+    fn expanded_diff_details_render_only_real_changes() {
+        let content = ToolCallContent::Diff {
+            path: "src/main.rs".into(),
+            old_text: Some(ToolCallOutput {
+                text: "before\nsame\nold value\nafter".into(),
+                truncated: false,
+            }),
+            new_text: ToolCallOutput {
+                text: "before\nsame\nnew value\nafter".into(),
+                truncated: false,
+            },
+        };
+
+        let lines = tool_detail_lines(&[content], &[], true);
+
+        assert_eq!(
+            lines,
+            vec![
+                "    Δ src/main.rs",
+                "    │ before",
+                "    │ same",
+                "    - old value",
+                "    + new value",
+                "    │ after",
+            ]
+        );
+        assert_eq!(
+            tool_detail_line_style("  └ - old value"),
+            theme::TOOL_DIFF_REMOVED
+        );
+        assert_eq!(
+            tool_detail_line_style("    + new value"),
+            theme::TOOL_DIFF_ADDED
+        );
+    }
+
+    #[test]
+    fn expanded_new_file_diff_renders_additions() {
+        let content = ToolCallContent::Diff {
+            path: "src/new.rs".into(),
+            old_text: None,
+            new_text: ToolCallOutput {
+                text: "first\nsecond".into(),
+                truncated: false,
+            },
+        };
+
+        let lines = tool_detail_lines(&[content], &[], true);
+
+        assert_eq!(
+            lines,
+            vec!["    Δ src/new.rs", "    + first", "    + second",]
+        );
+    }
+
+    #[test]
+    fn expanded_diff_details_respect_the_global_line_cap() {
+        let content = ToolCallContent::Diff {
+            path: "src/large.rs".into(),
+            old_text: Some(ToolCallOutput {
+                text: (0..300)
+                    .map(|index| format!("old {index}"))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+                truncated: false,
+            }),
+            new_text: ToolCallOutput {
+                text: (0..300)
+                    .map(|index| format!("new {index}"))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+                truncated: false,
+            },
+        };
+
+        let lines = tool_detail_lines(&[content], &[], true);
+
+        let removed = lines
+            .iter()
+            .filter(|line| line.starts_with("    - "))
+            .count();
+        let added = lines
+            .iter()
+            .filter(|line| line.starts_with("    + "))
+            .count();
+        assert!(lines.len() <= MAX_TOOL_DETAIL_LINES);
+        assert!(removed > 0);
+        assert!(added > 0);
+        assert!(removed.abs_diff(added) <= 1);
+        assert!(lines.iter().any(|line| line == "    │ …"));
     }
 
     #[test]

--- a/tools/wta/src/ui/line_diff.rs
+++ b/tools/wta/src/ui/line_diff.rs
@@ -86,7 +86,7 @@ pub(crate) fn preview<'a>(
     let core_exceeds_limit =
         old_core.len() > MAX_DIFF_CORE_LINES || new_core.len() > MAX_DIFF_CORE_LINES;
     if core_exceeds_limit && shares_line(old_core, new_core) {
-        push_omitted(&mut lines);
+        append_large_shared_core(&mut lines, old_core, new_core);
     } else {
         let old_bounded = &old_core[..old_core.len().min(MAX_DIFF_CORE_LINES)];
         let new_bounded = &new_core[..new_core.len().min(MAX_DIFF_CORE_LINES)];
@@ -128,6 +128,44 @@ fn shares_line(old_lines: &[&str], new_lines: &[&str]) -> bool {
     };
     let lines = shorter.iter().copied().collect::<HashSet<_>>();
     longer.iter().any(|line| lines.contains(line))
+}
+
+fn append_large_shared_core<'a>(
+    output: &mut Vec<DiffLine<'a>>,
+    old_lines: &[&'a str],
+    new_lines: &[&'a str],
+) {
+    if old_lines.len() <= MAX_DIFF_CORE_LINES || new_lines.len() <= MAX_DIFF_CORE_LINES {
+        push_omitted(output);
+        return;
+    }
+
+    let edge_lines = MAX_DIFF_CORE_LINES / 2;
+    let old_head = &old_lines[..edge_lines];
+    let new_head = &new_lines[..edge_lines];
+    if suffix_anchor_matches(old_head, new_head) {
+        append_collapsed_ops(output, &diff_ops(old_head, new_head));
+    } else {
+        push_omitted(output);
+    }
+
+    push_omitted(output);
+
+    let old_tail = &old_lines[old_lines.len() - edge_lines..];
+    let new_tail = &new_lines[new_lines.len() - edge_lines..];
+    if prefix_anchor_matches(old_tail, new_tail) {
+        append_collapsed_ops(output, &diff_ops(old_tail, new_tail));
+    } else {
+        push_omitted(output);
+    }
+}
+
+fn suffix_anchor_matches(old_lines: &[&str], new_lines: &[&str]) -> bool {
+    old_lines[old_lines.len() - CONTEXT_LINES..] == new_lines[new_lines.len() - CONTEXT_LINES..]
+}
+
+fn prefix_anchor_matches(old_lines: &[&str], new_lines: &[&str]) -> bool {
+    old_lines[..CONTEXT_LINES] == new_lines[..CONTEXT_LINES]
 }
 
 fn diff_ops<'a>(old_lines: &[&'a str], new_lines: &[&'a str]) -> Vec<DiffLine<'a>> {
@@ -415,6 +453,34 @@ mod tests {
         let lines = preview(Some(&old), &new, false, 32);
 
         assert_eq!(rendered(&lines), vec![(DiffLineKind::Omitted, "")]);
+    }
+
+    #[test]
+    fn large_aligned_core_keeps_head_and_tail_edits() {
+        let old = (0..300)
+            .map(|index| format!("same {index}"))
+            .collect::<Vec<_>>();
+        let mut new = old.clone();
+        new[0] = "changed head".to_string();
+        new[299] = "changed tail".to_string();
+        let old = old.join("\n");
+        let new = new.join("\n");
+
+        let lines = preview(Some(&old), &new, false, 32);
+
+        assert!(lines
+            .iter()
+            .any(|line| line.kind == DiffLineKind::Removed && line.text == "same 0"));
+        assert!(lines
+            .iter()
+            .any(|line| line.kind == DiffLineKind::Added && line.text == "changed head"));
+        assert!(lines
+            .iter()
+            .any(|line| line.kind == DiffLineKind::Removed && line.text == "same 299"));
+        assert!(lines
+            .iter()
+            .any(|line| line.kind == DiffLineKind::Added && line.text == "changed tail"));
+        assert!(lines.iter().any(|line| line.kind == DiffLineKind::Omitted));
     }
 
     #[test]

--- a/tools/wta/src/ui/line_diff.rs
+++ b/tools/wta/src/ui/line_diff.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 const MAX_DIFF_CORE_LINES: usize = 256;
+const MAX_ASYMMETRIC_CORE_LINES: usize = 4096;
 const CONTEXT_LINES: usize = 2;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -86,7 +87,13 @@ pub(crate) fn preview<'a>(
     let core_exceeds_limit =
         old_core.len() > MAX_DIFF_CORE_LINES || new_core.len() > MAX_DIFF_CORE_LINES;
     if core_exceeds_limit && shares_line(old_core, new_core) {
-        append_large_shared_core(&mut lines, old_core, new_core);
+        if old_core.len() > MAX_DIFF_CORE_LINES && new_core.len() > MAX_DIFF_CORE_LINES {
+            append_large_shared_core(&mut lines, old_core, new_core);
+        } else if old_core.len().max(new_core.len()) <= MAX_ASYMMETRIC_CORE_LINES {
+            append_collapsed_ops(&mut lines, &diff_ops(old_core, new_core));
+        } else {
+            push_omitted(&mut lines);
+        }
     } else {
         let old_bounded = &old_core[..old_core.len().min(MAX_DIFF_CORE_LINES)];
         let new_bounded = &new_core[..new_core.len().min(MAX_DIFF_CORE_LINES)];
@@ -135,11 +142,6 @@ fn append_large_shared_core<'a>(
     old_lines: &[&'a str],
     new_lines: &[&'a str],
 ) {
-    if old_lines.len() <= MAX_DIFF_CORE_LINES || new_lines.len() <= MAX_DIFF_CORE_LINES {
-        push_omitted(output);
-        return;
-    }
-
     let edge_lines = MAX_DIFF_CORE_LINES / 2;
     let old_head = &old_lines[..edge_lines];
     let new_head = &new_lines[..edge_lines];
@@ -586,5 +588,25 @@ mod tests {
         assert!(balanced
             .iter()
             .any(|line| line.kind == DiffLineKind::Omitted));
+    }
+
+    #[test]
+    fn asymmetric_core_uses_bounded_full_alignment() {
+        let mut old = (0..10)
+            .map(|index| format!("old {index}"))
+            .collect::<Vec<_>>();
+        old.insert(5, "shared line".to_string());
+        let mut new = (0..300)
+            .map(|index| format!("new {index}"))
+            .collect::<Vec<_>>();
+        new.insert(150, "shared line".to_string());
+        let old = old.join("\n");
+        let new = new.join("\n");
+
+        let lines = preview(Some(&old), &new, false, 32);
+
+        assert!(lines.iter().any(|line| line.kind == DiffLineKind::Removed));
+        assert!(lines.iter().any(|line| line.kind == DiffLineKind::Added));
+        assert!(lines.iter().any(|line| line.kind == DiffLineKind::Omitted));
     }
 }

--- a/tools/wta/src/ui/line_diff.rs
+++ b/tools/wta/src/ui/line_diff.rs
@@ -86,21 +86,20 @@ pub(crate) fn preview<'a>(
     let new_core = &new_lines[prefix..new_core_end];
     let core_exceeds_limit =
         old_core.len() > MAX_DIFF_CORE_LINES || new_core.len() > MAX_DIFF_CORE_LINES;
-    if core_exceeds_limit && shares_line(old_core, new_core) {
-        if old_core.len() > MAX_DIFF_CORE_LINES && new_core.len() > MAX_DIFF_CORE_LINES {
-            append_large_shared_core(&mut lines, old_core, new_core);
-        } else if old_core.len().max(new_core.len()) <= MAX_ASYMMETRIC_CORE_LINES {
-            append_collapsed_ops(&mut lines, &diff_ops(old_core, new_core));
+    if core_exceeds_limit {
+        if shares_line(old_core, new_core) {
+            if old_core.len() > MAX_DIFF_CORE_LINES && new_core.len() > MAX_DIFF_CORE_LINES {
+                append_large_shared_core(&mut lines, old_core, new_core);
+            } else if old_core.len().max(new_core.len()) <= MAX_ASYMMETRIC_CORE_LINES {
+                append_collapsed_ops(&mut lines, &diff_ops(old_core, new_core));
+            } else {
+                push_omitted(&mut lines);
+            }
         } else {
-            push_omitted(&mut lines);
+            append_large_disjoint_core(&mut lines, old_core, new_core);
         }
     } else {
-        let old_bounded = &old_core[..old_core.len().min(MAX_DIFF_CORE_LINES)];
-        let new_bounded = &new_core[..new_core.len().min(MAX_DIFF_CORE_LINES)];
-        append_collapsed_ops(&mut lines, &diff_ops(old_bounded, new_bounded));
-        if core_exceeds_limit {
-            push_omitted(&mut lines);
-        }
+        append_collapsed_ops(&mut lines, &diff_ops(old_core, new_core));
     }
 
     let suffix_context = suffix.min(CONTEXT_LINES);
@@ -135,6 +134,37 @@ fn shares_line(old_lines: &[&str], new_lines: &[&str]) -> bool {
     };
     let lines = shorter.iter().copied().collect::<HashSet<_>>();
     longer.iter().any(|line| lines.contains(line))
+}
+
+fn append_large_disjoint_core<'a>(
+    output: &mut Vec<DiffLine<'a>>,
+    old_lines: &[&'a str],
+    new_lines: &[&'a str],
+) {
+    output.extend(
+        old_lines
+            .iter()
+            .take(MAX_DIFF_CORE_LINES)
+            .map(|text| DiffLine {
+                kind: DiffLineKind::Removed,
+                text,
+            }),
+    );
+    if old_lines.len() > MAX_DIFF_CORE_LINES {
+        push_omitted(output);
+    }
+    output.extend(
+        new_lines
+            .iter()
+            .take(MAX_DIFF_CORE_LINES)
+            .map(|text| DiffLine {
+                kind: DiffLineKind::Added,
+                text,
+            }),
+    );
+    if new_lines.len() > MAX_DIFF_CORE_LINES {
+        push_omitted(output);
+    }
 }
 
 fn append_large_shared_core<'a>(
@@ -588,6 +618,27 @@ mod tests {
         assert!(balanced
             .iter()
             .any(|line| line.kind == DiffLineKind::Omitted));
+    }
+
+    #[test]
+    fn disjoint_truncated_run_marks_omission_before_next_kind() {
+        let old = (0..300)
+            .map(|index| format!("old {index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let lines = preview(Some(&old), "replacement", false, 32);
+        let added = lines
+            .iter()
+            .position(|line| line.kind == DiffLineKind::Added)
+            .expect("replacement must remain visible");
+
+        assert!(lines[..added]
+            .iter()
+            .any(|line| line.kind == DiffLineKind::Omitted));
+        assert!(lines[added + 1..]
+            .iter()
+            .all(|line| line.kind != DiffLineKind::Omitted));
     }
 
     #[test]

--- a/tools/wta/src/ui/line_diff.rs
+++ b/tools/wta/src/ui/line_diff.rs
@@ -1,0 +1,397 @@
+const MAX_DIFF_CORE_LINES: usize = 256;
+const CONTEXT_LINES: usize = 2;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DiffLineKind {
+    Context,
+    Added,
+    Removed,
+    Omitted,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct DiffLine<'a> {
+    pub(crate) kind: DiffLineKind,
+    pub(crate) text: &'a str,
+}
+
+pub(crate) fn preview<'a>(
+    old_text: Option<&'a str>,
+    new_text: &'a str,
+    source_truncated: bool,
+    max_lines: usize,
+) -> Vec<DiffLine<'a>> {
+    let old_lines = old_text.map_or_else(Vec::new, |text| text.lines().collect());
+    let new_lines = new_text.lines().collect::<Vec<_>>();
+    let mut lines = Vec::new();
+
+    if source_truncated {
+        push_omitted(&mut lines);
+    }
+
+    if old_text.is_none() {
+        lines.extend(
+            new_lines
+                .iter()
+                .take(MAX_DIFF_CORE_LINES)
+                .map(|text| DiffLine {
+                    kind: DiffLineKind::Added,
+                    text,
+                }),
+        );
+        if new_lines.len() > MAX_DIFF_CORE_LINES {
+            push_omitted(&mut lines);
+        }
+        return balance_preview(lines, max_lines);
+    }
+
+    let mut prefix = 0;
+    while prefix < old_lines.len()
+        && prefix < new_lines.len()
+        && old_lines[prefix] == new_lines[prefix]
+    {
+        prefix += 1;
+    }
+
+    let mut suffix = 0;
+    while suffix < old_lines.len().saturating_sub(prefix)
+        && suffix < new_lines.len().saturating_sub(prefix)
+        && old_lines[old_lines.len() - suffix - 1] == new_lines[new_lines.len() - suffix - 1]
+    {
+        suffix += 1;
+    }
+
+    if prefix == old_lines.len() && prefix == new_lines.len() {
+        return balance_preview(lines, max_lines);
+    }
+
+    if prefix > CONTEXT_LINES {
+        push_omitted(&mut lines);
+    }
+    lines.extend(
+        old_lines[prefix.saturating_sub(CONTEXT_LINES)..prefix]
+            .iter()
+            .map(|text| DiffLine {
+                kind: DiffLineKind::Context,
+                text,
+            }),
+    );
+
+    let old_core_end = old_lines.len() - suffix;
+    let new_core_end = new_lines.len() - suffix;
+    let old_core = &old_lines[prefix..old_core_end];
+    let new_core = &new_lines[prefix..new_core_end];
+    let old_bounded = &old_core[..old_core.len().min(MAX_DIFF_CORE_LINES)];
+    let new_bounded = &new_core[..new_core.len().min(MAX_DIFF_CORE_LINES)];
+    append_collapsed_ops(&mut lines, &diff_ops(old_bounded, new_bounded));
+    if old_core.len() > old_bounded.len() || new_core.len() > new_bounded.len() {
+        push_omitted(&mut lines);
+    }
+
+    let suffix_context = suffix.min(CONTEXT_LINES);
+    lines.extend(
+        old_lines[old_core_end..old_core_end + suffix_context]
+            .iter()
+            .map(|text| DiffLine {
+                kind: DiffLineKind::Context,
+                text,
+            }),
+    );
+    if suffix > CONTEXT_LINES {
+        push_omitted(&mut lines);
+    }
+
+    balance_preview(lines, max_lines)
+}
+
+fn diff_ops<'a>(old_lines: &[&'a str], new_lines: &[&'a str]) -> Vec<DiffLine<'a>> {
+    let columns = new_lines.len() + 1;
+    let mut common_lengths = vec![0u16; (old_lines.len() + 1) * columns];
+    for old_index in (0..old_lines.len()).rev() {
+        for new_index in (0..new_lines.len()).rev() {
+            let index = old_index * columns + new_index;
+            common_lengths[index] = if old_lines[old_index] == new_lines[new_index] {
+                common_lengths[(old_index + 1) * columns + new_index + 1] + 1
+            } else {
+                common_lengths[(old_index + 1) * columns + new_index]
+                    .max(common_lengths[old_index * columns + new_index + 1])
+            };
+        }
+    }
+
+    let mut lines = Vec::with_capacity(old_lines.len() + new_lines.len());
+    let (mut old_index, mut new_index) = (0, 0);
+    while old_index < old_lines.len() || new_index < new_lines.len() {
+        if old_index < old_lines.len()
+            && new_index < new_lines.len()
+            && old_lines[old_index] == new_lines[new_index]
+        {
+            lines.push(DiffLine {
+                kind: DiffLineKind::Context,
+                text: old_lines[old_index],
+            });
+            old_index += 1;
+            new_index += 1;
+        } else if old_index < old_lines.len()
+            && (new_index == new_lines.len()
+                || common_lengths[(old_index + 1) * columns + new_index]
+                    >= common_lengths[old_index * columns + new_index + 1])
+        {
+            lines.push(DiffLine {
+                kind: DiffLineKind::Removed,
+                text: old_lines[old_index],
+            });
+            old_index += 1;
+        } else {
+            lines.push(DiffLine {
+                kind: DiffLineKind::Added,
+                text: new_lines[new_index],
+            });
+            new_index += 1;
+        }
+    }
+    lines
+}
+
+fn append_collapsed_ops<'a>(output: &mut Vec<DiffLine<'a>>, operations: &[DiffLine<'a>]) {
+    let mut index = 0;
+    while index < operations.len() {
+        if operations[index].kind != DiffLineKind::Context {
+            output.push(operations[index]);
+            index += 1;
+            continue;
+        }
+
+        let start = index;
+        while index < operations.len() && operations[index].kind == DiffLineKind::Context {
+            index += 1;
+        }
+        let run = &operations[start..index];
+        if run.len() <= CONTEXT_LINES * 2 {
+            output.extend_from_slice(run);
+        } else {
+            output.extend_from_slice(&run[..CONTEXT_LINES]);
+            push_omitted(output);
+            output.extend_from_slice(&run[run.len() - CONTEXT_LINES..]);
+        }
+    }
+}
+
+fn push_omitted<'a>(lines: &mut Vec<DiffLine<'a>>) {
+    if lines
+        .last()
+        .is_none_or(|line| line.kind != DiffLineKind::Omitted)
+    {
+        lines.push(DiffLine {
+            kind: DiffLineKind::Omitted,
+            text: "",
+        });
+    }
+}
+
+fn balance_preview<'a>(lines: Vec<DiffLine<'a>>, max_lines: usize) -> Vec<DiffLine<'a>> {
+    if lines.len() <= max_lines {
+        return lines;
+    }
+    if max_lines == 0 {
+        return Vec::new();
+    }
+
+    let removed = indices_for_kind(&lines, DiffLineKind::Removed);
+    let added = indices_for_kind(&lines, DiffLineKind::Added);
+    let kinds = usize::from(!removed.is_empty()) + usize::from(!added.is_empty());
+    if kinds == 0 {
+        return vec![DiffLine {
+            kind: DiffLineKind::Omitted,
+            text: "",
+        }];
+    }
+
+    // Each selected kind contributes at most two contiguous ranges (head and
+    // tail), so reserving `2 * kinds + 1` rows covers every possible gap.
+    let change_budget = max_lines.saturating_sub(2 * kinds + 1).max(kinds);
+    let (removed_budget, added_budget) = match (removed.is_empty(), added.is_empty()) {
+        (false, false) => {
+            let removed_budget = change_budget.div_ceil(2);
+            (removed_budget, change_budget - removed_budget)
+        }
+        (false, true) => (change_budget, 0),
+        (true, false) => (0, change_budget),
+        (true, true) => unreachable!(),
+    };
+
+    let mut selected = vec![false; lines.len()];
+    select_edges(&removed, removed_budget, &mut selected);
+    select_edges(&added, added_budget, &mut selected);
+    rebuild_selected(&lines, &selected, max_lines)
+}
+
+fn indices_for_kind(lines: &[DiffLine<'_>], kind: DiffLineKind) -> Vec<usize> {
+    lines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, line)| (line.kind == kind).then_some(index))
+        .collect()
+}
+
+fn select_edges(indices: &[usize], budget: usize, selected: &mut [bool]) {
+    let budget = budget.min(indices.len());
+    let head = budget.div_ceil(2);
+    let tail = budget - head;
+    for index in indices.iter().take(head) {
+        selected[*index] = true;
+    }
+    for index in indices.iter().rev().take(tail) {
+        selected[*index] = true;
+    }
+}
+
+fn rebuild_selected<'a>(
+    lines: &[DiffLine<'a>],
+    selected: &[bool],
+    max_lines: usize,
+) -> Vec<DiffLine<'a>> {
+    let mut output = Vec::with_capacity(max_lines);
+    let mut omitted = false;
+    for (line, selected) in lines.iter().zip(selected) {
+        if *selected {
+            if omitted {
+                push_omitted(&mut output);
+                omitted = false;
+            }
+            output.push(*line);
+        } else {
+            omitted = true;
+        }
+    }
+    if omitted {
+        push_omitted(&mut output);
+    }
+    output.truncate(max_lines);
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rendered<'a>(lines: &'a [DiffLine<'a>]) -> Vec<(DiffLineKind, &'a str)> {
+        lines.iter().map(|line| (line.kind, line.text)).collect()
+    }
+
+    #[test]
+    fn reports_only_changed_lines_with_context() {
+        let lines = preview(
+            Some("before\nsame\nold value\nafter\ntail"),
+            "before\nsame\nnew value\nafter\ntail",
+            false,
+            32,
+        );
+
+        assert_eq!(
+            rendered(&lines),
+            vec![
+                (DiffLineKind::Context, "before"),
+                (DiffLineKind::Context, "same"),
+                (DiffLineKind::Removed, "old value"),
+                (DiffLineKind::Added, "new value"),
+                (DiffLineKind::Context, "after"),
+                (DiffLineKind::Context, "tail"),
+            ]
+        );
+    }
+
+    #[test]
+    fn new_file_reports_additions() {
+        let lines = preview(None, "first\nsecond", false, 32);
+
+        assert_eq!(
+            rendered(&lines),
+            vec![
+                (DiffLineKind::Added, "first"),
+                (DiffLineKind::Added, "second"),
+            ]
+        );
+    }
+
+    #[test]
+    fn long_unchanged_regions_are_collapsed() {
+        let old = (0..20)
+            .map(|index| format!("line {index}"))
+            .collect::<Vec<_>>();
+        let mut new = old.clone();
+        new[3] = "changed 3".to_string();
+        new[16] = "changed 16".to_string();
+        let old = old.join("\n");
+        let new = new.join("\n");
+        let lines = preview(Some(&old), &new, false, 32);
+
+        assert!(lines.iter().any(|line| line.kind == DiffLineKind::Omitted));
+        assert!(lines
+            .iter()
+            .any(|line| line.kind == DiffLineKind::Removed && line.text == "line 3"));
+        assert!(lines
+            .iter()
+            .any(|line| line.kind == DiffLineKind::Added && line.text == "changed 16"));
+    }
+
+    #[test]
+    fn truncated_sources_are_marked_as_partial() {
+        let lines = preview(Some("old"), "new", true, 32);
+
+        assert_eq!(lines[0].kind, DiffLineKind::Omitted);
+        assert!(lines.iter().any(|line| line.kind == DiffLineKind::Removed));
+        assert!(lines.iter().any(|line| line.kind == DiffLineKind::Added));
+    }
+
+    #[test]
+    fn replacement_heavy_preview_balances_removed_and_added_lines() {
+        let old = (0..100)
+            .map(|index| format!("old {index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let new = (0..100)
+            .map(|index| format!("new {index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let lines = preview(Some(&old), &new, false, 20);
+        let removed = lines
+            .iter()
+            .filter(|line| line.kind == DiffLineKind::Removed)
+            .count();
+        let added = lines
+            .iter()
+            .filter(|line| line.kind == DiffLineKind::Added)
+            .count();
+
+        assert!(lines.len() <= 20);
+        assert!(removed > 0);
+        assert!(added > 0);
+        assert!(removed.abs_diff(added) <= 1);
+        assert_eq!(lines[0].kind, DiffLineKind::Removed);
+        assert!(lines.iter().any(|line| line.kind == DiffLineKind::Omitted));
+        assert_eq!(
+            lines.last().map(|line| line.kind),
+            Some(DiffLineKind::Added)
+        );
+    }
+
+    #[test]
+    fn one_sided_preview_uses_the_available_change_budget() {
+        let new = (0..100)
+            .map(|index| format!("new {index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let old = new.replace("new", "old");
+        for (lines, expected) in [
+            (preview(None, &new, false, 12), DiffLineKind::Added),
+            (preview(Some(&old), "", false, 12), DiffLineKind::Removed),
+        ] {
+            assert!(lines.len() <= 12);
+            assert!(lines
+                .iter()
+                .all(|line| matches!(line.kind, DiffLineKind::Omitted) || line.kind == expected));
+            assert!(lines.iter().filter(|line| line.kind == expected).count() >= 8);
+        }
+    }
+}

--- a/tools/wta/src/ui/line_diff.rs
+++ b/tools/wta/src/ui/line_diff.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 const MAX_DIFF_CORE_LINES: usize = 256;
 const CONTEXT_LINES: usize = 2;
 
@@ -21,8 +23,8 @@ pub(crate) fn preview<'a>(
     source_truncated: bool,
     max_lines: usize,
 ) -> Vec<DiffLine<'a>> {
-    let old_lines = old_text.map_or_else(Vec::new, |text| text.lines().collect());
-    let new_lines = new_text.lines().collect::<Vec<_>>();
+    let old_lines = old_text.map_or_else(Vec::new, snapshot_lines);
+    let new_lines = snapshot_lines(new_text);
     let mut lines = Vec::new();
 
     if source_truncated {
@@ -81,11 +83,17 @@ pub(crate) fn preview<'a>(
     let new_core_end = new_lines.len() - suffix;
     let old_core = &old_lines[prefix..old_core_end];
     let new_core = &new_lines[prefix..new_core_end];
-    let old_bounded = &old_core[..old_core.len().min(MAX_DIFF_CORE_LINES)];
-    let new_bounded = &new_core[..new_core.len().min(MAX_DIFF_CORE_LINES)];
-    append_collapsed_ops(&mut lines, &diff_ops(old_bounded, new_bounded));
-    if old_core.len() > old_bounded.len() || new_core.len() > new_bounded.len() {
+    let core_exceeds_limit =
+        old_core.len() > MAX_DIFF_CORE_LINES || new_core.len() > MAX_DIFF_CORE_LINES;
+    if core_exceeds_limit && shares_line(old_core, new_core) {
         push_omitted(&mut lines);
+    } else {
+        let old_bounded = &old_core[..old_core.len().min(MAX_DIFF_CORE_LINES)];
+        let new_bounded = &new_core[..new_core.len().min(MAX_DIFF_CORE_LINES)];
+        append_collapsed_ops(&mut lines, &diff_ops(old_bounded, new_bounded));
+        if core_exceeds_limit {
+            push_omitted(&mut lines);
+        }
     }
 
     let suffix_context = suffix.min(CONTEXT_LINES);
@@ -102,6 +110,24 @@ pub(crate) fn preview<'a>(
     }
 
     balance_preview(lines, max_lines)
+}
+
+fn snapshot_lines(text: &str) -> Vec<&str> {
+    let mut lines = text.lines().collect::<Vec<_>>();
+    if text.ends_with('\n') {
+        lines.push("");
+    }
+    lines
+}
+
+fn shares_line(old_lines: &[&str], new_lines: &[&str]) -> bool {
+    let (shorter, longer) = if old_lines.len() <= new_lines.len() {
+        (old_lines, new_lines)
+    } else {
+        (new_lines, old_lines)
+    };
+    let lines = shorter.iter().copied().collect::<HashSet<_>>();
+    longer.iter().any(|line| lines.contains(line))
 }
 
 fn diff_ops<'a>(old_lines: &[&'a str], new_lines: &[&'a str]) -> Vec<DiffLine<'a>> {
@@ -207,10 +233,8 @@ fn balance_preview<'a>(lines: Vec<DiffLine<'a>>, max_lines: usize) -> Vec<DiffLi
         }];
     }
 
-    // Each selected kind contributes at most two contiguous ranges (head and
-    // tail), so reserving `2 * kinds + 1` rows covers every possible gap.
-    let change_budget = max_lines.saturating_sub(2 * kinds + 1).max(kinds);
-    let (removed_budget, added_budget) = match (removed.is_empty(), added.is_empty()) {
+    let change_budget = max_lines.saturating_sub(1).max(kinds);
+    let (mut removed_budget, mut added_budget) = match (removed.is_empty(), added.is_empty()) {
         (false, false) => {
             let removed_budget = change_budget.div_ceil(2);
             (removed_budget, change_budget - removed_budget)
@@ -220,10 +244,30 @@ fn balance_preview<'a>(lines: Vec<DiffLine<'a>>, max_lines: usize) -> Vec<DiffLi
         (true, true) => unreachable!(),
     };
 
-    let mut selected = vec![false; lines.len()];
-    select_edges(&removed, removed_budget, &mut selected);
-    select_edges(&added, added_budget, &mut selected);
-    rebuild_selected(&lines, &selected, max_lines)
+    loop {
+        let mut selected = vec![false; lines.len()];
+        select_edges(&removed, removed_budget, &mut selected);
+        select_edges(&added, added_budget, &mut selected);
+        let rebuilt = rebuild_selected(&lines, &selected);
+        if rebuilt.len() <= max_lines {
+            return rebuilt;
+        }
+
+        let minimum_removed = usize::from(!removed.is_empty());
+        let minimum_added = usize::from(!added.is_empty());
+        if removed_budget > minimum_removed
+            && (removed_budget >= added_budget || added_budget == minimum_added)
+        {
+            removed_budget -= 1;
+        } else if added_budget > minimum_added {
+            added_budget -= 1;
+        } else {
+            return vec![DiffLine {
+                kind: DiffLineKind::Omitted,
+                text: "",
+            }];
+        }
+    }
 }
 
 fn indices_for_kind(lines: &[DiffLine<'_>], kind: DiffLineKind) -> Vec<usize> {
@@ -246,12 +290,8 @@ fn select_edges(indices: &[usize], budget: usize, selected: &mut [bool]) {
     }
 }
 
-fn rebuild_selected<'a>(
-    lines: &[DiffLine<'a>],
-    selected: &[bool],
-    max_lines: usize,
-) -> Vec<DiffLine<'a>> {
-    let mut output = Vec::with_capacity(max_lines);
+fn rebuild_selected<'a>(lines: &[DiffLine<'a>], selected: &[bool]) -> Vec<DiffLine<'a>> {
+    let mut output = Vec::new();
     let mut omitted = false;
     for (line, selected) in lines.iter().zip(selected) {
         if *selected {
@@ -267,7 +307,6 @@ fn rebuild_selected<'a>(
     if omitted {
         push_omitted(&mut output);
     }
-    output.truncate(max_lines);
     output
 }
 
@@ -281,12 +320,9 @@ mod tests {
 
     #[test]
     fn reports_only_changed_lines_with_context() {
-        let lines = preview(
-            Some("before\nsame\nold value\nafter\ntail"),
-            "before\nsame\nnew value\nafter\ntail",
-            false,
-            32,
-        );
+        let old = ["before", "same", "old value", "after", "tail"].join("\n");
+        let new = ["before", "same", "new value", "after", "tail"].join("\n");
+        let lines = preview(Some(&old), &new, false, 32);
 
         assert_eq!(
             rendered(&lines),
@@ -303,7 +339,8 @@ mod tests {
 
     #[test]
     fn new_file_reports_additions() {
-        let lines = preview(None, "first\nsecond", false, 32);
+        let new = ["first", "second"].join("\n");
+        let lines = preview(None, &new, false, 32);
 
         assert_eq!(
             rendered(&lines),
@@ -342,6 +379,42 @@ mod tests {
         assert_eq!(lines[0].kind, DiffLineKind::Omitted);
         assert!(lines.iter().any(|line| line.kind == DiffLineKind::Removed));
         assert!(lines.iter().any(|line| line.kind == DiffLineKind::Added));
+    }
+
+    #[test]
+    fn reports_end_of_file_newline_changes() {
+        let added = preview(Some("value"), "value\n", false, 32);
+        let removed = preview(Some("value\n"), "value", false, 32);
+
+        assert_eq!(
+            rendered(&added),
+            vec![(DiffLineKind::Context, "value"), (DiffLineKind::Added, ""),]
+        );
+        assert_eq!(
+            rendered(&removed),
+            vec![
+                (DiffLineKind::Context, "value"),
+                (DiffLineKind::Removed, ""),
+            ]
+        );
+    }
+
+    #[test]
+    fn large_unaligned_core_falls_back_to_omission() {
+        let unchanged = (0..300)
+            .map(|index| format!("same {index}"))
+            .collect::<Vec<_>>();
+        let old = unchanged.join("\n");
+        let mut new = (0..300)
+            .map(|index| format!("inserted {index}"))
+            .collect::<Vec<_>>();
+        new.extend(unchanged);
+        new.push("changed tail".to_string());
+        let new = new.join("\n");
+
+        let lines = preview(Some(&old), &new, false, 32);
+
+        assert_eq!(rendered(&lines), vec![(DiffLineKind::Omitted, "")]);
     }
 
     #[test]
@@ -393,5 +466,59 @@ mod tests {
                 .all(|line| matches!(line.kind, DiffLineKind::Omitted) || line.kind == expected));
             assert!(lines.iter().filter(|line| line.kind == expected).count() >= 8);
         }
+    }
+
+    #[test]
+    fn undersized_budget_never_truncates_one_change_kind() {
+        let old = ["old first", "old second"].join("\n");
+        let new = ["new first", "new second"].join("\n");
+        let lines = preview(Some(&old), &new, false, 2);
+
+        assert_eq!(rendered(&lines), vec![(DiffLineKind::Omitted, "")]);
+    }
+
+    #[test]
+    fn multi_hunk_budget_accounts_for_every_omission() {
+        let lines = vec![
+            DiffLine {
+                kind: DiffLineKind::Removed,
+                text: "old first",
+            },
+            DiffLine {
+                kind: DiffLineKind::Context,
+                text: "same first",
+            },
+            DiffLine {
+                kind: DiffLineKind::Added,
+                text: "new first",
+            },
+            DiffLine {
+                kind: DiffLineKind::Context,
+                text: "same second",
+            },
+            DiffLine {
+                kind: DiffLineKind::Removed,
+                text: "old second",
+            },
+            DiffLine {
+                kind: DiffLineKind::Context,
+                text: "same third",
+            },
+            DiffLine {
+                kind: DiffLineKind::Added,
+                text: "new second",
+            },
+        ];
+
+        let balanced = balance_preview(lines, 4);
+
+        assert!(balanced.len() <= 4);
+        assert!(balanced
+            .iter()
+            .any(|line| line.kind == DiffLineKind::Removed));
+        assert!(balanced.iter().any(|line| line.kind == DiffLineKind::Added));
+        assert!(balanced
+            .iter()
+            .any(|line| line.kind == DiffLineKind::Omitted));
     }
 }

--- a/tools/wta/src/ui/mod.rs
+++ b/tools/wta/src/ui/mod.rs
@@ -10,6 +10,7 @@ mod config_popup;
 mod debug_panel;
 mod input;
 mod layout;
+mod line_diff;
 mod model_popup;
 mod permission;
 mod popup;

--- a/tools/wta/src/ui/tool_presentation.rs
+++ b/tools/wta/src/ui/tool_presentation.rs
@@ -155,7 +155,8 @@ impl<'a> ToolPresentation<'a> {
                 | ToolCallKind::Think
                 | ToolCallKind::SwitchMode
                 | ToolCallKind::Other
-        );
+        ) || (matches!(self.phase, ToolPhase::Failed(_))
+            && matches!(self.kind, ToolCallKind::Edit | ToolCallKind::Delete));
         (kind_uses_title && !self.title_contains_target())
             .then(|| self.display_target())
             .flatten()
@@ -384,6 +385,30 @@ mod tests {
 
         assert_eq!(presentation.primary_text(false), r"Creating src\main.rs");
         assert_eq!(presentation.primary_text(true), r"src\main.rs");
+    }
+
+    #[test]
+    fn failed_mutation_keeps_target_when_title_does_not_contain_it() {
+        let locations = vec![ToolCallLocation {
+            path: r"C:\project\src\main.rs".into(),
+            line: None,
+        }];
+        let presentation = ToolPresentation::new(
+            "Edit source",
+            "Failed",
+            ToolCallKind::Edit,
+            None,
+            false,
+            None,
+            None,
+            &locations,
+        );
+
+        assert_eq!(presentation.primary_text(false), "Edit source");
+        assert_eq!(
+            presentation.secondary_target().as_deref(),
+            Some(r"src\main.rs")
+        );
     }
 
     #[test]

--- a/tools/wta/src/ui/tool_presentation.rs
+++ b/tools/wta/src/ui/tool_presentation.rs
@@ -132,6 +132,11 @@ impl<'a> ToolPresentation<'a> {
                 .inline_compact_command()
                 .map(Cow::Borrowed)
                 .unwrap_or_else(|| self.display_title()),
+            ToolCallKind::Edit | ToolCallKind::Delete
+                if !compact && matches!(self.phase, ToolPhase::Failed(_)) =>
+            {
+                self.display_title()
+            }
             ToolCallKind::Read
             | ToolCallKind::Edit
             | ToolCallKind::Delete
@@ -357,6 +362,27 @@ mod tests {
         assert_eq!(presentation.display_title(), r"Viewing src\main.rs");
         assert!(presentation.title_contains_target());
         assert_eq!(presentation.target_name(), Some("main.rs"));
+        assert_eq!(presentation.primary_text(true), r"src\main.rs");
+    }
+
+    #[test]
+    fn failed_mutations_keep_the_provider_operation_title() {
+        let locations = vec![ToolCallLocation {
+            path: r"C:\project\src\main.rs".into(),
+            line: None,
+        }];
+        let presentation = ToolPresentation::new(
+            r"Creating C:\project\src\main.rs",
+            "Failed: Path already exists",
+            ToolCallKind::Edit,
+            None,
+            false,
+            None,
+            None,
+            &locations,
+        );
+
+        assert_eq!(presentation.primary_text(false), r"Creating src\main.rs");
         assert_eq!(presentation.primary_text(true), r"src\main.rs");
     }
 


### PR DESCRIPTION
## Summary
- compute real line-level Edit hunks from ACP old/new snapshots instead of rendering whole snapshots as removed and added
- preserve a small amount of context and collapse unchanged or omitted regions
- balance large replacement previews across removed and added lines while preserving operation order
- bound diff computation and rendering, with a 32-line expanded-detail cap and per-line truncation
- style file headers, additions, and removals distinctly

## Validation
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml` (1808 passed)
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- live Debug package verification for large replacement previews

<img width="1112" height="430" alt="image" src="https://github.com/user-attachments/assets/6317443b-6750-4661-94d7-e6ed6c19ccc7" />
