### PR TITLE
Fix pseudo-locale app names

### DIFF
--- a/.github/skills/store-listing-localizer/references/intelligent-terminal-translations.md
+++ b/.github/skills/store-listing-localizer/references/intelligent-terminal-translations.md
@@ -66,9 +66,9 @@
 | pl-PL | Inteligentny Terminal |
 | pt-BR | Terminal Inteligente |
 | pt-PT | Terminal Inteligente |
-| qps-ploc | Terminal |
-| qps-ploca | Terminal |
-| qps-plocm | Terminal |
+| qps-ploc | Intelligent Terminal |
+| qps-ploca | Intelligent Terminal |
+| qps-plocm | Intelligent Terminal |
 | quz-PE | Yuyaysapa Terminal |
 | ro-RO | Terminal Inteligent |
 | ru-RU | Интеллектуальный Терминал |


### PR DESCRIPTION
## Summary
- use the full Intelligent Terminal product name for qps-ploc
- align qps-ploca and qps-plocm with the canonical pseudo-locale name

## Testing
- documentation-only table correction