### PR TITLE
Keep agent thinking visible throughout in-flight turns

### DIFF
--- a/tools/wta/README.md
+++ b/tools/wta/README.md
@@ -126,9 +126,11 @@ shell, so any pane-launched process — including wta and wtcli — inherits it.
 Tool rows keep a localized type label such as **Run**, **Read**, **Search**, or
 **Edit** visible across pending, running, and completed states. Consecutive
 successful Read, Search, Edit, and Delete calls collapse into one summary row;
-click that row to inspect each call. ACP thought chunks stream as temporary
-**Think** activity and disappear when the visible answer begins. Expanded Edit
-details show bounded line-level `+`/`-` hunks computed from ACP snapshots.
+click that row to inspect each call. While a turn is in flight, ACP thought
+chunks update a temporary **Think** row alongside visible answers; when the
+provider is silent, the row remains as `Think · …` until the turn ends.
+Expanded Edit details show bounded line-level `+`/`-` hunks computed from ACP
+snapshots.
 
 | Key | Action |
 |-----|--------|

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -927,7 +927,9 @@ impl TabSession {
                 .nth(remove_chars)
                 .map_or(self.streaming_thought.len(), |(index, _)| index);
             self.streaming_thought.drain(..cut_at);
-            self.reveal_chars = self.reveal_chars.saturating_sub(remove_chars);
+            if self.streaming_agent_text().is_none() {
+                self.reveal_chars = self.reveal_chars.saturating_sub(remove_chars);
+            }
         }
     }
 

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -802,22 +802,17 @@ impl TabSession {
             })
     }
 
-    pub(crate) fn should_show_streaming_thought(&self) -> bool {
-        self.should_show_persistent_thinking()
-            && self
-                .streaming_thought_text()
-                .is_some_and(|text| !text.trim().is_empty())
+    fn has_visible_streaming_thought(&self) -> bool {
+        self.streaming_thought_text()
+            .is_some_and(|text| !text.trim().is_empty())
     }
 
     pub(crate) fn should_show_thinking(&self) -> bool {
-        self.can_show_turn_activity() && !self.should_show_streaming_thought()
+        self.can_show_turn_activity() && !self.has_visible_streaming_thought()
     }
 
-    pub(crate) fn should_show_persistent_thinking(&self) -> bool {
-        self.turn.is_in_flight()
-            && (self.streaming_agent_text().is_some()
-                || self.streaming_thought_text().is_some()
-                || !self.can_show_turn_activity())
+    pub(crate) fn should_show_inline_thinking(&self) -> bool {
+        self.turn.is_in_flight() && !self.should_show_thinking()
     }
 
     /// Whether the input box is the live, enterable caret target.

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -803,7 +803,7 @@ impl TabSession {
     }
 
     pub(crate) fn should_show_streaming_thought(&self) -> bool {
-        self.can_show_turn_activity()
+        self.should_show_persistent_thinking()
             && self
                 .streaming_thought_text()
                 .is_some_and(|text| !text.trim().is_empty())
@@ -811,6 +811,13 @@ impl TabSession {
 
     pub(crate) fn should_show_thinking(&self) -> bool {
         self.can_show_turn_activity() && !self.should_show_streaming_thought()
+    }
+
+    pub(crate) fn should_show_persistent_thinking(&self) -> bool {
+        self.turn.is_in_flight()
+            && (self.streaming_agent_text().is_some()
+                || self.streaming_thought_text().is_some()
+                || !self.can_show_turn_activity())
     }
 
     /// Whether the input box is the live, enterable caret target.
@@ -905,7 +912,9 @@ impl TabSession {
             return;
         }
         if self.streaming_thought.is_empty() {
-            self.reveal_chars = 0;
+            if self.streaming_agent_text().is_none() {
+                self.reveal_chars = 0;
+            }
         }
         self.streaming_thought.push_str(text);
 
@@ -924,7 +933,9 @@ impl TabSession {
 
     pub fn clear_streaming_thought(&mut self) {
         self.streaming_thought.clear();
-        self.reveal_chars = 0;
+        if self.streaming_agent_text().is_none() {
+            self.reveal_chars = 0;
+        }
     }
 
     pub fn streaming_thought_text(&self) -> Option<&str> {

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -11268,17 +11268,19 @@ fn first_message_chunk_transitions_to_streaming_with_transcript_text() {
     assert!(app.current_tab().turn.is_streaming());
     assert!(
         !app.current_tab().should_show_thinking(),
-        "visible response text replaces the generic Thinking row"
+        "visible response text replaces the generic Thinking row with inline activity"
     );
+    app.current_tab_mut().reveal_chars = "partial".chars().count();
+    assert!(render_to_text(&mut app, 80, 20).contains("Think · …"));
     app.advance_reveal();
     assert!(
         !app.current_tab().should_show_thinking(),
-        "revealing response text remains the visible progress indicator"
+        "inline activity remains visible beside revealed response text"
     );
 }
 
 #[test]
-fn thought_chunks_stream_ephemerally_until_visible_message_text_arrives() {
+fn latest_thought_remains_visible_alongside_streaming_message_until_turn_end() {
     let mut app = test_app();
     submit_test_prompt(&mut app, "hi");
     let advanced = app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, "thinking…");
@@ -11294,13 +11296,28 @@ fn thought_chunks_stream_ephemerally_until_visible_message_text_arrives() {
     let tab = app.current_tab();
     assert_eq!(tab.streaming_thought_text(), None);
     assert_eq!(tab.streaming_agent_text(), Some("Final answer"));
-    assert!(!app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, "late hidden thought"));
-    assert_eq!(app.current_tab().streaming_thought_text(), None);
     app.current_tab_mut().reveal_chars = "Final answer".chars().count();
+    let reveal_chars = app.current_tab().reveal_chars;
+    assert!(app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, "late visible thought"));
+    assert_eq!(
+        app.current_tab().streaming_thought_text(),
+        Some("late visible thought")
+    );
+    assert_eq!(
+        app.current_tab().reveal_chars,
+        reveal_chars,
+        "late thought chunks must not rewind visible response text"
+    );
     let rendered = render_to_text(&mut app, 80, 20);
     assert!(rendered.contains("Final"));
     assert!(!rendered.contains("thinking"));
-    assert!(!rendered.contains("late hidden thought"));
+    assert!(rendered.contains("Think · late visible thought"));
+
+    app.handle_event(AppEvent::AgentMessageEnd {
+        session_id: DEFAULT_TAB_ID.into(),
+    });
+    assert_eq!(app.current_tab().streaming_thought_text(), None);
+    assert!(!render_to_text(&mut app, 80, 20).contains("Think ·"));
 }
 
 #[test]
@@ -11364,6 +11381,10 @@ fn running_tool_replaces_thinking_until_tool_completes() {
         "the running tool card is already visible progress"
     );
     assert_eq!(app.current_tab().streaming_thought_text(), None);
+    assert!(
+        render_to_text(&mut app, 80, 20).contains("Think · …"),
+        "tool activity must retain inline Thinking until the turn ends"
+    );
 
     app.handle_event(AppEvent::ToolCallUpdate {
         session_id: DEFAULT_TAB_ID.into(),

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -11341,6 +11341,30 @@ fn live_thought_buffer_is_bounded_without_splitting_unicode() {
 }
 
 #[test]
+fn bounded_late_thought_does_not_rewind_revealed_assistant_response() {
+    let mut app = test_app();
+    submit_test_prompt(&mut app, "hi");
+    app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Message, "Final answer");
+    app.current_tab_mut().reveal_chars = "Final answer".chars().count();
+    let reveal_chars = app.current_tab().reveal_chars;
+
+    app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, &"思".repeat(4100));
+
+    let tab = app.current_tab();
+    assert_eq!(
+        tab.streaming_thought_text()
+            .expect("late thought stream")
+            .chars()
+            .count(),
+        4000
+    );
+    assert_eq!(
+        tab.reveal_chars, reveal_chars,
+        "bounding a late thought must not rewind fully revealed response text"
+    );
+}
+
+#[test]
 fn structured_stream_hides_thinking_after_response_is_visible() {
     let mut app = test_app();
     submit_test_prompt(&mut app, "hi");

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -11259,6 +11259,8 @@ fn submit_clears_messages_and_pushes_user_bubble() {
 
 #[test]
 fn first_message_chunk_transitions_to_streaming_with_transcript_text() {
+    let _locale = crate::test_support::lock_locale();
+    rust_i18n::set_locale("en-US");
     let mut app = test_app();
     submit_test_prompt(&mut app, "hi");
     assert!(app.current_tab().should_show_thinking());
@@ -11281,6 +11283,8 @@ fn first_message_chunk_transitions_to_streaming_with_transcript_text() {
 
 #[test]
 fn latest_thought_remains_visible_alongside_streaming_message_until_turn_end() {
+    let _locale = crate::test_support::lock_locale();
+    rust_i18n::set_locale("en-US");
     let mut app = test_app();
     submit_test_prompt(&mut app, "hi");
     let advanced = app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, "thinking…");
@@ -11359,6 +11363,8 @@ fn structured_stream_hides_thinking_after_response_is_visible() {
 
 #[test]
 fn running_tool_replaces_thinking_until_tool_completes() {
+    let _locale = crate::test_support::lock_locale();
+    rust_i18n::set_locale("en-US");
     let mut app = test_app();
     submit_test_prompt(&mut app, "inspect");
     app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, "Choosing files");

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -11341,6 +11341,19 @@ fn live_thought_buffer_is_bounded_without_splitting_unicode() {
 }
 
 #[test]
+fn whitespace_thought_keeps_only_generic_thinking_activity() {
+    let mut app = test_app();
+    submit_test_prompt(&mut app, "hi");
+
+    app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, " ");
+
+    let tab = app.current_tab();
+    assert!(tab.should_show_thinking());
+    assert!(!tab.should_show_inline_thinking());
+    assert_eq!(crate::ui::chat::pending_render_text(tab), None);
+}
+
+#[test]
 fn bounded_late_thought_does_not_rewind_revealed_assistant_response() {
     let mut app = test_app();
     submit_test_prompt(&mut app, "hi");

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -139,9 +139,6 @@ impl App {
                 true
             }
             (TurnState::Streaming { .. }, ChunkKind::Thought) => {
-                if tab.streaming_agent_text().is_some() {
-                    return false;
-                }
                 tab.append_thought_chunk(text);
                 !text.is_empty()
             }

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -1481,53 +1481,63 @@ pub(crate) fn pending_render_text(tab: &crate::app::TabSession) -> Option<Cow<'_
                 .flatten()
                 .and_then(user_visible_stream_text)
         })
+        .or_else(|| {
+            tab.should_show_persistent_thinking()
+                .then_some(Cow::Borrowed("…"))
+        })
 }
 
 fn build_pending_stream_lines<'a>(app: &App, wrap_width: usize) -> Vec<Line<'a>> {
     let tab = app.current_tab();
-    let Some(text) = pending_render_text(tab) else {
-        return Vec::new();
-    };
-    let is_thought = tab
+    let agent_text = tab
         .streaming_agent_text()
-        .and_then(user_visible_stream_text)
-        .is_none();
-    // Typewriter smoothing: only reveal the first `reveal_chars` characters of
-    // the streaming text. The reveal cursor is advanced toward the full length
-    // by the `RevealTick` animation (`App::advance_reveal`), turning the
-    // upstream ~90-char-every-~100ms bursts into a smooth character flow. The
-    // full text is always in the ordered transcript, and finalize moves that
-    // transcript to history unchanged.
-    let revealed: Cow<'_, str> = {
+        .and_then(user_visible_stream_text);
+    let mut lines = Vec::new();
+    if let Some(text) = agent_text.as_ref() {
         let total = text.chars().count();
         let shown = tab.reveal_chars.max(1).min(total);
-        if shown >= total {
-            text
+        let revealed = if shown >= total {
+            Cow::Borrowed(text.as_ref())
         } else {
             Cow::Owned(text.chars().take(shown).collect())
-        }
-    };
-    let mut lines = Vec::new();
-    let rendered = if is_thought {
-        Cow::Owned(format!(
+        };
+        push_dot_prefixed_lines(
+            &mut lines,
+            &revealed,
+            wrap_width,
+            theme::DOT_AGENT,
+            theme::AGENT_TEXT,
+        );
+    }
+    if tab.should_show_persistent_thinking() {
+        let thought = tab
+            .streaming_thought_text()
+            .and_then(user_visible_stream_text)
+            .unwrap_or(Cow::Borrowed("…"));
+        let revealed = if agent_text.is_some() {
+            thought
+        } else {
+            let total = thought.chars().count();
+            let shown = tab.reveal_chars.max(1).min(total);
+            if shown >= total {
+                thought
+            } else {
+                Cow::Owned(thought.chars().take(shown).collect())
+            }
+        };
+        let rendered = Cow::Owned(format!(
             "{} · {}",
             t!("chat.tool_kind.think"),
             revealed.as_ref()
-        ))
-    } else {
-        revealed
-    };
-    push_dot_prefixed_lines(
-        &mut lines,
-        &rendered,
-        wrap_width,
-        theme::DOT_AGENT,
-        if is_thought {
-            theme::DIM
-        } else {
-            theme::AGENT_TEXT
-        },
-    );
+        ));
+        push_dot_prefixed_lines(
+            &mut lines,
+            &rendered,
+            wrap_width,
+            theme::DOT_AGENT,
+            theme::DIM,
+        );
+    }
     lines
 }
 

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -1476,13 +1476,13 @@ pub(crate) fn pending_render_text(tab: &crate::app::TabSession) -> Option<Cow<'_
     tab.streaming_agent_text()
         .and_then(user_visible_stream_text)
         .or_else(|| {
-            tab.should_show_streaming_thought()
+            tab.should_show_inline_thinking()
                 .then(|| tab.streaming_thought_text())
                 .flatten()
                 .and_then(user_visible_stream_text)
         })
         .or_else(|| {
-            tab.should_show_persistent_thinking()
+            tab.should_show_inline_thinking()
                 .then_some(Cow::Borrowed("…"))
         })
 }
@@ -1509,7 +1509,7 @@ fn build_pending_stream_lines<'a>(app: &App, wrap_width: usize) -> Vec<Line<'a>>
             theme::AGENT_TEXT,
         );
     }
-    if tab.should_show_persistent_thinking() {
+    if tab.should_show_inline_thinking() {
         let thought = tab
             .streaming_thought_text()
             .and_then(user_visible_stream_text)


### PR DESCRIPTION
## Summary
- keep Thinking activity visible throughout an in-flight ACP turn, including alongside streamed assistant text and tool activity
- show the latest thought when available, with `Think · …` as a stable fallback while the provider is silent
- preserve assistant reveal progress when late or oversized thought chunks arrive, and remove Thinking only when the turn ends

## Validation
- `cargo fmt --manifest-path tools/wta/Cargo.toml -- --check`
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml` (1824 passed, 1 ignored)
- `cargo build --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`