### PR TITLE
Fix /sessions resume: keep the pane and un-suppress the status fallback

### DIFF
--- a/doc/specs/hybrid-agent-session-tracking.md
+++ b/doc/specs/hybrid-agent-session-tracking.md
@@ -153,9 +153,19 @@ The master keeps **two disjoint** ownership sets (`master/mod.rs`):
 
 `handle_session_hook` routes each inbound event: a binding-only event (the
 dedicated `intellterm.wta/session_born_bound` method, or a
-`ResumeDispatched`/`ResumePaneAssigned` resume-binding event) → `born_bound`;
-anything else (a real hook / ACP event) → `hook_owned` (and, if the session was
-born-bound, drops it from `born_bound` — a real hook **takes over**).
+`ResumeDispatched`/`ResumePaneAssigned` resume-binding event) → `born_bound`
+(and drops any stale `hook_owned` claim — see below); anything else (a real
+hook / ACP event) → `hook_owned` (and, if the session was born-bound, drops it
+from `born_bound` — a real hook **takes over**).
+
+The two sets are disjoint **in both directions**. A born-bound event means WTA
+has just (re)launched that session id, so an ownership claim left by an earlier
+generation of the same id is over. Without the reverse removal, resuming a
+session that had already run once in the same master process left it in
+`hook_owned` forever; since `apply_watcher_event` checks `hook_owned` first,
+every watcher status event for the resumed row was dropped and the row sat at
+`Idle` for its whole life. A real hook re-claims ownership on its very next
+event, so nothing is lost when hooks are working.
 
 `apply_watcher_event` then, in order:
 

--- a/doc/specs/hybrid-agent-session-tracking.md
+++ b/doc/specs/hybrid-agent-session-tracking.md
@@ -195,6 +195,21 @@ the hook-free resume binding, so `handle_session_hook` records them in
 treated as hook-owned and its row would sit at `Idle` forever even as the watcher
 saw activity.
 
+**Resume pane ownership.** `ResumePaneAssigned` marks the row's pane binding
+`born_bound_pane` (`session_registry.rs`). WTA creates the resume pane and binds
+it *before* the agent CLI starts, so that pane belongs to exactly one session
+id. Copilot's `--resume` boots a throwaway bootstrap session and only switches
+to the requested one seconds later, so its deferred `SessionStart` hook reports
+the **bootstrap** id against the resumed pane's GUID. Master's `SessionStarted`
+reducer therefore refuses the `active_by_pane` handoff when the pane's current
+owner is a live born-bound row with a different key: the incoming session is
+still recorded, it just gets no pane binding. Without the guard the resumed row
+was demoted to `Ended`, and because terminal-state rows refuse resurrection it
+stayed there for the rest of the CLI's life — the watcher's status fallback
+silently dropped every event. The flag clears itself whenever the row gives up
+the pane (`SessionStopped`, `PaneClosed`, `end_entry`) or once a `SessionStarted`
+for the *same* key claims it, so the protection needs no timer.
+
 ### Liveness gate: scoping to this IT window
 
 The four CLIs write their session state to **per-user** roots, so the watcher

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -6149,7 +6149,15 @@ async fn handle_session_hook(
     //
     //  * binding-only (#266 delegate born-bound + resume binding events): record
     //    in `born_bound` so the watcher may still supply STATUS when no real hook
-    //    is installed — without re-binding the pane.
+    //    is installed — without re-binding the pane. Also drop any **stale**
+    //    `hook_owned` claim: the two sets are disjoint by contract, and a
+    //    born-bound event means WTA has just (re)launched this session id, so an
+    //    ownership claim left by a previous generation of the same session is
+    //    over. Without this a `/sessions` resume of a session that ran earlier
+    //    in the same master process stayed `hook_owned` forever, and because
+    //    `apply_watcher_event` checks `hook_owned` first, every watcher status
+    //    event for the resumed row was dropped — the row sat at Idle for the
+    //    whole session. A real hook re-claims ownership on its very next event.
     //  * real hook / ACP agent-pane event: authoritative for binding AND
     //    activity. Record in `hook_owned` (full watcher suppression) and, if the
     //    session was previously born-bound, drop it from `born_bound` — the real
@@ -6157,6 +6165,7 @@ async fn handle_session_hook(
     if let Some(key) = &refresh_key {
         let sid = acp::schema::v1::SessionId::new(key.clone());
         if binding_only {
+            state.hook_owned.lock().await.remove(&sid);
             state.born_bound.lock().await.insert(sid);
         } else {
             state.hook_owned.lock().await.insert(sid.clone());

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -10395,3 +10395,76 @@ async fn resume_binding_events_are_born_bound_not_hook_owned() {
     );
     assert!(!state.hook_owned.lock().await.contains(&sid));
 }
+
+#[tokio::test]
+async fn resume_binding_events_clear_a_stale_hook_ownership_claim() {
+    // Regression: resuming a session that already ran once in THIS master
+    // process. The earlier run's hooks put the id in `hook_owned`, and
+    // `hook_owned` used to be sticky — the resume added `born_bound` but left
+    // the stale claim in place, so `apply_watcher_event`'s first check dropped
+    // every watcher status event and the resumed row sat at Idle for its whole
+    // life. The two sets are disjoint by contract; a born-bound event means WTA
+    // just relaunched the id, so the previous generation's claim is over.
+    let state = make_state();
+    let sid = acp::schema::v1::SessionId::new("sid-rerun".to_string());
+
+    let first_run = crate::agent_sessions::SessionEvent::SessionStarted {
+        key: "sid-rerun".to_string(),
+        cli_source: crate::agent_sessions::CliSource::Copilot,
+        pane_session_id: "pane-old".to_string(),
+        cwd: std::path::PathBuf::from("C:\\repo"),
+        title: String::new(),
+    };
+    handle_session_hook(&state, first_run, false)
+        .await
+        .expect("real hook accepted");
+    assert!(state.hook_owned.lock().await.contains(&sid));
+
+    let dispatched = crate::agent_sessions::SessionEvent::ResumeDispatched {
+        key: "sid-rerun".to_string(),
+    };
+    handle_session_hook(&state, dispatched, false)
+        .await
+        .expect("resume dispatched accepted");
+
+    assert!(
+        !state.hook_owned.lock().await.contains(&sid),
+        "the resume must drop the previous run's hook_owned claim, or the \
+         watcher's status fallback stays suppressed for the whole session"
+    );
+    assert!(
+        state.born_bound.lock().await.contains(&sid),
+        "the resumed session is born-bound"
+    );
+}
+
+#[tokio::test]
+async fn born_bound_delegate_clears_a_stale_hook_ownership_claim() {
+    // Same invariant for the dedicated born-bound method (`?<prompt>`
+    // delegation), which reaches `handle_session_hook` with is_born_bound=true.
+    let state = make_state();
+    let sid = acp::schema::v1::SessionId::new("sid-delegate".to_string());
+
+    let earlier = crate::agent_sessions::SessionEvent::ToolStarting {
+        key: "sid-delegate".to_string(),
+        tool_name: "Bash".to_string(),
+    };
+    handle_session_hook(&state, earlier, false)
+        .await
+        .expect("real hook accepted");
+    assert!(state.hook_owned.lock().await.contains(&sid));
+
+    let born = crate::agent_sessions::SessionEvent::SessionStarted {
+        key: "sid-delegate".to_string(),
+        cli_source: crate::agent_sessions::CliSource::Copilot,
+        pane_session_id: "pane-new".to_string(),
+        cwd: std::path::PathBuf::from("C:\\repo"),
+        title: String::new(),
+    };
+    handle_session_hook(&state, born, true)
+        .await
+        .expect("born-bound accepted");
+
+    assert!(!state.hook_owned.lock().await.contains(&sid));
+    assert!(state.born_bound.lock().await.contains(&sid));
+}

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -1036,6 +1036,25 @@ pub struct SessionInfo {
     /// `SessionInfo` directly.
     #[serde(skip)]
     pub bound_pid: Option<u32>,
+    /// True while this row's pane binding was established by WTA itself
+    /// (`/sessions` resume → `ResumePaneAssigned`) rather than by a hook.
+    ///
+    /// WTA creates the resume pane and binds it *before* the agent CLI even
+    /// starts, so the binding is authoritative: for that pane, only this
+    /// session id may claim ownership. The flag exists because Copilot's
+    /// `--resume` boots a throwaway bootstrap session first and only switches
+    /// to the requested one seconds later; its `SessionStart` hook therefore
+    /// arrives carrying the *bootstrap* id together with the resumed pane's
+    /// GUID. Honouring that handoff ends the resumed row, and terminal-state
+    /// rows refuse resurrection, so the row stays `Ended` for the rest of its
+    /// life while the CLI keeps running. See
+    /// [`apply_event_locked`]'s `SessionStarted` arm.
+    ///
+    /// Cleared whenever the row gives up the pane (ended, pane closed,
+    /// rebound), so the protection releases itself without a timer.
+    /// Master-internal — never serialized, exactly like [`Self::bound_pid`].
+    #[serde(skip)]
+    pub born_bound_pane: bool,
 }
 
 impl SessionInfo {
@@ -1057,6 +1076,7 @@ impl SessionInfo {
             last_error: None,
             location: crate::agent_sessions::SessionLocation::Host,
             bound_pid: None,
+            born_bound_pane: false,
         }
     }
 
@@ -1103,6 +1123,9 @@ pub fn agent_session_to_session_info(s: &AgentSession) -> SessionInfo {
         // History-scan / helper-sourced rows have no bound pid; only the
         // file watcher's bind step populates it.
         bound_pid: None,
+        // Master-internal: only master's own `ResumePaneAssigned` reducer
+        // marks a pane binding as WTA-owned.
+        born_bound_pane: false,
     }
 }
 
@@ -1438,6 +1461,7 @@ fn end_entry(state: &mut RegistryState, sid: &acp::schema::v1::SessionId, now: u
     if let Some(pane) = entry.pane_session_id.take() {
         state.active_by_pane.remove(&pane_key(&pane));
     }
+    entry.born_bound_pane = false;
     entry.current_tool = None;
     entry.attention_reason = None;
     entry.last_activity_at_ms = Some(now);
@@ -1542,6 +1566,31 @@ fn apply_event_locked(state: &mut RegistryState, ev: SessionEvent) -> bool {
                 return true;
             }
 
+            // A pane that WTA bound itself during `/sessions` resume belongs to
+            // exactly one session id: the one the user asked to resume. Copilot's
+            // `--resume` boots a throwaway bootstrap session first and only
+            // switches to the requested one seconds later, so its (deferred)
+            // SessionStart hook reports the *bootstrap* id against the resumed
+            // pane's GUID. Taking the handoff would end the resumed row, and
+            // terminal-state rows refuse resurrection, so the row would sit at
+            // Ended for the rest of the CLI's life while the watcher's status
+            // fallback is silently dropped. Require the hook's session id to
+            // match the pane's born-bound owner; a mismatch still records the
+            // session, it just gets no pane binding.
+            let pane_owned_by_other_born_bound = state
+                .active_by_pane
+                .get(&pane_session_id)
+                .filter(|prev_sid| **prev_sid != sid)
+                .and_then(|prev_sid| state.sessions.get(prev_sid))
+                .is_some_and(|prev| {
+                    prev.born_bound_pane
+                        && matches!(
+                            prev.status,
+                            Some(AgentStatus::Idle | AgentStatus::Working | AgentStatus::Attention)
+                        )
+                });
+            let pane_known = pane_known && !pane_owned_by_other_born_bound;
+
             if pane_known {
                 if let Some(prev_sid) = state.active_by_pane.get(&pane_session_id).cloned() {
                     if prev_sid != sid {
@@ -1595,6 +1644,10 @@ fn apply_event_locked(state: &mut RegistryState, ev: SessionEvent) -> bool {
             } else {
                 entry.pane_session_id = None;
             }
+            // The CLI's own hook has now claimed (or disclaimed) this pane, so
+            // the WTA-owned resume binding no longer needs protecting: a later
+            // session started in the same pane may take over normally.
+            entry.born_bound_pane = false;
             true
         }
         SessionEvent::ToolStarting { key, tool_name } => {
@@ -1693,6 +1746,7 @@ fn apply_event_locked(state: &mut RegistryState, ev: SessionEvent) -> bool {
                 if let Some(pane) = entry.pane_session_id.take() {
                     state.active_by_pane.remove(&pane_key(&pane));
                 }
+                entry.born_bound_pane = false;
             }
             entry.current_tool = None;
             entry.attention_reason = None;
@@ -1708,6 +1762,7 @@ fn apply_event_locked(state: &mut RegistryState, ev: SessionEvent) -> bool {
             };
             entry.status = Some(AgentStatus::Ended);
             entry.pane_session_id = None;
+            entry.born_bound_pane = false;
             entry.current_tool = None;
             entry.attention_reason = None;
             entry.last_activity_at_ms = Some(now);
@@ -1766,6 +1821,10 @@ fn apply_event_locked(state: &mut RegistryState, ev: SessionEvent) -> bool {
             }
             entry.pane_session_id = Some(pane_session_id.clone());
             entry.last_activity_at_ms = Some(now);
+            // WTA created this pane and bound it before the agent CLI started,
+            // so until the CLI's own hook confirms the binding, no other
+            // session id may claim the pane. See `born_bound_pane`.
+            entry.born_bound_pane = true;
             state.active_by_pane.insert(pane_session_id, sid);
             true
         }
@@ -2487,6 +2546,7 @@ mod tests {
             last_error: Some("previous failure".into()),
             location: crate::agent_sessions::SessionLocation::Host,
             bound_pid: None,
+            born_bound_pane: false,
         };
 
         let json = serde_json::to_string(&row).expect("serialize SessionInfo");
@@ -2555,6 +2615,7 @@ mod tests {
             last_error: None,
             location: crate::agent_sessions::SessionLocation::Host,
             bound_pid: None,
+            born_bound_pane: false,
         };
         let raw = build_sessions_list_response(vec![row.clone()]);
         let parsed = parse_sessions_list_response(&raw).expect("response parses");
@@ -2855,6 +2916,7 @@ mod tests {
             last_error: None,
             location: crate::agent_sessions::SessionLocation::Host,
             bound_pid: None,
+            born_bound_pane: false,
         })
         .await;
         reg.apply_event(crate::agent_sessions::SessionEvent::ResumeDispatched {
@@ -2876,6 +2938,167 @@ mod tests {
         assert!(changed);
         assert_eq!(row.status, Some(crate::agent_sessions::AgentStatus::Idle));
         assert_eq!(row.pane_session_id.as_deref(), Some("new-pane"));
+    }
+
+    /// Seed a `/sessions` resume: a historical row promoted to Idle and bound
+    /// to a freshly-spawned pane by WTA itself, before the CLI has started.
+    async fn seed_resumed_pane(reg: &InMemoryRegistry, key: &str, pane: &str) {
+        let mut info = SessionInfo::new(
+            acp::schema::v1::SessionId::new(key.to_string()),
+            PathBuf::from("C:\\x"),
+        );
+        info.status = Some(crate::agent_sessions::AgentStatus::Historical);
+        info.cli_source = Some(crate::agent_sessions::CliSource::Copilot);
+        reg.upsert(info).await;
+        reg.apply_event(crate::agent_sessions::SessionEvent::ResumeDispatched { key: key.into() })
+            .await;
+        reg.apply_event(crate::agent_sessions::SessionEvent::ResumePaneAssigned {
+            key: key.into(),
+            pane_session_id: pane.into(),
+        })
+        .await;
+    }
+
+    /// Regression: Copilot's `--resume` boots a throwaway bootstrap session and
+    /// only switches to the requested one seconds later, so the SessionStart
+    /// hook reports the bootstrap id against the resumed pane's GUID. That must
+    /// not evict the resumed row — doing so ended it permanently, because
+    /// terminal-state rows refuse resurrection.
+    #[tokio::test]
+    async fn master_reducer_foreign_session_start_cannot_steal_a_resumed_pane() {
+        let reg = InMemoryRegistry::new();
+        seed_resumed_pane(&reg, "resumed", "pane-1").await;
+
+        reg.apply_event(crate::agent_sessions::SessionEvent::SessionStarted {
+            key: "bootstrap".into(),
+            cli_source: crate::agent_sessions::CliSource::Copilot,
+            pane_session_id: "pane-1".into(),
+            cwd: PathBuf::from("C:\\x"),
+            title: "t".into(),
+        })
+        .await;
+
+        let resumed = reg
+            .lookup(&acp::schema::v1::SessionId::new("resumed"))
+            .await
+            .unwrap();
+        assert_eq!(
+            resumed.status,
+            Some(crate::agent_sessions::AgentStatus::Idle),
+            "the resumed row must survive a foreign session start on its pane"
+        );
+        assert_eq!(resumed.pane_session_id.as_deref(), Some("pane-1"));
+
+        let bootstrap = reg
+            .lookup(&acp::schema::v1::SessionId::new("bootstrap"))
+            .await
+            .unwrap();
+        assert!(
+            bootstrap.pane_session_id.is_none(),
+            "the bootstrap session is still recorded, just never bound to the pane"
+        );
+    }
+
+    /// The point of keeping the row live: the hookless watcher's status
+    /// fallback still reaches it. An Ended row would drop the event.
+    #[tokio::test]
+    async fn master_reducer_resumed_row_still_takes_status_after_foreign_session_start() {
+        let reg = InMemoryRegistry::new();
+        seed_resumed_pane(&reg, "resumed", "pane-1").await;
+        reg.apply_event(crate::agent_sessions::SessionEvent::SessionStarted {
+            key: "bootstrap".into(),
+            cli_source: crate::agent_sessions::CliSource::Copilot,
+            pane_session_id: "pane-1".into(),
+            cwd: PathBuf::from("C:\\x"),
+            title: "t".into(),
+        })
+        .await;
+
+        let changed = reg
+            .apply_event(crate::agent_sessions::SessionEvent::ToolStarting {
+                key: "resumed".into(),
+                tool_name: "shell".into(),
+            })
+            .await;
+        let resumed = reg
+            .lookup(&acp::schema::v1::SessionId::new("resumed"))
+            .await
+            .unwrap();
+
+        assert!(changed);
+        assert_eq!(
+            resumed.status,
+            Some(crate::agent_sessions::AgentStatus::Working)
+        );
+    }
+
+    /// The guard releases itself: once the CLI's own hook claims the pane for
+    /// the resumed id, a genuinely new session in that pane takes over as
+    /// before.
+    #[tokio::test]
+    async fn master_reducer_own_session_start_releases_the_resumed_pane_guard() {
+        let reg = InMemoryRegistry::new();
+        seed_resumed_pane(&reg, "resumed", "pane-1").await;
+        reg.apply_event(crate::agent_sessions::SessionEvent::SessionStarted {
+            key: "resumed".into(),
+            cli_source: crate::agent_sessions::CliSource::Copilot,
+            pane_session_id: "pane-1".into(),
+            cwd: PathBuf::from("C:\\x"),
+            title: "t".into(),
+        })
+        .await;
+
+        reg.apply_event(crate::agent_sessions::SessionEvent::SessionStarted {
+            key: "typed-later".into(),
+            cli_source: crate::agent_sessions::CliSource::Copilot,
+            pane_session_id: "pane-1".into(),
+            cwd: PathBuf::from("C:\\x"),
+            title: "t".into(),
+        })
+        .await;
+
+        let resumed = reg
+            .lookup(&acp::schema::v1::SessionId::new("resumed"))
+            .await
+            .unwrap();
+        let typed = reg
+            .lookup(&acp::schema::v1::SessionId::new("typed-later"))
+            .await
+            .unwrap();
+        assert_eq!(
+            resumed.status,
+            Some(crate::agent_sessions::AgentStatus::Ended)
+        );
+        assert!(resumed.pane_session_id.is_none());
+        assert_eq!(typed.pane_session_id.as_deref(), Some("pane-1"));
+    }
+
+    /// The other release path: the resumed session exits (`/exit` → SessionEnd
+    /// hook), so the next session started in that pane binds normally.
+    #[tokio::test]
+    async fn master_reducer_session_stopped_releases_the_resumed_pane_guard() {
+        let reg = InMemoryRegistry::new();
+        seed_resumed_pane(&reg, "resumed", "pane-1").await;
+        reg.apply_event(crate::agent_sessions::SessionEvent::SessionStopped {
+            key: "resumed".into(),
+            reason: "user_exit".into(),
+        })
+        .await;
+
+        reg.apply_event(crate::agent_sessions::SessionEvent::SessionStarted {
+            key: "typed-later".into(),
+            cli_source: crate::agent_sessions::CliSource::Copilot,
+            pane_session_id: "pane-1".into(),
+            cwd: PathBuf::from("C:\\x"),
+            title: "t".into(),
+        })
+        .await;
+
+        let typed = reg
+            .lookup(&acp::schema::v1::SessionId::new("typed-later"))
+            .await
+            .unwrap();
+        assert_eq!(typed.pane_session_id.as_deref(), Some("pane-1"));
     }
 
     // ─── Task C sessions/list + sessions/changed schemas ───────────

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -1580,12 +1580,12 @@ fn apply_event_locked(state: &mut RegistryState, ev: SessionEvent) -> bool {
             let pane_owned_by_other_born_bound = state
                 .active_by_pane
                 .get(&pane_session_id)
-                .filter(|prev_sid| **prev_sid != sid)
-                .and_then(|prev_sid| state.sessions.get(prev_sid))
-                .is_some_and(|prev| {
-                    prev.born_bound_pane
+                .filter(|owner_sid| **owner_sid != sid)
+                .and_then(|owner_sid| state.sessions.get(owner_sid))
+                .is_some_and(|owner| {
+                    owner.born_bound_pane
                         && matches!(
-                            prev.status,
+                            owner.status,
                             Some(AgentStatus::Idle | AgentStatus::Working | AgentStatus::Attention)
                         )
                 });


### PR DESCRIPTION
Two related fixes for `/sessions` resume, both verified live. Symptom: a
resumed Copilot session's row went `Ended` and never recovered, or stayed at
`Idle` forever while the CLI was clearly working.

## Root cause: Copilot's bootstrap session

`copilot --resume <id>` starts the TUI immediately, but the TUI needs a
foreground session to render. So Copilot allocates a **throwaway session id**,
boots on it, and swaps in the requested one once it finishes loading:

```
09:10:37.505  Workspace initialized: 0c495b37-…          <- bootstrap
09:10:37.532  Starting Copilot CLI: 1.0.82
09:10:37.567  Registering foreground session: 0c495b37-…
      … 15 s of MCP startup / plugin reconciliation …
09:10:52.201  Workspace initialized: dcd1de24-…          <- the requested one
09:10:52.336  Unregistering foreground session: 0c495b37-…
09:10:52.356  Registering foreground session: dcd1de24-…
```

The bootstrap id is never persisted — there is no
`~/.copilot/session-state/0c495b37-…/`. Copilot's `SessionStart` hook is
deferred until `loadDeferredRepoHooks` and plugin reconciliation finish, so it
fires *after* the swap, carrying `COPILOT_SESSION_ID=<bootstrap>` together with
the resumed pane's `WT_SESSION`.

It looks intermittent because it is a race. When the target loads before the
TUI boots there is no bootstrap session at all and the same gesture works:

```
08:51:00.168  Workspace initialized: 259c8fb9-…          <- target first
08:51:00.249  Starting Copilot CLI: 1.0.82
08:51:00.273  Registering foreground session: 259c8fb9-…
```

The failing run spent 15 s on MCP startup, the working one 1.4 s. Across the
master log, 6 of 11 distinct hook-reported Copilot session ids had no on-disk
workspace, so bootstrap sessions are common rather than exotic.

## Fix 1 — keep a resumed pane bound to the session the user resumed

`/sessions` resume creates the pane and binds it through `ResumePaneAssigned`
*before* the agent CLI starts, so that pane belongs to exactly one session id.
Master's `active_by_pane` handoff took the bootstrap hook at face value and
called `end_entry` on the resumed row. Because `ToolStarting` / `ToolCompleted`
refuse to resurrect terminal-state rows (an intentional guard against
straggling hooks), every later status event was then dropped — the row was
stuck at `Ended` for the rest of the CLI's life.

Mark such a binding `born_bound_pane` and refuse the handoff when the pane's
current owner is a **live** born-bound row with a different key. The incoming
session is still recorded, it just gets no pane binding — mirroring the
existing `is_protected_agent_pane` guard a few lines above.

The flag releases itself, so no timer is involved:

| Event | Effect |
| --- | --- |
| `SessionStopped` (`/exit` → SessionEnd hook) | clears flag, releases pane |
| `PaneClosed` / `end_entry` | same |
| `SessionStarted` for the **same** key | clears flag — the CLI confirmed the binding, so later sessions in that pane take over normally |
| row reaches `Ended` / `Historical` / `Error` | status check stops protecting |

Exiting the resumed CLI and typing `copilot` again in the same pane therefore
still rebinds exactly as before.

`born_bound_pane` is `#[serde(skip)]` and master-internal, like the
neighbouring `bound_pid`; it never reaches a `sessions/list` response.

## Fix 2 — drop a stale `hook_owned` claim when a session is born-bound again

`hook_owned` was sticky: once a session id landed there it stayed for the
lifetime of the master process. `handle_session_hook` removed a session from
`born_bound` when a real hook arrived, but never did the reverse.

So resuming a session that had already run once in the same master process
added `born_bound` while the old claim remained. Since `apply_watcher_event`
checks `hook_owned` **first**, every watcher status event for the resumed row
was dropped, and the row sat at `Idle` for its whole life.

That combination is easy to hit precisely because of the bootstrap session: it
consumes the `SessionStart` hook, so the resumed id never emits another hook
and the watcher is the only remaining status producer — and it was suppressed.

Restore the documented disjointness by removing the id from `hook_owned` on the
binding-only path. A born-bound event means WTA has just relaunched that id, so
the previous generation's claim is over, and a real hook re-claims ownership on
its very next event.

## Live verification

Session `ad907a19-…` resumed from `/sessions`, master started `07:13:18`, so
everything below is one master lifetime.

**Setup — the session was hook-owned before the resume:**

```
07:25:40  session_hook: SessionStarted / ToolStarting
07:25:53  session_hook: Notification
07:27:05  session_hook: ToolCompleted
07:27:10  session_hook: SessionStopped          -> hook_owned contains ad907a19
07:28:11  session_hook: ResumeDispatched        -> fix 2: hook_owned.remove()
07:28:12  session_hook: ResumePaneAssigned { pane FB59B7C1-… }
07:28:30  session_hook: SessionStarted { dca801a5-…, pane FB59B7C1-… }  x4   <- bootstrap, same pane
07:28:30  session_hook: SessionStopped { dca801a5-…, user_exit }        x4
```

**Fix 1 —** `dca801a5` has no on-disk workspace and did not take the pane;
`ad907a19` stayed live and kept working until its pane closed at `07:35`.
Before the fix this row went `Ended` with `pane = -`.

**Fix 2 —** after the resume `ad907a19` received **no further hook events**
(the bootstrap consumed `SessionStart`), so the watcher was the only status
producer. Transcript records and master broadcasts line up one-to-one:

| `events.jsonl` record | master `sessions/changed` | status |
| --- | --- | --- |
| `07:29:08` `assistant.turn_start` | `07:29:08.719` | → Working |
| `07:29:25` `tool.execution_start` | `07:29:25.742` | → Working |
| `07:35:08` `tool.execution_complete` + `turn_end` + `turn_start` | `07:35:09.053` | → Idle → Working |
| `07:35:11` `assistant.turn_end` | `07:35:11.278` | → Idle |

There are **zero inbound hook events** in that window — every update came from
the watcher's born-bound branch. Before the fix master broadcast nothing at all
here. The `07:30`–`07:34` silence is correct: one tool ran from `07:29:25` to
`07:35:08`, so the transcript had no records in between.

## Tests

`session_registry::tests` (fix 1):

- `master_reducer_foreign_session_start_cannot_steal_a_resumed_pane` — the regression itself
- `master_reducer_resumed_row_still_takes_status_after_foreign_session_start` — proves the watcher fallback still lands, which is the symptom users actually saw
- `master_reducer_own_session_start_releases_the_resumed_pane_guard`
- `master_reducer_session_stopped_releases_the_resumed_pane_guard`

`master::tests` (fix 2):

- `resume_binding_events_clear_a_stale_hook_ownership_claim`
- `born_bound_delegate_clears_a_stale_hook_ownership_claim`

```
cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml
test result: ok. 1828 passed; 0 failed; 1 ignored
cargo fmt --check  -> clean
```

## Scope

`wta.exe`-only; no C++, packaging, or protocol changes. Spec updated in
`doc/specs/hybrid-agent-session-tracking.md`.

## Known, not addressed here

**Ghost rows can outlive their session.** `sync_host_history` prunes terminal
Class-B host rows from `listed_ever ∖ listed_ids`, and `listed_ever` only grows
from real `session/list` output. A bootstrap id the agent never listed is
therefore never prunable and stays in the picker as an `Ended` row titled by
cwd basename. Whether it gets cleaned up is luck — in the run above
`dca801a5` happened to be listed once and was dropped two seconds later:

```
07:28:32  reconcile: dropped host row no longer in session/list key=dca801a5-… cli=Some(Copilot)
```

while an earlier `f7b62077-…` was never listed and is still in the list.
Fixing it needs `is_stale_host_history_row` to compare `location` as well as
`cli_source` first — today `listed_ever` is the only thing stopping a WSL
Copilot agent and a host Copilot agent from pruning each other's rows.

**Duplicate hook registrations.** The bootstrap hooks arrived 4x duplicated
(`hookCount=10` for the bootstrap session vs `5` for the real one), i.e.
`wt-agent-hooks` is registered more than once. Separate from this fix.
