### PR TITLE
Hide BYOK compatibility warning in empty state

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -179,10 +179,6 @@
                             HorizontalAlignment="Right"
                             Click="{x:Bind ViewModel.AddCustomModelProvider}"
                             Style="{StaticResource AccentButtonStyle}" />
-                    <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                               Text="{x:Bind ViewModel.CustomModelProviderUnsupportedMessage, Mode=OneWay}"
-                               TextWrapping="Wrap"
-                               Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(ViewModel.CustomModelProviderUnsupportedMessage), Mode=OneWay}" />
                 </StackPanel>
             </local:SettingContainer>
 


### PR DESCRIPTION
## Summary

- hide the unsupported-agent BYOK message from the non-expandable empty-provider row
- keep the message in the expandable provider details where it provides context for saved providers

## Validation

- built Microsoft.Terminal.Settings.Editor on the latest main branch