### PR TITLE
Split request_terminal_actions into one MCP tool per action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,8 @@ Agent or human CLI --> wta/wtcli --> COM IProtocolServer --> Windows Terminal
   using the same key share one process and multiplex sessions through it.
 - **WT Protocol** is the terminal-control boundary. `wtcli.exe` activates
   `IProtocolServer` through the package COM registration.
-- **Session MCP** exposes `request_terminal_actions` and `request_user_input`.
+- **Session MCP** exposes `terminal_send`, `terminal_open`,
+  `terminal_open_and_send`, and `request_user_input`.
   It routes requests to the owning helper and never executes terminal actions
   itself.
 - Agent panes are ordinary `ConptyConnection` panes hosting `wta-helper`; C++

--- a/doc/specs/WTA-terminal-action-proposals.md
+++ b/doc/specs/WTA-terminal-action-proposals.md
@@ -13,11 +13,11 @@ and every eligible ACP session receives a distinct bearer capability:
 
 ```text
 ACP session
-  -> HTTP MCP: intellterm_<public-id>/{request_terminal_actions,request_user_input}
+  -> HTTP MCP: intellterm_<public-id>/{terminal_send,terminal_open,terminal_open_and_send,request_user_input}
   -> wta-master capability -> ACP SessionId
   -> session_to_helper -> existing master/helper ACP pipe
   -> owning Helper
-       -> request_terminal_actions -> recommendation card -> wtcli/COM executor
+       -> terminal_* -> recommendation card -> wtcli/COM executor
        -> request_user_input -> blocking choice/freeform modal -> structured answer
 ```
 
@@ -25,7 +25,7 @@ The endpoint presents typed terminal actions for review and blocking
 clarification questions. It cannot read or mutate Windows Terminal. The
 existing card confirmation is the sole mutation boundary.
 
-`request_terminal_actions` returns as soon as the Helper commits its card;
+The `terminal_*` tools return as soon as the Helper commits its card;
 confirmation or cancellation then happens independently. `request_user_input`
 deliberately keeps the MCP call open until the user answers, cancels, the
 caller disconnects, or the ten-minute timeout expires.
@@ -93,7 +93,9 @@ intellterm_<public-id>
 Tools:
 
 ```text
-request_terminal_actions
+terminal_send
+terminal_open
+terminal_open_and_send
 request_user_input
 ```
 
@@ -102,30 +104,32 @@ over stateless Streamable HTTP JSON-RPC. POST responses use JSON or HTTP 202
 for notifications; GET and DELETE return 405 because server-initiated streams
 are unnecessary. It exposes no terminal read or execution tools.
 
-Input:
+Input, for `terminal_send`:
 
 ```json
 {
-  "type": "send",
   "title": "Run tests",
   "rationale": "Verify the current change.",
   "input": "cargo test"
 }
 ```
 
-Each MCP call proposes exactly one action. Supported actions are:
+Each MCP call proposes exactly one action. One tool per action shape, rather
+than a single tool with a `type` discriminator, so each schema advertises
+exactly the fields that action accepts and `additionalProperties: false`
+rejects a field belonging to another action. The action tools are:
 
-- `send`: submit input to the trusted active pane;
-- `open`: open an empty tab or panel;
-- `open_and_send`: open a tab or panel and submit input there.
+- `terminal_send`: submit input to the trusted active pane;
+- `terminal_open`: open an empty tab or panel;
+- `terminal_open_and_send`: open a tab or panel and submit input there.
 
-Open actions may include `cwd`, `profile`, and panel `direction`. The
+The open tools may include `cwd`, `profile`, and panel `direction`. The
 user-facing `title` also becomes the requested destination title.
-`open_and_send` may set `delegate: true`; the Helper substitutes the configured
-delegate agent. A model cannot name an arbitrary agent.
+`terminal_open_and_send` may set `delegate: true`; the Helper substitutes the
+configured delegate agent. A model cannot name an arbitrary agent.
 
-Autofix uses the same tool but the Helper supplies the trusted Autofix origin
-and requires a `send` action.
+Autofix uses the same tools but the Helper supplies the trusted Autofix origin
+and requires a `terminal_send` action.
 
 Tool result statuses:
 
@@ -191,9 +195,8 @@ execution path.
 Permission remains an optional compatibility preflight. Some agents call MCP
 without requesting permission.
 
-When an adapter requests permission for either the current
-`intellterm_<public-id>/request_terminal_actions` tool or the legacy
-`intelligent_terminal/request_terminal_actions` name, the Helper:
+When an adapter requests permission for one of the
+`intellterm_<public-id>/terminal_*` action tools, the Helper:
 
 1. verifies the trusted ACP SessionId owns the current issued turn;
 2. silently selects `AllowOnce`; and

--- a/test/e2e/fixtures/Mock-AcpInteractionAgent.ps1
+++ b/test/e2e/fixtures/Mock-AcpInteractionAgent.ps1
@@ -121,9 +121,8 @@ function Invoke-TerminalActionTool {
         id = 2
         method = 'tools/call'
         params = @{
-            name = 'request_terminal_actions'
+            name = 'terminal_open_and_send'
             arguments = @{
-                type = 'open_and_send'
                 title = "Direction $Marker"
                 input = "echo $Marker"
                 target = 'tab'

--- a/test/e2e/fixtures/Mock-AcpProposalAgent.ps1
+++ b/test/e2e/fixtures/Mock-AcpProposalAgent.ps1
@@ -37,9 +37,8 @@ function Invoke-ProposalTool {
         id = 1
         method = 'tools/call'
         params = @{
-            name = 'request_terminal_actions'
+            name = 'terminal_send'
             arguments = @{
-                type = 'send'
                 title = "Run echo $Marker"
                 input = "echo $Marker"
             }

--- a/tools/wta/AGENTS.md
+++ b/tools/wta/AGENTS.md
@@ -42,7 +42,9 @@ Master owns one loopback Streamable HTTP listener and publishes an independent
 server name and bearer capability for each eligible ACP session. WSL sessions
 use an on-demand distro-local relay to that listener. The endpoint exposes:
 
-- `request_terminal_actions`
+- `terminal_send`
+- `terminal_open`
+- `terminal_open_and_send`
 - `request_user_input`
 
 Treat the bearer capability as the session identity. Revoke it when the exact

--- a/tools/wta/OVERVIEW.md
+++ b/tools/wta/OVERVIEW.md
@@ -113,7 +113,8 @@ name and a distinct bearer capability, so name-keyed Agent caches cannot
 overwrite another session's header. Master maps the capability to SessionId,
 resolves the current Helper through `session_to_helper`, and forwards the typed
 input over the existing ACP pipe.
-The endpoint exposes `request_terminal_actions`, which returns after the Helper
+The endpoint exposes `terminal_send`, `terminal_open`, and
+`terminal_open_and_send`, which return after the Helper
 confirms that the recommendation card was presented, and `request_user_input`,
 which blocks until the user answers, cancels, disconnects, or the request times
 out. The latter is a WTA-owned fallback and does not intercept provider-native

--- a/tools/wta/prompts/auto-fix.md
+++ b/tools/wta/prompts/auto-fix.md
@@ -17,9 +17,8 @@ Help the user resume their intended work after a command fails. Determine the go
 
 ## Hand off
 
-Intelligent Terminal provides an MCP server for this session. When ready, call `request_terminal_actions` next without prose. Treat its advertised input schema as the sole authority.
-
-Submit exactly one `send` action so the user can accept the corrected command before it runs in the failing pane.
+Intelligent Terminal provides an MCP server for this session. When ready, call `terminal_send` next without prose. Treat its advertised input schema as the sole authority.
+Submit exactly one `terminal_send` call so the user can accept the corrected command before it runs in the failing pane.
 
 The command must advance the user's intended outcome, not merely diagnose or prepare for it. Use the exact shell and cwd without wrapping another shell. With an unknown shell, use only safely portable syntax or explain.
 

--- a/tools/wta/prompts/terminal-agent.md
+++ b/tools/wta/prompts/terminal-agent.md
@@ -16,7 +16,7 @@ Use the active pane's shell syntax. Treat runtime `cwd` as authoritative, use ab
 
 Your own shell, bash, and other execution tools are Agent-owned work. Intelligent Terminal may display the command, working directory, status, and output that the Agent reports, but it does not own or control those processes. Do not describe them as running in the user's pane or as an Intelligent Terminal action.
 
-`request_terminal_actions` is the separate user-owned path for changing the user's terminal workflow. Use it only when the intended result should run, open, split, or otherwise mutate a terminal pane. Internal investigation remains an Agent-owned tool call and must not be proposed as a pane action.
+`terminal_send`, `terminal_open`, and `terminal_open_and_send` are the separate user-owned path for changing the user's terminal workflow. Use them only when the intended result should run, open, split, or otherwise mutate a terminal pane. Internal investigation remains an Agent-owned tool call and must not be proposed as a pane action.
 
 When the user's intent or a material requirement is unclear and clarification could change what you do, use the session's `request_user_input` tool to ask one focused question before continuing instead of guessing. Supply concise choices when the decision has a bounded set of answers and enable freeform input only when needed. Do not ask when the answer is already available in context or a safe, reversible default is clear. Wait for the tool result before continuing. This is a WTA-provided interaction; do not claim that it intercepts or replaces the Agent implementation's own input tools.
 
@@ -37,21 +37,21 @@ Command resolution and other probes are context enrichment, not user-visible act
 
 ## Acting in Windows Terminal
 
-Intelligent Terminal provides an MCP server for this session. Its `request_terminal_actions` tool is the supported way to hand an action back to the terminal. When completing the user's request requires an action in a terminal pane, call that tool next without first emitting prose, a plan, or reasoning. Investigation needed to prepare the action may happen before this point.
+Intelligent Terminal provides an MCP server for this session. Its `terminal_send`, `terminal_open`, and `terminal_open_and_send` tools are the supported way to hand an action back to the terminal. When completing the user's request requires an action in a terminal pane, call the matching tool next without first emitting prose, a plan, or reasoning. Investigation needed to prepare the action may happen before this point.
 
-Prefer a `send` action in the current pane for a simple, bounded action that continues the current shell, cwd, and workflow. Use a new panel for related parallel work that benefits from side-by-side visibility. Use a new tab for independent work, a different cwd or profile, or a long-running task with its own lifecycle.
+Prefer `terminal_send` in the current pane for a simple, bounded action that continues the current shell, cwd, and workflow. Use a new panel for related parallel work that benefits from side-by-side visibility. Use a new tab for independent work, a different cwd or profile, or a long-running task with its own lifecycle.
 
-Submit exactly one action. Treat the tool's advertised input schema as the sole authority for its arguments; do not infer a payload shape from conversation text or print one yourself. Routing is automatic. If `activeTarget` is missing, do not request an action in the current pane or a new panel.
+Submit exactly one action. Each tool advertises exactly the arguments it accepts; treat its advertised input schema as the sole authority and do not infer a payload shape from conversation text or print one yourself. Routing is automatic. If `activeTarget` is missing, do not request an action in the current pane or a new panel.
 
 Use delegation only when handing the task to the configured delegate agent. Its task must be a self-contained briefing with cwd, goal, constraints, and completion criteria.
 
 After `accepted`, end the turn without additional assistant text. Correct a `retryable:true` rejection at most twice. Do not retry stale, duplicate, or unavailable outcomes.
 
-If the MCP server or `request_terminal_actions` is unavailable, explain in prose that the terminal action could not be handed off. Never encode actions as JSON in assistant text or substitute another proposal mechanism.
+If the MCP server or its terminal action tools are unavailable, explain in prose that the terminal action could not be handed off. Never encode actions as JSON in assistant text or substitute another proposal mechanism.
 
 ## Delegating work
 
-Delegate through an `open_and_send` action with `delegate:true`. Choose a tab or panel that fits the requested workflow and provide a self-contained task containing the cwd, goal, relevant context, constraints, and completion criteria. The Helper selects the configured delegate agent.
+Delegate through a `terminal_open_and_send` call with `delegate:true`. Choose a tab or panel that fits the requested workflow and provide a self-contained task containing the cwd, goal, relevant context, constraints, and completion criteria. The Helper selects the configured delegate agent.
 
 ## Runtime context
 

--- a/tools/wta/src/agent_tools/action_proposal/pipe.rs
+++ b/tools/wta/src/agent_tools/action_proposal/pipe.rs
@@ -32,7 +32,10 @@ enum ProposalCompletion {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProposalPayloadSource {
     Cli,
-    Mcp,
+    /// An MCP `tools/call`. Carries which action tool was selected, so the
+    /// action shape travels with the payload instead of being re-encoded as a
+    /// discriminator field inside it.
+    Mcp(crate::agent_tools::action_proposal::schema::McpActionTool),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -252,7 +255,7 @@ async fn serve_connection(
         .await;
     }
 
-    let completion = if source == ProposalPayloadSource::Mcp {
+    let completion = if matches!(source, ProposalPayloadSource::Mcp(_)) {
         if !manager.accept_validation_detached(&proposal_id) {
             return write_validation_failure(
                 &mut write_half,

--- a/tools/wta/src/agent_tools/action_proposal/schema.rs
+++ b/tools/wta/src/agent_tools/action_proposal/schema.rs
@@ -160,20 +160,27 @@ pub struct ProposalChoiceWire {
     pub actions: Vec<ProposalActionWire>,
 }
 
+/// Payload for `terminal_send`. Required fields are plain (not `Option`), so
+/// serde rejects a missing one directly — there is no post-parse
+/// "is this field valid for this variant" pass, because the tool a model
+/// chose already fixes the shape.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct McpProposalWire {
-    #[serde(rename = "type")]
-    pub action_type: McpActionType,
+pub struct McpSendWire {
     pub title: String,
     #[serde(default)]
     pub rationale: String,
+    pub input: String,
+}
+
+/// Payload for `terminal_open`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct McpOpenWire {
+    pub title: String,
     #[serde(default)]
-    pub input: Option<String>,
-    #[serde(default)]
-    pub target: Option<ProposalOpenTargetWire>,
-    #[serde(default)]
-    pub delegate: Option<bool>,
+    pub rationale: String,
+    pub target: ProposalOpenTargetWire,
     #[serde(default)]
     pub cwd: Option<String>,
     #[serde(default)]
@@ -182,12 +189,50 @@ pub struct McpProposalWire {
     pub profile: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum McpActionType {
+/// Payload for `terminal_open_and_send`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct McpOpenAndSendWire {
+    pub title: String,
+    #[serde(default)]
+    pub rationale: String,
+    pub target: ProposalOpenTargetWire,
+    pub input: String,
+    #[serde(default)]
+    pub delegate: bool,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub direction: Option<String>,
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// Which action tool a `tools/call` selected. Replaces the former `type`
+/// discriminator field: the choice now lives in the tool name, so an
+/// invalid field/variant combination is unrepresentable rather than
+/// rejected after the fact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpActionTool {
     Send,
     Open,
     OpenAndSend,
+}
+
+impl McpActionTool {
+    pub const ALL: [Self; 3] = [Self::Send, Self::Open, Self::OpenAndSend];
+
+    pub fn tool_name(self) -> &'static str {
+        match self {
+            Self::Send => "terminal_send",
+            Self::Open => "terminal_open",
+            Self::OpenAndSend => "terminal_open_and_send",
+        }
+    }
+
+    pub fn from_tool_name(name: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|tool| tool.tool_name() == name)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -267,50 +312,61 @@ pub fn parse_proposal_payload(bytes: &[u8]) -> Result<ProposalWire, ProposalErro
     Ok(wire)
 }
 
-pub fn parse_mcp_proposal_payload(
+/// Decode a `tools/call` payload for one of the three action tools.
+///
+/// The selected tool fixes the action shape, so this is a plain deserialize
+/// plus a wrap — no per-variant field-applicability pass. `serde` enforces
+/// whether a field is required (required fields are not `Option`) and
+/// `deny_unknown_fields`
+/// rejects anything the chosen tool does not accept.
+pub fn parse_mcp_action_payload(
+    tool: McpActionTool,
     bytes: &[u8],
     is_autofix_turn: bool,
 ) -> Result<ProposalWire, ProposalError> {
     if bytes.len() > MAX_PAYLOAD_BYTES {
         return Err(ProposalError::TooLarge { size: bytes.len() });
     }
-    let proposal: McpProposalWire =
-        serde_json::from_slice(bytes).map_err(|e| ProposalError::Malformed(e.to_string()))?;
-    let action = match proposal.action_type {
-        McpActionType::Send => {
-            reject_mcp_fields(&[
-                ("target", proposal.target.is_some()),
-                ("delegate", proposal.delegate.is_some()),
-                ("cwd", proposal.cwd.is_some()),
-                ("direction", proposal.direction.is_some()),
-                ("profile", proposal.profile.is_some()),
-            ])?;
-            ProposalActionWire::Send {
-                input: required_mcp_field(proposal.input, "input", "send")?,
-            }
+    let malformed = |e: serde_json::Error| ProposalError::Malformed(e.to_string());
+    let (title, rationale, action) = match tool {
+        McpActionTool::Send => {
+            let wire: McpSendWire = serde_json::from_slice(bytes).map_err(malformed)?;
+            (
+                wire.title,
+                wire.rationale,
+                ProposalActionWire::Send { input: wire.input },
+            )
         }
-        McpActionType::Open => {
-            reject_mcp_fields(&[
-                ("input", proposal.input.is_some()),
-                ("delegate", proposal.delegate.is_some()),
-            ])?;
-            ProposalActionWire::Open {
-                target: required_mcp_field(proposal.target, "target", "open")?,
-                cwd: proposal.cwd,
-                title: Some(proposal.title.clone()),
-                direction: proposal.direction,
-                profile: proposal.profile,
-            }
+        McpActionTool::Open => {
+            let wire: McpOpenWire = serde_json::from_slice(bytes).map_err(malformed)?;
+            (
+                wire.title.clone(),
+                wire.rationale,
+                ProposalActionWire::Open {
+                    target: wire.target,
+                    cwd: wire.cwd,
+                    title: Some(wire.title),
+                    direction: wire.direction,
+                    profile: wire.profile,
+                },
+            )
         }
-        McpActionType::OpenAndSend => ProposalActionWire::OpenAndSend {
-            target: required_mcp_field(proposal.target, "target", "open_and_send")?,
-            input: required_mcp_field(proposal.input, "input", "open_and_send")?,
-            delegate: proposal.delegate.unwrap_or(false),
-            cwd: proposal.cwd,
-            title: Some(proposal.title.clone()),
-            direction: proposal.direction,
-            profile: proposal.profile,
-        },
+        McpActionTool::OpenAndSend => {
+            let wire: McpOpenAndSendWire = serde_json::from_slice(bytes).map_err(malformed)?;
+            (
+                wire.title.clone(),
+                wire.rationale,
+                ProposalActionWire::OpenAndSend {
+                    target: wire.target,
+                    input: wire.input,
+                    delegate: wire.delegate,
+                    cwd: wire.cwd,
+                    title: Some(wire.title),
+                    direction: wire.direction,
+                    profile: wire.profile,
+                },
+            )
+        }
     };
     Ok(ProposalWire {
         schema_version: SCHEMA_VERSION,
@@ -322,73 +378,86 @@ pub fn parse_mcp_proposal_payload(
         recommended_choice: Some(1),
         choices: vec![ProposalChoiceWire {
             choice: 1,
-            title: proposal.title,
-            rationale: proposal.rationale,
+            title,
+            rationale,
             actions: vec![action],
         }],
     })
 }
 
-fn required_mcp_field<T>(
-    value: Option<T>,
-    field: &str,
-    action_type: &str,
-) -> Result<T, ProposalError> {
-    value.ok_or_else(|| {
-        ProposalError::Malformed(format!("field `{field}` is required for `{action_type}`"))
+fn mcp_title_property() -> serde_json::Value {
+    serde_json::json!({ "type": "string", "minLength": 1, "maxLength": MAX_TITLE_CHARS })
+}
+
+fn mcp_target_properties() -> serde_json::Value {
+    serde_json::json!({
+        "target": { "type": "string", "enum": ["tab", "panel"] },
+        "cwd": { "type": "string", "minLength": 1, "maxLength": MAX_INPUT_CHARS },
+        "direction": { "type": "string", "enum": ["right", "left", "up", "down", "auto"] },
+        "profile": { "type": "string", "minLength": 1, "maxLength": MAX_TITLE_CHARS }
     })
 }
 
-fn reject_mcp_fields(fields: &[(&str, bool)]) -> Result<(), ProposalError> {
-    if let Some((field, _)) = fields.iter().find(|(_, present)| *present) {
-        return Err(ProposalError::Malformed(format!(
-            "field `{field}` is not valid for this action type"
-        )));
-    }
-    Ok(())
-}
+/// Build the schema for one action tool.
+///
+/// Every advertised property is genuinely accepted by that tool and every
+/// required one is listed, so `additionalProperties: false` plus `required`
+/// expresses the whole contract. No property needs prose explaining when it
+/// does or does not apply.
+pub fn mcp_action_input_schema(tool: McpActionTool) -> serde_json::Value {
+    let mut properties = serde_json::Map::new();
+    properties.insert("title".to_string(), mcp_title_property());
+    properties.insert(
+        "rationale".to_string(),
+        serde_json::json!({ "type": "string", "maxLength": MAX_RATIONALE_CHARS }),
+    );
 
-pub fn mcp_input_schema() -> serde_json::Value {
+    let mut required = vec!["title"];
+    if matches!(tool, McpActionTool::Send | McpActionTool::OpenAndSend) {
+        properties.insert(
+            "input".to_string(),
+            serde_json::json!({ "type": "string", "minLength": 1, "maxLength": MAX_INPUT_CHARS }),
+        );
+        required.push("input");
+    }
+    if matches!(tool, McpActionTool::Open | McpActionTool::OpenAndSend) {
+        let Some(target) = mcp_target_properties().as_object().cloned() else {
+            unreachable!("mcp_target_properties builds an object literal")
+        };
+        properties.extend(target);
+        required.push("target");
+    }
+    if matches!(tool, McpActionTool::OpenAndSend) {
+        properties.insert(
+            "delegate".to_string(),
+            serde_json::json!({ "type": "boolean", "description": "Use the configured delegate agent" }),
+        );
+    }
+
     serde_json::json!({
         "type": "object",
         "additionalProperties": false,
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": ["send", "open", "open_and_send"],
-                "description": "send uses the current pane; open creates an empty target; open_and_send creates a target and submits input"
-            },
-            "title": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": MAX_TITLE_CHARS,
-                "description": "Short user-facing title for the proposed action"
-            },
-            "rationale": {
-                "type": "string",
-                "maxLength": MAX_RATIONALE_CHARS
-            },
-            "input": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": MAX_INPUT_CHARS,
-                "description": "Required for send and open_and_send"
-            },
-            "target": {
-                "type": "string",
-                "enum": ["tab", "panel"],
-                "description": "Required for open and open_and_send"
-            },
-            "delegate": {
-                "type": "boolean",
-                "description": "For open_and_send, use the configured delegate agent"
-            },
-            "cwd": { "type": "string", "minLength": 1, "maxLength": MAX_INPUT_CHARS },
-            "direction": { "type": "string", "enum": ["right", "left", "up", "down", "auto"] },
-            "profile": { "type": "string", "minLength": 1, "maxLength": MAX_TITLE_CHARS }
-        },
-        "required": ["type", "title"]
+        "properties": properties,
+        "required": required
     })
+}
+
+/// User-facing description for one action tool.
+pub fn mcp_action_description(tool: McpActionTool) -> &'static str {
+    // Routing guidance appears only on the two tools that create a target.
+    // "At most one action per turn" lives in prompts/terminal-agent.md rather
+    // than being repeated on all three tools here.
+    match tool {
+        McpActionTool::Send => "Run one bounded command in the user's current terminal pane.",
+        McpActionTool::Open => {
+            "Open an empty tab or panel in the user's terminal. Panel for related parallel work; \
+             tab for independent, different-environment, or long-running work."
+        }
+        McpActionTool::OpenAndSend => {
+            "Open a tab or panel in the user's terminal and run input in it. Panel for related \
+             parallel work; tab for independent, different-environment, or long-running work."
+        }
+    }
 }
 
 /// Convert a decoded [`ProposalWire`] into a [`RecommendationSet`], applying
@@ -617,6 +686,7 @@ fn check_len(field: &str, value: &str, max_chars: usize) -> Result<(), ProposalE
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::{json, Value};
 
     fn terminal_agent_wire() -> ProposalWire {
         ProposalWire {
@@ -662,12 +732,11 @@ mod tests {
     #[test]
     fn flat_mcp_send_converts_to_one_recommended_action() {
         let payload = br#"{
-            "type": "send",
             "title": "Run tests",
             "rationale": "Verify the fix",
             "input": "cargo test"
         }"#;
-        let wire = parse_mcp_proposal_payload(payload, false).unwrap();
+        let wire = parse_mcp_action_payload(McpActionTool::Send, payload, false).unwrap();
         assert_eq!(wire.origin, ProposalOrigin::TerminalAgent);
         assert_eq!(wire.recommended_choice, Some(1));
         assert_eq!(wire.choices.len(), 1);
@@ -683,14 +752,13 @@ mod tests {
     #[test]
     fn flat_mcp_open_and_send_converts_to_one_action() {
         let payload = br#"{
-            "type": "open_and_send",
             "title": "Run tests",
             "input": "cargo test",
             "target": "panel",
             "direction": "right",
             "delegate": true
         }"#;
-        let wire = parse_mcp_proposal_payload(payload, false).unwrap();
+        let wire = parse_mcp_action_payload(McpActionTool::OpenAndSend, payload, false).unwrap();
         assert!(matches!(
             &wire.choices[0].actions[0],
             ProposalActionWire::OpenAndSend {
@@ -707,13 +775,12 @@ mod tests {
     #[test]
     fn flat_mcp_open_and_send_tab_accepts_direction() {
         let payload = br#"{
-            "type": "open_and_send",
             "title": "Project walkthrough",
             "input": "Walk through this project",
             "target": "tab",
             "direction": "auto"
         }"#;
-        let wire = parse_mcp_proposal_payload(payload, false).unwrap();
+        let wire = parse_mcp_action_payload(McpActionTool::OpenAndSend, payload, false).unwrap();
         let set = build_recommendation_set(&wire, false, None, None, None).unwrap();
         assert!(matches!(
             &set.choices[0].actions[0],
@@ -734,33 +801,150 @@ mod tests {
                 "actions": [{"type": "send", "input": "cargo test"}]
             }]
         }"#;
-        let err = parse_mcp_proposal_payload(payload, false).unwrap_err();
+        let err = parse_mcp_action_payload(McpActionTool::Send, payload, false).unwrap_err();
         assert!(matches!(err, ProposalError::Malformed(_)));
     }
 
     #[test]
-    fn flat_mcp_schema_has_no_nested_arrays_or_unions() {
-        let schema = mcp_input_schema();
-        assert!(schema.pointer("/properties/type").is_some());
-        assert!(schema.pointer("/properties/title").is_some());
-        assert!(schema.pointer("/properties/input").is_some());
-        assert!(schema.pointer("/properties/choices").is_none());
-        assert!(schema.pointer("/properties/actions").is_none());
-        assert!(!schema.to_string().contains("\"oneOf\""));
+    fn every_action_tool_schema_is_strict_provider_safe() {
+        for tool in McpActionTool::ALL {
+            let schema = mcp_action_input_schema(tool);
+            let name = tool.tool_name();
+            assert_eq!(schema.get("type").and_then(Value::as_str), Some("object"));
+            assert_eq!(schema.get("additionalProperties"), Some(&json!(false)));
+            assert!(schema.pointer("/properties/title").is_some(), "{name}");
+            assert!(schema.pointer("/properties/choices").is_none(), "{name}");
+            assert!(schema.pointer("/properties/actions").is_none(), "{name}");
+            // The discriminator is gone: the tool name carries the shape.
+            assert!(schema.pointer("/properties/type").is_none(), "{name}");
+            for keyword in ["oneOf", "anyOf", "allOf", "enum", "const", "not"] {
+                assert!(
+                    schema.get(keyword).is_none(),
+                    "{name}: top-level {keyword} is rejected by strict providers"
+                );
+            }
+            let serialized = schema.to_string();
+            for keyword in ["oneOf", "anyOf", "allOf"] {
+                assert!(
+                    !serialized.contains(&format!("\"{keyword}\"")),
+                    "{name}: {keyword} must not appear at any depth"
+                );
+            }
+        }
     }
 
+    /// The point of the split: each tool advertises exactly the fields it
+    /// accepts, so `additionalProperties: false` alone rejects a field that
+    /// belongs to a different action — no separate applicability pass.
     #[test]
-    fn flat_mcp_requires_action_specific_fields() {
-        let err = parse_mcp_proposal_payload(br#"{"type":"send","title":"Run tests"}"#, false)
-            .unwrap_err();
-        assert!(matches!(err, ProposalError::Malformed(_)));
+    fn each_tool_advertises_exactly_the_fields_it_accepts() {
+        let expected: [(McpActionTool, &[&str], &[&str]); 3] = [
+            (
+                McpActionTool::Send,
+                &["title", "rationale", "input"],
+                &["title", "input"],
+            ),
+            (
+                McpActionTool::Open,
+                &[
+                    "title",
+                    "rationale",
+                    "target",
+                    "cwd",
+                    "direction",
+                    "profile",
+                ],
+                &["title", "target"],
+            ),
+            (
+                McpActionTool::OpenAndSend,
+                &[
+                    "title",
+                    "rationale",
+                    "input",
+                    "target",
+                    "cwd",
+                    "direction",
+                    "profile",
+                    "delegate",
+                ],
+                &["title", "target", "input"],
+            ),
+        ];
+        for (tool, properties, required) in expected {
+            let schema = mcp_action_input_schema(tool);
+            let advertised: std::collections::BTreeSet<_> = schema
+                .pointer("/properties")
+                .and_then(Value::as_object)
+                .expect("properties")
+                .keys()
+                .map(String::as_str)
+                .collect();
+            assert_eq!(
+                advertised,
+                properties.iter().copied().collect(),
+                "{}",
+                tool.tool_name()
+            );
+            let advertised_required: std::collections::BTreeSet<_> = schema
+                .pointer("/required")
+                .and_then(Value::as_array)
+                .expect("required")
+                .iter()
+                .filter_map(Value::as_str)
+                .collect();
+            assert_eq!(
+                advertised_required,
+                required.iter().copied().collect(),
+                "{}",
+                tool.tool_name()
+            );
+        }
+    }
 
-        let err = parse_mcp_proposal_payload(
-            br#"{"type":"open","title":"New tab","target":"tab","input":"echo hi"}"#,
+    /// A field belonging to another action is now rejected by `serde`'s
+    /// `deny_unknown_fields`, not by a hand-written applicability check.
+    #[test]
+    fn send_rejects_a_target_only_field_as_unknown() {
+        let err = parse_mcp_action_payload(
+            McpActionTool::Send,
+            br#"{"title":"Show weather quickly","input":"curl example.com","cwd":"C:\\repo"}"#,
             false,
         )
         .unwrap_err();
-        assert!(matches!(err, ProposalError::Malformed(_)));
+        let ProposalError::Malformed(message) = err else {
+            panic!("expected a malformed payload error");
+        };
+        assert!(message.contains("cwd"), "{message}");
+
+        // The same payload without the stray field parses.
+        parse_mcp_action_payload(
+            McpActionTool::Send,
+            br#"{"title":"Show weather quickly","input":"curl example.com"}"#,
+            false,
+        )
+        .expect("send payload without the stray field must parse");
+    }
+
+    #[test]
+    fn missing_required_field_is_rejected_by_serde() {
+        for (tool, payload) in [
+            (McpActionTool::Send, &br#"{"title":"Run tests"}"#[..]),
+            (McpActionTool::Open, &br#"{"title":"New tab"}"#[..]),
+            (
+                McpActionTool::OpenAndSend,
+                &br#"{"title":"New tab","target":"tab"}"#[..],
+            ),
+        ] {
+            assert!(
+                matches!(
+                    parse_mcp_action_payload(tool, payload, false),
+                    Err(ProposalError::Malformed(_))
+                ),
+                "{}",
+                tool.tool_name()
+            );
+        }
     }
 
     #[test]

--- a/tools/wta/src/agent_tools/session_mcp.rs
+++ b/tools/wta/src/agent_tools/session_mcp.rs
@@ -10,7 +10,6 @@ use crate::agent_tools::user_input::UserInputResponse;
 const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
 const SUPPORTED_MCP_PROTOCOL_VERSIONS: &[&str] =
     &["2024-11-05", "2025-03-26", MCP_PROTOCOL_VERSION];
-const TERMINAL_ACTION_TOOL_NAME: &str = "request_terminal_actions";
 const USER_INPUT_TOOL_NAME: &str = "request_user_input";
 pub const SERVER_NAME_PREFIX: &str = "intellterm_";
 pub const SERVER_ID_HEX_LEN: usize = 20;
@@ -22,6 +21,13 @@ pub const CANCEL_USER_INPUT_HELPER_REQUEST_METHOD: &str = "_intellterm.wta/cance
 #[serde(deny_unknown_fields)]
 pub struct HelperRequest {
     pub session_id: String,
+    /// Which action tool the agent selected. Carries the action shape
+    /// alongside the payload, so it never has to be re-encoded as a
+    /// discriminator field inside the arguments. Required: this struct is
+    /// only ever used for terminal actions (user input has its own request
+    /// type), so serde enforces presence rather than deferring to a runtime
+    /// check in the helper.
+    pub tool: String,
     pub arguments: Value,
 }
 
@@ -72,7 +78,7 @@ pub async fn dispatch<A, ActionFuture, U, UserInputFuture>(
     request_user_input: U,
 ) -> Option<Value>
 where
-    A: FnOnce(Value) -> ActionFuture,
+    A: FnOnce(super::action_proposal::schema::McpActionTool, Value) -> ActionFuture,
     ActionFuture: Future<Output = anyhow::Result<ProposalValidationResponse>>,
     U: FnOnce(Value) -> UserInputFuture,
     UserInputFuture: Future<Output = anyhow::Result<UserInputResponse>>,
@@ -100,58 +106,49 @@ where
             })
         }
         "ping" => json!({}),
-        "tools/list" => json!({
-            "tools": [
-                {
-                    "name": TERMINAL_ACTION_TOOL_NAME,
-                    "description": "Request one terminal action in Intelligent Terminal. Use send for a simple bounded action in the current pane, open for a new empty tab or panel, and open_and_send for a new destination with input. Prefer a panel for related parallel work and a tab for independent work, a different environment, or a long-running task. Routing is automatic. Call at most once per turn, then end without assistant prose.",
-                    "inputSchema": super::action_proposal::schema::mcp_input_schema()
-                },
-                {
-                    "name": USER_INPUT_TOOL_NAME,
-                    "description": "Ask the user a blocking clarification question in Intelligent Terminal. Supply up to 8 choices, allow freeform input, or both. Use only when the answer is required to continue the current task.",
-                    "inputSchema": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "required": ["question"],
-                        "properties": {
-                            "question": {
+        "tools/list" => {
+            let mut tools: Vec<Value> = super::action_proposal::schema::McpActionTool::ALL
+                .into_iter()
+                .map(|tool| {
+                    json!({
+                        "name": tool.tool_name(),
+                        "description": super::action_proposal::schema::mcp_action_description(tool),
+                        "inputSchema": super::action_proposal::schema::mcp_action_input_schema(tool)
+                    })
+                })
+                .collect();
+            tools.push(json!({
+                "name": USER_INPUT_TOOL_NAME,
+                "description": "Ask the user a blocking clarification question in Intelligent Terminal. Supply up to 8 choices, set allow_freeform to true, or both; a call with neither is rejected. Use only when the answer is required to continue the current task.",
+                "inputSchema": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["question"],
+                    "properties": {
+                        "question": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 2000
+                        },
+                        "choices": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 8,
+                            "items": {
                                 "type": "string",
                                 "minLength": 1,
-                                "maxLength": 2000
-                            },
-                            "choices": {
-                                "type": "array",
-                                "maxItems": 8,
-                                "items": {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "maxLength": 200
-                                }
-                            },
-                            "allow_freeform": {
-                                "type": "boolean",
-                                "default": false
+                                "maxLength": 200
                             }
                         },
-                        "anyOf": [
-                            {
-                                "required": ["choices"],
-                                "properties": {
-                                    "choices": { "minItems": 1 }
-                                }
-                            },
-                            {
-                                "required": ["allow_freeform"],
-                                "properties": {
-                                    "allow_freeform": { "const": true }
-                                }
-                            }
-                        ]
+                        "allow_freeform": {
+                            "type": "boolean",
+                            "default": false
+                        }
                     }
                 }
-            ]
-        }),
+            }));
+            json!({ "tools": tools })
+        }
         "tools/call" => {
             let name = request.pointer("/params/name").and_then(Value::as_str);
             let arguments = request
@@ -159,8 +156,16 @@ where
                 .cloned()
                 .unwrap_or_else(|| json!({}));
             match name {
-                Some(TERMINAL_ACTION_TOOL_NAME) => {
-                    terminal_action_result(submit_action(arguments).await)
+                Some(name)
+                    if super::action_proposal::schema::McpActionTool::from_tool_name(name)
+                        .is_some() =>
+                {
+                    let Some(tool) =
+                        super::action_proposal::schema::McpActionTool::from_tool_name(name)
+                    else {
+                        unreachable!("guarded by the match arm")
+                    };
+                    terminal_action_result(submit_action(tool, arguments).await)
                 }
                 Some(USER_INPUT_TOOL_NAME) => {
                     user_input_result(request_user_input(arguments).await)
@@ -274,36 +279,82 @@ mod tests {
     async fn lists_session_tools() {
         let response = dispatch(
             json!({"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}),
-            |_| async { unreachable!() },
+            |_, _| async { unreachable!() },
             |_| async { unreachable!() },
         )
         .await
         .unwrap();
+        let names: Vec<&str> = response
+            .pointer("/result/tools")
+            .and_then(Value::as_array)
+            .expect("tools")
+            .iter()
+            .filter_map(|tool| tool.get("name").and_then(Value::as_str))
+            .collect();
         assert_eq!(
-            response
-                .pointer("/result/tools/0/name")
-                .and_then(Value::as_str),
-            Some(TERMINAL_ACTION_TOOL_NAME)
+            names,
+            vec![
+                "terminal_send",
+                "terminal_open",
+                "terminal_open_and_send",
+                USER_INPUT_TOOL_NAME
+            ]
         );
+        // The superseded single-tool name is neither advertised nor accepted;
+        // `tools/call` returns "unknown tool" for it. Spelled out here rather
+        // than kept as a production constant, since nothing else refers to it
+        // anymore.
+        assert!(!names.contains(&"request_terminal_actions"));
+        let user_input_schema = response
+            .pointer("/result/tools/3/inputSchema")
+            .expect("user input schema");
         assert_eq!(
-            response
-                .pointer("/result/tools")
-                .and_then(Value::as_array)
-                .map(Vec::len),
-            Some(2)
+            user_input_schema.get("type").and_then(Value::as_str),
+            Some("object")
         );
+        for keyword in ["oneOf", "anyOf", "allOf", "enum", "const", "not"] {
+            assert!(
+                user_input_schema.get(keyword).is_none(),
+                "top-level {keyword} is rejected by strict OpenAI-compatible providers"
+            );
+        }
+        // An empty choice list is never meaningful — omit the field instead.
+        // Constraining it here stops a model from emitting `choices: []` and
+        // then tripping `UserInputRequest::validate()` when it also leaves
+        // `allow_freeform` at its default of false.
         assert_eq!(
-            response
-                .pointer("/result/tools/1/name")
-                .and_then(Value::as_str),
-            Some(USER_INPUT_TOOL_NAME)
+            user_input_schema
+                .pointer("/properties/choices/minItems")
+                .and_then(Value::as_u64),
+            Some(1)
         );
-        assert_eq!(
-            response
-                .pointer("/result/tools/1/inputSchema/anyOf")
-                .and_then(Value::as_array)
-                .map(Vec::len),
-            Some(2)
+    }
+
+    /// Prints the serialized `tools/list` size so the cost of the tool surface
+    /// can be compared across revisions with a real number rather than an
+    /// estimate. Every published tool is sent on every request, so this is a
+    /// per-request cost worth measuring deliberately when the surface changes.
+    ///
+    /// Ignored by default: it asserts nothing, so it would spend CI time and
+    /// emit output without adding coverage. Run it explicitly with the cargo
+    /// test flags that select ignored tests and disable output capture.
+    #[tokio::test]
+    #[ignore = "measurement helper, not a regression test; run explicitly"]
+    async fn measure_tools_list_size() {
+        let response = dispatch(
+            json!({"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}),
+            |_, _| async { unreachable!() },
+            |_| async { unreachable!() },
+        )
+        .await
+        .unwrap();
+        let tools = response.pointer("/result/tools").expect("tools");
+        let serialized = serde_json::to_string(tools).expect("serialize");
+        println!(
+            "MEASURE tools={} chars={} approx_tokens={}",
+            tools.as_array().map(Vec::len).unwrap_or(0),
+            serialized.len(),
+            serialized.len() / 4
         );
     }
 
@@ -317,7 +368,7 @@ mod tests {
         });
         let response = dispatch(
             request,
-            |_| async { unreachable!() },
+            |_, _| async { unreachable!() },
             |_| async { unreachable!() },
         )
         .await
@@ -343,7 +394,7 @@ mod tests {
                     "arguments":{"question":"Choose","choices":["A","B"]}
                 }
             }),
-            |_| async { unreachable!() },
+            |_, _| async { unreachable!() },
             |_| async {
                 Ok(UserInputResponse::Answered {
                     answer: "B".into(),

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -180,7 +180,7 @@ impl App {
         source: crate::agent_tools::action_proposal::pipe::ProposalPayloadSource,
     ) -> DirectProposalEvaluation {
         use crate::agent_tools::action_proposal::schema::{
-            build_recommendation_set, parse_mcp_proposal_payload, parse_proposal_payload,
+            build_recommendation_set, parse_mcp_action_payload, parse_proposal_payload,
         };
 
         if !self.session_to_tab.contains_key(session_id) {
@@ -228,8 +228,8 @@ impl App {
             crate::agent_tools::action_proposal::pipe::ProposalPayloadSource::Cli => {
                 parse_proposal_payload(payload.as_bytes())
             }
-            crate::agent_tools::action_proposal::pipe::ProposalPayloadSource::Mcp => {
-                parse_mcp_proposal_payload(payload.as_bytes(), is_autofix)
+            crate::agent_tools::action_proposal::pipe::ProposalPayloadSource::Mcp(tool) => {
+                parse_mcp_action_payload(tool, payload.as_bytes(), is_autofix)
             }
         };
         let wire = match wire {

--- a/tools/wta/src/master/session_mcp.rs
+++ b/tools/wta/src/master/session_mcp.rs
@@ -863,7 +863,7 @@ async fn serve_connection(
             let action_capability = capability.clone();
             let response = crate::agent_tools::session_mcp::dispatch(
                 message,
-                |arguments| submit_to_helper(&state, action_capability, arguments),
+                |tool, arguments| submit_to_helper(&state, action_capability, tool, arguments),
                 |arguments| submit_user_input_to_helper(&state, capability, arguments),
             );
             let response = if is_user_input {
@@ -920,6 +920,7 @@ fn is_user_input_call(message: &Value) -> bool {
 async fn submit_to_helper(
     state: &MasterStateInner,
     capability: CapabilityResolution,
+    tool: crate::agent_tools::action_proposal::schema::McpActionTool,
     arguments: Value,
 ) -> Result<ProposalValidationResponse> {
     let started = std::time::Instant::now();
@@ -927,6 +928,7 @@ async fn submit_to_helper(
         state,
         capability,
         arguments,
+        tool.tool_name(),
         "request_terminal_actions",
         crate::agent_tools::session_mcp::HELPER_REQUEST_METHOD,
         HELPER_TIMEOUT,
@@ -938,6 +940,7 @@ async fn submit_to_helper(
         target: "session_mcp",
         step = "helper→master",
         op = "request_terminal_actions",
+        tool = tool.tool_name(),
         session_id = %session_id,
         status = ?response.status,
         retryable = response.retryable,
@@ -1099,6 +1102,7 @@ async fn forward_to_helper(
     state: &MasterStateInner,
     capability: CapabilityResolution,
     arguments: Value,
+    tool: &'static str,
     op: &'static str,
     helper_method: &'static str,
     timeout: Duration,
@@ -1107,6 +1111,7 @@ async fn forward_to_helper(
     let (session_id, helper_id, forwarder) = resolve_helper(state, capability, op).await?;
     let params = serde_json::value::to_raw_value(&HelperRequest {
         session_id: session_id.to_string(),
+        tool: tool.to_string(),
         arguments,
     })
     .context("encode Helper request")?;
@@ -1115,6 +1120,7 @@ async fn forward_to_helper(
         target: "session_mcp",
         step = "master→helper",
         op,
+        tool,
         helper_id = ?helper_id,
         session_id = %session_id,
         "routing MCP request to owning Helper"
@@ -1395,7 +1401,16 @@ mod tests {
         assert!(server_id
             .chars()
             .all(|ch| ch.is_ascii_digit() || ('a'..='f').contains(&ch)));
-        assert!(format!("mcp__{}__request_terminal_actions", config.name).len() <= 64);
+        // Some agent CLIs cap the fully-qualified MCP tool name at 64 chars.
+        // Assert against the longest name actually published.
+        for tool in crate::agent_tools::action_proposal::schema::McpActionTool::ALL {
+            let qualified = format!("mcp__{}__{}", config.name, tool.tool_name());
+            assert!(
+                qualified.len() <= 64,
+                "{qualified} is {} chars",
+                qualified.len()
+            );
+        }
         assert!(!config.name.contains(&pending.secret));
         assert_eq!(config.url, "http://127.0.0.1:4321/mcp");
         assert_eq!(config.headers.len(), 1);

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -1006,14 +1006,23 @@ fn is_session_mcp_server_name(name: &str) -> bool {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SessionMcpTool {
-    TerminalActions,
+    TerminalAction(crate::agent_tools::action_proposal::schema::McpActionTool),
     UserInput,
 }
 
 impl SessionMcpTool {
+    const ALL: [Self; 4] = [
+        Self::TerminalAction(crate::agent_tools::action_proposal::schema::McpActionTool::Send),
+        Self::TerminalAction(crate::agent_tools::action_proposal::schema::McpActionTool::Open),
+        Self::TerminalAction(
+            crate::agent_tools::action_proposal::schema::McpActionTool::OpenAndSend,
+        ),
+        Self::UserInput,
+    ];
+
     fn name(self) -> &'static str {
         match self {
-            Self::TerminalActions => "request_terminal_actions",
+            Self::TerminalAction(tool) => tool.tool_name(),
             Self::UserInput => "request_user_input",
         }
     }
@@ -1024,7 +1033,7 @@ fn session_mcp_tool_from_title(title: Option<&str>) -> Option<SessionMcpTool> {
         return None;
     };
     let title = title.strip_prefix("Use MCP tool: ").unwrap_or(title);
-    for tool in [SessionMcpTool::TerminalActions, SessionMcpTool::UserInput] {
+    for tool in SessionMcpTool::ALL {
         for separator in ["/", "-"] {
             if let Some(server_name) = title.strip_suffix(&format!("{separator}{}", tool.name())) {
                 if is_session_mcp_server_name(server_name) {
@@ -1051,18 +1060,23 @@ fn session_mcp_tool_call(
         return Some(tool);
     }
     let tool = match title.map(str::trim) {
-        Some("request_terminal_actions") => SessionMcpTool::TerminalActions,
-        Some("request_user_input") => SessionMcpTool::UserInput,
-        _ => return None,
+        Some(name) => SessionMcpTool::ALL
+            .into_iter()
+            .find(|tool| tool.name() == name)?,
+        None => return None,
     };
     let Some(raw_input) = raw_input else {
         return None;
     };
     let valid = match tool {
-        SessionMcpTool::TerminalActions => serde_json::to_vec(raw_input).is_ok_and(|payload| {
-            crate::agent_tools::action_proposal::schema::parse_mcp_proposal_payload(&payload, false)
+        SessionMcpTool::TerminalAction(action) => {
+            serde_json::to_vec(raw_input).is_ok_and(|payload| {
+                crate::agent_tools::action_proposal::schema::parse_mcp_action_payload(
+                    action, &payload, false,
+                )
                 .is_ok()
-        }),
+            })
+        }
         SessionMcpTool::UserInput => serde_json::from_value::<
             crate::agent_tools::user_input::UserInputRequest,
         >(raw_input.clone())
@@ -1210,7 +1224,9 @@ impl WtaClient {
             self.hide_session_mcp_tool_call(
                 &session_id,
                 &tool_call_id,
-                SessionMcpTool::TerminalActions,
+                SessionMcpTool::TerminalAction(
+                    crate::agent_tools::action_proposal::schema::McpActionTool::Send,
+                ),
             );
         }
         let title = args
@@ -1254,7 +1270,7 @@ impl WtaClient {
                 ));
             };
             let permission_result = match tool {
-                SessionMcpTool::TerminalActions => self
+                SessionMcpTool::TerminalAction(_) => self
                     .state
                     .proposal_channels
                     .validate_mcp_permission(&session_id),
@@ -1487,7 +1503,9 @@ impl WtaClient {
                     self.hide_session_mcp_tool_call(
                         &sid,
                         &tool_call_id,
-                        SessionMcpTool::TerminalActions,
+                        SessionMcpTool::TerminalAction(
+                            crate::agent_tools::action_proposal::schema::McpActionTool::Send,
+                        ),
                     );
                     return Ok(());
                 }
@@ -1536,7 +1554,9 @@ impl WtaClient {
                     self.hide_session_mcp_tool_call(
                         &sid,
                         &tool_call_id,
-                        SessionMcpTool::TerminalActions,
+                        SessionMcpTool::TerminalAction(
+                            crate::agent_tools::action_proposal::schema::McpActionTool::Send,
+                        ),
                     );
                     return Ok(());
                 }
@@ -1857,6 +1877,20 @@ impl WtaClient {
                     "invalid terminal action request parameters: {error}"
                 ))
             })?;
+        let action_tool = {
+            use crate::agent_tools::action_proposal::schema::McpActionTool;
+            McpActionTool::from_tool_name(&request.tool).ok_or_else(|| {
+                acp::Error::invalid_params().data(format!(
+                    "unknown terminal action tool `{}`; expected one of: {}",
+                    request.tool,
+                    McpActionTool::ALL
+                        .iter()
+                        .map(|tool| tool.tool_name())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ))
+            })?
+        };
         let payload = serde_json::to_string(&request.arguments).map_err(|error| {
             acp::Error::internal_error().data(format!(
                 "failed to encode terminal action arguments: {error}"
@@ -1904,7 +1938,7 @@ impl WtaClient {
             .send(AppEvent::DirectTerminalActionProposal {
                 context,
                 payload,
-                source: ProposalPayloadSource::Mcp,
+                source: ProposalPayloadSource::Mcp(action_tool),
                 responder: validation_tx,
             })
             .is_err()
@@ -4923,9 +4957,8 @@ mod tests {
             ToolCallUpdate::new(
                 ToolCallId::new("proposal-mcp-tool"),
                 ToolCallUpdateFields::new()
-                    .title("request_terminal_actions")
+                    .title("terminal_send")
                     .raw_input(serde_json::json!({
-                        "type": "send",
                         "title": "Run test",
                         "input": "cargo test"
                     })),
@@ -5197,8 +5230,8 @@ mod tests {
         let params =
             serde_json::value::to_raw_value(&crate::agent_tools::session_mcp::HelperRequest {
                 session_id: "proposal-session".to_string(),
+                tool: "terminal_send".to_string(),
                 arguments: serde_json::json!({
-                    "type": "send",
                     "title": "Run test",
                     "input": "cargo test"
                 }),
@@ -5220,7 +5253,9 @@ mod tests {
                 } => {
                     assert_eq!(
                         source,
-                        crate::agent_tools::action_proposal::pipe::ProposalPayloadSource::Mcp
+                        crate::agent_tools::action_proposal::pipe::ProposalPayloadSource::Mcp(
+                            crate::agent_tools::action_proposal::schema::McpActionTool::Send
+                        )
                     );
                     responder
                         .send(
@@ -5400,16 +5435,20 @@ mod tests {
     #[test]
     fn session_mcp_tool_title_accepts_supported_permission_shapes() {
         let dynamic = "intellterm_01234567890123456789";
-        for title in [
-            "Use MCP tool: intelligent_terminal/request_terminal_actions".to_string(),
-            "intelligent_terminal-request_terminal_actions".to_string(),
-            format!("Use MCP tool: {dynamic}/request_terminal_actions"),
-            format!("mcp__{dynamic}__request_terminal_actions"),
-        ] {
-            assert_eq!(
-                session_mcp_tool_from_title(Some(&title)),
-                Some(SessionMcpTool::TerminalActions)
-            );
+        for tool in crate::agent_tools::action_proposal::schema::McpActionTool::ALL {
+            let name = tool.tool_name();
+            for title in [
+                format!("Use MCP tool: intelligent_terminal/{name}"),
+                format!("intelligent_terminal-{name}"),
+                format!("Use MCP tool: {dynamic}/{name}"),
+                format!("mcp__{dynamic}__{name}"),
+            ] {
+                assert_eq!(
+                    session_mcp_tool_from_title(Some(&title)),
+                    Some(SessionMcpTool::TerminalAction(tool)),
+                    "{title}"
+                );
+            }
         }
         assert_eq!(
             session_mcp_tool_from_title(Some(&format!(
@@ -5418,11 +5457,14 @@ mod tests {
             Some(SessionMcpTool::UserInput)
         );
         for title in [
-            "intellterm_0123456789abcdef/request_terminal_actions",
-            "intellterm_0123456789012345678A/request_terminal_actions",
-            "Use MCP tool: other/request_terminal_actions",
+            "intellterm_0123456789abcdef/terminal_send",
+            "intellterm_0123456789012345678A/terminal_send",
+            "Use MCP tool: other/terminal_send",
+            // The superseded single-tool name is no longer a tool.
+            "Use MCP tool: intelligent_terminal/request_terminal_actions",
+            "mcp__intellterm_01234567890123456789__request_terminal_actions",
         ] {
-            assert_eq!(session_mcp_tool_from_title(Some(title)), None);
+            assert_eq!(session_mcp_tool_from_title(Some(title)), None, "{title}");
         }
     }
 

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -2303,7 +2303,7 @@ async fn session_notification_hides_proposal_mcp_tool_call() {
             "s1",
             acp::schema::v1::SessionUpdate::ToolCall(acp::schema::v1::ToolCall::new(
                 acp::schema::v1::ToolCallId::new("proposal-mcp-tool"),
-                "intellterm_01234567890123456789/request_terminal_actions",
+                "intellterm_01234567890123456789/terminal_send",
             )),
         ))
         .await

--- a/tools/wta/src/protocol/acp/prompt.rs
+++ b/tools/wta/src/protocol/acp/prompt.rs
@@ -281,16 +281,35 @@ mod tests {
     fn embedded_prompts_use_the_mcp_tool_schema_as_authority() {
         for prompt in [EMBEDDED_DEFAULT_PROMPT, EMBEDDED_AUTOFIX_PROMPT] {
             assert!(prompt.contains("provides an MCP server for this session"));
-            assert!(prompt.contains("`request_terminal_actions`"));
+            assert!(prompt.contains("terminal_send"));
+            assert!(!prompt.contains("request_terminal_actions"));
             assert!(prompt.contains("advertised input schema as the sole authority"));
             assert!(!prompt.contains(r#"{"type""#));
             assert!(!prompt.contains("recommended_choice"));
             assert!(!prompt.contains("```json"));
         }
+        // The default prompt drives every action, so it must name each tool.
+        for tool in ["terminal_send", "terminal_open", "terminal_open_and_send"] {
+            assert!(
+                EMBEDDED_DEFAULT_PROMPT.contains(tool),
+                "default prompt must name {tool}"
+            );
+        }
+        // Autofix is deliberately restricted to `terminal_send` — the Helper
+        // rejects any other action for an autofix turn — so naming the target
+        // tools there would invite a call that cannot be accepted.
+        // `terminal_open` alone would already catch `terminal_open_and_send`
+        // by substring; both are asserted so the intent survives a rename.
+        for tool in ["terminal_open", "terminal_open_and_send"] {
+            assert!(
+                !EMBEDDED_AUTOFIX_PROMPT.contains(tool),
+                "autofix prompt must not name {tool}"
+            );
+        }
         assert!(EMBEDDED_DEFAULT_PROMPT.contains("Submit exactly one action"));
         assert!(EMBEDDED_DEFAULT_PROMPT.contains("`request_user_input`"));
         assert!(EMBEDDED_DEFAULT_PROMPT.contains("instead of guessing"));
-        assert!(EMBEDDED_AUTOFIX_PROMPT.contains("Submit exactly one `send` action"));
+        assert!(EMBEDDED_AUTOFIX_PROMPT.contains("Submit exactly one `terminal_send` call"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replaces the single `request_terminal_actions` tool — a `type` discriminator with the fields for all three actions flattened into one schema — with one tool per action:

| tool | accepted fields | required |
|---|---|---|
| `terminal_send` | `title`, `rationale`, `input` | `title`, `input` |
| `terminal_open` | `title`, `rationale`, `target`, `cwd`, `direction`, `profile` | `title`, `target` |
| `terminal_open_and_send` | all of the above plus `delegate` | `title`, `target`, `input` |

Closes the second half of #674. Design discussion in #676.

## The problem

Because the schema was flat, **every field was advertised for every `type`**, and only the field descriptions distinguished them — `cwd`, `direction`, and `profile` had no description at all. A model choosing `type: "send"` would attach target-only fields and be rejected:

```
Terminal action request rejected: malformed payload:
field `cwd` is not valid for this action type
```

## Evidence this actually fixes it

Measured against a live Azure deployment. Same prompt ("Show me the weather quickly in my current terminal") five times per schema on `gpt-5.3-codex`, counting target-only fields attached to a send:

| schema | stray field on a send |
|---|---|
| `main` | **5 / 5** |
| per-field descriptions (the interim #674 mitigation) | **4 / 5** |
| **this PR** | **0 / 5** |

`main` reproduces the reported failure every time. A representative payload:

```json
{"type":"send","input":"curl -s 'https://wttr.in/?format=3'",
 "target":"panel","delegate":false,"cwd":".","direction":"auto","profile":"default"}
```

**Describing applicability in prose barely helped — 5/5 to 4/5.** Telling a model which fields apply to which `type` does not stop it populating a field the schema advertises. The 0/5 here is structural rather than statistical: `terminal_send` has no `cwd` property, so the payload cannot be formed.

This also matters for weaker models. The flat schema requires evaluating a conditional — *"I chose `send`, therefore `cwd`, `direction`, and `profile` are forbidden, even though all nine fields are listed"* — sustained across the whole payload. One tool per action removes the conditional entirely, and structure does not degrade as model capability drops.

## Schema validity

Published `tools/list` schemas were posted as `tools:` to the same Azure resource, with `main` as the control:

| branch | chat-completions (`model-router`) | responses API (`gpt-5.3-codex`) |
|---|---|---|
| `main` | FAIL — `Invalid schema for function` | PASS |
| **this PR** | **PASS** | **PASS** |

The responses-API column shows no regression for agents on that path.

## Implementation

- `additionalProperties: false` plus an exact `required` list expresses the whole contract; required fields stop being `Option<T>`, so `serde` enforces requiredness.
- `reject_mcp_fields` and `required_mcp_field` are deleted, along with the per-variant reject lists.
- The selected tool travels as `ProposalPayloadSource::Mcp(McpActionTool)` from the MCP boundary through `app_turn` to the parser, with `HelperRequest.tool` carrying it across the master/helper hop — the action shape is held by the type system end to end rather than re-encoded into the payload.
- `SessionMcpTool::TerminalActions` becomes `TerminalAction(McpActionTool)` so permission-title matching covers all three names.
- Still no `oneOf`/`anyOf` anywhere, which is the strict-provider constraint from #674.

## Cost

+73 tokens on the published tool surface (601 vs 528), measured by the `measure_tools_list_size` test rather than estimated. Production code grows 39 lines, trading roughly 42 lines of hand-written validation for declarative struct definitions that `serde` enforces.

The three structs cannot share their common fields via `#[serde(flatten)]` — serde does not support `flatten` together with `deny_unknown_fields`, and that attribute is the entire validation mechanism. The duplication is forced by the design.

## Tests

- `every_action_tool_schema_is_strict_provider_safe` — each published schema is a top-level object with no composition keyword at the top level or any depth.
- `each_tool_advertises_exactly_the_fields_it_accepts` — advertised properties and `required` match the parser exactly, per tool, so the hand-written struct and schema builder cannot drift.
- `send_rejects_a_target_only_field_as_unknown` — the reported payload is rejected by `deny_unknown_fields`; the corrected payload parses.
- `missing_required_field_is_rejected_by_serde`, per tool.
- The qualified-name assertion now covers every published tool; longest is `mcp__intellterm_<20 hex>__terminal_open_and_send` at 60 of 64 chars.

`action_proposal` 45/45, `session_mcp` 16/16, `embedded_prompts` 1/1, `session_mcp_tool_title` 1/1, `server_configs_isolate` 1/1, `session_notification_hides_proposal` 2/2.

> The unfiltered WTA suite was deliberately not used: it contains integration tests that drive the real terminal through `wtcli` and spawn tabs and panes in the developer's live session.

## Worth a maintainer decision

1. **No compatibility shim.** `request_terminal_actions` is neither advertised nor accepted. `tools/list` is re-advertised on every session initialize, so this should be safe, but resumed sessions with seeded ACP history are the case to consider.
2. **Dual source of truth remains.** The structs and the schema builder are both hand-written. `each_tool_advertises_exactly_the_fields_it_accepts` pins them so drift fails CI, but only deriving the schema from the structs would remove the class — that needs a new dependency plus `cgmanifest.json` and `NOTICE.md` regeneration, so it is out of scope here.
3. **Log continuity.** The internal helper-pipe method name and the master tracing `op` value are deliberately unchanged; the specific tool is added as a new `tool` field alongside.

## Testing gap

App-level E2E (`Feature.ProposalMcpRouting`, `Feature.AgentProposedCommand`, `Feature.AgentProposalFocus`, `Feature.AgentProtocolExperience`, `Feature.AgentCompactLayout`, `Feature.AutofixPane`, `Feature.Delegate`) was **not** run: building `CascadiaPackage` in this environment fails in the XAML compiler (`WMC9999: Value cannot be null`) inside `TerminalSettingsEditor`. That failure is pre-existing — this commit touches zero C++, XAML, or project files, so the affected compilation is bit-identical to `main`.

The two E2E mock-agent fixtures were updated and validated offline: their payloads are accepted by the corresponding new schemas, with all required fields present and no field outside the advertised set.
