### PR TITLE
Treat a status-less born-bound row as live in the pane guard

### DIFF
--- a/tools/wta/src/session_registry.rs
+++ b/tools/wta/src/session_registry.rs
@@ -1577,6 +1577,14 @@ fn apply_event_locked(state: &mut RegistryState, ev: SessionEvent) -> bool {
             // fallback is silently dropped. Require the hook's session id to
             // match the pane's born-bound owner; a mismatch still records the
             // session, it just gets no pane binding.
+            //
+            // Phrased as "not terminal" rather than "one of the live states" so
+            // that `status: None` counts as live. A row reaches
+            // `ResumePaneAssigned` with no status whenever `ResumeDispatched`
+            // found it neither Historical nor Ended, and `mark_resume_dispatched`
+            // already renders `None` as "Idle"; matching on the live states
+            // instead would leave exactly those rows unprotected and let the
+            // regression through.
             let pane_owned_by_other_born_bound = state
                 .active_by_pane
                 .get(&pane_session_id)
@@ -1584,9 +1592,9 @@ fn apply_event_locked(state: &mut RegistryState, ev: SessionEvent) -> bool {
                 .and_then(|owner_sid| state.sessions.get(owner_sid))
                 .is_some_and(|owner| {
                     owner.born_bound_pane
-                        && matches!(
+                        && !matches!(
                             owner.status,
-                            Some(AgentStatus::Idle | AgentStatus::Working | AgentStatus::Attention)
+                            Some(AgentStatus::Ended | AgentStatus::Historical | AgentStatus::Error)
                         )
                 });
             let pane_known = pane_known && !pane_owned_by_other_born_bound;
@@ -2943,11 +2951,29 @@ mod tests {
     /// Seed a `/sessions` resume: a historical row promoted to Idle and bound
     /// to a freshly-spawned pane by WTA itself, before the CLI has started.
     async fn seed_resumed_pane(reg: &InMemoryRegistry, key: &str, pane: &str) {
+        seed_resumed_pane_with_status(
+            reg,
+            key,
+            pane,
+            Some(crate::agent_sessions::AgentStatus::Historical),
+        )
+        .await;
+    }
+
+    /// [`seed_resumed_pane`] with control over the row's status before the
+    /// resume, so a test can reproduce a row that reaches `ResumePaneAssigned`
+    /// with `status: None` (`ResumeDispatched` only promotes Historical/Ended).
+    async fn seed_resumed_pane_with_status(
+        reg: &InMemoryRegistry,
+        key: &str,
+        pane: &str,
+        status: Option<crate::agent_sessions::AgentStatus>,
+    ) {
         let mut info = SessionInfo::new(
             acp::schema::v1::SessionId::new(key.to_string()),
             PathBuf::from("C:\\x"),
         );
-        info.status = Some(crate::agent_sessions::AgentStatus::Historical);
+        info.status = status;
         info.cli_source = Some(crate::agent_sessions::CliSource::Copilot);
         reg.upsert(info).await;
         reg.apply_event(crate::agent_sessions::SessionEvent::ResumeDispatched { key: key.into() })
@@ -2996,6 +3022,49 @@ mod tests {
         assert!(
             bootstrap.pane_session_id.is_none(),
             "the bootstrap session is still recorded, just never bound to the pane"
+        );
+    }
+
+    /// `ResumeDispatched` only promotes Historical/Ended rows, so a row whose
+    /// status was never set reaches `ResumePaneAssigned` with `status: None`.
+    /// The guard must still protect it — `mark_resume_dispatched` already
+    /// renders `None` as "Idle", and matching on the live states instead of
+    /// excluding the terminal ones left exactly these rows evictable.
+    #[tokio::test]
+    async fn master_reducer_status_none_resumed_pane_is_still_protected() {
+        let reg = InMemoryRegistry::new();
+        seed_resumed_pane_with_status(&reg, "resumed", "pane-1", None).await;
+        assert!(
+            reg.lookup(&acp::schema::v1::SessionId::new("resumed"))
+                .await
+                .unwrap()
+                .status
+                .is_none(),
+            "precondition: the row carries no status"
+        );
+
+        reg.apply_event(crate::agent_sessions::SessionEvent::SessionStarted {
+            key: "bootstrap".into(),
+            cli_source: crate::agent_sessions::CliSource::Copilot,
+            pane_session_id: "pane-1".into(),
+            cwd: PathBuf::from("C:\\x"),
+            title: "t".into(),
+        })
+        .await;
+
+        let resumed = reg
+            .lookup(&acp::schema::v1::SessionId::new("resumed"))
+            .await
+            .unwrap();
+        assert_eq!(
+            resumed.pane_session_id.as_deref(),
+            Some("pane-1"),
+            "a status-less born-bound row must keep its pane"
+        );
+        assert_ne!(
+            resumed.status,
+            Some(crate::agent_sessions::AgentStatus::Ended),
+            "a status-less born-bound row must not be evicted"
         );
     }
 


### PR DESCRIPTION
## What this changes

The born-bound pane guard added by #713 asks for a positive match:

```rust
owner.born_bound_pane
    && matches!(owner.status, Some(AgentStatus::Idle | Working | Attention))
```

`SessionInfo.status` is `Option<AgentStatus>`, and `None` reads as **live**
everywhere else in the reducer — `mark_resume_dispatched` literally renders it
as `"Idle"`. This is the one place that treats a status-less row as not-live.

The fix inverts the predicate to exclude only the terminal states:

```rust
owner.born_bound_pane
    && !matches!(owner.status, Some(Ended | Historical | Error))
```

`Error` stays excluded on purpose — the pane's connection is gone, so a later
session started there should take over.

## This is hardening, not a user-visible fix

**The state it guards against is not reachable on `main` today.** I traced
every write path into master's registry before opening this PR:

| Write path | `status` |
| --- | --- |
| `new_session` (`master/mod.rs`) | `Some(Idle)` |
| `load_session` (`master/mod.rs`) | `Some(Idle)` |
| `sync_host_history` → `agent_session_to_session_info` | always `Some(..)` |
| pane-loss demotion | `Some(Ended)` |
| `SessionStarted` reducer | baselines a new row to `Idle` |

and `.status = None` has **zero** occurrences in the crate. `SessionInfo::new`
does default to `None`, but the only caller that leaves it that way is the
helper's alive-session mirror (`AliveSnapshotLoaded`), which never reaches
master's registry or this guard.

So the value here is removing a latent inconsistency that currently survives
only because every write path *happens* to set a status. A future write path
that does not would silently lose the guard — and the failure mode is not
graceful: Copilot's `--resume` boots a throwaway bootstrap session whose
`SessionStart` hook reports the bootstrap id against the resumed pane's GUID,
so the resumed row gets evicted to `Ended`, and terminal rows refuse
resurrection (`ToolStarting` / `ToolCompleted` / `Notification` all bail on
`Ended`/`Historical`). The user would see a just-resumed session flip to
"ended" and stop updating for the rest of the CLI's life.

## Test coverage gap this closes

`seed_resumed_pane` seeds `Historical`, which `ResumeDispatched` promotes to
`Idle` — so every prior test exercised only the `Some(Idle)` path. It is
parameterized into `seed_resumed_pane_with_status`, and
`master_reducer_status_none_resumed_pane_is_still_protected` covers the
`None` case, asserting both the precondition (the row really carries no
status) and that the row keeps its pane instead of being evicted to `Ended`.

## Why this is a separate PR

This is the follow-up commit to #713 that **lost a merge race**: it was
committed to that branch at `2026-08-31T08:44:15Z`, eleven minutes after #713
was squash-merged at `08:33:15Z`, so it never reached `main`. Cherry-picked
from a45b2000b7818af481bd0a9d10aa2ae09a6f0102 onto current `main` with no
conflicts.

## Validation

- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
  — **1878 passed, 0 failed**
- `cargo fmt --check` clean