### PR TITLE
Stop a closing Terminal from being resurrected over COM

### DIFF
--- a/doc/wtcli-commands.md
+++ b/doc/wtcli-commands.md
@@ -5,6 +5,14 @@ running Terminal via the `WT_COM_CLSID` environment variable, calls
 `CoCreateInstance(CLSCTX_LOCAL_SERVER)` to obtain `IProtocolServer`, and
 exposes a tmux-style command surface over its IDL methods.
 
+Before activating, it opens the event named by `WT_COM_HOST` and gives up if
+that event is gone. The class is registered as a packaged ExeServer, so
+activation does not fail once the owning Terminal has exited — DCOM launches a
+windowless `WindowsTerminal.exe -Embedding` that has no panes to act on and no
+window to close. `WT_COM_HOST` is a liveness handle, not a credential; when it
+is absent (an older Terminal, or an environment copied by hand) `wtcli`
+activates as before.
+
 - Source: `src/tools/wtcli/main.cpp`
 - IDL: `src/cascadia/TerminalProtocol/TerminalProtocol.idl`
 - Primary in-tree caller: `tools/wta/src/shell/wt_channel/cli_channel.rs` (and

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -73,10 +73,19 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             // (set by WindowEmperor::_initializeProtocolServer). These must be
             // injected here because regenerate() builds _initialEnv from the
             // registry, not the process environment block.
+            //
+            // WT_COM_HOST names a kernel object that only lives as long as this
+            // Terminal does. Panes need it as well as the CLSID: the CLSID is a
+            // packaged ExeServer registration, so a client that activates it
+            // after we exit silently starts a new, windowless Terminal instead
+            // of failing. Checking the event first is what lets a client tell
+            // those two situations apart.
             {
                 wchar_t buf[512];
                 if (GetEnvironmentVariableW(L"WT_COM_CLSID", buf, ARRAYSIZE(buf)))
                     environment.as_map().insert_or_assign(L"WT_COM_CLSID", buf);
+                if (GetEnvironmentVariableW(L"WT_COM_HOST", buf, ARRAYSIZE(buf)))
+                    environment.as_map().insert_or_assign(L"WT_COM_HOST", buf);
             }
 
             // Directory hook integrations may write diagnostics into.

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -46,6 +46,17 @@ static constexpr ULONG_PTR TERMINAL_HANDOFF_MAGIC = 0x4c414e494d524554; // 'TERM
 static constexpr ULONG_PTR TERMINAL_HANDOFF_MAGIC = 0x4d524554; // 'TERM'
 #endif
 
+// Reaps a COM activation that never asked for a window. Both of our classes
+// (the defterm handoff and TerminalProtocolComServer) are registered as one
+// packaged ExeServer, so any CoCreateInstance that arrives while no server is
+// running makes DCOM start `WindowsTerminal.exe -Embedding`. A handoff turns
+// into a window within moments; a protocol activation that raced our exit never
+// will, and without this it would sit in Task Manager as a windowless process,
+// holding the single-instance mutex and the global hotkeys, until the user
+// found and killed it. The delay only has to outlast an in-flight handoff.
+static constexpr UINT_PTR COM_ACTIVATION_REAP_TIMER_ID = 1;
+static constexpr UINT COM_ACTIVATION_REAP_TIMEOUT_MS = 30 * 1000;
+
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
 // A convenience function around CommandLineToArgv.
@@ -669,8 +680,12 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
             // Stay headless and leave the saved layout alone; whichever
             // activation actually wants a window restores it.
             //
-            // TODO: Here we could start a timer and exit after, say, 5 seconds
-            // if no windows are created. But that's a minor concern.
+            // But don't stay headless forever: a protocol activation that
+            // raced the exit of the Terminal that owned the calling pane can
+            // never produce a window, and the process it started would outlive
+            // every window the user could see. Give a real activation time to
+            // ask for its window, then reap ourselves if none did.
+            SetTimer(_window.get(), COM_ACTIVATION_REAP_TIMER_ID, COM_ACTIVATION_REAP_TIMEOUT_MS, nullptr);
         }
         else
         {
@@ -1360,6 +1375,28 @@ LRESULT WindowEmperor::_messageHandler(HWND window, UINT const message, WPARAM c
         case WM_HOTKEY:
             _hotkeyPressed(static_cast<long>(wParam));
             return 0;
+        case WM_TIMER:
+            if (wParam == COM_ACTIVATION_REAP_TIMER_ID)
+            {
+                KillTimer(window, COM_ACTIVATION_REAP_TIMER_ID);
+                // _deferPersistedLayoutRestore is cleared by the first
+                // CreateNewWindow(), so it still being set means no activation
+                // ever wanted a window and we are the useless leftover of one
+                // that raced a Terminal exit. It also keeps
+                // _finalizeSessionPersistence() off the saved layout, so
+                // quitting here cannot overwrite the session we never restored.
+                //
+                // A window that opened and closed again in the meantime has
+                // already been through _postQuitMessageIfNeeded(), and
+                // AllowHeadless users opted into a windowless process — both
+                // are respected by deferring to that same helper.
+                if (_deferPersistedLayoutRestore)
+                {
+                    _postQuitMessageIfNeeded();
+                }
+                return 0;
+            }
+            break;
         case WM_QUERYENDSESSION:
             // For WM_QUERYENDSESSION and WM_ENDSESSION, refer to:
             // https://docs.microsoft.com/en-us/windows/win32/rstmgr/guidelines-for-applications
@@ -1874,6 +1911,28 @@ void WindowEmperor::_initializeProtocolServer()
         {
             _comClsid = clsidStr.get();
             SetEnvironmentVariableW(L"WT_COM_CLSID", _comClsid.c_str());
+
+            // The CLSID alone cannot tell a caller whether we are still here:
+            // it is registered as a packaged ExeServer, so activating it after
+            // we exit doesn't fail, it makes DCOM launch a fresh, windowless
+            // `WindowsTerminal.exe -Embedding` that has no panes to act on and
+            // no window to show. Panes get this event name alongside the CLSID
+            // so a client can check first and give up instead of resurrecting
+            // a Terminal the user just closed.
+            //
+            // The name carries our PID, so it identifies *this* host rather
+            // than "some Terminal": the object dies with us, and a PID reused
+            // by anything that isn't a Terminal never recreates it.
+            auto livenessName = fmt::format(FMT_COMPILE(L"Local\\IntelligentTerminal.ProtocolHost.{}.{}"), _comClsid, GetCurrentProcessId());
+            _comHostLiveness.reset(CreateEventW(nullptr, TRUE, FALSE, livenessName.c_str()));
+            if (_comHostLiveness)
+            {
+                SetEnvironmentVariableW(L"WT_COM_HOST", livenessName.c_str());
+            }
+            else
+            {
+                LOG_LAST_ERROR();
+            }
         }
     }
 

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -106,6 +106,11 @@ private:
 
     // Protocol server for AI CLI integration
     std::wstring _comClsid; // Stringified CLSID for WT_COM_CLSID env var
+    // A named event whose mere existence means "the Terminal that owns this
+    // pane is still running". Its name goes to panes as WT_COM_HOST so that
+    // clients can tell a live host from one that a COM activation would
+    // resurrect. See _initializeProtocolServer().
+    wil::unique_handle _comHostLiveness;
     void _initializeProtocolServer();
     std::vector<winrt::Microsoft::Terminal::Settings::Model::GlobalSummonArgs> _hotkeys;
     NOTIFYICONDATA _notificationIcon{};

--- a/src/tools/wtcli/main.cpp
+++ b/src/tools/wtcli/main.cpp
@@ -97,6 +97,31 @@ static winrt::com_ptr<ITerminalProtocol> ConnectToTerminal(bool* outAuthenticate
         return nullptr;
     }
 
+    // Refuse to activate a Terminal that is no longer there. The protocol class
+    // is registered as a packaged ExeServer, so CoCreateInstance does not fail
+    // when the Terminal that owned our pane has exited — DCOM starts a fresh
+    // `WindowsTerminal.exe -Embedding` instead, which has no windows and no
+    // panes and therefore nothing any of our commands can act on. That process
+    // is invisible apart from Task Manager, and it lingers.
+    //
+    // This races most often at teardown, when the last thing a pane's tooling
+    // does on its way out is publish an event to a Terminal that is already
+    // gone. WT_COM_HOST names an event that only exists while our Terminal
+    // runs, so opening it tells us which of the two situations we are in.
+    // Absent (an older Terminal, or a re-exported environment) means we can
+    // only fall back to activating and hoping.
+    wchar_t hostEvent[MAX_PATH]{};
+    if (GetEnvironmentVariableW(L"WT_COM_HOST", hostEvent, ARRAYSIZE(hostEvent)))
+    {
+        const wil::unique_handle host{ OpenEventW(SYNCHRONIZE, FALSE, hostEvent) };
+        if (!host)
+        {
+            if (!quiet)
+                fprintf(stderr, "[wtcli] The Intelligent Terminal that owns this pane has exited.\n");
+            return nullptr;
+        }
+    }
+
     winrt::com_ptr<ITerminalProtocol> server;
     auto hr = CoCreateInstance(cls, nullptr, CLSCTX_LOCAL_SERVER, __uuidof(ITerminalProtocol), server.put_void());
     if (FAILED(hr))
@@ -829,17 +854,26 @@ int wmain(int argc, wchar_t** argv)
         GetEnvironmentVariableW(L"WT_COM_CLSID", clsid, ARRAYSIZE(clsid));
         auto cl = winrt::to_string(winrt::hstring{ clsid });
 
+        // Carry the liveness handle too, or the copied environment would work
+        // until the Terminal it names exits and then start resurrecting it.
+        wchar_t hostEvent[MAX_PATH]{};
+        GetEnvironmentVariableW(L"WT_COM_HOST", hostEvent, ARRAYSIZE(hostEvent));
+        auto host = winrt::to_string(winrt::hstring{ hostEvent });
+
         if (setEnvShell == "powershell" || setEnvShell == "pwsh")
         {
             if (!cl.empty()) printf("$env:WT_COM_CLSID = '%s'\n", cl.c_str());
+            if (!host.empty()) printf("$env:WT_COM_HOST = '%s'\n", host.c_str());
         }
         else if (setEnvShell == "bash" || setEnvShell == "sh" || setEnvShell == "zsh")
         {
             if (!cl.empty()) printf("export WT_COM_CLSID='%s'\n", cl.c_str());
+            if (!host.empty()) printf("export WT_COM_HOST='%s'\n", host.c_str());
         }
         else if (setEnvShell == "cmd")
         {
             if (!cl.empty()) printf("set WT_COM_CLSID=%s\n", cl.c_str());
+            if (!host.empty()) printf("set WT_COM_HOST=%s\n", host.c_str());
         }
     });
 

--- a/tools/wta/README.md
+++ b/tools/wta/README.md
@@ -105,14 +105,23 @@ WTA discovers Windows Terminal via the `WT_COM_CLSID` environment variable. WT
 sets this in its own environment at startup and propagates it to every conpty
 shell, so any pane-launched process — including wta and wtcli — inherits it.
 
+WT propagates `WT_COM_HOST` the same way. It names an event that exists only
+while that Terminal process does, and `wtcli` checks it before activating the
+class: the CLSID is a packaged ExeServer registration, so activating it after
+the Terminal exits would make DCOM start a new, windowless
+`WindowsTerminal.exe -Embedding` rather than fail. That is a real race at
+teardown, when the last thing a pane publishes can outlive the window it was
+published to.
+
 ## Environment Variables
 
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `WT_COM_CLSID` | Yes* | Stringified GUID of WT's `TerminalProtocolComServer` COM class |
+| `WT_COM_HOST` | No* | Name of a kernel event that lives exactly as long as the owning WT process; `wtcli` refuses to connect once it is gone |
 | `WTA_LOG` | No | Rust tracing filter, such as `debug` or `trace` |
 
-\* Set automatically by WT when it spawns a conpty child. If you launch `wta` from outside WT, run `eval "$(wta set-env)"` to copy the value over (only useful when you've previously captured it from a WT shell).
+\* Set automatically by WT when it spawns a conpty child. If you launch `wta` from outside WT, run `eval "$(wta set-env)"` to copy the value over (only useful when you've previously captured it from a WT shell). Without `WT_COM_HOST`, `wtcli` activates the CLSID as it always did.
 
 ## Global CLI Options
 

--- a/tools/wta/src/cli/args.rs
+++ b/tools/wta/src/cli/args.rs
@@ -331,7 +331,7 @@ pub(crate) enum Command {
     },
     /// Discover and print the WT COM CLSID used for protocol routing
     PipeId,
-    /// Print shell commands to set WT_COM_CLSID
+    /// Print shell commands to set WT_COM_CLSID and WT_COM_HOST
     #[command(alias = "setenv")]
     SetEnv {
         /// Shell syntax: bash (default), powershell, cmd

--- a/tools/wta/src/cli/wt.rs
+++ b/tools/wta/src/cli/wt.rs
@@ -546,22 +546,38 @@ fn run_pipe_id(json_mode: bool) -> Result<()> {
 fn run_set_env(shell_type: &str) -> Result<()> {
     let clsid = std::env::var("WT_COM_CLSID")
         .map_err(|_| anyhow::anyhow!("{}", t!("error.wt_com_clsid_not_set")))?;
+    // Liveness handle for the Terminal that owns this pane. Copied alongside the
+    // CLSID so the target shell keeps refusing to activate a Terminal that has
+    // already exited instead of having DCOM start a windowless one.
+    let host = std::env::var("WT_COM_HOST").ok();
 
     match shell_type {
         "bash" | "sh" | "zsh" => {
             println!("export WT_COM_CLSID='{}'", clsid);
+            if let Some(host) = &host {
+                println!("export WT_COM_HOST='{}'", host);
+            }
             eprintln!("# Run: eval \"$(wta set-env)\"");
         }
         "powershell" | "pwsh" | "ps" => {
             println!("$env:WT_COM_CLSID = '{}'", clsid);
+            if let Some(host) = &host {
+                println!("$env:WT_COM_HOST = '{}'", host);
+            }
             eprintln!("# Run: wta set-env -s powershell | Invoke-Expression");
         }
         "cmd" => {
             println!("set WT_COM_CLSID={}", clsid);
+            if let Some(host) = &host {
+                println!("set WT_COM_HOST={}", host);
+            }
             eprintln!("REM Run in a for /f loop or copy-paste");
         }
         "fish" => {
             println!("set -gx WT_COM_CLSID '{}'", clsid);
+            if let Some(host) = &host {
+                println!("set -gx WT_COM_HOST '{}'", host);
+            }
             eprintln!("# Run: wta set-env -s fish | source");
         }
         other => bail!("{}", t!("error.unknown_shell_type", shell = other)),


### PR DESCRIPTION
## Summary

Closing Intelligent Terminal could leave a windowless `WindowsTerminal.exe -Embedding` behind, parented to `svchost.exe` (DcomLaunch), a second or two after the last window went away. It shows up in Task Manager as a background process and never exits.

Reported from a test run of #665, with the timeline pinned by logs:

| Time | What happened |
| --- | --- |
| 12:57:16 | Terminal closed — helper takes `CTRL_CLOSE`, master exits, `state.json` written |
| 12:57:18 | DcomLaunch starts `WindowsTerminal.exe -Embedding`, no window, never exits |

## This is not a regression from #665

That PR does not touch `WindowEmperor.cpp` at all — the `-Embedding` branch and `_deferPersistedLayoutRestore` both come from `main`. Two older commits already describe this exact activation:

- **#551** (`9e34e6c6a`, 2026-08-25) names it outright: *"Our ExeServer registers both the defterm handoff class and TerminalProtocolComServer, so an -Embedding launch is just as likely a wtcli protocol activation as a console handoff."* It fixed the worst consequence — the headless instance overwriting the persisted layout — but not the instance itself.
- That it also stays resident was left as an explicit TODO upstream in microsoft/terminal#19088 (2025-07-01): *"Here we could start a timer and exit after, say, 5 seconds if no windows are created. But that's a minor concern."*

What #665 changed is the **odds**, not the mechanism: more agent panes alive at close means more helpers publishing on the way out. Since #551 stopped it from eating the saved layout, it degraded into a silent leftover that only shows in Task Manager, which is why it survived this long unnoticed.

## Root cause

The package manifest registers `TerminalProtocolComServer` under the `WindowsTerminal.exe` ExeServer, next to the defterm handoff class. `wtcli` reaches it with `CoCreateInstance(CLSCTX_LOCAL_SERVER)`, and COM offers no "connect, but do not launch" for a local server: once the Terminal that owned the calling pane is gone, the SCM does not fail the call, it starts a fresh server from the registration.

The race lives at teardown. A helper still inside its `CTRL_CLOSE` grace window publishes one last event, `CliChannel` spawns a `wtcli` process for it, and by the time that process activates the class the Terminal has exited. The instance DCOM starts has no panes to act on and no window to show, and by design it stays headless — so it stays forever, holding the single-instance mutex and the global hotkeys. The next real launch then hands its command line to a process the user cannot see.

## The fix, in two layers

### Prevent the activation

`_initializeProtocolServer()` creates an event named after the CLSID and our PID and exports the name as `WT_COM_HOST`; `ConptyConnection` injects it into every pane next to `WT_COM_CLSID`. `wtcli` opens that event before activating and gives up if it is gone.

The name is the point: the object dies with us, and a PID reused by anything that is not a Terminal never recreates it — so the check cannot be fooled in either direction. If a new Terminal *does* land on that PID, it recreates the same name and is a valid host anyway.

When `WT_COM_HOST` is absent — an older Terminal, a hand-copied environment, the E2E harness, which sets only `WT_COM_CLSID` — activation behaves exactly as it does today. `wtcli set-env` and `wta set-env` emit the new variable too, or a copied environment would work right up until the Terminal it names exits and then start resurrecting it.

### Reap the process anyway

An `-Embedding` start arms a 30s timer and quits if no activation ever asked for a window. This covers callers we do not own, older `wtcli` binaries, and any residual race.

`_deferPersistedLayoutRestore` is the test, and it is the right one for two independent reasons: it is cleared by the first `CreateNewWindow()`, so it still being set means no window was ever created; and it is the same flag that already keeps `_finalizeSessionPersistence()` off the saved layout, so quitting here **cannot** overwrite a session we never restored.

The quit itself goes through the existing `_postQuitMessageIfNeeded()`, so a window that opened and closed again in the meantime is left alone (it has already been through that path), and `allowHeadless` users — who explicitly opted into a windowless process — keep theirs. A defterm handoff produces its window in milliseconds, far inside the delay.

## Not addressed here

The teardown-time publish itself. With this change it fails cleanly and says so, which is deliberate: the failure now prints `The Intelligent Terminal that owns this pane has exited.` into the helper log, so the next person to look can see *which* component was still publishing at close. I have a mechanism-level account of that (a helper inside its `CTRL_CLOSE` grace window) but no direct log evidence naming the caller, so silencing it would be guesswork.

## Verification

- **C++** — full solution `bz` on this branch: **Build succeeded, 0 Error(s)**.
- **WTA** — `cargo test --target x86_64-pc-windows-msvc`: **1842 passed, 0 failed, 1 ignored**.
- **By hand** — against a deployed debug build.

To reproduce the reaper independently of the wtcli gate, run `wtcli` with `WT_COM_CLSID` set but `WT_COM_HOST` unset (an old-client simulation) while no Terminal is running: DCOM starts the `-Embedding` instance, and it exits on its own 30 seconds later.
