### PR TITLE
Derive delegate and protocol-tab context from the user's terminal pane

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -220,7 +220,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(BuildStartupActionsContentStashesAgentFirstPaneAsNewTab);
         TEST_METHOD(BuildStartupActionsContentStashesAgentLaterSplitAsExistingTab);
         TEST_METHOD(TransferredAgentContentFirstPaneDefersTabRekey);
-        TEST_METHOD(ProtocolTabProfileSourceSkipsAgentPane);
+        TEST_METHOD(SourceTerminalPaneSkipsAgentPane);
         TEST_METHOD(TransferredAgentContentSplitPaneRetiresDestinationAgentPane);
         TEST_METHOD(TransferredAgentStatusReplaysMissedTabRekey);
 
@@ -2067,7 +2067,7 @@ namespace TerminalAppLocalTests
         });
     }
 
-    void TabTests::ProtocolTabProfileSourceSkipsAgentPane()
+    void TabTests::SourceTerminalPaneSkipsAgentPane()
     {
         auto page = _commonSetup();
 
@@ -2088,26 +2088,32 @@ namespace TerminalAppLocalTests
             VERIFY_IS_NOT_NULL(agentPane);
             agentPane->IsAgentPane(true);
 
-            // `_SplitPane` focuses the new pane, exactly like opening the agent
-            // pane and driving its session picker does.
+            // `_SplitPane` focuses the new pane, exactly like clicking into the
+            // agent pane or driving its session picker does.
             page->_SplitPane(focusedTab, SplitDirection::Down, 0.3f, agentPane);
             VERIFY_IS_NOT_NULL(focusedTab->GetActivePane());
             VERIFY_IS_TRUE(focusedTab->GetActivePane()->IsAgentPane());
 
-            // Sanity check that this is the state that used to leak the agent
-            // pane's profile into protocol-created tabs.
+            // This is the state that used to leak the agent pane's identity
+            // into protocol tabs, delegate agent selection, and delegate cwd.
             const auto focusedProfile = focusedTab->GetFocusedProfile();
             VERIFY_IS_NOT_NULL(focusedProfile);
             VERIFY_ARE_EQUAL(L"profile1", focusedProfile.Name());
 
-            const auto sourcePane = page->_ProtocolTabProfileSourcePane(focusedTab);
+            const auto sourcePane = page->_SourceTerminalPaneForTab(focusedTab);
             VERIFY_IS_NOT_NULL(sourcePane);
             VERIFY_IS_FALSE(sourcePane->IsAgentPane());
             VERIFY_IS_TRUE(sourcePane == terminalPane);
 
-            const auto sourceContent = sourcePane->GetContent().try_as<winrt::TerminalApp::TerminalPaneContent>();
-            VERIFY_IS_NOT_NULL(sourceContent);
-            VERIFY_ARE_EQUAL(L"profile0", sourceContent.GetProfile().Name());
+            // The source pane is deliberately not `_lastActive`, so resolving
+            // its profile must not go through `Pane::GetFocusedProfile()` —
+            // that returns null here, which is what silently dropped the
+            // profile's `commandPaletteAgent`.
+            VERIFY_IS_NULL(sourcePane->GetFocusedProfile());
+
+            const auto sourceProfile = page->_SourceTerminalProfileForTab(focusedTab);
+            VERIFY_IS_NOT_NULL(sourceProfile);
+            VERIFY_ARE_EQUAL(L"profile0", sourceProfile.Name());
         });
     }
 

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -220,6 +220,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(BuildStartupActionsContentStashesAgentFirstPaneAsNewTab);
         TEST_METHOD(BuildStartupActionsContentStashesAgentLaterSplitAsExistingTab);
         TEST_METHOD(TransferredAgentContentFirstPaneDefersTabRekey);
+        TEST_METHOD(ProtocolTabProfileSourceSkipsAgentPane);
         TEST_METHOD(TransferredAgentContentSplitPaneRetiresDestinationAgentPane);
         TEST_METHOD(TransferredAgentStatusReplaysMissedTabRekey);
 
@@ -2063,6 +2064,50 @@ namespace TerminalAppLocalTests
             const auto pendingSourceProfileGuid = impl->TakePendingAgentSourceProfileGuid();
             VERIFY_IS_TRUE(pendingSourceProfileGuid.has_value());
             VERIFY_IS_TRUE(pendingSourceProfileGuid.value() == sourceProfileGuid);
+        });
+    }
+
+    void TabTests::ProtocolTabProfileSourceSkipsAgentPane()
+    {
+        auto page = _commonSetup();
+
+        TestOnUIThread([&]() {
+            const auto focusedTab = page->_GetFocusedTabImpl();
+            VERIFY_IS_NOT_NULL(focusedTab);
+
+            const auto terminalPane = focusedTab->GetActivePane();
+            VERIFY_IS_NOT_NULL(terminalPane);
+            VERIFY_IS_FALSE(terminalPane->IsAgentPane());
+
+            // The real agent pane runs the hidden "Agent Pane" profile, which
+            // is `closeOnExit: always`. Stand in for it with a profile that is
+            // not the tab's (and not the global default) so the assertions
+            // below can tell the two apart.
+            NewTerminalArgs agentArgs{ 1 };
+            auto agentPane = page->_WrapInAgentPaneContent(page->_MakePane(agentArgs, nullptr, nullptr));
+            VERIFY_IS_NOT_NULL(agentPane);
+            agentPane->IsAgentPane(true);
+
+            // `_SplitPane` focuses the new pane, exactly like opening the agent
+            // pane and driving its session picker does.
+            page->_SplitPane(focusedTab, SplitDirection::Down, 0.3f, agentPane);
+            VERIFY_IS_NOT_NULL(focusedTab->GetActivePane());
+            VERIFY_IS_TRUE(focusedTab->GetActivePane()->IsAgentPane());
+
+            // Sanity check that this is the state that used to leak the agent
+            // pane's profile into protocol-created tabs.
+            const auto focusedProfile = focusedTab->GetFocusedProfile();
+            VERIFY_IS_NOT_NULL(focusedProfile);
+            VERIFY_ARE_EQUAL(L"profile1", focusedProfile.Name());
+
+            const auto sourcePane = page->_ProtocolTabProfileSourcePane(focusedTab);
+            VERIFY_IS_NOT_NULL(sourcePane);
+            VERIFY_IS_FALSE(sourcePane->IsAgentPane());
+            VERIFY_IS_TRUE(sourcePane == terminalPane);
+
+            const auto sourceContent = sourcePane->GetContent().try_as<winrt::TerminalApp::TerminalPaneContent>();
+            VERIFY_IS_NOT_NULL(sourceContent);
+            VERIFY_ARE_EQUAL(L"profile0", sourceContent.GetProfile().Name());
         });
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
@@ -574,8 +574,9 @@ namespace winrt::TerminalApp::implementation
     // away then takes the whole tab with it, because a lone agent pane
     // collapses its subtree (see `Pane::_CloseChildRoutine`).
     //
-    // `_SourceTerminalPaneForTab` is what keeps the agent pane out of the
-    // lookup; see its comment in TerminalPage.cpp.
+    // `_SourceTerminalProfileForTab` is what keeps the agent pane out of that
+    // lookup — it resolves through `_SourceTerminalPaneForTab`, whose comment
+    // in TerminalPage.cpp explains the ordering.
     IAsyncOperation<Protocol::TabCreationResult> TerminalPage::CreateProtocolTab(NewTerminalArgs args, bool background)
     {
         auto strong = get_strong();

--- a/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
@@ -574,51 +574,8 @@ namespace winrt::TerminalApp::implementation
     // away then takes the whole tab with it, because a lone agent pane
     // collapses its subtree (see `Pane::_CloseChildRoutine`).
     //
-    // So skip agent panes: prefer the pane the agent pane was opened from, then
-    // any other terminal pane on the tab, and finally report "nothing usable"
-    // so the caller falls back to the user's global default profile.
-    std::shared_ptr<Pane> TerminalPage::_ProtocolTabProfileSourcePane(const winrt::com_ptr<Tab>& tab)
-    {
-        if (!tab)
-        {
-            return nullptr;
-        }
-
-        // Only terminal panes carry a profile; agent panes wrap one but must
-        // never be picked, and scratchpad-style content has none at all.
-        const auto isProfileSource = [](const std::shared_ptr<Pane>& pane) {
-            return pane &&
-                   !pane->IsAgentPane() &&
-                   pane->GetContent().try_as<TerminalApp::TerminalPaneContent>() != nullptr;
-        };
-
-        if (const auto activePane = tab->GetActivePane(); isProfileSource(activePane))
-        {
-            return activePane;
-        }
-
-        const auto rootPane = tab->GetRootPane();
-        if (!rootPane)
-        {
-            return nullptr;
-        }
-
-        std::shared_ptr<Pane> sourcePane{ nullptr };
-        rootPane->WalkTree([&](const auto& pane) {
-            if (!isProfileSource(pane))
-            {
-                return;
-            }
-            // The pane the user was working in when the agent pane took focus
-            // is the best match; otherwise settle for the first terminal pane.
-            if (!sourcePane || pane->IsSourceOfAgentPane())
-            {
-                sourcePane = pane;
-            }
-        });
-        return sourcePane;
-    }
-
+    // `_SourceTerminalPaneForTab` is what keeps the agent pane out of the
+    // lookup; see its comment in TerminalPage.cpp.
     IAsyncOperation<Protocol::TabCreationResult> TerminalPage::CreateProtocolTab(NewTerminalArgs args, bool background)
     {
         auto strong = get_strong();
@@ -641,9 +598,7 @@ namespace winrt::TerminalApp::implementation
         // session (same intent as PR #366); fall back to the user's global
         // default profile when there is no focused terminal. Either way this is
         // never left empty — that's what re-introduces the auto-closing
-        // "Defaults" profile. `_ProtocolTabProfileSourcePane` is what keeps the
-        // agent pane out of that lookup — see its comment for why pinning the
-        // agent pane's profile is even worse than the "Defaults" profile.
+        // "Defaults" profile.
         //
         // Scope this narrowly to the case that actually hits the bug: a
         // commandline with no explicit profile selection. A caller that omits
@@ -655,15 +610,9 @@ namespace winrt::TerminalApp::implementation
         if (args && !args.Commandline().empty() && args.Profile().empty() && !args.ProfileIndex())
         {
             auto profileGuid = _settings.GlobalSettings().DefaultProfile();
-            if (const auto sourcePane = _ProtocolTabProfileSourcePane(_GetFocusedTabImpl()))
+            if (const auto sourceProfile = _SourceTerminalProfileForTab(_GetFocusedTabImpl()))
             {
-                if (const auto termContent = sourcePane->GetContent().try_as<TerminalApp::TerminalPaneContent>())
-                {
-                    if (const auto sourceProfile = termContent.GetProfile())
-                    {
-                        profileGuid = sourceProfile.Guid();
-                    }
-                }
+                profileGuid = sourceProfile.Guid();
             }
             args.Profile(::Microsoft::Console::Utils::GuidToString(profileGuid));
         }

--- a/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.Protocol.cpp
@@ -562,6 +562,63 @@ namespace winrt::TerminalApp::implementation
         co_return false;
     }
 
+    // Resolves the pane whose profile a protocol-created tab should inherit.
+    //
+    // `wtcli new-tab` is frequently invoked *from* the agent pane — the session
+    // picker resuming an agent CLI, delegate hand-off, and so on — so the tab's
+    // active pane is often the agent pane itself. Its hidden "Agent Pane"
+    // profile sets `closeOnExit: always`, and pinning that onto a brand-new
+    // terminal tab makes the tab vanish the moment its command exits for *any*
+    // reason, including a Ctrl+C (`STATUS_CONTROL_C_EXIT` is a non-zero exit
+    // code, so the connection lands in `Failed`, not `Closed`). The pane going
+    // away then takes the whole tab with it, because a lone agent pane
+    // collapses its subtree (see `Pane::_CloseChildRoutine`).
+    //
+    // So skip agent panes: prefer the pane the agent pane was opened from, then
+    // any other terminal pane on the tab, and finally report "nothing usable"
+    // so the caller falls back to the user's global default profile.
+    std::shared_ptr<Pane> TerminalPage::_ProtocolTabProfileSourcePane(const winrt::com_ptr<Tab>& tab)
+    {
+        if (!tab)
+        {
+            return nullptr;
+        }
+
+        // Only terminal panes carry a profile; agent panes wrap one but must
+        // never be picked, and scratchpad-style content has none at all.
+        const auto isProfileSource = [](const std::shared_ptr<Pane>& pane) {
+            return pane &&
+                   !pane->IsAgentPane() &&
+                   pane->GetContent().try_as<TerminalApp::TerminalPaneContent>() != nullptr;
+        };
+
+        if (const auto activePane = tab->GetActivePane(); isProfileSource(activePane))
+        {
+            return activePane;
+        }
+
+        const auto rootPane = tab->GetRootPane();
+        if (!rootPane)
+        {
+            return nullptr;
+        }
+
+        std::shared_ptr<Pane> sourcePane{ nullptr };
+        rootPane->WalkTree([&](const auto& pane) {
+            if (!isProfileSource(pane))
+            {
+                return;
+            }
+            // The pane the user was working in when the agent pane took focus
+            // is the best match; otherwise settle for the first terminal pane.
+            if (!sourcePane || pane->IsSourceOfAgentPane())
+            {
+                sourcePane = pane;
+            }
+        });
+        return sourcePane;
+    }
+
     IAsyncOperation<Protocol::TabCreationResult> TerminalPage::CreateProtocolTab(NewTerminalArgs args, bool background)
     {
         auto strong = get_strong();
@@ -584,7 +641,9 @@ namespace winrt::TerminalApp::implementation
         // session (same intent as PR #366); fall back to the user's global
         // default profile when there is no focused terminal. Either way this is
         // never left empty — that's what re-introduces the auto-closing
-        // "Defaults" profile.
+        // "Defaults" profile. `_ProtocolTabProfileSourcePane` is what keeps the
+        // agent pane out of that lookup — see its comment for why pinning the
+        // agent pane's profile is even worse than the "Defaults" profile.
         //
         // Scope this narrowly to the case that actually hits the bug: a
         // commandline with no explicit profile selection. A caller that omits
@@ -596,11 +655,14 @@ namespace winrt::TerminalApp::implementation
         if (args && !args.Commandline().empty() && args.Profile().empty() && !args.ProfileIndex())
         {
             auto profileGuid = _settings.GlobalSettings().DefaultProfile();
-            if (const auto focusedTab = _GetFocusedTabImpl())
+            if (const auto sourcePane = _ProtocolTabProfileSourcePane(_GetFocusedTabImpl()))
             {
-                if (const auto focusedProfile = focusedTab->GetFocusedProfile())
+                if (const auto termContent = sourcePane->GetContent().try_as<TerminalApp::TerminalPaneContent>())
                 {
-                    profileGuid = focusedProfile.Guid();
+                    if (const auto sourceProfile = termContent.GetProfile())
+                    {
+                        profileGuid = sourceProfile.Guid();
+                    }
                 }
             }
             args.Profile(::Microsoft::Console::Utils::GuidToString(profileGuid));

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1345,28 +1345,79 @@ namespace winrt::TerminalApp::implementation
         };
     }
 
-    static winrt::Microsoft::Terminal::Settings::Model::Profile _GetAgentSourceProfile(
-        const winrt::com_ptr<Tab>& tab)
+    // The pane the user is actually working in, ignoring the agent pane.
+    //
+    // The agent pane is a real focusable pane, so once the user clicks into it
+    // (or drives its session picker) it becomes the tab's `_activePane` and
+    // starts answering "where is the user?" on behalf of the terminal pane it
+    // was opened from. Everything that derives *user context* — the profile a
+    // delegate/protocol tab should inherit, the cwd a delegated agent should
+    // start in — has to look past it, or it silently picks up the hidden
+    // "Agent Pane" profile and the helper process's own working directory.
+    //
+    // Order: the active pane when it is an ordinary terminal pane, then the
+    // pane the agent pane was opened from, then any other terminal pane on the
+    // tab. Returns nullptr when the tab has no terminal pane at all.
+    //
+    // Deliberately does NOT go through `Pane::GetFocusedProfile()`: that
+    // resolves through `GetActivePane()` (`_lastActive`), and the pane we want
+    // here is by definition *not* the active one, so it would always come back
+    // empty in exactly the case this helper exists for.
+    std::shared_ptr<Pane> TerminalPage::_SourceTerminalPaneForTab(const winrt::com_ptr<Tab>& tab)
     {
         if (!tab)
         {
             return nullptr;
         }
 
-        auto sourcePane = tab->GetActivePane();
-        if (sourcePane && sourcePane->IsAgentPane())
+        // Only terminal panes carry a profile and a working directory. Agent
+        // panes wrap one but must never be picked; scratchpad-style content
+        // has neither.
+        const auto isSourceCandidate = [](const std::shared_ptr<Pane>& pane) {
+            return pane &&
+                   !pane->IsAgentPane() &&
+                   pane->GetContent().try_as<TerminalApp::TerminalPaneContent>() != nullptr;
+        };
+
+        if (const auto activePane = tab->GetActivePane(); isSourceCandidate(activePane))
         {
-            if (const auto rootPane = tab->GetRootPane())
+            return activePane;
+        }
+
+        const auto rootPane = tab->GetRootPane();
+        if (!rootPane)
+        {
+            return nullptr;
+        }
+
+        std::shared_ptr<Pane> sourcePane{ nullptr };
+        rootPane->WalkTree([&](const auto& pane) {
+            if (!isSourceCandidate(pane))
             {
-                rootPane->WalkTree([&](const auto& pane) {
-                    if (pane->IsSourceOfAgentPane())
-                    {
-                        sourcePane = pane;
-                    }
-                });
+                return;
+            }
+            // `IsSourceOfAgentPane` records the pane the user was working in
+            // when the agent pane took focus, so it is the precise answer;
+            // otherwise settle for the first terminal pane on the tab.
+            if (!sourcePane || pane->IsSourceOfAgentPane())
+            {
+                sourcePane = pane;
+            }
+        });
+        return sourcePane;
+    }
+
+    winrt::Microsoft::Terminal::Settings::Model::Profile TerminalPage::_SourceTerminalProfileForTab(
+        const winrt::com_ptr<Tab>& tab)
+    {
+        if (const auto sourcePane = _SourceTerminalPaneForTab(tab))
+        {
+            if (const auto termContent = sourcePane->GetContent().try_as<TerminalApp::TerminalPaneContent>())
+            {
+                return termContent.GetProfile();
             }
         }
-        return sourcePane ? sourcePane->GetFocusedProfile() : tab->GetFocusedProfile();
+        return nullptr;
     }
 
     static const winrt::guid& _ProfileDefaultsAgentBackendGuid()
@@ -1384,7 +1435,7 @@ namespace winrt::TerminalApp::implementation
                    profile.Guid();
     }
 
-    static winrt::Microsoft::Terminal::Settings::Model::Profile _ResolveAgentSourceProfile(
+    winrt::Microsoft::Terminal::Settings::Model::Profile TerminalPage::_ResolveAgentSourceProfile(
         const winrt::com_ptr<Tab>& tab,
         const winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings& settings)
     {
@@ -1406,7 +1457,7 @@ namespace winrt::TerminalApp::implementation
                 return settings.ProfileDefaults();
             }
         }
-        return _GetAgentSourceProfile(tab);
+        return _SourceTerminalProfileForTab(tab);
     }
 
     // The agent identity a restored agent pane has to record.
@@ -1644,7 +1695,7 @@ namespace winrt::TerminalApp::implementation
         auto delegateModel = globals.DelegateModel();
         winrt::hstring delegateSource{ L"host" };
         winrt::hstring delegateWslDistro;
-        if (const auto sourceProfile = _GetAgentSourceProfile(_GetFocusedTabImpl()))
+        if (const auto sourceProfile = _SourceTerminalProfileForTab(_GetFocusedTabImpl()))
         {
             const auto configuredValue = sourceProfile.CommandPaletteAgent();
             const std::wstring_view configured{ configuredValue };
@@ -1753,11 +1804,19 @@ namespace winrt::TerminalApp::implementation
             cmdline += L" --delegate-model " + quoteArg(std::wstring_view{ delegateModel });
         }
 
-        // Pass CWD from the active pane.
+        // Pass CWD from the pane the user is working in. `_GetActiveControl()`
+        // would hand back the agent pane's own control whenever the agent pane
+        // holds focus (which it does whenever the user just interacted with
+        // it), and the wta-helper process inherits WindowsTerminal.exe's
+        // working directory — so the delegated agent would start in
+        // `C:\Windows\system32` instead of the user's project.
         winrt::hstring activeCwd;
-        if (const auto& activeControl = _GetActiveControl())
+        if (const auto sourcePane = _SourceTerminalPaneForTab(_GetFocusedTabImpl()))
         {
-            activeCwd = activeControl.WorkingDirectory();
+            if (const auto& sourceControl = sourcePane->GetTerminalControl())
+            {
+                activeCwd = sourceControl.WorkingDirectory();
+            }
         }
         if (activeCwd.empty())
         {

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -902,6 +902,7 @@ namespace winrt::TerminalApp::implementation
         std::optional<uint32_t> _GetTabIndex(const TerminalApp::Tab& tab) const noexcept;
         TerminalApp::Tab _GetFocusedTab() const noexcept;
         winrt::com_ptr<Tab> _GetFocusedTabImpl() const noexcept;
+        static std::shared_ptr<Pane> _ProtocolTabProfileSourcePane(const winrt::com_ptr<Tab>& tab);
         TerminalApp::Tab _GetTabByTabViewItem(const IInspectable& tabViewItem) const noexcept;
 
         // Spec A §4.1: routing indirection so TabManagement.cpp doesn't have to

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -902,7 +902,9 @@ namespace winrt::TerminalApp::implementation
         std::optional<uint32_t> _GetTabIndex(const TerminalApp::Tab& tab) const noexcept;
         TerminalApp::Tab _GetFocusedTab() const noexcept;
         winrt::com_ptr<Tab> _GetFocusedTabImpl() const noexcept;
-        static std::shared_ptr<Pane> _ProtocolTabProfileSourcePane(const winrt::com_ptr<Tab>& tab);
+        static std::shared_ptr<Pane> _SourceTerminalPaneForTab(const winrt::com_ptr<Tab>& tab);
+        static winrt::Microsoft::Terminal::Settings::Model::Profile _SourceTerminalProfileForTab(const winrt::com_ptr<Tab>& tab);
+        static winrt::Microsoft::Terminal::Settings::Model::Profile _ResolveAgentSourceProfile(const winrt::com_ptr<Tab>& tab, const winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings& settings);
         TerminalApp::Tab _GetTabByTabViewItem(const IInspectable& tabViewItem) const noexcept;
 
         // Spec A §4.1: routing indirection so TabManagement.cpp doesn't have to


### PR DESCRIPTION
## Problem

The agent pane is an ordinary focusable pane, so the moment the user clicks into it
-- or drives its session picker -- it becomes the tab's `_activePane`. Three places
that derive *user context* from the active pane then answered with the agent pane
instead of the terminal pane it was opened from.

### 1. Protocol-created tabs inherited the agent pane's profile

`CreateProtocolTab` pins a real profile when the caller supplies a commandline but
no profile, so a non-zero exit stays visible instead of being swallowed by the
auto-closing `Defaults` profile. It read that profile from the focused tab's active
pane -- the agent pane -- yielding the hidden `Agent Pane` profile, which is
`"closeOnExit": "always"` (`defaults.json`).

Resuming a session from the `/sessions` picker therefore produced a tab that
vanished on *any* exit:

1. Ctrl+C terminates the CLI with `STATUS_CONTROL_C_EXIT` (`0xC000013A`).
2. Non-zero exit code, so `ConptyConnection` goes to `Failed`, not `Closed`.
3. `closeOnExit: always` closes the pane anyway.
4. Only the agent pane is left, so `Pane::_CloseChildRoutine` collapses the subtree
   and the tab goes with it.

The tabs also silently picked up that profile's `scrollbarState: hidden`,
`padding: 8,8,8,0` and `suppressApplicationTitle`.

### 2. Per-profile delegate agent was silently dropped

`_LaunchDelegate` resolved the profile through `Pane::GetFocusedProfile()`, which
goes through `GetActivePane()` (`_lastActive`). `Tab::_UpdateActivePane` calls
`ClearActive()` before marking the agent pane active, so the source pane this code
wants is by definition *not* `_lastActive` -- the call always returned null and the
profile's `commandPaletteAgent` was skipped in favor of the global `delegateAgent`
on the host.

### 3. Delegate cwd came from the helper process

`_LaunchDelegate` took the cwd from `_GetActiveControl()`, i.e. the wta-helper's
own control. The helper inherits WindowsTerminal.exe's working directory, so the
delegated agent started in `C:\Windows\system32`.

Observed live from one Ubuntu tab, differing only in which pane had focus:

| focus | `--delegate-agent` | `--delegate-source` | `--cwd` |
| --- | --- | --- | --- |
| Ubuntu terminal pane | `copilot` | `wsl` + `Ubuntu` | `/home/yuazha` |
| agent pane | `codex` | `host` | `C:\Windows\system32` |

## Fix

Add `_SourceTerminalPaneForTab` / `_SourceTerminalProfileForTab`, which resolve the
pane the user is actually working in:

1. the active pane, when it is an ordinary terminal pane;
2. otherwise the pane the agent pane was opened from (`IsSourceOfAgentPane`);
3. otherwise any other terminal pane on the tab;
4. otherwise nothing, so callers fall back to their own default.

Profiles are read straight off the pane's content and never through
`Pane::GetFocusedProfile()`, which is what made case 2 fail. Non-terminal content
(settings / scratchpad panes) is skipped -- it carries no profile.

All three call sites share the helper. `_ResolveAgentSourceProfile` becomes a member
function so it can call it too.

Semantics are unchanged when a terminal pane has focus, which is why per-profile
`commandPaletteAgent` appeared to work: the command palette is a XAML overlay and
does not move pane focus, so the bug only surfaced after the user had interacted with
the agent pane.

## Validation

- `bcz no_clean` (Debug, x64): 0 errors.
- Added `TabTests::SourceTerminalPaneSkipsAgentPane`: focuses an agent pane running a
  distinct profile and asserts the helper returns the tab's terminal pane and its
  profile, including an explicit assertion that `GetFocusedProfile()` is null on that
  pane -- the exact trap this change avoids. The `LocalTests_TerminalApp` harness does
  not initialize on my machine (the untouched `TabTests::TryZoomPane` fails identically
  in `_initializeTerminalPage`), so this runs in CI.
- Deployed the Debug package for manual verification: resume a session and press Ctrl+C
  (tab must stay open showing `[process exited with code 3221225786]`); and with the
  agent pane focused, run `?<prompt>` from an Ubuntu tab and confirm the launch line
  carries `--delegate-source "wsl" --delegate-wsl-distro "Ubuntu" --cwd "/home/yuazha"`.
