### PR TITLE
Update the FRE agent setup page title

### DIFF
--- a/src/cascadia/TerminalApp/Resources/af-ZA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/af-ZA/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Welkom by Intelligente Terminaal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Stel jou terminaalagent op</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Kies wat om nou op te stel. Jy kan dit enige tyd verander. </value>

--- a/src/cascadia/TerminalApp/Resources/am-ET/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/am-ET/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>እንኣን ወደ ብልህ ተርሚናል በደህና መጡ</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>የተርሚናል ኤጅንትዎን ያዋቅሩ</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>አሁን ምን ማዋቀር እንደሚፈልጉ ይምረጡ። እነዚህን በማንኛውም ጊዜ መቀየር ይችላሉ። </value>

--- a/src/cascadia/TerminalApp/Resources/ar-SA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ar-SA/Resources.resw
@@ -150,8 +150,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>مرحبًا بك في الوحدة الطرفية الذكية</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>قم بإعداد وكيل الذكاء الاصطناعي لطرفيتك</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>اختر ما تريد إعداده الآن. يمكنك تغيير هذه في أي وقت. </value>

--- a/src/cascadia/TerminalApp/Resources/as-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/as-IN/Resources.resw
@@ -150,8 +150,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>ইন্টেলিজেন্ট টাৰ্মিনেল লৈ স্বাগতম</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>আপোনাৰ টাৰ্মিনেল এজেণ্ট ছেট আপ কৰক</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>এতিয়া কি ছেট আপ কৰিব বাছনি কৰক। আপুনি যিকোনো সময়তে এইবোৰ সলনি কৰিব পাৰে। </value>

--- a/src/cascadia/TerminalApp/Resources/az-Latn-AZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/az-Latn-AZ/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Ağıllı Terminal-a xoş gəlmisiniz</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Terminal agentinizi qurun</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>İndi nəyi qurmaq istədiyinizi seçin. Bunları istənilən vaxt dəyişə bilərsiniz. </value>

--- a/src/cascadia/TerminalApp/Resources/bg-BG/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bg-BG/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Добре дошли в Интелигентен Терминал</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Настройте терминалния си агент</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Изберете какво да настроите сега. Можете да промените тези настройки по всяко време. </value>

--- a/src/cascadia/TerminalApp/Resources/bn-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bn-IN/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>ইন্টেলিজেন্ট টার্মিনাল-এ স্বাগতম</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>আপনার টার্মিনাল এজেন্ট সেট আপ করুন</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>এখন কী সেট আপ করবেন তা বেছে নিন। আপনি যেকোনো সময় এগুলি পরিবর্তন করতে পারেন। </value>

--- a/src/cascadia/TerminalApp/Resources/bs-Latn-BA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bs-Latn-BA/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Dobrodošli u Inteligentni Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Postavite svog terminalskog agenta</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Odaberite šta želite sada postaviti. Ovo možete promijeniti u bilo kojem trenutku. </value>

--- a/src/cascadia/TerminalApp/Resources/ca-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ca-ES/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Us donem la benvinguda a l'Terminal Intel·ligent</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Configureu el vostre agent de terminal</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Trieu què voleu configurar ara. Podeu canviar-ho en qualsevol moment. </value>

--- a/src/cascadia/TerminalApp/Resources/ca-Es-VALENCIA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ca-Es-VALENCIA/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Vos donem la benvinguda a l'Terminal Intel·ligent</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Configureu el vostre agent de terminal</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Trieu què voleu configurar ara. Podeu canviar-ho en qualsevol moment. </value>

--- a/src/cascadia/TerminalApp/Resources/cs-CZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/cs-CZ/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Vítejte v Inteligentní Terminál</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Nastavte si terminálového agenta</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Vyberte, co chcete nyní nastavit. Tato nastavení můžete kdykoli změnit. </value>

--- a/src/cascadia/TerminalApp/Resources/cy-GB/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/cy-GB/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Croeso i Terfynell Ddeallus</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Gosodwch eich asiant terfynell</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Dewiswch beth i'w sefydlu nawr. Gallwch newid y rhain ar unrhyw adeg. </value>

--- a/src/cascadia/TerminalApp/Resources/da-DK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/da-DK/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Velkommen til Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"} "Intelligent Terminal" is the product name.</comment>
+    <value>Konfigurer din terminalagent</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Vælg, hvad du vil konfigurere nu. Du kan ændre disse indstillinger når som helst. </value>

--- a/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
@@ -1048,8 +1048,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Willkommen bei Intelligentes Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Richten Sie Ihren Terminal-Agenten ein</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Wählen Sie, was Sie jetzt einrichten möchten. Sie können diese Einstellungen jederzeit ändern. </value>

--- a/src/cascadia/TerminalApp/Resources/el-GR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/el-GR/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Καλώς ήρθατε στο Έξυπνο Τερματικό</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Ρυθμίστε τον πράκτορα του τερματικού σας</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Επιλέξτε τι θέλετε να ρυθμίσετε τώρα. Μπορείτε να αλλάξετε αυτές τις ρυθμίσεις ανά πάσα στιγμή. </value>

--- a/src/cascadia/TerminalApp/Resources/en-GB/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-GB/Resources.resw
@@ -146,8 +146,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Welcome to Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"} "Intelligent Terminal" is the product name.</comment>
+    <value>Set up your terminal agent</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Choose what to set up now. You can change these anytime. </value>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1110,8 +1110,8 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Welcome to Intelligent Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Set up your terminal agent</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Choose what to set up now. You can change these anytime. </value>

--- a/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
@@ -1045,8 +1045,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Bienvenido a Terminal Inteligente</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Configura tu agente de terminal</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Elige qué configurar ahora. Puedes cambiar estos ajustes en cualquier momento. </value>

--- a/src/cascadia/TerminalApp/Resources/es-MX/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-MX/Resources.resw
@@ -146,8 +146,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Bienvenido a Terminal Inteligente</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Configura tu agente de terminal</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Elige qué configurar ahora. Puedes cambiar estos ajustes en cualquier momento. </value>

--- a/src/cascadia/TerminalApp/Resources/et-EE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/et-EE/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Tere tulemast Nutikas Terminali</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Seadistage oma terminaliagent</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Valige, mida soovite nüüd seadistada. Saate neid seadeid igal ajal muuta. </value>

--- a/src/cascadia/TerminalApp/Resources/eu-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/eu-ES/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Ongi etorri Terminal Adimenduna-era</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Konfiguratu zure terminaleko agentea</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Aukeratu zer konfiguratu nahi duzun orain. Hauek edozein unetan alda ditzakezu. </value>

--- a/src/cascadia/TerminalApp/Resources/fa-IR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fa-IR/Resources.resw
@@ -150,8 +150,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>به پایانه هوشمند خوش آمدید</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>عامل ترمینال خود را تنظیم کنید</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>انتخاب کنید که الان چه چیزی را تنظیم کنید. می‌توانید اینها را در هر زمان تغییر دهید. </value>

--- a/src/cascadia/TerminalApp/Resources/fi-FI/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fi-FI/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Tervetuloa Älykäs Pääteiin</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Määritä terminaaliagenttisi</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Valitse, mitä haluat määrittää nyt. Voit muuttaa näitä asetuksia milloin tahansa. </value>

--- a/src/cascadia/TerminalApp/Resources/fil-PH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fil-PH/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Maligayang pagdating sa Matalinong Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>I-set up ang iyong terminal agent</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Piliin kung ano ang ise-set up ngayon. Maaari mong baguhin ang mga ito anumang oras. </value>

--- a/src/cascadia/TerminalApp/Resources/fr-CA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-CA/Resources.resw
@@ -146,8 +146,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Bienvenue dans Terminal Intelligent</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Configurez votre agent de terminal</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Choisissez ce que vous souhaitez configurer maintenant. Vous pouvez modifier ces paramètres à tout moment. </value>

--- a/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
@@ -1046,8 +1046,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Bienvenue dans Terminal Intelligent</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Configurez votre agent de terminal</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Choisissez ce que vous souhaitez configurer maintenant. Vous pouvez modifier ces paramètres à tout moment. </value>

--- a/src/cascadia/TerminalApp/Resources/ga-IE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ga-IE/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Fáilte go Teirminéal Cliste</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Socraigh do ghníomhaire teirminéil</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Roghnaigh cad ba mhaith leat a shocrú anois. Is féidir leat iad seo a athrú ag am ar bith. </value>

--- a/src/cascadia/TerminalApp/Resources/gd-gb/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gd-gb/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Fàilte gu Tèirmineal Glic</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Suidhich neach-gnìomha an terminal agad</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Tagh dè a tha thu airson a shuidheachadh an-dràsta. 'S urrainn dhut na roghainnean seo atharrachadh aig àm sam bith. </value>

--- a/src/cascadia/TerminalApp/Resources/gl-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gl-ES/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Benvido a Terminal Intelixente</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Configure o axente do seu terminal</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Escolla que quere configurar agora. Pode cambiar estes axustes en calquera momento. </value>

--- a/src/cascadia/TerminalApp/Resources/gu-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gu-IN/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>ઇન્ટેલિજન્ટ ટર્મિનલ માં આપનું સ્વાગત છે</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>તમારા ટર્મિનલ એજન્ટને સેટ અપ કરો</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>હવે શું સેટ કરવું તે પસંદ કરો. તમે આને ગમે ત્યારે બદલી શકો છો. </value>

--- a/src/cascadia/TerminalApp/Resources/he-IL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/he-IL/Resources.resw
@@ -150,8 +150,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>ברוכים הבאים ל-מסוף חכם</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>הגדר את סוכן הטרמינל שלך</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>בחר מה להגדיר כעת. ניתן לשנות הגדרות אלה בכל עת. </value>

--- a/src/cascadia/TerminalApp/Resources/hi-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hi-IN/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>इंटेलिजेंट टर्मिनल में आपका स्वागत है</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>अपना टर्मिनल एजेंट सेट अप करें</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>चुनें कि अभी क्या सेट अप करना है। आप इन्हें कभी भी बदल सकते हैं। </value>

--- a/src/cascadia/TerminalApp/Resources/hr-HR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hr-HR/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Dobro došli u Inteligentni Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Postavite svog terminalskog agenta</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Odaberite što želite sada postaviti. Ovo možete promijeniti u bilo kojem trenutku. </value>

--- a/src/cascadia/TerminalApp/Resources/hu-HU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hu-HU/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Üdvözli az Intelligens Terminál</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Állítsa be a terminálügynökét</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Válassza ki, mit szeretne most beállítani. Ezeket a beállításokat bármikor módosíthatja. </value>

--- a/src/cascadia/TerminalApp/Resources/hy-AM/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hy-AM/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Բարի գալուստ Խելացի տերմինալ</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Կարգավորեք ձեր տերմինալի գործակալը</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Ընտրեք, թdelays delays delays delays delays ի՛նdelays delays delays delays delays delays </value>

--- a/src/cascadia/TerminalApp/Resources/id-ID/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/id-ID/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Selamat datang di Terminal Cerdas</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Siapkan agen terminal Anda</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Pilih apa yang ingin Anda atur sekarang. Anda dapat mengubahnya kapan saja. </value>

--- a/src/cascadia/TerminalApp/Resources/is-IS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/is-IS/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Velkomin í Snjallútstöð</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Settu upp agentinn fyrir skjáherminn þinn</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Veldu hvað á að setja upp núna. Þú getur breytt þessu hvenær sem er. </value>

--- a/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
@@ -1045,8 +1045,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Benvenuto in Terminale Intelligente</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Configura il tuo agente del terminale</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Scegli cosa configurare adesso. Puoi modificare queste impostazioni in qualsiasi momento. </value>

--- a/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
@@ -1050,8 +1050,8 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>インテリジェント ターミナルへようこそ</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>ターミナル エージェントを設定する</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>今すぐ設定する項目を選択してください。これらはいつでも変更できます。</value>

--- a/src/cascadia/TerminalApp/Resources/ka-GE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ka-GE/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>ჭკვიანი ტერმინალი-ში მოგესალმებით</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>დააკონფიგურირეთ თქვენი ტერმინალის აგენტი</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>აირჩიეთ რა გსურთ ახლა დააყენოთ. ამის შეცვლა ნებისმიერ დროს შეგიძლიათ. </value>

--- a/src/cascadia/TerminalApp/Resources/kk-KZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kk-KZ/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Зияткер терминал-ға қош келдіңіз</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Терминал агентіңізді реттеңіз</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Қазір нені реттегіңіз келетінін таңдаңыз. Бұларды кез келген уақытта өзгертуге болады. </value>

--- a/src/cascadia/TerminalApp/Resources/km-KH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/km-KH/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>សូមស្វាគមន៍មកកាន់ ស្ថានីយឆ្លាតវៃ</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>រៀបចំភ្នាក់ងារ AI សម្រាប់តេរ្មីណលរបស់អ្នក</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>ជ្រើសរើសអ្វីដែលត្រូវដំឡើងឥឡូវនេះ។ អ្នកអាចផ្លាស់ប្តូរទាំងនេះបានគ្រប់ពេល។ </value>

--- a/src/cascadia/TerminalApp/Resources/kn-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kn-IN/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>ಇಂಟೆಲಿಜೆಂಟ್ ಟರ್ಮಿನಲ್-ಗೆ ಸ್ವಾಗತ</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>ನಿಮ್ಮ ಟರ್ಮಿನಲ್ ಏಜೆಂಟ್ ಅನ್ನು ಹೊಂದಿಸಿ</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>ಈಗ ಏನನ್ನು ಹೊಂದಿಸಬೇಕೆಂದು ಆಯ್ಕೆಮಾಡಿ. ನೀವು ಇವುಗಳನ್ನು ಯಾವುದೇ ಸಮಯದಲ್ಲಿ ಬದಲಾಯಿಸಬಹುಡು. </value>

--- a/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
@@ -1077,8 +1077,8 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>지능형 터미널에 오신 것을 환영합니다</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>터미널 에이전트를 설정하세요</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>지금 설정할 항목을 선택하세요. 이 항목은 언제든지 변경할 수 있습니다. </value>

--- a/src/cascadia/TerminalApp/Resources/kok-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kok-IN/Resources.resw
@@ -150,8 +150,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>इंटेलिजंट टर्मिनल ंत आपलें स्वागत</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>तुमचो टर्मिनल एजेंट सेट अप करात</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>आतां कितें सेट करपाचें ते वेंचून काडात. तुमी हें केन्नाय बदलूं येता. </value>

--- a/src/cascadia/TerminalApp/Resources/lb-LU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lb-LU/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Wëllkomm am Intelligenten Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Setzt Ären Terminal-Agent op</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Wielt aus, wat Dir elo astellen wëllt. Dir kënnt dës Astellungen all Moment änneren. </value>

--- a/src/cascadia/TerminalApp/Resources/lo-LA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lo-LA/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>ຍິນດີຕ້ອນຮັບສູ່ ເທອຮ໌ມິນັລອັດຊະລິຍະ</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>ຕັ້ງຄ່າ agent ສຳລັບ terminal ຂອງທ່ານ</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>ເລືອກສິ່ງທີ່ຈະຕັ້ງຄ່າຕອນນີ້. ທ່ານສາມາດປ່ຽນແປງສິ່ງເຫຼົ່ານີ້ໄດ້ທຸກເວລາ. </value>

--- a/src/cascadia/TerminalApp/Resources/lt-LT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lt-LT/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Sveiki atvykę į Išmanusis Terminalas</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Nustatykite savo terminalo agentą</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Pasirinkite, ką norite nustatyti dabar. Šiuos nustatymus galite pakeisti bet kada. </value>

--- a/src/cascadia/TerminalApp/Resources/lv-LV/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lv-LV/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Laipni lūdzam Viedais Terminālis</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Iestatiet savu termināļa aģentu</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Izvēlieties, ko vēlaties iestatīt tagad. Šos iestatījumus varat mainīt jebkurā laikā. </value>

--- a/src/cascadia/TerminalApp/Resources/mi-NZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mi-NZ/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Nāu mai ki Iho Atamai</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Whakaritea tō kaitiaki tauranga</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Kōwhiria he aha hei whakarite ināianei. Ka taea e koe te huri i ēnei i ngā wā katoa. </value>

--- a/src/cascadia/TerminalApp/Resources/mk-MK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mk-MK/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Добредојдовте во Интелигентен Терминал</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Поставете го вашиот терминален агент</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Изберете што сакате да поставите сега. Можете да ги промените овие поставки во секое време. </value>

--- a/src/cascadia/TerminalApp/Resources/ml-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ml-IN/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>ഇന്റലിജന്റ് ടെർമിനൽ-ലേക്ക് സ്വാഗതം</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>നിങ്ങളുടെ ടെർമിനൽ ഏജന്റ് സജ്ജമാക്കുക</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>ഇപ്പോൾ എന്ത് സജ്ജമാക്കണമെന്ന് തിരഞ്ഞെടുക്കുക. നിങ്ങൾക്ക് ഇവ എപ്പോൾ വേണമെങ്കിലും മാറ്റാം. </value>

--- a/src/cascadia/TerminalApp/Resources/mr-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mr-IN/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>इंटेलिजंट टर्मिनल मध्ये आपले स्वागत आहे</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>तुमचा टर्मिनल एजंट सेट अप करा</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>आता काय सेट करायचे ते निवडा. तुम्ही हे कधीही बदलू शकता. </value>

--- a/src/cascadia/TerminalApp/Resources/ms-MY/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ms-MY/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Selamat datang ke Terminal Pintar</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Sediakan ejen terminal anda</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Pilih apa yang hendak disediakan sekarang. Anda boleh menukar ini pada bila-bila masa. </value>

--- a/src/cascadia/TerminalApp/Resources/mt-MT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mt-MT/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Merħba fl-Terminal Intelliġenti</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Issettja l-aġent tat-terminal tiegħek</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Agħżel x'trid tissettja issa. Tista' tibdel dawn fi kwalunkwe ħin. </value>

--- a/src/cascadia/TerminalApp/Resources/nb-NO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nb-NO/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Velkommen til Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"} "Intelligent Terminal" is the product name.</comment>
+    <value>Konfigurer terminalagenten din</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Velg hva du vil konfigurere nå. Du kan endre disse innstillingene når som helst. </value>

--- a/src/cascadia/TerminalApp/Resources/ne-NP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ne-NP/Resources.resw
@@ -150,8 +150,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>इन्टेलिजेन्ट टर्मिनल मा स्वागत छ</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>आफ्नो टर्मिनल एजेन्ट सेटअप गर्नुहोस्</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>अहिले के सेटअप गर्ने छनौट गर्नुहोस्। तपाईं यी कुनै पनि समयमा परिवर्तन गर्न सक्नुहुन्छ। </value>

--- a/src/cascadia/TerminalApp/Resources/nl-NL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nl-NL/Resources.resw
@@ -146,8 +146,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Welkom bij Intelligente Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Stel uw terminalagent in</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Kies wat u nu wilt instellen. U kunt deze instellingen op elk gewenst moment wijzigen. </value>

--- a/src/cascadia/TerminalApp/Resources/nn-NO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nn-NO/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Velkomen til Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"} "Intelligent Terminal" is the product name.</comment>
+    <value>Set opp terminalagenten din</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Vel kva du vil konfigurere no. Du kan endre desse innstillingane når som helst. </value>

--- a/src/cascadia/TerminalApp/Resources/or-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/or-IN/Resources.resw
@@ -150,8 +150,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>ଇଣ୍ଟେଲିଜେଣ୍ଟ ଟର୍ମିନାଲ କୁ ସ୍ୱାଗତ</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>ଆପଣଙ୍କ ଟର୍ମିନାଲ ଏଜେଣ୍ଟ ସେଟଅପ୍ କରନ୍ତୁ</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>ବର୍ତ୍ତମାନ କ'ଣ ସେଟଅପ୍ କରିବେ ତାହା ବାଛନ୍ତୁ। ଆପଣ ଏଗୁଡ଼ିକୁ ଯେକୌଣସି ସମୟରେ ପରିବର୍ତ୍ତନ କରିପାରିବେ। </value>

--- a/src/cascadia/TerminalApp/Resources/pa-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pa-IN/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>ਇੰਟੈਲੀਜੈਂਟ ਟਰਮੀਨਲ ਵਿੱਚ ਤੁਹਾਡਾ ਸੁਆਗਤ ਹੈ</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>ਆਪਣਾ ਟਰਮੀਨਲ ਏਜੰਟ ਸੈੱਟ ਅੱਪ ਕਰੋ</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>ਚੁਣੋ ਕਿ ਹੁਣ ਕੀ ਸੈੱਟ ਅੱਪ ਕਰਨਾ ਹੈ। ਤੁਸੀਂ ਇਹਨਾਂ ਨੂੰ ਕਿਸੇ ਵੀ ਸਮੇਂ ਬਦਲ ਸਕਦੇ ਹੋ। </value>

--- a/src/cascadia/TerminalApp/Resources/pl-PL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pl-PL/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Witamy w Inteligentny Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Skonfiguruj swojego agenta terminalowego</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Wybierz, co chcesz teraz skonfigurować. Możesz zmienić te ustawienia w dowolnym momencie. </value>

--- a/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
@@ -1069,8 +1069,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Bem-vindo ao Terminal Inteligente</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Configure seu agente do terminal</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Escolha o que configurar agora. Você pode alterar essas opções a qualquer momento. </value>

--- a/src/cascadia/TerminalApp/Resources/pt-PT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-PT/Resources.resw
@@ -146,8 +146,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Bem-vindo ao Terminal Inteligente</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Configure o seu agente do terminal</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Escolha o que pretende configurar agora. Pode alterar estas definições a qualquer momento. </value>

--- a/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
@@ -1034,8 +1034,8 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Welcome to Intelligent Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Set up your terminal agent</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Choose what to set up now. You can change these anytime. </value>

--- a/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
@@ -1034,8 +1034,8 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Welcome to Intelligent Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Set up your terminal agent</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Choose what to set up now. You can change these anytime. </value>

--- a/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
@@ -1034,8 +1034,8 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Welcome to Intelligent Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Set up your terminal agent</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Choose what to set up now. You can change these anytime. </value>

--- a/src/cascadia/TerminalApp/Resources/quz-PE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/quz-PE/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Allillanchu Yuyaysapa Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Churay terminal agentiykita</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Kunan imata churanata akllay. Kay churanakunata mayk'aqpipas tikrayta atinki. </value>

--- a/src/cascadia/TerminalApp/Resources/ro-RO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ro-RO/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Bun venit la Terminal Inteligent</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Configurați-vă agentul AI pentru terminal</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Alegeți ce doriți să configurați acum. Puteți modifica aceste setări oricând. </value>

--- a/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
@@ -1072,8 +1072,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Добро пожаловать в Интеллектуальный Терминал</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Настройте ИИ-агента для терминала</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Выберите, что настроить сейчас. Вы можете изменить это в любое время. </value>

--- a/src/cascadia/TerminalApp/Resources/sk-SK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sk-SK/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Vitajte v Inteligentný Terminál</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Nastavte si AI agenta pre terminál</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Vyberte, čo chcete teraz nastaviť. Tieto nastavenia môžete kedykoľvek zmeniť. </value>

--- a/src/cascadia/TerminalApp/Resources/sl-SI/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sl-SI/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Dobrodošli v Inteligentni Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Nastavite svojega agenta AI za terminal</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Izberite, kaj želite zdaj nastaviti. Te nastavitve lahko kadar koli spremenite. </value>

--- a/src/cascadia/TerminalApp/Resources/sq-AL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sq-AL/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Mirë se vini në Terminali inteligjent</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Konfiguroni agjentin tuaj AI për terminalin</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Zgjidhni çfarë dëshiron të konfigurosh tani. Mund t'i ndryshosh këto në çdo kohë. </value>

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-BA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-BA/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Добро дошли у Интелигентни Терминал</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Подесите ВИ агента за терминал</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Изаберите шта желите сада да подесите. Ова подешавања можете да промените у било ком тренутку. </value>

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
@@ -1029,8 +1029,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Добро дошли у Интелигентни Терминал</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Подесите ВИ агента за терминал</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Изаберите шта желите сада да подесите. Ова подешавања можете да промените у било ком тренутку. </value>

--- a/src/cascadia/TerminalApp/Resources/sr-Latn-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Latn-RS/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Dobrodošli u Inteligentni Terminal</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Podesite VI agenta za terminal</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Izaberite šta želite sada da podesite. Ova podešavanja možete da promenite u bilo kom trenutku. </value>

--- a/src/cascadia/TerminalApp/Resources/sv-SE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sv-SE/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Välkommen till Intelligent Terminal</value>
-    <comment>{Locked="Intelligent Terminal"} "Intelligent Terminal" is the product name.</comment>
+    <value>Konfigurera din AI-agent för terminalen</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Välj vad du vill konfigurera nu. Du kan ändra dessa inställningar när som helst. </value>

--- a/src/cascadia/TerminalApp/Resources/ta-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ta-IN/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>அறிவாண் முனையம்-க்கு வரவேற்கிறோம்</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>உங்கள் முனையத்திற்கான AI முகவரை அமைக்கவும்</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>இப்போது என்ன அமைக்க வேண்டும் என்பதைத் தேர்வு செய்யுங்கள். இவற்றை எப்போது வேண்டுமானாலும் மாற்றலாம். </value>

--- a/src/cascadia/TerminalApp/Resources/te-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/te-IN/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>ఇంటెలిజెంట్ టెర్మినల్-కు స్వాగతం</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>మీ టెర్మినల్ AI ఏజెంట్‌ను సెటప్ చేయండి</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>ఇప్పుడు ఏమి సెటప్ చేయాలో ఎంచుకోండి. మీరు వీటిని ఎప్పుడైనా మార్చవచ్చు. </value>

--- a/src/cascadia/TerminalApp/Resources/th-TH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/th-TH/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>ยินดีต้อนรับสู่ เทอร์มินัลอัจฉริยะ</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>ตั้งค่าเอเจนต์ AI สำหรับเทอร์มินัลของคุณ</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>เลือกสิ่งที่ต้องการตั้งค่าตอนนี้ คุณสามารถเปลี่ยนแปลงการตั้งค่าเหล่านี้ได้ตลอดเวลา </value>

--- a/src/cascadia/TerminalApp/Resources/tr-TR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/tr-TR/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Akıllı Terminal'e hoş geldiniz</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Terminal için AI aracınızı ayarlayın</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Şimdi neyi ayarlamak istediğinizi seçin. Bunları istediğiniz zaman değiştirebilirsiniz. </value>

--- a/src/cascadia/TerminalApp/Resources/tt-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/tt-RU/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Акыллы терминал-га рәхим итегез</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Терминал өчен AI агентыгызны көйләгез</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Хәзер нәрсәләрне көйләргә кирәклеген сайлагыз. Сез аларны теләгән вакытта үзгәртә аласыз. </value>

--- a/src/cascadia/TerminalApp/Resources/ug-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ug-CN/Resources.resw
@@ -36,8 +36,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>ئەقلىي تېرمىنال ھە خوش كەلدىڭىز</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>تېرمىنال AI ۋەكىلىڭىزنى تەڭشەڭ</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>ھازىر نېمىنى تەڭشەشنى تاللاڭ. بۇلارنى ھەر ۋاقىتتا ئۆزگەرتەلەيسىز. </value>

--- a/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
@@ -1041,8 +1041,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Ласкаво просимо до Інтелектуальний Термінал</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Налаштуйте агента ШІ для терміналу</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Виберіть, що потрібно налаштувати зараз. Ви можете змінити ці параметри в будь-який час. </value>

--- a/src/cascadia/TerminalApp/Resources/ur-PK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ur-PK/Resources.resw
@@ -150,8 +150,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>ذہین ٹرمینل میں خوش آمدید</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>اپنا ٹرمینل AI ایجنٹ سیٹ اپ کریں</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>منتخب کریں کہ ابھی کیا ترتیب دینا ہے۔ آپ انہیں کسی بھی وقت تبدیل کر سکتے ہیں۔ </value>

--- a/src/cascadia/TerminalApp/Resources/uz-Latn-UZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uz-Latn-UZ/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Aqlli terminal-ga xush kelibsiz</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Terminal uchun AI agentingizni sozlang</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Hozir nimani sozlashni tanlang. Bularni istalgan vaqtda o'zgartirishingiz mumkin. </value>

--- a/src/cascadia/TerminalApp/Resources/vi-VN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/vi-VN/Resources.resw
@@ -149,8 +149,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>Chào mừng bạn đến Đầu cuối thông minh</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>Thiết lập tác tử AI cho terminal của bạn</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>Chọn những gì cần thiết lập ngay bây giờ. Bạn có thể thay đổi các tùy chọn này bất cứ lúc nào. </value>

--- a/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
@@ -1079,8 +1079,8 @@
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>欢迎使用智能终端</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>设置你的终端智能体</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>选择要立即设置的项目。你可以随时更改这些设置。</value>

--- a/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
@@ -1049,8 +1049,8 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <!-- ═══ FRE Settings Page ═══ -->
   <data name="FreOverlay_SettingsTitle.Text" xml:space="preserve">
-    <value>歡迎使用智能終端</value>
-    <comment>{Locked=qps-ploc,qps-ploca,qps-plocm} "Intelligent Terminal" is the product name.</comment>
+    <value>設定您的終端機 AI 智能體</value>
+    <comment>{Locked="Copilot","Claude","Gemini"} In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), not a human agent or representative.</comment>
   </data>
   <data name="FreOverlay_SettingsSubtitlePrefix" xml:space="preserve">
     <value>選擇要立即設定的項目。您可以隨時變更這些設定。</value>


### PR DESCRIPTION
## Summary of the Pull Request

Changes the second first-run experience page title from **“Welcome to Intelligent Terminal”** to **“Set up your terminal agent”**.

The first page keeps the original **“Welcome to Intelligent Terminal”** title.

## References and Relevant Issues

Addresses review feedback that both FRE pages used the same H1, making it difficult to distinguish their purposes.

## Detailed Description of the Pull Request / Additional comments

- Updates `FreOverlay_SettingsTitle.Text` across all 89 TerminalApp locales.
- Keeps `FreOverlay_WelcomeTitle.Text` unchanged.
- Updates the translator guidance to clarify that “agent” refers to an AI agent rather than a human representative.
- The second page's accessibility name automatically uses the updated localized resource.

## Validation Steps Performed

- Built `CascadiaPackage` successfully using the x64 Debug configuration.
- Validated all modified `.resw` files as well-formed XML.
- Verified that UTF-8 BOMs were preserved.
- Verified that the first-page title was unchanged in every locale.
- Verified that the two FRE pages no longer have identical titles.

## PR Checklist

- [ ] Closes #xxx
- [x] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)