### PR TITLE
docs: document /config and /move slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,11 @@ Inside the agent pane, type `/` to see available commands. Type `/help` at any t
 |---------|-------------|
 | `/agent [id]` | Pick the agent source for this tab. In a WSL pane, the picker includes agents installed on Windows and in that pane's WSL distro; it never offers other distros. |
 | `/clear` | Clear the chat scrollback (keeps the current session) |
+| `/config` | Configure the current agent session using the options your agent exposes |
 | `/fix [hint]` | Diagnose the active terminal and suggest a fix; add an optional hint to steer it (e.g. `/fix the path looks wrong`) |
 | `/help` | Show the command list |
-| `/model [id]` | Pick the model for this pane; bare `/model` opens a picker, `/model <id>` switches directly |
+| `/model [id]` | Pick the model for this pane; bare `/model` opens a picker of your configured BYOK models, `/model <id>` switches directly |
+| `/move [position]` | Move this tab's agent pane without changing the global setting or other tabs; `/move left\|right\|up\|down` (aliases `l`/`r`/`u`/`d`) |
 | `/new` | Start a fresh agent session (drops history) |
 | `/restart` | Restart the agent with a clean session |
 | `/sessions` | Open agent management (same as <kbd>Ctrl+Shift+/</kbd>) |

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Inside the agent pane, type `/` to see available commands. Type `/help` at any t
 |---------|-------------|
 | `/agent [id]` | Pick the agent source for this tab. In a WSL pane, the picker includes agents installed on Windows and in that pane's WSL distro; it never offers other distros. |
 | `/clear` | Clear the chat scrollback (keeps the current session) |
-| `/config` | Configure the current agent session using the options your agent exposes |
+| `/config` | Configure the current agent session using the options your agent exposes. With GitHub Copilot, for example, you can set the mode (agent, plan, or autopilot), model, reasoning effort, and whether it asks for approval before using tools |
 | `/fix [hint]` | Diagnose the active terminal and suggest a fix; add an optional hint to steer it (e.g. `/fix the path looks wrong`) |
 | `/help` | Show the command list |
 | `/model [id]` | Pick the model for this pane; bare `/model` opens a picker of your configured BYOK models, `/model <id>` switches directly |


### PR DESCRIPTION
## Summary of the Pull Request

Documents the two agent-pane slash commands that shipped after the last README refresh but were never added to the Slash Commands table: `/config` and `/move`. Also tightens the `/model` description to match current behavior.

## References and Relevant Issues

Follow-up audit of README coverage against the live slash-command registry (`tools/wta/src/commands.rs`). The commands were added in #616/#663 (`/config`, ACP session config) and #599/#663 (`/move`, direction hints on tab actions); the README was last updated for v0.2 in #602.

## Detailed Description of the Pull Request / Additional comments

- **`/config`** — configure the current agent session using the options the agent exposes.
- **`/move [position]`** — reposition this tab's agent pane (`left`/`right`/`up`/`down`, aliases `l`/`r`/`u`/`d`) without changing the global pane-position setting or other tabs.
- **`/model`** — clarified that the bare picker lists your configured BYOK models (cloud/native models are managed via Settings).

Both new rows are inserted alphabetically to match the existing table order. The table now documents all 11 registered commands. No new keybindings shipped, so the hotkey table is unchanged.

## Validation Steps Performed

Docs-only change. Verified the command set and descriptions against `REGISTRY` and the `CommandKind` doc comments in `tools/wta/src/commands.rs`, and against the localized summaries in `tools/wta/locales/en-US.yml`. Reviewed rendered Markdown for table formatting.

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [x] Documentation updated
 - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)