### PR TITLE
Pin wta-master's working directory to the user profile

### DIFF
--- a/src/cascadia/TerminalApp/SharedWta.cpp
+++ b/src/cascadia/TerminalApp/SharedWta.cpp
@@ -349,6 +349,49 @@ namespace winrt::TerminalApp::implementation::details
         }
     }
 
+    // Pin wta-master to the user's profile directory.
+    //
+    // A packaged Terminal launched from the Start menu runs in
+    // C:\Windows\system32, and CreateProcess would hand that down to the
+    // master and, in turn, to every pooled agent CLI the master spawns
+    // (tools/wta/src/master/mod.rs passes `cwd: None`, i.e. "inherit"), so
+    // agents would report system32 as their working directory.
+    //
+    // This is deliberately a neutral fallback rather than any particular
+    // tab's directory. Per-session accuracy already comes from the ACP
+    // `session/new` cwd, and the agent CLI pool is shared across tabs, so a
+    // project path here would only encode whichever tab happened to start
+    // the process first. It also must not point at a project: a long-lived
+    // process holds a handle to its working directory and would block that
+    // directory from being deleted or renamed.
+    std::optional<std::wstring> ResolveMasterWorkingDirectory() noexcept
+    {
+        try
+        {
+            auto home = wil::TryGetEnvironmentVariableW<std::wstring>(L"USERPROFILE");
+            if (home.empty())
+            {
+                return std::nullopt;
+            }
+
+            // Verify it still resolves to a directory. CreateProcess fails
+            // outright on a bad lpCurrentDirectory, so a stale or redirected
+            // USERPROFILE would take the master down with it.
+            const auto attributes = ::GetFileAttributesW(home.c_str());
+            if (attributes == INVALID_FILE_ATTRIBUTES || !WI_IsFlagSet(attributes, FILE_ATTRIBUTE_DIRECTORY))
+            {
+                return std::nullopt;
+            }
+
+            return home;
+        }
+        catch (...)
+        {
+            LOG_CAUGHT_EXCEPTION();
+            return std::nullopt;
+        }
+    }
+
     bool ResumeSuspendedProcess(
         const HANDLE thread,
         const HANDLE process,
@@ -853,6 +896,10 @@ namespace winrt::TerminalApp::implementation
             return false;
         }
 
+        // See ResolveMasterWorkingDirectory: nullopt falls back to inheriting
+        // Terminal's own working directory, which is the pre-existing behavior.
+        const auto workingDirectory = details::ResolveMasterWorkingDirectory();
+
         std::wstring mutableCmdLine{ commandline };
         if (!CreateProcessW(
                 /* lpApplicationName    */ nullptr,
@@ -862,7 +909,7 @@ namespace winrt::TerminalApp::implementation
                 /* bInheritHandles      */ FALSE,
                 /* dwCreationFlags      */ creationFlags,
                 /* lpEnvironment        */ environmentBlock->empty() ? nullptr : environmentBlock->data(),
-                /* lpCurrentDirectory   */ nullptr,
+                /* lpCurrentDirectory   */ workingDirectory ? workingDirectory->c_str() : nullptr,
                 /* lpStartupInfo        */ &si,
                 /* lpProcessInformation */ &pi))
         {

--- a/src/cascadia/TerminalApp/SharedWta.h
+++ b/src/cascadia/TerminalApp/SharedWta.h
@@ -149,6 +149,11 @@ namespace winrt::TerminalApp::implementation
         std::optional<std::wstring> BuildEnvironmentBlock(
             std::span<const std::pair<std::wstring, std::wstring>> overrides) noexcept;
 
+        // The working directory to start wta-master in. nullopt means no usable
+        // directory was resolved and the caller should let CreateProcess inherit
+        // Terminal's own working directory.
+        std::optional<std::wstring> ResolveMasterWorkingDirectory() noexcept;
+
         struct SuspendedProcessOperations
         {
             DWORD(WINAPI* resumeThread)(HANDLE){ ::ResumeThread };

--- a/src/cascadia/ut_app/SharedWtaTests.cpp
+++ b/src/cascadia/ut_app/SharedWtaTests.cpp
@@ -120,6 +120,8 @@ namespace TerminalAppUnitTests
         TEST_METHOD(RejectsEqualsInEnvironmentName);
         TEST_METHOD(RejectsEmbeddedNullInEnvironmentName);
         TEST_METHOD(RejectsEmbeddedNullInEnvironmentValue);
+        TEST_METHOD(MasterWorkingDirectoryResolvesToUserProfile);
+        TEST_METHOD(MasterWorkingDirectoryIgnoresTerminalCurrentDirectory);
         TEST_METHOD(ResumeFailureCleansUpSuspendedProcess);
         TEST_METHOD(RestartWaitsForRetiredProcessBeforeContinuing);
         TEST_METHOD(RestartTimeoutTerminatesThenReapsRetiredProcess);
@@ -233,6 +235,48 @@ namespace TerminalAppUnitTests
     {
         constexpr wchar_t value[]{ L'd', L'e', L'b', L'u', L'g', L'\0', L't', L'r', L'a', L'c', L'e' };
         VERIFY_IS_FALSE(details::IsValidEnvironmentOverride(L"WTA_LOG", std::wstring_view{ value, std::size(value) }));
+    }
+
+    void SharedWtaTests::MasterWorkingDirectoryResolvesToUserProfile()
+    {
+        const auto expected = wil::TryGetEnvironmentVariableW<std::wstring>(L"USERPROFILE");
+        if (expected.empty())
+        {
+            Log::Comment(L"USERPROFILE is not set in this environment; nothing to verify.");
+            return;
+        }
+
+        const auto resolved = details::ResolveMasterWorkingDirectory();
+
+        VERIFY_IS_TRUE(resolved.has_value());
+        VERIFY_ARE_EQUAL(expected, *resolved);
+
+        const auto attributes = ::GetFileAttributesW(resolved->c_str());
+        VERIFY_ARE_NOT_EQUAL(INVALID_FILE_ATTRIBUTES, attributes);
+        VERIFY_IS_TRUE(WI_IsFlagSet(attributes, FILE_ATTRIBUTE_DIRECTORY));
+    }
+
+    void SharedWtaTests::MasterWorkingDirectoryIgnoresTerminalCurrentDirectory()
+    {
+        // A packaged Terminal launched from the Start menu runs in
+        // C:\Windows\system32. wta-master used to inherit that and hand it
+        // down to every pooled agent CLI, so agents reported system32 as
+        // their working directory regardless of the tab's profile.
+        wchar_t systemDirectory[MAX_PATH]{};
+        VERIFY_IS_TRUE(::GetSystemDirectoryW(systemDirectory, ARRAYSIZE(systemDirectory)) > 0);
+
+        wchar_t originalDirectory[MAX_PATH]{};
+        VERIFY_IS_TRUE(::GetCurrentDirectoryW(ARRAYSIZE(originalDirectory), originalDirectory) > 0);
+        const auto restoreDirectory = wil::scope_exit([&]() noexcept {
+            ::SetCurrentDirectoryW(originalDirectory);
+        });
+
+        VERIFY_IS_TRUE(::SetCurrentDirectoryW(systemDirectory));
+
+        const auto resolved = details::ResolveMasterWorkingDirectory();
+
+        VERIFY_IS_TRUE(resolved.has_value());
+        VERIFY_ARE_NOT_EQUAL(0, _wcsicmp(systemDirectory, resolved->c_str()));
     }
 
     void SharedWtaTests::ResumeFailureCleansUpSuspendedProcess()

--- a/tools/wta/src/protocol/acp/spawn.rs
+++ b/tools/wta/src/protocol/acp/spawn.rs
@@ -227,10 +227,14 @@ impl AgentSpawn {
 /// `cwd` pins the child's working directory to the user's active pane cwd so
 /// the agent's `execute_command` tool — which inherits the agent process cwd
 /// when its shell wrapper doesn't explicitly set one — starts in the user's
-/// project. None preserves the parent's cwd (probe path, where it doesn't
-/// matter). `agent_id` is authoritative when supplied by the master, so a
-/// custom command whose executable happens to match a built-in agent cannot
-/// inherit that built-in's BYOK configuration.
+/// project. `None` leaves the child on this process's own cwd. The master pool
+/// takes that path deliberately: one agent CLI is shared by every tab using the
+/// same key, so no single tab's directory is correct for it. Its cwd instead
+/// comes from wta-master, which `SharedWta::_SpawnLocked` pins to the user's
+/// profile directory. Per-session accuracy comes from the ACP `session/new`
+/// cwd, not from the process cwd. `agent_id` is authoritative when supplied by
+/// the master, so a custom command whose executable happens to match a built-in
+/// agent cannot inherit that built-in's BYOK configuration.
 pub(crate) fn spawn_agent_process(
     agent_cmd: &str,
     cwd: Option<&Path>,


### PR DESCRIPTION
## Problem

Agent panes reported `C:\Windows\system32` as their working directory, no matter which profile the tab used. Opening a fresh PowerShell 7 tab — whose profile sets `startingDirectory` to `%USERPROFILE%` — still produced an agent sitting in `system32`.

## Root cause

The working directory was inherited down a three-process chain, and nothing along it ever set one:

```
WindowsTerminal.exe          cwd = C:\Windows\system32   (packaged app launched from the Start menu)
  └─ wta --master            CreateProcessW(lpCurrentDirectory = nullptr)   -> inherits
       └─ copilot --acp      spawn(cwd: None)                               -> inherits
```

- `SharedWta::_SpawnLocked` passed `nullptr` for `lpCurrentDirectory`.
- `spawn_one_agent` passes `cwd: None`, which `spawn_agent_process_with_provider` treats as "keep the parent's directory".

Confirmed by reading `CurrentDirectory` out of the PEB of a running packaged Terminal:

```
WindowsTerminal pid=13768  cwd=C:\Windows\system32\
```

This is independent of the tab's profile, which is why a PowerShell 7 tab was affected too.

Note that only the *process* cwd was wrong. The helper pane's directory (`TerminalPage.cpp`, four-level fallback) and the ACP `session/new` cwd (derived from the helper's own `current_dir()`) were already correct — so the agent's session directory was right while the process it ran in was not.

## Fix

Resolve `%USERPROFILE%` and pass it as wta-master's working directory. The pooled agent CLIs inherit it, so one change fixes the whole chain and no Rust change is required.

If `USERPROFILE` is unset or no longer names a directory, fall back to the previous inherit-from-Terminal behavior — `CreateProcess` fails outright on a bad `lpCurrentDirectory`, so a stale or redirected value must not take the master down.

### Why a neutral directory instead of the tab's

- The agent CLI pool is keyed on agent identity, execution source, and command — **not** on cwd. One process is shared by many tabs, so a project path would only encode whichever tab happened to start it first, producing order-dependent behavior that is harder to reason about than a stable value.
- A long-lived process holds a handle to its working directory. Pointing it at a project would block that folder from being deleted or renamed.
- Per-session accuracy already comes from the ACP `session/new` cwd. The process cwd is only the fallback for anything without session context, so it should be stable and neutral.
- `%USERPROFILE%` is already Windows Terminal's own `DEFAULT_STARTING_DIRECTORY` (`src/inc/DefaultSettings.h`), used by the built-in profiles and the PowerShell, WSL, and Azure generators.

## Changes

- `SharedWta.h` / `SharedWta.cpp`: add `details::ResolveMasterWorkingDirectory()` and pass it to `CreateProcessW`.
- `ut_app/SharedWtaTests.cpp`: two tests, one asserting the resolved value is the user profile and an existing directory, one that sets the current directory to `system32` to reproduce the reported scenario and asserts the result no longer follows it.
- `spawn.rs`: update the `cwd` doc comment, whose "probe path, where it doesn't matter" description of `None` no longer covers the master pool.

## Validation

- `bx` in `src/cascadia/TerminalApp` — 0 errors.
- `bx` in `src/cascadia/ut_app` — 0 errors.
- `TE.exe Terminal.App.Unit.Tests.dll /name:*SharedWtaTests*` — **34/34 passed**, including the two new cases.
- `cargo fmt --check` — clean.
