### PR TITLE
Restore terminal transparency and simplify agent separators

### DIFF
--- a/src/cascadia/TerminalApp/AgentPaneContent.cpp
+++ b/src/cascadia/TerminalApp/AgentPaneContent.cpp
@@ -313,7 +313,7 @@ namespace winrt::TerminalApp::implementation
 
     // Apply the supplied colors to the agent-pane top bar (#348). The vector
     // logo paths bind to the label's foreground, so both take the same tint.
-    // The bottom border uses the tab row's theme-aware background resource.
+    // The bottom border uses the TabViewBackground theme resource.
     void AgentPaneContent::ApplyThemeColors(const Media::Brush& background,
                                             const Media::Brush& foreground)
     {

--- a/src/cascadia/TerminalApp/AgentPaneContent.cpp
+++ b/src/cascadia/TerminalApp/AgentPaneContent.cpp
@@ -313,25 +313,13 @@ namespace winrt::TerminalApp::implementation
 
     // Apply the supplied colors to the agent-pane top bar (#348). The vector
     // logo paths bind to the label's foreground, so both take the same tint.
-    // The 1px bottom hairline uses the foreground color at ~15% alpha, so it
-    // reads as a soft separator (like the original #26FFFFFF) — consistent
-    // with the text but not a hard full-white/black line.
+    // The bottom border stays aligned with WTA's fixed input-box border color.
     void AgentPaneContent::ApplyThemeColors(const Media::Brush& background,
                                             const Media::Brush& foreground)
     {
         if (const auto barRoot = AgentBarRoot())
         {
             barRoot.Background(background);
-            if (const auto fgSolid = foreground.try_as<Media::SolidColorBrush>())
-            {
-                auto c = fgSolid.Color();
-                c.A = 0x26;
-                barRoot.BorderBrush(Media::SolidColorBrush{ c });
-            }
-            else
-            {
-                barRoot.BorderBrush(foreground);
-            }
         }
         if (const auto label = AgentLabelText())
         {

--- a/src/cascadia/TerminalApp/AgentPaneContent.cpp
+++ b/src/cascadia/TerminalApp/AgentPaneContent.cpp
@@ -313,7 +313,7 @@ namespace winrt::TerminalApp::implementation
 
     // Apply the supplied colors to the agent-pane top bar (#348). The vector
     // logo paths bind to the label's foreground, so both take the same tint.
-    // The bottom border stays aligned with WTA's fixed input-box border color.
+    // The bottom border uses the tab row's theme-aware background resource.
     void AgentPaneContent::ApplyThemeColors(const Media::Brush& background,
                                             const Media::Brush& foreground)
     {

--- a/src/cascadia/TerminalApp/AgentPaneContent.xaml
+++ b/src/cascadia/TerminalApp/AgentPaneContent.xaml
@@ -24,7 +24,7 @@
                 Grid.Row="0"
                 Height="36"
                 Background="#FF000000"
-                BorderBrush="{StaticResource AgentChromeBorderBrush}"
+                BorderBrush="{ThemeResource TabViewBackground}"
                 BorderThickness="0,0,0,1">
             <Grid Padding="10,0,0,0">
                 <!--  Left cluster: logo + label. History and other actions

--- a/src/cascadia/TerminalApp/AgentPaneContent.xaml
+++ b/src/cascadia/TerminalApp/AgentPaneContent.xaml
@@ -16,7 +16,7 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <!--  ========= Agent bar (Figma: 36px tall, 1px bottom hairline) =========
+        <!--  ========= Agent bar (36px tall, 1px bottom border) =========
               Only a bottom hairline: the top edge sits against the terminal
               pane / focused-pane border above, which already provides the
               separation, so a top border would double it up (#348).  -->
@@ -24,7 +24,7 @@
                 Grid.Row="0"
                 Height="36"
                 Background="#FF000000"
-                BorderBrush="#26FFFFFF"
+                BorderBrush="#FF323232"
                 BorderThickness="0,0,0,1">
             <Grid Padding="10,0,0,0">
                 <!--  Left cluster: logo + label. History and other actions

--- a/src/cascadia/TerminalApp/AgentPaneContent.xaml
+++ b/src/cascadia/TerminalApp/AgentPaneContent.xaml
@@ -24,7 +24,7 @@
                 Grid.Row="0"
                 Height="36"
                 Background="#FF000000"
-                BorderBrush="#FF323232"
+                BorderBrush="{StaticResource AgentChromeBorderBrush}"
                 BorderThickness="0,0,0,1">
             <Grid Padding="10,0,0,0">
                 <!--  Left cluster: logo + label. History and other actions

--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -22,6 +22,8 @@
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls"
                                        ControlsResourcesVersion="Version2" />
                 <ResourceDictionary>
+                    <SolidColorBrush x:Key="AgentChromeBorderBrush"
+                                     Color="#FF323232" />
 
                     <!--
                         We're going to apply this style to the root Grid acting

--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -22,8 +22,6 @@
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls"
                                        ControlsResourcesVersion="Version2" />
                 <ResourceDictionary>
-                    <SolidColorBrush x:Key="AgentChromeBorderBrush"
-                                     Color="#FF323232" />
 
                     <!--
                         We're going to apply this style to the root Grid acting

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4607,9 +4607,6 @@ namespace winrt::TerminalApp::implementation
         Grid::SetColumn(InfoBarsPanel(), 1);
         Grid::SetColumnSpan(InfoBarsPanel(), 1);
 
-        Grid::SetColumn(TabContentFiller(), 1);
-        Grid::SetColumnSpan(TabContentFiller(), 1);
-
         Grid::SetColumn(_tabContent, 1);
         Grid::SetColumnSpan(_tabContent, 1);
 

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -93,7 +93,7 @@
              window chrome, but its state reflects the *active tab*'s agent
              pane (toggle lit when active tab has an AgentPaneContent,
              diagnostics from the active tab's autofix state, etc.).
-             The top border uses the tab row's theme-aware background color. -->
+             The top border uses the TabViewBackground theme resource. -->
         <Border x:Name="BottomBarRoot"
                 Grid.Row="3"
                 Grid.ColumnSpan="2"

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -93,12 +93,12 @@
              window chrome, but its state reflects the *active tab*'s agent
              pane (toggle lit when active tab has an AgentPaneContent,
              diagnostics from the active tab's autofix state, etc.).
-             The top border shares the WTA input-box border color. -->
+             The top border uses the tab row's theme-aware background color. -->
         <Border x:Name="BottomBarRoot"
                 Grid.Row="3"
                 Grid.ColumnSpan="2"
                 Background="#000000"
-                BorderBrush="{StaticResource AgentChromeBorderBrush}"
+                BorderBrush="{ThemeResource TabViewBackground}"
                 BorderThickness="0,1,0,0"
                 VerticalAlignment="Top">
         <Grid x:Name="BottomBar"

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -79,18 +79,6 @@
             </mux:InfoBar>
         </StackPanel>
 
-        <!-- Solid filler behind TabContent so any transparent edge pixels
-             (pane border, padding rounding, etc.) between the pane and the
-             BottomBar read as a seamless continuation of the BottomBar
-             instead of showing the desktop behind the window. Uses the
-             BottomBar color so the gap — if any — visually merges into
-             the bar. Declared before TabContent so it sits behind. -->
-        <Border x:Name="TabContentFiller"
-                Grid.Row="2"
-                Grid.ColumnSpan="2"
-                Background="#000000"
-                IsHitTestVisible="False" />
-
         <Grid x:Name="TabContent"
               Grid.Row="2"
               Grid.ColumnSpan="2"
@@ -105,37 +93,19 @@
              window chrome, but its state reflects the *active tab*'s agent
              pane (toggle lit when active tab has an AgentPaneContent,
              diagnostics from the active tab's autofix state, etc.).
-             Wrapped in a Border so we can draw a 1-pixel divider between
-             the terminal pane and the bar. The divider is a child Border
-             (not BorderThickness) because XAML's BorderBrush paints the
-             thickness strip OUTSIDE the Background fill — so a
-             semi-transparent BorderBrush would alpha-blend against the
-             transparent window underneath instead of the bar's black.
-             Stacking a 1px Border on top of the solid-black outer Border
-             makes the alpha blend correctly. -->
+             The opaque top border is the pre-composited equivalent of the
+             design's 15%-white divider over the bar's black background. -->
         <Border x:Name="BottomBarRoot"
                 Grid.Row="3"
                 Grid.ColumnSpan="2"
                 Background="#000000"
+                BorderBrush="#FF262626"
+                BorderThickness="0,1,0,0"
                 VerticalAlignment="Top">
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="1" />
-                <RowDefinition Height="40" />
-            </Grid.RowDefinitions>
-
-            <!-- Divider: design spec #FFFFFF26 (= XAML #26FFFFFF, white 15% alpha).
-                 Sits on the outer Border's #000000, so it renders as a subtle
-                 dark-gray hairline. -->
-            <Border Grid.Row="0" Background="#26FFFFFF" />
-
         <Grid x:Name="BottomBar"
-              Grid.Row="1"
+              Height="40"
               Padding="12,0,12,0"
               HorizontalAlignment="Stretch">
-            <Grid.Background>
-                <SolidColorBrush Color="#000000" />
-            </Grid.Background>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
@@ -279,7 +249,6 @@
                 </Image>
             </Button>
 
-        </Grid>
         </Grid>
         </Border>
 

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -93,13 +93,12 @@
              window chrome, but its state reflects the *active tab*'s agent
              pane (toggle lit when active tab has an AgentPaneContent,
              diagnostics from the active tab's autofix state, etc.).
-             The opaque top border is the pre-composited equivalent of the
-             design's 15%-white divider over the bar's black background. -->
+             The top border shares the WTA input-box border color. -->
         <Border x:Name="BottomBarRoot"
                 Grid.Row="3"
                 Grid.ColumnSpan="2"
                 Background="#000000"
-                BorderBrush="#FF262626"
+                BorderBrush="{StaticResource AgentChromeBorderBrush}"
                 BorderThickness="0,1,0,0"
                 VerticalAlignment="Top">
         <Grid x:Name="BottomBar"


### PR DESCRIPTION
## Problem

Terminal content with opacity or acrylic enabled was composited against black instead of the desktop. `TabContentFiller` stretched across the entire content row, making the XAML surface opaque before DWM could blend it with the desktop.

The filler was originally added to hide a gap above the agent bar, but the bar already occupies its own layout row and can draw that separator itself.

## Changes

- Remove the opaque filler behind `TabContent`.
- Draw the window-level agent bar separator on `BottomBarRoot` with a 1px top border.
- Use Terminal's theme-aware `TabViewBackground` resource for window-level and agent-pane separators.
- Stop replacing the agent-pane separator with a translucent foreground-derived brush.

This restores desktop composition for both regular opacity and acrylic while preserving a clear separator above the agent bar. The separator automatically follows Dark, Light, and High Contrast themes.

## Validation

- Built `TerminalAppLib` with `bx`.
- Built the full Debug solution with `bcz no_clean`.
- Deployed and launched the Debug package for visual testing.

Fixes #677
