### PR TITLE
Refresh session titles when the agent CLI renames a session

### DIFF
--- a/doc/specs/per-cli-history-filtering.md
+++ b/doc/specs/per-cli-history-filtering.md
@@ -297,6 +297,31 @@ Reconcile is deliberately stricter than title refresh:
 title upgrade is non-destructive, while `is_stale_host_history_row` requires
 both sides known and equal because deletion is not.
 
+The title an agent reports is not stable, so the poll re-adopts it rather than
+only filling a blank. Copilot answers `session/list` with a session's **first
+user message** until it generates a real summary; that echo is an ordinary
+non-synthetic title, so a synthetic-only upgrade latched it permanently and the
+session view kept showing the first message after the CLI had renamed the
+session. `refresh_titles_from_listing` therefore adopts the current listing
+title for every row `row_refreshable_by_connected_agent` admits, reusing the
+same 2 s-cached fetch, so no extra round-trip.
+
+Authority there is the session id, **not** `SessionInfo::location`. Host Copilot
+and an in-distro Copilot share a `CliSource` while enumerating disjoint stores,
+but a host listing simply never contains an in-distro session id (a host/WSL key
+collision is astronomically unlikely — see `wsl-session-management.md`). Adding a
+`location` gate would instead lose refreshes: only the born-bound path calls
+`set_location`, so an ordinary `session_hook` row for a CLI running inside WSL
+keeps the reducer's default `Host` and the in-distro agent that actually holds
+its title would be skipped forever.
+
+Because `adopt_agent_title` overwrites unconditionally, the candidate filters
+became load-bearing in a way they were not before: an injected-context echo or a
+provider placeholder would clobber a good title on every poll instead of merely
+failing to replace a synthetic one. They live in
+`session_registry::title_is_displayable` and are applied both where
+`host_titles_via_acp` builds the map and at the point of mutation.
+
 ### Consequences
 
 - The registry now holds up to `N × 50` historical rows for `N` pooled CLIs

--- a/doc/specs/session-history-via-acp.md
+++ b/doc/specs/session-history-via-acp.md
@@ -387,8 +387,9 @@ Implemented and verified on the feature branch:
   `spawn_wsl_seed` (async WSL), `host_history_via_acp` → `host_session_list_raw`
   (the `Arc<[SessionInfo]>` 2 s cache), the `sync_host_history` /
   `is_stale_host_history_row` reconcile, `host_titles_via_acp` + the
-  synthetic-title refresh (`refresh_synthetic_titles_from`,
-  `try_refresh_title_via_acp`, `row_refreshable_by_connected_agent`,
+  title refresh (`refresh_synthetic_titles_from`, `try_refresh_title_via_acp`
+  for still-synthetic rows, `refresh_titles_from_listing` for rows whose
+  CLI-side title has since changed, `row_refreshable_by_connected_agent`,
   `host_list_cache`).
 - The on-disk loaders, title parsers, the resume phantom-guard, **and the live
   phantom-prune flow** were deleted; `session_watcher` was kept. Phantom cleanup

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -6020,8 +6020,13 @@ async fn sync_host_history(state: &MasterStateInner, agent: &AgentCli) -> Option
 /// whatever it is handed, so every candidate is re-checked with
 /// [`crate::session_registry::title_is_displayable`] here, at the point of
 /// mutation, and not only where [`host_titles_via_acp`] builds the map. The
-/// row's own `cli_source` is the stamp to check against: it is the CLI that
-/// actually produced the session.
+/// row's own `cli_source` is the stamp to check against when it has one — it
+/// is the CLI that actually produced the session — falling back to
+/// `listing_cli` for a row `row_refreshable_by_connected_agent` admitted while
+/// unstamped. Without that fallback an unstamped row would skip the
+/// provider-specific placeholder check entirely and adopt, say, OpenCode's
+/// `New session - <timestamp>`; the candidate came from the listing agent, so
+/// that agent's provider is the right rule to judge it by.
 async fn refresh_titles_from_listing(
     reg: &dyn crate::session_registry::SessionRegistry,
     titles: &std::collections::HashMap<String, String>,
@@ -6038,7 +6043,8 @@ async fn refresh_titles_from_listing(
         let Some(title) = titles.get(row.session_id.0.as_ref()) else {
             continue;
         };
-        if !crate::session_registry::title_is_displayable(row.cli_source.as_ref(), title) {
+        let judging_cli = row.cli_source.as_ref().or(listing_cli);
+        if !crate::session_registry::title_is_displayable(judging_cli, title) {
             continue;
         }
         if reg.adopt_agent_title(&row.session_id, title).await {

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -5893,20 +5893,15 @@ async fn host_titles_via_acp(agent: &AgentCli) -> std::collections::HashMap<Stri
         .filter_map(|row| {
             row.title
                 .clone()
+                // Drop candidates that must never become a display name — most
+                // notably the delegate's injected first-message echo, which an
+                // agent CLI (e.g. Copilot) briefly reports as a session's
+                // `session/list` title before it generates its real summary and
+                // which embeds the `## Terminal Context (pane …)` block.
+                // `refresh_titles_from_listing` applies the same predicate at
+                // the point of mutation.
                 .filter(|title| {
-                    // Drop the delegate's injected first-message echo. An agent CLI
-                    // (e.g. Copilot) can briefly report the baked `?<prompt>` — which
-                    // embeds the `## Terminal Context (pane …)` block — as a session's
-                    // `session/list` title before it generates its real summary.
-                    // Adopting it would leak the injected context (pane GUID included)
-                    // and, being non-synthetic, lock the row out of the later upgrade
-                    // to the CLI's real name. Skipping it leaves the born-bound row
-                    // synthetic so a subsequent poll adopts the real summary instead.
-                    !title.is_empty()
-                        && !crate::session_registry::title_is_injected_context_echo(title)
-                        && !agent.cli_source.as_ref().is_some_and(|cli| {
-                            crate::agent_sessions::title_is_placeholder(cli, title)
-                        })
+                    crate::session_registry::title_is_displayable(agent.cli_source.as_ref(), title)
                 })
                 .map(|title| (row.session_id.to_string(), title))
         })
@@ -5984,7 +5979,81 @@ async fn sync_host_history(state: &MasterStateInner, agent: &AgentCli) -> Option
         }
     }
 
+    // Title refresh: the agent CLI owns a session's display name and keeps
+    // rewriting it (Copilot reports the first user message until it generates
+    // a summary), so re-adopt the current listing title for every row this
+    // agent owns — not just the still-synthetic ones, which is all
+    // `refresh_synthetic_titles_from` can do. A row that latched the transient
+    // first-message echo is non-synthetic and would otherwise display it
+    // forever. Uses the UNFILTERED title map so live Class-A agent-pane rows,
+    // which `host_history_via_acp` subtracts, are refreshed too, and reuses the
+    // same 2 s-cached `session/list` fetch this function already made.
+    if refresh_titles_from_listing(
+        &*state.registry,
+        &host_titles_via_acp(agent).await,
+        listing_cli,
+    )
+    .await
+    {
+        changed = true;
+    }
+
     Some((changed, rows.len()))
+}
+
+/// Adopt `titles` (session_id → the listing agent's own `session/list` title)
+/// for every registry row that agent owns, replacing a stale real title rather
+/// than only filling a synthetic one. Returns true if any row changed.
+///
+/// Authority is `row_refreshable_by_connected_agent` plus the session id
+/// itself, and deliberately NOT `SessionInfo::location`. Host Copilot and an
+/// in-distro Copilot share a `CliSource` while enumerating disjoint stores, but
+/// the id is what separates them: a host agent's listing simply never contains
+/// an in-distro session id (`doc/specs/wsl-session-management.md` calls a
+/// host/WSL key collision astronomically unlikely). Gating on `location` would
+/// instead *lose* refreshes, because only the born-bound path stamps it —
+/// an ordinary `session_hook` row for a CLI running inside WSL keeps the
+/// reducer's default `Host`, so the in-distro agent that actually holds its
+/// title would be skipped.
+///
+/// [`crate::session_registry::SessionRegistry::adopt_agent_title`] overwrites
+/// whatever it is handed, so every candidate is re-checked with
+/// [`crate::session_registry::title_is_displayable`] here, at the point of
+/// mutation, and not only where [`host_titles_via_acp`] builds the map. The
+/// row's own `cli_source` is the stamp to check against: it is the CLI that
+/// actually produced the session.
+async fn refresh_titles_from_listing(
+    reg: &dyn crate::session_registry::SessionRegistry,
+    titles: &std::collections::HashMap<String, String>,
+    listing_cli: Option<&crate::agent_sessions::CliSource>,
+) -> bool {
+    if titles.is_empty() {
+        return false;
+    }
+    let mut changed = false;
+    for row in reg.snapshot().await {
+        if !row_refreshable_by_connected_agent(&row, listing_cli) {
+            continue;
+        }
+        let Some(title) = titles.get(row.session_id.0.as_ref()) else {
+            continue;
+        };
+        if !crate::session_registry::title_is_displayable(row.cli_source.as_ref(), title) {
+            continue;
+        }
+        if reg.adopt_agent_title(&row.session_id, title).await {
+            // The title itself is user content (a chat summary), so log only
+            // the identity of the row that changed.
+            tracing::info!(
+                target: "master_history",
+                key = %row.session_id.0,
+                cli = ?listing_cli,
+                "title refresh: adopted updated session/list title"
+            );
+            changed = true;
+        }
+    }
+    changed
 }
 
 /// Whether a registry row is a stale host-history row to drop during reconcile:
@@ -8017,7 +8086,14 @@ async fn refresh_synthetic_titles_from(
 /// session while this agent is copilot) can never appear in it — skip it
 /// rather than issue a per-event round-trip that can't match. A `None` cli on
 /// either side is treated as "attempt" (the lookup simply no-ops when the id is
-/// absent); this leniency is safe only because the upgrade is non-destructive.
+/// absent).
+///
+/// That leniency stays safe for the destructive caller
+/// ([`refresh_titles_from_listing`], which overwrites rather than fills) because
+/// the session id is the real authority: an unstamped row only gets a title when
+/// the listing agent actually returned that exact id, which makes it that
+/// agent's own session. Reconcile is deliberately stricter — see
+/// [`is_stale_host_history_row`] — because deletion cannot be justified that way.
 fn row_refreshable_by_connected_agent(
     info: &crate::session_registry::SessionInfo,
     conn_cli: Option<&crate::agent_sessions::CliSource>,

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -9620,6 +9620,56 @@ async fn refresh_titles_from_listing_skips_rows_from_another_cli() {
     );
 }
 
+/// Copilot review finding: an unstamped row (`cli_source == None`, which
+/// `row_refreshable_by_connected_agent` deliberately admits) would skip the
+/// provider-specific placeholder check if the row's own stamp were the only
+/// thing consulted. The candidate came from the listing agent, so that agent's
+/// provider is the correct rule to judge it by.
+#[tokio::test]
+async fn refresh_titles_from_listing_judges_unstamped_rows_by_the_listing_cli() {
+    use crate::agent_sessions::CliSource;
+    use std::collections::HashMap;
+
+    let state = make_state();
+    let mut unstamped = crate::session_registry::SessionInfo::new(
+        acp::schema::v1::SessionId::new("sid-unstamped".to_string()),
+        std::path::PathBuf::from("/repo/project"),
+    );
+    assert!(
+        unstamped.cli_source.is_none(),
+        "this test is only meaningful for a row with no cli stamp"
+    );
+    unstamped.title = Some("Real Summary".to_string());
+    state.registry.upsert(unstamped).await;
+
+    let titles = HashMap::from([(
+        "sid-unstamped".to_string(),
+        "New session - 2026-07-23T01:14:00.422Z".to_string(),
+    )]);
+    assert!(
+        !refresh_titles_from_listing(&*state.registry, &titles, Some(&CliSource::OpenCode)).await,
+        "the listing agent's provider must supply the placeholder rule"
+    );
+    assert_eq!(
+        state
+            .registry
+            .lookup(&acp::schema::v1::SessionId::new(
+                "sid-unstamped".to_string()
+            ))
+            .await
+            .unwrap()
+            .title
+            .as_deref(),
+        Some("Real Summary")
+    );
+
+    // The same string is a legitimate title for a CLI that has no such
+    // placeholder convention, so the fallback must not over-reject.
+    assert!(
+        refresh_titles_from_listing(&*state.registry, &titles, Some(&CliSource::Copilot)).await
+    );
+}
+
 /// Authority is the session id, not `SessionInfo::location`. Only the
 /// born-bound path calls `set_location`, so an ordinary `session_hook` row for
 /// a CLI running inside WSL keeps the reducer's default `Host` while its title
@@ -9633,7 +9683,7 @@ async fn refresh_titles_from_listing_retitles_an_unstamped_in_distro_row() {
     let state = make_state();
     let mut hook_row = crate::session_registry::SessionInfo::new(
         acp::schema::v1::SessionId::new("sid-in-distro".to_string()),
-        std::path::PathBuf::from("/home/yuazha/repo"),
+        std::path::PathBuf::from("/home/dev/repo"),
     );
     hook_row.cli_source = Some(CliSource::Copilot);
     hook_row.title = Some("first user message echoed as a title".to_string());

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -9546,6 +9546,214 @@ async fn refresh_synthetic_titles_from_skips_when_id_absent() {
     );
 }
 
+// ── refresh_titles_from_listing ─────────────────────────────────
+
+/// The reported bug: Copilot reports a session's first user message as its
+/// `session/list` title until it generates a real summary. That echo is an
+/// ordinary non-synthetic title, so `refresh_synthetic_titles_from` skipped the
+/// row forever and the session view kept showing the first message.
+#[tokio::test]
+async fn refresh_titles_from_listing_adopts_changed_real_title() {
+    use crate::agent_sessions::CliSource;
+    use std::collections::HashMap;
+
+    let state = make_state();
+    let mut row = crate::session_registry::SessionInfo::new(
+        acp::schema::v1::SessionId::new("sid-stale".to_string()),
+        std::path::PathBuf::from("/repo/project"),
+    );
+    row.cli_source = Some(CliSource::Copilot);
+    row.title = Some("first user message echoed as a title".to_string());
+    state.registry.upsert(row).await;
+
+    let titles = HashMap::from([(
+        "sid-stale".to_string(),
+        "Check Copilot Resume Hooks".to_string(),
+    )]);
+    assert!(
+        refresh_titles_from_listing(&*state.registry, &titles, Some(&CliSource::Copilot)).await
+    );
+    assert_eq!(
+        state
+            .registry
+            .lookup(&acp::schema::v1::SessionId::new("sid-stale".to_string()))
+            .await
+            .unwrap()
+            .title
+            .as_deref(),
+        Some("Check Copilot Resume Hooks")
+    );
+
+    // Steady state must not report a change, or every poll would broadcast.
+    assert!(
+        !refresh_titles_from_listing(&*state.registry, &titles, Some(&CliSource::Copilot)).await
+    );
+}
+
+#[tokio::test]
+async fn refresh_titles_from_listing_skips_rows_from_another_cli() {
+    use crate::agent_sessions::CliSource;
+    use std::collections::HashMap;
+
+    let state = make_state();
+    let mut other_cli = crate::session_registry::SessionInfo::new(
+        acp::schema::v1::SessionId::new("sid-claude".to_string()),
+        std::path::PathBuf::from("/repo/project"),
+    );
+    other_cli.cli_source = Some(CliSource::Claude);
+    other_cli.title = Some("claude title".to_string());
+    state.registry.upsert(other_cli).await;
+
+    let titles = HashMap::from([("sid-claude".to_string(), "hijacked".to_string())]);
+    assert!(
+        !refresh_titles_from_listing(&*state.registry, &titles, Some(&CliSource::Copilot)).await
+    );
+    assert_eq!(
+        state
+            .registry
+            .lookup(&acp::schema::v1::SessionId::new("sid-claude".to_string()))
+            .await
+            .unwrap()
+            .title
+            .as_deref(),
+        Some("claude title")
+    );
+}
+
+/// Authority is the session id, not `SessionInfo::location`. Only the
+/// born-bound path calls `set_location`, so an ordinary `session_hook` row for
+/// a CLI running inside WSL keeps the reducer's default `Host` while its title
+/// lives in the in-distro agent's listing. Gating on `location` would skip
+/// exactly that row forever.
+#[tokio::test]
+async fn refresh_titles_from_listing_retitles_an_unstamped_in_distro_row() {
+    use crate::agent_sessions::{CliSource, SessionLocation};
+    use std::collections::HashMap;
+
+    let state = make_state();
+    let mut hook_row = crate::session_registry::SessionInfo::new(
+        acp::schema::v1::SessionId::new("sid-in-distro".to_string()),
+        std::path::PathBuf::from("/home/yuazha/repo"),
+    );
+    hook_row.cli_source = Some(CliSource::Copilot);
+    hook_row.title = Some("first user message echoed as a title".to_string());
+    assert_eq!(
+        hook_row.location,
+        SessionLocation::Host,
+        "an ordinary session_hook row is created with the reducer's default"
+    );
+    state.registry.upsert(hook_row).await;
+
+    // The listing comes from the Ubuntu Copilot agent, whose rows would be
+    // stamped `Wsl { Ubuntu }` had they been seeded through `sync_host_history`.
+    let titles = HashMap::from([("sid-in-distro".to_string(), "Real Summary".to_string())]);
+    assert!(
+        refresh_titles_from_listing(&*state.registry, &titles, Some(&CliSource::Copilot)).await
+    );
+    assert_eq!(
+        state
+            .registry
+            .lookup(&acp::schema::v1::SessionId::new(
+                "sid-in-distro".to_string()
+            ))
+            .await
+            .unwrap()
+            .title
+            .as_deref(),
+        Some("Real Summary")
+    );
+}
+
+/// `adopt_agent_title` overwrites unconditionally, so a candidate that must
+/// never be displayed would not merely stick (the pre-`adopt` failure mode) but
+/// actively clobber a good title on every poll. The guard lives at the point of
+/// mutation, not only where `host_titles_via_acp` builds the map.
+#[tokio::test]
+async fn refresh_titles_from_listing_rejects_undisplayable_candidates() {
+    use crate::agent_sessions::CliSource;
+    use std::collections::HashMap;
+
+    let state = make_state();
+    for (id, cli) in [
+        ("sid-echo", CliSource::Copilot),
+        ("sid-placeholder", CliSource::OpenCode),
+        ("sid-empty", CliSource::Copilot),
+    ] {
+        let mut row = crate::session_registry::SessionInfo::new(
+            acp::schema::v1::SessionId::new(id.to_string()),
+            std::path::PathBuf::from("/repo/project"),
+        );
+        row.cli_source = Some(cli);
+        row.title = Some("Real Summary".to_string());
+        state.registry.upsert(row).await;
+    }
+
+    let titles = HashMap::from([
+        (
+            "sid-echo".to_string(),
+            format!(
+                "hi test\n\n{}8A9B4ABA-BEB4-4F94-B0D3-55569420B902)\n```\nPowerShell 7.6.3\n```",
+                crate::session_registry::TERMINAL_CONTEXT_TITLE_MARKER
+            ),
+        ),
+        (
+            "sid-placeholder".to_string(),
+            "New session - 2026-07-23T01:14:00.422Z".to_string(),
+        ),
+        ("sid-empty".to_string(), String::new()),
+    ]);
+
+    // A `None` listing cli is the lenient case that reaches every row, so this
+    // also proves the guard does not depend on the cli gate.
+    assert!(!refresh_titles_from_listing(&*state.registry, &titles, None).await);
+    for id in ["sid-echo", "sid-placeholder", "sid-empty"] {
+        assert_eq!(
+            state
+                .registry
+                .lookup(&acp::schema::v1::SessionId::new(id.to_string()))
+                .await
+                .unwrap()
+                .title
+                .as_deref(),
+            Some("Real Summary"),
+            "{id} must keep its real title"
+        );
+    }
+}
+
+#[tokio::test]
+async fn refresh_titles_from_listing_ignores_unlisted_rows() {
+    use crate::agent_sessions::CliSource;
+
+    let state = make_state();
+    let mut row = crate::session_registry::SessionInfo::new(
+        acp::schema::v1::SessionId::new("sid-unlisted".to_string()),
+        std::path::PathBuf::from("/repo/project"),
+    );
+    row.cli_source = Some(CliSource::Copilot);
+    row.title = Some("kept".to_string());
+    state.registry.upsert(row).await;
+
+    assert!(
+        !refresh_titles_from_listing(
+            &*state.registry,
+            &std::collections::HashMap::new(),
+            Some(&CliSource::Copilot),
+        )
+        .await
+    );
+    assert_eq!(
+        state
+            .registry
+            .lookup(&acp::schema::v1::SessionId::new("sid-unlisted".to_string()))
+            .await
+            .unwrap()
+            .title
+            .as_deref(),
+        Some("kept")
+    );
+}
+
 #[test]
 fn row_refreshable_skips_only_definitively_cross_cli() {
     use crate::agent_sessions::CliSource;

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -1222,6 +1222,26 @@ pub trait SessionRegistry: Send + Sync {
         sid: &acp::schema::v1::SessionId,
         candidate: &str,
     ) -> bool;
+
+    /// Atomically replace `title` for `sid` with the listing agent's current
+    /// `session/list` title, whatever the row already holds. Returns `true`
+    /// iff the title actually changed. The candidate must be non-empty.
+    ///
+    /// The CLI owns a session's display name and keeps rewriting it: Copilot
+    /// reports the session's *first user message* until it generates a real
+    /// summary, then swaps in the summary. [`upgrade_title_if_synthetic`]
+    /// cannot recover from that, because the transient first-message echo is
+    /// an ordinary non-synthetic title — adopting it once would freeze the row
+    /// on it forever. This is the counterpart primitive that lets the poll
+    /// re-adopt the agent's current answer.
+    ///
+    /// Callers must first establish that the listing agent owns this row (see
+    /// `master::row_titled_by_listing_agent`) and must filter placeholder and
+    /// injected-context candidates, since this method applies whatever it is
+    /// given.
+    ///
+    /// [`upgrade_title_if_synthetic`]: SessionRegistry::upgrade_title_if_synthetic
+    async fn adopt_agent_title(&self, sid: &acp::schema::v1::SessionId, candidate: &str) -> bool;
 }
 
 /// Production implementation. Uses `tokio::sync::Mutex` for parity with the
@@ -1267,8 +1287,8 @@ pub(crate) fn title_is_synthetic(info: &SessionInfo) -> bool {
 
 /// The literal heading the delegate `?<prompt>` flow injects into the prompt it
 /// bakes into a freshly launched agent CLI: `"<prompt>\n\n## Terminal Context
-/// (pane <id>)\n```…```"` (built in `main.rs`, which references this same
-/// constant so the two can't drift).
+/// (pane <id>)\n```…```"` (built in `cli/delegate.rs`, which references this
+/// same constant so the two can't drift).
 ///
 /// Agent CLIs (e.g. Copilot) briefly surface a session's *first user message* as
 /// its `session/list` title before they generate their real chat summary. For a
@@ -1281,12 +1301,36 @@ pub(crate) const TERMINAL_CONTEXT_TITLE_MARKER: &str = "## Terminal Context (pan
 /// [`TERMINAL_CONTEXT_TITLE_MARKER`]) rather than a real CLI-generated summary.
 ///
 /// Such a title must not be adopted as a session's display title: it leaks the
-/// injected terminal context (pane GUID included), and adopting it would lock
-/// the row out of the later upgrade to the CLI's real summary name (an echoed
-/// title is non-synthetic, so `refresh_synthetic_titles_from` would skip it
-/// forever). Callers drop it so the row stays synthetic and keeps upgrading.
+/// injected terminal context (pane GUID and the captured pane output included)
+/// into the session list for the whole window before the CLI generates its real
+/// summary. Callers drop it so the row keeps its own title and the next poll
+/// adopts the summary instead.
+///
+/// This filter is load-bearing for
+/// [`SessionRegistry::adopt_agent_title`], which overwrites whatever it is
+/// handed: an unfiltered echo would not merely stick (the pre-`adopt` failure
+/// mode, where a non-synthetic echo locked the row out of every later upgrade)
+/// but actively replace a good title, and be re-adopted on every 5 s poll until
+/// the summary lands.
 pub(crate) fn title_is_injected_context_echo(title: &str) -> bool {
     title.contains(TERMINAL_CONTEXT_TITLE_MARKER)
+}
+
+/// Whether a `session/list` title reported for `cli` is fit to become a
+/// session's display name.
+///
+/// The single source of truth for "is this candidate usable", shared by the
+/// producer (`master::host_titles_via_acp`, which builds the title map) and the
+/// destructive consumer (`master::refresh_titles_from_listing`, which feeds
+/// [`SessionRegistry::adopt_agent_title`]). An agent's *latest* answer is not
+/// automatically a *displayable* one: it can be empty, the delegate's injected
+/// first-message echo, or a CLI's own untouched-session placeholder. Keeping
+/// both ends on one predicate means a future caller can't reintroduce a
+/// clobbering candidate by rebuilding the map by hand.
+pub(crate) fn title_is_displayable(cli: Option<&CliSource>, title: &str) -> bool {
+    !title.is_empty()
+        && !title_is_injected_context_echo(title)
+        && !cli.is_some_and(|cli| crate::agent_sessions::title_is_placeholder(cli, title))
 }
 
 #[async_trait::async_trait]
@@ -1403,6 +1447,21 @@ impl SessionRegistry for InMemoryRegistry {
         if !title_is_synthetic(entry) {
             return false;
         }
+        if entry.title.as_deref() == Some(candidate) {
+            return false;
+        }
+        entry.title = Some(candidate.to_string());
+        true
+    }
+
+    async fn adopt_agent_title(&self, sid: &acp::schema::v1::SessionId, candidate: &str) -> bool {
+        if candidate.is_empty() {
+            return false;
+        }
+        let mut guard = self.inner.lock().await;
+        let Some(entry) = guard.sessions.get_mut(sid) else {
+            return false;
+        };
         if entry.title.as_deref() == Some(candidate) {
             return false;
         }
@@ -2208,12 +2267,13 @@ mod tests {
 
     #[test]
     fn title_is_injected_context_echo_detects_delegate_marker_only() {
-        // Mirrors the `?<prompt>` prompt built in `main.rs` from
+        // Mirrors the `?<prompt>` prompt built in `cli/delegate.rs` from
         // `TERMINAL_CONTEXT_TITLE_MARKER`: an agent CLI can echo this whole first
         // user message back as a `session/list` title before it generates a real
-        // summary. Such an echo must be dropped (see `host_titles_via_acp`) so the
-        // born-bound row stays synthetic and keeps upgrading — the counterpart
-        // behaviour is covered by `refresh_synthetic_titles_from_skips_when_id_absent`.
+        // summary. Such an echo must be dropped (see `host_titles_via_acp`), or
+        // `adopt_agent_title` would overwrite the row's title with the injected
+        // pane GUID and captured pane output on every poll until the summary
+        // lands.
         let echo = format!(
             "hi test\n\n{}8A9B4ABA-BEB4-4F94-B0D3-55569420B902)\n```\nPowerShell 7.6.3\n```",
             TERMINAL_CONTEXT_TITLE_MARKER
@@ -2226,6 +2286,35 @@ mod tests {
         ));
         assert!(!title_is_injected_context_echo("hi test"));
         assert!(!title_is_injected_context_echo(""));
+    }
+
+    #[test]
+    fn title_is_displayable_rejects_empty_echo_and_provider_placeholder() {
+        assert!(title_is_displayable(
+            Some(&CliSource::Copilot),
+            "Check Copilot Resume Hooks"
+        ));
+        assert!(title_is_displayable(None, "Check Copilot Resume Hooks"));
+        assert!(!title_is_displayable(Some(&CliSource::Copilot), ""));
+        assert!(!title_is_displayable(
+            Some(&CliSource::Copilot),
+            &format!("hi\n\n{TERMINAL_CONTEXT_TITLE_MARKER}pane-1)\n```\nx\n```")
+        ));
+        // An unknown cli can't recognize a provider placeholder, but the echo
+        // and empty checks still apply.
+        assert!(!title_is_displayable(
+            None,
+            &format!("hi\n\n{TERMINAL_CONTEXT_TITLE_MARKER}pane-1)\n```\nx\n```")
+        ));
+        let placeholder = "New session - 2026-07-23T01:14:00.422Z";
+        assert!(!title_is_displayable(
+            Some(&CliSource::OpenCode),
+            placeholder
+        ));
+        assert!(
+            title_is_displayable(Some(&CliSource::Copilot), placeholder),
+            "another CLI's placeholder shape is a real title here"
+        );
     }
 
     #[tokio::test]
@@ -2349,6 +2438,79 @@ mod tests {
         assert_eq!(found.last_activity_at_ms, Some(123_456_789));
         assert_eq!(found.origin, Some(SessionOrigin::Unknown));
         assert_eq!(found.cwd, PathBuf::from("C:\\Users\\alice"));
+    }
+
+    // ── adopt_agent_title ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn adopt_agent_title_replaces_a_stale_real_title() {
+        // Copilot surfaces the first user message as a session's
+        // `session/list` title until it generates a summary. That echo is
+        // non-synthetic, so `upgrade_title_if_synthetic` can never correct it.
+        let reg = InMemoryRegistry::new();
+        reg.upsert(info_with(
+            "s1",
+            "/repo/proj",
+            Some("first user message echoed as a title"),
+        ))
+        .await;
+        let sid = acp::schema::v1::SessionId::new("s1".to_string());
+        assert!(
+            !reg.upgrade_title_if_synthetic(&sid, "Check Copilot Resume Hooks")
+                .await
+        );
+        assert!(
+            reg.adopt_agent_title(&sid, "Check Copilot Resume Hooks")
+                .await
+        );
+        assert_eq!(
+            reg.lookup(&sid).await.unwrap().title.as_deref(),
+            Some("Check Copilot Resume Hooks")
+        );
+    }
+
+    #[tokio::test]
+    async fn adopt_agent_title_is_a_no_op_for_empty_same_or_missing() {
+        let reg = InMemoryRegistry::new();
+        reg.upsert(info_with("s1", "/repo/proj", Some("Same")))
+            .await;
+        let sid = acp::schema::v1::SessionId::new("s1".to_string());
+        // Empty candidate must never blank out a title.
+        assert!(!reg.adopt_agent_title(&sid, "").await);
+        // Steady state returns false so the poll doesn't broadcast every tick.
+        assert!(!reg.adopt_agent_title(&sid, "Same").await);
+        assert_eq!(
+            reg.lookup(&sid).await.unwrap().title.as_deref(),
+            Some("Same")
+        );
+        assert!(
+            !reg.adopt_agent_title(
+                &acp::schema::v1::SessionId::new("nope".to_string()),
+                "Real Title"
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn adopt_agent_title_preserves_other_fields() {
+        let reg = InMemoryRegistry::new();
+        let mut row = info_with("s1", "/repo/proj", Some("old"));
+        row.pane_session_id = Some("pane-abc".to_string());
+        row.status = Some(AgentStatus::Working);
+        row.cli_source = Some(CliSource::Copilot);
+        row.last_activity_at_ms = Some(123_456_789);
+        reg.upsert(row).await;
+
+        let sid = acp::schema::v1::SessionId::new("s1".to_string());
+        assert!(reg.adopt_agent_title(&sid, "new").await);
+
+        let found = reg.lookup(&sid).await.unwrap();
+        assert_eq!(found.title.as_deref(), Some("new"));
+        assert_eq!(found.pane_session_id.as_deref(), Some("pane-abc"));
+        assert_eq!(found.status, Some(AgentStatus::Working));
+        assert_eq!(found.cli_source, Some(CliSource::Copilot));
+        assert_eq!(found.last_activity_at_ms, Some(123_456_789));
     }
 
     // ── _meta.wta extract / inject ──────────────────────────────────

--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -1235,9 +1235,11 @@ pub trait SessionRegistry: Send + Sync {
     /// on it forever. This is the counterpart primitive that lets the poll
     /// re-adopt the agent's current answer.
     ///
-    /// Callers must first establish that the listing agent owns this row (see
-    /// `master::row_titled_by_listing_agent`) and must filter placeholder and
-    /// injected-context candidates, since this method applies whatever it is
+    /// Callers must first establish that the listing agent owns this row (in
+    /// master that is `row_refreshable_by_connected_agent` plus a session-id
+    /// match against that agent's own `session/list`) and must filter
+    /// placeholder and injected-context candidates with
+    /// [`title_is_displayable`], since this method applies whatever it is
     /// given.
     ///
     /// [`upgrade_title_if_synthetic`]: SessionRegistry::upgrade_title_if_synthetic


### PR DESCRIPTION
## Problem

Session management shows a stale title after the agent CLI renames a session.

Reported case: Copilot session `28d20b44-0acf-491f-b0d4-ec77c7ba3906`. Its
`workspace.yaml` had been updated to `name: Check Copilot Resume Hooks`, and
`wta probe-sessions --agent "copilot --acp --stdio"` confirmed the agent side
was already correct:

```
session_id : 28d20b44-0acf-491f-b0d4-ec77c7ba3906
title      : Check Copilot Resume Hooks
```

The session picker still showed the session's **first user message**.

## Root cause

The picker renders master's registry snapshot, whose titles come from ACP
`session/list`. Copilot answers that call with a session's first user message
until it generates a real summary, then swaps in the summary.

Master had only a one-way `synthetic -> real` refresh:

- `upgrade_title_if_synthetic` replaces a title only when it is empty, the cwd
  basename, or a provider placeholder.
- `sync_host_history` only `upsert_if_absent`s, so an existing row's title is
  never touched — neither the 5s poll nor F5 could correct it.

The transient first-message echo is an ordinary **non-synthetic** title, so the
row latched it permanently. Only a Terminal restart cleared it, because the
registry is in-memory.

## Fix

- Add `SessionRegistry::adopt_agent_title` — the counterpart primitive to
  `upgrade_title_if_synthetic`, replacing a title regardless of its current
  value.
- Add `refresh_titles_from_listing`, called from `sync_host_history`. It
  reuses the 2s-cached `session/list` fetch that function already made and the
  **unfiltered** `host_titles_via_acp` map, so agent-pane rows are covered and
  **no extra ACP round-trip** is added. An unchanged title reports no change, so
  the poll does not broadcast every tick.

### Authority is the session id, not `location`

Host Copilot and an in-distro Copilot share a `CliSource` while enumerating
disjoint stores, so a `location` gate looks tempting. It is the wrong trade:

- A host listing never contains an in-distro session id, so `location` guards
  against a collision the WSL spec itself calls *astronomically unlikely*.
- Only the born-bound path calls `set_location`. An ordinary `session_hook`
  row for a CLI running **inside WSL** keeps the reducer's default `Host`,
  while its title lives in the in-distro agent's listing — a `location` gate
  would skip exactly that row forever.

So the gate is `row_refreshable_by_connected_agent` (provider only) plus the
id. `is_stale_host_history_row` stays strict: deletion cannot be justified by
an id match.

### Candidate filters became load-bearing

`adopt_agent_title` overwrites unconditionally, so an injected-context echo or
a provider placeholder would now **clobber a good title on every poll** instead
of merely failing to replace a synthetic one. The existing checks are extracted
into `session_registry::title_is_displayable` and applied at **both** ends —
where `host_titles_via_acp` builds the map and at the point of mutation — so a
future caller cannot reintroduce a clobbering candidate by rebuilding the map by
hand.

## Behavior

While the session view is open, the title now corrects itself within one 5s poll
(or immediately on `sessions/changed` / F5). No behavior change when the view
is closed, when the agent cannot list, or for the still-synthetic upgrade paths.

## Validation

- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
  — **1880 passed, 0 failed**
- `cargo fmt --check` clean
- Verified against the live Copilot CLI with `wta probe-sessions` (output above)

New tests:

| Test | Covers |
| --- | --- |
| `refresh_titles_from_listing_adopts_changed_real_title` | The reported bug, plus no-change-on-steady-state |
| `refresh_titles_from_listing_retitles_an_unstamped_in_distro_row` | The row a `location` gate would have skipped |
| `refresh_titles_from_listing_skips_rows_from_another_cli` | Claude row untouched by a Copilot listing |
| `refresh_titles_from_listing_rejects_undisplayable_candidates` | Echo / placeholder / empty cannot clobber |
| `title_is_displayable_rejects_empty_echo_and_provider_placeholder` | The shared predicate |
| `adopt_agent_title_*` (3) | Replace, no-op cases, field preservation |